### PR TITLE
Adds iterator and client unit tests, and prepares for more fetch failure handling

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -60,12 +60,9 @@ object MetaUtils {
       bufferSize,
       CodecType.UNCOMPRESSED)
 
-    val columnMetaOffsets = new ArrayBuffer[Int](columns.length)
-    columns.foreach { col =>
-      columnMetaOffsets.append(addColumnMeta(fbb, baseAddress, col))
-    }
+    val columnMetaOffsets = columns.map(col => addColumnMeta(fbb, baseAddress, col)).toArray
 
-    val columnMetasOffset = TableMeta.createColumnMetasVector(fbb, columnMetaOffsets.toArray)
+    val columnMetasOffset = TableMeta.createColumnMetasVector(fbb, columnMetaOffsets)
     TableMeta.startTableMeta(fbb)
     TableMeta.addBufferMeta(fbb, bufferMetaOffset)
     TableMeta.addRowCount(fbb, numRows)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -39,6 +39,17 @@ object MetaUtils {
    * @return heap-based flatbuffer message
    */
   def buildTableMeta(tableId: Int, table: Table, buffer: DeviceMemoryBuffer): TableMeta = {
+    buildTableMeta(tableId,
+      (0 until table.getNumberOfColumns).map(i => table.getColumn(i)),
+      table.getRowCount,
+      buffer)
+  }
+
+  def buildTableMeta(
+      tableId: Int,
+      columns: Seq[ColumnVector],
+      numRows: Long,
+      buffer: DeviceMemoryBuffer): TableMeta = {
     val fbb = new FlatBufferBuilder(1024)
     val baseAddress = buffer.getAddress
     val bufferSize = buffer.getLength
@@ -49,15 +60,15 @@ object MetaUtils {
       bufferSize,
       CodecType.UNCOMPRESSED)
 
-    val columnMetaOffsets = new ArrayBuffer[Int](table.getNumberOfColumns)
-    for (i <- 0 until table.getNumberOfColumns) {
-      columnMetaOffsets.append(addColumnMeta(fbb, baseAddress, table.getColumn(i)))
+    val columnMetaOffsets = new ArrayBuffer[Int](columns.length)
+    columns.foreach { col =>
+      columnMetaOffsets.append(addColumnMeta(fbb, baseAddress, col))
     }
 
     val columnMetasOffset = TableMeta.createColumnMetasVector(fbb, columnMetaOffsets.toArray)
     TableMeta.startTableMeta(fbb)
     TableMeta.addBufferMeta(fbb, bufferMetaOffset)
-    TableMeta.addRowCount(fbb, table.getRowCount)
+    TableMeta.addRowCount(fbb, numRows)
     TableMeta.addColumnMetas(fbb, columnMetasOffset)
     fbb.finish(TableMeta.endTableMeta(fbb))
     // copy the message to trim the backing array to only what is needed

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -204,6 +204,8 @@ class ShuffleBufferCatalog(
 
   /**
     * Remove a buffer and table given a buffer ID
+    * NOTE: This function is not thread safe! The caller should only invoke if
+    * the [[ShuffleBufferId]] being removed is not being utilized by another thread.
     * @param id buffer identifier
     */
   def removeBuffer(id: ShuffleBufferId): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -201,6 +201,15 @@ class ShuffleBufferCatalog(
     val shuffleBufferId = getShuffleBufferId(tableId)
     acquireBuffer(shuffleBufferId)
   }
+
+  /**
+    * Remove a buffer and table given a buffer ID
+    * @param id buffer identifier
+    */
+  def removeBuffer(id: ShuffleBufferId): Unit = {
+    tableMap.remove(id.tableId)
+    catalog.removeBuffer(id)
+  }
 }
 
 object ShuffleBufferCatalog {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
@@ -99,6 +99,12 @@ class ShuffleReceivedBufferCatalog(
     acquireBuffer(shuffleBufferId)
   }
 
+  /**
+   * Remove a buffer and table given a buffer ID
+   * NOTE: This function is not thread safe! The caller should only invoke if
+   * the [[ShuffleReceivedBufferId]] being removed is not being utilized by another thread.
+   * @param id buffer identifier
+   */
   def removeBuffer(id: ShuffleReceivedBufferId): Unit = {
     tableMap.remove(id.tableId)
     catalog.removeBuffer(id)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -562,7 +562,7 @@ class RapidsShuffleClient(
       tx: Transaction,
       resp: RefCountedDirectByteBuffer,
       shuffleRequests: Seq[ShuffleBlockBatchId],
-      handler: RapidsShuffleFetchHandler): Unit = GpuShuffleEnv.synchronized{
+      handler: RapidsShuffleFetchHandler): Unit = {
     val start = System.currentTimeMillis()
     val handleMetaRange = new NvtxRange("Client.handleMeta", NvtxColor.CYAN)
     try {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -33,8 +33,27 @@ import org.apache.spark.storage.ShuffleBlockBatchId
   * expected number of batches (Tables) is, and the ids for each table as they are received.
   */
 trait RapidsShuffleFetchHandler {
+  /**
+    * After a response for shuffle metadata is received, the expected number of columnar
+    * batches is communicated back to the caller via this method.
+    * @param expectedBatches - number of columnar batches
+    */
   def start(expectedBatches: Int): Unit
+
+  /**
+    * Called when a buffer is received, and has been handed off to the catalog.
+    * @param bufferId - a tracked shuffle buffer id
+    */
   def batchReceived(bufferId: ShuffleReceivedBufferId): Unit
+
+  /**
+    * Called when an error is detected during a metadata or a buffer fetch.
+    *
+    * @note No retry mechanism currently exists before calling [[transferError]],
+    *       in the future, some retries may happen before handing off the error to the caller.
+    * @param errorMessage - a string containing an error message
+    */
+  def transferError(errorMessage: String): Unit
 }
 
 /**
@@ -153,6 +172,12 @@ class BufferReceiveState(
     */
   private[this] var isClosed = false
 
+  /**
+    * Becomes true when there is an error detected, allowing the client to close this
+    * [[BufferReceiveState]] prematurely.
+    */
+  private[this] var errorOcurred = false
+
   override def toString: String = {
     s"BufferReceiveState(isDone=$isDone, currentRequestDone=$currentRequestDone, " +
       s"requests=${requests.size}, currentReqIx=$currentRequestIndex, " +
@@ -189,7 +214,7 @@ class BufferReceiveState(
       if (currentRequestDone) {
         require(currentRequestOffset == currentRequest.getLength,
           "Current request marked as done, but not all bounce buffers were consumed?")
-        logDebug(s"Done copying ${currentRequest.tag}")
+        logDebug(s"Done copying ${TransportUtils.formatTag(currentRequest.tag)}")
         val res = buff
         // The buffer [[buff]] is being handed off to the caller.
         // It is the job of the caller to close it.
@@ -197,8 +222,8 @@ class BufferReceiveState(
         needsCleanup = false
         Some(res)
       } else {
-        logDebug(s"More copying left for ${currentRequest.tag}, current offset is " +
-          s"${currentRequestOffset} out of ${currentRequest.getLength}")
+        logDebug(s"More copying left for ${TransportUtils.formatTag(currentRequest.tag)}, " +
+           s"current offset is ${currentRequestOffset} out of ${currentRequest.getLength}")
         needsCleanup = false
         None
       }
@@ -314,8 +339,13 @@ class BufferReceiveState(
   def getCurrentRequestRemaining: Long = currentRequestRemaining
   def getCurrentRequestOffset : Long = currentRequestOffset
 
+  def closeWithError(): Unit = synchronized {
+    errorOcurred = true
+    close()
+  }
+
   override def close(): Unit = synchronized {
-    require(isDone)
+    require(isDone || errorOcurred)
     if (isClosed) {
       throw new IllegalStateException("ALREADY CLOSED")
     }
@@ -354,6 +384,33 @@ class RapidsShuffleClient(
     exec: Executor,
     clientCopyExecutor: Executor,
     maximumMetadataSize: Long) extends Logging {
+
+  private[this] var devStorage: RapidsDeviceMemoryStore = GpuShuffleEnv.getDeviceStorage
+  private[this] var catalog: ShuffleReceivedBufferCatalog = GpuShuffleEnv.getReceivedCatalog
+
+  /**
+    * Convenience constructor exposed for unit tests.
+    */
+  private[shuffle] def this(
+    localExecutorId: Long,
+    connection: ClientConnection,
+    transport: RapidsShuffleTransport,
+    exec: Executor,
+    clientCopyExecutor: Executor,
+    maximumMetadataSize: Long,
+    storage: RapidsDeviceMemoryStore,
+    catalog: ShuffleReceivedBufferCatalog) = {
+    this(
+      localExecutorId,
+      connection,
+      transport,
+      exec,
+      clientCopyExecutor,
+      maximumMetadataSize)
+
+    this.devStorage = storage
+    this.catalog = catalog
+  }
 
   object ShuffleClientOps {
     /**
@@ -501,18 +558,15 @@ class RapidsShuffleClient(
     * @param shuffleRequests blocks to fetch
     * @param handler iterator to callback to
     */
-  private[this] def doHandleMetadataResponse(tx: Transaction,
-                                             resp: RefCountedDirectByteBuffer,
-                                             shuffleRequests: Seq[ShuffleBlockBatchId],
-                                             handler: RapidsShuffleFetchHandler): Unit = {
+  private[this] def doHandleMetadataResponse(
+      tx: Transaction,
+      resp: RefCountedDirectByteBuffer,
+      shuffleRequests: Seq[ShuffleBlockBatchId],
+      handler: RapidsShuffleFetchHandler): Unit = GpuShuffleEnv.synchronized{
     val start = System.currentTimeMillis()
     val handleMetaRange = new NvtxRange("Client.handleMeta", NvtxColor.CYAN)
     try {
       tx.getStatus match {
-        case TransactionStatus.Error =>
-          throw new IllegalStateException(s"Error in metadata request transaction $tx")
-        case TransactionStatus.Cancelled =>
-          throw new IllegalStateException(s"Cancelled metadata request transaction, not handled.")
         case TransactionStatus.Success =>
           // start the receives
           val respBuffer = resp.getBuffer()
@@ -537,7 +591,8 @@ class RapidsShuffleClient(
             asyncOrBlock(FetchRetry(shuffleRequests, handler, metadataResponse.fullResponseSize()))
           }
         case _ =>
-          throw new IllegalStateException(s"Transaction is invalid state $tx")
+          handler.transferError(
+            tx.getErrorMessage.getOrElse(s"Unsuccessful metadata request ${tx}"))
       }
     } finally {
       logDebug(s"Metadata response handled in ${TransportUtils.timeDiffMs(start)} ms")
@@ -563,7 +618,7 @@ class RapidsShuffleClient(
     *                           future). The requests included in this state object originated in
     *                           the transport's throttle logic.
     */
-  private[this] def doIssueBufferReceives(bufferReceiveState: BufferReceiveState): Unit = {
+  private[shuffle] def doIssueBufferReceives(bufferReceiveState: BufferReceiveState): Unit = {
     logDebug(s"At issue for ${bufferReceiveState}, " +
       s"remaining: ${bufferReceiveState.getCurrentRequestRemaining}, " +
       s"offset: ${bufferReceiveState.getCurrentRequestOffset}")
@@ -593,10 +648,21 @@ class RapidsShuffleClient(
 
     connection.receive(buffersToReceive,
       tx => {
-        // TODO: during code review we agreed to make this receive per buffer, s.t. buffers could
-        //  begin go get freed earlier and likely out of order.
-        asyncOnCopyThread(HandleBounceBufferReceive(tx, bufferReceiveState,
-          currentRequest, buffersToReceive))
+        tx.getStatus match {
+          case TransactionStatus.Success =>
+            // TODO: during code review we agreed to make this receive per buffer, s.t.
+            //  buffers could begin go get freed earlier and likely out of order.
+            asyncOnCopyThread(HandleBounceBufferReceive(tx, bufferReceiveState,
+              currentRequest, buffersToReceive))
+          case _ => try {
+            val errMsg = s"Unsuccessful buffer receive ${tx}"
+            logError(errMsg)
+            currentRequest.handler.transferError(errMsg)
+          } finally {
+            tx.close()
+            bufferReceiveState.closeWithError()
+          }
+        }
       })
   }
 
@@ -663,7 +729,6 @@ class RapidsShuffleClient(
   private def queueTransferRequests(metaResponse: MetadataResponse,
                                     handler: RapidsShuffleFetchHandler): Unit = {
     val allTables = metaResponse.tableMetasLength()
-
     logDebug(s"Queueing transfer requests for ${allTables} tables " +
       s"from ${connection.getPeerExecutorId}")
 
@@ -753,13 +818,11 @@ class RapidsShuffleClient(
     * @param meta [[TableMeta]] describing [[buffer]]
     * @return the [[RapidsBufferId]] to be used to look up the buffer from catalog
     */
-  private def track(buffer: DeviceMemoryBuffer, meta: TableMeta): RapidsBufferId = {
-    val catalog = GpuShuffleEnv.getReceivedCatalog
+  private[shuffle] def track(buffer: DeviceMemoryBuffer, meta: TableMeta): RapidsBufferId = {
     val id: ShuffleReceivedBufferId = catalog.nextShuffleReceivedBufferId()
     logDebug(s"Adding buffer id ${id} to catalog")
     if (buffer != null) {
       // add the buffer to the catalog so it is available for spill
-      val devStorage = GpuShuffleEnv.getDeviceStorage
       devStorage.addBuffer(id, buffer, meta, SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
     } else {
       // no device data, just tracking metadata

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -132,6 +132,12 @@ class RapidsShuffleIterator(
 
   private var started: Boolean = false
 
+  // NOTE: `mapIndex` is utilized by the `FetchFailedException` to reference
+  // a map output by index from the statuses collection in `MapOutputTracker`.
+  //
+  // This is different than the `mapId` in the `ShuffleBlockBatchId`, because
+  // as of Spark 3.x the default shuffle protocol overloads `mapId` to be
+  // `taskAttemptId`.
   case class BlockIdMapIndex(id: ShuffleBlockBatchId, mapIndex: Int)
 
   def start(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
@@ -538,8 +538,9 @@ class DirectByteBufferPool(bufferSize: Long) extends Logging {
   * @param bb buffer to wrap
   * @param pool optional pool
   */
-class RefCountedDirectByteBuffer(bb: ByteBuffer,
-                                 pool: Option[DirectByteBufferPool] = None) extends AutoCloseable {
+class RefCountedDirectByteBuffer(
+    bb: ByteBuffer,
+    pool: Option[DirectByteBufferPool] = None) extends AutoCloseable {
   assert(bb.isDirect, "Only direct buffers are supported")
 
   var refCount: Int = 0

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleFetchFailedException.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleFetchFailedException.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import org.apache.spark.storage.BlockManagerId
+
+class RapidsShuffleFetchFailedException(
+    bmAddress: BlockManagerId,
+    shuffleId: Int,
+    mapId: Long,
+    mapIndex: Int,
+    reduceId: Int,
+    message: String)
+    extends FetchFailedException(
+      bmAddress, shuffleId, mapId, mapIndex, reduceId, message) {
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -79,6 +79,7 @@ object GpuShuffleEnv extends Logging {
   }
 
   def closeStorage(): Unit = {
+    logInfo("Closing shuffle storage")
     if (memoryEventHandler != null) {
       // Workaround for shutdown ordering problems where device buffers allocated with this handler
       // are being freed after the handler is destroyed

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
@@ -145,7 +145,7 @@ class RapidsCachingReader[K, C](
 
         val cbArrayFromUcx: Iterator[(K, C)] = if (blocksForRapidsTransport.nonEmpty) {
           val rapidsShuffleIterator = new RapidsShuffleIterator(localId, rapidsConf, transport.get,
-            blocksForRapidsTransport.toArray, TaskContext.get(), metricsUpdater)
+            blocksForRapidsTransport.toArray, metricsUpdater)
           rapidsShuffleIterator.map(cb => {
             (0, cb)
           }).asInstanceOf[Iterator[(K, C)]]

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
@@ -145,7 +145,7 @@ class RapidsCachingReader[K, C](
 
         val cbArrayFromUcx: Iterator[(K, C)] = if (blocksForRapidsTransport.nonEmpty) {
           val rapidsShuffleIterator = new RapidsShuffleIterator(localId, rapidsConf, transport.get,
-            blocksForRapidsTransport.toArray, metricsUpdater)
+            blocksForRapidsTransport.toArray, TaskContext.get(), metricsUpdater)
           rapidsShuffleIterator.map(cb => {
             (0, cb)
           }).asInstanceOf[Iterator[(K, C)]]

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -305,7 +305,7 @@ class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
     // NOTE: This type of reader is not possible for gpu shuffle, as we'd need
     // to use the optimization within our manager, and we don't.
-   wrapped.getReaderForRange(unwrapHandle(handle), startMapIndex, endMapIndex,
+    wrapped.getReaderForRange(unwrapHandle(handle), startMapIndex, endMapIndex,
       startPartition, endPartition, context, metrics)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -20,6 +20,7 @@ import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.format.TableMeta
 import com.nvidia.spark.rapids.shuffle.{RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport}
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.internal.{config, Logging}
@@ -86,6 +87,7 @@ class RapidsCachingWriter[K, V](
 
   private val numParts = handle.dependency.partitioner.numPartitions
   private val sizes = new Array[Long](numParts)
+  private val writtenBufferIds = new ArrayBuffer[ShuffleBufferId](numParts)
 
   override def write(records: Iterator[Product2[K, V]]): Unit = {
     val nvtxRange = new NvtxRange("RapidsCachingWriter.write", NvtxColor.CYAN)
@@ -129,6 +131,7 @@ class RapidsCachingWriter[K, V](
             sizes(partId) += 100
           }
         }
+        writtenBufferIds.append(bufferId)
       }
       metrics.incBytesWritten(bytesWritten)
       metrics.incRecordsWritten(recordsWritten)
@@ -137,11 +140,18 @@ class RapidsCachingWriter[K, V](
     }
   }
 
+  /**
+    * Used to remove shuffle buffers when the writing task detects an error, calling `stop(false)`
+    */
+  private def cleanStorage(): Unit = {
+    writtenBufferIds.foreach(catalog.removeBuffer)
+  }
+
   override def stop(success: Boolean): Option[MapStatus] = {
     val nvtxRange = new NvtxRange("RapidsCachingWriter.close", NvtxColor.CYAN)
     try {
       if (!success) {
-        shuffleStorage.close()
+        cleanStorage()
         None
       } else {
         // upon seeing this port, the other side will try to connect to the port
@@ -295,7 +305,7 @@ class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
       metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
     // NOTE: This type of reader is not possible for gpu shuffle, as we'd need
     // to use the optimization within our manager, and we don't.
-    wrapped.getReaderForRange(unwrapHandle(handle), startMapIndex, endMapIndex,
+   wrapped.getReaderForRange(unwrapHandle(handle), startMapIndex, endMapIndex,
       startPartition, endPartition, context, metrics)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import ai.rapids.cudf.{DeviceMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.format.TableMeta
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+
+class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
+  def prepareBufferReceiveState(
+      tableMeta: TableMeta,
+      bounceBuffers: Seq[MemoryBuffer]): BufferReceiveState = {
+    val brs = spy(new BufferReceiveState(mockTransport, bounceBuffers))
+    val tag = 123
+    val ptr = PendingTransferRequest(client, tableMeta, tag, mockHandler)
+    val targetAlt = mock[AddressLengthTag]
+    when(targetAlt.cudaCopyFrom(any(), any())).thenReturn(bounceBuffers.head.getLength)
+    brs.addRequest(ptr)
+    brs
+  }
+
+  def verifyTableMeta(expected: TableMeta, actual: TableMeta): Unit = {
+    assertResult(expected.rowCount())(actual.rowCount())
+    assertResult(expected.columnMetasLength())(actual.columnMetasLength())
+    assertResult(expected.bufferMeta().id())(actual.bufferMeta().id())
+    assertResult(expected.bufferMeta().actualSize())(actual.bufferMeta().actualSize())
+    assertResult(expected.bufferMeta().compressedSize())(actual.bufferMeta().compressedSize())
+    assertResult(expected.bufferMeta().codec())(actual.bufferMeta().codec())
+  }
+
+  test("successful metadata fetch") {
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Success)
+    val shuffleRequests = RapidsShuffleTestHelper.getShuffleBlocks
+    val contigBuffSize = 100000
+    val numBatches = 3
+    val tableMetas =
+      RapidsShuffleTestHelper.mockMetaResponse(mockTransport, contigBuffSize, numBatches)
+
+    // initialize metadata fetch
+    client.doFetch(shuffleRequests.map(_._1), mockHandler)
+
+    // the connection saw one request (for metadata)
+    assertResult(1)(mockConnection.requests.size)
+
+    // upon a successful response, the `start()` method in the fetch handler
+    // will be called with 3 expected batches
+    verify(mockHandler, times(1)).start(ArgumentMatchers.eq(numBatches))
+
+    // the transport will receive 3 pending requests (for buffers) for queuing
+    val ac = ArgumentCaptor.forClass(classOf[Seq[PendingTransferRequest]])
+    verify(mockTransport, times(1)).queuePending(ac.capture())
+    val ptrs = ac.getValue.asInstanceOf[Seq[PendingTransferRequest]]
+    assertResult(numBatches)(ptrs.size)
+
+    // we check their metadata below
+    (0 until numBatches).foreach { t =>
+      val expected = tableMetas(t)
+      val tm = ptrs(t).tableMeta
+      verifyTableMeta(expected, tm)
+    }
+  }
+
+  test("errored/cancelled metadata fetch") {
+    Seq(TransactionStatus.Error, TransactionStatus.Cancelled).foreach { status =>
+      when(mockTransaction.getStatus).thenReturn(status)
+      when(mockTransaction.getErrorMessage).thenReturn(Some("Error/cancel occurred"))
+
+      val shuffleRequests = RapidsShuffleTestHelper.getShuffleBlocks
+      val contigBuffSize = 100000
+      RapidsShuffleTestHelper.mockMetaResponse(
+        mockTransport, contigBuffSize, 3)
+
+      client.doFetch(shuffleRequests.map(_._1), mockHandler)
+
+      assertResult(1)(mockConnection.requests.size)
+
+      // upon an errored response, the start handler will not be called
+      verify(mockHandler, times(0)).start(any())
+
+      // but the error handler will
+      verify(mockHandler, times(1)).transferError(anyString())
+
+      // the transport will receive no pending requests (for buffers) for queuing
+      verify(mockTransport, times(0)).queuePending(any())
+
+      newMocks()
+    }
+  }
+
+  test("successful buffer fetch") {
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Success)
+
+    val numRows = 25001
+    val tableMeta =
+      RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
+
+    // assume we obtained 2 bounce buffers for reuse
+    val numBuffers = 2
+    // 10000 in bytes ~ 2500 rows (minus validity/offset buffers) worth of contiguous
+    // single column int table, so we need 10 buffer-lengths to receive all of 25000 rows,
+    // the extra one adds 1 receive. Note that each receive is 2 buffers (except for the last one),
+    // so that is 6 receives expected.
+    val sizePerBuffer = 10000
+    // 5 receives (each with 2 buffers) makes for 100000 bytes + 1 receive for the remaining byte
+    val expectedReceives = 6
+    val bbs = (0 until numBuffers).map( _ => DeviceMemoryBuffer.allocate(sizePerBuffer))
+
+    withResource(bbs) { bounceBuffers =>
+      val brs = prepareBufferReceiveState(tableMeta, bounceBuffers)
+
+      assert(!brs.isDone)
+
+      // Kick off receives
+      client.doIssueBufferReceives(brs)
+
+      // If transactions are successful, we should have completed the receive
+      assert(brs.isDone)
+
+      // we would issue as many requests as required in order to get the full contiguous
+      // buffer
+      verify(mockConnection, times(expectedReceives))
+        .receive(any[Seq[AddressLengthTag]](), any[TransactionCallback]())
+
+      // the mock connection keeps track of every receive length
+      val totalReceived = mockConnection.receiveLengths.sum
+      val numBuffersUsed = mockConnection.receiveLengths.size
+
+      assertResult(tableMeta.bufferMeta().actualSize())(totalReceived)
+      assertResult(11)(numBuffersUsed)
+
+      // we would perform 1 request to issue a `TransferRequest`, so the server can start.
+      verify(mockConnection, times(1)).request(any(), any(), any[TransactionCallback]())
+
+      // we will hand off a `DeviceMemoryBuffer` to the catalog
+      val dmbCaptor = ArgumentCaptor.forClass(classOf[DeviceMemoryBuffer])
+      val tmCaptor = ArgumentCaptor.forClass(classOf[TableMeta])
+      verify(client, times(1)).track(any[DeviceMemoryBuffer](), tmCaptor.capture())
+      verifyTableMeta(tableMeta, tmCaptor.getValue.asInstanceOf[TableMeta])
+      verify(mockStorage, times(1))
+          .addBuffer(any(), dmbCaptor.capture(), any(), any())
+
+      assertResult(tableMeta.bufferMeta().actualSize())(
+        dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer].getLength)
+
+      // after closing, we should have freed our bounce buffers.
+      val capturedBuffers: ArgumentCaptor[Seq[MemoryBuffer]] =
+        ArgumentCaptor.forClass(classOf[Seq[MemoryBuffer]])
+      verify(mockTransport, times(1))
+        .freeReceiveBounceBuffers(capturedBuffers.capture())
+
+      val freedBuffers = capturedBuffers.getValue
+      assertResult(bounceBuffers)(freedBuffers)
+    }
+  }
+
+  test("errored/cancelled buffer fetch") {
+    Seq(TransactionStatus.Error, TransactionStatus.Cancelled).foreach { status =>
+      when(mockTransaction.getStatus).thenReturn(status)
+      when(mockTransaction.getErrorMessage).thenReturn(Some("Error/cancel occurred"))
+
+      val numRows = 100000
+      val tableMeta =
+        RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
+
+      // assume we obtained 2 bounce buffers, for reuse
+      val numBuffers = 2
+
+      // error condition, so it doesn't matter much what we set here, only the first
+      // receive will happen
+      val sizePerBuffer = numRows * 4 / 10
+      val bbs = (0 until numBuffers).map(_ => DeviceMemoryBuffer.allocate(sizePerBuffer))
+      withResource(bbs) { bounceBuffers =>
+        val brs = prepareBufferReceiveState(tableMeta, bounceBuffers)
+
+        assert(!brs.isDone)
+
+        // Kick off receives
+        client.doIssueBufferReceives(brs)
+
+        // Errored transaction. Therefore we should not be done
+        assert(!brs.isDone)
+
+        // We should have called `transferError` in the `RapidsShuffleFetchHandler`
+        verify(mockHandler, times(1)).transferError(any())
+
+        // there was 1 receive, and the chain stopped because it wasn't successful
+        verify(mockConnection, times(1)).receive(any[Seq[AddressLengthTag]](), any())
+
+        // we would have issued 1 request to issue a `TransferRequest` for the server to start
+        verify(mockConnection, times(1)).request(any(), any(), any())
+
+        // ensure we closed the BufferReceiveState => releasing the bounce buffers
+        val capturedBuffers: ArgumentCaptor[Seq[MemoryBuffer]] =
+          ArgumentCaptor.forClass(classOf[Seq[MemoryBuffer]])
+        verify(mockTransport, times(1))
+            .freeReceiveBounceBuffers(capturedBuffers.capture())
+
+        val freedBuffers = capturedBuffers.getValue
+        assertResult(bounceBuffers)(freedBuffers)
+      }
+
+      newMocks()
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -30,16 +30,11 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
   test("inability to get a client raises a fetch failure") {
     val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
 
-    val taskContext = mock[TaskContext]
-
-    when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
-
     val cl = new RapidsShuffleIterator(
       RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
       null,
       mockTransport,
-      blocksByAddress.toArray,
-      taskContext,
+      blocksByAddress,
       null)
 
     when(mockTransaction.getStatus).thenReturn(TransactionStatus.Error)
@@ -56,16 +51,11 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
 
       val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
 
-      val taskContext = mock[TaskContext]
-
-      when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
-
       val cl = new RapidsShuffleIterator(
         RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
         null,
         mockTransport,
-        blocksByAddress.toArray,
-        taskContext,
+        blocksByAddress,
         null)
 
       val ac = ArgumentCaptor.forClass(classOf[RapidsShuffleFetchHandler])
@@ -86,18 +76,13 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
   test("a new good batch is queued") {
     val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
 
-    val taskContext = mock[TaskContext]
-
-    when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
-
     val mockMetrics = mock[ShuffleMetricsUpdater]
 
     val cl = new RapidsShuffleIterator(
       RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
       null,
       mockTransport,
-      blocksByAddress.toArray,
-      taskContext,
+      blocksByAddress,
       mockMetrics,
       mockCatalog)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import com.nvidia.spark.rapids.{RapidsBuffer, ShuffleReceivedBufferId}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+
+import org.apache.spark.TaskContext
+import org.apache.spark.shuffle.RapidsShuffleFetchFailedException
+import org.apache.spark.sql.rapids.ShuffleMetricsUpdater
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
+  test("inability to get a client raises a fetch failure") {
+    val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
+
+    val taskContext = mock[TaskContext]
+
+    when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
+
+    val cl = new RapidsShuffleIterator(
+      RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
+      null,
+      mockTransport,
+      blocksByAddress.toArray,
+      taskContext,
+      null)
+
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Error)
+
+    when(mockTransport.makeClient(any(), any())).thenThrow(new IllegalStateException("Test"))
+
+    assert(cl.hasNext)
+    assertThrows[RapidsShuffleFetchFailedException](cl.next())
+  }
+
+  test("a transport error/cancellation raises a fetch failure") {
+    Seq(TransactionStatus.Error, TransactionStatus.Cancelled).foreach { status =>
+      when(mockTransaction.getStatus).thenReturn(status)
+
+      val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
+
+      val taskContext = mock[TaskContext]
+
+      when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
+
+      val cl = new RapidsShuffleIterator(
+        RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
+        null,
+        mockTransport,
+        blocksByAddress.toArray,
+        taskContext,
+        null)
+
+      val ac = ArgumentCaptor.forClass(classOf[RapidsShuffleFetchHandler])
+      when(mockTransport.makeClient(any(), any())).thenReturn(client)
+      doNothing().when(client).doFetch(any(), ac.capture(), any())
+      cl.start()
+
+      val handler = ac.getValue.asInstanceOf[RapidsShuffleFetchHandler]
+      handler.transferError("Test")
+
+      assert(cl.hasNext)
+      assertThrows[RapidsShuffleFetchFailedException](cl.next())
+
+      newMocks()
+    }
+  }
+
+  test("a new good batch is queued") {
+    val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
+
+    val taskContext = mock[TaskContext]
+
+    when(taskContext.addTaskCompletionListener[Unit](any())).thenReturn(null)
+
+    val mockMetrics = mock[ShuffleMetricsUpdater]
+
+    val cl = new RapidsShuffleIterator(
+      RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
+      null,
+      mockTransport,
+      blocksByAddress.toArray,
+      taskContext,
+      mockMetrics,
+      mockCatalog)
+
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Error)
+
+    val ac = ArgumentCaptor.forClass(classOf[RapidsShuffleFetchHandler])
+    when(mockTransport.makeClient(any(), any())).thenReturn(client)
+    doNothing().when(client).doFetch(any(), ac.capture(), any())
+    val bufferId = ShuffleReceivedBufferId(1)
+    val mockBuffer = mock[RapidsBuffer]
+
+    val cb = new ColumnarBatch(Seq[ColumnVector]().toArray, 10)
+
+    when(mockBuffer.getColumnarBatch).thenReturn(cb)
+    when(mockCatalog.acquireBuffer(any[ShuffleReceivedBufferId]())).thenReturn(mockBuffer)
+    doNothing().when(mockCatalog).removeBuffer(any())
+    cl.start()
+
+    val handler = ac.getValue.asInstanceOf[RapidsShuffleFetchHandler]
+    handler.start(1)
+    handler.batchReceived(bufferId)
+
+    assert(cl.hasNext)
+    assertResult(cb)(cl.next())
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import java.util.concurrent.Executor
+
+import ai.rapids.cudf.{ColumnVector, ContiguousTable}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.format.TableMeta
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{spy, when}
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.mockito.MockitoSugar
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockBatchId}
+
+class RapidsShuffleTestHelper extends FunSuite
+    with BeforeAndAfterEach
+    with MockitoSugar
+    with Arm {
+  var mockTransaction: Transaction = _
+  var mockConnection: MockConnection = _
+  var mockTransport: RapidsShuffleTransport = _
+  var mockExecutor: Executor = _
+  var mockCopyExecutor: Executor = _
+  var mockHandler: RapidsShuffleFetchHandler = _
+  var mockStorage: RapidsDeviceMemoryStore = _
+  var mockCatalog: ShuffleReceivedBufferCatalog = _
+  var client: RapidsShuffleClient = _
+
+  override def beforeEach(): Unit = {
+    newMocks()
+  }
+
+  def newMocks(): Unit = {
+    mockTransaction = mock[Transaction]
+    mockConnection = spy(new MockConnection(mockTransaction))
+    mockTransport = mock[RapidsShuffleTransport]
+    mockExecutor = new ImmediateExecutor
+    mockCopyExecutor = new ImmediateExecutor
+    mockHandler = mock[RapidsShuffleFetchHandler]
+    mockStorage = mock[RapidsDeviceMemoryStore]
+    mockCatalog = mock[ShuffleReceivedBufferCatalog]
+    client = spy(new RapidsShuffleClient(
+      1,
+      mockConnection,
+      mockTransport,
+      mockExecutor,
+      mockCopyExecutor,
+      1024,
+      mockStorage,
+      mockCatalog))
+  }
+}
+
+object RapidsShuffleTestHelper extends MockitoSugar with Arm {
+  def buildMockTableMeta(tableId: Int, contigTable: ContiguousTable): TableMeta = {
+    val tbl = contigTable.getTable
+    val cols = (0 until tbl.getNumberOfColumns).map(tbl.getColumn)
+    MetaUtils.buildTableMeta(tableId, cols, tbl.getRowCount, contigTable.getBuffer)
+  }
+
+  def withMockContiguousTable[T](numRows: Long)(body: ContiguousTable => T): T = {
+    val rows: Seq[Integer] = (0 until numRows.toInt).map(new Integer(_))
+    withResource(ColumnVector.fromBoxedInts(rows:_*)) { cvBase =>
+      cvBase.incRefCount()
+      val gpuCv = GpuColumnVector.from(cvBase)
+      withResource(new ColumnarBatch(Seq(gpuCv).toArray)) { cb =>
+        withResource(GpuColumnVector.from(cb)) { table =>
+          withResource(table.contiguousSplit(0, numRows.toInt)) { ct =>
+            body(ct(1)) // we get a degenerate table at 0 and another at 2
+          }
+        }
+      }
+    }
+  }
+
+  def mockMetaResponse(
+      mockTransport: RapidsShuffleTransport,
+      numRows: Long,
+      numBatches: Int,
+      maximumResponseSize: Long = 10000): Seq[TableMeta] =
+    withMockContiguousTable(numRows) { ct =>
+      val tableMetas = (0 until numBatches).map(b => buildMockTableMeta(b, ct))
+      val res = ShuffleMetadata.buildMetaResponse(tableMetas, maximumResponseSize)
+      val refCountedRes = new RefCountedDirectByteBuffer(res)
+      when(mockTransport.getMetaBuffer(any())).thenReturn(refCountedRes)
+      tableMetas
+    }
+
+  def prepareMetaTransferResponse(
+      mockTransport: RapidsShuffleTransport,
+      numRows: Long): TableMeta =
+    withMockContiguousTable(numRows) { ct =>
+      val tableMeta = buildMockTableMeta(1, ct)
+      val bufferMeta = tableMeta.bufferMeta()
+      val res = ShuffleMetadata.buildBufferTransferResponse(Seq(bufferMeta))
+      val refCountedRes = new RefCountedDirectByteBuffer(res)
+      when(mockTransport.getMetaBuffer(any())).thenReturn(refCountedRes)
+      tableMeta
+    }
+
+  def getShuffleBlocks: Seq[(ShuffleBlockBatchId, Long, Int)] = {
+    Seq(
+      (ShuffleBlockBatchId(1,1,1,1), 123L, 1),
+      (ShuffleBlockBatchId(2,2,2,2), 456L, 2),
+      (ShuffleBlockBatchId(3,3,3,3), 456L, 3)
+    )
+  }
+
+  def makeMockBlockManager(execId: String, host: String): BlockManagerId = {
+    val bmId = mock[BlockManagerId]
+    when(bmId.executorId).thenReturn(execId)
+    when(bmId.host).thenReturn(host)
+    bmId
+  }
+
+  def getBlocksByAddress: Array[(BlockManagerId, Seq[(BlockId, Long, Int)])] = {
+    val blocksByAddress = new ArrayBuffer[(BlockManagerId, Seq[(BlockId, Long, Int)])]()
+    val blocks = getShuffleBlocks
+    blocksByAddress.append((makeMockBlockManager("2", "2"), blocks))
+    blocksByAddress.toArray
+  }
+}
+
+class ImmediateExecutor extends Executor {
+  override def execute(runnable: Runnable): Unit = {
+    runnable.run()
+  }
+}
+
+class MockConnection(mockTransaction: Transaction) extends ClientConnection {
+  val requests = new ArrayBuffer[AddressLengthTag]
+  val receiveLengths = new ArrayBuffer[Long]
+  override def request(
+      request: AddressLengthTag,
+      response: AddressLengthTag,
+      cb: TransactionCallback): Transaction = {
+    requests.append(request)
+    cb(mockTransaction)
+    mockTransaction
+  }
+
+  override def receive(header: AddressLengthTag, cb: TransactionCallback): Transaction = {
+    cb(mockTransaction)
+    mockTransaction
+  }
+
+  override def receive(
+      bounceBuffers: Seq[AddressLengthTag],
+      cb: TransactionCallback): Transaction = {
+    receiveLengths.appendAll(bounceBuffers.map(_.length))
+    cb(mockTransaction)
+    mockTransaction
+  }
+
+  override def getPeerExecutorId: Long =
+    throw new UnsupportedOperationException
+
+  override def assignResponseTag: Long = 1L
+  override def assignBufferTag(msgId: Int): Long = 2L
+  override def composeRequestTag(requestType:  RequestType.Value): Long = 3L
+}
+


### PR DESCRIPTION
This is an initial PR introducing the `RapidsShuffleFetchFailedException` and some usage, to try and address some of the issues brought up in: https://github.com/NVIDIA/spark-rapids/issues/326

It also adds initial unit tests for the client side.

Note that the write side has a change squeezed in there. When a task fails, it will call the writer with `stop(false)` to signify a failure during its processing. Prior to this PR, we would shut down the storage all-together => this would cause all peers to *this* executor to fail in the future, given that we would now reuse the executor's JVM. This change tracks these "uncomitted" ShuffleBufferIds at the writer level. @jlowe FYI, happy to split that off, handle it differently, but adding it here for discussion.