### PR TITLE
Fix download link

### DIFF
--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -43,7 +43,7 @@ scala version 2.12 is currently supported by the accelerator.
 ## Download the RAPIDS jars
 The [accelerator](https://mvnrepository.com/artifact/com.nvidia/rapids-4-spark_2.12) and 
 [cudf](https://mvnrepository.com/artifact/ai.rapids/cudf) jars are available in the 
-[download](/docs/version/stable-release#download) section.
+[download](../version/stable-release.md#download) section.
 
 Download the RAPIDS Accelerator for Apache Spark plugin jar. Then download the version of the cudf
 jar that your version of the accelerator depends on. Each cudf jar is for a specific version of


### PR DESCRIPTION
Fixes #408 

Updates the download link to be relative and referencing the markdown file.  @sameerz I tested this with Github's normal markdown rendering, would be good to verify this works with Jekyll. 