### PR TITLE
Fix shims provider override config not being seen by executors

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -107,7 +107,11 @@ class RapidsDriverPlugin extends DriverPlugin with Logging {
   override def init(sc: SparkContext, pluginContext: PluginContext): util.Map[String, String] = {
     val sparkConf = pluginContext.conf
     RapidsPluginUtils.fixupConfigs(sparkConf)
-    new RapidsConf(sparkConf).rapidsConfMap
+    val conf = new RapidsConf(sparkConf)
+    if (conf.shimsProviderOverride.isDefined) {
+      ShimLoader.setSparkShimProviderClass(conf.shimsProviderOverride.get)
+    }
+    conf.rapidsConfMap
   }
 }
 
@@ -120,6 +124,9 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       extraConf: util.Map[String, String]): Unit = {
     try {
       val conf = new RapidsConf(extraConf.asScala.toMap)
+      if (conf.shimsProviderOverride.isDefined) {
+        ShimLoader.setSparkShimProviderClass(conf.shimsProviderOverride.get)
+      }
 
       // we rely on the Rapids Plugin being run with 1 GPU per executor so we can initialize
       // on executor startup.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -201,6 +201,11 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
 
   private val rapidsConf = new RapidsConf(conf)
 
+  // set the shim override if specified since the shuffle manager loads early
+  if (rapidsConf.shimsProviderOverride.isDefined) {
+    ShimLoader.setSparkShimProviderClass(rapidsConf.shimsProviderOverride.get)
+  }
+
   protected val wrapped = new SortShuffleManager(conf)
   GpuShuffleEnv.setRapidsShuffleManagerInitialized(true, this.getClass.getCanonicalName)
   logWarning("Rapids Shuffle Plugin Enabled")


### PR DESCRIPTION
#765 has an issue where the configuration for the shim override is not being seen by the ShimLoader on the executors.  Rather than loading a fresh `SparkConf` directly in `ShimLoader` this leverages the config being passed to the driver/executor plugins to set the shim provider override class on startup if one is specified in the configs.

Manually tested on a standalone cluster and verified the shim provider override message appears both in the driver logs and the executor logs.