### PR TITLE
Small fix for race in catalog where a buffer could get spilled while …

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -192,7 +192,7 @@ abstract class RapidsBufferStore(
   protected def createBuffer(buffer: RapidsBuffer, stream: Cuda.Stream): RapidsBufferBase
 
   /** Update bookkeeping for a new buffer */
-  protected def addBuffer(buffer: RapidsBufferBase): Unit = {
+  protected def addBuffer(buffer: RapidsBufferBase): Unit = synchronized {
     buffers.add(buffer)
     catalog.registerNewBuffer(buffer)
   }


### PR DESCRIPTION
This makes it impossible for a spill to happen while we are adding a buffer, which is the issue reported here (https://github.com/NVIDIA/spark-rapids/issues/643).

Closes #643 