### PR TITLE
Use fresh SparkSession when capturing to avoid late capture of previous query

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -21,6 +21,7 @@ import org.json4s.JsonAST
 import org.apache.spark.{SparkContext, SparkEnv, SparkUpgradeException}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.InputMetrics
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, IdentityBroadcastMode}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
@@ -69,4 +70,7 @@ object TrampolineUtil {
                                 cause: Throwable): SparkUpgradeException = {
     new SparkUpgradeException(version, message, cause)
   }
+
+  /** Shuts down and cleans up any existing Spark session */
+  def cleanupAnyExistingSession(): Unit = SparkSession.cleanupAnyExistingSession()
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 
 object TestResourceFinder {
@@ -225,6 +226,8 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   : (Array[Row], SparkPlan, Array[Row], SparkPlan) = {
     conf.setIfMissing("spark.sql.shuffle.partitions", "2")
 
+    // force a new session to avoid accidentally capturing a late callback from a previous query
+    TrampolineUtil.cleanupAnyExistingSession()
     ExecutionPlanCaptureCallback.startCapture()
     var cpuPlan: Option[SparkPlan] = null
     val fromCpu =


### PR DESCRIPTION
Signed-off-by: Jason Lowe <jlowe@nvidia.com>

This hopefully fixes #473.

I believe what's happening in that bug is the test just before the one that fails isn't trying to capture yet the capture callback is still enabled.  I suspect the callback on the last test's query is late, occurring while the next test is already running and _after_ it enables the callback capture.  That causes it to capture the previous test's GPU run as the CPU run and the subsequent GPU run captures the CPU run instead which explains why we see a CPU plan when it fails.

This updates `runOnCpuAndGpuWithCapture` to force a new Spark session which should drain the listener callbacks during the session stop and should create a hard boundary between the previous test and the next test that is trying to capture.  The downside is that using captures will be slower due to the new session being created.