### PR TITLE
Fix data size metric always 0 when using RAPIDS shuffle

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleDependency.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleDependency.scala
@@ -22,6 +22,7 @@ import org.apache.spark.{Aggregator, Partitioner, ShuffleDependency, SparkEnv}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ShuffleWriteProcessor
+import org.apache.spark.sql.execution.metric.SQLMetric
 
 class GpuShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     rdd: RDD[_ <: Product2[K, V]],
@@ -30,10 +31,10 @@ class GpuShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     keyOrdering: Option[Ordering[K]] = None,
     aggregator: Option[Aggregator[K, V, C]] = None,
     mapSideCombine: Boolean = false,
-    shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor)
+    shuffleWriterProcessor: ShuffleWriteProcessor = new ShuffleWriteProcessor,
+    val metrics: Map[String, SQLMetric] = Map.empty)
   extends ShuffleDependency[K, V, C](rdd, partitioner, serializer, keyOrdering,
     aggregator, mapSideCombine, shuffleWriterProcessor) {
 
   override def toString: String = "GPU Shuffle Dependency"
 }
-

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -28,9 +28,8 @@ import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.errors._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
-import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.{Exchange, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.metric._
 import org.apache.spark.sql.internal.SQLConf
@@ -110,7 +109,8 @@ abstract class GpuShuffleExchangeExecBase(
       outputPartitioning,
       serializer,
       metrics,
-      writeMetrics)
+      writeMetrics,
+      additionalMetrics)
   }
 
   /**
@@ -137,7 +137,8 @@ object GpuShuffleExchangeExec {
       newPartitioning: Partitioning,
       serializer: Serializer,
       metrics: Map[String, SQLMetric],
-      writeMetrics: Map[String, SQLMetric])
+      writeMetrics: Map[String, SQLMetric],
+      additionalMetrics: Map[String, SQLMetric])
   : ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
     val isRoundRobin = newPartitioning match {
       case _: GpuRoundRobinPartitioning => true
@@ -228,7 +229,8 @@ object GpuShuffleExchangeExec {
       rddWithPartitionIds,
       new BatchPartitionIdPassthrough(newPartitioning.numPartitions),
       serializer,
-      shuffleWriterProcessor = ShuffleExchangeExec.createShuffleWriteProcessor(writeMetrics))
+      shuffleWriterProcessor = ShuffleExchangeExec.createShuffleWriteProcessor(writeMetrics),
+      metrics = additionalMetrics)
 
     dependency
   }


### PR DESCRIPTION
Fixes #511.

This connects the existing `dataSize` metric to the RAPIDS shuffle.  In the legacy shuffle this metric is updated via the serializer, but using the RAPIDS shuffle side-steps the serializer and thus the metric never is set.

This approach puts the metric into the shuffle dependency, and then the metric is passed to to the RAPIDS shuffle writer when it is constructed.