### PR TITLE
Add GPU decode time metric to scans

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchScanExec.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.execution.datasources.{HadoopFileLinesReader, Partit
 import org.apache.spark.sql.execution.datasources.csv.CSVDataSource
 import org.apache.spark.sql.execution.datasources.v2._
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DateType, StructField, StructType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -59,10 +59,7 @@ case class GpuBatchScanExec(
 
   override def supportsColumnar = true
 
-  override lazy val additionalMetrics = Map(
-    "bufferTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "buffer time"),
-    "peakDevMemory" -> SQLMetrics.createSizeMetric(sparkContext, "peak device memory")
-  )
+  override lazy val additionalMetrics = GpuMetricNames.buildGpuScanMetrics(sparkContext)
 
   scan match {
     case s: ScanWithMetrics => s.metrics = metrics ++ additionalMetrics
@@ -387,10 +384,9 @@ class CSVPartitionReader(
     }
   }
 
-  private def readPartFile(): (HostMemoryBuffer, Long, Integer) = {
-    val nvtxRange = new NvtxWithMetrics("Buffer file split", NvtxColor.YELLOW,
-      metrics("bufferTime"))
-    try {
+  private def readPartFile(): (HostMemoryBuffer, Long) = {
+    withResource(new NvtxWithMetrics("Buffer file split", NvtxColor.YELLOW,
+        metrics("bufferTime"))) { _ =>
       isFirstChunkForIterator = false
       val separator = parsedOptions.lineSeparatorInRead.getOrElse(Array('\n'.toByte))
       var succeeded = false
@@ -424,15 +420,12 @@ class CSVPartitionReader(
           hmb.close()
         }
       }
-      (hmb, totalSize, totalRows)
-    } finally {
-      nvtxRange.close()
+      (hmb, totalSize)
     }
   }
 
   private def readBatch(): Option[ColumnarBatch] = {
-    val nvtxRange = new NvtxWithMetrics("CSV readBatch", NvtxColor.GREEN, metrics(TOTAL_TIME))
-    try {
+    withResource(new NvtxWithMetrics("CSV readBatch", NvtxColor.GREEN, metrics(TOTAL_TIME))) { _ =>
       val hasHeader = partFile.start == 0 && isFirstChunkForIterator && parsedOptions.headerFlag
       val table = readToTable(hasHeader)
       try {
@@ -445,13 +438,11 @@ class CSVPartitionReader(
         metrics(NUM_OUTPUT_BATCHES) += 1
         table.foreach(_.close())
       }
-    } finally {
-      nvtxRange.close()
     }
   }
 
   private def readToTable(hasHeader: Boolean): Option[Table] = {
-    val (dataBuffer, dataSize, totalRows) = readPartFile()
+    val (dataBuffer, dataSize) = readPartFile()
     try {
       if (dataSize == 0) {
         None
@@ -469,7 +460,10 @@ class CSVPartitionReader(
         GpuSemaphore.acquireIfNecessary(TaskContext.get())
 
         // The buffer that is sent down
-        val table = Table.readCSV(cudfSchema, csvOpts, dataBuffer, 0, dataSize)
+        val table = withResource(new NvtxWithMetrics("CSV decode", NvtxColor.DARK_GREEN,
+            metrics(GPU_DECODE_TIME))) { _ =>
+          Table.readCSV(cudfSchema, csvOpts, dataBuffer, 0, dataSize)
+        }
         maxDeviceMemory = max(GpuColumnVector.getTotalDeviceMemoryUsed(table), maxDeviceMemory)
         val numColumns = table.getNumberOfColumns
         if (newReadDataSchema.length != numColumns) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -26,6 +26,7 @@ object GpuMetricNames {
 
   // Metric names.
   val BUFFER_TIME = "bufferTime"
+  val GPU_DECODE_TIME = "gpuDecodeTime"
   val NUM_INPUT_ROWS = "numInputRows"
   val NUM_INPUT_BATCHES = "numInputBatches"
   val NUM_OUTPUT_ROWS = "numOutputRows"
@@ -45,6 +46,7 @@ object GpuMetricNames {
     Map(
       NUM_OUTPUT_BATCHES -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_OUTPUT_BATCHES),
       TOTAL_TIME -> SQLMetrics.createNanoTimingMetric(sparkContext, DESCRIPTION_TOTAL_TIME),
+      GPU_DECODE_TIME -> SQLMetrics.createNanoTimingMetric(sparkContext, "GPU decode time"),
       BUFFER_TIME -> SQLMetrics.createNanoTimingMetric(sparkContext, "buffer time"),
       PEAK_DEVICE_MEMORY -> SQLMetrics.createSizeMetric(sparkContext,
         DESCRIPTION_PEAK_DEVICE_MEMORY))


### PR DESCRIPTION
This adds a scan metric to measure the time libcudf takes to complete a decode of the data once it's been loaded from the distributed filesystem.  An existing `bufferTIme` metric shows how much time was spent loading the data from the distributed filesystem.

This also performs minor cleanup in the scan code, updating to use `withResource` and removing an unused result from CSV's `readPartFile`.