### PR TITLE
Add support for accelerated arrow exchange with python

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -166,6 +166,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.Or"></a>spark.rapids.sql.expression.Or|`or`|Logical OR|true|None|
 <a name="sql.expression.Pmod"></a>spark.rapids.sql.expression.Pmod|`pmod`|Pmod|true|None|
 <a name="sql.expression.Pow"></a>spark.rapids.sql.expression.Pow|`pow`, `power`|lhs ^ rhs|true|None|
+<a name="sql.expression.PythonUDF"></a>spark.rapids.sql.expression.PythonUDF| |UDF run in an external python process. Does not actually run on the GPU, but the transfer of data to/from it can be accelerated.|true|None|
 <a name="sql.expression.Quarter"></a>spark.rapids.sql.expression.Quarter|`quarter`|Returns the quarter of the year for date, in the range 1 to 4|true|None|
 <a name="sql.expression.Rand"></a>spark.rapids.sql.expression.Rand|`random`, `rand`|Generate a random column with i.i.d. uniformly distributed values in [0, 1)|true|None|
 <a name="sql.expression.RegExpReplace"></a>spark.rapids.sql.expression.RegExpReplace|`regexp_replace`|RegExpReplace support for string literal input patterns|true|None|
@@ -249,6 +250,7 @@ Name | Description | Default Value | Notes
 <a name="sql.exec.CartesianProductExec"></a>spark.rapids.sql.exec.CartesianProductExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
 <a name="sql.exec.ShuffledHashJoinExec"></a>spark.rapids.sql.exec.ShuffledHashJoinExec|Implementation of join using hashed shuffled data|true|None|
 <a name="sql.exec.SortMergeJoinExec"></a>spark.rapids.sql.exec.SortMergeJoinExec|Sort merge join, replacing with shuffled hash join|true|None|
