### PR TITLE
Skip cudf_udf test by default

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -103,7 +103,7 @@ To run cudf_udf tests, need following configuration changes:
 As an example, here is the `spark-submit` command with the cudf_udf parameter:
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
 ```
 
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -87,12 +87,12 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 The cudf_tests disabled by default because of complicated environment setup. The cudf_udf tests in this framework can be enabled by providing option:
 
-   * `cudf_udf` (optional, defaults to "False", )
+   * `cudf_udf` (optional, defaults to "False")
 
 cudf_udf tests needs a couple of different settings, it may need to run separately.
 
 To enable cudf_udf tests, need following pre requirements:
-   * Install Cudf library. This library could be installed via Conda, the details could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library.
+   * Install Cudf library. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library via Conda or use other ways like building from source.
    * Disable the GPU exclusive mode. The sample command is `sudo nvidia-smi -c DEFAULT`
    
 To run cudf_udf tests, need following configuration changes:   

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,7 +85,8 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 ### Enabling cudf_udf Tests
 
-The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF, which is still an experimental feature. They are disabled by default because of complicated environment setup and can be enabled by providing option:
+The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF. They are disabled by default not only because of the complicated environment setup, but also because GPU resources scheduling for Pandas UDF is an experimental feature now, the performance may not always be better.
+The tests can be enabled by providing option:
 
    * `cudf_udf` (optional, defaults to "False")
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,7 +85,7 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 ### Enabling cudf_udf Tests
 
-The cudf_tests disabled by default because of complicated environment setup. The cudf_udf tests in this framework can be enabled by providing option:
+The cudf_tests are disabled by default because of complicated environment setup. The cudf_udf tests in this framework can be enabled by providing option:
 
    * `cudf_udf` (optional, defaults to "False")
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,14 +85,14 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 ### Enabling cudf_udf Tests
 
-The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF. They are disabled by default because of complicated environment setup and can be enabled by providing option:
+The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF, which is still an experimental feature. They are disabled by default because of complicated environment setup and can be enabled by providing option:
 
    * `cudf_udf` (optional, defaults to "False")
 
 cudf_udf tests needs a couple of different settings, they may need to run separately.
 
 To enable cudf_udf tests, need following pre requirements:
-   * Install cuDF library on all the nodes running executors. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
+   * Install cuDF Python library on all the nodes running executors. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
    * Disable the GPU exclusive mode on all the nodes running executors. The sample command is `sudo nvidia-smi -c DEFAULT`
    
 To run cudf_udf tests, need following configuration changes:   

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,16 +85,24 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 ### Enabling cudf_udf Tests
 
-The cudf_udf tests in this framework can be enabled by providing following option:
+The cudf_tests disabled by default because of complicated environment setup. The cudf_udf tests in this framework can be enabled by providing option:
 
-   * `cudf_udf` (optional, defaults to "False")
+   * `cudf_udf` (optional, defaults to "False", )
 
-To enable cudf_udf tests, need to install Cudf library. This library could be installed via Conda, the detail could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library.  
+cudf_udf tests needs a couple of different settings, it may need to run separately.
+
+To enable cudf_udf tests, need following pre requirements:
+   * Install Cudf library. This library could be installed via Conda, the details could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library.
+   * Disable the GPU exclusive mode. The sample command is `sudo nvidia-smi -c DEFAULT`
+   
+To run cudf_udf tests, need following configuration changes:   
+   * Add some extra necessary configs, like py-files and spark.executorEnv.PYTHONPATH to specify the plugin jar for python modules 'rapids/daemon' 'rapids/worker'.
+   * Decrease spark.rapids.memory.gpu.allocFraction to reserve enough GPU memory for processes.
 
 As an example, here is the `spark-submit` command with the cudf_udf parameters:
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.4 --py-files ""rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
 ```
 
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -86,9 +86,9 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 ### Enabling cudf_udf Tests
 
 The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF. They are disabled by default not only because of the complicated environment setup, but also because GPU resources scheduling for Pandas UDF is an experimental feature now, the performance may not always be better.
