### PR TITLE
Added in basic support for broadcast nested loop join

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -84,7 +84,7 @@ incompatibilities.
 
 ### Expressions
 
-Name | Description | Default Value | Incompatibilities
+Name | Description | Default Value | Notes
 -----|-------------|---------------|------------------
 <a name="sql.expression.Abs"></a>spark.rapids.sql.expression.Abs|absolute value|true|None|
 <a name="sql.expression.Acos"></a>spark.rapids.sql.expression.Acos|inverse cosine|true|None|
@@ -218,7 +218,7 @@ Name | Description | Default Value | Incompatibilities
 
 ### Execution
 
-Name | Description | Default Value | Incompatibilities
+Name | Description | Default Value | Notes
 -----|-------------|---------------|------------------
 <a name="sql.exec.CoalesceExec"></a>spark.rapids.sql.exec.CoalesceExec|The backend for the dataframe coalesce method|true|None|
 <a name="sql.exec.CollectLimitExec"></a>spark.rapids.sql.exec.CollectLimitExec|Reduce to single partition and apply limit|true|None|
@@ -238,14 +238,14 @@ Name | Description | Default Value | Incompatibilities
 <a name="sql.exec.BroadcastExchangeExec"></a>spark.rapids.sql.exec.BroadcastExchangeExec|The backend for broadcast exchange of data|true|None|
 <a name="sql.exec.ShuffleExchangeExec"></a>spark.rapids.sql.exec.ShuffleExchangeExec|The backend for most data being exchanged between processes|true|None|
 <a name="sql.exec.BroadcastHashJoinExec"></a>spark.rapids.sql.exec.BroadcastHashJoinExec|Implementation of join using broadcast data|true|None|
-<a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|true|None|
+<a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
 <a name="sql.exec.ShuffledHashJoinExec"></a>spark.rapids.sql.exec.ShuffledHashJoinExec|Implementation of join using hashed shuffled data|true|None|
 <a name="sql.exec.SortMergeJoinExec"></a>spark.rapids.sql.exec.SortMergeJoinExec|Sort merge join, replacing with shuffled hash join|true|None|
 <a name="sql.exec.WindowExec"></a>spark.rapids.sql.exec.WindowExec|Window-operator backend|true|None|
 
 ### Scans
 
-Name | Description | Default Value | Incompatibilities
+Name | Description | Default Value | Notes
 -----|-------------|---------------|------------------
 <a name="sql.input.CSVScan"></a>spark.rapids.sql.input.CSVScan|CSV parsing|true|None|
 <a name="sql.input.OrcScan"></a>spark.rapids.sql.input.OrcScan|ORC parsing|true|None|
@@ -253,7 +253,7 @@ Name | Description | Default Value | Incompatibilities
 
 ### Partitioning
 
-Name | Description | Default Value | Incompatibilities
+Name | Description | Default Value | Notes
 -----|-------------|---------------|------------------
 <a name="sql.partitioning.HashPartitioning"></a>spark.rapids.sql.partitioning.HashPartitioning|Hash based partitioning|true|None|
 <a name="sql.partitioning.RangePartitioning"></a>spark.rapids.sql.partitioning.RangePartitioning|Range Partitioning|true|None|

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -238,6 +238,7 @@ Name | Description | Default Value | Incompatibilities
 <a name="sql.exec.BroadcastExchangeExec"></a>spark.rapids.sql.exec.BroadcastExchangeExec|The backend for broadcast exchange of data|true|None|
 <a name="sql.exec.ShuffleExchangeExec"></a>spark.rapids.sql.exec.ShuffleExchangeExec|The backend for most data being exchanged between processes|true|None|
 <a name="sql.exec.BroadcastHashJoinExec"></a>spark.rapids.sql.exec.BroadcastHashJoinExec|Implementation of join using broadcast data|true|None|
+<a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|true|None|
 <a name="sql.exec.ShuffledHashJoinExec"></a>spark.rapids.sql.exec.ShuffledHashJoinExec|Implementation of join using hashed shuffled data|true|None|
 <a name="sql.exec.SortMergeJoinExec"></a>spark.rapids.sql.exec.SortMergeJoinExec|Sort merge join, replacing with shuffled hash join|true|None|
 <a name="sql.exec.WindowExec"></a>spark.rapids.sql.exec.WindowExec|Window-operator backend|true|None|

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -87,7 +87,6 @@ def test_broadcast_join_right_table(data_gen, join_type):
         return left.join(broadcast(right), left.a == right.r_a, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join)
 
