### PR TITLE
Fix name of scan

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -44,6 +44,10 @@ case class GpuFileSourceScanExec(
     override val tableIdentifier: Option[TableIdentifier])
     extends DataSourceScanExec with GpuExec {
 
+  override val nodeName: String = {
+    s"GpuScan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
+  }
+
   private[this] val wrapped: FileSourceScanExec = {
     val tclass = classOf[org.apache.spark.sql.execution.FileSourceScanExec]
     val constructors = tclass.getConstructors()


### PR DESCRIPTION
This fixes #51 

![Screenshot_2020-06-17 Spark shell - Details for Query 19(1)](https://user-images.githubusercontent.com/3441321/84944689-c6d58680-b0ab-11ea-8476-39734f2cfec3.png)
