### PR TITLE
Fix tests failing on Spark 3.1

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -222,9 +222,10 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
       val df = longsCsvDf(spark)
 
       // A coalesce step is added after the filter to help with the case where much of the
-      // data is filtered out
+      // data is filtered out.  The select is there to prevent the coalesce from being
+      // the last thing in the plan which will cause the coalesce to be optimized out.
       val df2 = df
-        .filter(df.col("six").gt(5))
+        .filter(df.col("six").gt(5)).select(df.col("six") * 2)
 
       val coalesce = df2.queryExecution.executedPlan
         .find(_.isInstanceOf[GpuCoalesceBatches]).get


### PR DESCRIPTION
This fixes a couple of Scala tests that were failing on Spark 3.1.0-SNAPSHOT.

One of the tests was relying on a `ProjectExec` to work correctly, and Spark 3.1.0 optimized it out.  I added an explicit project after the filter to work around it.

The other test failed because something that doesn't work in Spark 3.0 now works in Spark 3.1.  Updated the test to check the Spark version before deciding what kind of test to run.