### PR TITLE
Run mortgage test both with AQE on and off

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageAdaptiveSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageAdaptiveSparkSuite.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tests.mortgage
+
+class MortgageAdaptiveSparkSuite extends MortgageSparkSuite {
+  override def adaptiveQueryEnabled: Boolean = true
+}

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -23,10 +23,18 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
 class MortgageSparkSuite extends FunSuite {
+
+  /**
+   * This is intentionally a def rather than a val so that scalatest uses the correct value (from
+   * this class or the derived class) when registering tests.
+   */
+  def adaptiveQueryEnabled = false
+
   lazy val  session: SparkSession = {
     var builder = SparkSession.builder
       .master("local[2]")
       .appName("MortgageTests")
+      .config("spark.sql.adaptive.enabled", adaptiveQueryEnabled)
       .config("spark.sql.join.preferSortMergeJoin", false)
       .config("spark.sql.shuffle.partitions", 2)
       .config("spark.plugins", "com.nvidia.spark.SQLPlugin")


### PR DESCRIPTION
In preparation for adding optimized AQE support, this PR updates the mortgage ETL integration test to run with AQE on and off, for consistency with the TPCHLike tests.