### PR TITLE
Fix Spark 3.1.0 build for HashJoin changes

### DIFF
--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
@@ -19,7 +19,10 @@ import ai.rapids.cudf.{NvtxColor, Table}
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.TaskContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftExistence, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.joins.HashJoin
@@ -241,5 +244,14 @@ trait GpuHashJoin extends GpuExec with HashJoin {
     } finally {
       joinedTable.close()
     }
+  }
+
+ override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    throw new UnsupportedOperationException("inputRDDs is used by codegen which we don't support")
+  }
+
+  protected override def prepareRelation(ctx: CodegenContext): (String, Boolean) = {
+    throw new UnsupportedOperationException(
+      "prepareRelation is used by codegen which we don't support")
   }
 }

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
@@ -246,7 +246,7 @@ trait GpuHashJoin extends GpuExec with HashJoin {
     }
   }
 
- override def inputRDDs(): Seq[RDD[InternalRow]] = {
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
     throw new UnsupportedOperationException("inputRDDs is used by codegen which we don't support")
   }
 


### PR DESCRIPTION
Spark 3.1.0 committed a change (https://github.com/apache/spark/commit/ae82768c1396bfe626b52c4eac33241a9eb91f54) to add codegen to ShuffledHashJoin. This moved the CodegenSupport to be in the base HashJoin which we inherit from and requires a couple more api's to be implemented.
This PR is simply to fix the build because more changes will be required to make it functionally correct so that we don't try to do CodeGen with GpuShuffledHashJoin. Follow up issue for that is: https://github.com/NVIDIA/spark-rapids/issues/489


Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
