### PR TITLE
Add in basic support for GpuCartesianProductExec

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -239,6 +239,7 @@ Name | Description | Default Value | Notes
 <a name="sql.exec.ShuffleExchangeExec"></a>spark.rapids.sql.exec.ShuffleExchangeExec|The backend for most data being exchanged between processes|true|None|
 <a name="sql.exec.BroadcastHashJoinExec"></a>spark.rapids.sql.exec.BroadcastHashJoinExec|Implementation of join using broadcast data|true|None|
 <a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
+<a name="sql.exec.CartesianProductExec"></a>spark.rapids.sql.exec.CartesianProductExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
 <a name="sql.exec.ShuffledHashJoinExec"></a>spark.rapids.sql.exec.ShuffledHashJoinExec|Implementation of join using hashed shuffled data|true|None|
 <a name="sql.exec.SortMergeJoinExec"></a>spark.rapids.sql.exec.SortMergeJoinExec|Sort merge join, replacing with shuffled hash join|true|None|
 <a name="sql.exec.WindowExec"></a>spark.rapids.sql.exec.WindowExec|Window-operator backend|true|None|

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -38,6 +38,7 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
       .set("spark.sql.join.preferSortMergeJoin", "false")
       .set("spark.sql.shuffle.partitions", "2") // hack to try and work around bug in cudf
       .set("spark.rapids.sql.exec.BroadcastNestedLoopJoinExec", "true")
