### PR TITLE
Turn off noscaladoc rule until codebase is fixed

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -96,17 +96,17 @@ You can also disable only one rule, by specifying its rule id, as specified in:
     <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage"
            enabled="true"/>
 
+    <!-- ================================================================================ -->
+    <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
+    <!-- ================================================================================ -->
+
     <check customId="NoScalaDoc" level="error" class="org.scalastyle.file.RegexChecker"
-           enabled="true">
+           enabled="false">
         <parameters>
             <parameter name="regex">(?m)^(\s*)/[*][*].*$(\r|)\n^\1  [*]</parameter>
         </parameters>
         <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
     </check>
-
-    <!-- ================================================================================ -->
-    <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
-    <!-- ================================================================================ -->
 
     <!-- This project uses Javadoc rather than Scaladoc so scaladoc checks are disabled -->
     <check enabled="false" class="org.scalastyle.scalariform.ScalaDocChecker" level="warning"/>


### PR DESCRIPTION
The NoScalaDoc rule was turned on by #449 but this was tested without #450 applied.  When they both went in with separate CI checks, the build broke.  We need the fix from #461 but until we get the needed signoff this will disable the check to allow CI and builds to pass.