### PR TITLE
Fix collect time metric in CoalesceBatches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -163,7 +163,6 @@ abstract class AbstractGpuCoalesceIterator(origIter: Iterator[ColumnarBatch],
   private var collectMetric: Option[MetricRange] = None
   private var totalMetric: Option[MetricRange] = None
 
-
   /** We need to track the sizes of string columns to make sure we don't exceed 2GB */
   private val stringFieldIndices: Array[Int] = schema.fields.zipWithIndex
     .filter(_._1.dataType == DataTypes.StringType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -178,7 +178,7 @@ abstract class AbstractGpuCoalesceIterator(origIter: Iterator[ColumnarBatch],
     .foreach(_.addTaskCompletionListener[Unit](_ => onDeck.foreach(_.close())))
 
   override def hasNext: Boolean = {
-    collectMetric.getOrElse {
+    if (!collectMetric.isDefined) {
       // use one being not set as indicator that neither are intialized to avoid
       // 2 checks or extra initialized variable
       collectMetric = Some(new MetricRange(collectTime))


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/658

GpuCoalesceBatches has a collectTime metric that measures the time a task spent waiting to collect all the input batches. This metric can be incorrect when a task becomes blocked by the GPU semaphore trying to access the GPU. GpuCoalesceBatches only starts the collectTime metric in the next() call, but the GPU semphore may try to be acquired by an upstream node when GpuCoalesceBatches's input iterator's hasNext() call is invoked. Any time spent in the first invocation of the input iterator hasNext() method is not tracked, leading to large discrepancies in time as reported in #622.

Moved the start of this into hasNext which was most straight forward.
Note also needed to move the totalTime metric.

attached is screenshot of the fix where GpuCoalesceBatches properly shows collect batch time and total time very close to the GpuShuffledHashJoin build time.  Without the fix the times are very different.

After Fix:
![Screen Shot 2020-09-10 at 5 23 25 PM](https://user-images.githubusercontent.com/4563792/92816068-96d80f80-f38a-11ea-91d7-fab6e23ad170.png)

Before Fix:
![Screen Shot 2020-09-10 at 5 26 04 PM](https://user-images.githubusercontent.com/4563792/92816211-c5ee8100-f38a-11ea-879c-473f771dcaed.png)


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
