### PR TITLE
Add in driverExtraClassPath for standalone mode docs

### DIFF
--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -159,6 +159,7 @@ overlapping I/O and computation.
 $SPARK_HOME/bin/spark-shell \
        --master spark://${MASTER_HOST}:7077 \
        --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
+       --conf spark.driver.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
        --conf spark.rapids.sql.concurrentGpuTasks=1 \
        --driver-memory 2G \
        --conf spark.executor.memory=4G \


### PR DESCRIPTION
In standalone mode we need to add in the driverExtraClassPath to pick up the SQLPlugin properly.  Otherwise you get exception:

20/08/11 08:33:20 ERROR SparkContext: Error initializing SparkContext.
java.lang.ClassNotFoundException: com.nvidia.spark.SQLPlugin

closes #269 

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
