### PR TITLE
Removed SNAPSHOT reference from configs.md

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -10,7 +10,7 @@ The following is the list of options that `rapids-plugin-4-spark` supports.
 On startup use: `--conf [conf key]=[conf value]`. For example:
 
 ```
-${SPARK_HOME}/bin/spark --jars 'rapids-4-spark_2.12-0.1-SNAPSHOT.jar,cudf-0.14-SNAPSHOT-cuda10.jar' \
+${SPARK_HOME}/bin/spark --jars 'rapids-4-spark_2.12-0.1.0.jar,cudf-0.14.jar' \
 --conf spark.plugins=com.nvidia.spark.SQLPlugin \
 --conf spark.rapids.sql.incompatibleOps.enabled=true
 ```


### PR DESCRIPTION
1. Please write a description in this text box of the changes that are being made.

Removed SNAPSHOT from configs.md.  Did not update the RapidsConf.scala file that generates this config.md since that would need to be done on the branch-0.1.  I can make the change via that route if it is better.  Did not change RapidsConf.scala in branch-0.2 since that config file already refers to cudf 0.15.  

2. Please ensure that you have written units tests for the changes made/features added.

Tested with `docker run --rm -it --volume="$PWD:/srv/jekyll" -p 4000:4000 sameerz/jekyll:0.1 jekyll serve` in cloned gh-pages branch.