### PR TITLE
fix checkout-ref for automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: branch-0.2 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

As https://github.com/NVIDIA/spark-rapids/pull/668 got merged but existing PRs does not have to be rebased on that, 

so the latest automerge files will not be checkout in triggered workflow since by default it uses the PR's base ref which is not we were expecting.

This PR is going to fix this by forcing checkout workflow files from the latest remote `branch-0.2`

After:
![image](https://user-images.githubusercontent.com/8086184/92638067-4fab3980-f30c-11ea-9f83-4556d3006013.png)

Before:
![image](https://user-images.githubusercontent.com/8086184/92638349-b7fa1b00-f30c-11ea-9426-97749d87f31b.png)