-The tests can be enabled by providing option:
+The tests can be enabled by just appending the option `--cudf_udf` to the command.
 
-   * `cudf_udf` (optional, defaults to "False")
+   * `--cudf_udf` (enable the cudf_udf tests when provided, and remove this option if you want to disable the tests)
 
 cudf_udf tests needs a couple of different settings, they may need to run separately.
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -85,24 +85,25 @@ $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf
 
 ### Enabling cudf_udf Tests
 
-The cudf_tests are disabled by default because of complicated environment setup. The cudf_udf tests in this framework can be enabled by providing option:
+The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF. They are disabled by default because of complicated environment setup and can be enabled by providing option:
 
    * `cudf_udf` (optional, defaults to "False")
 
-cudf_udf tests needs a couple of different settings, it may need to run separately.
+cudf_udf tests needs a couple of different settings, they may need to run separately.
 
 To enable cudf_udf tests, need following pre requirements:
-   * Install Cudf library. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library via Conda or use other ways like building from source.
-   * Disable the GPU exclusive mode. The sample command is `sudo nvidia-smi -c DEFAULT`
+   * Install cuDF library on all the nodes running executors. The instruction could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cuDF library via Conda or use other ways like building from source.
+   * Disable the GPU exclusive mode on all the nodes running executors. The sample command is `sudo nvidia-smi -c DEFAULT`
    
 To run cudf_udf tests, need following configuration changes:   
-   * Add some extra necessary configs, like py-files and spark.executorEnv.PYTHONPATH to specify the plugin jar for python modules 'rapids/daemon' 'rapids/worker'.
-   * Decrease spark.rapids.memory.gpu.allocFraction to reserve enough GPU memory for processes.
+   * Add configurations `--py-files` and `spark.executorEnv.PYTHONPATH` to specify the plugin jar for python modules 'rapids/daemon' 'rapids/worker'.
+   * Decrease `spark.rapids.memory.gpu.allocFraction` and `spark.rapids.python.memory.gpu.allocFraction` to reserve enough GPU memory for Python processes in case of out-of-memory.
+   * Add `spark.rapids.python.concurrentPythonWorkers` to reserve enough GPU memory for Python processes in case of out-of-memory.
 
-As an example, here is the `spark-submit` command with the cudf_udf parameters:
+As an example, here is the `spark-submit` command with the cudf_udf parameter:
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.4 --py-files ""rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-0.2.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
 ```
 
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -97,8 +97,8 @@ To enable cudf_udf tests, need following pre requirements:
    
 To run cudf_udf tests, need following configuration changes:   
    * Add configurations `--py-files` and `spark.executorEnv.PYTHONPATH` to specify the plugin jar for python modules 'rapids/daemon' 'rapids/worker'.
-   * Decrease `spark.rapids.memory.gpu.allocFraction` and `spark.rapids.python.memory.gpu.allocFraction` to reserve enough GPU memory for Python processes in case of out-of-memory.
-   * Add `spark.rapids.python.concurrentPythonWorkers` to reserve enough GPU memory for Python processes in case of out-of-memory.
+   * Decrease `spark.rapids.memory.gpu.allocFraction` to reserve enough GPU memory for Python processes in case of out-of-memory.
+   * Add `spark.rapids.python.concurrentPythonWorkers` and `spark.rapids.python.memory.gpu.allocFraction` to reserve enough GPU memory for Python processes in case of out-of-memory.
 
 As an example, here is the `spark-submit` command with the cudf_udf parameter:
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -83,6 +83,21 @@ As an example, here is the `spark-submit` command with the TPCxBB parameters:
 $SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" ./runtests.py --tpcxbb_format="csv" --tpcxbb_path="/path/to/tpcxbb/csv"
 ```
 
