### PR TITLE
Add oss.sonatype.org to download the cudf jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,16 @@
     </build>
     <repositories>
         <repository>
+            <id>snapshots-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>snapshots</id>
             <name>sw-spark-maven</name>
             <url>https://urm.nvidia.com:443/artifactory/sw-spark-maven</url>


### PR DESCRIPTION
Adds oss.sonatype.org as a snapshot repo option in order to get artifacts like `cudf` SNAPSHOT that are not in maven central yet.

Closes #300.