### PR TITLE
[FEA] Add signoff check to gh-pages

### DIFF
--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -1,0 +1,36 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow to check if PR got sign-off
+name: signoff check
+
+on:
+  pull_request_target:
+    branches:
+      - gh-pages
+    types: [opened, synchronize, reopened]
+
+jobs:
+  signoff-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: sigoff-check job
+        uses: ./.github/workflows/signoff-check
+        env:
+          OWNER: NVIDIA
+          REPO_NAME: spark-rapids
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/signoff-check/Dockerfile
+++ b/.github/workflows/signoff-check/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:alpine
+
+WORKDIR /
+COPY signoff-check .
+RUN pip install PyGithub && chmod +x /signoff-check
+
+# require envs: OWNER,REPO_NAME,GITHUB_TOKEN,PULL_NUMBER
+ENTRYPOINT ["/signoff-check"]

--- a/.github/workflows/signoff-check/action.yml
+++ b/.github/workflows/signoff-check/action.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'signoff check action'
+description: 'check if PR got signed off'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/workflows/signoff-check/signoff-check
+++ b/.github/workflows/signoff-check/signoff-check
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A signoff check
+
+The tool checks if any commit got signoff in a pull request.
+"""
+import os
+import re
+import sys
+from argparse import ArgumentParser
+
+from github import Github
+
+parser = ArgumentParser(description="signoff check")
+parser.add_argument("--owner", help="repo owner", default='')
+parser.add_argument("--repo_name", help="repo name", default='')
+parser.add_argument("--token", help="github token, will use GITHUB_TOKEN if empty", default='')
+parser.add_argument("--pull_number", help="pull request number", type=int)
+args = parser.parse_args()
+
+OWNER = args.owner if args.owner else os.environ.get('OWNER')
+assert OWNER, 'env OWNER should not be empty'
+REPO_NAME = args.repo_name if args.repo_name else os.environ.get('REPO_NAME')
+assert REPO_NAME, 'env REPO_NAME should not be empty'
+GITHUB_TOKEN = args.token if args.token else os.environ.get('GITHUB_TOKEN')
+assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
+PULL_NUMBER = args.pull_number if args.pull_number else int(os.environ.get('PULL_NUMBER'))
+assert PULL_NUMBER, 'env PULL_NUMBER should not be empty'
+
+signoff_re = re.compile('Signed-off-by:')
+
+
+def signoff():
+    gh = Github(GITHUB_TOKEN, per_page=100, user_agent='signoff-check', verify=True)
+    pr = gh.get_repo(f"{OWNER}/{REPO_NAME}").get_pull(PULL_NUMBER)
+    for c in pr.get_commits():
+        if signoff_re.search(c.commit.message):
+            print('Found signoff.\n')
+            print(f"Commit sha:\n{c.commit.sha}")
+            print(f"Commit message:\n{c.commit.message}")
+            return True
+    return False
+
+
+def main():
+    try:
+        if not signoff():
+            raise Exception('No commits w/ signoff')
+    except Exception as e:  # pylint: disable=broad-except
+        print(e)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
fix #604 

After this got merged, we should update branch rule on `gh-pages` to enable this check.
e.g.
![image](https://user-images.githubusercontent.com/8086184/91411914-995f4300-e87b-11ea-8b8c-f0961f496eec.png)
