### PR TITLE
Switch CICD pipelines to Github

### DIFF
--- a/jenkins/Jenkinsfile.merge
+++ b/jenkins/Jenkinsfile.merge
@@ -71,16 +71,4 @@ pipeline {
             }
         }   
     }
-    
-    post {
-        always {
-            script {
-                if (currentBuild.currentResult == "SUCCESS") {
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "success")
-                } else {
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "failed")
-                }
-            }
-        }
-    }
 }

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -75,16 +75,14 @@ pipeline {
         always {
             script {
                 if (currentBuild.currentResult == "SUCCESS") {
-                    build(job: 'spark/plugin_integration',
+                    build(job: 'spark/rapids_integration-0.1-github',
                           propagate: false,
                           parameters: [string(name: 'REF', value: 'branch-0.1'),
                                        string(name: 'CUDF_VER', value: '0.14-SNAPSHOT'),
                                        booleanParam(name: 'BUILD_CENTOS7', value: false),])
 
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "success")
                     slack("#rapidsai-spark-cicd", "Success", color: "#33CC33")
                 } else {
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "failed")
                     slack("#rapidsai-spark-cicd", "Failed", color: "#FF0000")
                 }
             }

--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -28,11 +28,10 @@ pipeline {
         ansiColor('xterm')
         timeout(time: 120, unit: 'MINUTES')
         buildDiscarder(logRotator(numToKeepStr: '10'))
-        gitLabConnection('GitLab Master')
     }
 
     parameters {
-        string(name: 'REF', defaultValue: '\${gitlabBranch}', description: 'Commit to build')
+        string(name: 'REF', defaultValue: '\${sha1}', description: 'Commit to build')
     }
 
     environment {
@@ -70,16 +69,4 @@ pipeline {
             }
         }
     } // end of stages
-
-    post {
-        always {
-            script {
-                if (currentBuild.currentResult == "SUCCESS") {
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "success")
-                } else {
-                    updateGitlabCommitStatus(name: 'Jenkins CI', state: "failed")
-                }
-            }
-        }
-    }
 } // end of pipeline


### PR DESCRIPTION
1,  Change ${gitlabBranch} to ${sha1} in Jenkinsfile.premerge, because on Github, the env VAR of Jenkins reference branch is 'sha1'.
    Remove all the 'Gitlab' related functions.
    Point the integration pipeline name (spark/plugin_integration) to the Github one (spark/rapids_integration-0.1-github).

2, Only update Jenkins scripts, no source change. No unit tests needed. Ngcc pipelines against forked Github PASS on pre-merge, nightly, and integration.

3, No Github issue related to the PR

4, CICD will work, after Ngcc pipelines updated.

