### PR TITLE
Implement build-side rules for shuffle hash join

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -60,11 +60,6 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
     (A, B) => A.join(B, A("longs") === B("longs"), "Right")
   }
 
-  IGNORE_ORDER_testSparkResultsAreEqual2("Test hash full join", longsDf, biggerLongsDf,
-    conf = shuffledJoinConf) {
-    (A, B) => A.join(B, A("longs") === B("longs"), "FullOuter")
-  }
-
   IGNORE_ORDER_testSparkResultsAreEqual2("Test cross join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {
     (A, B) => A.join(B.hint("broadcast"), A("longs") < B("longs"), "Cross")

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -60,6 +60,11 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
     (A, B) => A.join(B, A("longs") === B("longs"), "Right")
   }
 
+  IGNORE_ORDER_testSparkResultsAreEqual2("Test hash full join", longsDf, biggerLongsDf,
+    conf = shuffledJoinConf) {
+    (A, B) => A.join(B, A("longs") === B("longs"), "FullOuter")
+  }
+
   IGNORE_ORDER_testSparkResultsAreEqual2("Test cross join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {
     (A, B) => A.join(B.hint("broadcast"), A("longs") < B("longs"), "Cross")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
@@ -82,12 +82,22 @@ class GpuSortMergeJoinMeta(
       childPlans(1).convertIfNeeded())
   }
 
+  /**
+   * Determine if this type of join supports using the right side of the join as the build side.
+   *
+   * These rules match those in Spark's ShuffleHashJoinExec.
+   */
   private def canBuildRight(joinType: JoinType): Boolean = joinType match {
     case _: InnerLike | LeftOuter | LeftSemi | LeftAnti | _: ExistenceJoin => true
     case _ => false
   }
 
-  // note that the plugin supports FullOuter shuffle hash joins where Spark does not
+  /**
+   * Determine if this type of join supports using the left side of the join as the build side.
+   *
+   * These rules match those in Spark's ShuffleHashJoinExec, with the addition of support for
+   * full outer joins.
+   */
   private def canBuildLeft(joinType: JoinType): Boolean = joinType match {
     case _: InnerLike | RightOuter | FullOuter => true
     case _ => false


### PR DESCRIPTION
This PR implements the same logic that Spark uses to determine whether the left or right side of a shuffle hash join can safely be used as the build side.

This fixed one test failure in the AQE proof-of-concept work (hash right join).