### PR TITLE
Fix build warnings for ColumnViewAccess

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids;
 
+import ai.rapids.cudf.BaseDeviceMemoryBuffer;
 import ai.rapids.cudf.ColumnViewAccess;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.HostColumnVector;
@@ -198,10 +199,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     }
   }
 
-  protected static final DataType getSparkTypeFrom(ColumnViewAccess access) {
+  protected static final DataType getSparkTypeFrom(ColumnViewAccess<BaseDeviceMemoryBuffer> access) {
     DType type = access.getDataType();
     if (type == DType.LIST) {
-      try (ColumnViewAccess child = access.getChildColumnViewAccess(0)) {
+      try (ColumnViewAccess<BaseDeviceMemoryBuffer> child = access.getChildColumnViewAccess(0)) {
         return new ArrayType(getSparkTypeFrom(child), true);
       }
     } else {

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids;
 
-import ai.rapids.cudf.BaseDeviceMemoryBuffer;
 import ai.rapids.cudf.ColumnViewAccess;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.HostColumnVector;
@@ -199,10 +198,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     }
   }
 
-  protected static final DataType getSparkTypeFrom(ColumnViewAccess<BaseDeviceMemoryBuffer> access) {
+  protected static final <T> DataType getSparkTypeFrom(ColumnViewAccess<T> access) {
     DType type = access.getDataType();
     if (type == DType.LIST) {
-      try (ColumnViewAccess<BaseDeviceMemoryBuffer> child = access.getChildColumnViewAccess(0)) {
+      try (ColumnViewAccess<T> child = access.getChildColumnViewAccess(0)) {
         return new ArrayType(getSparkTypeFrom(child), true);
       }
     } else {


### PR DESCRIPTION
Signed-off-by: Kuhu Shukla <kuhus@nvidia.com>

This fixes https://github.com/NVIDIA/spark-rapids/issues/553 by adding the type we expect ColumnVectors to have. Appreciate any comments if there is a better way to do this. 