### PR TITLE
Add ability to ignore tests depending on spark shim version

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -41,7 +41,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 class Spark300Shims extends SparkShims {
 
-  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 0, 0)
+  override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
 
   override def getScalaUDFAsExpression(
       function: AnyRef,

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -41,6 +41,8 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 class Spark300Shims extends SparkShims {
 
+  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 0, 0)
+
   override def getScalaUDFAsExpression(
       function: AnyRef,
       dataType: DataType,

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/SparkShimServiceProvider.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/SparkShimServiceProvider.scala
@@ -16,14 +16,16 @@
 
 package com.nvidia.spark.rapids.shims.spark300
 
-import com.nvidia.spark.rapids.SparkShims
+import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+
+object SparkShimServiceProvider {
+  val VERSION = SparkShimVersion(3,0,0)
+}
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 
-  val VERSIONNAME = "3.0.0"
-
   def matchesVersion(version: String): Boolean = {
-    version == VERSIONNAME
+    version == SparkShimServiceProvider.VERSION.toString()
   }
 
   def buildShim: SparkShims = {

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/SparkShimServiceProvider.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/SparkShimServiceProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shims.spark300
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3,0,0)
+  val VERSION = SparkShimVersion(3, 0, 0)
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {

--- a/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/Spark300dbShims.scala
+++ b/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/Spark300dbShims.scala
@@ -37,6 +37,8 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 
 class Spark300dbShims extends Spark300Shims {
 
+  override def getSparkShimVersion: ShimVersion = SparkShimVersionProvider.VERSION
+
   override def getGpuBroadcastNestedLoopJoinShim(
       left: SparkPlan,
       right: SparkPlan,

--- a/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/SparkShimServiceProvider.scala
+++ b/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/SparkShimServiceProvider.scala
@@ -16,14 +16,17 @@
 
 package com.nvidia.spark.rapids.shims.spark300db
 
-import com.nvidia.spark.rapids.SparkShims
+import com.nvidia.spark.rapids.{DatabricksShimVersion, SparkShims}
+
+object SparkShimServiceProvider {
+  val VERSION = DatabricksShimVersion(3, 0, 0)
+  val VERSIONNAMES = Seq(s"$VERSION")
+}
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 
-  val VERSIONNAMES = Seq("3.0.0-databricks")
-
   def matchesVersion(version: String): Boolean = {
-    VERSIONNAMES.contains(version)
+    SparkShimServiceProvider.VERSIONNAMES.contains(version)
   }
 
   def buildShim: SparkShims = {

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/Spark301Shims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/Spark301Shims.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.SparkPlan
 
 class Spark301Shims extends Spark300Shims {
 
-  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 0, 1)
+  override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
 
   def exprs301: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[First](

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/Spark301Shims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/Spark301Shims.scala
@@ -28,6 +28,8 @@ import org.apache.spark.sql.execution.SparkPlan
 
 class Spark301Shims extends Spark300Shims {
 
+  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 0, 1)
+
   def exprs301: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[First](
       "first aggregate operator",

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkShimServiceProvider.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkShimServiceProvider.scala
@@ -16,14 +16,16 @@
 
 package com.nvidia.spark.rapids.shims.spark301
 
-import com.nvidia.spark.rapids.SparkShims
+import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
+object SparkShimServiceProvider {
+  val VERSION = SparkShimVersion(3,0,1)
+  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+}
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 
-  val VERSIONNAMES = Seq("3.0.1-SNAPSHOT", "3.0.1")
-
   def matchesVersion(version: String): Boolean = {
-    VERSIONNAMES.contains(version)
+    SparkShimServiceProvider.VERSIONNAMES.contains(version)
   }
 
   def buildShim: SparkShims = {

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkShimServiceProvider.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkShimServiceProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shims.spark301
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3,0,1)
+  val VERSION = SparkShimVersion(3, 0, 1)
   val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
 }
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -39,7 +39,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 class Spark310Shims extends Spark301Shims {
 
-  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 1, 0)
+  override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
 
   override def getScalaUDFAsExpression(
       function: AnyRef,

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -39,6 +39,8 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 class Spark310Shims extends Spark301Shims {
 
+  override def getSparkShimVersion: ShimVersion = SparkShimVersion(3, 1, 0)
+
   override def getScalaUDFAsExpression(
       function: AnyRef,
       dataType: DataType,

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/SparkShimServiceProvider.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/SparkShimServiceProvider.scala
@@ -16,14 +16,17 @@
 
 package com.nvidia.spark.rapids.shims.spark310
 
-import com.nvidia.spark.rapids.SparkShims
+import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+
+object SparkShimServiceProvider {
+  val VERSION = SparkShimVersion(3,1,0)
+  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+}
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 
-  val VERSIONNAMES = Seq("3.1.0-SNAPSHOT", "3.1.0")
-
   def matchesVersion(version: String): Boolean = {
-    VERSIONNAMES.contains(version)
+    SparkShimServiceProvider.VERSIONNAMES.contains(version)
   }
 
   def buildShim: SparkShims = {

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/SparkShimServiceProvider.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/SparkShimServiceProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shims.spark310
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3,1,0)
+  val VERSION = SparkShimVersion(3, 1, 0)
   val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -38,8 +38,14 @@ case object GpuBuildRight extends GpuBuildSide
 case object GpuBuildLeft extends GpuBuildSide
 
 sealed abstract class ShimVersion
-case class SparkShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion
-case class DatabricksShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion
+
+case class SparkShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion {
+  override def toString(): String = s"$major.$minor.$patch"
+}
+
+case class DatabricksShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion {
+  override def toString(): String = s"$major.$minor.$patch-databricks"
+}
 
 trait SparkShims {
   def getSparkShimVersion: ShimVersion

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -37,7 +37,12 @@ case object GpuBuildRight extends GpuBuildSide
 
 case object GpuBuildLeft extends GpuBuildSide
 
+sealed abstract class ShimVersion
+case class SparkShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion
+case class DatabricksShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion
+
 trait SparkShims {
+  def getSparkShimVersion: ShimVersion
   def isGpuHashJoin(plan: SparkPlan): Boolean
   def isGpuBroadcastHashJoin(plan: SparkPlan): Boolean
   def isGpuShuffledHashJoin(plan: SparkPlan): Boolean

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFallbackSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFallbackSuite.scala
@@ -30,14 +30,14 @@ class StringFallbackSuite extends SparkQueryCompareTestSuite {
     nullableStringsFromCsv, execsAllowedNonGpu = Seq("ProjectExec", "Alias",
       "RegExpReplace", "AttributeReference", "Literal")) {
     frame => {
-      ShimLoader.getSparkShims.getSparkShimVersion match {
-        case SparkShimVersion(major, minor, _) =>
-          // this test is not valid in Spark 3.1 and later because the expression is
-          // NullIntolerant and gets replaced with a null literal instead
-          val isValidTestForSparkVersion = major <= 3 && minor == 0
-          assume(isValidTestForSparkVersion)
-        case _ =>
+      // this test is only valid in Spark 3.0.x because the expression is NullIntolerant
+      // since Spark 3.1.0 and gets replaced with a null literal instead
+      val isValidTestForSparkVersion = ShimLoader.getSparkShims.getSparkShimVersion match {
+        case SparkShimVersion(major, minor, _) => major == 3 && minor == 0
+        case DatabricksShimVersion(major, minor, _) => major == 7
+        case _ => true
       }
+      assume(isValidTestForSparkVersion)
       frame.selectExpr("regexp_replace(strings,null,'D')")
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFallbackSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFallbackSuite.scala
@@ -34,7 +34,7 @@ class StringFallbackSuite extends SparkQueryCompareTestSuite {
       // since Spark 3.1.0 and gets replaced with a null literal instead
       val isValidTestForSparkVersion = ShimLoader.getSparkShims.getSparkShimVersion match {
         case SparkShimVersion(major, minor, _) => major == 3 && minor == 0
-        case DatabricksShimVersion(major, minor, _) => major == 7
+        case DatabricksShimVersion(major, minor, _) => major == 3 && minor == 0
         case _ => true
       }
       assume(isValidTestForSparkVersion)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Adds the ability to ignore scala tests conditionally, depending on the version of Spark we are testing with.

Also closes https://github.com/NVIDIA/spark-rapids/issues/382