### PR TITLE
Use SQLConf instead of SparkConf when looking up SQL configs

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -203,7 +203,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
     if (!GpuShuffleEnv.isRapidsShuffleEnabled) {
       fallThroughReasons += "external shuffle is enabled"
     }
-    if (conf.get(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key).toBoolean) {
+    if (SQLConf.get.adaptiveExecutionEnabled) {
       fallThroughReasons += "adaptive query execution is enabled"
     }
     if (fallThroughReasons.nonEmpty) {


### PR DESCRIPTION
Signed-off-by: Jason Lowe <jlowe@nvidia.com>

The shuffle manager can crash during planning because it is trying to lookup a `SQLConf` config property on the `SparkConf` passed to the shuffle manager during init.  If the user doesn't set the `spark.sql.adaptive.enabled` property then the query fails with a `java.util.NoSuchElementException: spark.sql.adaptive.enabled` error trying to lookup the missing property.

This updates the shuffle manager to get the `SQLConf` instance and use that to lookup the SQL-specific config key.