### PR TITLE
fix blossom checkout repo

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          repository: ${{ github.repository }}
+          repository: ${{ fromJson(steps.pull_request_data.outputs.data).head.repo.full_name }}
           ref: ${{ fromJson(steps.pull_request_data.outputs.data).head.ref }}
           lfs: 'true'
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

another quick fix for the forked repo. So this will get head.repo info from the PR
