### PR TITLE
Move GpuParquetScan/GpuOrcScan into Shim

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -29,9 +29,11 @@ def read_orc_sql(data_path):
 
 @pytest.mark.parametrize('name', ['timestamp-date-test.orc'])
 @pytest.mark.parametrize('read_func', [read_orc_df, read_orc_sql])
-def test_basic_read(std_input_path, name, read_func):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_basic_read(std_input_path, name, read_func, v1_enabled_list):
     assert_gpu_and_cpu_are_equal_collect(
-            read_func(std_input_path + '/' + name))
+            read_func(std_input_path + '/' + name),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 orc_gens_list = [[byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
     string_gen, boolean_gen, DateGen(start=date(1590, 1, 1)),
@@ -59,13 +61,15 @@ def test_orc_fallback(spark_tmp_path, read_func, disable_conf):
 
 @pytest.mark.parametrize('orc_gens', orc_gens_list, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_orc_df, read_orc_sql])
-def test_read_round_trip(spark_tmp_path, orc_gens, read_func):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_read_round_trip(spark_tmp_path, orc_gens, read_func, v1_enabled_list):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(orc_gens)]
     data_path = spark_tmp_path + '/ORC_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.orc(data_path))
     assert_gpu_and_cpu_are_equal_collect(
-            read_func(data_path))
+            read_func(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 orc_pred_push_gens = [
         byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen, boolean_gen,
@@ -79,7 +83,8 @@ orc_pred_push_gens = [
 
 @pytest.mark.parametrize('orc_gen', orc_pred_push_gens, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_orc_df, read_orc_sql])
-def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func, v1_enabled_list):
     data_path = spark_tmp_path + '/ORC_DATA'
     gen_list = [('a', RepeatSeqGen(orc_gen, 100)), ('b', orc_gen)]
     s0 = gen_scalar(orc_gen, force_no_nulls=True)
@@ -87,22 +92,26 @@ def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func):
             lambda spark : gen_df(spark, gen_list).orderBy('a').write.orc(data_path))
     rf = read_func(data_path)
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: rf(spark).select(f.col('a') >= s0))
+            lambda spark: rf(spark).select(f.col('a') >= s0),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 orc_compress_options = ['none', 'uncompressed', 'snappy', 'zlib']
 # The following need extra jars 'lzo'
 # https://github.com/NVIDIA/spark-rapids/issues/143
 
 @pytest.mark.parametrize('compress', orc_compress_options)
-def test_compress_read_round_trip(spark_tmp_path, compress):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_compress_read_round_trip(spark_tmp_path, compress, v1_enabled_list):
     data_path = spark_tmp_path + '/ORC_DATA'
     with_cpu_session(
             lambda spark : binary_op_df(spark, long_gen).write.orc(data_path),
             conf={'spark.sql.orc.compression.codec': compress})
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.orc(data_path))
+            lambda spark : spark.read.orc(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
-def test_simple_partitioned_read(spark_tmp_path):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_simple_partitioned_read(spark_tmp_path, v1_enabled_list):
     # Once https://github.com/NVIDIA/spark-rapids/issues/131 is fixed
     # we should go with a more standard set of generators
     orc_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -117,10 +126,12 @@ def test_simple_partitioned_read(spark_tmp_path):
             lambda spark : gen_df(spark, gen_list).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.orc(data_path))
+            lambda spark : spark.read.orc(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 @pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/135')
-def test_merge_schema_read(spark_tmp_path):
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_merge_schema_read(spark_tmp_path, v1_enabled_list):
     # Once https://github.com/NVIDIA/spark-rapids/issues/131 is fixed
     # we should go with a more standard set of generators
     orc_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -136,7 +147,8 @@ def test_merge_schema_read(spark_tmp_path):
             lambda spark : gen_df(spark, second_gen_list).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.option('mergeSchema', 'true').orc(data_path))
