### PR TITLE
Add a timeout for RapidsShuffleIterator to prevent jobs to hang infin…

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -36,6 +36,7 @@ Name | Description | Default Value
 <a name="memory.gpu.reserve"></a>spark.rapids.memory.gpu.reserve|The amount of GPU memory that should remain unallocated by RMM and left for system use such as memory needed for kernels, kernel launches or JIT compilation.|1073741824
 <a name="memory.host.spillStorageSize"></a>spark.rapids.memory.host.spillStorageSize|Amount of off-heap host memory to use for buffering spilled GPU data before spilling to local disk|1073741824
 <a name="memory.pinnedPool.size"></a>spark.rapids.memory.pinnedPool.size|The size of the pinned memory pool in bytes unless otherwise specified. Use 0 to disable the pool.|0
+<a name="shuffle.fetchTimeout"></a>spark.rapids.shuffle.fetchTimeout|Timeout that the RapidsShuffleIterator will wait for a resolved batch. It defaults to 120s since this is the value that Spark uses for `spark.network.timeout`.|120
 <a name="shuffle.transport.enabled"></a>spark.rapids.shuffle.transport.enabled|When set to true, enable the Rapids Shuffle Transport for accelerated shuffle.|false
 <a name="shuffle.transport.maxReceiveInflightBytes"></a>spark.rapids.shuffle.transport.maxReceiveInflightBytes|Maximum aggregate amount of bytes that be fetched at any given time from peers during shuffle|1073741824
 <a name="shuffle.ucx.managementServerHost"></a>spark.rapids.shuffle.ucx.managementServerHost|The host to be used to start the management server|null

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -36,7 +36,6 @@ Name | Description | Default Value
 <a name="memory.gpu.reserve"></a>spark.rapids.memory.gpu.reserve|The amount of GPU memory that should remain unallocated by RMM and left for system use such as memory needed for kernels, kernel launches or JIT compilation.|1073741824
 <a name="memory.host.spillStorageSize"></a>spark.rapids.memory.host.spillStorageSize|Amount of off-heap host memory to use for buffering spilled GPU data before spilling to local disk|1073741824
 <a name="memory.pinnedPool.size"></a>spark.rapids.memory.pinnedPool.size|The size of the pinned memory pool in bytes unless otherwise specified. Use 0 to disable the pool.|0
-<a name="shuffle.fetchTimeout"></a>spark.rapids.shuffle.fetchTimeout|Timeout that the RapidsShuffleIterator will wait for a resolved batch. It defaults to 120s since this is the value that Spark uses for `spark.network.timeout`.|120
 <a name="shuffle.transport.enabled"></a>spark.rapids.shuffle.transport.enabled|When set to true, enable the Rapids Shuffle Transport for accelerated shuffle.|false
 <a name="shuffle.transport.maxReceiveInflightBytes"></a>spark.rapids.shuffle.transport.maxReceiveInflightBytes|Maximum aggregate amount of bytes that be fetched at any given time from peers during shuffle|1073741824
 <a name="shuffle.ucx.managementServerHost"></a>spark.rapids.shuffle.ucx.managementServerHost|The host to be used to start the management server|null

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -17,7 +17,6 @@ package com.nvidia.spark.rapids
 
 import java.io.{File, FileOutputStream}
 import java.util
-import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{HashMap, ListBuffer}
@@ -223,10 +222,6 @@ class ConfBuilder(val key: String, val register: ConfEntry[_] => Unit) {
 
   def stringConf: TypedConfBuilder[String] = {
     new TypedConfBuilder[String](this, identity[String])
-  }
-
-  def timeConf(unit: TimeUnit): TypedConfBuilder[Long] = {
-    new TypedConfBuilder[Long](this, JavaUtils.timeStringAs(_, unit))
   }
 }
 
