### PR TITLE
Record spark plan SQL metrics to JSON when running benchmarks

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -279,7 +279,7 @@ object BenchUtils {
    */
   def generateDotGraph(a: SparkPlanNode, b: Option[SparkPlanNode], filename: String): Unit = {
 
-    val idGen = new AtomicInteger()
+    var nextId = 0
 
     /** Skip WholeStageCodegen and InputAdapter nodes when producing the graph */
     def skipWrappers(p: SparkPlanNode): SparkPlanNode = {
@@ -339,7 +339,8 @@ object BenchUtils {
              | /* ${a.description} */
              |""".stripMargin)
         a.children.indices.foreach(i => {
-            val childId = idGen.incrementAndGet()
+            val childId = nextId
+            nextId += 1
             writeGraph(w, a.children(i), b.children(i), childId);
             w.println(s"node$id -> node$childId;")
           })

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -32,7 +32,6 @@ import org.apache.spark.{SPARK_BUILD_USER, SPARK_VERSION}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
-import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.util.QueryExecutionListener
 
@@ -318,7 +317,7 @@ object BenchUtils {
                 case "nsTiming" =>
                   val n1 = metric1.value.toString.toLong
                   val n2 = metric2.value.toString.toLong
-                  val pct = Math.signum(n2-n1) * Math.abs(n2-n1) * 100.0 / n1
+                  val pct = (n2-n1) * 100.0 / n1
                   val pctStr = if (pct < 0) {
                     f"$pct%.1f"
                   } else {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -19,7 +19,6 @@ import java.io.{File, FileOutputStream, FileWriter, PrintWriter}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.NANOSECONDS
-import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.convert.ImplicitConversions.`iterator asScala`
 import scala.collection.mutable.ListBuffer

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
@@ -49,6 +49,7 @@ class BenchUtilsSuite extends FunSuite with BeforeAndAfterEach {
       writeOptions = Map("header" -> "true"),
       query = "q1",
       queryPlan = QueryPlan("logical", "physical"),
+      Seq.empty,
       queryTimes = Seq(99, 88, 77))
 
     val filename = s"$TEST_FILES_ROOT/BenchUtilsSuite-${System.currentTimeMillis()}.json"


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR updates the benchmark code to record the spark plan with SQL metrics and also adds a utility to produce a diff of two query plans in DOT format (which can easily be converted to image formats with Graphviz and other tools). See the example below.

This makes it easier to compare two runs and find where the performance differences are. 

![plandiff](https://user-images.githubusercontent.com/934084/93537542-04df8200-f909-11ea-9abc-71511665b8e9.png)

