### PR TITLE
refactor automerge to support merge for protected branch

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,6 +36,4 @@ jobs:
           REPO_NAME: spark-rapids
           HEAD: branch-0.2
           BASE: branch-0.3
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use to approve and merge PR
-          NVAUTO_TOKEN: ${{ secrets.NVAUTO_TOKEN }} # use to trigger checks.
-
+          AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,6 +36,6 @@ jobs:
           REPO_NAME: spark-rapids
           HEAD: branch-0.2
           BASE: branch-0.3
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use to create and merge PR
-          NVAUTO_TOKEN: ${{ secrets.NVAUTO_TOKEN }} # PR has to be approved by a different token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use to approve and merge PR
+          NVAUTO_TOKEN: ${{ secrets.NVAUTO_TOKEN }} # use to trigger checks.
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,16 +23,19 @@ on:
 
 jobs:
   auto-merge:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
 
       - name: auto-merge job
-        if: github.event.pull_request.merged == true
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
           HEAD: branch-0.2
           BASE: branch-0.3
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use to create and merge PR
+          NVAUTO_TOKEN: ${{ secrets.NVAUTO_TOKEN }} # PR has to be approved by a different token
+

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -119,4 +119,5 @@ def main():
     auto_merge(number, sha)
 
 
-main()
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -99,7 +99,7 @@ def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str,
     except Exception as e:
         comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
                 content=f"""**FAILURE** - Unable to auto-merge. Manual operation is required.
-```json
+```
 {e}
 ```
 """)
@@ -131,7 +131,7 @@ def main(github_token: str, nvauto_token: str, owner: str, repo_name: str, head:
             sys.exit(0)
 
         # skip pre-merge blossom CI w/ [skip ci] in PR title
-        comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number, content='build')
+        comment(github_token=nvauto_token, owner=owner, repo_name=repo_name, number=number, content='build')
 
         time.sleep(600)  # sleep 10 minutes, then try auto-merge
         auto_merge(github_token=github_token, nvauto_token=nvauto_token,

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -31,11 +31,7 @@ import requests
 API_URL = 'https://api.github.com'
 
 
-def create(github_token: str, owner: str, repo_name: str, head: str, base: str):
-    auth_header = {
-        'Authorization': 'token ' + github_token
-    }
-
+def create(nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
     url = f'{API_URL}/repos/{owner}/{repo_name}/pulls'
     params = {
         'title': f'[auto-merge] {head} to {base} [skip ci] [bot]',
@@ -45,7 +41,7 @@ def create(github_token: str, owner: str, repo_name: str, head: str, base: str):
                 'this PR is unable to be merged due to conflicts, it will remain open until manually fix.',
         'maintainer_can_modify': True
     }
-    r = requests.post(url, headers=auth_header, json=params)
+    r = requests.post(url, headers={'Authorization': 'token ' + nvauto_token}, json=params)
     if r.status_code == 201:
         print('SUCCESS - create PR')
         pull = r.json()
@@ -63,7 +59,10 @@ def create(github_token: str, owner: str, repo_name: str, head: str, base: str):
     sys.exit(1)
 
 
-def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str, number: str, commit_id: str):
+def auto_merge(github_token: str, owner: str, repo_name: str, number: str, commit_id: str):
+    auth_header = {
+        'Authorization': 'token ' + github_token
+    }
     try:
         # auto-approve PR
         approve_url = f'{API_URL}/repos/{owner}/{repo_name}/pulls/{number}/reviews'
@@ -72,9 +71,9 @@ def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str,
             'event': 'APPROVE',
             'body': 'auto-approved',
         }
-        r = requests.post(approve_url, headers={'Authorization': 'token ' + nvauto_token}, json=approve_params)
+        r = requests.post(approve_url, headers=auth_header, json=approve_params)
         if r.status_code == 200:
-            comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+            comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
                     content='**SUCCESS** - auto-approve')
             print('SUCCESS - auto-approve')
         else:
@@ -87,9 +86,9 @@ def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str,
             'sha': commit_id,
             'merge_method': 'merge',
         }
-        r = requests.put(merge_url, headers={'Authorization': 'token ' + github_token}, json=merge_params)
+        r = requests.put(merge_url, headers=auth_header, json=merge_params)
         if r.status_code == 200:
-            comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+            comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
                     content='**SUCCESS** - auto-merge')
             print('SUCCESS - auto-merge')
             sys.exit(0)
@@ -97,7 +96,7 @@ def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str,
             print('FAILURE - auto-merge')
             raise Exception(r.json())
     except Exception as e:
