### PR TITLE
Remove sorts when replacing sort aggregate if possible

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuSortMergeJoinExec.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuSortMergeJoinExec.scala
@@ -50,7 +50,7 @@ class GpuSortMergeJoinMeta(
         s"see ${RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key}")
     }
 
-    // make sure this is last check - if this is SortMergeJoin, the children can be Sorts and we
+    // make sure this is the last check - if this is SortMergeJoin, the children can be Sorts and we
     // want to validate they can run on GPU and remove them before replacing this with a
     // ShuffleHashJoin
     if (canThisBeReplaced) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -247,7 +247,7 @@ class GpuSortAggregateMeta(
       }
     }
 
-    // make sure this is last check - if this is SortAggregate, the children can be Sorts and we
+    // make sure this is the last check - if this is SortAggregate, the children can be Sorts and we
     // want to validate they can run on GPU and remove them before replacing this with a
     // HashAggregate.  We don't want to do this if there is a first or last aggregate,
     // because dropping the sort will make them no longer deterministic.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, HashPartitioning, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.execution.{ExplainUtils, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{ExplainUtils, SortExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.{CudfAggregate, GpuAggregateExpression, GpuDeclarativeAggregate}
@@ -246,6 +246,34 @@ class GpuSortAggregateMeta(
             s"'complete', or 'all'")
       }
     }
+
+    // make sure this is last check - if this is SortAggregate, the children can be Sorts and we
+    // want to validate they can run on GPU and remove them before replacing this with a
+    // HashAggregate.  We don't want to do this if there is a first or last aggregate,
+    // because dropping the sort will make them no longer deterministic.
+    // In the future we might be able to pull the sort functionality into the aggregate so
+    // we can sort a single batch at a time and sort the combined result as well which would help
+    // with data skew.
+    val hasFirstOrLast = agg.aggregateExpressions.exists { agg =>
+      agg.aggregateFunction match {
+        case _: First => true
+        case _: Last => true
+        case _ => false
+      }
+    }
+    if (canThisBeReplaced && !hasFirstOrLast) {
+      childPlans.foreach { plan =>
+        if (plan.wrapped.isInstanceOf[SortExec]) {
+          if (!plan.canThisBeReplaced) {
+            willNotWorkOnGpu(s"can't replace sortAggregate because one of the SortExec's before " +
+              s"can't be replaced.")
+          } else {
+            plan.shouldBeRemoved("removing SortExec as part replacing sortAggregate with " +
+              s"hashAggregate")
+          }
+        }
+      }
+    }
   }
 
   override def convertToGpu(): GpuExec = {
@@ -260,7 +288,6 @@ class GpuSortAggregateMeta(
       resultExpressions.map(_.convertToGpu()).asInstanceOf[Seq[NamedExpression]],
       childPlans(0).convertIfNeeded())
   }
-
 }
 
 /**


### PR DESCRIPTION
This fixes #601 

The code will remove the sort iff the sort could run on the GPU just like with the sort merge join, and there are no first or last aggregates, which become deterministic( or at least a lot more deterministic) when sort is involved, but are not otherwise.