### PR TITLE
Change shims dependency to spark-3.0.1

### DIFF
--- a/api_validation/README.md
+++ b/api_validation/README.md
@@ -2,7 +2,7 @@
 
 API validation script checks the compatibility of community Spark Execs and GPU Execs in the Rapids Plugin for Spark.  
 For example: HashAggregateExec with GpuHashAggregateExec.
-Script can be used to audit different versions of Spark(3.0.0, 3.0.1-SNAPSHOT and 3.1.0-SNAPSHOT)
+Script can be used to audit different versions of Spark(3.0.0, 3.0.1 and 3.1.0-SNAPSHOT)
 The script prints Execs where validation fails. 
 Validation fails when:
 1) The number of parameters differ between community Spark Execs and Gpu Execs.
@@ -17,7 +17,7 @@ It requires cudf, rapids-4-spark and spark jars.
 
 ```
 cd api_validation
-// To run validation script on all version of Spark(3.0.0, 3.0.1-SNAPSHOT and 3.1.0-SNAPSHOT)
+// To run validation script on all version of Spark(3.0.0, 3.0.1 and 3.1.0-SNAPSHOT)
 sh auditAllVersions.sh
 
 // To run script on particular version we can use profile(spark300, spark301 and spark310)

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -41,7 +41,7 @@
         <profile>
             <id>spark301tests</id>
             <properties>
-                <spark.test.version>3.0.1-SNAPSHOT</spark.test.version>
+                <spark.test.version>3.0.1</spark.test.version>
             </properties>
         </profile>
         <profile>

--- a/jenkins/Jenkinsfile.301.integration
+++ b/jenkins/Jenkinsfile.301.integration
@@ -51,9 +51,9 @@ pipeline {
     }
 
     stages {
-        stage('IT on 3.0.1-SNAPSHOT') {
+        stage('IT on 3.0.1') {
             agent { label 'docker-gpu' }
-            environment {SPARK_VER='3.0.1-SNAPSHOT'}
+            environment {SPARK_VER='3.0.1'}
             steps {
                 script {
                     def CUDA_NAME=sh(returnStdout: true,

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <!--
          If you update a dependendy version so it is no longer a SNAPSHOT
          please update the snapshot-shims profile as well so it is accurate -->
-        <spark301.version>3.0.1-SNAPSHOT</spark301.version>
+        <spark301.version>3.0.1</spark301.version>
         <spark302.version>3.0.2-SNAPSHOT</spark302.version>
         <spark310.version>3.1.0-SNAPSHOT</spark310.version>
     </properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -43,7 +43,7 @@
         <profile>
             <id>spark301tests</id>
             <properties>
-                <spark.test.version>3.0.1-SNAPSHOT</spark.test.version>
+                <spark.test.version>3.0.1</spark.test.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
The original spark-rapids shims layer is against spark-3.0.1-SNAPSHOT.
As spark version 3.0.1 has been released, change shims dependency from 3.0.1-SNAPSHOT to 3.0.1

This change doesn't add/change unit tests.

No issue related to this change.