### PR TITLE
getCatalog can be called from the driver, and can return null

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -124,6 +124,12 @@ object GpuShuffleEnv extends Logging {
     Option(env).foreach(_.closeStorage())
   }
 
+  def getCatalog: ShuffleBufferCatalog = if (env == null) {
+    null
+  } else {
+    env.getCatalog
+  }
+
   //
   // Functions below only get called from the executor
   //
@@ -134,8 +140,6 @@ object GpuShuffleEnv extends Logging {
     shuffleEnv.initStorage(devInfo)
     env = shuffleEnv
   }
-
-  def getCatalog: ShuffleBufferCatalog = env.getCatalog
 
   def getReceivedCatalog: ShuffleReceivedBufferCatalog = env.getReceivedCatalog
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -202,6 +202,8 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
 
   //Many of these values like blockManager are not initialized when the constructor is called,
   // so they all need to be lazy values that are executed when things are first called
+
+  // NOTE: this can be null in the driver side.
   private[this] lazy val catalog = GpuShuffleEnv.getCatalog
   private lazy val env = SparkEnv.get
   private lazy val blockManager = env.blockManager
@@ -284,7 +286,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
           gpu.asInstanceOf[GpuShuffleHandle[K, V]],
           mapId,
           metrics,
-          GpuShuffleEnv.getCatalog,
+          catalog,
           GpuShuffleEnv.getDeviceStorage,
           server)
       case other =>


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/556

When unregistering shuffles we blindly call `unregisterGpuShuffle` from the driver or executor. This depends on a lazy val that needs a `GpuShuffleEnv` initialized (we need RMM for our storage, and the driver doesn't have RMM/CUDA so we don't have storage and therefore the `GpuShuffleEnv` is never initialized). This makes the driver not fail with an NPE in this case as the shuffle manager already was checking for a null catalog.