### PR TITLE
Revert change to make dependencies of shaded jar optional

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -35,13 +35,11 @@
        <groupId>com.nvidia</groupId>
        <artifactId>rapids-4-spark-sql_${scala.binary.version}</artifactId>
        <version>${project.version}</version>
-       <optional>true</optional>
     </dependency>
     <dependency>
        <groupId>com.nvidia</groupId>
        <artifactId>rapids-4-spark-shuffle_${scala.binary.version}</artifactId>
        <version>${project.version}</version>
-       <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -63,7 +63,7 @@ $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
 
 ###### Deploy the artifact jar(s) ######
 
+# Distribution jar is a shaded artifact so use the reduced dependency pom.
 $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             $SRC_DOC_JARS \
-            -Dfile=$FPATH.jar -DpomFile=${DIST_PL}/pom.xml
-
+            -Dfile=$FPATH.jar -DpomFile=${DIST_PL}/dependency-reduced-pom.xml


### PR DESCRIPTION
This reverts #225.

I thought the change in #225 would resolve the issue reported by the build team where the artifact cannot be used in a downstream project.  The current artifact can indeed be used as a Maven dependency in a project without requiring the sql and shuffle projects to be resolved.  However the same is true _without_ marking the dependencies of the shaded artifact as optional.

Marking them as optional can lead to syntax highlighting issues in IntelliJ.  Since the optional tag does not seem to be providing any tangible benefit and is causing issues elsewhere, we should revert that change.

I verified that with this change I could install only the rapids_4_spark_2.12-0.2.0-SNAPSHOT artifact to a newly created, local Maven repository and then build a sample Maven project that depends upon rapids_4_spark_2.12-0.2.0-SNAPSHOT using that same local Maven repository without issues.
