### PR TITLE
disable codegen in 3.1 shim for hash join

### DIFF
--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
@@ -47,6 +47,8 @@ object GpuHashJoin {
 
 trait GpuHashJoin extends GpuExec with HashJoin {
 
+  override def supportCodegen: Boolean = false
+
   override def output: Seq[Attribute] = {
     joinType match {
       case _: InnerLike =>


### PR DESCRIPTION
This closes https://github.com/NVIDIA/spark-rapids/issues/489