### PR TITLE
Add closeOnExcept to clean up code that closes resources only on exceptions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -15,6 +15,8 @@
  */
 package com.nvidia.spark.rapids
 
+import scala.collection.mutable.ArrayBuffer
+
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 /** Implementation of the automatic-resource-management pattern */
@@ -35,6 +37,39 @@ trait Arm {
       block(r)
     } finally {
       r.safeClose()
+    }
+  }
+
+  /** Executes the provided code block, closing the resource only if an exception occurs */
+  def closeOnExcept[T <: AutoCloseable, V](r: T)(block: T => V): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.safeClose()
+        throw t
+    }
+  }
+
+  /** Executes the provided code block, closing the resources only if an exception occurs */
+  def closeOnExcept[T <: AutoCloseable, V](r: Seq[T])(block: Seq[T] => V): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.safeClose()
+        throw t
+    }
+  }
+
+  /** Executes the provided code block, closing the resources only if an exception occurs */
+  def closeOnExcept[T <: AutoCloseable, V](r: ArrayBuffer[T])(block: ArrayBuffer[T] => V): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.safeClose()
+        throw t
     }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.scalatest.FunSuite
+
+class ArmSuite extends FunSuite with Arm {
+  class TestResource extends AutoCloseable {
+    var closed = false
+
+    override def close(): Unit = {
+      closed = true
+    }
+  }
+
+  class TestException extends RuntimeException
+
+  test("closeOnExcept single instance") {
+    val resource = new TestResource
+    closeOnExcept(resource) { r => assertResult(resource)(r) }
+    assertResult(false)(resource.closed)
+    try {
+      closeOnExcept(resource) { _ => throw new TestException }
+    } catch {
+      case _: TestException =>
+    }
+    assert(resource.closed)
+  }
+
+  test("closeOnExcept sequence") {
+    val resources = new Array[TestResource](3)
+    resources(0) = new TestResource
+    resources(2) = new TestResource
+    closeOnExcept(resources) { r => assertResult(resources)(r) }
+    assert(resources.forall(r => Option(r).forall(!_.closed)))
+    try {
+      closeOnExcept(resources) { _ => throw new TestException }
+    } catch {
+      case _: TestException =>
+    }
+    assert(resources.forall(r => Option(r).forall(_.closed)))
+  }
+
+  test("closeOnExcept arraybuffer") {
+    val resources = new ArrayBuffer[TestResource]
+    closeOnExcept(resources) { r =>
+      r += new TestResource
+      r += null
+      r += new TestResource
+    }
+    assertResult(3)(resources.length)
+    assert(resources.forall(r => Option(r).forall(!_.closed)))
+    try {
+      closeOnExcept(resources) { r =>
+        r += new TestResource
+        throw new TestException
+      }
+    } catch {
+      case _: TestException =>
+    }
+    assertResult(4)(resources.length)
+    assert(resources.forall(r => Option(r).forall(_.closed)))
+  }
+}


### PR DESCRIPTION
I've been bumping into a number of cases where a resource is obtained, some computation needs to happen on that resource, then ownership of the resource is handed off to somewhere else.  During the computation it's important to cover the exception path, which means writing code that looks something like this:
```
val r = ...some code that obtains a resource...
try {
  ...some code that computes on the resource...
} catch {
  case t: Throwable =>
    r.safeClose()
    throw t
}
```

The `withResource` code is a nice wrapper for handling the case where a resource must always be closed, but we don't have something to cover the case where a resource should only be closed if an exception occurs.

This PR adds `closeOnExcept` methods that are similar to `withResource` but closing in a `catch` clause rather than a `finally` block.  It also updates code that was using this code pattern.