### PR TITLE
[REVIEW] Fix incorrect output from averages with filters in partial only mode

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -280,26 +280,9 @@ def test_hash_multiple_filters(data_gen, conf):
         "hash_agg_table",
         'select count(a) filter (where c > 50),' +
         'count(b) filter (where c > 100),' +
-        # Uncomment after https://github.com/NVIDIA/spark-rapids/issues/155 is fixed
-        # 'avg(b) filter (where b > 20),' +
+        'avg(b) filter (where b > 20),' +
         'min(a), max(b) filter (where c > 250) from hash_agg_table group by a',
         conf)
-
-
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/155')
-@ignore_order
-@allow_non_gpu(
-    'HashAggregateExec', 'AggregateExpression',
-    'AttributeReference', 'Alias', 'Sum', 'Count', 'Max', 'Min', 'Average', 'Cast',
-    'KnownFloatingPointNormalized', 'NormalizeNaNAndZero', 'GreaterThan', 'Literal', 'If',
-    'EqualTo', 'First', 'SortAggregateExec', 'Coalesce')
-@pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
-def test_hash_multiple_filters_fail(data_gen):
-    assert_gpu_and_cpu_are_equal_sql(
-        lambda spark : gen_df(spark, data_gen, length=100),
-        "hash_agg_table",
-        'select avg(b) filter (where b > 20) from hash_agg_table group by a',
-        _no_nans_float_conf_partial)
 
 
 @ignore_order

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -1635,4 +1635,45 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       .set(RapidsConf.ENABLE_FLOAT_AGG.key, "true")) {
     frame => frame.groupBy(col("double")).agg(sum(col("int")))
   }
+
+  testSparkResultsAreEqual("Agg expression with filter avg with nulls", nullDf, execsAllowedNonGpu =
+    Seq("HashAggregateExec", "AggregateExpression", "AttributeReference", "Alias", "Average",
+      "Count", "Cast"),
+    conf = partialOnlyConf, repart = 2) {
+    frame => frame.createOrReplaceTempView("testTable")
+      frame.sparkSession.sql(
+        s"""
+           | SELECT
+           |   avg(more_longs) filter (where more_longs > 2)
+           | FROM testTable
+           |   group by longs
+           |""".stripMargin)
+  }
+
+  testSparkResultsAreEqual("Agg expression with filter count with nulls",
+    nullDf, execsAllowedNonGpu = Seq("HashAggregateExec", "AggregateExpression",
+      "AttributeReference", "Alias", "Count", "Cast"),
+    conf = partialOnlyConf, repart = 2) {
+    frame => frame.createOrReplaceTempView("testTable")
+      frame.sparkSession.sql(
+        s"""
+           | SELECT
+           |   count(more_longs) filter (where more_longs > 2)
+           | FROM testTable
+           |   group by longs
+           |""".stripMargin)
+  }
+
+  testSparkResultsAreEqual("Agg expression with filter sum with nulls", nullDf, execsAllowedNonGpu =
+    Seq("HashAggregateExec", "AggregateExpression", "AttributeReference", "Alias", "Sum", "Cast"),
+    conf = partialOnlyConf, repart = 2) {
+    frame => frame.createOrReplaceTempView("testTable")
+      frame.sparkSession.sql(
+        s"""
+           | SELECT
+           |   sum(more_longs) filter (where more_longs > 2)
+           | FROM testTable
+           |   group by longs
+           |""".stripMargin)
+  }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1234,6 +1234,14 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     ).toDF("doubles")
   }
 
+  def nullDf(session: SparkSession): DataFrame = {
+    import session.sqlContext.implicits._
+    Seq[(java.lang.Long, java.lang.Long)](
+      (100L, 15L),
+      (100L, null)
+    ).toDF("longs", "more_longs")
+  }
+
   def mixedDoubleDf(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
     Seq[(java.lang.Double, java.lang.Double)](


### PR DESCRIPTION
Fixes #155 .

This is WIP for a couple reasons and also as I want to get more comments on the approach shown in the PR.

As the associated issue explains in some detail, how we are ending up with nulls being sent down to the CPU's final aggregation. The fix tries to circumvent this by special casing how averages are handled by the case-when of the filter. One thing to note is, we need this special case since we don't have a clean way to pass the filter down to the `GpuAverage` DeclarativeAggregate itself. When a `null` comes into the filter we want it not pass down any further but instead default to `(0.0, 0)`. This seems to be specific for averages while other aggregates like `count` require nulls. I had to use another case-when with `isnotnull` to make this happen. I have some concerns on the else condition added in this PR and would like to know what others think is a _better_ way to do this. I tried some games with having initialValues be reused in the filter it was not straight forward what do to with their data types. At the end, I am also open to use this PR to morph the solution to put the hammer on filters+avg+partial_only_conf to fall back on the CPU, but that is not my first preference. Tagging @abellina for some discussion to get this PR going.