### PR TITLE
Build docker image with Dockerfile

### DIFF
--- a/jenkins/Dockerfile.integration.centos7
+++ b/jenkins/Dockerfile.integration.centos7
@@ -33,7 +33,7 @@ RUN yum update -y && \
 # The default mvn verision is 3.05 on centos7 docker container.
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /usr/local && \
+RUN wget https://urm.nvidia.com/artifactory/sw-spark-maven/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz -P /usr/local && \
     tar xzvf $MAVEN_HOME-bin.tar.gz -C /usr/local && \
     rm -f $MAVEN_HOME-bin.tar.gz
 
@@ -42,3 +42,7 @@ RUN python -m pip install pytest sre_yield
 
 # Set ENV for mvn
 ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk"
+
+RUN groupadd --gid 30 dip
+RUN adduser --uid 26576 --gid 30 --shell /bin/bash svcngcc
+USER svcngcc

--- a/jenkins/Dockerfile.ubuntu16
+++ b/jenkins/Dockerfile.ubuntu16
@@ -37,3 +37,5 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 RUN ln -s /usr/bin/python3.6 /usr/bin/python
 RUN python -m pip install pytest sre_yield requests
 
+RUN adduser --uid 26576 --gid 30 --shell /bin/bash svcngcc
+USER svcngcc

--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -54,15 +54,21 @@ pipeline {
                     def CUDA_NAME=sh(returnStdout: true,
                         script: '. jenkins/version-def.sh>&2 && echo -n $CUDA_CLASSIFIER | sed "s/-/./g"')
                     def IMAGE_NAME="urm.nvidia.com/sw-spark-docker/plugin:it-centos7-$CUDA_NAME"
-                    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-                    sh """
-                        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
-                        $DOCKER_CMD pull $IMAGE_NAME
-                        $DOCKER_CMD logout https://urm.nvidia.com
-                    """
+                    def CUDA_VER="$CUDA_NAME" - "cuda"
+                    def urmImage=docker.image(IMAGE_NAME)
+                    urmImage.pull()
+                    // docker inspect returns "sha256:urmImageID"
+                    def urmImageID=sh(returnStdout: true, script: "docker inspect -f {{'.Id'}} $IMAGE_NAME") - "sha256:"
+                    // Speed up Docker building via '--cache-from $IMAGE_NAME'
+                    def buildImage=docker.build(IMAGE_NAME,
+                        "-f jenkins/Dockerfile.integration.centos7 --build-arg CUDA_VER=$CUDA_VER --cache-from $IMAGE_NAME -t $IMAGE_NAME .")
+                    def buildImageID=sh(returnStdout: true, script: "docker inspect -f {{'.Id'}} $IMAGE_NAME") - "sha256:"
+                    if (! buildImageID.equals(urmImageID)) {
+                        echo "Dockerfile updated, upload docker image to URM"
+                        uploadDocker(IMAGE_NAME)
+                    }
 
-                    docker.image(IMAGE_NAME).inside("--runtime=nvidia -v ${HOME}/.zinc:${HOME}/.zinc:rw \
-                        -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group") {
+                    buildImage.inside("--runtime=nvidia -v ${HOME}/.zinc:${HOME}/.zinc:rw") {
                         echo "Running integration tests on centos7 $CUDA_NAME"
                         sh "bash $TEST_SCRIPT"
                     }
@@ -86,6 +92,15 @@ pipeline {
         }
     }
 } // end of pipeline
