### PR TITLE
Enable configuration check for cast string to timestamp

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -70,6 +70,13 @@ class CastExprMeta[INPUT <: CastBase](
         "operation on the GPU, set" +
         s" ${RapidsConf.ENABLE_CAST_STRING_TO_INTEGER} to true.")
     }
+    if (!conf.isCastStringToTimestampEnabled && fromType == DataTypes.StringType
+      && toType == DataTypes.TimestampType) {
+      willNotWorkOnGpu("The GPU only supports a subset of formats " +
+        "when casting strings to timestamps. Refer to the CAST documentation " +
+        "for more details. To enable this operation on the GPU, set" +
+        s" ${RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP} to true.")
+    }
   }
 
   override def convertToGpu(child: Expression): GpuExpression =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -72,7 +72,7 @@ class CastExprMeta[INPUT <: CastBase](
     }
     if (!conf.isCastStringToTimestampEnabled && fromType == DataTypes.StringType
       && toType == DataTypes.TimestampType) {
-      willNotWorkOnGpu("The GPU only supports a subset of formats " +
+      willNotWorkOnGpu("the GPU only supports a subset of formats " +
         "when casting strings to timestamps. Refer to the CAST documentation " +
         "for more details. To enable this operation on the GPU, set" +
         s" ${RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP} to true.")


### PR DESCRIPTION
We were seeing timestamp values returned as null on the GPU side when the CPU side returned valid data. It looks like we somehow weren't checking the conf we added which defaults to false when trying to convert strings to timestamps.

In this case the timestamp format was: 2017-11-29 20:00:35 which according to our docs we don't support. https://nvidia.github.io/spark-rapids/docs/compatibility.html#string-to-timestamp

I manually tested this for now:

        !Expression <Cast> cast(from_unixtime(value#0L, yyyy-MM-dd HH:mm:ss, Some(UTC)) as timestamp) cannot run on GPU because the GPU only supports a subset of formats when casting strings to timestamps. Refer to the CAST documentation for more details. To enable this operation on the GPU, set spark.rapids.sql.castStringToTimestamp.enabled to true.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
