### PR TITLE
Document Parquet and ORC compression support

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -166,7 +166,7 @@ appears to work for dates after the epoch as described
 
 The plugin supports reading `uncompressed`, `snappy` and `zlib` ORC files and writing `uncompressed`
  and `snappy` ORC files.  At this point, the plugin does not have the ability to fall back to the 
- CPU when reading or writing an unsupported compression format, and will error out in that case. 
+ CPU when reading an unsupported compression format, and will error out in that case. 
 
 ## Parquet
 
@@ -190,7 +190,7 @@ compatibility with other tools then set `spark.sql.parquet.outputTimestampType` 
 
 The plugin supports reading `uncompressed`, `snappy` and `gzip` Parquet files and writing 
 `uncompressed` and `snappy` Parquet files.  At this point, the plugin does not have the ability to 
-fall back to the CPU when reading or writing an unsupported compression format, and will error out 
+fall back to the CPU when reading an unsupported compression format, and will error out 
 in that case. 
 
 ## Timestamps

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -164,6 +164,9 @@ similar issue exists for writing dates as described
 appears to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140). 
 
+ORC reading is supported for `uncompressed`, `snappy` and `zlib` compressed files.  ORC writing is 
+supports `uncompressed` and `snappy` compression. 
+
 ## Parquet
 
 The Parquet format has more configs because there are multiple versions with some compatibility
@@ -183,6 +186,9 @@ does not support writing timestamps in the INT96 format, so by default writing t
 Parquet will not be GPU-accelerated. If the INT96 timestamp format is not required for
 compatibility with other tools then set `spark.sql.parquet.outputTimestampType` to
 `TIMESTAMP_MICROS`.
+
+Parquet reading is supported for `uncompressed`, `snappy` and `gzip` compressed files.  Parquet
+writing is supports  `uncompressed` and `snappy` compression. 
 
 ## Timestamps
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -164,8 +164,7 @@ similar issue exists for writing dates as described
 appears to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140). 
 
-ORC supports reading `uncompressed`, `snappy` and `zlib` compressed files.  ORC supports 
-writing `uncompressed` and `snappy` compression. 
+The plugin supports reading `uncompressed`, `snappy` and `zlib` ORC files and writing `uncompressed` and `snappy` ORC files. 
 
 ## Parquet
 
@@ -187,8 +186,7 @@ Parquet will not be GPU-accelerated. If the INT96 timestamp format is not requir
 compatibility with other tools then set `spark.sql.parquet.outputTimestampType` to
 `TIMESTAMP_MICROS`.
 
-Parquet supports reading `uncompressed`, `snappy` and `gzip` compressed files.  Parquet writing 
-supports `uncompressed` and `snappy` compression. 
+The plugin supports reading `uncompressed`, `snappy` and `gzip` Parquet files and writing `uncompressed` and `snappy` Parquet files. 
 
 ## Timestamps
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -164,8 +164,8 @@ similar issue exists for writing dates as described
 appears to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140). 
 
-ORC reading is supported for `uncompressed`, `snappy` and `zlib` compressed files.  ORC writing is 
-supports `uncompressed` and `snappy` compression. 
+ORC supports reading `uncompressed`, `snappy` and `zlib` compressed files.  ORC supports 
+writing `uncompressed` and `snappy` compression. 
 
 ## Parquet
 
@@ -187,8 +187,8 @@ Parquet will not be GPU-accelerated. If the INT96 timestamp format is not requir
 compatibility with other tools then set `spark.sql.parquet.outputTimestampType` to
 `TIMESTAMP_MICROS`.
 
-Parquet reading is supported for `uncompressed`, `snappy` and `gzip` compressed files.  Parquet
-writing is supports  `uncompressed` and `snappy` compression. 
+Parquet supports reading `uncompressed`, `snappy` and `gzip` compressed files.  Parquet writing 
+supports `uncompressed` and `snappy` compression. 
 
 ## Timestamps
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -164,7 +164,9 @@ similar issue exists for writing dates as described
 appears to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140). 
 
-The plugin supports reading `uncompressed`, `snappy` and `zlib` ORC files and writing `uncompressed` and `snappy` ORC files. 
+The plugin supports reading `uncompressed`, `snappy` and `zlib` ORC files and writing `uncompressed`
+ and `snappy` ORC files.  At this point, the plugin does not have the ability to fall back to the 
+ CPU when reading or writing an unsupported compression format, and will error out in that case. 
 
 ## Parquet
 
@@ -186,7 +188,10 @@ Parquet will not be GPU-accelerated. If the INT96 timestamp format is not requir
 compatibility with other tools then set `spark.sql.parquet.outputTimestampType` to
 `TIMESTAMP_MICROS`.
 
-The plugin supports reading `uncompressed`, `snappy` and `gzip` Parquet files and writing `uncompressed` and `snappy` Parquet files. 
+The plugin supports reading `uncompressed`, `snappy` and `gzip` Parquet files and writing 
+`uncompressed` and `snappy` Parquet files.  At this point, the plugin does not have the ability to 
+fall back to the CPU when reading or writing an unsupported compression format, and will error out 
+in that case. 
 
 ## Timestamps
 


### PR DESCRIPTION
1. Please write a description in this text box of the changes that are being
   made.

Add documentation on compression formats supported for Parquet and ORC on read and write.  Closes issue #341 

2. Please ensure that you have written units tests for the changes made/features
   added.

Reviewed in .md file in github.  

