### PR TITLE
Fix compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -105,15 +105,6 @@
         </resources>
         <plugins>
             <plugin>
-                <!--Skip the tests-->
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
-            <plugin>
               <artifactId>maven-antrun-plugin</artifactId>
               <executions>
                 <execution>
@@ -161,14 +152,6 @@
                         </launcher>
                     </launchers>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.scalatest</groupId>
-                <artifactId>scalatest-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.scoverage</groupId>
-                <artifactId>scoverage-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.scalastyle</groupId>

--- a/sql-plugin/src/main/scala/ai/rapids/spark/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/spark/GpuDeviceManager.scala
@@ -188,7 +188,8 @@ object GpuDeviceManager extends Logging {
         s"${initialAllocation / 1024 / 1024.0} MB on gpuId $gpuId")
 
       try {
-        Rmm.initialize(init, logConf, initialAllocation, gpuId)
+        Cuda.setDevice(gpuId)
+        Rmm.initialize(init, logConf, initialAllocation)
         GpuShuffleEnv.initStorage(conf, info)
       } catch {
         case e: Exception => logError("Could not initialize RMM", e)

--- a/sql-plugin/src/main/scala/ai/rapids/spark/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/spark/GpuOrcScan.scala
@@ -642,7 +642,7 @@ class GpuOrcPartitionReader(
           .withCompression(orcReader.getCompressionKind)
           .withFileSystem(fs)
           .withPath(filePath)
-          .withTypeCount(orcReader.getTypes.size)
+          .withTypeCount(org.apache.orc.OrcUtils.getOrcTypes(orcReader.getSchema).size)
           .withZeroCopy(zeroCopy)
           .withMaxDiskRangeChunkLimit(maxDiskRangeChunkLimit)
           .build())

--- a/sql-plugin/src/main/scala/ai/rapids/spark/Plugin.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/spark/Plugin.scala
@@ -266,9 +266,8 @@ class SQLPlugin extends SparkPlugin with Logging {
 
 /**
  * Old version of SQLPlugin kept for backwards compatibility
- * @deprecated please use SQLPlugin instead
  */
-@scala.deprecated
+@scala.deprecated("Please use ai.rapids.spark.SQLPlugin instead", since="0.1")
 class RapidsSparkPlugin extends SQLPlugin {
   override def driverPlugin(): DriverPlugin = {
     logWarning(s"The plugin class ${this.getClass.getName} is deprecated please use " +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
@@ -38,6 +38,7 @@ object ShiftHelper extends Arm {
   private def maskForDistance(t: DType): Int = t match {
     case DType.INT32 =>  0x1F // 0b11111
     case DType.INT64 =>  0x3F //0b111111
+    case t => throw new IllegalArgumentException(s"$t is not a supported type for java bit shifts")
   }
 
   def fixupDistanceNoClose(t: DType, distance: ColumnVector): ColumnVector = {


### PR DESCRIPTION
This fixes #54 

All that is left are deprecation warnings for Parquet, which we cannot fix or suppress.  There are also some warnings about the zinc server not being up.  Those I am not worried about.
