### PR TITLE
Unit test for GPU exchange re-use with AQE

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -262,6 +262,9 @@ class AdaptiveQueryExecSuite
   }
 
   test("Exchange reuse") {
+
+    assumeSpark301orLater()
+
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
@@ -360,6 +363,16 @@ class AdaptiveQueryExecSuite
       case p: PartialReducerPartitionSpec => p.reducerIndex
     }.distinct
     assert(rightSkew.length == rightSkewNum)
+  }
+
+  private def assumeSpark301orLater(): Unit = {
+    // all AQE tests requires Spark 3.0.1 or later
+    val isValidTestForSparkVersion = ShimLoader.getSparkShims.getSparkShimVersion match {
+      case SparkShimVersion(3, 0, 0) => false
+      case DatabricksShimVersion(3, 0, 0) => false
+      case _ => true
+    }
+    assume(isValidTestForSparkVersion)
   }
 
   private def setupTestData(spark: SparkSession): Unit = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -22,11 +22,12 @@ import com.nvidia.spark.rapids.AdaptiveQueryExecSuite.TEST_FILES_ROOT
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{PartialReducerPartitionSpec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, BroadcastQueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
-import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.execution.exchange.{Exchange, ReusedExchangeExec}
+import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.{GpuCustomShuffleReaderExec, GpuShuffledHashJoinBase}
@@ -73,9 +74,28 @@ class AdaptiveQueryExecSuite
     (dfAdaptive.queryExecution.sparkPlan, adaptivePlan)
   }
 
-  private def findTopLevelSortMergeJoin(plan: SparkPlan): Seq[GpuShuffledHashJoinBase] = {
+  private def findTopLevelSortMergeJoin(plan: SparkPlan): Seq[SortMergeJoinExec] = {
+    collect(plan) {
+      case j: SortMergeJoinExec => j
+    }
+  }
+
+  private def findTopLevelGpuBroadcastHashJoin(plan: SparkPlan): Seq[GpuExec] = {
+    collect(plan) {
+      case j: GpuExec if ShimLoader.getSparkShims.isBroadcastExchangeLike(j) => j
+    }
+  }
+
+  private def findTopLevelGpuShuffleHashJoin(plan: SparkPlan): Seq[GpuShuffledHashJoinBase] = {
     collect(plan) {
       case j: GpuShuffledHashJoinBase => j
+    }
+  }
+
+  private def findReusedExchange(plan: SparkPlan): Seq[ReusedExchangeExec] = {
+    collectWithSubqueries(plan) {
+      case ShuffleQueryStageExec(_, e: ReusedExchangeExec) => e
+      case BroadcastQueryStageExec(_, e: ReusedExchangeExec) => e
     }
   }
 
@@ -84,7 +104,7 @@ class AdaptiveQueryExecSuite
       val (_, innerAdaptivePlan) = runAdaptiveAndVerifyResult(
         spark,
         "SELECT * FROM skewData1 join skewData2 ON key1 = key2")
-      val innerSmj = findTopLevelSortMergeJoin(innerAdaptivePlan)
+      val innerSmj = findTopLevelGpuShuffleHashJoin(innerAdaptivePlan)
       checkSkewJoin(innerSmj, 2, 1)
     }
   }
@@ -94,7 +114,7 @@ class AdaptiveQueryExecSuite
       val (_, leftAdaptivePlan) = runAdaptiveAndVerifyResult(
         spark,
         "SELECT * FROM skewData1 left outer join skewData2 ON key1 = key2")
-      val leftSmj = findTopLevelSortMergeJoin(leftAdaptivePlan)
+      val leftSmj = findTopLevelGpuShuffleHashJoin(leftAdaptivePlan)
       checkSkewJoin(leftSmj, 2, 0)
     }
   }
@@ -104,7 +124,7 @@ class AdaptiveQueryExecSuite
       val (_, rightAdaptivePlan) = runAdaptiveAndVerifyResult(
         spark,
         "SELECT * FROM skewData1 right outer join skewData2 ON key1 = key2")
-      val rightSmj = findTopLevelSortMergeJoin(rightAdaptivePlan)
+      val rightSmj = findTopLevelGpuShuffleHashJoin(rightAdaptivePlan)
       checkSkewJoin(rightSmj, 0, 1)
     }
   }
@@ -241,6 +261,33 @@ class AdaptiveQueryExecSuite
     }, conf)
   }
 
+  test("Exchange reuse") {
+    val conf = new SparkConf()
+        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+        .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+
+    withGpuSparkSession(spark => {
+      setupTestData(spark)
+
+      val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(spark,
+        "SELECT value FROM testData join testData2 ON key = a " +
+            "join (SELECT value v from testData join testData3 ON key = a) on value = v")
+
+      // initial plan should have three SMJs
+      val smj = findTopLevelSortMergeJoin(plan)
+      assert(smj.size == 3)
+
+      // executed GPU plan replaces SMJ with SHJ
+      val shj = findTopLevelGpuShuffleHashJoin(adaptivePlan)
+      assert(shj.size == 3)
+
+      // Even with local shuffle reader, the query stage reuse can also work.
+      val ex = findReusedExchange(adaptivePlan)
+      assert(ex.size == 1)
+
+    }, conf)
+  }
+
   def skewJoinTest(fun: SparkSession => Unit) {
     assumeSpark301orLater
 
@@ -313,4 +360,39 @@ class AdaptiveQueryExecSuite
     assert(rightSkew.length == rightSkewNum)
   }
 