+            lambda spark : spark.read.option('mergeSchema', 'true').orc(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 orc_write_gens_list = [
         [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -20,7 +20,7 @@ from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session
+from spark_session import with_cpu_session, with_gpu_session
 
 def read_parquet_df(data_path):
     return lambda spark : spark.read.parquet(data_path)
@@ -35,14 +35,15 @@ parquet_gens_list = [[byte_gen, short_gen, int_gen, long_gen, float_gen, double_
 
 @pytest.mark.parametrize('parquet_gens', parquet_gens_list, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])
-def test_read_round_trip(spark_tmp_path, parquet_gens, read_func):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_read_round_trip(spark_tmp_path, parquet_gens, read_func, v1_enabled_list):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED'})
-    assert_gpu_and_cpu_are_equal_collect(
-            read_func(data_path))
+    assert_gpu_and_cpu_are_equal_collect(read_func(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 @allow_non_gpu('FileSourceScanExec')
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])
@@ -67,13 +68,15 @@ parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
 # https://github.com/NVIDIA/spark-rapids/issues/143
 
 @pytest.mark.parametrize('compress', parquet_compress_options)
-def test_compress_read_round_trip(spark_tmp_path, compress):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_compress_read_round_trip(spark_tmp_path, compress, v1_enabled_list):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
             lambda spark : binary_op_df(spark, long_gen).write.parquet(data_path),
             conf={'spark.sql.parquet.compression.codec': compress})
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.parquet(data_path))
+            lambda spark : spark.read.parquet(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_pred_push_gens = [
         byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen, boolean_gen,
@@ -84,8 +87,9 @@ parquet_pred_push_gens = [
 
 @pytest.mark.parametrize('parquet_gen', parquet_pred_push_gens, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])
-def test_pred_push_round_trip(spark_tmp_path, parquet_gen, read_func):
-    data_path = spark_tmp_path + '/ORC_DATA'
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_pred_push_round_trip(spark_tmp_path, parquet_gen, read_func, v1_enabled_list):
+    data_path = spark_tmp_path + '/PARQUET_DATA'
     gen_list = [('a', RepeatSeqGen(parquet_gen, 100)), ('b', parquet_gen)]
     s0 = gen_scalar(parquet_gen, force_no_nulls=True)
     with_cpu_session(
@@ -93,13 +97,15 @@ def test_pred_push_round_trip(spark_tmp_path, parquet_gen, read_func):
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED'})
     rf = read_func(data_path)
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: rf(spark).select(f.col('a') >= s0))
+            lambda spark: rf(spark).select(f.col('a') >= s0),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_ts_write_options = ['INT96', 'TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS']
 
 @pytest.mark.parametrize('ts_write', parquet_ts_write_options)
 @pytest.mark.parametrize('ts_rebase', ['CORRECTED', 'LEGACY'])
-def test_ts_read_round_trip(spark_tmp_path, ts_write, ts_rebase):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_ts_read_round_trip(spark_tmp_path, ts_write, ts_rebase, v1_enabled_list):
     # Once https://github.com/NVIDIA/spark-rapids/issues/132 is fixed replace this with
     # timestamp_gen
     gen = TimestampGen(start=datetime(1900, 1, 1, tzinfo=timezone.utc))
@@ -109,7 +115,8 @@ def test_ts_read_round_trip(spark_tmp_path, ts_write, ts_rebase):
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
                 'spark.sql.parquet.outputTimestampType': ts_write})
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.parquet(data_path))
+            lambda spark : spark.read.parquet(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_gens_legacy_list = [[byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
     string_gen, boolean_gen, DateGen(start=date(1590, 1, 1)),
@@ -118,16 +125,19 @@ parquet_gens_legacy_list = [[byte_gen, short_gen, int_gen, long_gen, float_gen, 
     pytest.param([date_gen], marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/133'))]
 
 @pytest.mark.parametrize('parquet_gens', parquet_gens_legacy_list, ids=idfn)
-def test_read_round_trip_legacy(spark_tmp_path, parquet_gens):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_read_round_trip_legacy(spark_tmp_path, parquet_gens, v1_enabled_list):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'LEGACY'})
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.parquet(data_path))
+            lambda spark : spark.read.parquet(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
-def test_simple_partitioned_read(spark_tmp_path):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_simple_partitioned_read(spark_tmp_path, v1_enabled_list):
     # Once https://github.com/NVIDIA/spark-rapids/issues/133 and https://github.com/NVIDIA/spark-rapids/issues/132 are fixed 
     # we should go with a more standard set of generators
     parquet_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -144,11 +154,13 @@ def test_simple_partitioned_read(spark_tmp_path):
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED'})
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.parquet(data_path))
+            lambda spark : spark.read.parquet(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 @pytest.mark.xfail(condition=is_databricks_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/192')
-def test_read_merge_schema(spark_tmp_path):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_read_merge_schema(spark_tmp_path, v1_enabled_list):
     # Once https://github.com/NVIDIA/spark-rapids/issues/133 and https://github.com/NVIDIA/spark-rapids/issues/132 are fixed 
     # we should go with a more standard set of generators
     parquet_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -166,14 +178,16 @@ def test_read_merge_schema(spark_tmp_path):
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED'})
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.read.option('mergeSchema', 'true').parquet(data_path))
+            lambda spark : spark.read.option('mergeSchema', 'true').parquet(data_path),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_write_gens_list = [
         [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
             string_gen, boolean_gen, date_gen, timestamp_gen]]
 
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
-def test_write_round_trip(spark_tmp_path, parquet_gens):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_write_round_trip(spark_tmp_path, parquet_gens, v1_enabled_list):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_writes_are_equal_collect(
@@ -181,7 +195,8 @@ def test_write_round_trip(spark_tmp_path, parquet_gens):
             lambda spark, path: spark.read.parquet(path),
             data_path,
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
-                'spark.sql.parquet.outputTimestampType': 'TIMESTAMP_MICROS'})
+                'spark.sql.parquet.outputTimestampType': 'TIMESTAMP_MICROS',
+                'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_part_write_gens = [
         byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -192,7 +207,8 @@ parquet_part_write_gens = [
 # There are race conditions around when individual files are read in for partitioned data
 @ignore_order
 @pytest.mark.parametrize('parquet_gen', parquet_part_write_gens, ids=idfn)
-def test_part_write_round_trip(spark_tmp_path, parquet_gen):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_part_write_round_trip(spark_tmp_path, parquet_gen, v1_enabled_list):
     gen_list = [('a', RepeatSeqGen(parquet_gen, 10)),
             ('b', parquet_gen)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -201,19 +217,23 @@ def test_part_write_round_trip(spark_tmp_path, parquet_gen):
             lambda spark, path: spark.read.parquet(path),
             data_path,
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
-                'spark.sql.parquet.outputTimestampType': 'TIMESTAMP_MICROS'})
+                'spark.sql.parquet.outputTimestampType': 'TIMESTAMP_MICROS',
+                'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
 parquet_write_compress_options = ['none', 'uncompressed', 'snappy']
 @pytest.mark.parametrize('compress', parquet_write_compress_options)
-def test_compress_write_round_trip(spark_tmp_path, compress):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_compress_write_round_trip(spark_tmp_path, compress, v1_enabled_list):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_writes_are_equal_collect(
             lambda spark, path : binary_op_df(spark, long_gen).coalesce(1).write.parquet(path),
             lambda spark, path : spark.read.parquet(path),
             data_path,
-            conf={'spark.sql.parquet.compression.codec': compress})
+            conf={'spark.sql.parquet.compression.codec': compress,
+                'spark.sql.sources.useV1SourceList': v1_enabled_list})
 
-def test_input_meta(spark_tmp_path):
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+def test_input_meta(spark_tmp_path, v1_enabled_list):
     first_data_path = spark_tmp_path + '/PARQUET_DATA/key=0'
     with_cpu_session(
             lambda spark : unary_op_df(spark, long_gen).write.parquet(first_data_path))
@@ -227,4 +247,6 @@ def test_input_meta(spark_tmp_path):
                     .selectExpr('a',
                         'input_file_name()',
                         'input_file_block_start()',
-                        'input_file_block_length()'))
+                        'input_file_block_length()'),
+            conf={'spark.sql.sources.useV1SourceList': v1_enabled_list})
+

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuOrcScan.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuOrcScan.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark300
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+// FileScan changed in Spark 3.1.0 so need to compile in Shim
+case class GpuOrcScan(
+    sparkSession: SparkSession,
+    hadoopConf: Configuration,
+    fileIndex: PartitioningAwareFileIndex,
+    dataSchema: StructType,
+    readDataSchema: StructType,
+    readPartitionSchema: StructType,
+    options: CaseInsensitiveStringMap,
+    pushedFilters: Array[Filter],
+    partitionFilters: Seq[Expression],
+    dataFilters: Seq[Expression],
+    rapidsConf: RapidsConf)
+  extends GpuOrcScanBase(sparkSession, hadoopConf, dataSchema, readDataSchema,
+    readPartitionSchema, pushedFilters, rapidsConf) with FileScan {
+
+  override def isSplitable(path: Path): Boolean = super.isSplitableBase(path)
+
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactoryBase()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case o: GpuOrcScan =>
+      super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
+        equivalentFilters(pushedFilters, o.pushedFilters) && rapidsConf == o.rapidsConf
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def description(): String = {
+    super.description() + ", PushedFilters: " + seqToString(pushedFilters)
+  }
+
+  override def withFilters(
+      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+}

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuOrcScan.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuOrcScan.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.shims.spark300
 
-import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.{GpuOrcScanBase, RapidsConf}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuParquetScan.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuParquetScan.scala
@@ -16,54 +16,18 @@
 
 package com.nvidia.spark.rapids.shims.spark300
 
-import java.io.OutputStream
-import java.net.URI
-import java.nio.charset.StandardCharsets
-import java.util.{Collections, Locale}
-
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
-import scala.math.max
-
-import ai.rapids.cudf.{ColumnVector, DType, HostMemoryBuffer, NvtxColor, ParquetOptions, Table}
-import com.nvidia.spark.RebaseHelper
-import com.nvidia.spark.rapids.GpuMetricNames._
-import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
-import com.nvidia.spark.rapids.RapidsConf.ENABLE_SMALL_FILES_PARQUET
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import org.apache.commons.io.IOUtils
-import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
+import com.nvidia.spark.rapids.{GpuParquetScanBase, RapidsConf}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FSDataInputStream, Path}
-import org.apache.parquet.bytes.BytesUtils
-import org.apache.parquet.column.ColumnDescriptor
-import org.apache.parquet.filter2.predicate.FilterApi
-import org.apache.parquet.format.converter.ParquetMetadataConverter
-import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
-import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData, ColumnPath, FileMetaData, ParquetMetadata}
-import org.apache.parquet.schema.{GroupType, MessageType, Types}
+import org.apache.hadoop.fs.Path
 
