### PR TITLE
Update type of parameter of GpuExpandExec to make it consistent

### DIFF
--- a/sql-plugin/src/main/scala/ai/rapids/spark/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/spark/GpuExpandExec.scala
@@ -50,7 +50,7 @@ class GpuExpandExecMeta(
    */
   override def convertToGpu(): GpuExec = {
     val projections = gpuProjections.map(_.map(_.convertToGpu()))
-    val attributes = outputAttributes.map(_.convertToGpu()).asInstanceOf[Seq[NamedExpression]]
+    val attributes = outputAttributes.map(_.convertToGpu()).asInstanceOf[Seq[GpuAttributeReference]]
     GpuExpandExec(projections, attributes, childPlans.head.convertIfNeeded())
   }
 }
@@ -60,12 +60,12 @@ class GpuExpandExecMeta(
  * multiple output rows for an input row.
  * @param projections The group of expressions, all of the group expressions should
  *                    output the same schema specified bye the parameter `output`
- * @param resultExpressions The output Schema
+ * @param resultExpressions Attribute references to Output
  * @param child       Child operator
  */
 case class GpuExpandExec(
     projections: Seq[Seq[GpuExpression]],
-    resultExpressions: Seq[NamedExpression],
+    resultExpressions: Seq[GpuAttributeReference],
     child: SparkPlan)
   extends UnaryExecNode with GpuExec {
 


### PR DESCRIPTION
This is to keep the parameter type consistent between Spark and plugin Execs.  Type in Spark in `Attribute` . This is done as part of audit work. Please let me know if this is good to go.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
