### PR TITLE
Add in neverReplaceExec and several rules for it

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -573,9 +573,9 @@ final class RuleNotFoundSparkPlanMeta[INPUT <: SparkPlan](
 }
 
 /**
- * Metadata for `SparkPlan` that should not be replaced.
+ * Metadata for `SparkPlan` that should not be replaced or have any kind of warning for
  */
-final class DoNotReplaceSparkPlanMeta[INPUT <: SparkPlan](
+final class DoNotReplaceOrWarnSparkPlanMeta[INPUT <: SparkPlan](
     plan: INPUT,
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]])


### PR DESCRIPTION
This extends the great work done in #647 but fixes an issue there where we were still outputting config documentation for execs we never plan to replace.

I also made adding one of these in simpler and more common.  I then added in rules for all of the other commands we currently don't want to warn about or ever replace.

This fixes #499 