-        comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+        comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
                 content=f"""**FAILURE** - Unable to auto-merge. Manual operation is required.
 ```
 {e}
@@ -107,15 +106,12 @@ def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str,
         sys.exit(1)
 
 
-def comment(github_token: str, owner: str, repo_name: str, number: str, content: str):
-    auth_header = {
-        'Authorization': 'token ' + github_token
-    }
+def comment(token: str, owner: str, repo_name: str, number: str, content: str):
     url = f'{API_URL}/repos/{owner}/{repo_name}/issues/{number}/comments'
     params = {
         'body': content
     }
-    r = requests.post(url, headers=auth_header, json=params)
+    r = requests.post(url, headers={'Authorization': 'token ' + token}, json=params)
     if r.status_code == 201:
         print('SUCCESS - create comment')
     else:
@@ -126,16 +122,17 @@ def comment(github_token: str, owner: str, repo_name: str, number: str, content:
 
 def main(github_token: str, nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
     try:
-        number, sha, term = create(github_token=github_token, owner=owner, repo_name=repo_name, head=head, base=base)
+        # NOTE: github actions can not be trigger by default github-actions bot
+        # So use nvauto_token to trigger checks
+        number, sha, term = create(nvauto_token=nvauto_token, owner=owner, repo_name=repo_name, head=head, base=base)
         if term:
             sys.exit(0)
 
         # skip pre-merge blossom CI w/ [skip ci] in PR title
-        comment(github_token=nvauto_token, owner=owner, repo_name=repo_name, number=number, content='build')
+        comment(token=nvauto_token, owner=owner, repo_name=repo_name, number=number, content='build')
 
         time.sleep(600)  # sleep 10 minutes, then try auto-merge
-        auto_merge(github_token=github_token, nvauto_token=nvauto_token,
-                   owner=owner, repo_name=repo_name, number=number, commit_id=sha)
+        auto_merge(github_token=github_token, owner=owner, repo_name=repo_name, number=number, commit_id=sha)
     except Exception as e:
         print("Unexpected error: ", e)
         exit(-1)

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -17,7 +17,8 @@
 """A auto-merge tool
 
 Create a PR to merge HEAD to BASE branch.
-The PR will be automatically merged if no conflict. Otherwise, manual operation will be required.
+NOTE:
+    The generated PR should be automatically merged if no conflict. Otherwise, manual operation will be required.
 """
 
 import os
@@ -26,42 +27,32 @@ import time
 
 import requests
 
-# ENV
-OWNER = os.environ.get('OWNER')
-assert OWNER, 'env OWNER should not be empty'
-REPO_NAME = os.environ.get('REPO_NAME')
-assert REPO_NAME, 'env REPO_NAME should not be empty'
-HEAD = os.environ.get('HEAD')
-assert HEAD, 'env HEAD should not be empty'
-BASE = os.environ.get('BASE')
-assert BASE, 'env BASE should not be empty'
-GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
-assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
 # static
 API_URL = 'https://api.github.com'
-AUTH_HEADERS = {
-    'Authorization': 'token ' + GITHUB_TOKEN
-}
 
 
-def create():
-    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/pulls'
+def create(github_token: str, owner: str, repo_name: str, head: str, base: str):
+    auth_header = {
+        'Authorization': 'token ' + github_token
+    }
+
+    url = f'{API_URL}/repos/{owner}/{repo_name}/pulls'
     params = {
-        'title': f'[auto-merge] {HEAD} to {BASE} [skip ci] [bot]',
-        'head': HEAD,
-        'base': BASE,
-        'body': f'auto-merge triggered by github actions on `{HEAD}` to create a PR keeping `{BASE}` up-to-date. If '
+        'title': f'[auto-merge] {head} to {base} [skip ci] [bot]',
+        'head': head,
+        'base': base,
+        'body': f'auto-merge triggered by github actions on `{head}` to create a PR keeping `{base}` up-to-date. If '
                 'this PR is unable to be merged due to conflicts, it will remain open until manually fix.',
         'maintainer_can_modify': True
     }
-    r = requests.post(url, headers=AUTH_HEADERS, json=params)
+    r = requests.post(url, headers=auth_header, json=params)
     if r.status_code == 201:
         print('SUCCESS - create PR')
         pull = r.json()
         number = str(pull['number'])
         sha = str(pull['head']['sha'])
         return number, sha, False
-    if r.status_code == 422:
+    if r.status_code == 422:  # early-terminate if no commits between HEAD and BASE
         print('SUCCESS - No commits')
         print(r.json())
         return '', '', True
@@ -72,45 +63,59 @@ def create():
     sys.exit(1)
 
 
-def auto_merge(number, sha):
-    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/pulls/{number}/merge'
-    params = {
-        'sha': sha,
-        'merge_method': 'merge'
-    }
-    r = requests.put(url, headers=AUTH_HEADERS, json=params)
-    if r.status_code == 200:
-        comment(number, '**SUCCESS** - auto-merge')
-        print('SUCCESS - auto-merge')
-        sys.exit(0)
-    else:
-        comment(number, """**FAILURE** - Unable to auto-merge due to conflicts. Manual operation is required.
+def auto_merge(github_token: str, nvauto_token: str, owner: str, repo_name: str, number: str, commit_id: str):
+    try:
+        # auto-approve PR
+        approve_url = f'{API_URL}/repos/{owner}/{repo_name}/pulls/{number}/reviews'
+        approve_params = {
+            'commit_id': commit_id,
+            'event': 'APPROVE',
+            'body': 'auto-approved',
+        }
+        r = requests.post(approve_url, headers={'Authorization': 'token ' + nvauto_token}, json=approve_params)
+        if r.status_code == 200:
+            comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+                    content='**SUCCESS** - auto-approve')
+            print('SUCCESS - auto-approve')
+        else:
+            print('FAILURE - auto-approve')
+            raise Exception(r.json())
 
