### PR TITLE
Update Spark dependency to the released 3.0.0 artifacts

### DIFF
--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -38,8 +38,8 @@ pipeline {
             description: '-Dclassifier=\n\n cuda10-1, cuda10-2, EMPTY as cuda10-1')
         string(name: 'PROJECT_VER', defaultValue: '0.1-SNAPSHOT',
             description: 'Default project version 0.1-SNAPSHOT')
-        string(name: 'SPARK_VER', defaultValue: '3.0.1-SNAPSHOT',
-            description: 'Default spark version 3.0.1-SNAPSHOT')
+        string(name: 'SPARK_VER', defaultValue: '3.0.0',
+            description: 'Default spark version 3.0.0')
         string(name: 'SERVER_URL', defaultValue: 'https://urm.nvidia.com:443/artifactory/sw-spark-maven',
             description: 'Default maven repo URL where to download Spark3.0 tar file.')
         string(name: 'REF', defaultValue: 'branch-0.1', description: 'Commit to build')

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -64,7 +64,7 @@ pipeline {
                         -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group") {
                         sh "mvn -U -B clean deploy $MVN_URM_MIRROR"
                         sh "jenkins/printJarVersion.sh 'CUDFVersion' '${HOME}/.m2/repository/ai/rapids/cudf/0.14' 'cudf-0.14' '-cuda10-1.jar'"
-                        sh "jenkins/printJarVersion.sh 'SPARKVersion' '${HOME}/.m2/repository/org/apache/spark/spark-core_2.12/3.0.1-SNAPSHOT' 'spark-core_2.12-3.0.1-' '.jar'"
+                        sh "jenkins/printJarVersion.sh 'SPARKVersion' '${HOME}/.m2/repository/org/apache/spark/spark-core_2.12/3.0.0' 'spark-core_2.12-3.0.0-' '.jar'"
                     }
                 }
             }

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -20,7 +20,7 @@ set -ex
 nvidia-smi
 
 if [ "$SPARK_VER"x == x ];then
-    SPARK_VER="3.0.1-SNAPSHOT"
+    SPARK_VER="3.0.0"
 fi
 
 SCALA_BINARY_VER=${SCALA_BINARY_VER:-2.12}

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -25,7 +25,7 @@ if [ "$PROJECT_VER"x == x ];then
 fi
 
 if [ "$SPARK_VER"x == x ];then
-    SPARK_VER="3.0.1-SNAPSHOT"
+    SPARK_VER="3.0.0"
 fi
 
 SCALA_BINARY_VER=${SCALA_BINARY_VER:-2.12}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spark.version>3.0.1-SNAPSHOT</spark.version>
+        <spark.version>3.0.0</spark.version>
         <cuda.version>cuda10-1</cuda.version>
         <cudf.version>0.14</cudf.version>
         <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
Now that the official Apache Spark 3.0.0 artifact is available, this updates the dependencies to use the official artifacts rather than snapshots in preparation for the 0.1 release.