+<a name="sql.exec.ArrowEvalPythonExec"></a>spark.rapids.sql.exec.ArrowEvalPythonExec|Runs python UDFs.  The python code does not actually run on the GPU, but the transfer of data between the python process and the java process is accelerated.|false|This is disabled by default because Performance is not ideal for UDFs that take a long time.|
 <a name="sql.exec.WindowExec"></a>spark.rapids.sql.exec.WindowExec|Window-operator backend|true|None|
 
 ### Scans

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_are_equal_collect
+from data_gen import *
+from marks import incompat, approximate_float, allow_non_gpu, ignore_order
+from pyspark.sql import Window
+from pyspark.sql.types import *
+import pyspark.sql.functions as f
+from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
+import pandas as pd
+from typing import Iterator, Tuple
+
+try:
+    require_minimum_pyarrow_version()
+except Exception as e:
+    pytestmark = pytest.mark.skip(reason=str(e))
+
+arrow_udf_conf = {'spark.sql.execution.arrow.pyspark.enabled': 'true',
+        'spark.rapids.sql.exec.ArrowEvalPythonExec': 'true'}
+
+####################################################################
+# NOTE: pytest does not play well with pyspark udfs, because pyspark
+# tries to import the dependencies for top level functions and
+# pytest messes around with imports. To make this work, all UDFs
+# must either be lambdas or totally defined within the test method
+# itself.
+####################################################################
+
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_pandas_math_udf(data_gen):
+    def add(a, b):
+        return a + b
+    my_udf = f.pandas_udf(add, returnType=LongType())
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen).select(
+                my_udf(f.col('a') - 3, f.col('b'))),
+            conf=arrow_udf_conf)
+
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_iterator_math_udf(data_gen):
+    def iterator_add(to_process: Iterator[Tuple[pd.Series, pd.Series]]) -> Iterator[pd.Series]:
+        for a, b in to_process:
+            yield a + b
+
+    my_udf = f.pandas_udf(iterator_add, returnType=LongType())
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen).select(
+                my_udf(f.col('a'), f.col('b'))),
+            conf=arrow_udf_conf)
+
+@allow_non_gpu('AggregateInPandasExec', 'PythonUDF', 'Alias')
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_single_aggregate_udf(data_gen):
+    @f.pandas_udf('double')
+    def pandas_sum(to_process: pd.Series) -> float:
+        return to_process.sum()
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, data_gen).select(
+                pandas_sum(f.col('a'))),
+            conf=arrow_udf_conf)
+
+@ignore_order
+@allow_non_gpu('AggregateInPandasExec', 'PythonUDF', 'Alias')
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_group_aggregate_udf(data_gen):
+    @f.pandas_udf('long')
+    def pandas_sum(to_process: pd.Series) -> int:
+        return to_process.sum()
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen)\
+                    .groupBy('a')\
+                    .agg(pandas_sum(f.col('b'))),
+            conf=arrow_udf_conf)
+
+@ignore_order
+@allow_non_gpu('WindowInPandasExec', 'PythonUDF', 'WindowExpression', 'Alias', 'WindowSpecDefinition', 'SpecifiedWindowFrame', 'UnboundedPreceding$', 'UnboundedFollowing$')
+@pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+def test_window_aggregate_udf(data_gen):
+    @f.pandas_udf('long')
+    def pandas_sum(to_process: pd.Series) -> int:
+        return to_process.sum()
+
+    w = Window\
+            .partitionBy('a') \
+            .rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen).select(
+                pandas_sum(f.col('b')).over(w)),
+            conf=arrow_udf_conf)
+
+@ignore_order
+@allow_non_gpu('FlatMapGroupsInPandasExec', 'PythonUDF', 'Alias')
+@pytest.mark.parametrize('data_gen', [LongGen()], ids=idfn)
+def test_group_apply_udf(data_gen):
+    def pandas_add(data):
+        data.sum = data.b + data.a
+        return data
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen)\
+                    .groupBy('a')\
+                    .applyInPandas(pandas_add, schema="a long, b long"),
+            conf=arrow_udf_conf)
+
+
+@allow_non_gpu('MapInPandasExec', 'PythonUDF', 'Alias')
+@pytest.mark.parametrize('data_gen', [LongGen()], ids=idfn)
+def test_map_apply_udf(data_gen):
+    def pandas_filter(iterator):
+        for data in iterator:
+            yield data[data.b <= data.a]
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen)\
+                    .mapInPandas(pandas_filter, schema="a long, b long"),
+            conf=arrow_udf_conf)
+
+def create_df(spark, data_gen, left_length, right_length):
+    left = binary_op_df(spark, data_gen, length=left_length)
+    right = binary_op_df(spark, data_gen, length=right_length)
+    return left, right
+
+@ignore_order
+@allow_non_gpu('FlatMapCoGroupsInPandasExec', 'PythonUDF', 'Alias')
+@pytest.mark.parametrize('data_gen', [ShortGen(nullable=False)], ids=idfn)
+def test_cogroup_apply_udf(data_gen):
+    def asof_join(l, r):
+        return pd.merge_asof(l, r, on='a', by='b')
+
+    def do_it(spark):
+        left, right = create_df(spark, data_gen, 500, 500)
+        return left.groupby('a').cogroup(
+                right.groupby('a')).applyInPandas(
+                        asof_join, schema="a int, b int")
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf=arrow_udf_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -224,12 +224,14 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
   private def indent(append: StringBuilder, depth: Int): Unit =
     append.append("  " * depth)
 
