### PR TITLE
Make internal project dependencies optional for shaded artifact

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -35,11 +35,13 @@
        <groupId>com.nvidia</groupId>
        <artifactId>rapids-4-spark-sql_${scala.binary.version}</artifactId>
        <version>${project.version}</version>
+       <optional>true</optional>
     </dependency>
     <dependency>
        <groupId>com.nvidia</groupId>
        <artifactId>rapids-4-spark-shuffle_${scala.binary.version}</artifactId>
        <version>${project.version}</version>
+       <optional>true</optional>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The maven shade plugin generates a reduced dependency pom but does not place it in the shaded jar.  Instead the original pom appears in the jar, so that jar says it still depends upon the artifacts pulled into the jar.

This updates the dependencies of the distribution project to be `optional`.  They will still be shaded but will not be forced to be fetched by any project attempting to retrieve the distribution artifact.