### PR TITLE
Add config to override shims provider class

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -691,7 +691,11 @@ object RapidsConf {
   val SHIMS_PROVIDER_OVERRIDE = conf("spark.rapids.shims-provider-override")
     .internal()
     .doc("Overrides the automatic Spark shim detection logic and forces a specific shims " +
-      "provider class to be used. Set to the fully qualified shims provider class to use.")
+      "provider class to be used. Set to the fully qualified shims provider class to use. " +
+      "If you are using a custom Spark version such as Spark 3.0.0.0 then this can be used to " +
+      "specify the shims provider that matches the base Spark version of Spark 3.0.0, i.e.: " +
+      "com.nvidia.spark.rapids.shims.spark300.SparkShimServiceProvider. If you modified Spark " +
+      "then there is no guarantee the RAPIDS Accelerator will function properly.")
     .stringConf
     .createOptional
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -688,6 +688,13 @@ object RapidsConf {
     .stringConf
     .createWithDefault("NONE")
 
+  val SHIMS_PROVIDER_OVERRIDE = conf("spark.rapids.shims-provider-override")
+    .internal()
+    .doc("Overrides the automatic Spark shim detection logic and forces a specific shims " +
+      "provider class to be used. Set to the fully qualified shims provider class to use.")
+    .stringConf
+    .createOptional
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -952,6 +959,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shuffleCompressionCodec: String = get(SHUFFLE_COMPRESSION_CODEC)
 
   lazy val shuffleCompressionMaxBatchMemory: Long = get(SHUFFLE_COMPRESSION_MAX_BATCH_MEMORY)
+
+  lazy val shimsProviderOverride: Option[String] = get(SHIMS_PROVIDER_OVERRIDE)
 
   def isOperatorEnabled(key: String, incompat: Boolean, isDisabledByDefault: Boolean): Boolean = {
     val default = !(isDisabledByDefault || incompat) || (incompat && isIncompatEnabled)


### PR DESCRIPTION
This is related to #409 but only partially addresses it.

This provides an internal config property that allows a user to override the normal, automatic shim detection logic.  This can be used to force a particular shim provider class to be used in cases where the shim detection logic does not work (e.g.: when the reported Spark version is unrecognized).

A warning is emitted when the shims provider is overridden as it is very likely the combination of Spark version and shim version is untested and may not fully function properly.