+  def couldReplaceMessage: String = "could run on GPU"
+  def noReplacementPossibleMessage(reasons: String): String = s"cannot run on GPU because $reasons"
+
   private def willWorkOnGpuInfo: String = cannotBeReplacedReasons match {
     case None => "NOT EVALUATED FOR GPU YET"
-    case Some(v) if v.isEmpty => "could run on GPU"
+    case Some(v) if v.isEmpty => couldReplaceMessage
     case Some(v) =>
-      val reasons = v mkString "; "
-      s"cannot run on GPU because ${reasons}"
+      noReplacementPossibleMessage(v mkString "; ")
   }
 
   private def willBeRemovedInfo: String = shouldBeRemovedReasons match {
@@ -237,7 +239,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     case Some(v) if v.isEmpty => ""
     case Some(v) =>
       val reasons = v mkString "; "
-      s" but is going to be removed because ${reasons}"
+      s" but is going to be removed because $reasons"
   }
 
   /**
@@ -399,7 +401,7 @@ final class RuleNotFoundDataWritingCommandMeta[INPUT <: DataWritingCommand](
     extends DataWritingCommandMeta[INPUT](cmd, conf, parent, new NoRuleConfKeysAndIncompat) {
 
   override def tagSelfForGpu(): Unit = {
-    willNotWorkOnGpu(s"no GPU enabled version of command ${cmd.getClass} could be found")
+    willNotWorkOnGpu(s"no GPU accelerated version of command ${cmd.getClass} could be found")
   }
 
   override def convertToGpu(): GpuDataWritingCommand =

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuArrowEvalPythonExec.scala
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+
+import java.io.{DataInputStream, DataOutputStream}
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import ai.rapids.cudf.{ArrowIPCWriterOptions, HostBufferConsumer, HostBufferProvider, HostMemoryBuffer, NvtxColor, NvtxRange, StreamedTableReader, Table}
+import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuColumnVector, GpuExec, GpuProjectExec, GpuUnevaluable}
+import com.nvidia.spark.rapids.GpuMetricNames._
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.api.python.{BasePythonRunner, ChainedPythonFunctions, PythonEvalType, PythonFunction, PythonRDD, SpecialLengths}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.toPrettySQL
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.python.PythonUDFRunner
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.Utils
+
+class RebatchingIterator(
+    wrapped: Iterator[ColumnarBatch],
+    targetRowSize: Int,
+    inputRows: SQLMetric,
+    inputBatches: SQLMetric)
+    extends Iterator[ColumnarBatch] with Arm {
+  var pending: Table = _
+
+  override def hasNext: Boolean = pending != null || wrapped.hasNext
+
+  private[this] def updatePending(): Unit = {
+    if (pending == null) {
+      withResource(wrapped.next()) { cb =>
+        inputBatches += 1
+        inputRows += cb.numRows()
+        pending = GpuColumnVector.from(cb)
+      }
+    }
+  }
+
+  override def next(): ColumnarBatch = {
+    updatePending()
+
+    while (pending.getRowCount < targetRowSize) {
+      if (wrapped.hasNext) {
+        val combined = withResource(wrapped.next()) { cb =>
+          inputBatches += 1
+          inputRows += cb.numRows()
+          withResource(GpuColumnVector.from(cb)) { nextTable =>
+            Table.concatenate(pending, nextTable)
+          }
+        }
+        pending.close()
+        pending = combined
+      } else {
+        // No more to data so return what is left
+        val ret = withResource(pending) { p =>
+          GpuColumnVector.from(p)
+        }
+        pending = null
+        return ret
+      }
+    }
+
+    // We got lucky
+    if (pending.getRowCount == targetRowSize) {
+      val ret = withResource(pending) { p =>
+        GpuColumnVector.from(p)
+      }
+      pending = null
+      return ret
+    }
+
+    val split = pending.contiguousSplit(targetRowSize)
+    split.foreach(_.getBuffer.close())
+    pending.close()
+    pending = split(1).getTable
+    withResource(split.head.getTable) { ret =>
+      GpuColumnVector.from(ret)
+    }
+  }
+}
+
+// TODO extend this with spilling and other wonderful things
+class BatchQueue extends AutoCloseable {
+  // TODO for now we will use an built in queue
+  private val queue: mutable.Queue[ColumnarBatch] = mutable.Queue[ColumnarBatch]()
+
+  def add(batch: ColumnarBatch): Unit = synchronized {
+    // If you cannot add something blow up
+    queue.enqueue(batch)
+  }
+
+  def remove(): ColumnarBatch = synchronized {
+    if (queue.isEmpty) {
+      null
+    } else {
+      queue.dequeue()
+    }
+  }
+
+  override def close(): Unit = synchronized {
+    while(queue.nonEmpty) {
+      queue.dequeue().close()
+    }
+  }
+}
+
+/**
+ * Helper functions for [[GpuPythonUDF]]
+ */
+object GpuPythonUDF {
+  private[this] val SCALAR_TYPES = Set(
+    PythonEvalType.SQL_BATCHED_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+  )
+
+  def isScalarPythonUDF(e: Expression): Boolean = {
+    e.isInstanceOf[GpuPythonUDF] && SCALAR_TYPES.contains(e.asInstanceOf[GpuPythonUDF].evalType)
+  }
+
+  def isGroupedAggPandasUDF(e: Expression): Boolean = {
+    e.isInstanceOf[GpuPythonUDF] &&
+        e.asInstanceOf[GpuPythonUDF].evalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
+  }
+
+  // This is currently same as GroupedAggPandasUDF, but we might support new types in the future,
+  // e.g, N -> N transform.
+  def isWindowPandasUDF(e: Expression): Boolean = isGroupedAggPandasUDF(e)
+}
+
+/**
+ * A serialized version of a Python lambda function. This is a special expression, which needs a
+ * dedicated physical operator to execute it, and thus can't be pushed down to data sources.
+ */
+case class GpuPythonUDF(
+    name: String,
+    func: PythonFunction,
+    dataType: DataType,
+    children: Seq[Expression],
+    evalType: Int,
+    udfDeterministic: Boolean,
+    resultId: ExprId = NamedExpression.newExprId)
+    extends Expression with GpuUnevaluable with NonSQLExpression with UserDefinedExpression {
+
+  override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+
+  override def toString: String = s"$name(${children.mkString(", ")})"
+
+  lazy val resultAttribute: Attribute = AttributeReference(toPrettySQL(this), dataType, nullable)(
+    exprId = resultId)
+
+  override def nullable: Boolean = true
+
+  override lazy val canonicalized: Expression = {
+    val canonicalizedChildren = children.map(_.canonicalized)
+    // `resultId` can be seen as cosmetic variation in PythonUDF, as it doesn't affect the result.
+    this.copy(resultId = ExprId(-1)).withNewChildren(canonicalizedChildren)
+  }
+}
+
+/**
+ * A trait that can be mixed-in with `BasePythonRunner`. It implements the logic from
+ * Python (Arrow) to GPU/JVM (ColumnarBatch).
+ */
+trait GpuPythonArrowOutput extends Arm { self: BasePythonRunner[_, ColumnarBatch] =>
+
+  protected def newReaderIterator(
+      stream: DataInputStream,
+      writerThread: WriterThread,
+      startTime: Long,
+      env: SparkEnv,
+      worker: Socket,
+      releasedOrClosed: AtomicBoolean,
+      context: TaskContext): Iterator[ColumnarBatch] = {
+
+    new ReaderIterator(stream, writerThread, startTime, env, worker, releasedOrClosed, context) {
+
+      private[this] var arrowReader: StreamedTableReader = _
+
+      context.addTaskCompletionListener[Unit] { _ =>
+        if (arrowReader != null) {
+          arrowReader.close()
+          arrowReader = null
+        }
+      }
+
+      private var batchLoaded = true
+
+      protected override def read(): ColumnarBatch = {
+        if (writerThread.exception.isDefined) {
+          throw writerThread.exception.get
+        }
+        try {
+          if (arrowReader != null && batchLoaded) {
+            val table =
+              withResource(new NvtxRange("read python batch", NvtxColor.DARK_GREEN)) { _ =>
+                arrowReader.getNextIfAvailable
+              }
+            if (table == null) {
+              batchLoaded = false
+              arrowReader.close()
+              arrowReader = null
+              read()
+            } else {
+              withResource(table) { table =>
+                batchLoaded = true
+                GpuColumnVector.from(table)
+              }
+            }
+          } else {
+            stream.readInt() match {
+              case SpecialLengths.START_ARROW_STREAM =>
+                arrowReader = Table.readArrowIPCChunked(new StreamToBufferProvider(stream))
+                read()
+              case SpecialLengths.TIMING_DATA =>
+                handleTimingData()
+                read()
+              case SpecialLengths.PYTHON_EXCEPTION_THROWN =>
+                throw handlePythonException()
+              case SpecialLengths.END_OF_DATA_SECTION =>
+                handleEndOfDataSection()
+                null
+            }
+          }
+        } catch handleException
+      }
+    }
+  }
+}
+
+
+/**
+ * Similar to `PythonUDFRunner`, but exchange data with Python worker via Arrow stream.
+ */
+class GpuArrowPythonRunner(
+    funcs: Seq[ChainedPythonFunctions],
+    evalType: Int,
+    argOffsets: Array[Array[Int]],
+    schema: StructType,
+    timeZoneId: String,
+    conf: Map[String, String])
+    extends BasePythonRunner[ColumnarBatch, ColumnarBatch](funcs, evalType, argOffsets)
+        with GpuPythonArrowOutput {
+
+  override val bufferSize: Int = SQLConf.get.pandasUDFBufferSize
+  require(
+    bufferSize >= 4,
+    "Pandas execution requires more than 4 bytes. Please set higher buffer. " +
+        s"Please change '${SQLConf.PANDAS_UDF_BUFFER_SIZE.key}'.")
+
+  protected override def newWriterThread(
+      env: SparkEnv,
+      worker: Socket,
+      inputIterator: Iterator[ColumnarBatch],
+      partitionIndex: Int,
+      context: TaskContext): WriterThread = {
+    new WriterThread(env, worker, inputIterator, partitionIndex, context) {
+
+      protected override def writeCommand(dataOut: DataOutputStream): Unit = {
+
+        // Write config for the worker as a number of key -> value pairs of strings
+        dataOut.writeInt(conf.size)
+        for ((k, v) <- conf) {
+          PythonRDD.writeUTF(k, dataOut)
+          PythonRDD.writeUTF(v, dataOut)
+        }
+
+        PythonUDFRunner.writeUDFs(dataOut, funcs, argOffsets)
+      }
+
+      protected override def writeIteratorToStream(dataOut: DataOutputStream): Unit = {
+        val writer = {
+          val builder = ArrowIPCWriterOptions.builder()
+          schema.foreach { field =>
+            if (field.nullable) {
+              builder.withColumnNames(field.name)
+            } else {
+              builder.withNotNullableColumnNames(field.name)
+            }
+          }
+          Table.writeArrowIPCChunked(builder.build(), new BufferToStreamWriter(dataOut))
+        }
+        Utils.tryWithSafeFinally {
+          while(inputIterator.hasNext) {
+            withResource(inputIterator.next()) { nextBatch =>
+              withResource(GpuColumnVector.from(nextBatch)) { table =>
+                withResource(new NvtxRange("write python batch", NvtxColor.DARK_GREEN)) { _ =>
+                  writer.write(table)
+                }
+              }
+            }
+          }
+        } {
+          writer.close()
+          dataOut.flush()
+        }
+      }
+    }
+  }
+}
+
+class BufferToStreamWriter(outputStream: DataOutputStream) extends HostBufferConsumer with Arm {
+  private[this] val tempBuffer = new Array[Byte](128 * 1024)
+
+  override def handleBuffer(hostBuffer: HostMemoryBuffer, length: Long): Unit = {
+    withResource(hostBuffer) { buffer =>
+      var len = length
+      var offset: Long = 0
+      while(len > 0) {
+        val toCopy = math.min(tempBuffer.length, len).toInt
+        buffer.getBytes(tempBuffer, 0, offset, toCopy)
+        outputStream.write(tempBuffer, 0, toCopy)
+        len = len - toCopy
+        offset = offset + toCopy
+      }
+    }
+  }
+}
+
+class StreamToBufferProvider(inputStream: DataInputStream) extends HostBufferProvider {
+  private[this] val tempBuffer = new Array[Byte](128 * 1024)
+
+  override def readInto(hostBuffer: HostMemoryBuffer, length: Long): Long = {
+    var amountLeft = length
+    var totalRead : Long = 0
+    while (amountLeft > 0) {
+      val amountToRead = Math.min(tempBuffer.length, amountLeft).toInt
+      val amountRead = inputStream.read(tempBuffer, 0, amountToRead)
+      if (amountRead <= 0) {
+        // Reached EOF
+        amountLeft = 0
+      } else {
+        amountLeft -= amountRead
+        hostBuffer.setBytes(totalRead, tempBuffer, 0, amountRead)
+        totalRead += amountRead
+      }
+    }
+    totalRead
+  }
+}
+
+/**
+ * A physical plan that evaluates a [[GpuPythonUDF]]. The transformation of the data to arrow
+ * happens on the GPU (practically a noop), But execution of the UDFs are on the CPU.
+ */
+case class GpuArrowEvalPythonExec(
+    udfs: Seq[GpuPythonUDF],
+    resultAttrs: Seq[Attribute],
+    child: SparkPlan,
+    evalType: Int) extends UnaryExecNode with GpuExec {
+
+  // We split the input batch up into small pieces when sending to python for compatibility reasons
+  override def coalesceAfter: Boolean = true
+
+  override def output: Seq[Attribute] = child.output ++ resultAttrs
+
+  override def producedAttributes: AttributeSet = AttributeSet(resultAttrs)
+
+  private def collectFunctions(udf: GpuPythonUDF): (ChainedPythonFunctions, Seq[Expression]) = {
+    udf.children match {
+      case Seq(u: GpuPythonUDF) =>
+        val (chained, children) = collectFunctions(u)
+        (ChainedPythonFunctions(chained.funcs ++ Seq(udf.func)), children)
+      case children =>
+        // There should not be any other UDFs, or the children can't be evaluated directly.
+        assert(children.forall(_.find(_.isInstanceOf[GpuPythonUDF]).isEmpty))
+        (ChainedPythonFunctions(Seq(udf.func)), udf.children)
+    }
+  }
+
+  private val batchSize = conf.arrowMaxRecordsPerBatch
+  private val sessionLocalTimeZone = conf.sessionLocalTimeZone
+  private val pythonRunnerConf = ArrowUtils.getPythonRunnerConfMap(conf)
+
+
+  override protected def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+
+  override lazy val metrics: Map[String, SQLMetric] = Map(
+    NUM_OUTPUT_ROWS -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_OUTPUT_ROWS),
+    NUM_OUTPUT_BATCHES -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_OUTPUT_BATCHES),
+    NUM_INPUT_ROWS -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_INPUT_ROWS),
+    NUM_INPUT_BATCHES -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_INPUT_BATCHES)
+  )
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val numOutputRows = longMetric(NUM_OUTPUT_ROWS)
+    val numOutputBatches = longMetric(NUM_OUTPUT_BATCHES)
+    val numInputRows = longMetric(NUM_INPUT_ROWS)
+    val numInputBatches = longMetric(NUM_INPUT_BATCHES)
+
+    val inputRDD = child.executeColumnar()
+    inputRDD.mapPartitions { iter =>
+      val queue: BatchQueue = new BatchQueue()
+      val context = TaskContext.get()
+      context.addTaskCompletionListener[Unit](_ => queue.close())
+
+      val (pyFuncs, inputs) = udfs.map(collectFunctions).unzip
+
+      // Not sure why we are doing this in every task.  It is not going to change, but it might
+      // just be less that we have to ship.
+
+      // flatten all the arguments
+      val allInputs = new ArrayBuffer[Expression]
+      // TODO eventually we should just do type checking on these, but that can get a little complex
+      // with how things are setup for replacement...
+      // perhaps it needs to be with the special, it is an gpu compatible expression, but not a
+      // gpu expression...
+      val dataTypes = new ArrayBuffer[DataType]
+      val argOffsets = inputs.map { input =>
+        input.map { e =>
+          if (allInputs.exists(_.semanticEquals(e))) {
+            allInputs.indexWhere(_.semanticEquals(e))
+          } else {
+            allInputs += e
+            dataTypes += e.dataType
+            allInputs.length - 1
+          }
+        }.toArray
+      }.toArray
+
+      val schema = StructType(dataTypes.zipWithIndex.map { case (dt, i) =>
+        StructField(s"_$i", dt)
+      })
+
+      val boundReferences = GpuBindReferences.bindReferences(allInputs, child.output)
+      val batchedIterator = new RebatchingIterator(iter, batchSize, numInputRows, numInputBatches)
+      val projectedIterator = batchedIterator.map { batch =>
+        queue.add(batch)
+        GpuProjectExec.project(batch, boundReferences)
+      }
+
+      val outputBatchIterator = new GpuArrowPythonRunner(
+        pyFuncs,
+        evalType,
+        argOffsets,
+        schema,
+        sessionLocalTimeZone,
+        pythonRunnerConf).compute(projectedIterator,
+        context.partitionId(),
+        context)
+
+      outputBatchIterator.map { outputBatch =>
+        withResource(outputBatch) { outBatch =>
+          withResource(queue.remove()) { origBatch =>
+            val rows = origBatch.numRows()
+            assert(outBatch.numRows() == rows)
+            val lColumns = GpuColumnVector.extractColumns(origBatch)
+            val rColumns = GpuColumnVector.extractColumns(outBatch)
+            numOutputBatches += 1
+            numOutputRows += rows
+            new ColumnarBatch(lColumns.map(_.incRefCount()) ++ rColumns.map(_.incRefCount()),
+              rows)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the first step in adding in support for accelerating the data exchange between spark and python processes.

It has some issues currently that I plan to address in a follow on PR, but fixing some of them will require changes to CUDF, which could only go into the 0.16 release or later.

* We don't release the GPU semaphore after sending data to the python process, and we don't acquire it when we get data back. This results in bad performance for python processes that take a long time to run.  It requires changes to cudf to be able to fix this.
* We have a size limit on some batches read from the python process.  This requires changes to cudf to be able to fix.  Part of the issue is that larger batches tend to be much more efficient so this is preventing testing to see what is the ideal batch size.
* Need tests for String and other data types besides int types.
* Need documentation about how to tune this for ideal performance, and call out https://issues.apache.org/jira/browse/SPARK-32612
* Need to address TODOs in the code to make it so that cached data can spill from GPU memory if needed.  This is really a requirement if we release the GPU semaphore because for now we will not go much past a single batch.
* Need to do profiling, especially around the split code to see what is the ideal way to split a large incoming batch up.


This partially addresses #305 but not enough to close it.