+      .set("spark.rapids.sql.exec.CartesianProductExec", "true")
 
   IGNORE_ORDER_testSparkResultsAreEqual2("Test hash join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {
@@ -67,6 +68,11 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
   IGNORE_ORDER_testSparkResultsAreEqual2("Test cross join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {
     (A, B) => A.join(B.hint("broadcast"), A("longs") < B("longs"), "Cross")
+  }
+
+  IGNORE_ORDER_testSparkResultsAreEqual2("Test cross join 2", longsDf, biggerLongsDf,
+    conf = shuffledJoinConf) {
+    (A, B) => A.join(B, A("longs") < B("longs"), "Cross")
   }
 
   // test replacement of sort merge join with hash join

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -89,7 +89,7 @@ private class GpuColumnarBatchSerializerInstance(
           } finally {
             range.close()
           }
-        }  else {
+        } else {
           val range = new NvtxRange("Serialize Row Only Batch", NvtxColor.YELLOW)
           try {
             JCudfSerialization.writeRowsToStream(dOut, numRows)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1729,8 +1729,11 @@ object GpuOverrides {
         override val childExprs: Seq[BaseExprMeta[_]] = condition.toSeq
 
         override def convertToGpu(): GpuExec =
-          GpuCartesianProductExec(childPlans.head.convertIfNeeded(),
-            childPlans(1).convertIfNeeded(), condition.map(_.convertToGpu()))
+          GpuCartesianProductExec(
+            childPlans.head.convertIfNeeded(),
+            childPlans(1).convertIfNeeded(),
+            condition.map(_.convertToGpu()),
+            conf.gpuTargetBatchSizeBytes)
       })
         .disabledByDefault("large joins can cause out of memory errors"),
     exec[SortMergeJoinExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, CartesianProductExec, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
@@ -1719,6 +1719,19 @@ object GpuOverrides {
     exec[BroadcastNestedLoopJoinExec](
       "Implementation of join using brute force",
       (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r))
+        .disabledByDefault("large joins can cause out of memory errors"),
+    exec[CartesianProductExec](
+      "Implementation of join using brute force",
+      (join, conf, p, r) => new SparkPlanMeta[CartesianProductExec](join, conf, p, r) {
+        val condition: Option[BaseExprMeta[_]] =
+          join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+
+        override val childExprs: Seq[BaseExprMeta[_]] = condition.toSeq
+
+        override def convertToGpu(): GpuExec =
+          GpuCartesianProductExec(childPlans.head.convertIfNeeded(),
+            childPlans(1).convertIfNeeded(), condition.map(_.convertToGpu()))
+      })
         .disabledByDefault("large joins can cause out of memory errors"),
     exec[SortMergeJoinExec](
       "Sort merge join, replacing with shuffled hash join",

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
+
+import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuColumnarBatchSerializer, GpuColumnVector, GpuExec, GpuExpression, GpuSemaphore}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+
+import org.apache.spark.{Dependency, NarrowDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.execution.{BinaryExecNode, ExplainUtils, SparkPlan}
+import org.apache.spark.sql.execution.joins.BuildLeft
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.rapids.execution.GpuBroadcastNestedLoopJoinExec
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.util.{CompletionIterator, Utils}
+
+@SerialVersionUID(100L)
+class GpuSerializableBatch(batch: ColumnarBatch)
+    extends Serializable with AutoCloseable with Arm {
+
+  assert(batch != null)
+  @transient private var internalBatch: ColumnarBatch = batch
+
+  def getBatch: ColumnarBatch = {
+    assert(internalBatch != null)
+    internalBatch
+  }
+
+  private def writeObject(out: ObjectOutputStream): Unit = {
+    withResource (new NvtxRange("SerializeBatch", NvtxColor.PURPLE)) { _ =>
+      if (internalBatch == null) {
+        throw new IllegalStateException("Cannot re-serialize a batch this way...")
+      } else {
+        val numRows = internalBatch.numRows()
+        val columns = GpuColumnVector.extractBases(internalBatch).map(_.copyToHost())
+        internalBatch.close()
+        internalBatch = null
+        GpuSemaphore.releaseIfNecessary(TaskContext.get())
+        JCudfSerialization.writeToStream(columns, out, 0, numRows)
+        columns.safeClose()
+      }
+    }
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = {
+    GpuSemaphore.acquireIfNecessary(TaskContext.get())
+    withResource (new NvtxRange("DeserializeBatch", NvtxColor.PURPLE)) { _ =>
+      withResource(JCudfSerialization.readTableFrom(in)) { tableInfo =>
+        val tmp = tableInfo.getTable
+        if (tmp == null) {
+          throw new IllegalStateException("Empty Batch???")
+        }
+        this.internalBatch = GpuColumnVector.from(tmp)
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    if (internalBatch != null) {
+      internalBatch.close()
+    }
+  }
+}
+
+class GpuCartesianPartition(
+    idx: Int,
+    @transient private val rdd1: RDD[_],
+    @transient private val rdd2: RDD[_],
+    s1Index: Int,
+    s2Index: Int
+) extends Partition {
+  var s1: Partition = rdd1.partitions(s1Index)
+  var s2: Partition = rdd2.partitions(s2Index)
+  override val index: Int = idx
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    // Update the reference to parent split at the time of task serialization
+    s1 = rdd1.partitions(s1Index)
+    s2 = rdd2.partitions(s2Index)
+    oos.defaultWriteObject()
+  }
+}
+
+class GpuCartesianRDD(
+    sc: SparkContext,
+    boundCondition: Option[GpuExpression],
+    joinTime: SQLMetric,
+    joinOutputRows: SQLMetric,
+    numOutputRows: SQLMetric,
+    numOutputBatches: SQLMetric,
+    filterTime: SQLMetric,
+    totalTime: SQLMetric,
+    var rdd1 : RDD[GpuSerializableBatch],
+    var rdd2 : RDD[GpuSerializableBatch])
+    extends RDD[ColumnarBatch](sc, Nil)
+        with Serializable with Arm {
+
+  private val numPartitionsInRdd2 = rdd2.partitions.length
+
+  override def getPartitions: Array[Partition] = {
+    // create the cross product split
+    val array = new Array[Partition](rdd1.partitions.length * rdd2.partitions.length)
+    for (s1 <- rdd1.partitions; s2 <- rdd2.partitions) {
+      val idx = s1.index * numPartitionsInRdd2 + s2.index
+      array(idx) = new GpuCartesianPartition(idx, rdd1, rdd2, s1.index, s2.index)
+    }
+    array
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    val currSplit = split.asInstanceOf[GpuCartesianPartition]
+    (rdd1.preferredLocations(currSplit.s1) ++ rdd2.preferredLocations(currSplit.s2)).distinct
+  }
+
+  override def compute(split: Partition, context: TaskContext):
+  Iterator[ColumnarBatch] = {
+    val currSplit = split.asInstanceOf[GpuCartesianPartition]
+    rdd1.iterator(currSplit.s1, context).flatMap { lhs =>
+      val table = withResource(lhs) { lhs =>
+        GpuColumnVector.from(lhs.getBatch)
+      }
+      // Ideally instead of looping through and recomputing rdd2 for
+      // each batch in rdd1 we would instead cache rdd2 in a way that
+      // it could spill to disk so we can avoid re-computation
+      val ret = GpuBroadcastNestedLoopJoinExec.innerLikeJoin(
+        rdd2.iterator(currSplit.s2, context).map(i => i.getBatch),
+        table,
+        BuildLeft,
+        boundCondition,
+        joinTime,
+        joinOutputRows,
+        numOutputRows,
+        numOutputBatches,
+        filterTime,
+        totalTime)
+
+      CompletionIterator[ColumnarBatch, Iterator[ColumnarBatch]](ret, table.close())
+    }
+  }
+
+  override def getDependencies: Seq[Dependency[_]] = List(
+    new NarrowDependency(rdd1) {
+      def getParents(id: Int): Seq[Int] = List(id / numPartitionsInRdd2)
+    },
+    new NarrowDependency(rdd2) {
+      def getParents(id: Int): Seq[Int] = List(id % numPartitionsInRdd2)
+    }
+  )
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdd1 = null
+    rdd2 = null
+  }
+}
+
+case class GpuCartesianProductExec(
+    left: SparkPlan,
+    right: SparkPlan,
+    condition: Option[Expression]) extends BinaryExecNode with GpuExec {
+  override def output: Seq[Attribute]= left.output ++ right.output
+
+  override def verboseStringWithOperatorId(): String = {
+    val joinCondStr = if (condition.isDefined) s"${condition.get}" else "None"
+    s"""
+       |$formattedNodeName
+       |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
+     """.stripMargin
+  }
+
+  override lazy val additionalMetrics: Map[String, SQLMetric] = Map(
+    "joinTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "join time"),
+    "joinOutputRows" -> SQLMetrics.createMetric(sparkContext, "join output rows"),
+    "filterTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "filter time"),
+    "dataSize" -> SQLMetrics.createMetric(sparkContext, "size of shuffled data"))
+
+  private val serializer: Serializer =
+    new GpuColumnarBatchSerializer(output.size, longMetric("dataSize"))
+
+  protected override def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException("This should only be called from columnar")
+
+  protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    import com.nvidia.spark.rapids.GpuMetricNames._
+    val numOutputRows = longMetric(NUM_OUTPUT_ROWS)
+    val numOutputBatches = longMetric(NUM_OUTPUT_BATCHES)
+    val joinTime = longMetric("joinTime")
+    val joinOutputRows = longMetric("joinOutputRows")
+    val filterTime = longMetric("filterTime")
+    val totalTime = longMetric(TOTAL_TIME)
+
+    val boundCondition = condition.map(GpuBindReferences.bindGpuReference(_, output))
+
+    if (output.isEmpty) {
+      // special case for crossJoin.count.  Doing it this way
+      // because it is more readable then trying to fit it into the
+      // existing join code.
+      assert(boundCondition.isEmpty)
+
+      def getRowCountAndClose(cb: ColumnarBatch): Long = {
+        val ret = cb.numRows()
+        cb.close()
+        GpuSemaphore.releaseIfNecessary(TaskContext.get())
+        ret
+      }
+
+      val maxRowCount = 100000000
+
+      def divideIntoBatches(rows: Long): Iterable[ColumnarBatch] = {
+        val numBatches = (rows + maxRowCount - 1)/maxRowCount
+        (0L until numBatches).map(i => {
+          val ret = new ColumnarBatch(new Array[ColumnVector](0))
+          if ((i + 1) * maxRowCount > rows) {
+            ret.setNumRows((rows - (i * maxRowCount)).toInt)
+          } else {
+            ret.setNumRows(maxRowCount)
+          }
+          numOutputRows += ret.numRows()
+          numOutputBatches += 1
+          ret
+        })
+      }
+      val l = left.executeColumnar().map(getRowCountAndClose)
+      val r = right.executeColumnar().map(getRowCountAndClose)
+      // TODO here too it would probably be best to avoid doing any re-computation
+      //  that happens with the built in cartesian, but writing another custom RDD
+      //  just for this use case is not worth it without an explicit use case.
+      val prods = l.cartesian(r).map(p => p._1 * p._2)
+      prods.flatMap(divideIntoBatches)
+    } else {
+      new GpuCartesianRDD(sparkContext,
+        boundCondition,
+        joinTime,
+        joinOutputRows,
+        numOutputRows,
+        numOutputBatches,
+        filterTime,
+        totalTime,
+        left.executeColumnar().map(cb => new GpuSerializableBatch(cb)),
+        right.executeColumnar().map(cb => new GpuSerializableBatch(cb)))
+    }
+  }
+}


### PR DESCRIPTION
This adds in very basic support for one form of cross join.  It is off by default because of memory issues.  I also found a bug in the GPU implementation of BroadcastNestedLoopJoin, which I added a test for with an xfail pointing to the bug.

This still needs some follow on work to avoid the memory issues.

This fixes #265