### PR TITLE
CI Add unit tests running for Spark 3.0.1

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -20,6 +20,10 @@ set -ex
 . jenkins/version-def.sh
 
 mvn -U -B clean deploy $MVN_URM_MIRROR -Dmaven.repo.local=$WORKSPACE/.m2
+# Run unit tests against other spark versions
+mvn -U -B -Pspark301tests test $MVN_URM_MIRROR -Dmaven.repo.local=$WORKSPACE/.m2
+# spark310 unit tests fail - https://github.com/NVIDIA/spark-rapids/issues/382
+#mvn -U -B -Pspark310tests test $MVN_URM_MIRROR -Dmaven.repo.local=$WORKSPACE/.m2
 
 # Parse cudf and spark files from local mvn repo
 jenkins/printJarVersion.sh "CUDFVersion" "${WORKSPACE}/.m2/ai/rapids/cudf/${CUDF_VER}" "cudf-${CUDF_VER}" "-${CUDA_CLASSIFIER}.jar"

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -38,6 +38,9 @@ tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
 
 mvn -U -B $MVN_URM_MIRROR clean verify -Dpytest.TEST_TAGS=''
+mvn -U -B $MVN_URM_MIRROR -Pspark301tests test -Dpytest.TEST_TAGS=''
+# spark310 unit tests fail - https://github.com/NVIDIA/spark-rapids/issues/382
+#mvn -U -B $MVN_URM_MIRROR -Pspark310tests test -Dpytest.TEST_TAGS=''
 
 # The jacoco coverage should have been collected, but because of how the shade plugin
 # works and jacoco we need to clean some things up so jacoco will only report for the

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -38,9 +38,10 @@ tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
 
 mvn -U -B $MVN_URM_MIRROR clean verify -Dpytest.TEST_TAGS=''
-mvn -U -B $MVN_URM_MIRROR -Pspark301tests test -Dpytest.TEST_TAGS=''
+# Run the unit tests for other Spark versions but dont run full python integration tests
+env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark301tests test -Dpytest.TEST_TAGS=''
 # spark310 unit tests fail - https://github.com/NVIDIA/spark-rapids/issues/382
-#mvn -U -B $MVN_URM_MIRROR -Pspark310tests test -Dpytest.TEST_TAGS=''
+#env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark310tests test -Dpytest.TEST_TAGS=''
 
 # The jacoco coverage should have been collected, but because of how the shade plugin
 # works and jacoco we need to clean some things up so jacoco will only report for the


### PR DESCRIPTION
Nightly and Premerge run unit tests against Spark 3.0.1 as well. 3.1.0 have a few failures we need to fix first.

Let me know thoughts if we think this will take to long for premerge. 