+  private def setupTestData(spark: SparkSession): Unit = {
+    testData(spark)
+    testData2(spark)
+    testData3(spark)
+  }
+
+  /** Ported from org.apache.spark.sql.test.SQLTestData */
+  private def testData(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    val data: Seq[(Int, String)] = (1 to 100).map(i => (i, i.toString))
+    val df = data.toDF("key", "value")
+        .repartition(6)
+    df.createOrReplaceTempView("testData")
+    df
+  }
+
+  /** Ported from org.apache.spark.sql.test.SQLTestData */
+  private def testData2(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    val df = Seq[(Int, Int)]((1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2))
+      .toDF("a", "b")
+      .repartition(2)
+    df.createOrReplaceTempView("testData2")
+    df
+  }
+
+  /** Ported from org.apache.spark.sql.test.SQLTestData */
+  private def testData3(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    val df = Seq[(Int, Option[Int])]((1, None), (2, Some(2)))
+      .toDF("a", "b")
+        .repartition(6)
+    df.createOrReplaceTempView("testData3")
+    df
+  }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -284,6 +284,10 @@ class AdaptiveQueryExecSuite
       // Even with local shuffle reader, the query stage reuse can also work.
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.size == 1)
+      assert(ShimLoader.getSparkShims.isShuffleExchangeLike(ex.head.child))
+
+      //TODO this fails, so it looks like we might have a bug around re-using GPU exchanges
+      //assert(ex.head.child.isInstanceOf[GpuExec])
 
     }, conf)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -22,7 +22,7 @@ import com.nvidia.spark.rapids.AdaptiveQueryExecSuite.TEST_FILES_ROOT
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.{Dataset, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{PartialReducerPartitionSpec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, BroadcastQueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
@@ -281,13 +281,11 @@ class AdaptiveQueryExecSuite
       val shj = findTopLevelGpuShuffleHashJoin(adaptivePlan)
       assert(shj.size == 3)
 
-      // Even with local shuffle reader, the query stage reuse can also work.
+      // one of the GPU exchanges should have been re-used
       val ex = findReusedExchange(adaptivePlan)
       assert(ex.size == 1)
       assert(ShimLoader.getSparkShims.isShuffleExchangeLike(ex.head.child))
-
-      //TODO this fails, so it looks like we might have a bug around re-using GPU exchanges
-      //assert(ex.head.child.isInstanceOf[GpuExec])
+      assert(ex.head.child.isInstanceOf[GpuExec])
 
     }, conf)
   }
@@ -371,32 +369,37 @@ class AdaptiveQueryExecSuite
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData(spark: SparkSession): DataFrame = {
+  private def testData(spark: SparkSession) {
     import spark.implicits._
     val data: Seq[(Int, String)] = (1 to 100).map(i => (i, i.toString))
     val df = data.toDF("key", "value")
         .repartition(6)
-    df.createOrReplaceTempView("testData")
-    df
-  }
+    registerAsParquetTable(spark, df, "testData")  }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData2(spark: SparkSession): DataFrame = {
+  private def testData2(spark: SparkSession) {
     import spark.implicits._
     val df = Seq[(Int, Int)]((1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2))
       .toDF("a", "b")
       .repartition(2)
-    df.createOrReplaceTempView("testData2")
-    df
+    registerAsParquetTable(spark, df, "testData2")
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData3(spark: SparkSession): DataFrame = {
+  private def testData3(spark: SparkSession) {
     import spark.implicits._
     val df = Seq[(Int, Option[Int])]((1, None), (2, Some(2)))
       .toDF("a", "b")
         .repartition(6)
-    df.createOrReplaceTempView("testData3")
-    df
+    registerAsParquetTable(spark, df, "testData3")
   }
+
+  private def registerAsParquetTable(spark: SparkSession, df: Dataset[Row], name: String) {
+    val path = new File(TEST_FILES_ROOT, s"$name.parquet").getAbsolutePath
+    df.write
+        .mode(SaveMode.Overwrite)
+        .parquet(path)
+    spark.read.parquet(path).createOrReplaceTempView(name)
+  }
+
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -263,7 +263,7 @@ class AdaptiveQueryExecSuite
 
   test("Exchange reuse") {
 
-    assumeSpark301orLater()
+    assumeSpark301orLater
 
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
@@ -363,16 +363,6 @@ class AdaptiveQueryExecSuite
       case p: PartialReducerPartitionSpec => p.reducerIndex
     }.distinct
     assert(rightSkew.length == rightSkewNum)
-  }
-
-  private def assumeSpark301orLater(): Unit = {
-    // all AQE tests requires Spark 3.0.1 or later
-    val isValidTestForSparkVersion = ShimLoader.getSparkShims.getSparkShimVersion match {
-      case SparkShimVersion(3, 0, 0) => false
-      case DatabricksShimVersion(3, 0, 0) => false
-      case _ => true
-    }
-    assume(isValidTestForSparkVersion)
   }
 
   private def setupTestData(spark: SparkSession): Unit = {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Implements a unit test to check that GPU exchanges are re-used correctly when AQE is enabled.
