### PR TITLE
Fix issues with cannonicalization of WrappedAggFunction

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -28,14 +28,14 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
  * return the same answer given any input (i.e. false negatives are possible).
  *
  * The following rules are applied:
- *  - Names and nullability hints for [[org.apache.spark.sql.types.DataType]]s are stripped.
- *  - Names for [[GetStructField]] are stripped.
- *  - TimeZoneId for [[Cast]] and [[AnsiCast]] are stripped if `needsTimeZone` is false.
- *  - Commutative and associative operations ([[Add]] and [[Multiply]]) have their children ordered
+ *  - Names and nullability hints for `org.apache.spark.sql.types.DataTypes` are stripped.
+ *  - Names for `GetStructField` are stripped.
+ *  - TimeZoneId for `Cast` and `AnsiCast` are stripped if `needsTimeZone` is false.
+ *  - Commutative and associative operations (`Add` and `Multiply`) have their children ordered
  *    by `hashCode`.
- *  - [[EqualTo]] and [[EqualNullSafe]] are reordered by `hashCode`.
- *  - Other comparisons ([[GreaterThan]], [[LessThan]]) are reversed by `hashCode`.
- *  - Elements in [[In]] are reordered by `hashCode`.
+ *  - `EqualTo` and `EqualNullSafe` are reordered by hashCode.
+ *  - Other comparisons (`GreaterThan`, `LessThan`) are reversed by `hashCode`.
+ *  - Elements in `In` are reordered by `hashCode`.
  *
  *  This is essentially a copy of the Spark `Canonicalize` class but updated for GPU operators
  */

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -66,50 +66,50 @@ trait GpuAggregateFunction extends GpuExpression {
   }
 }
 
+case class WrappedAggFunction(aggregateFunction: GpuAggregateFunction, filter: Expression)
+    extends GpuDeclarativeAggregate {
+  override val inputProjection: Seq[GpuExpression] = {
+    val caseWhenExpressions = aggregateFunction.inputProjection.map { ip =>
+      // special case average with null result from the filter as expected values should be
+      // (0.0,0) for (sum, count)
+      val initialValue: Expression =
+        aggregateFunction match {
+          case _ : GpuAverage => ip.dataType match {
+            case doubleType: DoubleType => GpuLiteral(0D, doubleType)
+            case _ : LongType => GpuLiteral(0L, LongType)
+          }
+          case _ => GpuLiteral(null, ip.dataType)
+        }
+      val filterConditional = GpuCaseWhen(Seq((filter, ip)))
+      GpuCaseWhen(Seq((GpuIsNotNull(filterConditional), filterConditional)), Some(initialValue))
+    }
+    caseWhenExpressions
+  }
+  /** Attributes of fields in aggBufferSchema. */
+  override def aggBufferAttributes: Seq[AttributeReference] =
+    aggregateFunction.aggBufferAttributes
+  override def nullable: Boolean = aggregateFunction.nullable
+
+  override def dataType: DataType = aggregateFunction.dataType
+
+  override def children: Seq[Expression] = Seq(aggregateFunction, filter)
+
+  override val initialValues: Seq[GpuExpression] =
+    aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].initialValues
+  override val updateExpressions: Seq[Expression] =
+    aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].updateExpressions
+  override val mergeExpressions: Seq[GpuExpression] =
+    aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].mergeExpressions
+  override val evaluateExpression: Expression =
+    aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].evaluateExpression
+}
+
 case class GpuAggregateExpression(origAggregateFunction: GpuAggregateFunction,
                                   mode: AggregateMode,
                                   isDistinct: Boolean,
                                   filter: Option[Expression],
                                   resultId: ExprId)
   extends GpuExpression with GpuUnevaluable {
-
-  case class WrappedAggFunction(aggregateFunction: GpuAggregateFunction, filter: Expression)
-    extends GpuDeclarativeAggregate {
-    override val inputProjection: Seq[GpuExpression] = {
-      val caseWhenExpressions = aggregateFunction.inputProjection.map { ip =>
-        // special case average with null result from the filter as expected values should be
-        // (0.0,0) for (sum, count)
-        val initialValue: Expression =
-          origAggregateFunction match {
-            case _ : GpuAverage => ip.dataType match {
-              case doubleType: DoubleType => GpuLiteral(0D, doubleType)
-              case _ : LongType => GpuLiteral(0L, LongType)
-            }
-            case _ => GpuLiteral(null, ip.dataType)
-          }
-        val filterConditional = GpuCaseWhen(Seq((filter, ip)))
-        GpuCaseWhen(Seq((GpuIsNotNull(filterConditional), filterConditional)), Some(initialValue))
-      }
-      caseWhenExpressions
-    }
-    /** Attributes of fields in aggBufferSchema. */
-    override def aggBufferAttributes: Seq[AttributeReference] =
-      aggregateFunction.aggBufferAttributes
-    override def nullable: Boolean = aggregateFunction.nullable
-
-    override def dataType: DataType = aggregateFunction.dataType
-
-    override def children: Seq[Expression] = Seq(aggregateFunction, filter)
-
-    override val initialValues: Seq[GpuExpression] =
-      aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].initialValues
-    override val updateExpressions: Seq[Expression] =
-      aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].updateExpressions
-    override val mergeExpressions: Seq[GpuExpression] =
-      aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].mergeExpressions
-    override val evaluateExpression: Expression =
-      aggregateFunction.asInstanceOf[GpuDeclarativeAggregate].evaluateExpression
-  }
 
   val aggregateFunction = if (filter.isDefined) {
     WrappedAggFunction(origAggregateFunction, filter.get)


### PR DESCRIPTION
This fixes #671 

The magic in Spark around `TreeNode` does not work if the `Expression` or `SparkPlan` is an inner class.  This just moved `WrappedAggFunction` from being an inner class to being a top level class and it fixed the bug.

I also cleaned up some doc warning for Canonicalization code that was copied and pasted from Spark.