### PR TITLE
Fix metrics for writes

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
@@ -33,7 +33,10 @@ import org.apache.spark.util.SerializableConfiguration
  * An extension of `DataWritingCommand` that allows columnar execution.
  */
 trait GpuDataWritingCommand extends DataWritingCommand {
-  override lazy val metrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.metrics
+  lazy val basicMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.basicMetrics
+  lazy val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+
+  override lazy val metrics: Map[String, SQLMetric] = basicMetrics ++ taskMetrics
 
   override final def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] =
     throw new UnsupportedOperationException(
@@ -44,7 +47,7 @@ trait GpuDataWritingCommand extends DataWritingCommand {
   def gpuWriteJobStatsTracker(
       hadoopConf: Configuration): GpuWriteJobStatsTracker = {
     val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
-    GpuWriteJobStatsTracker(serializableHadoopConf)
+    GpuWriteJobStatsTracker(serializableHadoopConf, this)
   }
 
   def requireSingleBatch: Boolean

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuWriteStatsTracker.scala
@@ -16,10 +16,11 @@
 
 package org.apache.spark.sql.rapids
 
+import com.nvidia.spark.rapids.GpuDataWritingCommand
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, WriteTaskStats}
+import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -60,9 +61,9 @@ object GpuWriteJobStatsTracker {
   val GPU_TIME_KEY = "gpuTime"
   val WRITE_TIME_KEY = "writeTime"
 
-  lazy val basicMetrics: Map[String, SQLMetric] = BasicWriteJobStatsTracker.metrics
+  def basicMetrics: Map[String, SQLMetric] = BasicWriteJobStatsTracker.metrics
 
-  lazy val taskMetrics: Map[String, SQLMetric] = {
+  def taskMetrics: Map[String, SQLMetric] = {
     val sparkContext = SparkContext.getActive.get
     Map(
       GPU_TIME_KEY -> SQLMetrics.createNanoTimingMetric(sparkContext, "GPU time"),
@@ -70,8 +71,7 @@ object GpuWriteJobStatsTracker {
     )
   }
 
-  def metrics: Map[String, SQLMetric] = basicMetrics ++ taskMetrics
-
-  def apply(serializableHadoopConf: SerializableConfiguration): GpuWriteJobStatsTracker =
-    new GpuWriteJobStatsTracker(serializableHadoopConf, basicMetrics, taskMetrics)
+  def apply(serializableHadoopConf: SerializableConfiguration,
+      command: GpuDataWritingCommand): GpuWriteJobStatsTracker =
+    new GpuWriteJobStatsTracker(serializableHadoopConf, command.basicMetrics, command.taskMetrics)
 }


### PR DESCRIPTION
This fixes #40 

The metrics were coming from a singleton instead of being re-created each time. I will file a follow on issue to add tests for metrics.  For now I manually tested this.

First run:
![Screenshot_2020-06-17 Spark shell - Details for Query 19](https://user-images.githubusercontent.com/3441321/84934573-211b1b00-b09d-11ea-9975-5cbc6d786e96.png)


Fifth run:
![Screenshot_2020-06-17 Spark shell - Details for Query 23](https://user-images.githubusercontent.com/3441321/84934593-2bd5b000-b09d-11ea-890f-c7ac63d3b42b.png)

The numbers are the same