### PR TITLE
Show plan in assertion message if test fails

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -46,8 +46,8 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
           case _ => None
         }
       }
-      assert(gpuAgg.isDefined,
-        s"as the GPU plan expected a GPU aggregate but did not find any! Plan: $plan")
+      assert(gpuAgg.isDefined, s"as the GPU plan expected a GPU aggregate but did not find any! " +
+          s"plan: $plan; executedPlan: $executedPlan")
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -46,7 +46,8 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
           case _ => None
         }
       }
-      assert(gpuAgg.isDefined, "as the GPU plan expected a GPU aggregate but did not find any!")
+      assert(gpuAgg.isDefined,
+        s"as the GPU plan expected a GPU aggregate but did not find any! Plan: $plan")
     }
   }
 


### PR DESCRIPTION
This PR simply updates an assertion message to include the plan that caused the assertion to fail. This will hopefully help us better understand what is causing https://github.com/NVIDIA/spark-rapids/issues/473