### PR TITLE
Re-enable noscaladoc check

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -96,17 +96,17 @@ You can also disable only one rule, by specifying its rule id, as specified in:
     <check level="error" class="org.scalastyle.scalariform.NotImplementedErrorUsage"
            enabled="true"/>
 
-    <!-- ================================================================================ -->
-    <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
-    <!-- ================================================================================ -->
-
     <check customId="NoScalaDoc" level="error" class="org.scalastyle.file.RegexChecker"
-           enabled="false">
+           enabled="true">
         <parameters>
             <parameter name="regex">(?m)^(\s*)/[*][*].*$(\r|)\n^\1  [*]</parameter>
         </parameters>
         <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
     </check>
+
+    <!-- ================================================================================ -->
+    <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
+    <!-- ================================================================================ -->
 
     <!-- This project uses Javadoc rather than Scaladoc so scaladoc checks are disabled -->
     <check enabled="false" class="org.scalastyle.scalariform.ScalaDocChecker" level="warning"/>


### PR DESCRIPTION
Now that the UCX fixes are in from #461 we can re-enable the noscaladoc check.

This reverts #464.