### PR TITLE
Fix batch use-after-close in partitioning, shuffle env init

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioning.scala
@@ -121,6 +121,7 @@ case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
     //  We are doing this here because the cudf partition command is at this level
     val totalRange = new NvtxRange("Hash partition", NvtxColor.PURPLE)
     try {
+      val numRows = batch.numRows
       val (partitionIndexes, partitionColumns) = {
         val partitionRange = new NvtxRange("partition", NvtxColor.BLUE)
         try {
@@ -129,7 +130,7 @@ case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
           partitionRange.close()
         }
       }
-      val ret = sliceInternalGpuOrCpu(batch, partitionIndexes, partitionColumns)
+      val ret = sliceInternalGpuOrCpu(numRows, partitionIndexes, partitionColumns)
       partitionColumns.safeClose()
       // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioning.scala
@@ -120,6 +120,7 @@ case class GpuRangePartitioning(
       slicedSortedTbl = new Table(sortColumns: _*)
       //get the final column batch, remove the sort order sortColumns
       finalSortedCb = GpuColumnVector.from(sortedTbl, numSortCols, sortedTbl.getNumberOfColumns)
+      val numRows = finalSortedCb.numRows
       partitionColumns = GpuColumnVector.extractColumns(finalSortedCb)
       // get the ranges table and get upper bounds if possible
       // rangeBounds can be empty or of length < numPartitions in cases where the samples are less
@@ -132,7 +133,7 @@ case class GpuRangePartitioning(
         retCv = slicedSortedTbl.upperBound(nullFlags.toArray, rangesTbl, descFlags.toArray)
         parts = parts ++ GpuColumnVector.toIntArray(retCv)
       }
-      slicedCb = sliceInternalGpuOrCpu(finalSortedCb, parts, partitionColumns)
+      slicedCb = sliceInternalGpuOrCpu(numRows, parts, partitionColumns)
     } finally {
       batch.close()
       if (inputCvs != null) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -67,6 +67,7 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
     }
     val totalRange = new NvtxRange("Round Robin partition", NvtxColor.PURPLE)
     try {
+      val numRows = batch.numRows
       val (partitionIndexes, partitionColumns) = {
         val partitionRange = new NvtxRange("partition", NvtxColor.BLUE)
         try {
@@ -77,7 +78,7 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
         }
       }
       val ret: Array[ColumnarBatch] =
-        sliceInternalGpuOrCpu(batch, partitionIndexes, partitionColumns)
+        sliceInternalGpuOrCpu(numRows, partitionIndexes, partitionColumns)
       partitionColumns.safeClose()
       // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
@@ -38,14 +38,13 @@ case class GpuSinglePartitioning(expressions: Seq[Expression])
       Array(batch).zipWithIndex
     } else {
       try {
-        // Need to produce a contiguous table. Until there's a direct way to do this, using
-        // contiguous split as a workaround, closing any degenerate table after the first one.
+        // Nothing needs to be sliced but a contiguous table is needed for GPU shuffle which
+        // slice will produce.
         val sliced = sliceInternalGpuOrCpu(
-          batch,
-          Array(0, batch.numRows),
+          batch.numRows,
+          Array(0),
           GpuColumnVector.extractColumns(batch))
-        sliced.drop(1).foreach(_.close())
-        sliced.take(1).zipWithIndex
+        sliced.zipWithIndex
       } finally {
         batch.close()
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{Cuda, Table}
+import org.scalatest.FunSuite
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.rapids.GpuShuffleEnv
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GpuSinglePartitioningSuite extends FunSuite with Arm {
+  private def buildBatch(): ColumnarBatch = {
+    withResource(new Table.TestBuilder()
+        .column(5, null.asInstanceOf[java.lang.Integer], 3, 1, 1, 1, 1, 1, 1, 1)
+        .column("five", "two", null, null, "one", "one", "one", "one", "one", "one")
+        .column(5.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        .build()) { table =>
+      GpuColumnVector.from(table)
+    }
+  }
+
+  test("generates contiguous split") {
+    val conf = new SparkConf().set("spark.shuffle.manager", GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS)
+    TestUtils.withGpuSparkSession(conf) { _ =>
+      GpuShuffleEnv.init(Cuda.memGetInfo())
+      val partitioner = GpuSinglePartitioning(Nil)
+      withResource(buildBatch()) { expected =>
+        // partition will consume batch, so make a new batch with incremented refcounts
+        val columns = GpuColumnVector.extractColumns(expected)
+        columns.foreach(_.incRefCount())
+        val batch = new ColumnarBatch(columns.toArray, expected.numRows)
+        val result = partitioner.columnarEval(batch).asInstanceOf[Array[(ColumnarBatch, Int)]]
+        try {
+          assertResult(1)(result.length)
+          assertResult(0)(result.head._2)
+          val resultBatch = result.head._1
+          // verify this is a contiguous split table
+          assert(resultBatch.column(0).isInstanceOf[GpuColumnVectorFromBuffer])
+          TestUtils.compareBatches(expected, resultBatch)
+        } finally {
+          result.foreach(_._1.close())
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I noticed that `GpuHashPartitioning` was closing the batch in `partitionInternal` but then subsequently passing it to `sliceInternalGpuOrCpu`.  This "works" because all the latter function really wants from the batch is the row count.  To avoid any nasty surprises in the future, I updated this method to expect the row count instead of the batch.

This also addresses the TODO in `GpuSingleGpuPartitioning` where it is over-slicing the table and then throwing away the degenerate pieces as a workaround to a problem in libcudf's splitting functionality.  That has since been fixed, so the workaround is removed.  I added a unit test to verify this is working as intended, and in the process discovered that `GpuShuffleEnv` can attempt to be accessed by the shuffle manager before it's initialized which is also fixed here.