### PR TITLE
Add our session extension correctly if there are other extensions configured

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -67,7 +67,7 @@ object RapidsPluginUtils extends Logging {
     if (conf.contains(SQL_PLUGIN_CONF_KEY)) {
       val previousValue = conf.get(SQL_PLUGIN_CONF_KEY).split(",").map(_.trim)
       if (!previousValue.contains(SQL_PLUGIN_NAME)) {
-        conf.set(SQL_PLUGIN_CONF_KEY, previousValue + "," + SQL_PLUGIN_NAME)
+        conf.set(SQL_PLUGIN_CONF_KEY, (previousValue :+ SQL_PLUGIN_NAME).mkString(","))
       } else {
         conf.set(SQL_PLUGIN_CONF_KEY, previousValue.mkString(","))
       }


### PR DESCRIPTION
Fixes a small bug if other Spark Session Extensions (`--conf spark.sql.extensions`) were already specified at launch, as we mutate this collection to add our own extension.