### PR TITLE
modify run_pyspark_from_build.sh to be bash 3 friendly

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -ex
 
-if [[ "${SKIP_TESTS,,}" == "true" ]];
+if [[ $( echo ${SKIP_TESTS} | tr [:upper:] [:lower:] ) == "true" ]];
 then
     echo "PYTHON INTEGRATION TESTS SKIPPED..."
 elif [[ -z "$SPARK_HOME" ]];


### PR DESCRIPTION
1. Please write a description in this text box of the changes that are being
   made.

Modify run_pyspark_from_build.sh to remove bash 4 specific parameter expansion

2. Please ensure that you have written units tests for the changes made/features
   added.

Ran mvn clean verify -DskipTests with =true, True, TRUE, False to test. 
