### PR TITLE
Fix init order issue in GpuShuffleEnv when RAPIDS shuffle configured

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -190,7 +190,7 @@ object GpuDeviceManager extends Logging {
       try {
         Cuda.setDevice(gpuId)
         Rmm.initialize(init, logConf, initialAllocation)
-        GpuShuffleEnv.init(info)
+        GpuShuffleEnv.init(conf, info)
       } catch {
         case e: Exception => logError("Could not initialize RMM", e)
       }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -21,10 +21,8 @@ import com.nvidia.spark.rapids._
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.util.Utils
 
-class GpuShuffleEnv extends Logging {
+class GpuShuffleEnv(rapidsConf: RapidsConf) extends Logging {
   private val catalog = new RapidsBufferCatalog
   private var shuffleCatalog: ShuffleBufferCatalog = _
   private var shuffleReceivedBufferCatalog: ShuffleReceivedBufferCatalog = _
@@ -34,7 +32,6 @@ class GpuShuffleEnv extends Logging {
   private var memoryEventHandler: DeviceMemoryEventHandler = _
 
   private lazy val conf = SparkEnv.get.conf
-  private lazy val rapidsConf = new RapidsConf(SparkSession.active.sqlContext.conf)
 
   lazy val isRapidsShuffleConfigured: Boolean = {
     conf.contains("spark.shuffle.manager") &&
@@ -102,9 +99,9 @@ object GpuShuffleEnv extends Logging {
   private var isRapidsShuffleManagerInitialized: Boolean  = false
   @volatile private var env: GpuShuffleEnv = _
 
-  def init(devInfo: CudaMemInfo): Unit = {
+  def init(conf: RapidsConf, devInfo: CudaMemInfo): Unit = {
     Option(env).foreach(_.closeStorage())
-    val shuffleEnv = new GpuShuffleEnv
+    val shuffleEnv = new GpuShuffleEnv(conf)
     shuffleEnv.initStorage(devInfo)
     env = shuffleEnv
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -60,7 +60,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
     SparkSession.getActiveSession.foreach(_.close())
     val conf = new SparkConf()
     TestUtils.withGpuSparkSession(conf) { _ =>
-      GpuShuffleEnv.init(Cuda.memGetInfo())
+      GpuShuffleEnv.init(new RapidsConf(conf), Cuda.memGetInfo())
       val partitionIndices = Array(0, 2)
       val gp = new GpuPartitioning {
         override val numPartitions: Int = partitionIndices.length

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -37,7 +37,7 @@ class GpuSinglePartitioningSuite extends FunSuite with Arm {
   test("generates contiguous split") {
     val conf = new SparkConf().set("spark.shuffle.manager", GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS)
     TestUtils.withGpuSparkSession(conf) { _ =>
-      GpuShuffleEnv.init(Cuda.memGetInfo())
+      GpuShuffleEnv.init(new RapidsConf(conf), Cuda.memGetInfo())
       val partitioner = GpuSinglePartitioning(Nil)
       withResource(buildBatch()) { expected =>
         // partition will consume batch, so make a new batch with incremented refcounts


### PR DESCRIPTION
Signed-off-by: Jason Lowe <jlowe@nvidia.com>

This fixes an initialization ordering issue recently introduced in `GpuShuffleEnv` where it tries to access a SparkSession while it's being created and hasn't been advertised yet.  It needs it for a `RapidsConf`, and rather than finding another way to construct one from scratch, it turns out the caller already has one prepped.  It's cheaper and simpler to just pass the existing conf.