+
+void uploadDocker(String IMAGE_NAME) {
+    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
+    sh """
+        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
+        $DOCKER_CMD push $IMAGE_NAME
+        $DOCKER_CMD logout https://urm.nvidia.com
+    """
+}
 
 void slack(Map params = [:], String channel, String message) {
     Map defaultParams = [

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -55,13 +55,21 @@ pipeline {
                     def CUDA_NAME=sh(returnStdout: true,
                         script: '. jenkins/version-def.sh>&2 && echo -n $CUDA_CLASSIFIER | sed "s/-/./g"')
                     def IMAGE_NAME="urm.nvidia.com/sw-spark-docker/plugin:dev-ubuntu16-$CUDA_NAME"
-                    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-                    sh """
-                        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
-                        $DOCKER_CMD pull $IMAGE_NAME
-                        $DOCKER_CMD logout https://urm.nvidia.com
-                    """
-                    docker.image(IMAGE_NAME).inside("--runtime=nvidia \
+                    def CUDA_VER="$CUDA_NAME" - "cuda"
+                    def urmImage=docker.image(IMAGE_NAME)
+                    urmImage.pull()
+                    // docker inspect returns "sha256:urmImageID"
+                    def urmImageID=sh(returnStdout: true, script: "docker inspect -f {{'.Id'}} $IMAGE_NAME") - "sha256:"
+                    // Speed up Docker building via '--cache-from $IMAGE_NAME'
+                    def buildImage=docker.build(IMAGE_NAME,
+                        "-f jenkins/Dockerfile.ubuntu16 --build-arg CUDA_VER=$CUDA_VER --cache-from $IMAGE_NAME -t $IMAGE_NAME .")
+                    def buildImageID=sh(returnStdout: true, script: "docker inspect -f {{'.Id'}} $IMAGE_NAME") - "sha256:"
+                    if (! buildImageID.equals(urmImageID)) {
+                        echo "Dockerfile updated, upload docker image to URM"
+                        uploadDocker(IMAGE_NAME)
+                    }
+
+                    buildImage.inside("--runtime=nvidia \
                         -v ${HOME}/.zinc:${HOME}/.zinc:rw \
                         -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group") {
                         sh "jenkins/spark-nightly-build.sh"
@@ -87,6 +95,15 @@ pipeline {
         }
     }
 } // end of pipeline
+
+void uploadDocker(String IMAGE_NAME) {
+    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
+    sh """
+        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
+        $DOCKER_CMD push $IMAGE_NAME
+        $DOCKER_CMD logout https://urm.nvidia.com
+    """
+}
 
 void slack(Map params = [:], String channel, String message) {
     Map defaultParams = [

--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -39,7 +39,6 @@ pipeline {
         BUILD_SCRIPT = '$JENKINS_ROOT/spark-premerge-build.sh'
         MVN_URM_MIRROR='-s jenkins/settings.xml -P mirror-apache-to-urm'
         LIBCUDF_KERNEL_CACHE_PATH='/tmp'
-        URM_CREDS = credentials("svcngcc_artifactory")
     }
 
     stages {
@@ -50,15 +49,11 @@ pipeline {
                     def CUDA_NAME=sh(returnStdout: true,
                         script: '. jenkins/version-def.sh>&2 && echo -n $CUDA_CLASSIFIER | sed "s/-/./g"')
                     def IMAGE_NAME="urm.nvidia.com/sw-spark-docker/plugin:dev-ubuntu16-$CUDA_NAME"
-                    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-                    sh """
-                        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
-                        $DOCKER_CMD pull $IMAGE_NAME
-                        $DOCKER_CMD build -f jenkins/Dockerfile.ubuntu16 --cache-from $IMAGE_NAME -t $IMAGE_NAME .
-                        $DOCKER_CMD logout https://urm.nvidia.com
-                    """
-                    docker.image(IMAGE_NAME).inside("--runtime=nvidia -v ${HOME}/.m2:${HOME}/.m2:rw \
-                        -v ${HOME}/.zinc:${HOME}/.zinc:rw") {
+                    sh "docker pull $IMAGE_NAME"
+                    def CUDA_VER="$CUDA_NAME" - "cuda"
+                    def buildImage=docker.build(IMAGE_NAME,
+                        "-f jenkins/Dockerfile.ubuntu16 --build-arg CUDA_VER=$CUDA_VER --cache-from $IMAGE_NAME -t $IMAGE_NAME .")
+                    buildImage.inside("--runtime=nvidia -v ${HOME}/.m2:${HOME}/.m2:rw -v ${HOME}/.zinc:${HOME}/.zinc:rw") {
                         sh "bash $BUILD_SCRIPT $MVN_URM_MIRROR"
                         step([$class: 'JacocoPublisher',
                               execPattern: '**/target/jacoco.exec',

--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -54,11 +54,11 @@ pipeline {
                     sh """
                         echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
                         $DOCKER_CMD pull $IMAGE_NAME
+                        $DOCKER_CMD build -f jenkins/Dockerfile.ubuntu16 --cache-from $IMAGE_NAME -t $IMAGE_NAME .
                         $DOCKER_CMD logout https://urm.nvidia.com
                     """
                     docker.image(IMAGE_NAME).inside("--runtime=nvidia -v ${HOME}/.m2:${HOME}/.m2:rw \
-                        -v ${HOME}/.zinc:${HOME}/.zinc:rw \
-                        -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group") {
+                        -v ${HOME}/.zinc:${HOME}/.zinc:rw") {
                         sh "bash $BUILD_SCRIPT $MVN_URM_MIRROR"
                         step([$class: 'JacocoPublisher',
                               execPattern: '**/target/jacoco.exec',

--- a/jenkins/Jenkinsfile.release
+++ b/jenkins/Jenkinsfile.release
@@ -41,7 +41,6 @@ pipeline {
         IMAGE_NAME="urm.nvidia.com/sw-spark-docker/plugin:dev-ubuntu16-cuda10.1"
         LIBCUDF_KERNEL_CACHE_PATH='/tmp/.cudf'
         MVN_MIRROR='-s jenkins/settings.xml -P mirror-apache-to-urm'
-        URM_CREDS = credentials("svcngcc_artifactory")
         DIST_PL='dist'
         SQL_PL='sql-plugin'
     }
@@ -50,12 +49,7 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-                    sh """
-                        echo $URM_CREDS_PSW | $DOCKER_CMD login https://urm.nvidia.com -u $URM_CREDS_USR --password-stdin
-                        $DOCKER_CMD pull $IMAGE_NAME
-                        $DOCKER_CMD logout https://urm.nvidia.com
-                    """
+                    sh "docker pull $IMAGE_NAME"
                     sh "mkdir -p ${HOME}/.zinc"
                     docker.image("$IMAGE_NAME").inside("--runtime=nvidia -v ${HOME}/.m2:${HOME}/.m2:rw \
                         -v ${HOME}/.zinc:${HOME}/.zinc:rw \

--- a/jenkins/settings.xml
+++ b/jenkins/settings.xml
@@ -79,12 +79,6 @@
         </repository>
       </repositories>
     </profile>
-    <profile>
-      <id>deploy-to-sh04</id>
-      <properties>
-        <altDeploymentRepository>sh04-release-repo::http://apt-sh04:8081/repository/xgboost-spark-release</altDeploymentRepository>
-      </properties>
-    </profile>
   </profiles>
   <activeProfiles>
     <activeProfile>artifactory</activeProfile>


### PR DESCRIPTION
1, For prebuild pipeline, build the latest docker image form the Dockerfile, to make sure the pre-merge pipeline syncs up with any Dockerfile updating.

    For the nightly pipeline, check if the image from Docker repo is the same as the lastest one, which is built from Dockerfile. Otherwise, push the latest image onto the Docker repo

    For release pipeline, only need to pull a docker image from Docker repo.

    Remove "-v /etc/group:/etc/group:ro ..." from docker image, run Jenkins with 26576:30 svcngcc user

2, Only update Jenkins scripts, no source change. No unit tests needed.

3, No Github issue related to the PR.
