### PR TITLE
Move spark 3.0.1-shims out of snapshot-shims

### DIFF
--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -74,12 +74,6 @@
                     <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>
@@ -88,6 +82,12 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark300_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Signed-off-by: gashen <gashen@nvidia.com>

In shims/pom.xml, spark301 is already moved out of snapshot-shims profile.
In shims/aggregator/pom.xml, it should also be moved out.
Otherwise, the running on spark 3.0.1 will not find shims.