### PR TITLE
Fix leak if RebaseHelper throws during Parquet read

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -806,19 +806,19 @@ class MultiFileParquetPartitionReader(
             metrics(GPU_DECODE_TIME))) { _ =>
           Table.readParquet(parseOpts, dataBuffer, 0, dataSize)
         }
-        if (!isCorrectRebaseMode) {
-          (0 until table.getNumberOfColumns).foreach { i =>
-            if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
-              table.close()
-              throw RebaseHelper.newRebaseExceptionInRead("Parquet")
+        closeOnExcept(table) { _ =>
+          if (!isCorrectRebaseMode) {
+            (0 until table.getNumberOfColumns).foreach { i =>
+              if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
+                throw RebaseHelper.newRebaseExceptionInRead("Parquet")
+              }
             }
           }
-        }
-        maxDeviceMemory = max(GpuColumnVector.getTotalDeviceMemoryUsed(table), maxDeviceMemory)
-        if (readDataSchema.length < table.getNumberOfColumns) {
-          table.close()
-          throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-            s"but read ${table.getNumberOfColumns} from $currentChunkedBlocks")
+          maxDeviceMemory = max(GpuColumnVector.getTotalDeviceMemoryUsed(table), maxDeviceMemory)
+          if (readDataSchema.length < table.getNumberOfColumns) {
+            throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
+              s"but read ${table.getNumberOfColumns} from $currentChunkedBlocks")
+          }
         }
         metrics(NUM_OUTPUT_BATCHES) += 1
         Some(evolveSchemaIfNeededAndClose(table, splits.mkString(","), clippedSchema))
@@ -1038,19 +1038,19 @@ class ParquetPartitionReader(
             metrics(GPU_DECODE_TIME))) { _ =>
           Table.readParquet(parseOpts, dataBuffer, 0, dataSize)
         }
-        if (!isCorrectedRebaseMode) {
-          (0 until table.getNumberOfColumns).foreach { i =>
-            if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
-              table.close()
-              throw RebaseHelper.newRebaseExceptionInRead("Parquet")
+        closeOnExcept(table) { _ =>
+          if (!isCorrectedRebaseMode) {
+            (0 until table.getNumberOfColumns).foreach { i =>
+              if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
+                throw RebaseHelper.newRebaseExceptionInRead("Parquet")
+              }
             }
           }
-        }
-        maxDeviceMemory = max(GpuColumnVector.getTotalDeviceMemoryUsed(table), maxDeviceMemory)
-        if (readDataSchema.length < table.getNumberOfColumns) {
-          table.close()
-          throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-            s"but read ${table.getNumberOfColumns} from $filePath")
+          maxDeviceMemory = max(GpuColumnVector.getTotalDeviceMemoryUsed(table), maxDeviceMemory)
+          if (readDataSchema.length < table.getNumberOfColumns) {
+            throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
+              s"but read ${table.getNumberOfColumns} from $filePath")
+          }
         }
         metrics(NUM_OUTPUT_BATCHES) += 1
         Some(evolveSchemaIfNeededAndClose(table, filePath.toString, clippedParquetSchema))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -809,6 +809,7 @@ class MultiFileParquetPartitionReader(
         if (!isCorrectRebaseMode) {
           (0 until table.getNumberOfColumns).foreach { i =>
             if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
+              table.close()
               throw RebaseHelper.newRebaseExceptionInRead("Parquet")
             }
           }
@@ -1040,6 +1041,7 @@ class ParquetPartitionReader(
         if (!isCorrectedRebaseMode) {
           (0 until table.getNumberOfColumns).foreach { i =>
             if (RebaseHelper.isDateTimeRebaseNeededRead(table.getColumn(i))) {
+              table.close()
               throw RebaseHelper.newRebaseExceptionInRead("Parquet")
             }
           }


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/626

This fixes a memory leak message that shows up in the parquet_tests when we throw.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
