### PR TITLE
Include the UDF compiler in the dist jar

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -47,6 +47,11 @@
        <version>${project.version}</version>
     </dependency>
     <dependency>
+       <groupId>com.nvidia</groupId>
+       <artifactId>rapids-4-spark-udf_${scala.binary.version}</artifactId>
+       <version>${project.version}</version>
+    </dependency>
+    <dependency>
        <!-- required for conf generation script -->
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-sql_${scala.binary.version}</artifactId>

--- a/udf-compiler/README.md
+++ b/udf-compiler/README.md
@@ -20,6 +20,7 @@ export SPARK_HOME=[your spark distribution directory]
 export JARS=[path to cudf 0.15 jar]
 
 $SPARK_HOME/bin/spark-shell \
---jars $JARS/cudf-0.15-cuda10-1.jar,udf-compiler/target/rapids-4-spark-udf_2.12-0.2.0-SNAPSHOT.jar,sql-plugin/target/rapids-4-spark-sql_2.12-0.2.0-SNAPSHOT.jar \
---conf spark.sql.extensions="com.nvidia.spark.SQLPlugin,com.nvidia.spark.udf.Plugin"
+--jars $JARS/cudf-0.15-cuda10-1.jar,dist/target/rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar \
+--conf spark.sql.extensions="com.nvidia.spark.udf.Plugin"
+--conf spark.plugins="com.nvidia.spark.SQLPlugin"
 ```

--- a/udf-compiler/README.md
+++ b/udf-compiler/README.md
@@ -10,17 +10,10 @@ From `rapids-plugin-4-spark` root directory, use this command to run the `Opcode
 mvn test -DwildcardSuites=com.nvidia.spark.OpcodeSuite
 ```
 
-How to run spark shell
-----------------------
+How to run
+----------
 
-To run the spark-shell, you need a `SPARK_HOME`, the `cudf-0.15-cuda10-1.jar`, and the jars produced in the plugin. The cudf jar will be downloaded when mvn test (or package) is run into the ~/.m2 directory. It's easy to get the jar from this directory, and place somewhere accessible. In the case below, the cudf jar is assumed to be in a directory `$JARS`:
+The UDF compiler is included in the rapids-4-spark jar that is produced by the `dist` maven project.  Set up your cluster to run the RAPIDS Accelerator for Apache Spark
+and set the spark config `spark.sql.extensions` to include `com.nvidia.spark.udf.Plugin`.
 
-```
-export SPARK_HOME=[your spark distribution directory]
-export JARS=[path to cudf 0.15 jar]
-
-$SPARK_HOME/bin/spark-shell \
---jars $JARS/cudf-0.15-cuda10-1.jar,dist/target/rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar \
---conf spark.sql.extensions="com.nvidia.spark.udf.Plugin"
---conf spark.plugins="com.nvidia.spark.SQLPlugin"
-```
+The plugin is still disabled by default and you will need to set `spark.rapids.sql.udfCompiler.enabled` to `true` to enable it. 


### PR DESCRIPTION
This fixes #680 

I manually verified that the instructions are correct in the README.md and that it is able to run properly with only including cudf and the accelerator jar in the classpath.

This does not address the glaring lack of documentation for this feature though.