### PR TITLE
Add partial and final only hash aggregate tests and fix nulls corner case for Average

### DIFF
--- a/sql-plugin/src/main/scala/ai/rapids/spark/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/spark/nullExpressions.scala
@@ -45,22 +45,6 @@ object GpuNvl {
   }
 }
 
-case class GpuNvl(left: GpuExpression, right: GpuExpression) extends GpuBinaryExpression {
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
-    GpuNvl(lhs, rhs)
-  }
-
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
-    throw new IllegalStateException("Should not be used with lhs as scalar")
-  }
-
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
-    GpuNvl(lhs, rhs)
-  }
-
-  override def dataType: DataType = left.dataType
-}
-
 case class GpuCoalesce(children: Seq[GpuExpression]) extends GpuExpression with
   ComplexTypeMergingExpression {
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -381,7 +381,7 @@ case class GpuAverage(child: GpuExpression) extends GpuDeclarativeAggregate {
   override lazy val inputProjection: Seq[GpuExpression] = Seq(
     child match {
       case literal: GpuLiteral => toDoubleLit(literal.value)
-      case _ => GpuNvl(GpuCast(child, DoubleType), GpuLiteral(0D, DoubleType))
+      case _ => GpuCoalesce(Seq(GpuCast(child, DoubleType), GpuLiteral(0D, DoubleType)))
     },
     child match {
       case literal : GpuLiteral => GpuLiteral(if (literal.value != null) 1L else 0L, LongType)


### PR DESCRIPTION
Please write a description in this text box of the changes that are being made.

This PR fixes https://github.com/NVIDIA/spark-rapids/issues/110 and https://github.com/NVIDIA/spark-rapids/issues/154
and adds tests for `final` and `partial` modes for hash aggregate tests. It highlights a couple of failures/bugs caught during testing (marked xfail with comments)uses GpuNvl/GpuCoalesce to stop averages to pass down nulls to the CPU. Additionally contains minor nits to the python test file for hash aggregates. 

