### PR TITLE
[DOC][Minor] Fix typo in spark config name.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -333,7 +333,7 @@ $SPARK_HOME/bin/spark-shell \
        --conf spark.sql.files.maxPartitionBytes=512m \
        --conf spark.sql.shuffle.partitions=10 \
        --conf spark.plugins=com.nvidia.spark.SQLPlugin \
-       --conf spark.resourceDiscovery.plugin=com.nvidia.spark.ExclusiveModeGpuDiscoveryPlugin \
+       --conf spark.resources.discoveryPlugin=com.nvidia.spark.ExclusiveModeGpuDiscoveryPlugin \
        --conf spark.executor.resource.gpu.discoveryScript=./getGpusResources.sh \
        --files ${SPARK_RAPIDS_DIR}/getGpusResources.sh \
        --jars  ${SPARK_CUDF_JAR},${SPARK_RAPIDS_PLUGIN_JAR}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin.scala
@@ -37,7 +37,7 @@ import org.apache.spark.resource.{ResourceInformation, ResourceRequest}
  *  other executors will not be able to use it.
  *
  *  This plugin can be activated in spark with the configuration:
- *  `--conf spark.resourceDiscovery.plugin=com.nvidia.spark.ExclusiveModeGpuDiscoveryPlugin`
+ *  `--conf spark.resources.discoveryPlugin=com.nvidia.spark.ExclusiveModeGpuDiscoveryPlugin`
  */
 class ExclusiveModeGpuDiscoveryPlugin extends ResourceDiscoveryPlugin with Logging {
   override def discoverResource(


### PR DESCRIPTION
`spark.resourceDiscovery.plugin` should be `spark.resources.discoveryPlugin` as of https://spark.apache.org/docs/latest/configuration.html#application-properties