-To maintainers, please use the following steps to fix the merge conflicts manually:
-This is a example to fix conflict from `branch-0.2` to `branch-0.3`
-```bash
-git fetch <spark-rapids_remote>
-git checkout -b branch-0.3-merge-branch-0.2 <spark-rapids_remote>/branch-0.3
-git merge <spark-rapids_remote>/branch-0.2
-# fix the merge conflict, then
-git commit -am "merge branch-0.2 to branch-0.3"
-git push <your forked remote> branch-0.3-merge-branch-0.2
+        # auto-merge PR
+        merge_url = f'{API_URL}/repos/{owner}/{repo_name}/pulls/{number}/merge'
+        merge_params = {
+            'sha': commit_id,
+            'merge_method': 'merge',
+        }
+        r = requests.put(merge_url, headers={'Authorization': 'token ' + github_token}, json=merge_params)
+        if r.status_code == 200:
+            comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+                    content='**SUCCESS** - auto-merge')
+            print('SUCCESS - auto-merge')
+            sys.exit(0)
+        else:
+            print('FAILURE - auto-merge')
+            raise Exception(r.json())
+    except Exception as e:
+        comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number,
+                content=f"""**FAILURE** - Unable to auto-merge. Manual operation is required.
+```json
+{e}
 ```
-When this is done, create a PR targets the base branch (`branch-0.3` in this example). 
-Once the PR get merged, close the auto-merge PR. 
 """)
-        print('FAILURE - auto-merge')
-        print(f'status code: {r.status_code}')
-        print(r.json())
+        print(e)
         sys.exit(1)
 
 
-def comment(number, content):
-    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/issues/{number}/comments'
+def comment(github_token: str, owner: str, repo_name: str, number: str, content: str):
+    auth_header = {
+        'Authorization': 'token ' + github_token
+    }
+    url = f'{API_URL}/repos/{owner}/{repo_name}/issues/{number}/comments'
     params = {
         'body': content
     }
-    r = requests.post(url, headers=AUTH_HEADERS, json=params)
+    r = requests.post(url, headers=auth_header, json=params)
     if r.status_code == 201:
         print('SUCCESS - create comment')
     else:
@@ -119,14 +124,32 @@ def comment(number, content):
         print(r.json())
 
 
-def main():
-    number, sha, term = create()
-    if term:
-        sys.exit(0)
+def main(github_token: str, nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
+    try:
+        number, sha, term = create(github_token=github_token, owner=owner, repo_name=repo_name, head=head, base=base)
+        if term:
+            sys.exit(0)
 
-    time.sleep(10)  # sleep, then comment
-    auto_merge(number, sha)
+        time.sleep(300)  # sleep 5 minutes, then try auto-merge
+        auto_merge(github_token=github_token, nvauto_token=nvauto_token,
+                   owner=owner, repo_name=repo_name, number=number, commit_id=sha)
+    except Exception as e:
+        print("Unexpected error: ", e)
+        exit(-1)
 
 
 if __name__ == "__main__":
-    main()
+    GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+    assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
+    NVAUTO_TOKEN = os.environ.get('NVAUTO_TOKEN')
+    assert NVAUTO_TOKEN, 'env NVAUTO_TOKEN should not be empty'
+    OWNER = os.environ.get('OWNER')
+    assert OWNER, 'env OWNER should not be empty'
+    REPO_NAME = os.environ.get('REPO_NAME')
+    assert REPO_NAME, 'env REPO_NAME should not be empty'
+    HEAD = os.environ.get('HEAD')
+    assert HEAD, 'env HEAD should not be empty'
+    BASE = os.environ.get('BASE')
+    assert BASE, 'env BASE should not be empty'
+
+    main(github_token=GITHUB_TOKEN, nvauto_token=NVAUTO_TOKEN, owner=OWNER, repo_name=REPO_NAME, head=HEAD, base=BASE)

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -27,21 +27,35 @@ import time
 
 import requests
 
+# ENV
+OWNER = os.environ.get('OWNER')
+assert OWNER, 'env OWNER should not be empty'
+REPO_NAME = os.environ.get('REPO_NAME')
+assert REPO_NAME, 'env REPO_NAME should not be empty'
+HEAD = os.environ.get('HEAD')
+assert HEAD, 'env HEAD should not be empty'
+BASE = os.environ.get('BASE')
+assert BASE, 'env BASE should not be empty'
+AUTOMERGE_TOKEN = os.environ.get('AUTOMERGE_TOKEN')
+assert AUTOMERGE_TOKEN, 'env AUTOMERGE_TOKEN should not be empty'
 # static
 API_URL = 'https://api.github.com'
+AUTH_HEADERS = {
+    'Authorization': 'token ' + AUTOMERGE_TOKEN
+}
 
 
-def create(nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
-    url = f'{API_URL}/repos/{owner}/{repo_name}/pulls'
+def create():
+    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/pulls'
     params = {
-        'title': f'[auto-merge] {head} to {base} [skip ci] [bot]',
-        'head': head,
-        'base': base,
-        'body': f'auto-merge triggered by github actions on `{head}` to create a PR keeping `{base}` up-to-date. If '
+        'title': f'[auto-merge] {HEAD} to {BASE} [skip ci] [bot]',
+        'head': HEAD,
+        'base': BASE,
+        'body': f'auto-merge triggered by github actions on `{HEAD}` to create a PR keeping `{BASE}` up-to-date. If '
                 'this PR is unable to be merged due to conflicts, it will remain open until manually fix.',
         'maintainer_can_modify': True
     }
-    r = requests.post(url, headers={'Authorization': 'token ' + nvauto_token}, json=params)
+    r = requests.post(url, headers=AUTH_HEADERS, json=params)
     if r.status_code == 201:
         print('SUCCESS - create PR')
         pull = r.json()
@@ -59,59 +73,35 @@ def create(nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
     sys.exit(1)
 
 
-def auto_merge(github_token: str, owner: str, repo_name: str, number: str, commit_id: str):
-    auth_header = {
-        'Authorization': 'token ' + github_token
+def auto_merge(number, sha):
+    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/pulls/{number}/merge'
+    params = {
+        'sha': sha,
+        'merge_method': 'merge'
     }
-    try:
-        # auto-approve PR
-        approve_url = f'{API_URL}/repos/{owner}/{repo_name}/pulls/{number}/reviews'
-        approve_params = {
-            'commit_id': commit_id,
-            'event': 'APPROVE',
-            'body': 'auto-approved',
-        }
-        r = requests.post(approve_url, headers=auth_header, json=approve_params)
-        if r.status_code == 200:
-            comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
-                    content='**SUCCESS** - auto-approve')
-            print('SUCCESS - auto-approve')
-        else:
-            print('FAILURE - auto-approve')
-            raise Exception(r.json())
-
-        # auto-merge PR
-        merge_url = f'{API_URL}/repos/{owner}/{repo_name}/pulls/{number}/merge'
-        merge_params = {
-            'sha': commit_id,
-            'merge_method': 'merge',
-        }
-        r = requests.put(merge_url, headers=auth_header, json=merge_params)
-        if r.status_code == 200:
-            comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
-                    content='**SUCCESS** - auto-merge')
-            print('SUCCESS - auto-merge')
-            sys.exit(0)
-        else:
-            print('FAILURE - auto-merge')
-            raise Exception(r.json())
-    except Exception as e:
-        comment(token=github_token, owner=owner, repo_name=repo_name, number=number,
-                content=f"""**FAILURE** - Unable to auto-merge. Manual operation is required.
+    r = requests.put(url, headers=AUTH_HEADERS, json=params)
+    if r.status_code == 200:
+        comment(number, '**SUCCESS** - auto-merge')
+        print('SUCCESS - auto-merge')
+        sys.exit(0)
+    else:
+        print('FAILURE - auto-merge')
+        comment(number=number, content=f"""**FAILURE** - Unable to auto-merge. Manual operation is required.
 ```
