### PR TITLE
Fix snapshot plugin jar version in docs

### DIFF
--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -512,7 +512,7 @@ To enable _GPU Scheduling for Pandas UDF_, you need to configure your spark job 
     On Standalone, you need to add
     ```shell
     ...
-    --conf spark.executorEnv.PYTHONPATH=rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar \
+    --conf spark.executorEnv.PYTHONPATH=rapids-4-spark_2.12-0.2.0.jar \
     --py-files ${SPARK_RAPIDS_PLUGIN_JAR}
     ```
 


### PR DESCRIPTION
This fixes a missed 0.2.0-SNAPSHOT version after the recent doc update in #637 