### PR TITLE
[FEA] Persist workspace data on PVC for premerge

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -29,6 +29,9 @@ def pluginDockerBuild = """
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext: # ref: https://github.com/kubernetes/examples/issues/260
+    runAsUser: 0
+    runAsGroup: 0
   containers:
   - name: plugin-docker
     image: docker:19.03.12
@@ -61,6 +64,9 @@ def pluginPremerge = """
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
   containers:
   - name: plugin-premerge
     image: IMAGE_PREMERGE
@@ -115,10 +121,11 @@ pipeline {
         LIBCUDF_KERNEL_CACHE_PATH = '/tmp/.cudf'
         ARTIFACTORY_NAME = "${ArtifactoryConstants.ARTIFACTORY_NAME}"
         GITHUB_TOKEN = credentials("github-token")
-        // TODO: rename this credential after we shutdown premerge pipeline on ngcc
-        URM_CREDS = credentials("svcngcc_artifactory")
+        URM_CREDS = credentials("urm_creds")
         URM_URL = "https://${ArtifactoryConstants.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
         GPU_TYPES = credentials("pre-merge_gpu_types")
+        PVC = credentials("pvc")
+        CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
     }
 
     stages {
@@ -126,8 +133,9 @@ pipeline {
             steps {
                 script {
                     githubHelper = GithubHelper.getInstance("${GITHUB_TOKEN}", githubData)
-                    def title = githubHelper.getIssue().title
+                    githubHelper.updateCommitStatus("$BUILD_URL", "Running", GitHubCommitState.PENDING)
 
+                    def title = githubHelper.getIssue().title
                     if (title ==~ /.*\[skip ci\].*/) {
                         githubHelper.updateCommitStatus("$BUILD_URL", "Skipped", GitHubCommitState.SUCCESS)
                         currentBuild.result == "SUCCESS"
@@ -151,13 +159,13 @@ pipeline {
                     label "premerge-docker-${BUILD_TAG}"
                     cloud 'sc-ipp-blossom-prod'
                     yaml "$pluginDockerBuild"
+                    workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                    customWorkspace "${CUSTOM_WORKSPACE}"
                 }
             }
 
             steps {
                 script {
-                    githubHelper.updateCommitStatus("$BUILD_URL", "Running", GitHubCommitState.PENDING)
-
                     currentBuild.description = githubHelper.getBuildDescription()
                     checkout(
                             changelog: false,
@@ -209,25 +217,13 @@ pipeline {
                     label "premerge-test-${BUILD_TAG}"
                     cloud 'sc-ipp-blossom-prod'
                     yaml "$pluginPremerge"
+                    workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                    customWorkspace "${CUSTOM_WORKSPACE}"
                 }
             }
 
             steps {
                 script {
-                    checkout(
-                            changelog: false,
-                            poll: true,
-                            scm: [
-                                    $class: 'GitSCM', branches: [[name: "pr/" + githubHelper.getPRNumber()]],
-                                    doGenerateSubmoduleConfigurations: false,
-                                    submoduleCfg: [],
-                                    userRemoteConfigs: [[
-                                        credentialsId: 'github-token',
-                                        url: githubHelper.getCloneUrl(),
-                                        refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*']]
-                            ]
-                    )
-
                     container('plugin-premerge') {
                         sh "$PREMERGE_SCRIPT"
                         step([$class                : 'JacocoPublisher',


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Job on blossom is running in pod, by default the workspace data will be disappear when the container is terminated.

This PR is to persist the workspace data on PVC storage for per-merge pipeline. Because the PVC provided by blossom is backed by NFS, we run the job as root(uid:0) to save us a headache (https://github.com/kubernetes/examples/issues/260)

Every build will have it own workspace folder on PVC, and I have setup a hourly-cleaner to clean out-dated workspaces