### PR TITLE
Add ucx license in NOTICE-binary

### DIFF
--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -22,3 +22,42 @@ Foundation (http://www.apache.org/).
 
 This product includes software developed by Hewlett-Packard:
 (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P
+
+---------------------------------------------------------------------
+UCF Consortium - Unified Communication X (UCX)
+
+Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
+Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
+Copyright (C) 2014-2015      The University of Houston System. All rights reserved.
+Copyright (C) 2015           The University of Tennessee and The University 
+                             of Tennessee Research Foundation. All rights reserved.
+Copyright (C) 2016           ARM Ltd. All rights reserved.
+Copyright (c) 2016           Los Alamos National Security, LLC. All rights reserved.
+Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
+Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
+Copyright (c) 2018-2019      NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions 
+are met:
+
+1. Redistributions of source code must retain the above copyright 
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its 
+contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
UCX is licensed under BSD-3. They require the include of the license text included from  when redistributing binaries.

We distribute the jucx 1.8 jar with our spark-rapids jar, so adding the LICENSE from the 1.8.x branch, specifically: https://github.com/openucx/ucx/blob/84538d2d8753f9a597a6da3b5c7458b9c2bc178c/LICENSE,  to our NOTICE-binary file, which gets included into the spark-rapids jar, to comply with the redistribution in binary form clause.

When we move to the jucx 1.9+ jar, we will refresh our NOTICE-binary file, as needed.