### PR TITLE
Make GpuShuffledHashJoin Api consistent

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -21,7 +21,6 @@ import com.nvidia.spark.rapids.GpuMetricNames._
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClusteredDistribution}
 import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
@@ -50,21 +49,21 @@ class GpuShuffledHashJoinMeta(
 
   override def convertToGpu(): GpuExec =
     GpuShuffledHashJoinExec(
-      leftKeys.map(_.convertToGpu()),
-      rightKeys.map(_.convertToGpu()),
+      leftKeys.map(_.convertToGpu()).asInstanceOf[Seq[GpuExpression]],
+      rightKeys.map(_.convertToGpu()).asInstanceOf[Seq[GpuExpression]],
       join.joinType,
       join.buildSide,
-      condition.map(_.convertToGpu()),
+      condition.map(_.convertToGpu()).asInstanceOf[Option[GpuExpression]],
       childPlans(0).convertIfNeeded(),
       childPlans(1).convertIfNeeded())
 }
 
 case class GpuShuffledHashJoinExec(
-    leftKeys: Seq[Expression],
-    rightKeys: Seq[Expression],
+    leftKeys: Seq[GpuExpression],
+    rightKeys: Seq[GpuExpression],
     joinType: JoinType,
     buildSide: BuildSide,
-    condition: Option[Expression],
+    condition: Option[GpuExpression],
     left: SparkPlan,
     right: SparkPlan) extends BinaryExecNode with GpuHashJoin {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinExec.scala
@@ -65,11 +65,11 @@ class GpuSortMergeJoinMeta(
 
   override def convertToGpu(): GpuExec = {
     GpuShuffledHashJoinExec(
-      leftKeys.map(_.convertToGpu()),
-      rightKeys.map(_.convertToGpu()),
+      leftKeys.map(_.convertToGpu()).asInstanceOf[Seq[GpuExpression]],
+      rightKeys.map(_.convertToGpu()).asInstanceOf[Seq[GpuExpression]],
       join.joinType,
       BuildRight, // just hardcode one side
-      condition.map(_.convertToGpu()),
+      condition.map(_.convertToGpu()).asInstanceOf[Option[GpuExpression]],
       childPlans(0).convertIfNeeded(),
       childPlans(1).convertIfNeeded())
   }


### PR DESCRIPTION
This is a simple PR where the GpuShuffledHashJoin uses GpuExpression instead of Expression. 
This closes https://github.com/NVIDIA/spark-rapids/issues/238
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
