### PR TITLE
Fix bug with nullability reporting in GpuFilterExec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -24,6 +24,16 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputT
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, BooleanType, DataType, DoubleType, FloatType}
 
+trait GpuPredicateHelper {
+  protected def splitConjunctivePredicates(condition: Expression): Seq[Expression] = {
+    condition match {
+      case GpuAnd(cond1, cond2) =>
+        splitConjunctivePredicates(cond1) ++ splitConjunctivePredicates(cond2)
+      case other => other :: Nil
+    }
+  }
+}
+
 case class GpuNot(child: Expression) extends CudfUnaryExpression
     with Predicate with ImplicitCastInputTypes with NullIntolerant {
   override def toString: String = s"NOT $child"

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -105,28 +105,25 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       .agg(first(col("c0"), ignoreNulls = true), last(col("c0"), ignoreNulls = true))
   }
 
-  test("nullable aggregate with not null filter") {
+  IGNORE_ORDER_testSparkResultsAreEqualWithCapture(
+      "nullable aggregate with not null filter",
+      firstDf,
+      repart = 2) {
+    frame => frame.coalesce(1)
+        .sort(col("c2").asc, col("c0").asc) // force deterministic use case
+        .groupBy(col("c2"))
+        .agg(min(col("c0")).alias("mymin"),
+          max(col("c0")).alias("mymax"))
+        .filter(col("mymin").isNotNull
+            .and(col("mymax").isNotNull))
+  } { (_, gpuPlan) => {
+    checkExecPlan(gpuPlan)
 
-    withGpuSparkSession(spark => {
-      val df = firstDf(spark)
-          .coalesce(1)
-          .sort(col("c2").asc, col("c0").asc) // force deterministic use case
-          .groupBy(col("c2"))
-          .agg(min(col("c0")).alias("mymin"),
-            max(col("c0")).alias("mymax"))
-          .filter(col("mymin").isNotNull
-              .and(col("mymax").isNotNull))
-
-      df.collect()
-
-      val finalPlan = df.queryExecution.executedPlan
-
-      // IsNotNull filter means that the aggregates should not be nullable
-      val output = finalPlan.output
-      assert(!output(1).nullable)
-      assert(!output(2).nullable)
-    })
-  }
+    // IsNotNull filter means that the aggregates should not be nullable
+    val output = gpuPlan.output
+    assert(!output(1).nullable)
+    assert(!output(2).nullable)
+  } }
 
   test("SortAggregateExec is translated correctly ENABLE_HASH_OPTIMIZE_SORT=false") {
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -105,6 +105,29 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       .agg(first(col("c0"), ignoreNulls = true), last(col("c0"), ignoreNulls = true))
   }
 
+  test("nullable aggregate with not null filter") {
+
+    withGpuSparkSession(spark => {
+      val df = firstDf(spark)
+          .coalesce(1)
+          .sort(col("c2").asc, col("c0").asc) // force deterministic use case
+          .groupBy(col("c2"))
+          .agg(min(col("c0")).alias("mymin"),
+            max(col("c0")).alias("mymax"))
+          .filter(col("mymin").isNotNull
+              .and(col("mymax").isNotNull))
+
+      df.collect()
+
+      val finalPlan = df.queryExecution.executedPlan
+
+      // IsNotNull filter means that the aggregates should not be nullable
+      val output = finalPlan.output
+      assert(!output(1).nullable)
+      assert(!output(2).nullable)
+    })
+  }
+
   test("SortAggregateExec is translated correctly ENABLE_HASH_OPTIMIZE_SORT=false") {
 
     val conf = new SparkConf()


### PR DESCRIPTION
`GpuFilterExec` contains code to look for `IsNotNull` predicates and uses that information to modify the output attributes to report that those attributes now have nullability=false. However, this code did not work because it was specifically looking for Spark case classes `And` (when extracting conjunctive predicates) and `IsNotNull` and did not recognize the GPU replacements for these expressions.

This closes https://github.com/NVIDIA/spark-rapids/issues/525