### PR TITLE
Change spark tgz package name

### DIFF
--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -30,12 +30,12 @@ rm -rf $ARTF_ROOT && mkdir -p $ARTF_ROOT
 
 # Download a full version of spark
 $MVN_GET_CMD \
-    -DgroupId=org.apache -DartifactId=spark -Dversion=$SPARK_VER -Dclassifier=bin-hadoop3 -Dpackaging=tar.gz
+    -DgroupId=org.apache -DartifactId=spark -Dversion=$SPARK_VER -Dclassifier=bin-hadoop3.2 -Dpackaging=tgz
 
-export SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3"
+export SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3.2"
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
-tar zxf $SPARK_HOME.tar.gz -C $ARTF_ROOT && \
-    rm -f $SPARK_HOME.tar.gz
+tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
+    rm -f $SPARK_HOME.tgz
 
 mvn -U -B $MVN_URM_MIRROR clean verify -Dpytest.TEST_TAGS=''
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -49,12 +49,12 @@ RAPDIS_INT_TESTS_TGZ="$ARTF_ROOT/rapids-4-spark-integration-tests_${SCALA_BINARY
 tar xzf "$RAPDIS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPDIS_INT_TESTS_TGZ"
 
 $MVN_GET_CMD \
-    -DgroupId=org.apache -DartifactId=spark -Dversion=$SPARK_VER -Dclassifier=bin-hadoop3 -Dpackaging=tar.gz
+    -DgroupId=org.apache -DartifactId=spark -Dversion=$SPARK_VER -Dclassifier=bin-hadoop3.2 -Dpackaging=tgz
 
-SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3"
+SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3.2"
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
-tar zxf $SPARK_HOME.tar.gz -C $ARTF_ROOT && \
-    rm -f $SPARK_HOME.tar.gz
+tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
+    rm -f $SPARK_HOME.tgz
 
 PARQUET_PERF="$WORKSPACE/integration_tests/src/test/resources/parquet_perf"
 PARQUET_ACQ="$WORKSPACE/integration_tests/src/test/resources/parquet_acq"


### PR DESCRIPTION
1, Change the spark tgz package name to align the apache release package name. 

    `From: spark-3.0.1-SNAPSHOT-bin-hadoop3.tar.gz`

    `To:   spark-3.0.1-SNAPSHOT-bin-hadoop3.2.tgz`

2, Only update Jenkins scripts, no source change. No unit tests needed.

3, No Github issue related to the PR.