### PR TITLE
CI: Update cudf python to 0.16 nightly

### DIFF
--- a/jenkins/Dockerfile.integration.centos7
+++ b/jenkins/Dockerfile.integration.centos7
@@ -23,6 +23,10 @@ ARG CUDA_VER=10.1
 
 FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 
+ARG CUDA_VER=10.1
+ARG CUDF_VER
+ARG URM_URL
+
 #Install java-8, maven, docker image
 RUN yum update -y && \
     yum install -y centos-release-scl && \
@@ -31,27 +35,20 @@ RUN yum update -y && \
 # The default mvn verision is 3.05 on centos7 docker container.
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"
-ARG URM_URL
 RUN wget ${URM_URL}/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz -P /usr/local && \
     tar xzvf $MAVEN_HOME-bin.tar.gz -C /usr/local && \
     rm -f $MAVEN_HOME-bin.tar.gz
 
-ENV PATH "$MAVEN_HOME/bin:$PATH"
-
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm -f ~/miniconda.sh
 
-ENV PATH="/opt/conda/bin:${PATH}"
+ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 
-RUN . /opt/conda/bin/activate && \
-    conda init && \
-    conda --version
-
-ARG CUDA_TOOLKIT_VER=10.1
-RUN conda install -y -c rapidsai -c nvidia -c conda-forge -c defaults cudf=0.15 python=3.7 cudatoolkit=${CUDA_TOOLKIT_VER} && \
-    conda install -y spacy && \
-    python -m spacy download en_core_web_sm && \
-    conda install -y -c anaconda pytest requests pandas pyarrow && \
+# 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
+RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.7 cudatoolkit=${CUDA_VER} && \
+    conda install -y spacy && python -m spacy download en_core_web_sm && \
+    conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 

--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -58,6 +58,8 @@ pipeline {
             agent { label 'docker-gpu' }
             steps {
                 script {
+                    def CUDF_VER=sh(returnStdout: true,
+                        script: '. jenkins/version-def.sh>&2 && echo -n $CUDF_VER') - "-SNAPSHOT"
                     def CUDA_NAME=sh(returnStdout: true,
                         script: '. jenkins/version-def.sh>&2 && echo -n $CUDA_CLASSIFIER | sed "s/-/./g"')
                     def IMAGE_NAME="$ARTIFACTORY_NAME/sw-spark-docker/plugin:it-centos7-$CUDA_NAME"
@@ -67,7 +69,7 @@ pipeline {
                     // Speed up Docker building via '--cache-from $IMAGE_NAME'
                     def buildImage=docker.build(IMAGE_NAME,
                         "-f jenkins/Dockerfile.integration.centos7 --build-arg CUDA_VER=$CUDA_VER \
-                            --build-arg URM_URL=$URM_URL --cache-from $IMAGE_NAME -t $IMAGE_NAME .")
+                            --build-arg URM_URL=$URM_URL --build-arg CUDF_VER=$CUDF_VER --cache-from $IMAGE_NAME -t $IMAGE_NAME .")
                     def buildImageID=sh(returnStdout: true, script: "docker inspect -f {{'.Id'}} $IMAGE_NAME")
                     if (! buildImageID.equals(urmImageID)) {
                         echo "Dockerfile updated, upload docker image to URM"

--- a/python/rapids/worker.py
+++ b/python/rapids/worker.py
@@ -52,6 +52,8 @@ def initialize_gpu_mem():
                              "`RAPIDS_POOLED_MEM_SIZE`.")
         if pool_max_size == 0:
             pool_max_size = max_size
+        pool_max_size = pool_max_size >> 8 << 8
+        pool_size = pool_size >> 8 << 8
         print("DEBUG: Pooled memory, pool size: {} MiB, max size: {} MiB".format(
                 pool_size / 1024.0 / 1024,
                 ('unlimited' if pool_max_size == max_size else pool_max_size / 1024.0 / 1024)))


### PR DESCRIPTION
And 
- make the pool size and max pool size to be multiple of 256 bytes, which is required by the cudf 0.16.
- make the cudf version to be an argument of dockerfile and get its value from Jenkins env.

Verified on local jenkins.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