@@ -558,14 +553,6 @@ object RapidsConf {
     .internal()
     .booleanConf
     .createWithDefault(true)
-
-  // USER FACING SHUFFLE CONFIGS
-  val SHUFFLE_FETCH_TIMEOUT  = conf("spark.rapids.shuffle.fetchTimeout")
-    .doc("Timeout that the RapidsShuffleIterator will wait for a resolved batch. " +
-        "It defaults to 120s since this is the value that Spark uses for " +
-        "`spark.network.timeout`.")
-    .timeConf(TimeUnit.SECONDS)
-    .createWithDefault(120)
 
   val SHUFFLE_TRANSPORT_ENABLE = conf("spark.rapids.shuffle.transport.enabled")
     .doc("When set to true, enable the Rapids Shuffle Transport for accelerated shuffle.")
@@ -933,8 +920,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shuffleCompressionCodec: String = get(SHUFFLE_COMPRESSION_CODEC)
 
   lazy val shuffleCompressionMaxBatchMemory: Long = get(SHUFFLE_COMPRESSION_MAX_BATCH_MEMORY)
-
-  lazy val shuffleFetchTimeout: Long = get(SHUFFLE_FETCH_TIMEOUT)
 
   def isOperatorEnabled(key: String, incompat: Boolean, isDisabledByDefault: Boolean): Boolean = {
     val default = !(isDisabledByDefault || incompat) || (incompat && isIncompatEnabled)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -80,7 +80,13 @@ class RapidsShuffleIterator(
       mapIndex: Int,
       errorMessage: String) extends ShuffleClientResult
 
+  // when batches (or errors) arrive from the transport, the are pushed
+  // to the `resolvedBatches` queue.
   private[this] val resolvedBatches = new LinkedBlockingQueue[ShuffleClientResult]()
+
+  // a user configurable timeout in seconds for the maximum time the iterator
+  // will wait for a batch to appear in `resolvedBatches`
+  private[this] val timeoutSeconds = rapidsConf.shuffleFetchTimeout
 
   // Used to track requests that are pending where the number of [[ColumnarBatch]] results is
   // not known yet
@@ -311,7 +317,7 @@ class RapidsShuffleIterator(
 
     val blockedStart = System.currentTimeMillis()
     var result: Option[ShuffleClientResult] = None
-    val timeoutSeconds = rapidsConf.shuffleFetchTimeout
+
     result = pollForResult(timeoutSeconds)
     val blockedTime = System.currentTimeMillis() - blockedStart
     result match {

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
@@ -28,3 +28,5 @@ class RapidsShuffleFetchFailedException(
     extends FetchFailedException(
       bmAddress, shuffleId, mapId, mapIndex, reduceId, message) {
 }
+
+class RapidsShuffleTimeoutException(message: String) extends Exception(message)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -146,4 +146,9 @@ object GpuShuffleEnv extends Logging {
   def getDeviceStorage: RapidsDeviceMemoryStore = env.getDeviceStorage
 
   def rapidsShuffleCodec: Option[TableCompressionCodec] = env.rapidsShuffleCodec
+
+  def shuffleFetchTimeoutSeconds: Long = {
+    val sparkEnv = SparkEnv.get
+    sparkEnv.conf.getTimeAsSeconds("spark.network.timeout", "120")
+  }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -149,6 +149,11 @@ object GpuShuffleEnv extends Logging {
 
   def shuffleFetchTimeoutSeconds: Long = {
     val sparkEnv = SparkEnv.get
-    sparkEnv.conf.getTimeAsSeconds("spark.network.timeout", "120")
+    val defaultValue = 120
+    if (sparkEnv != null) {
+      sparkEnv.conf.getTimeAsSeconds("spark.network.timeout", defaultValue.toString)
+    } else {
+      defaultValue
+    }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -95,6 +95,10 @@ class GpuShuffleEnv(rapidsConf: RapidsConf) extends Logging {
   def getReceivedCatalog: ShuffleReceivedBufferCatalog = shuffleReceivedBufferCatalog
 
   def getDeviceStorage: RapidsDeviceMemoryStore = deviceStorage
+
+  def getShuffleFetchTimeoutSeconds: Long = {
+    conf.getTimeAsSeconds("spark.network.timeout", "120s")
+  }
 }
 
 object GpuShuffleEnv extends Logging {
@@ -147,13 +151,5 @@ object GpuShuffleEnv extends Logging {
 
   def rapidsShuffleCodec: Option[TableCompressionCodec] = env.rapidsShuffleCodec
 
-  def shuffleFetchTimeoutSeconds: Long = {
-    val sparkEnv = SparkEnv.get
-    val defaultValue = 120
-    if (sparkEnv != null) {
-      sparkEnv.conf.getTimeAsSeconds("spark.network.timeout", defaultValue.toString)
-    } else {
-      defaultValue
-    }
-  }
+  def shuffleFetchTimeoutSeconds: Long = env.getShuffleFetchTimeoutSeconds
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -34,7 +34,8 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
-      mockCatalog)
+      mockCatalog,
+      123)
 
     when(mockTransaction.getStatus).thenReturn(TransactionStatus.Error)
 
@@ -54,13 +55,14 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
 
       val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
 
-      val cl = new RapidsShuffleIterator(
+      val cl = spy(new RapidsShuffleIterator(
         RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
         mockConf,
         mockTransport,
         blocksByAddress,
         testMetricsUpdater,
-        mockCatalog)
+        mockCatalog,
+        123))
 
       val ac = ArgumentCaptor.forClass(classOf[RapidsShuffleFetchHandler])
       when(mockTransport.makeClient(any(), any())).thenReturn(client)
@@ -92,7 +94,8 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
-      mockCatalog))
+      mockCatalog,
+      123))
 
     val ac = ArgumentCaptor.forClass(classOf[RapidsShuffleFetchHandler])
     when(mockTransport.makeClient(any(), any())).thenReturn(client)
@@ -121,7 +124,8 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
-      mockCatalog)
+      mockCatalog,
+      123)
 
     when(mockTransaction.getStatus).thenReturn(TransactionStatus.Error)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -32,7 +32,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
 
     val cl = new RapidsShuffleIterator(
       RapidsShuffleTestHelper.makeMockBlockManager("1", "1"),
-      null,
+      mockConf,
       mockTransport,
       blocksByAddress,
       null,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -79,10 +79,6 @@ class RapidsShuffleTestHelper extends FunSuite
     mockConf = mock[RapidsConf]
     testMetricsUpdater = spy(new TestShuffleMetricsUpdater)
 
-    val sparkEnvMock = mock[SparkEnv]
-    when(sparkEnvMock.conf).thenReturn(new SparkConf())
-    SparkEnv.set(sparkEnvMock)
-
     client = spy(new RapidsShuffleClient(
       1,
       mockConnection,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shuffle
 import java.util.concurrent.Executor
 
 import ai.rapids.cudf.{ColumnVector, ContiguousTable}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsConf, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, when}
@@ -42,6 +42,7 @@ class RapidsShuffleTestHelper extends FunSuite
   var mockHandler: RapidsShuffleFetchHandler = _
   var mockStorage: RapidsDeviceMemoryStore = _
   var mockCatalog: ShuffleReceivedBufferCatalog = _
+  var mockConf: RapidsConf = _
   var client: RapidsShuffleClient = _
 
   override def beforeEach(): Unit = {
@@ -57,6 +58,7 @@ class RapidsShuffleTestHelper extends FunSuite
     mockHandler = mock[RapidsShuffleFetchHandler]
     mockStorage = mock[RapidsDeviceMemoryStore]
     mockCatalog = mock[ShuffleReceivedBufferCatalog]
+    mockConf = mock[RapidsConf]
     client = spy(new RapidsShuffleClient(
       1,
       mockConnection,


### PR DESCRIPTION
Subset of https://github.com/NVIDIA/spark-rapids/issues/326. 

This PR adds basic timeouts in the iterator. This makes no attempt to make the job recoverable after the timeout, assuming that the network issue is fatal. UCX is not able to report certain failures, like the issue this is trying to address. It was a system that had a network config issue, and UCX didn't report that to the application. With a timeout, the application will at least eventually unblock and alert the user that there is a likely network issue.

We are using `spark.network.timeout` as the config to trigger this timeout, so if a user sets `spark.network.timeout`, it will also apply to the UCX shuffle.