### PR TITLE
Check a PR has been committed using git signoff

### DIFF
--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -53,7 +53,7 @@ pipeline {
                 script {
                     //Check if a PR has been committed using git signoff
                     if (!isSignedOff()) {
-                        echo "Signed-off-by check FAIED"
+                        echo "Signed-off-by check FAILED"
                         exit(-1)
                     }
 

--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -53,8 +53,7 @@ pipeline {
                 script {
                     //Check if a PR has been committed using git signoff
                     if (!isSignedOff()) {
-                        echo "Signed-off-by check FAILED"
-                        exit(-1)
+                        error "Signed-off-by check FAILED"
                     }
 
                     def CUDA_NAME=sh(returnStdout: true,
@@ -88,7 +87,7 @@ boolean isSignedOff() {
     def signed_off = false
     for( String commit : revs_arr ) {
         def signed_log = sh(returnStdout: true,
-                script: "git show ${commit} --shortstat | grep 'Signed-off-by'")
+                script: "git show ${commit} --shortstat | grep 'Signed-off-by' || true")
         echo "commit: ${commit}, signed_log: ${signed_log}"
         // Find `Signed-off-by` comment in one of the commits
         if (signed_log?.trim()) {

--- a/jenkins/Jenkinsfile.premerge
+++ b/jenkins/Jenkinsfile.premerge
@@ -51,6 +51,12 @@ pipeline {
             agent { label 'docker-gpu' }
             steps {
                 script {
+                    //Check if a PR has been committed using git signoff
+                    if (!isSignedOff()) {
+                        echo "Signed-off-by check FAIED"
+                        exit(-1)
+                    }
+
                     def CUDA_NAME=sh(returnStdout: true,
                         script: '. jenkins/version-def.sh>&2 && echo -n $CUDA_CLASSIFIER | sed "s/-/./g"')
                     def IMAGE_NAME="$ARTIFACTORY_NAME/sw-spark-docker/plugin:dev-ubuntu16-$CUDA_NAME"
@@ -72,3 +78,24 @@ pipeline {
         }
     } // end of stages
 } // end of pipeline
+
+boolean isSignedOff() {
+    def target_rev = sh(returnStdout: true,
+            script: "git rev-parse refs/remotes/origin/${ghprbTargetBranch}").trim()
+    def revs_arr = sh(returnStdout: true,
+            script: "git log ${target_rev}..${ghprbActualCommit} --pretty=format:%h").split()
+
+    def signed_off = false
+    for( String commit : revs_arr ) {
+        def signed_log = sh(returnStdout: true,
+                script: "git show ${commit} --shortstat | grep 'Signed-off-by'")
+        echo "commit: ${commit}, signed_log: ${signed_log}"
+        // Find `Signed-off-by` comment in one of the commits
+        if (signed_log?.trim()) {
+            signed_off = true
+            break;
+        }
+    }
+
+    return signed_off
+}


### PR DESCRIPTION
1. Pre-merge build fails without seeing a `-s` signoff from anyone committing to a PR.

    If the author of a commit adds a single commit with a `-s`, that will be sufficient for the pre-merge build to pass.

2, Only update Jenkins scripts, no source change. No unit tests needed.

3, No Github issue related to the PR.