### PR TITLE
Fix Scala compile phase to allow Java classes referencing Scala classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,14 @@
                         </execution>
                         <execution>
                             <id>scala-compile-first</id>
+                            <phase>process-resources</phase>
                             <goals>
                                 <goal>compile</goal>
                             </goals>
                         </execution>
                         <execution>
                             <id>scala-test-compile-first</id>
+                            <phase>process-test-resources</phase>
                             <goals>
                                 <goal>testCompile</goal>
                             </goals>


### PR DESCRIPTION
While working on a side-project, I noticed that I couldn't successfully reference a Scala class from a Java class in the same project.  The Java classes were being compiled before the Scala classes, and therefore the java compiler couldn't find the classes.  This updates the phase when Scala is compiled to fix the cross-reference issue.