### PR TITLE
Fix rat issue for notebooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
                     <artifactId>apache-rat-plugin</artifactId>
                     <version>0.13</version>
                     <configuration>
-			    <consoleOutput>${rat.consoleOutput}</consoleOutput>
+                        <consoleOutput>${rat.consoleOutput}</consoleOutput>
                     </configuration>
                     <executions>
                         <execution>
@@ -481,8 +481,10 @@
                         <exclude>**/.m2/**</exclude>
                         <exclude>.gnupg/**</exclude>
                         <exclude>pom.xml.asc</exclude>
-			<exclude>jenkins/databricks/*.patch</exclude>
-			<exclude>*.jar</exclude>
+                        <exclude>jenkins/databricks/*.patch</exclude>
+                        <exclude>*.jar</exclude>
+                        <exclude>docs/demo/**/*.ipynb</exclude>
+                        <exclude>docs/demo/**/*.zpln</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Some notebooks were added as demos.  I have opted to exclude them from the rat checks because the notebooks are all JSON formatted files and I am not sure how the tools will react to having a license header inserted into them.  I am also not sure how the rat tool would react if we tried to insert the license into the notebook itself, which would then turn it into a JSON string with `\n` escaped.