### PR TITLE
add signoff-check use github actions

### DIFF
--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -1,0 +1,36 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow to check if PR got sign-off
+name: signoff check
+
+on:
+  pull_request_target:
+    branches:
+      - branch-*
+    types: [opened, synchronize, reopened]
+
+jobs:
+  signoff-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: sigoff-check job
+        uses: ./.github/workflows/signoff-check
+        env:
+          OWNER: NVIDIA
+          REPO_NAME: spark-rapids
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -17,8 +17,6 @@ name: signoff check
 
 on:
   pull_request_target:
-    branches:
-      - branch-*
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/signoff-check/Dockerfile
+++ b/.github/workflows/signoff-check/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:alpine
+
+WORKDIR /
+COPY signoff-check .
+RUN pip install PyGithub && chmod +x /signoff-check
+
+# require envs: OWNER,REPO_NAME,GITHUB_TOKEN,PULL_NUMBER
+ENTRYPOINT ["/signoff-check"]

--- a/.github/workflows/signoff-check/action.yml
+++ b/.github/workflows/signoff-check/action.yml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'signoff check action'
+description: 'check if PR got signed off'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/workflows/signoff-check/signoff-check
+++ b/.github/workflows/signoff-check/signoff-check
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A signoff check
+
+The tool checks if any commit got signoff in a pull request.
+
+NOTE: this script is for github actions only, you should not use it anywhere else.
+"""
+import os
+import re
+import sys
+from argparse import ArgumentParser
+
+from github import Github
+
+parser = ArgumentParser(description="signoff check")
+parser.add_argument("--owner", help="repo owner", default='')
+parser.add_argument("--repo_name", help="repo name", default='')
+parser.add_argument("--token", help="github token, will use GITHUB_TOKEN if empty", default='')
+parser.add_argument("--pull_number", help="pull request number", type=int)
+args = parser.parse_args()
+
+OWNER = args.owner if args.owner else os.environ.get('OWNER')
+assert OWNER, 'env OWNER should not be empty'
+REPO_NAME = args.repo_name if args.repo_name else os.environ.get('REPO_NAME')
+assert REPO_NAME, 'env REPO_NAME should not be empty'
+GITHUB_TOKEN = args.token if args.token else os.environ.get('GITHUB_TOKEN')
+assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
+PULL_NUMBER = args.pull_number if args.pull_number else int(os.environ.get('PULL_NUMBER'))
+assert PULL_NUMBER, 'env PULL_NUMBER should not be empty'
+
+signoff_re = re.compile('Signed-off-by:')
+
+
+def signoff():
+    gh = Github(GITHUB_TOKEN, per_page=100, user_agent='signoff-check', verify=True)
+    pr = gh.get_repo(f"{OWNER}/{REPO_NAME}").get_pull(PULL_NUMBER)
+    for c in pr.get_commits():
+        if signoff_re.search(c.commit.message):
+            print('Found signoff.\n')
+            print(f"Commit sha:\n{c.commit.sha}")
+            print(f"Commit message:\n{c.commit.message}")
+            return True
+    return False
+
+
+def main():
+    try:
+        if not signoff():
+            raise Exception('No commits w/ signoff')
+    except Exception as e:  # pylint: disable=broad-except
+        print(e)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/signoff-check/signoff-check
+++ b/.github/workflows/signoff-check/signoff-check
@@ -27,30 +27,14 @@ from argparse import ArgumentParser
 
 from github import Github
 
-parser = ArgumentParser(description="signoff check")
-parser.add_argument("--owner", help="repo owner", default='')
-parser.add_argument("--repo_name", help="repo name", default='')
-parser.add_argument("--token", help="github token, will use GITHUB_TOKEN if empty", default='')
-parser.add_argument("--pull_number", help="pull request number", type=int)
-args = parser.parse_args()
-
-OWNER = args.owner if args.owner else os.environ.get('OWNER')
-assert OWNER, 'env OWNER should not be empty'
-REPO_NAME = args.repo_name if args.repo_name else os.environ.get('REPO_NAME')
-assert REPO_NAME, 'env REPO_NAME should not be empty'
-GITHUB_TOKEN = args.token if args.token else os.environ.get('GITHUB_TOKEN')
-assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
-PULL_NUMBER = args.pull_number if args.pull_number else int(os.environ.get('PULL_NUMBER'))
-assert PULL_NUMBER, 'env PULL_NUMBER should not be empty'
-
-signoff_re = re.compile('Signed-off-by:')
+SIGNOFF_REGEX = re.compile('Signed-off-by:')
 
 
-def signoff():
-    gh = Github(GITHUB_TOKEN, per_page=100, user_agent='signoff-check', verify=True)
-    pr = gh.get_repo(f"{OWNER}/{REPO_NAME}").get_pull(PULL_NUMBER)
+def signoff(token: str, owner: str, repo_name: str, pull_number: int):
+    gh = Github(token, per_page=100, user_agent='signoff-check', verify=True)
+    pr = gh.get_repo(f"{owner}/{repo_name}").get_pull(pull_number)
     for c in pr.get_commits():
-        if signoff_re.search(c.commit.message):
+        if SIGNOFF_REGEX.search(c.commit.message):
             print('Found signoff.\n')
             print(f"Commit sha:\n{c.commit.sha}")
             print(f"Commit message:\n{c.commit.message}")
@@ -58,9 +42,9 @@ def signoff():
     return False
 
 
-def main():
+def main(token: str, owner: str, repo_name: str, pull_number: int):
     try:
-        if not signoff():
+        if not signoff(token, owner, repo_name, pull_number):
             raise Exception('No commits w/ signoff')
     except Exception as e:  # pylint: disable=broad-except
         print(e)
@@ -68,4 +52,20 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = ArgumentParser(description="signoff check")
+    parser.add_argument("--owner", help="repo owner", default='')
+    parser.add_argument("--repo_name", help="repo name", default='')
+    parser.add_argument("--token", help="github token, will use GITHUB_TOKEN if empty", default='')
+    parser.add_argument("--pull_number", help="pull request number", type=int)
+    args = parser.parse_args()
+
+    GITHUB_TOKEN = args.token if args.token else os.environ.get('GITHUB_TOKEN')
+    assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
+    OWNER = args.owner if args.owner else os.environ.get('OWNER')
+    assert OWNER, 'env OWNER should not be empty'
+    REPO_NAME = args.repo_name if args.repo_name else os.environ.get('REPO_NAME')
+    assert REPO_NAME, 'env REPO_NAME should not be empty'
+    PULL_NUMBER = args.pull_number if args.pull_number else int(os.environ.get('PULL_NUMBER'))
+    assert PULL_NUMBER, 'env PULL_NUMBER should not be empty'
+
+    main(token=GITHUB_TOKEN, owner=OWNER, repo_name=REPO_NAME, pull_number=PULL_NUMBER)


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Add `github-actions`-based signoff check for dev branches. 

This is the same as signoff-check  https://github.com/NVIDIA/spark-rapids/pull/615 for `gh-pages` except the modified trigger events

related to new blossom-ci https://github.com/NVIDIA/spark-rapids/pull/642. old signoff-check will retire when we shutdown ngcc premerge pipeline