### PR TITLE
Add project leads to pom developer list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,25 @@
         <developer>
             <id>revans2</id>
             <name>Robert Evans</name>
-            <email>bobby@apache.org</email>
+            <email>roberte@nvidia.com</email>
+            <roles>
+                <role>Committer</role>
+            </roles>
+            <timezone>-6</timezone>
+        </developer>
+        <developer>
+            <id>tgravescs</id>
+            <name>Thomas Graves</name>
+            <email>tgraves@nvidia.com</email>
+            <roles>
+                <role>Committer</role>
+            </roles>
+            <timezone>-6</timezone>
+        </developer>
+        <developer>
+            <id>jlowe</id>
+            <name>Jason Lowe</name>
+            <email>jlowe@nvidia.com</email>
             <roles>
                 <role>Committer</role>
             </roles>


### PR DESCRIPTION
Fixes #209 

The [Developers section in the Maven POM Reference](http://maven.apache.org/pom.html#developers) states this should not be a full developer list but only those expected to be contacted for the project.  As such I updated this list to contain the project leads.