### PR TITLE
Change '${gitlabBranch}' to '${sha1}'

### DIFF
--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -32,7 +32,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'REF', defaultValue: '\${gitlabBranch}', description: 'Commit to build')
+        string(name: 'REF', defaultValue: '\${sha1}', description: 'Commit to build')
     }
 
     environment {


### PR DESCRIPTION
This PR is for CI. GPRB(GitHub Pull Request Builder) is a Jenkins plugin, it downloads the pre-merge PRs from GitHub to build and verify. Change '${gitlabBranch}' var to '${sha1}', because GHPRB uses '${sha1}' instead.

No unit test needed for this PR.

No issue linked to this PR.