### PR TITLE
Stop reporting zero metrics for GpuCustomShuffleReader

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuCustomShuffleReaderExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuCustomShuffleReaderExec.scala
@@ -39,7 +39,14 @@ case class GpuCustomShuffleReaderExec(
     child: SparkPlan,
     partitionSpecs: Seq[ShufflePartitionSpec]) extends UnaryExecNode with GpuExec  {
 
-  override lazy val additionalMetrics: Map[String, SQLMetric] = Map(
+  /**
+   * We intentionally override metrics in this case rather than overriding additionalMetrics so
+   * that NUM_OUTPUT_ROWS and NUM_OUTPUT_BATCHES are removed, since this operator does not
+   * report any data for those metrics.
+   *
+   * The Spark version of this operator does not output any metrics.
+   */
+  override lazy val metrics: Map[String, SQLMetric] = Map(
     TOTAL_TIME -> SQLMetrics.createNanoTimingMetric(sparkContext, DESCRIPTION_TOTAL_TIME)
   )
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR simply stops GpuCustomShuffleReader from reporting zero metrics for total rows/batches. Spark does not report any metrics for the equivalent operator there.

If we do want to implement code to measure rows/batches and report those metrics, it would be good to do that as a separate issue/pr. 

This closes https://github.com/NVIDIA/spark-rapids/issues/630