### PR TITLE
Update documentation for Scala UDFs in 0.2 since you need two things

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -287,7 +287,7 @@ Casting from string to timestamp currently has the following limitations.
 To speedup the process of UDF, spark-rapids introduces a udf-compiler extension to translate UDFs to Catalyst expressions.
 
 To enable this operation on the GPU, set
-[`spark.rapids.sql.udfCompiler.enabled`](configs.md#sql.udfCompiler.enabled) to `true`.
+[`spark.rapids.sql.udfCompiler.enabled`](configs.md#sql.udfCompiler.enabled) to `true`, and `spark.sql.extensions=com.nvidia.spark.udf.Plugin`.
 
 However, Spark may produce different results for a compiled udf and the non-compiled. For example: a udf of `x/y` where `y` happens to be `0`, the compiled catalyst expressions will return `NULL` while the original udf would fail  the entire job with a `java.lang.ArithmeticException: / by zero`
 


### PR DESCRIPTION
Until we get this fix in: https://github.com/NVIDIA/spark-rapids/issues/688, we need to mention that you need to also change the extensions for spark, so that Scala UDFs will be enabled.