### PR TITLE
Explicitly disable AQE in one test

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -166,6 +166,10 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "FileSourceScanExec")
       .set("spark.rapids.sql.exec.FileSourceScanExec", "false") // force Parquet read onto CPU
       .set("spark.sql.shuffle.partitions", "1")
+      // this test isn't valid when AQE is enabled because the FileScan happens as part of
+      // a query stage that runs on the CPU, wrapped in a CPU Exchange, with a ColumnarToRow
+      // transition inserted
+      .set("spark.sql.adaptive.enabled", "false")
 
     val dir = Files.createTempDirectory("spark-rapids-test").toFile
     val path = new File(dir,


### PR DESCRIPTION
The "coalesce HostColumnarToGpu" test fails if AQE is enabled, due to reasons explained in this PR. The test now explicitly disables AQE.