### PR TITLE
Add tests for GpuPartition

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -190,7 +190,7 @@ object GpuDeviceManager extends Logging {
       try {
         Cuda.setDevice(gpuId)
         Rmm.initialize(init, logConf, initialAllocation)
-        GpuShuffleEnv.initStorage(conf, info)
+        GpuShuffleEnv.init(info)
       } catch {
         case e: Exception => logError("Could not initialize RMM", e)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -72,7 +72,7 @@ object GpuSemaphore {
    *       the semaphore is always released by the time the task completes.
    */
   def acquireIfNecessary(context: TaskContext): Unit = {
-    if (enabled) {
+    if (enabled && context != null) {
       getInstance.acquireIfNecessary(context)
     }
   }
@@ -81,7 +81,7 @@ object GpuSemaphore {
    * Tasks must call this when they are finished using the GPU.
    */
   def releaseIfNecessary(context: TaskContext): Unit = {
-    if (enabled) {
+    if (enabled && context != null) {
       getInstance.releaseIfNecessary(context)
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -368,7 +368,7 @@ class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
   override def shuffleBlockResolver: ShuffleBlockResolver = resolver
 
   override def stop(): Unit = {
-    GpuShuffleEnv.closeStorage()
+    GpuShuffleEnv.shutdown()
     wrapped.stop()
     server.foreach(_.close())
     transport.foreach(_.close())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.io.File
+
+import ai.rapids.cudf.{Cuda, Table}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import org.scalatest.FunSuite
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GpuPartitioningSuite extends FunSuite with Arm {
+  private def buildBatch(): ColumnarBatch = {
+    withResource(new Table.TestBuilder()
+        .column(5, null.asInstanceOf[java.lang.Integer], 3, 1, 1, 1, 1, 1, 1, 1)
+        .column("five", "two", null, null, "one", "one", "one", "one", "one", "one")
+        .column(5.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        .build()) { table =>
+      GpuColumnVector.from(table)
+    }
+  }
+
+  private def buildSubBatch(batch: ColumnarBatch, startRow: Int, endRow: Int): ColumnarBatch = {
+    val columns = GpuColumnVector.extractBases(batch)
+    val sliced = columns.safeMap(c => GpuColumnVector.from(c.subVector(startRow, endRow)))
+    new ColumnarBatch(sliced.toArray, endRow - startRow)
+  }
+
+  private def compareBatches(expected: ColumnarBatch, actual: ColumnarBatch): Unit = {
+    assertResult(expected.numRows)(actual.numRows)
+    assertResult(expected.numCols)(actual.numCols)
+    val expectedColumns = GpuColumnVector.extractBases(expected)
+    val actualColumns = GpuColumnVector.extractBases(expected)
+    expectedColumns.zip(actualColumns).foreach { case (expected, actual) =>
+      withResource(expected.equalToNullAware(actual)) { compareVector =>
+        withResource(compareVector.all()) { compareResult =>
+          assert(compareResult.getBoolean)
+        }
+      }
+    }
+  }
+
+  def withGpuSparkSession(conf: SparkConf)(f: SparkSession => Unit): Unit = {
+    SparkSession.getActiveSession.foreach(_.close())
+    val spark = SparkSession.builder()
+        .master("local[1]")
+        .config(conf)
+        .config(RapidsConf.SQL_ENABLED.key, "true")
+        .config("spark.plugins", "com.nvidia.spark.SQLPlugin")
+        .appName(classOf[GpuPartitioningSuite].getSimpleName)
+        .getOrCreate()
+    try {
+      f(spark)
+    } finally {
+      spark.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    }
+  }
+
+  test("GPU partition") {
+    SparkSession.getActiveSession.foreach(_.close())
+    val conf = new SparkConf()
+    withGpuSparkSession(conf) { spark =>
+      GpuShuffleEnv.init(Cuda.memGetInfo())
+      val partitionIndices = Array(0, 2)
+      val gp = new GpuPartitioning {
+        override val numPartitions: Int = partitionIndices.length
+      }
+      withResource(buildBatch()) { batch =>
+        val columns = GpuColumnVector.extractColumns(batch)
+        withResource(gp.sliceInternalOnGpu(batch, partitionIndices, columns)) { partitions =>
+          partitions.zipWithIndex.foreach { case (partBatch, partIndex) =>
+            val startRow = partitionIndices(partIndex)
+            val endRow = if (partIndex < partitionIndices.length - 1) {
+              partitionIndices(partIndex + 1)
+            } else {
+              batch.numRows
+            }
+            val expectedRows = endRow - startRow
+            assertResult(expectedRows)(partBatch.numRows)
+            val columns = (0 until partBatch.numCols).map(i => partBatch.column(i))
+            columns.foreach { column =>
+              assert(column.isInstanceOf[GpuColumnVectorFromBuffer])
+              assertResult(expectedRows)(column.asInstanceOf[GpuColumnVector].getRowCount)
+            }
+            withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
+              compareBatches(expectedBatch, partBatch)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds unit tests for `GpuPartition`.  During testing I found a number of issues that are also addressed in this PR:
- `GpuShuffleEnv` was a Scala object that didn't support reinitializing which is needed for unit tests to run in various shuffle configurations.  Updated it to support reinitializing the state.
- `SparkSessionHolder` doesn't handle cases where other tests tear down the Spark session and a new one needs to be created.  Updated the session holder to handle this case.
- HashSortOptimizeSuite assumed there was one and only one spark session, updated it to use the session handed to it.
- GpuSemaphore would crash if there was no task context.  I updated it to be a no-op when there's no task context (i.e.: during unit tests).
