### PR TITLE
Improve warnings about AQE nodes not supported on GPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1736,24 +1736,12 @@ object GpuOverrides {
             exec.partitionSpecs)
         }
       }),
-    exec[AdaptiveSparkPlanExec]("Adaptive query", (exec, conf, p, r) =>
-      new SparkPlanMeta[AdaptiveSparkPlanExec](exec, conf, p, r) {
-        override def tagPlanForGpu(): Unit =
-          willNotWorkOnGpu("this is an adaptive plan")
-        override def convertToGpu(): GpuExec = throw new IllegalStateException()
-      }),
-    exec[BroadcastQueryStageExec]("Broadcast query stage", (exec, conf, p, r) =>
-      new SparkPlanMeta[BroadcastQueryStageExec](exec, conf, p, r) {
-        override def tagPlanForGpu(): Unit =
-          willNotWorkOnGpu("this query stage already started executing")
-        override def convertToGpu(): GpuExec = throw new IllegalStateException()
-      }),
-    exec[ShuffleQueryStageExec]("Shuffle query stage", (exec, conf, p, r) =>
-      new SparkPlanMeta[ShuffleQueryStageExec](exec, conf, p, r) {
-        override def tagPlanForGpu(): Unit =
-          willNotWorkOnGpu("this query stage already started executing")
-        override def convertToGpu(): GpuExec = throw new IllegalStateException()
-      })
+    exec[AdaptiveSparkPlanExec]("Wrapper for adaptive query plan", (exec, conf, p, _) =>
+      new DoNotReplaceSparkPlanMeta[AdaptiveSparkPlanExec](exec, conf, p)),
+    exec[BroadcastQueryStageExec]("Broadcast query stage", (exec, conf, p, _) =>
+      new DoNotReplaceSparkPlanMeta[BroadcastQueryStageExec](exec, conf, p)),
+    exec[ShuffleQueryStageExec]("Shuffle query stage", (exec, conf, p, _) =>
+      new DoNotReplaceSparkPlanMeta[ShuffleQueryStageExec](exec, conf, p))
   ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
   val execs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
     commonExecs ++ ShimLoader.getSparkShims.getExecs


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR improves UX slightly by adding specific handling in GpuOverrides for AQE operators so that we can provide better information to the user, explaining why these nodes are not swapped out for GPU versions.

For example, before this change, the user might see:

```
!NOT_FOUND <ShuffleQueryStageExec> cannot run on GPU because no GPU enabled version of operator class org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec could be found
```

With this change, the user would see:

```
!Exec <ShuffleQueryStageExec> cannot run on GPU because this query stage already started executing
```

This is still slightly misleading, because the query stage may already be running on GPU, but at least looks less like an internal error or unsupported feature now.

This closes https://github.com/NVIDIA/spark-rapids/issues/607
