### PR TITLE
Let default branch to master per the release rule

### DIFF
--- a/jenkins/Jenkinsfile.release
+++ b/jenkins/Jenkinsfile.release
@@ -43,7 +43,7 @@ pipeline {
     parameters {
         choice(name: 'DEPLOY_TO', choices: ['Sonatype'],
             description: 'Where to deploy artifacts to')
-        string(name: 'REF', defaultValue: 'branch-0.1', description: 'Commit to build')
+        string(name: 'REF', defaultValue: 'master', description: 'Commit to build')
     }
 
     environment {


### PR DESCRIPTION
This PR is to change the default branch to master for the release Jenkins job.
No test is needed.
No issue is relevant.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