-import org.apache.spark.TaskContext
-import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile, PartitioningAwareFileIndex}
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, ParquetReadSupport}
-import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan}
-import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{StringType, StructType, TimestampType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.SerializableConfiguration
 
 // FileScan changed in Spark 3.1.0 so need to compile in Shim
 case class GpuParquetScan(
@@ -78,17 +42,12 @@ case class GpuParquetScan(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
     rapidsConf: RapidsConf)
-  extends FileScan with GpuParquetScanBase(sparkSession, hadoopConf, fileIndex, dataSchema,
-     readDataSchema, readPartitionSchema, pushedFilters, options, partitionFilters,
-     dataFilters, rapidsConf) {
+  extends GpuParquetScanBase(sparkSession, hadoopConf, dataSchema,
+     readDataSchema, readPartitionSchema, pushedFilters, rapidsConf) with FileScan {
 
-  override def isSplitable(path: Path): Boolean = super.isSplitable
+  override def isSplitable(path: Path): Boolean = super.isSplitableBase(path)
 
-  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactory()
-
-  override def equals(obj: Any): Boolean = super.equals(obj)
-
-  override def description(): String = super.description()
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactoryBase()
 
   override def equals(obj: Any): Boolean = obj match {
     case p: GpuParquetScan =>

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuParquetScan.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuParquetScan.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark300
+
+import java.io.OutputStream
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.{Collections, Locale}
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
+import scala.math.max
+
+import ai.rapids.cudf.{ColumnVector, DType, HostMemoryBuffer, NvtxColor, ParquetOptions, Table}
+import com.nvidia.spark.RebaseHelper
+import com.nvidia.spark.rapids.GpuMetricNames._
+import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
+import com.nvidia.spark.rapids.RapidsConf.ENABLE_SMALL_FILES_PARQUET
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import org.apache.commons.io.IOUtils
+import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.apache.parquet.bytes.BytesUtils
+import org.apache.parquet.column.ColumnDescriptor
+import org.apache.parquet.filter2.predicate.FilterApi
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
+import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData, ColumnPath, FileMetaData, ParquetMetadata}
+import org.apache.parquet.schema.{GroupType, MessageType, Types}
+
+import org.apache.spark.TaskContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, ParquetReadSupport}
+import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan}
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{StringType, StructType, TimestampType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
+
+// FileScan changed in Spark 3.1.0 so need to compile in Shim
+case class GpuParquetScan(
+    sparkSession: SparkSession,
+    hadoopConf: Configuration,
+    fileIndex: PartitioningAwareFileIndex,
+    dataSchema: StructType,
+    readDataSchema: StructType,
+    readPartitionSchema: StructType,
+    pushedFilters: Array[Filter],
+    options: CaseInsensitiveStringMap,
+    partitionFilters: Seq[Expression],
+    dataFilters: Seq[Expression],
+    rapidsConf: RapidsConf)
+  extends FileScan with GpuParquetScanBase(sparkSession, hadoopConf, fileIndex, dataSchema,
+     readDataSchema, readPartitionSchema, pushedFilters, options, partitionFilters,
+     dataFilters, rapidsConf) {
+
+  override def isSplitable(path: Path): Boolean = super.isSplitable
+
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactory()
+
+  override def equals(obj: Any): Boolean = super.equals(obj)
+
+  override def description(): String = super.description()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case p: GpuParquetScan =>
+      super.equals(p) && dataSchema == p.dataSchema && options == p.options &&
+        equivalentFilters(pushedFilters, p.pushedFilters) && rapidsConf == p.rapidsConf
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def description(): String = {
+    super.description() + ", PushedFilters: " + seqToString(pushedFilters)
+  }
+
+  override def withFilters(
+      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+}

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -31,14 +31,18 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{First, Last}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
-import org.apache.spark.sql.execution.datasources.{BucketingUtils, FilePartition, FileScanRDD, HadoopFsRelation, PartitionDirectory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, HadoopFsRelation, PartitionDirectory, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashJoin, SortMergeJoinExec}
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuTimeSub, ShuffleManagerShimBase}
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastMeta, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, GpuShuffleMeta}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
 import org.apache.spark.sql.rapids.shims.spark300._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.{BlockId, BlockManagerId}
@@ -215,6 +219,63 @@ class Spark300Shims extends SparkShims {
         })
     ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }
