### PR TITLE
FileSourceScanExec can have logicalRelation parameter on some distributions

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -52,7 +52,7 @@ case class GpuFileSourceScanExec(
     }
     val constructor = constructors(0)
     val instance = if (constructor.getParameterCount() == 8) {
-      // Some distributions of Spark modified FileSourceScanExec to take an addition parameter
+      // Some distributions of Spark modified FileSourceScanExec to take an additional parameter
       // that is the logicalRelation. We don't know what its used for exactly but haven't
       // run into any issues in testing using the one we create here.
       @transient val logicalRelation = LogicalRelation(relation)


### PR DESCRIPTION

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
This handles some distributions of Spark having an extra LogicalRelation parameter for FileSourceScanExec. We aren't sure what this is used for but all of our testing so far, this has worked.  We use reflection to determine the number of parameters it takes.

Tested with unit tests and integration tests and manually.