-
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
@@ -95,7 +94,7 @@ def test_broadcast_nested_loop_join(data_gen):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right))
-    assert_gpu_and_cpu_are_equal_collect(do_join)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.exec.BroadcastNestedLoopJoinExec': 'true'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
@@ -110,7 +109,7 @@ def test_broadcast_nested_loop_join_with_conditionals(data_gen, join_type):
         # that do not expose the error
         return left.join(broadcast(right),
                 (left.b >= right.r_b), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.exec.BroadcastNestedLoopJoinExec': 'true'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -55,7 +55,7 @@ def test_sortmerge_join_no_nulls(data_gen, join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti',
+@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross',
     pytest.param('FullOuter', marks=[pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/280')])], ids=idfn)
 def test_sortmerge_join(data_gen, join_type):
     def do_join(spark):
@@ -79,7 +79,7 @@ def test_broadcast_join_no_nulls(data_gen, join_type):
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti',
+@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross',
     pytest.param('FullOuter', marks=[pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/280')])], ids=idfn)
 def test_broadcast_join_right_table(data_gen, join_type):
     def do_join(spark):
@@ -87,12 +87,37 @@ def test_broadcast_join_right_table(data_gen, join_type):
         return left.join(broadcast(right), left.a == right.r_a, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join)
 
+
+# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
+def test_broadcast_nested_loop_join(data_gen):
+    def do_join(spark):
+        left, right = create_df(spark, data_gen, 50, 25)
+        return left.crossJoin(broadcast(right))
+    assert_gpu_and_cpu_are_equal_collect(do_join)
+
+# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
+@pytest.mark.parametrize('join_type', ['Inner', 'Cross'], ids=idfn)
+def test_broadcast_nested_loop_join_with_conditionals(data_gen, join_type):
+    def do_join(spark):
+        left, right = create_df(spark, data_gen, 50, 25)
+        # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294 
+        # if the sizes are large enough to have both 0.0 and -0.0 show up 500 and 250
+        # but these take a long time to verify so we run with smaller numbers by default
+        # that do not expose the error
+        return left.join(broadcast(right),
+                (left.b >= right.r_b), join_type)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
+
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti',
+@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross',
     pytest.param('FullOuter', marks=[pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/280')])], ids=idfn)
 def test_broadcast_join_left_table(data_gen, join_type):
     def do_join(spark):
@@ -103,7 +128,7 @@ def test_broadcast_join_left_table(data_gen, join_type):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-@pytest.mark.parametrize('join_type', ['Inner'], ids=idfn)
+@pytest.mark.parametrize('join_type', ['Inner', 'Cross'], ids=idfn)
 def test_broadcast_join_with_conditionals(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
@@ -118,7 +143,7 @@ _mixed_df2_with_nulls = [('a', RepeatSeqGen(LongGen(nullable=(True, 20.0)), leng
                          ('b', StringGen()), ('c', BooleanGen())]
 
 @ignore_order
-@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'FullOuter'], ids=idfn)
+@pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'FullOuter', 'Cross'], ids=idfn)
 def test_broadcast_join_mixed(join_type):
     def do_join(spark):
         left = gen_df(spark, _mixed_df1_with_nulls, length=500)

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -63,6 +63,11 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
     (A, B) => A.join(B, A("longs") === B("longs"), "FullOuter")
   }
 
+  IGNORE_ORDER_testSparkResultsAreEqual2("Test cross join", longsDf, biggerLongsDf,
+    conf = shuffledJoinConf) {
+    (A, B) => A.join(B.hint("broadcast"), A("longs") < B("longs"), "Cross")
+  }
+
   // test replacement of sort merge join with hash join
   // make sure broadcast size small enough it doesn't get used
   testSparkResultsAreEqual2("Test replace sort merge join with hash join",

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -37,6 +37,7 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
       .set("spark.sql.autoBroadcastJoinThreshold", "160")
       .set("spark.sql.join.preferSortMergeJoin", "false")
       .set("spark.sql.shuffle.partitions", "2") // hack to try and work around bug in cudf
+      .set("spark.rapids.sql.exec.BroadcastNestedLoopJoinExec", "true")
 
   IGNORE_ORDER_testSparkResultsAreEqual2("Test hash join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashJoin.scala
@@ -19,7 +19,7 @@ import ai.rapids.cudf.{NvtxColor, Table}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, Inner, InnerLike, JoinType, LeftAnti, LeftExistence, LeftOuter, LeftSemi, RightOuter}
+import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftExistence, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, HashJoin}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
@@ -31,7 +31,7 @@ object GpuHashJoin {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       condition: Option[Expression]): Unit = joinType match {
-    case Inner =>
+    case _: InnerLike =>
     case FullOuter =>
       if (leftKeys.exists(_.nullable) || rightKeys.exists(_.nullable)) {
         // https://github.com/rapidsai/cudf/issues/5563
@@ -227,7 +227,7 @@ trait GpuHashJoin extends GpuExec with HashJoin {
           .leftJoin(rightTable.onColumns(joinKeyIndices: _*))
       case RightOuter => rightTable.onColumns(joinKeyIndices: _*)
           .leftJoin(leftTable.onColumns(joinKeyIndices: _*))
-      case Inner =>
+      case _: InnerLike =>
         leftTable.onColumns(joinKeyIndices: _*).innerJoin(rightTable.onColumns(joinKeyIndices: _*))
       case LeftSemi =>
         leftTable.onColumns(joinKeyIndices: _*)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -53,8 +53,6 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 /**
  * Base class for all ReplacementRules
  * @param doWrap wraps a part of the plan in a [[RapidsMeta]] for further processing.
- * @param incomDoc docs explaining if this rule produces an GPU version that is incompatible with
- *                    the CPU version in some way.
  * @param desc a description of what this part of the plan does.
  * @param tag metadata used to determine what INPUT is at runtime.
  * @tparam INPUT the exact type of the class we are wrapping.
@@ -67,11 +65,14 @@ abstract class ReplacementRule[INPUT <: BASE, BASE, WRAP_TYPE <: RapidsMeta[INPU
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => WRAP_TYPE,
-    protected var incomDoc: Option[String],
     protected var desc: String,
     final val tag: ClassTag[INPUT]) extends ConfKeysAndIncompat {
 
-  override def incompatDoc: Option[String] = incomDoc
+  private var _incompatDoc: Option[String] = None
+  private var _disabledDoc: Option[String] = None
+
+  override def incompatDoc: Option[String] = _incompatDoc
+  override def disabledMsg: Option[String] = _disabledDoc
 
   /**
    * Mark this expression as incompatible with the original Spark version
@@ -79,7 +80,17 @@ abstract class ReplacementRule[INPUT <: BASE, BASE, WRAP_TYPE <: RapidsMeta[INPU
    * @return this for chaining.
    */
   final def incompat(str: String) : this.type = {
-    incomDoc = Some(str)
+    _incompatDoc = Some(str)
+    this
+  }
+
+  /**
+   * Mark this expression as disabled by default.
+   * @param str a description of why it is disabled by default.
+   * @return this for chaining.
+   */
+  final def disabledByDefault(str: String) : this.type = {
+    _disabledDoc = Some(str)
     this
   }
 
@@ -108,8 +119,6 @@ abstract class ReplacementRule[INPUT <: BASE, BASE, WRAP_TYPE <: RapidsMeta[INPU
     this
   }
 
-  def isIncompat: Boolean = incompatDoc.isDefined
-
   private var confKeyCache: String = null
   protected val confKeyPart: String
 
@@ -120,19 +129,21 @@ abstract class ReplacementRule[INPUT <: BASE, BASE, WRAP_TYPE <: RapidsMeta[INPU
     confKeyCache
   }
 
-  private def isIncompatMsg(): Option[String] = if (incompatDoc.isDefined) {
+  private def notes(): Option[String] = if (incompatDoc.isDefined) {
     Some(s"This is not 100% compatible with the Spark version because ${incompatDoc.get}")
+  } else if (disabledMsg.isDefined) {
+    Some(s"This is disabled by default because ${disabledMsg.get}")
   } else {
     None
   }
 
   def confHelp(asTable: Boolean = false): Unit = {
-    val incompatMsg = isIncompatMsg()
+    val notesMsg = notes()
     if (asTable) {
       import ConfHelper.makeConfAnchor
-      print(s"${makeConfAnchor(confKey)}|$desc|${incompatMsg.isEmpty}|")
-      if (incompatMsg.isDefined) {
-        print(s"${incompatMsg.get}")
+      print(s"${makeConfAnchor(confKey)}|$desc|${notesMsg.isEmpty}|")
+      if (notesMsg.isDefined) {
+        print(s"${notesMsg.get}")
       } else {
         print("None")
       }
@@ -141,10 +152,10 @@ abstract class ReplacementRule[INPUT <: BASE, BASE, WRAP_TYPE <: RapidsMeta[INPU
       println(s"$confKey:")
       println(s"\tEnable (true) or disable (false) the $tag $operationName.")
       println(s"\t$desc")
-      if (incompatMsg.isDefined) {
-        println(s"\t${incompatMsg.get}")
+      if (notesMsg.isDefined) {
+        println(s"\t${notesMsg.get}")
       }
-      println(s"\tdefault: ${incompatDoc.isEmpty}")
+      println(s"\tdefault: ${notesMsg.isEmpty}")
       println()
     }
   }
@@ -169,11 +180,9 @@ class ExprRule[INPUT <: Expression](
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => BaseExprMeta[INPUT],
-    incompatDoc: Option[String],
     desc: String,
     tag: ClassTag[INPUT])
-  extends ReplacementRule[INPUT, Expression, BaseExprMeta[INPUT]](doWrap,
-    incompatDoc, desc, tag) {
+  extends ReplacementRule[INPUT, Expression, BaseExprMeta[INPUT]](doWrap, desc, tag) {
 
   override val confKeyPart = "expression"
   override val operationName = "Expression"
@@ -188,11 +197,9 @@ class ScanRule[INPUT <: Scan](
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => ScanMeta[INPUT],
-    incompatDoc: Option[String],
     desc: String,
     tag: ClassTag[INPUT])
-  extends ReplacementRule[INPUT, Scan, ScanMeta[INPUT]](
-    doWrap, incompatDoc, desc, tag) {
+  extends ReplacementRule[INPUT, Scan, ScanMeta[INPUT]](doWrap, desc, tag) {
 
   override val confKeyPart: String = "input"
   override val operationName: String = "Input"
@@ -207,11 +214,9 @@ class PartRule[INPUT <: Partitioning](
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => PartMeta[INPUT],
-    incompatDoc: Option[String],
     desc: String,
     tag: ClassTag[INPUT])
-  extends ReplacementRule[INPUT, Partitioning,
-    PartMeta[INPUT]](doWrap, incompatDoc, desc, tag) {
+  extends ReplacementRule[INPUT, Partitioning, PartMeta[INPUT]](doWrap, desc, tag) {
 
   override val confKeyPart: String = "partitioning"
   override val operationName: String = "Partitioning"
@@ -226,10 +231,9 @@ class ExecRule[INPUT <: SparkPlan](
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => SparkPlanMeta[INPUT],
-    incompatDoc: Option[String],
     desc: String,
     tag: ClassTag[INPUT])
-  extends ReplacementRule[INPUT, SparkPlan, SparkPlanMeta[INPUT]](doWrap, incompatDoc, desc, tag) {
+  extends ReplacementRule[INPUT, SparkPlan, SparkPlanMeta[INPUT]](doWrap, desc, tag) {
 
   override val confKeyPart: String = "exec"
   override val operationName: String = "Exec"
@@ -245,11 +249,10 @@ class DataWritingCommandRule[INPUT <: DataWritingCommand](
         RapidsConf,
         Option[RapidsMeta[_, _, _]],
         ConfKeysAndIncompat) => DataWritingCommandMeta[INPUT],
-    incompatDoc: Option[String],
     desc: String,
     tag: ClassTag[INPUT])
     extends ReplacementRule[INPUT, DataWritingCommand, DataWritingCommandMeta[INPUT]](
-      doWrap, incompatDoc, desc, tag) {
+      doWrap, desc, tag) {
 
   override val confKeyPart: String = "output"
   override val operationName: String = "Output"
@@ -397,7 +400,7 @@ object GpuOverrides {
       (implicit tag: ClassTag[INPUT]): ExprRule[INPUT] = {
     assert(desc != null)
     assert(doWrap != null)
-    new ExprRule[INPUT](doWrap, None, desc, tag)
+    new ExprRule[INPUT](doWrap, desc, tag)
   }
 
   def scan[INPUT <: Scan](
@@ -407,7 +410,7 @@ object GpuOverrides {
     (implicit tag: ClassTag[INPUT]): ScanRule[INPUT] = {
     assert(desc != null)
     assert(doWrap != null)
-    new ScanRule[INPUT](doWrap, None, desc, tag)
+    new ScanRule[INPUT](doWrap, desc, tag)
   }
 
   def part[INPUT <: Partitioning](
@@ -417,7 +420,7 @@ object GpuOverrides {
     (implicit tag: ClassTag[INPUT]): PartRule[INPUT] = {
     assert(desc != null)
     assert(doWrap != null)
-    new PartRule[INPUT](doWrap, None, desc, tag)
+    new PartRule[INPUT](doWrap, desc, tag)
   }
 
   def exec[INPUT <: SparkPlan](
@@ -427,7 +430,7 @@ object GpuOverrides {
     (implicit tag: ClassTag[INPUT]): ExecRule[INPUT] = {
     assert(desc != null)
     assert(doWrap != null)
-    new ExecRule[INPUT](doWrap, None, desc, tag)
+    new ExecRule[INPUT](doWrap, desc, tag)
   }
 
   def dataWriteCmd[INPUT <: DataWritingCommand](
@@ -437,7 +440,7 @@ object GpuOverrides {
     (implicit tag: ClassTag[INPUT]): DataWritingCommandRule[INPUT] = {
     assert(desc != null)
     assert(doWrap != null)
-    new DataWritingCommandRule[INPUT](doWrap, None, desc, tag)
+    new DataWritingCommandRule[INPUT](doWrap, desc, tag)
   }
 
   def wrapExpr[INPUT <: Expression](
@@ -1715,7 +1718,8 @@ object GpuOverrides {
       (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
     exec[BroadcastNestedLoopJoinExec](
       "Implementation of join using brute force",
-      (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r)),
+      (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r))
+        .disabledByDefault("large joins can cause out of memory errors"),
     exec[SortMergeJoinExec](
       "Sort merge join, replacing with shuffled hash join",
       (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -42,11 +42,11 @@ import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinMeta, GpuBroadcastMeta}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinMeta, GpuBroadcastMeta, GpuBroadcastNestedLoopJoinMeta}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
@@ -1713,6 +1713,9 @@ object GpuOverrides {
     exec[ShuffledHashJoinExec](
       "Implementation of join using hashed shuffled data",
       (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
+    exec[BroadcastNestedLoopJoinExec](
+      "Implementation of join using brute force",
+      (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r)),
     exec[SortMergeJoinExec](
       "Sort merge join, replacing with shuffled hash join",
       (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -593,7 +593,7 @@ object RapidsConf {
 
   private def printToggleHeader(category: String): Unit = {
     printSectionHeader(category)
-    println("Name | Description | Default Value | Incompatibilities")
+    println("Name | Description | Default Value | Notes")
     println("-----|-------------|---------------|------------------")
   }
 
@@ -825,8 +825,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val shuffleMaxMetadataSize: Long = get(SHUFFLE_MAX_METADATA_SIZE)
 
-  def isOperatorEnabled(key: String, incompat: Boolean): Boolean = {
-    val default = !incompat || (incompat && isIncompatEnabled)
+  def isOperatorEnabled(key: String, incompat: Boolean, isDisabledByDefault: Boolean): Boolean = {
+    val default = !(isDisabledByDefault || incompat) || (incompat && isIncompatEnabled)
     conf.get(key).map(toBoolean(_, key)).getOrElse(default)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.execution
+
+import ai.rapids.cudf.NvtxColor
+import com.nvidia.spark.rapids.{BaseExprMeta, ConfKeysAndIncompat, GpuBindReferences, GpuColumnVector, GpuExec, GpuFilter, GpuOverrides, NvtxWithMetrics, RapidsConf, RapidsMeta, SparkPlanMeta}
+import com.nvidia.spark.rapids.GpuMetricNames.{NUM_OUTPUT_BATCHES, NUM_OUTPUT_ROWS, TOTAL_TIME}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, FullOuter, Inner, InnerLike, JoinType, LeftExistence, LeftOuter, RightOuter}
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, Distribution, IdentityBroadcastMode, UnspecifiedDistribution}
+import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.execution.joins.{BroadcastNestedLoopJoinExec, BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GpuBroadcastNestedLoopJoinMeta(
+    join: BroadcastNestedLoopJoinExec,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: ConfKeysAndIncompat)
+    extends SparkPlanMeta[BroadcastNestedLoopJoinExec](join, conf, parent, rule) {
+
+  val condition: Option[BaseExprMeta[_]] =
+    join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+
+  override val childExprs: Seq[BaseExprMeta[_]] = condition.toSeq
+
+  override def tagPlanForGpu(): Unit = {
+    join.joinType match {
+      case Inner =>
+      case Cross =>
+      case _ => willNotWorkOnGpu(s"$join.joinType currently is not supported")
+    }
+
+    val buildSide = join.buildSide match {
+      case BuildLeft => childPlans(0)
+      case BuildRight => childPlans(1)
+    }
+
+    if (!buildSide.canThisBeReplaced) {
+      willNotWorkOnGpu("the broadcast for this join must be on the GPU too")
+    }
+
+    if (!canThisBeReplaced) {
+      buildSide.willNotWorkOnGpu(
+        "the GpuBroadcastNestedLoopJoin this feeds is not on the GPU")
+    }
+  }
+
+  override def convertToGpu(): GpuExec = {
+    val left = childPlans(0).convertIfNeeded()
+    val right = childPlans(1).convertIfNeeded()
+    // The broadcast part of this must be a BroadcastExchangeExec
+    val buildSide = join.buildSide match {
+      case BuildLeft => left
+      case BuildRight => right
+    }
+    if (!buildSide.isInstanceOf[GpuBroadcastExchangeExec]) {
+      throw new IllegalStateException("the broadcast must be on the GPU too")
+    }
+    GpuBroadcastNestedLoopJoinExec(
+      left, right, join.buildSide,
+      join.joinType,
+      condition.map(_.convertToGpu()))
+  }
+}
+
+case class GpuBroadcastNestedLoopJoinExec(
+    left: SparkPlan,
+    right: SparkPlan,
+    buildSide: BuildSide,
+    joinType: JoinType,
+    condition: Option[Expression]) extends BinaryExecNode with GpuExec {
+
+  override protected def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException("This should only be called from columnar")
+
+  override lazy val additionalMetrics: Map[String, SQLMetric] = Map(
+    "buildDataSize" -> SQLMetrics.createSizeMetric(sparkContext, "build side size"),
+    "buildTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "build time"),
+    "joinTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "join time"),
+    "joinOutputRows" -> SQLMetrics.createMetric(sparkContext, "join output rows"),
+    "filterTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "filter time"))
+  //TODO need to figure out what if anything we can make common with GpuHashJoin
+
+  /** BuildRight means the right relation <=> the broadcast relation. */
+  private val (streamed, broadcast) = buildSide match {
+    case BuildRight => (left, right)
+    case BuildLeft => (right, left)
+  }
+
+  def broadcastExchange: GpuBroadcastExchangeExec = broadcast match {
+    case gpu: GpuBroadcastExchangeExec => gpu
+    case reused: ReusedExchangeExec => reused.child.asInstanceOf[GpuBroadcastExchangeExec]
+  }
+
+  override def requiredChildDistribution: Seq[Distribution] = buildSide match {
+    case BuildLeft =>
+      BroadcastDistribution(IdentityBroadcastMode) :: UnspecifiedDistribution :: Nil
+    case BuildRight =>
+      UnspecifiedDistribution :: BroadcastDistribution(IdentityBroadcastMode) :: Nil
+  }
+
+  override def output: Seq[Attribute] = {
+    joinType match {
+      case _: InnerLike =>
+        left.output ++ right.output
+      case LeftOuter =>
+        left.output ++ right.output.map(_.withNullability(true))
+      case RightOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output
+      case FullOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output.map(_.withNullability(true))
+      case j: ExistenceJoin =>
+        left.output :+ j.exists
+      case LeftExistence(_) =>
+        left.output
+      case x =>
+        throw new IllegalArgumentException(
+          s"BroadcastNestedLoopJoin should not take $x as the JoinType")
+    }
+  }
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val buildDataSize = longMetric("buildDataSize")
+    val numOutputRows = longMetric(NUM_OUTPUT_ROWS)
+    val numOutputBatches = longMetric(NUM_OUTPUT_BATCHES)
+    val totalTime = longMetric(TOTAL_TIME)
+    val buildTime = longMetric("buildTime")
+    val joinTime = longMetric("joinTime")
+    val filterTime = longMetric("filterTime")
+    val joinOutputRows = longMetric("joinOutputRows")
+
+    val broadcastedRelation =
+      broadcastExchange.executeColumnarBroadcast[SerializeConcatHostBuffersDeserializeBatch]()
+
+    val boundCondition = condition.map(GpuBindReferences.bindReference(_, output))
+
+    lazy val builtTable = {
+      withResource(new NvtxWithMetrics("build join table", NvtxColor.GREEN, buildTime)) { _ =>
+        val ret = GpuColumnVector.from(broadcastedRelation.value.batch)
+        // Don't warn for a leak, because we cannot control when we are done with this
+        (0 until ret.getNumberOfColumns).foreach( i => {
+          val column = ret.getColumn(i)
+          column.noWarnLeakExpected()
+          buildDataSize += column.getDeviceMemorySize
+        })
+        ret
+      }
+    }
+
+    joinType match {
+      case _: InnerLike =>
+        streamed.executeColumnar().mapPartitionsInternal { streamedIter =>
+          streamedIter.map { cb =>
+            val startTime = System.nanoTime()
+            val joined =
+              withResource(new NvtxWithMetrics("join", NvtxColor.ORANGE, joinTime)) { _ =>
+                withResource(cb) { cb =>
+                  val joinedTable = withResource(GpuColumnVector.from(cb)) { tab =>
+                    buildSide match {
+                      case BuildLeft => builtTable.crossJoin(tab)
+                      case BuildRight => tab.crossJoin(builtTable)
+                    }
+                  }
+                  withResource(joinedTable) { jt =>
+                    GpuColumnVector.from(jt)
+                  }
+                }
+              }
+            joinOutputRows += joined.numRows()
+            val ret = if (boundCondition.isDefined) {
+              GpuFilter(joined, boundCondition.get, numOutputRows, numOutputBatches, filterTime)
+            } else {
+              numOutputRows += joined.numRows()
+              numOutputBatches += 1
+              joined
+            }
+            totalTime += (System.nanoTime() - startTime)
+            ret
+          }
+        }
+      case _ => throw new IllegalArgumentException(s"$joinType + $buildSide is not supported" +
+          s" and should be run on the CPU")
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -20,7 +20,7 @@ import org.json4s.JsonAST
 
 import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, IdentityBroadcastMode}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -29,8 +29,10 @@ import org.apache.spark.util.Utils
 object TrampolineUtil {
   def doExecuteBroadcast[T](child: SparkPlan): Broadcast[T] = child.doExecuteBroadcast()
 
-  def isHashedRelation(mode: BroadcastMode): Boolean = {
-    mode.isInstanceOf[HashedRelationBroadcastMode]
+  def isSupportedRelation(mode: BroadcastMode): Boolean = mode match {
+    case _ : HashedRelationBroadcastMode => true
+    case IdentityBroadcastMode => true
+    case _ => false
   }
 
   def structTypeMerge(left: DataType, right: DataType): DataType = StructType.merge(left, right)


### PR DESCRIPTION
I would appreciate some reviews on this.

It is a part of #265 but is missing `CartesianExec` which is an implementation that shows up if one of the tables is too larger to be broadcast and it is an `inner` or `cross` join with no equality comparison.

It adds in support for Cross equality joins, that in those cases are the same as an Inner join.

It also add in support for BroadcastNestedLoopJoin on Cross and Inner joins.  The biggest issue is the amount of memory that could be used by a Cross join this big.

I plan on trying to use the current memory size of each table (left and right) to decide if we should play some games with memory.  If the size is too large then we break the tables down into smaller pieces.

i.e.

```
left_size_per_row = left_size_memory/left_rows
right_size_per_row = right_size_memory/right_rows

if (((left_size_per_row + right_size_per_row) * left_rows * right_rows) > target_batch_size) {
  split the tables.  Preferable just split the stream table, but if we cannot, then split both and loop.
}
```

This would still not fix all cases, because we could broadcast something really large and blow up from just trying to hold it in memory.