### PR TITLE
Add info about branches in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are two types of branches in this repository:
 
 * `main`: is the branch with the latest released code, and the version tag (i.e. `v0.1.0`)
   is held here. `main` will change with new releases, but otherwise it should not change with
-  every pull request merged, and should be a more stable branch.
+  every pull request merged, making it a more stable branch.
 
 We use maven for most aspects of the build. Some important parts of the build execute in
 the "verify" phase of maven.  We recommend when building at least running to the "verify" phase.   

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ may file one [here](https://github.com/NVIDIA/spark-rapids/issues/new/choose).
 
 ## Build
 
+There are two types of branches in this repository:
+
+* `branch-[version]`: are development branches which can change often. Note that we merge into 
+  the branch with the greatest version number, as that is our default branch.
+
+* `main`: is the branch with the latest released code, and the version tag (i.e. `v0.1.0`)
+  is held here. `main` will change with new releases, but otherwise it should not change with
+  every pull request merged, and should be a more stable branch.
+
 We use maven for most aspects of the build. Some important parts of the build execute in
 the "verify" phase of maven.  We recommend when building at least running to the "verify" phase.   
 


### PR DESCRIPTION
This is a WIP branch to capture a suggestion by @revans2, made here: https://github.com/NVIDIA/spark-rapids/issues/300#issuecomment-651061157

I believe that front and center in the README would be good in this case, but can create a separate FAQ page.