-{e}
+{r.json()}
 ```
 """)
-        print(e)
+        print(f'status code: {r.status_code}')
+        print(r.json())
         sys.exit(1)
 
 
-def comment(token: str, owner: str, repo_name: str, number: str, content: str):
-    url = f'{API_URL}/repos/{owner}/{repo_name}/issues/{number}/comments'
+def comment(number, content):
+    url = f'{API_URL}/repos/{OWNER}/{REPO_NAME}/issues/{number}/comments'
     params = {
         'body': content
     }
-    r = requests.post(url, headers={'Authorization': 'token ' + token}, json=params)
+    r = requests.post(url, headers=AUTH_HEADERS, json=params)
     if r.status_code == 201:
         print('SUCCESS - create comment')
     else:
@@ -120,36 +110,13 @@ def comment(token: str, owner: str, repo_name: str, number: str, content: str):
         print(r.json())
 
 
-def main(github_token: str, nvauto_token: str, owner: str, repo_name: str, head: str, base: str):
-    try:
-        # NOTE: github actions can not be trigger by default github-actions bot
-        # So use nvauto_token to trigger checks
-        number, sha, term = create(nvauto_token=nvauto_token, owner=owner, repo_name=repo_name, head=head, base=base)
-        if term:
-            sys.exit(0)
+def main():
+    number, sha, term = create()
+    if term:
+        sys.exit(0)
 
-        # skip pre-merge blossom CI w/ [skip ci] in PR title
-        comment(token=nvauto_token, owner=owner, repo_name=repo_name, number=number, content='build')
-
-        time.sleep(600)  # sleep 10 minutes, then try auto-merge
-        auto_merge(github_token=github_token, owner=owner, repo_name=repo_name, number=number, commit_id=sha)
-    except Exception as e:
-        print("Unexpected error: ", e)
-        exit(-1)
+    time.sleep(10)  # sleep 10s, then try auto-merge
+    auto_merge(number, sha)
 
 
-if __name__ == "__main__":
-    GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
-    assert GITHUB_TOKEN, 'env GITHUB_TOKEN should not be empty'
-    NVAUTO_TOKEN = os.environ.get('NVAUTO_TOKEN')
-    assert NVAUTO_TOKEN, 'env NVAUTO_TOKEN should not be empty'
-    OWNER = os.environ.get('OWNER')
-    assert OWNER, 'env OWNER should not be empty'
-    REPO_NAME = os.environ.get('REPO_NAME')
-    assert REPO_NAME, 'env REPO_NAME should not be empty'
-    HEAD = os.environ.get('HEAD')
-    assert HEAD, 'env HEAD should not be empty'
-    BASE = os.environ.get('BASE')
-    assert BASE, 'env BASE should not be empty'
-
-    main(github_token=GITHUB_TOKEN, nvauto_token=NVAUTO_TOKEN, owner=OWNER, repo_name=REPO_NAME, head=HEAD, base=BASE)
+main()

--- a/.github/workflows/auto-merge/automerge
+++ b/.github/workflows/auto-merge/automerge
@@ -130,7 +130,10 @@ def main(github_token: str, nvauto_token: str, owner: str, repo_name: str, head:
         if term:
             sys.exit(0)
 
-        time.sleep(300)  # sleep 5 minutes, then try auto-merge
+        # skip pre-merge blossom CI w/ [skip ci] in PR title
+        comment(github_token=github_token, owner=owner, repo_name=repo_name, number=number, content='build')
+
+        time.sleep(600)  # sleep 10 minutes, then try auto-merge
         auto_merge(github_token=github_token, nvauto_token=nvauto_token,
                    owner=owner, repo_name=repo_name, number=number, commit_id=sha)
     except Exception as e:


### PR DESCRIPTION
Previous auto-merge workflow only works for auto-merge into an unprotected branch, as how cudf's automerge does.
But this is not reasonable when we switch `branch-0.3` as default branch, so I added auto-approve for this automation workflow, and it will try approving auto-merged pr if possible.

demo PR: https://github.com/pxLi/spark-rapids/pull/153

NOTE: a new secret `NVAUTO_TOKEN` has to be added to repo since github requires a different account to approve the PR. `nvauto` is our automation account which has already been invited to spark-rapids repo.