+### Enabling cudf_udf Tests
+
+The cudf_udf tests in this framework can be enabled by providing following option:
+
+   * `cudf_udf` (optional, defaults to "False")
+
+To enable cudf_udf tests, need to install Cudf library. This library could be installed via Conda, the detail could be found at [here](https://rapids.ai/start.html). Please follow the steps to choose the version based on your environment and install the cudf library.  
+
+As an example, here is the `spark-submit` command with the cudf_udf parameters:
+
+```
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar,cudf-0.16-SNAPSHOT.jar,rapids-4-spark-tests_2.12-0.3.0-SNAPSHOT.jar" ./runtests.py --cudf_udf
+```
+
+
 ## Writing tests
 
 There are a number of libraries provided to help someone write new tests.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -50,3 +50,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runtime_env", action='store', default="Apache", help="the runtime environment for the tests - apache or databricks"
     )
+    parser.addoption(
+        "--cudf_udf", action='store_true', default=False, help="if true enable cudf_udf test"
+    )

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -365,3 +365,9 @@ def tpcds(request):
   else:
     yield TpcdsRunner(tpcds_format, tpcds_path)
 
+@pytest.fixture(scope="session")
+def enable_cudf_udf(request):
+    enable_udf_cudf = request.config.getoption("cudf_udf")
+    if not enable_udf_cudf:
+        pytest.skip("cudf_udf not configured to run")
+

--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import pandas as pd
+import pytest
 import time
+from distutils.version import LooseVersion
 from typing import Iterator
 from pyspark.sql import Window
 from pyspark.sql.functions import pandas_udf, PandasUDFType
+from spark_init_internal import spark_version
 from spark_session import with_cpu_session, with_gpu_session
 from marks import allow_non_gpu, cudf_udf
+
+pytestmark = pytest.mark.skipif(LooseVersion(spark_version()) >= LooseVersion('3.1.0'),
+    reason="Pandas UDF on GPU tests don't support Spark 3.1.0+ yet")
 
 
 _conf = {
@@ -31,11 +36,11 @@ _conf = {
         'spark.rapids.sql.python.gpu.enabled': 'true'
         }
 
+
 def _create_df(spark):
-    return spark.createDataFrame(
-            [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)],
-            ("id", "v")
-        )
+    elements = list(map(lambda i: (i, i/1.0), range(1, 5000)))
+    return spark.createDataFrame(elements * 2, ("id", "v"))
+
 
 # since this test requires to run different functions on CPU and GPU(need cudf),
 # create its own assert function
@@ -54,21 +59,22 @@ def _assert_cpu_gpu(cpu_func, gpu_func, cpu_conf={}, gpu_conf={}, is_sort=False)
         assert cpu_ret.sort() == gpu_ret.sort()
     else:
         assert cpu_ret == gpu_ret
-        
 
+
+# ======= Test Scalar =======
 @pandas_udf('int')
 def _plus_one_cpu_func(v: pd.Series) -> pd.Series:
     return v + 1
 
+
 @pandas_udf('int')
 def _plus_one_gpu_func(v: pd.Series) -> pd.Series:
     import cudf
-    gpu_serises = cudf.Series(v)
-    gpu_serises = gpu_serises + 1
-    return gpu_serises.to_pandas()
+    gpu_series = cudf.Series(v)
+    gpu_series = gpu_series + 1
+    return gpu_series.to_pandas()
 
-@allow_non_gpu(any=True)
-@pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
+
 @cudf_udf
 def test_with_column(enable_cudf_udf):
     def cpu_run(spark):
@@ -78,27 +84,31 @@ def test_with_column(enable_cudf_udf):
     def gpu_run(spark):
         df = _create_df(spark)
         return df.withColumn("v1", _plus_one_gpu_func(df.v)).collect()
-    
+
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf)
 
-@allow_non_gpu(any=True)
-@pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
+
 @cudf_udf
 def test_sql(enable_cudf_udf):
     def cpu_run(spark):
         _ = spark.udf.register("add_one_cpu", _plus_one_cpu_func)
