### PR TITLE
[BUG] Degenerate table metas were not getting copied to the heap

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -705,11 +705,11 @@ class RapidsShuffleClient(
 
     val ptrs = new ArrayBuffer[PendingTransferRequest](allTables)
     (0 until allTables).foreach { i =>
-      val tableMeta = metaResponse.tableMetas(i)
+      val tableMeta = ShuffleMetadata.copyTableMetaToHeap(metaResponse.tableMetas(i))
       if (tableMeta.bufferMeta() != null) {
         ptrs += PendingTransferRequest(
           this,
-          ShuffleMetadata.copyTableMetaToHeap(tableMeta),
+          tableMeta,
           connection.assignBufferTag(tableMeta.bufferMeta().id),
           handler)
       } else {


### PR DESCRIPTION
This a two-liner but a bad one. This makes sure that there is a JVM object for every `TableMeta`, not just non-degenerate ones.