+
+  override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
+    GpuOverrides.scan[CSVScan](
+      "CSV parsing",
+      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuCSVScan(a.sparkSession,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.options,
+            a.partitionFilters,
+            a.dataFilters,
+            conf.maxReadBatchSizeRows,
+            conf.maxReadBatchSizeBytes)
+      }),
+    GpuOverrides.scan[ParquetScan](
+      "Parquet parsing",
+      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit = GpuParquetScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuParquetScan(a.sparkSession,
+            a.hadoopConf,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.pushedFilters,
+            a.options,
+            a.partitionFilters,
+            a.dataFilters,
+            conf)
+      }),
+    GpuOverrides.scan[OrcScan](
+      "ORC parsing",
+      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit =
+          GpuOrcScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuOrcScan(a.sparkSession,
+            a.hadoopConf,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.options,
+            a.pushedFilters,
+            a.partitionFilters,
+            a.dataFilters,
+            conf)
+      })
+  ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def getBuildSide(join: HashJoin): GpuBuildSide = {
     GpuJoinUtils.getGpuBuildSide(join.buildSide)

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -221,23 +221,6 @@ class Spark300Shims extends SparkShims {
   }
 
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
-    GpuOverrides.scan[CSVScan](
-      "CSV parsing",
-      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuCSVScan(a.sparkSession,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
-      }),
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
       (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
@@ -260,7 +243,7 @@ class Spark300Shims extends SparkShims {
       "ORC parsing",
       (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
         override def tagSelfForGpu(): Unit =
-          GpuOrcScan.tagSupport(this)
+          GpuOrcScanBase.tagSupport(this)
 
         override def convertToGpu(): Scan =
           GpuOrcScan(a.sparkSession,

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -241,7 +241,7 @@ class Spark300Shims extends SparkShims {
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
       (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScan.tagSupport(this)
+        override def tagSelfForGpu(): Unit = GpuParquetScanBase.tagSupport(this)
 
         override def convertToGpu(): Scan =
           GpuParquetScan(a.sparkSession,

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuOrcScan.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuOrcScan.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark310
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+// FileScan changed in Spark 3.1.0 so need to compile in Shim
+case class GpuOrcScan(
+    sparkSession: SparkSession,
+    hadoopConf: Configuration,
+    fileIndex: PartitioningAwareFileIndex,
+    dataSchema: StructType,
+    readDataSchema: StructType,
+    readPartitionSchema: StructType,
+    options: CaseInsensitiveStringMap,
+    pushedFilters: Array[Filter],
+    partitionFilters: Seq[Expression],
+    dataFilters: Seq[Expression],
+    rapidsConf: RapidsConf)
+  extends GpuOrcScanBase(sparkSession, hadoopConf, dataSchema, readDataSchema,
+    readPartitionSchema, pushedFilters, rapidsConf) with FileScan {
+
+  override def isSplitable(path: Path): Boolean = super.isSplitableBase(path)
+
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactoryBase()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case o: GpuOrcScan =>
+      super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
+        equivalentFilters(pushedFilters, o.pushedFilters) && rapidsConf == o.rapidsConf
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def description(): String = {
+    super.description() + ", PushedFilters: " + seqToString(pushedFilters)
+  }
+
+  override def withFilters(
+      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+}

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuOrcScan.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuOrcScan.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.shims.spark310
 
-import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.{GpuOrcScanBase, RapidsConf}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuParquetScan.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuParquetScan.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark310
+
+import java.io.OutputStream
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.{Collections, Locale}
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
+import scala.math.max
+
+import ai.rapids.cudf.{ColumnVector, DType, HostMemoryBuffer, NvtxColor, ParquetOptions, Table}
+import com.nvidia.spark.RebaseHelper
+import com.nvidia.spark.rapids.GpuMetricNames._
+import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
+import com.nvidia.spark.rapids.RapidsConf.ENABLE_SMALL_FILES_PARQUET
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import org.apache.commons.io.IOUtils
+import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataInputStream, Path}
+import org.apache.parquet.bytes.BytesUtils
+import org.apache.parquet.column.ColumnDescriptor
+import org.apache.parquet.filter2.predicate.FilterApi
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
+import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData, ColumnPath, FileMetaData, ParquetMetadata}
+import org.apache.parquet.schema.{GroupType, MessageType, Types}
+
+import org.apache.spark.TaskContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.execution.QueryExecutionException
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, ParquetReadSupport}
+import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan}
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.{StringType, StructType, TimestampType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
+
+// FileScan changed in Spark 3.1.0 so need to compile in Shim
+case class GpuParquetScan(
+    sparkSession: SparkSession,
+    hadoopConf: Configuration,
+    fileIndex: PartitioningAwareFileIndex,
+    dataSchema: StructType,
+    readDataSchema: StructType,
+    readPartitionSchema: StructType,
+    pushedFilters: Array[Filter],
+    options: CaseInsensitiveStringMap,
+    partitionFilters: Seq[Expression],
+    dataFilters: Seq[Expression],
+    rapidsConf: RapidsConf)
+  extends FileScan with GpuParquetScanBase(sparkSession, hadoopConf, fileIndex, dataSchema,
+     readDataSchema, readPartitionSchema, pushedFilters, options, partitionFilters,
+     dataFilters, rapidsConf) {
+
+  override def isSplitable(path: Path): Boolean = super.isSplitable
+
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactory()
+
+  override def equals(obj: Any): Boolean = super.equals(obj)
+
+  override def description(): String = super.description()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case p: GpuParquetScan =>
+      super.equals(p) && dataSchema == p.dataSchema && options == p.options &&
+        equivalentFilters(pushedFilters, p.pushedFilters) && rapidsConf == p.rapidsConf
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def description(): String = {
+    super.description() + ", PushedFilters: " + seqToString(pushedFilters)
+  }
+
+  override def withFilters(
+      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
+    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+}

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuParquetScan.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuParquetScan.scala
@@ -16,54 +16,18 @@
 
 package com.nvidia.spark.rapids.shims.spark310
 
-import java.io.OutputStream
-import java.net.URI
-import java.nio.charset.StandardCharsets
-import java.util.{Collections, Locale}
-
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
-import scala.math.max
-
-import ai.rapids.cudf.{ColumnVector, DType, HostMemoryBuffer, NvtxColor, ParquetOptions, Table}
-import com.nvidia.spark.RebaseHelper
-import com.nvidia.spark.rapids.GpuMetricNames._
-import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
-import com.nvidia.spark.rapids.RapidsConf.ENABLE_SMALL_FILES_PARQUET
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import org.apache.commons.io.IOUtils
-import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
+import com.nvidia.spark.rapids.{GpuParquetScanBase, RapidsConf}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FSDataInputStream, Path}
-import org.apache.parquet.bytes.BytesUtils
-import org.apache.parquet.column.ColumnDescriptor
-import org.apache.parquet.filter2.predicate.FilterApi
-import org.apache.parquet.format.converter.ParquetMetadataConverter
-import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
-import org.apache.parquet.hadoop.metadata.{BlockMetaData, ColumnChunkMetaData, ColumnPath, FileMetaData, ParquetMetadata}
-import org.apache.parquet.schema.{GroupType, MessageType, Types}
+import org.apache.hadoop.fs.Path
 
-import org.apache.spark.TaskContext
-import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
-import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile, PartitioningAwareFileIndex}
-import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, ParquetReadSupport}
-import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan}
-import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
-import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.FileScan
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{StringType, StructType, TimestampType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.SerializableConfiguration
 
 // FileScan changed in Spark 3.1.0 so need to compile in Shim
 case class GpuParquetScan(
@@ -78,17 +42,12 @@ case class GpuParquetScan(
     partitionFilters: Seq[Expression],
     dataFilters: Seq[Expression],
     rapidsConf: RapidsConf)
-  extends FileScan with GpuParquetScanBase(sparkSession, hadoopConf, fileIndex, dataSchema,
-     readDataSchema, readPartitionSchema, pushedFilters, options, partitionFilters,
-     dataFilters, rapidsConf) {
+  extends GpuParquetScanBase(sparkSession, hadoopConf, dataSchema,
+    readDataSchema, readPartitionSchema, pushedFilters, rapidsConf) with FileScan {
 
-  override def isSplitable(path: Path): Boolean = super.isSplitable
+  override def isSplitable(path: Path): Boolean = super.isSplitableBase(path)
 
-  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactory()
-
-  override def equals(obj: Any): Boolean = super.equals(obj)
-
-  override def description(): String = super.description()
+  override def createReaderFactory(): PartitionReaderFactory = super.createReaderFactoryBase()
 
   override def equals(obj: Any): Boolean = obj match {
     case p: GpuParquetScan =>

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -168,23 +168,6 @@ class Spark310Shims extends Spark301Shims {
   }
 
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
-    GpuOverrides.scan[CSVScan](
-      "CSV parsing",
-      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuCSVScan(a.sparkSession,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
-      }),
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
       (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
@@ -207,7 +190,7 @@ class Spark310Shims extends Spark301Shims {
       "ORC parsing",
       (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
         override def tagSelfForGpu(): Unit =
-          GpuOrcScan.tagSupport(this)
+          GpuOrcScanBase.tagSupport(this)
 
         override def convertToGpu(): Scan =
           GpuOrcScan(a.sparkSession,

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -188,7 +188,7 @@ class Spark310Shims extends Spark301Shims {
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
       (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScan.tagSupport(this)
+        override def tagSelfForGpu(): Unit = GpuParquetScanBase.tagSupport(this)
 
         override def convertToGpu(): Scan =
           GpuParquetScan(a.sparkSession,

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -26,8 +26,12 @@ import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashJoin, SortMergeJoinExec}
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuTimeSub, ShuffleManagerShimBase}
@@ -162,6 +166,64 @@ class Spark310Shims extends Spark301Shims {
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r))
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
   }
+
+  override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
+    GpuOverrides.scan[CSVScan](
+      "CSV parsing",
+      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuCSVScan(a.sparkSession,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.options,
+            a.partitionFilters,
+            a.dataFilters,
+            conf.maxReadBatchSizeRows,
+            conf.maxReadBatchSizeBytes)
+      }),
+    GpuOverrides.scan[ParquetScan](
+      "Parquet parsing",
+      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit = GpuParquetScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuParquetScan(a.sparkSession,
+            a.hadoopConf,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.pushedFilters,
+            a.options,
+            a.partitionFilters,
+            a.dataFilters,
+            conf)
+      }),
+    GpuOverrides.scan[OrcScan](
+      "ORC parsing",
+      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
+        override def tagSelfForGpu(): Unit =
+          GpuOrcScan.tagSupport(this)
+
+        override def convertToGpu(): Scan =
+          GpuOrcScan(a.sparkSession,
+            a.hadoopConf,
+            a.fileIndex,
+            a.dataSchema,
+            a.readDataSchema,
+            a.readPartitionSchema,
+            a.options,
+            a.pushedFilters,
+            a.partitionFilters,
+            a.dataFilters,
+            conf)
+      })
+  ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
+
 
   override def getBuildSide(join: HashJoin): GpuBuildSide = {
     GpuJoinUtils.getGpuBuildSide(join.buildSide)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -45,20 +45,18 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.execution.datasources.{PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.orc.OrcUtils
-import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan}
+import org.apache.spark.sql.execution.datasources.v2.FilePartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.OrcFilters
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -62,23 +62,19 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 
-case class GpuOrcScan(
+abstract class GpuOrcScanBase(
     sparkSession: SparkSession,
     hadoopConf: Configuration,
-    fileIndex: PartitioningAwareFileIndex,
     dataSchema: StructType,
     readDataSchema: StructType,
     readPartitionSchema: StructType,
-    options: CaseInsensitiveStringMap,
     pushedFilters: Array[Filter],
-    partitionFilters: Seq[Expression],
-    dataFilters: Seq[Expression],
     rapidsConf: RapidsConf)
-  extends FileScan with ScanWithMetrics {
+  extends ScanWithMetrics {
 
-  override def isSplitable(path: Path): Boolean = true
+  def isSplitableBase(path: Path): Boolean = true
 
-  override def createReaderFactory(): PartitionReaderFactory = {
+  def createReaderFactoryBase(): PartitionReaderFactory = {
     // Unset any serialized search argument setup by Spark's OrcScanBuilder as
     // it will be incompatible due to shading and potential ORC classifier mismatch.
     hadoopConf.unset(OrcConf.KRYO_SARG.getAttribute)
@@ -88,26 +84,9 @@ case class GpuOrcScan(
     GpuOrcPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,
       dataSchema, readDataSchema, readPartitionSchema, pushedFilters, rapidsConf, metrics)
   }
-
-  override def equals(obj: Any): Boolean = obj match {
-    case o: GpuOrcScan =>
-      super.equals(o) && dataSchema == o.dataSchema && options == o.options &&
-        equivalentFilters(pushedFilters, o.pushedFilters) && rapidsConf == o.rapidsConf
-    case _ => false
-  }
-
-  override def hashCode(): Int = getClass.hashCode()
-
-  override def description(): String = {
-    super.description() + ", PushedFilters: " + seqToString(pushedFilters)
-  }
-
-  override def withFilters(
-      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
-    this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
 }
 
-object GpuOrcScan {
+object GpuOrcScanBase {
   def tagSupport(scanMeta: ScanMeta[OrcScan]): Unit = {
     val scan = scanMeta.wrapped
     val schema = StructType(scan.readDataSchema ++ scan.readPartitionSchema)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1504,62 +1504,7 @@ object GpuOverrides {
       .map(r => r.wrap(scan, conf, parent, r).asInstanceOf[ScanMeta[INPUT]])
       .getOrElse(new RuleNotFoundScanMeta(scan, conf, parent))
 
-  val scans : Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
-    scan[CSVScan](
-      "CSV parsing",
-      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuCSVScan(a.sparkSession,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
-      }),
-    scan[ParquetScan](
-      "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScan.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      }),
-    scan[OrcScan](
-      "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit =
-          GpuOrcScan.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      })
-  ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
+  val scans : Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = ShimLoader.getSparkShims.getScans
 
   def wrapPart[INPUT <: Partitioning](
       part: INPUT,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -48,7 +48,6 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.execution.datasources.{PartitionedFile, PartitioningAwareFileIndex}
@@ -60,27 +59,22 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{StringType, StructType, TimestampType}
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 
 abstract class GpuParquetScanBase(
     sparkSession: SparkSession,
     hadoopConf: Configuration,
-    fileIndex: PartitioningAwareFileIndex,
     dataSchema: StructType,
     readDataSchema: StructType,
     readPartitionSchema: StructType,
     pushedFilters: Array[Filter],
-    options: CaseInsensitiveStringMap,
-    partitionFilters: Seq[Expression],
-    dataFilters: Seq[Expression],
     rapidsConf: RapidsConf)
   extends ScanWithMetrics {
 
-  override def isSplitable(path: Path): Boolean = true
+  def isSplitableBase(path: Path): Boolean = true
 
-  override def createReaderFactory(): PartitionReaderFactory = {
+  def createReaderFactoryBase(): PartitionReaderFactory = {
     val broadcastedConf = sparkSession.sparkContext.broadcast(
       new SerializableConfiguration(hadoopConf))
     GpuParquetPartitionReaderFactory(sparkSession.sessionState.conf, broadcastedConf,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -82,7 +82,7 @@ abstract class GpuParquetScanBase(
   }
 }
 
-object GpuParquetScan {
+object GpuParquetScanBase {
   def tagSupport(scanMeta: ScanMeta[ParquetScan]): Unit = {
     val scan = scanMeta.wrapped
     val schema = StructType(scan.readDataSchema ++ scan.readPartitionSchema)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
@@ -63,7 +63,7 @@ object GpuReadOrcFileFormat {
     if (fsse.relation.options.getOrElse("mergeSchema", "false").toBoolean) {
       meta.willNotWorkOnGpu("mergeSchema and schema evolution is not supported yet")
     }
-    GpuOrcScan.tagSupport(
+    GpuOrcScanBase.tagSupport(
       fsse.sqlContext.sparkSession,
       fsse.requiredSchema,
       meta

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadParquetFileFormat.scala
@@ -60,7 +60,7 @@ class GpuReadParquetFileFormat extends ParquetFileFormat with GpuReadFileFormatW
 object GpuReadParquetFileFormat {
   def tagSupport(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val fsse = meta.wrapped
-    GpuParquetScan.tagSupport(
+    GpuParquetScanBase.tagSupport(
       fsse.sqlContext.sparkSession,
       fsse.requiredSchema,
       meta

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
 import org.apache.spark.sql.execution.datasources.{FilePartition, HadoopFsRelation, PartitionDirectory, PartitionedFile}
@@ -65,6 +66,8 @@ trait SparkShims {
   def getBuildSide(join: BroadcastNestedLoopJoinExec): GpuBuildSide
   def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]]
   def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]]
+  def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]]
+
   def getScalaUDFAsExpression(
     function: AnyRef,
     dataType: DataType,


### PR DESCRIPTION
spark 3.1.0 FileScan changed which requires us to move our GpuParquetScan and GpuOrcScan into the Shim layer.
this also modifies the tests to run the readers against both Datasource v1 and Datasource v2 apis.

I choose to do this rather then pull in FileScan because this seems like less code and still allows us to pick up any changes to FileScan that happen in Spark.

closes https://github.com/NVIDIA/spark-rapids/issues/587

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