-        return spark.sql("SELECT add_one_cpu(id) FROM range(3)").collect()
+        _create_df(spark).createOrReplaceTempView("test_table_cpu")
+        return spark.sql("SELECT add_one_cpu(id) FROM test_table_cpu").collect()
+
     def gpu_run(spark):
         _ = spark.udf.register("add_one_gpu", _plus_one_gpu_func)
-        return spark.sql("SELECT add_one_gpu(id) FROM range(3)").collect()
-    
+        _create_df(spark).createOrReplaceTempView("test_table_gpu")
+        return spark.sql("SELECT add_one_gpu(id) FROM test_table_gpu").collect()
+
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf)
 
 
+# ======= Test Scalar Iterator =======
 @pandas_udf("long")
 def _plus_one_cpu_iter_func(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
     for s in iterator:
         yield s + 1
+
 
 @pandas_udf("long")
 def _plus_one_gpu_iter_func(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
@@ -107,9 +117,8 @@ def _plus_one_gpu_iter_func(iterator: Iterator[pd.Series]) -> Iterator[pd.Series
         gpu_serises = cudf.Series(s)
         gpu_serises = gpu_serises + 1
         yield gpu_serises.to_pandas()
-        
-@allow_non_gpu(any=True)
-@pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
+
+
 @cudf_udf
 def test_select(enable_cudf_udf):
     def cpu_run(spark):
@@ -123,35 +132,37 @@ def test_select(enable_cudf_udf):
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
+# ======= Test Flat Map In Pandas =======
 @allow_non_gpu('GpuMapInPandasExec','PythonUDF')
 @cudf_udf
 def test_map_in_pandas(enable_cudf_udf):
     def cpu_run(spark):
-        df = _create_df(spark)
         def _filter_cpu_func(iterator):
             for pdf in iterator:
                 yield pdf[pdf.id == 1]
+        df = _create_df(spark)
         return df.mapInPandas(_filter_cpu_func, df.schema).collect()
 
     def gpu_run(spark):
-        df = _create_df(spark)
         def _filter_gpu_func(iterator):
             import cudf
             for pdf in iterator:
                 gdf = cudf.from_pandas(pdf)
                 yield gdf[gdf.id == 1].to_pandas()
+        df = _create_df(spark)
         return df.mapInPandas(_filter_gpu_func, df.schema).collect()
     
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf)
 
 
+# ======= Test Grouped Map In Pandas =======
 # To solve: Invalid udf: the udf argument must be a pandas_udf of type GROUPED_MAP
 # need to add udf type
 @pandas_udf("id long, v double", PandasUDFType.GROUPED_MAP)
 def _normalize_cpu_func(df):
     v = df.v
     return df.assign(v=(v - v.mean()) / v.std())
+
 
 @pandas_udf("id long, v double", PandasUDFType.GROUPED_MAP)
 def _normalize_gpu_func(df):
@@ -160,7 +171,7 @@ def _normalize_gpu_func(df):
     v = gdf.v
     return gdf.assign(v=(v - v.mean()) / v.std()).to_pandas()
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
+
 @allow_non_gpu('GpuFlatMapGroupsInPandasExec','PythonUDF')
 @cudf_udf
 def test_group_apply(enable_cudf_udf):
@@ -171,44 +182,45 @@ def test_group_apply(enable_cudf_udf):
     def gpu_run(spark):
         df = _create_df(spark)
         return df.groupby("id").apply(_normalize_gpu_func).collect()
-    
+
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuFlatMapGroupsInPandasExec','PythonUDF')
 @cudf_udf
 def test_group_apply_in_pandas(enable_cudf_udf):
     def cpu_run(spark):
-        df = _create_df(spark)
         def _normalize_cpu_in_pandas_func(df):
             v = df.v
             return df.assign(v=(v - v.mean()) / v.std())
+        df = _create_df(spark)
         return df.groupby("id").applyInPandas(_normalize_cpu_in_pandas_func, df.schema).collect()
 
     def gpu_run(spark):
-        df = _create_df(spark)
         def _normalize_gpu_in_pandas_func(df):
             import cudf
             gdf = cudf.from_pandas(df)
             v = gdf.v
             return gdf.assign(v=(v - v.mean()) / v.std()).to_pandas()
+        df = _create_df(spark)
         return df.groupby("id").applyInPandas(_normalize_gpu_in_pandas_func, df.schema).collect()
     
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 
 
+# ======= Test Aggregate In Pandas =======
 @pandas_udf("int")  
 def _sum_cpu_func(v: pd.Series) -> int:
     return v.sum()
 
+
 @pandas_udf("integer")  
 def _sum_gpu_func(v: pd.Series) -> int:
     import cudf
-    gpu_serises = cudf.Series(v)
-    return gpu_serises.sum()
+    gpu_series = cudf.Series(v)
+    return gpu_series.sum()
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
+
 @allow_non_gpu('GpuAggregateInPandasExec','PythonUDF','Alias')
 @cudf_udf
 def test_group_agg(enable_cudf_udf):
@@ -223,7 +235,6 @@ def test_group_agg(enable_cudf_udf):
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuAggregateInPandasExec','PythonUDF','Alias')
 @cudf_udf
 def test_sql_group(enable_cudf_udf):
@@ -240,8 +251,9 @@ def test_sql_group(enable_cudf_udf):
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
-@allow_non_gpu('GpuWindowInPandasExec','PythonUDF','Alias','WindowExpression','WindowSpecDefinition','SpecifiedWindowFrame','UnboundedPreceding$', 'UnboundedFollowing$')
+# ======= Test Window In Pandas =======
+@allow_non_gpu('GpuWindowInPandasExec','PythonUDF','Alias','WindowExpression','WindowSpecDefinition',
+               'SpecifiedWindowFrame','UnboundedPreceding$', 'UnboundedFollowing$')
 @cudf_udf
 def test_window(enable_cudf_udf):
     def cpu_run(spark):
@@ -254,37 +266,39 @@ def test_window(enable_cudf_udf):
         w = Window.partitionBy('id').rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
         return df.withColumn('sum_v', _sum_gpu_func('v').over(w)).collect()
 
-    _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True) 
+    _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 
 
-@pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
+# ======= Test CoGroup Map In Pandas =======
 @allow_non_gpu('GpuFlatMapCoGroupsInPandasExec','PythonUDF')
 @cudf_udf
 def test_cogroup(enable_cudf_udf):
     def cpu_run(spark):
-        df1 = spark.createDataFrame(
-                [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
-                ("time", "id", "v1"))
-        df2 = spark.createDataFrame(
-                [(20000101, 1, "x"), (20000101, 2, "y")],
-                ("time", "id", "v2"))
         def _cpu_join_func(l, r):
             return pd.merge(l, r, on="time")
-        return df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(_cpu_join_func, schema="time int, id_x int, id_y int, v1 double, v2 string").collect()
-
-    def gpu_run(spark):
         df1 = spark.createDataFrame(
                 [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
                 ("time", "id", "v1"))
         df2 = spark.createDataFrame(
                 [(20000101, 1, "x"), (20000101, 2, "y")],
                 ("time", "id", "v2"))
+        return df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(_cpu_join_func,
+            schema="time int, id_x int, id_y int, v1 double, v2 string").collect()
+
+    def gpu_run(spark):
         def _gpu_join_func(l, r):
             import cudf
             gl = cudf.from_pandas(l)
             gr = cudf.from_pandas(r)
             return gl.merge(gr, on="time").to_pandas()
-        return df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(_gpu_join_func, schema="time int, id_x int, id_y int, v1 double, v2 string").collect()
+        df1 = spark.createDataFrame(
+                [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
+                ("time", "id", "v1"))
+        df2 = spark.createDataFrame(
+                [(20000101, 1, "x"), (20000101, 2, "y")],
+                ("time", "id", "v2"))
+        return df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(_gpu_join_func,
+            schema="time int, id_x int, id_y int, v1 double, v2 string").collect()
 
     _assert_cpu_gpu(cpu_run, gpu_run, gpu_conf=_conf, is_sort=True)
 

--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -70,7 +70,7 @@ def _plus_one_gpu_func(v: pd.Series) -> pd.Series:
 @allow_non_gpu(any=True)
 @pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
 @cudf_udf
-def test_with_column():
+def test_with_column(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark) 
         return df.withColumn("v1", _plus_one_cpu_func(df.v)).collect()
@@ -84,7 +84,7 @@ def test_with_column():
 @allow_non_gpu(any=True)
 @pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
 @cudf_udf
-def test_sql():
+def test_sql(enable_cudf_udf):
     def cpu_run(spark):
         _ = spark.udf.register("add_one_cpu", _plus_one_cpu_func)
         return spark.sql("SELECT add_one_cpu(id) FROM range(3)").collect()
@@ -111,7 +111,7 @@ def _plus_one_gpu_iter_func(iterator: Iterator[pd.Series]) -> Iterator[pd.Series
 @allow_non_gpu(any=True)
 @pytest.mark.skip("exception in docker: OSError: Invalid IPC stream: negative continuation token, skip for now")
 @cudf_udf
-def test_select():
+def test_select(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         return df.select(_plus_one_cpu_iter_func(df.v)).collect()
@@ -126,7 +126,7 @@ def test_select():
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuMapInPandasExec','PythonUDF')
 @cudf_udf
-def test_map_in_pandas():
+def test_map_in_pandas(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         def _filter_cpu_func(iterator):
@@ -163,7 +163,7 @@ def _normalize_gpu_func(df):
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuFlatMapGroupsInPandasExec','PythonUDF')
 @cudf_udf
-def test_group_apply():
+def test_group_apply(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         return df.groupby("id").apply(_normalize_cpu_func).collect()
@@ -178,7 +178,7 @@ def test_group_apply():
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuFlatMapGroupsInPandasExec','PythonUDF')
 @cudf_udf
-def test_group_apply_in_pandas():
+def test_group_apply_in_pandas(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         def _normalize_cpu_in_pandas_func(df):
@@ -211,7 +211,7 @@ def _sum_gpu_func(v: pd.Series) -> int:
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuAggregateInPandasExec','PythonUDF','Alias')
 @cudf_udf
-def test_group_agg():
+def test_group_agg(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         return df.groupby("id").agg(_sum_cpu_func(df.v)).collect()
@@ -226,7 +226,7 @@ def test_group_agg():
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuAggregateInPandasExec','PythonUDF','Alias')
 @cudf_udf
-def test_sql_group():
+def test_sql_group(enable_cudf_udf):
     def cpu_run(spark):
         _ = spark.udf.register("sum_cpu_udf", _sum_cpu_func)
         q = "SELECT sum_cpu_udf(v1) FROM VALUES (3, 0), (2, 0), (1, 1) tbl(v1, v2) GROUP BY v2"
@@ -243,7 +243,7 @@ def test_sql_group():
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuWindowInPandasExec','PythonUDF','Alias','WindowExpression','WindowSpecDefinition','SpecifiedWindowFrame','UnboundedPreceding$', 'UnboundedFollowing$')
 @cudf_udf
-def test_window():
+def test_window(enable_cudf_udf):
     def cpu_run(spark):
         df = _create_df(spark)
         w = Window.partitionBy('id').rowsBetween(Window.unboundedPreceding, Window.unboundedFollowing)
@@ -260,7 +260,7 @@ def test_window():
 @pytest.mark.skip("https://github.com/NVIDIA/spark-rapids/issues/746")
 @allow_non_gpu('GpuFlatMapCoGroupsInPandasExec','PythonUDF')
 @cudf_udf
-def test_cogroup():
+def test_cogroup(enable_cudf_udf):
     def cpu_run(spark):
         df1 = spark.createDataFrame(
                 [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -39,8 +39,8 @@ tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
 
 mvn -U -B $MVN_URM_MIRROR '-P!snapshot-shims' clean verify -Dpytest.TEST_TAGS=''
 # Run the unit tests for other Spark versions but dont run full python integration tests
-env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark301tests,snapshot-shims test -Dpytest.TEST_TAGS='not cudf_udf'
-env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark310tests,snapshot-shims test -Dpytest.TEST_TAGS='not cudf_udf'
+env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark301tests,snapshot-shims test -Dpytest.TEST_TAGS=''
+env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark310tests,snapshot-shims test -Dpytest.TEST_TAGS=''
 
 # The jacoco coverage should have been collected, but because of how the shade plugin
 # works and jacoco we need to clean some things up so jacoco will only report for the

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -90,5 +90,5 @@ jps
 echo "----------------------------START TEST------------------------------------"
 rm -rf $OUTPUT
 spark-submit $BASE_SPARK_SUBMIT_ARGS $MORTGAGE_SPARK_SUBMIT_ARGS $TEST_PARAMS
-cd $RAPIDS_INT_TESTS_HOME && spark-submit $BASE_SPARK_SUBMIT_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -m "not cudf_udf" -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/"
-spark-submit $BASE_SPARK_SUBMIT_ARGS $CUDF_UDF_TEST_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -m "cudf_udf" -v -rfExXs
+cd $RAPIDS_INT_TESTS_HOME && spark-submit $BASE_SPARK_SUBMIT_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/"
+spark-submit $BASE_SPARK_SUBMIT_ARGS $CUDF_UDF_TEST_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -m "cudf_udf" -v -rfExXs --cudf_udf

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -70,10 +70,11 @@ MORTGAGE_SPARK_SUBMIT_ARGS=" --conf spark.plugins=com.nvidia.spark.SQLPlugin \
     --class com.nvidia.spark.rapids.tests.mortgage.Main \
     $RAPIDS_TEST_JAR"
 
-# need to disable pooling for udf test to prevent cudaErrorMemoryAllocation
-CUDF_UDF_TEST_ARGS="--conf spark.rapids.python.memory.gpu.pooling.enabled=false \
-    --conf spark.rapids.memory.gpu.pooling.enabled=false \
-    --conf spark.executorEnv.PYTHONPATH=rapids-4-spark_2.12-0.3.0-SNAPSHOT.jar \
+RAPIDS_FILE_NAME=${RAPIDS_PLUGIN_JAR##*/}
+CUDF_UDF_TEST_ARGS="--conf spark.rapids.memory.gpu.allocFraction=0.1 \
+    --conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
+    --conf spark.rapids.python.concurrentPythonWorkers=2 \
+    --conf spark.executorEnv.PYTHONPATH=${RAPIDS_FILE_NAME} \
     --py-files ${RAPIDS_PLUGIN_JAR}"
 
 TEST_PARAMS="$SPARK_VER $PARQUET_PERF $PARQUET_ACQ $OUTPUT"

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <rapids.shuffle.manager.override>false</rapids.shuffle.manager.override>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
-        <pytest.TEST_TAGS>not qarun and not cudf_udf</pytest.TEST_TAGS>
+        <pytest.TEST_TAGS>not qarun</pytest.TEST_TAGS>
         <rat.consoleOutput>false</rat.consoleOutput>
         <slf4j.version>1.7.30</slf4j.version>
         <spark300.version>3.0.0</spark300.version>


### PR DESCRIPTION
Some env check at the beginning of the python files may not work since they only execute on driver side. Such as cuDF python lib, disabling GPU exclusive mode, they are only required on the nodes running executors. So for now we add the argument **cudf_udf** to manually turn on/off the cudf_udf tests.

In this pr,
1. Add the argument **cudf_udf** to control enable/disable cudf_udf test, default is disable
2. Add the docs for cudf_udf test 
3. remove marker in premerge/pom.xml
4. use argument to control enable cudf_udf test in spark-test script.
5. remove pytest.skip in cudf_udf test.
6. update the conf for cudf tests to avoid OOM as much as possible.

This closes [#746 ]( https://github.com/NVIDIA/spark-rapids/issues/746)

