### PR TITLE
WIP:Update Jenkins scripts for release purpose

### DIFF
--- a/jenkins/Jenkinsfile.databricksrelease
+++ b/jenkins/Jenkinsfile.databricksrelease
@@ -63,8 +63,8 @@ pipeline {
         DATABRICKS_SECRET = credentials("TIM_DATABRICKS_SECRET")
         SCALA_VERSION = '2.12'
         SPARK_VERSION = '3.0.0-databricks'
-        CI_RAPIDS_JAR = 'rapids-4-spark_2.12-0.2.0-ci.jar'
-        CI_CUDF_JAR = 'cudf-0.15-cuda10-1.jar'
+        CI_RAPIDS_JAR = 'rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar'
+        CI_CUDF_JAR = 'cudf-0.14-cuda10-1.jar'
         URM_URL = "${urmUrl}"
     }
 

--- a/jenkins/Jenkinsfile.release
+++ b/jenkins/Jenkinsfile.release
@@ -57,7 +57,8 @@ pipeline {
                     sh "mkdir -p ${HOME}/.zinc"
                     docker.image("$IMAGE_NAME").inside("--runtime=nvidia -v ${HOME}/.m2:${HOME}/.m2:rw \
                         -v ${HOME}/.zinc:${HOME}/.zinc:rw") {
-                        sh "mvn -U -B clean install $MVN_MIRROR -P 'include-databricks,source-javadoc,!snapshot-shims'"
+                        sh "mvn dependency:purge-local-repository -DmanualInclude='com.nvidia:rapids-4-spark-shims-spark300-databricks_2.12' \
+                                -U -B clean install $MVN_MIRROR -P 'include-databricks,source-javadoc,!snapshot-shims'"
                     }
                 }
             }

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -90,9 +90,6 @@ mvn -B install:install-file \
 
 mvn -B '-Pdatabricks,!snapshot-shims' clean package -DskipTests
 
-# Bak up the original spark-rapids and CuDf jars
-sudo mv /databricks/jars/rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar /databricks/rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar
-sudo mv /databricks/jars/cudf-0.14-cuda10-1.jar /databricks/cudf-0.14-cuda10-1.jar
 # Copy so we pick up new built jar and latesty CuDF jar. Note that the jar names has to be
 # exactly what is in the staticly setup Databricks cluster we use. 
 echo "Copying rapids jars: dist/target/$RAPIDS_BUILT_JAR $DB_RAPIDS_JAR_LOC"
@@ -126,7 +123,3 @@ $SPARK_HOME/bin/spark-submit ./runtests.py --runtime_env="databricks"
 cd /home/ubuntu
 tar -zcvf spark-rapids-built.tgz spark-rapids
 /databricks/jars/
-
-# Restore the original spark-rapids and CuDf jars
-sudo mv /databricks/rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar /databricks/jars/rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar
-sudo mv /databricks/cudf-0.14-cuda10-1.jar /databricks/jars/cudf-0.14-cuda10-1.jar

--- a/jenkins/databricks/deploy.sh
+++ b/jenkins/databricks/deploy.sh
@@ -27,3 +27,7 @@ SERVER_URL="$URM_URL-local"
 DBJARFPATH=./shims/spark300db/target/rapids-4-spark-shims-spark300-databricks_$SCALA_VERSION-$DATABRICKS_VERSION.jar
 mvn -B deploy:deploy-file $MVN_URM_MIRROR '-P!snapshot-shims' -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
     -Dfile=$DBJARFPATH -DpomFile=shims/spark300db/pom.xml
+
+TESTSJARFPATH=integration_tests/target/rapids-4-spark-integration-tests_$SCALA_VERSION-$DATABRICKS_VERSION.jar
+mvn -B deploy:deploy-file $MVN_URM_MIRROR '-P!snapshot-shims' -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
+    -Dfile=$TESTSJARFPATH -DpomFile=integration_tests/pom.xml

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -45,13 +45,13 @@ def main():
   script_dest = '/home/ubuntu/build.sh'
   source_tgz = 'spark-rapids-ci.tgz'
   tgz_dest = '/home/ubuntu/spark-rapids-ci.tgz'
-  ci_rapids_jar = 'rapids-4-spark_2.12-0.2.0-ci.jar'
+  ci_rapids_jar = 'rapids-4-spark_2.12-0.1-SNAPSHOT-ci.jar'
   db_version = '0.2.0'
   scala_version = '2.12'
   spark_version = '3.0.0'
   cudf_version = '0.15'
   cuda_version = 'cuda10-1'
-  ci_cudf_jar = 'cudf-0.15-cuda10-1.jar'
+  ci_cudf_jar = 'cudf-0.14-cuda10-1.jar'
   base_spark_pom_version = '3.0.0'
 
   try:


### PR DESCRIPTION
1, Restore cuDF/rapids jar names for Databricks cluster because these names need to be compatible among all the Databricks clusters and scripts.
2, Purge the Databricks shims jar to make sure downloading the latest version of Databricks shims jar
3, Deploy integration_tests jar onto internal maven repo

Signed-off-by: Tim Liu <timl@nvidia.com>
