### PR TITLE
Implement AQE unit test for InsertAdaptiveSparkPlan

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -112,7 +112,7 @@ class AdaptiveQueryExecSuite
             .asInstanceOf[AdaptiveSparkPlanExec]
 
         // even though the write couldn't run on GPU, the read should have done
-        adaptivePlan.executedPlan.isInstanceOf[GpuExec]
+        assert(adaptivePlan.executedPlan.isInstanceOf[GpuExec])
 
     }, conf)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -16,8 +16,12 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.File
+
+import com.nvidia.spark.rapids.AdaptiveQueryExecSuite.TEST_FILES_ROOT
+
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{PartialReducerPartitionSpec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
@@ -25,6 +29,10 @@ import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.{GpuCustomShuffleReaderExec, GpuShuffledHashJoinBase}
+
+object AdaptiveQueryExecSuite {
+  val TEST_FILES_ROOT: File = TestUtils.getTempDir(this.getClass.getSimpleName)
+}
 
 class AdaptiveQueryExecSuite
     extends SparkQueryCompareTestSuite
@@ -91,29 +99,84 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("Plugin should translate child plan of write commands to GPU") {
+  test("Plugin should translate child plan of GPU DataWritingCommandExec to GPU") {
+
+    val conf = new SparkConf()
+        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+        .set(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY.key, "true")
+
+    withGpuSparkSession(spark => {
+      import spark.implicits._
+
+      // read from a parquet file so we can test reading on GPU
+      val path = new File(TEST_FILES_ROOT, "DataWritingCommandExecGPU.parquet").getAbsolutePath
+      (0 until 100).toDF("a")
+          .write
+          .mode(SaveMode.Overwrite)
+          .parquet(path)
+      spark.read.parquet(path).createOrReplaceTempView("testData")
+
+      spark.sql("CREATE TABLE IF NOT EXISTS DataWritingCommandExecGPU (a INT) USING parquet")
+          .collect()
+
+      val df = spark.sql("INSERT INTO TABLE DataWritingCommandExecGPU SELECT * FROM testData")
+      df.collect()
+
+      // write should be on GPU
+      val writeCommand = TestUtils.findOperator(df.queryExecution.executedPlan,
+        _.isInstanceOf[GpuDataWritingCommandExec])
+      assert(writeCommand.isDefined)
+
+      // the read should be an adaptive plan
+      val adaptiveSparkPlanExec = TestUtils.findOperator(writeCommand.get,
+        _.isInstanceOf[AdaptiveSparkPlanExec])
+        .get.asInstanceOf[AdaptiveSparkPlanExec]
+
+      // assert that at least part of the adaptive plan ran on GPU
+      assert(TestUtils.findOperator(adaptiveSparkPlanExec, _.isInstanceOf[GpuExec]).isDefined)
+    }, conf)
+  }
+
+  test("Plugin should translate child plan of CPU DataWritingCommandExec to GPU") {
 
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY.key, "true")
-      // DataWritingCommandExec does not get translated to GPU because the plugin
-      // currently doesn't support the CreateDataSourceTableAsSelectCommand command
+      // force DataWritingCommandExec onto CPU for this test because we want to verify that
+      // the read will still happen on GPU with a CPU write
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "DataWritingCommandExec")
       .set("spark.rapids.sql.exec.DataWritingCommandExec", "false")
 
       withGpuSparkSession(spark => {
-        frameFromParquet("timestamp-date-test.parquet")(spark)
-          .createOrReplaceTempView("testData")
+        import spark.implicits._
 
-        val df = spark.sql("CREATE TABLE t1 USING parquet AS SELECT * FROM testData")
+        // read from a parquet file so we can test reading on GPU
+        val path = new File(TEST_FILES_ROOT, "DataWritingCommandExecCPU.parquet").getAbsolutePath
+        (0 until 100).toDF("a")
+            .write
+            .mode(SaveMode.Overwrite)
+            .parquet(path)
+
+        spark.read.parquet(path).createOrReplaceTempView("testData")
+
+        spark.sql("CREATE TABLE IF NOT EXISTS DataWritingCommandExecCPU (a INT) USING parquet")
+            .collect()
+
+        val df = spark.sql("INSERT INTO TABLE DataWritingCommandExecCPU SELECT * FROM testData")
         df.collect()
 
-        val adaptivePlan = df.queryExecution.executedPlan
-            .asInstanceOf[DataWritingCommandExec].child
-            .asInstanceOf[AdaptiveSparkPlanExec]
+        // write should be on CPU
+        val writeCommand = TestUtils.findOperator(df.queryExecution.executedPlan,
+          _.isInstanceOf[DataWritingCommandExec])
+        assert(writeCommand.isDefined)
+
+        // the read should be an adaptive plan
+        val adaptiveSparkPlanExec = TestUtils.findOperator(writeCommand.get,
+          _.isInstanceOf[AdaptiveSparkPlanExec])
+            .get.asInstanceOf[AdaptiveSparkPlanExec]
 
         // even though the write couldn't run on GPU, the read should have done
-        assert(TestUtils.findOperator(adaptivePlan.executedPlan,
+        assert(TestUtils.findOperator(adaptiveSparkPlanExec.executedPlan,
           _.isInstanceOf[GpuExec]).isDefined)
 
     }, conf)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -99,6 +99,7 @@ class AdaptiveQueryExecSuite
       // DataWritingCommandExec does not get translated to GPU because the plugin
       // currently doesn't support the CreateDataSourceTableAsSelectCommand command
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "DataWritingCommandExec")
+      .set("spark.rapids.sql.exec.DataWritingCommandExec", "false")
 
       withGpuSparkSession(spark => {
         frameFromParquet("timestamp-date-test.parquet")(spark)
@@ -112,7 +113,8 @@ class AdaptiveQueryExecSuite
             .asInstanceOf[AdaptiveSparkPlanExec]
 
         // even though the write couldn't run on GPU, the read should have done
-        assert(adaptivePlan.executedPlan.isInstanceOf[GpuExec])
+        assert(TestUtils.findOperator(adaptivePlan.executedPlan,
+          _.isInstanceOf[GpuExec]).isDefined)
 
     }, conf)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.File
 
 import com.nvidia.spark.rapids.AdaptiveQueryExecSuite.TEST_FILES_ROOT
+import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{SaveMode, SparkSession}
@@ -36,7 +37,16 @@ object AdaptiveQueryExecSuite {
 
 class AdaptiveQueryExecSuite
     extends SparkQueryCompareTestSuite
-        with AdaptiveSparkPlanHelper {
+    with AdaptiveSparkPlanHelper
+    with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    TEST_FILES_ROOT.mkdirs()
+  }
+
+  override def afterEach(): Unit = {
+    org.apache.commons.io.FileUtils.deleteDirectory(TEST_FILES_ROOT)
+  }
 
   private def runAdaptiveAndVerifyResult(
       spark: SparkSession, query: String): (SparkPlan, SparkPlan) = {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This started out as a direct port of an existing Apache Spark unit test and tests that AQE kicks in for queries that write to tables, but has now been extended to confirm GPU reads when writing with either CPU or GPU with the plugin enabled.

This closes https://github.com/NVIDIA/spark-rapids/issues/662