### PR TITLE
Update HashAggregateSuite to work with AQE

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -21,7 +21,7 @@ import java.sql.Timestamp
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.execution.{SparkPlan, WholeStageCodegenExec}
-import org.apache.spark.sql.execution.adaptive.{BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DataTypes}
@@ -119,13 +119,19 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       val cpuPlan = df.queryExecution.sparkPlan
       assert(cpuPlan.find(_.isInstanceOf[SortAggregateExec]).isDefined)
 
-      val gpuPlan = df.queryExecution.executedPlan
+      var gpuPlan = df.queryExecution.executedPlan
+      df.collect()
 
       gpuPlan match {
         case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _)) =>
           assert(plan.children.head.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
+
+        case a: AdaptiveSparkPlanExec =>
+          assert(a.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
+          assert(a.executedPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
+          assert(a.executedPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 
         case _ =>
           fail("Incorrect plan")
@@ -149,6 +155,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       assert(cpuPlan.find(_.isInstanceOf[SortAggregateExec]).isDefined)
 
       val gpuPlan = df.queryExecution.executedPlan
+      df.collect()
 
       gpuPlan match {
         case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _)) =>
@@ -156,6 +163,12 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.find(_.isInstanceOf[GpuHashAggregateExec]).isDefined)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
+
+        case a: AdaptiveSparkPlanExec =>
+          assert(a.toString.startsWith("AdaptiveSparkPlan isFinalPlan=true"))
+          assert(a.executedPlan.find(_.isInstanceOf[GpuSortExec]).isDefined)
+          assert(a.executedPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
+          assert(a.executedPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 
         case _ =>
           fail("Incorrect plan")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -119,7 +119,8 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       val cpuPlan = df.queryExecution.sparkPlan
       assert(cpuPlan.find(_.isInstanceOf[SortAggregateExec]).isDefined)
 
-      var gpuPlan = df.queryExecution.executedPlan
+      val gpuPlan = df.queryExecution.executedPlan
+      // execute the plan so that the final adaptive plan is available when AQE is on
       df.collect()
 
       gpuPlan match {
@@ -155,6 +156,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       assert(cpuPlan.find(_.isInstanceOf[SortAggregateExec]).isDefined)
 
       val gpuPlan = df.queryExecution.executedPlan
+      // execute the plan so that the final adaptive plan is available when AQE is on
       df.collect()
 
       gpuPlan match {


### PR DESCRIPTION
Signed-off-by: Niranjan Artal <nartal@nvidia.com>

Updated tests and verified locally. This closes https://github.com/NVIDIA/spark-rapids/issues/453.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
