### PR TITLE
Fix calculation of string data for compressed batches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -217,6 +217,9 @@ abstract class AbstractGpuCoalesceIterator(origIter: Iterator[ColumnarBatch],
       case h: RapidsHostColumnVector =>
         val buff = h.getBase.getHostBufferFor(BufferType.DATA)
         if (buff == null) 0 else buff.getLength
+      case g: GpuCompressedColumnVector =>
+        val columnMeta = g.getTableMeta.columnMetas(index)
+        columnMeta.data().length()
       case _ =>
         defaultSize
     }


### PR DESCRIPTION
While running a query with the copy shuffle codec, I ran into the string data length exceeded exception in `GpuCoalesceBatches`.  The same setup without shuffle compression ran fine.  Tracked this down to calculation of string data sizes being wrong for compressed columns.  There wasn't specialized code for that case, so it ended up using the entire column size.  This can be a particularly bad estimate for columns where the average string length is relatively small so the offset vector size contributes significantly to the total size.

The fix is to leverage the compressed table metadata which has the size of each column buffer readily available.