### PR TITLE
Fix broadcast nested loop join for the no column case

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -98,7 +98,6 @@ def test_broadcast_nested_loop_join(data_gen):
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/323')
 def test_broadcast_nested_loop_join_special_case(data_gen):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)


### PR DESCRIPTION
This fixes #323

It fixes BroadcastExchangeExec to work for sending a ColumnarBatch with no columns, only a row count.  It also refactors the code in GpuCartesianProductExec.scala  that handles this use case so the code that can be common is.