### PR TITLE
Fix duplicates includes in assembly jar

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -105,6 +105,19 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>com.nvidia:rapids-4-spark_2.12:jar:</artifact>
+                  <includes>
+                    <include>META-INF/maven/com/nvidia/rapids-4-spark_2.12/</include>
+                  </includes>
+                  <excludes>
+                    <exclude>com/nvidia/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -108,12 +108,12 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>com.nvidia:rapids-4-spark_2.12:jar:</artifact>
+                  <artifact>com.nvidia:rapids-4-spark_2.12</artifact>
                   <includes>
-                    <include>META-INF/maven/com/nvidia/rapids-4-spark_2.12/</include>
+                    <include>META-INF/**</include>
                   </includes>
                   <excludes>
-                    <exclude>com/nvidia/**</exclude>
+                    <exclude>META-INF/services/**</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
After shimlayer was merged if you didn't clean you saw an error:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.2.1:shade (default) on project rapids-4-spark_2.12: Error creating shaded jar: duplicate entry: META-INF/services/com.nvidia.shaded.spark.orc.DataMask$Provider -> [Help 1]

The problem was actually there already that we are including the already built assembly jar, the new service loader transformer that was added just caused it to fail.

This modifies it to only include the META-INF pom file from that package when assembling:
     0 Thu Jul 23 21:51:06 CDT 2020 META-INF/maven/com.nvidia/rapids-4-spark_2.12/
  5987 Thu Jul 23 21:47:32 CDT 2020 META-INF/maven/com.nvidia/rapids-4-spark_2.12/pom.xml
   123 Thu Jul 23 21:50:08 CDT 2020 META-INF/maven/com.nvidia/rapids-4-spark_2.12/pom.properties

This is what we were including previously.