### PR TITLE
Update Databricks patch for 0.2 branch

### DIFF
--- a/jenkins/databricks/dbimports.patch
+++ b/jenkins/databricks/dbimports.patch
@@ -1,5 +1,5 @@
 diff --git a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala
-index b1599e6..b432fe0 100644
+index e6290d1..6ceb47d 100644
 --- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala
 +++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala
 @@ -18,8 +18,9 @@ package com.nvidia.spark.rapids
@@ -14,13 +14,13 @@ index b1599e6..b432fe0 100644
  import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
  
 diff --git a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
-index 6de4a95..90fb3e7 100644
+index 5be8d1a..6b4a58e 100644
 --- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
 +++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
-@@ -21,10 +21,11 @@ import com.nvidia.spark.rapids.GpuMetricNames._
- import org.apache.spark.TaskContext
+@@ -22,10 +22,11 @@ import org.apache.spark.TaskContext
  import org.apache.spark.rdd.RDD
  import org.apache.spark.sql.catalyst.InternalRow
+ import org.apache.spark.sql.catalyst.expressions.Expression
 +import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
  import org.apache.spark.sql.catalyst.plans.JoinType
  import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution}
@@ -31,7 +31,7 @@ index 6de4a95..90fb3e7 100644
  import org.apache.spark.sql.vectorized.ColumnarBatch
  
 diff --git a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
-index c493508..3e24a2d 100644
+index 3b2b447..e9e4051 100644
 --- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
 +++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
 @@ -17,8 +17,9 @@
@@ -46,7 +46,7 @@ index c493508..3e24a2d 100644
  class GpuSortMergeJoinMeta(
      join: SortMergeJoinExec,
 diff --git a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
-index 088b66b..b7f267f 100644
+index b02182a..1ed13d2 100644
 --- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
 +++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
 @@ -22,12 +22,13 @@ import com.nvidia.spark.rapids.GpuOverrides.isStringLit
@@ -65,13 +65,13 @@ index 088b66b..b7f267f 100644
  
  trait ConfKeysAndIncompat {
 diff --git a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
-index dc12bbe..a07add3 100644
+index 7be40e8..13c8500 100644
 --- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
 +++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
-@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.GpuMetricNames._
- 
+@@ -22,6 +22,7 @@ import com.nvidia.spark.rapids.GpuMetricNames._
  import org.apache.spark.rdd.RDD
  import org.apache.spark.sql.catalyst.InternalRow
+ import org.apache.spark.sql.catalyst.expressions.Expression
 +import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
  import org.apache.spark.sql.catalyst.plans.JoinType
  import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, Distribution, UnspecifiedDistribution}


### PR DESCRIPTION
Our nightly build failed for 0.2 branch because patch didn't apply.