### PR TITLE
Add nvcomp LZ4 codec support

### DIFF
--- a/sql-plugin/src/main/format/ShuffleCommon.fbs
+++ b/sql-plugin/src/main/format/ShuffleCommon.fbs
@@ -20,6 +20,9 @@ enum CodecType : byte {
 
   /// no compression codec was used on the data
   UNCOMPRESSED = 0,
+
+  /// data compressed with the nvcomp LZ4 codec
+  NVCOMP_LZ4 = 1,
 }
 
 /// Descriptor for a compressed buffer

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
@@ -12,8 +12,12 @@ public final class CodecType {
    * no compression codec was used on the data
    */
   public static final byte UNCOMPRESSED = 0;
+  /**
+   * data compressed with the nvcomp LZ4 codec
+   */
+  public static final byte NVCOMP_LZ4 = 1;
 
-  public static final String[] names = { "COPY", "UNCOMPRESSED", };
+  public static final String[] names = { "COPY", "UNCOMPRESSED", "NVCOMP_LZ4", };
 
   public static String name(int e) { return names[e - COPY]; }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
@@ -86,6 +86,7 @@ class BatchedCopyCompressor(maxBatchMemory: Long, stream: Cuda.Stream)
           inBuffer,
           CodecType.COPY,
           outBuffer.getLength)
+        stream.sync()
         CompressedTable(outBuffer.getLength, meta, outBuffer)
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
@@ -27,48 +27,59 @@ class CopyCompressionCodec extends TableCompressionCodec with Arm {
 
   override def compress(
       tableId: Int,
-      contigTable: ContiguousTable): CompressedTable = {
+      contigTable: ContiguousTable,
+      stream: Cuda.Stream): CompressedTable = {
     val buffer = contigTable.getBuffer
-    closeOnExcept(buffer.sliceWithCopy(0, buffer.getLength)) { outputBuffer =>
+    closeOnExcept(DeviceMemoryBuffer.allocate(buffer.getLength)) { outputBuffer =>
+      outputBuffer.copyFromDeviceBufferAsync(0, buffer, 0, buffer.getLength, stream)
       val meta = MetaUtils.buildTableMeta(
         tableId,
         contigTable.getTable,
         buffer,
         codecId,
         outputBuffer.getLength)
+      stream.sync()
       CompressedTable(buffer.getLength, meta, outputBuffer)
     }
   }
 
-  override def decompressBuffer(
+  override def decompressBufferAsync(
       outputBuffer: DeviceMemoryBuffer,
       outputOffset: Long,
       outputLength: Long,
       inputBuffer: DeviceMemoryBuffer,
       inputOffset: Long,
-      inputLength: Long): Unit = {
+      inputLength: Long,
+      stream: Cuda.Stream): Unit = {
     require(outputLength == inputLength)
     outputBuffer.copyFromDeviceBufferAsync(
       outputOffset,
       inputBuffer,
       inputOffset,
       inputLength,
-      Cuda.DEFAULT_STREAM)
+      stream)
   }
 
-  override def createBatchCompressor(maxBatchMemorySize: Long): BatchedTableCompressor =
-    new BatchedCopyCompressor(maxBatchMemorySize)
+  override def createBatchCompressor(
+      maxBatchMemorySize: Long,
+      stream: Cuda.Stream): BatchedTableCompressor =
+    new BatchedCopyCompressor(maxBatchMemorySize, stream)
 
-  override def createBatchDecompressor(maxBatchMemorySize: Long): BatchedBufferDecompressor =
-    new BatchedCopyDecompressor(maxBatchMemorySize)
+  override def createBatchDecompressor(
+      maxBatchMemorySize: Long,
+      stream: Cuda.Stream): BatchedBufferDecompressor =
+    new BatchedCopyDecompressor(maxBatchMemorySize, stream)
 }
 
-class BatchedCopyCompressor(maxBatchMemory: Long) extends BatchedTableCompressor(maxBatchMemory) {
-  override protected def compress(tables: Array[ContiguousTable]): Array[CompressedTable] = {
+class BatchedCopyCompressor(maxBatchMemory: Long, stream: Cuda.Stream)
+    extends BatchedTableCompressor(maxBatchMemory, stream) {
+  override protected def compress(
+      tables: Array[ContiguousTable],
+      stream: Cuda.Stream): Array[CompressedTable] = {
     tables.safeMap { ct =>
       val inBuffer = ct.getBuffer
       closeOnExcept(DeviceMemoryBuffer.allocate(inBuffer.getLength)) { outBuffer =>
-        outBuffer.copyFromDeviceBufferAsync(0, inBuffer, 0, inBuffer.getLength, Cuda.DEFAULT_STREAM)
+        outBuffer.copyFromDeviceBufferAsync(0, inBuffer, 0, inBuffer.getLength, stream)
         val meta = MetaUtils.buildTableMeta(
           0,
           ct.getTable,
@@ -81,16 +92,17 @@ class BatchedCopyCompressor(maxBatchMemory: Long) extends BatchedTableCompressor
   }
 }
 
-class BatchedCopyDecompressor(maxBatchMemory: Long)
-    extends BatchedBufferDecompressor(maxBatchMemory) {
+class BatchedCopyDecompressor(maxBatchMemory: Long, stream: Cuda.Stream)
+    extends BatchedBufferDecompressor(maxBatchMemory, stream) {
   override val codecId: Byte = CodecType.COPY
 
-  override def decompress(
+  override def decompressAsync(
       inputBuffers: Array[BaseDeviceMemoryBuffer],
-      bufferMetas: Array[BufferMeta]): Array[DeviceMemoryBuffer] = {
+      bufferMetas: Array[BufferMeta],
+      stream: Cuda.Stream): Array[DeviceMemoryBuffer] = {
     inputBuffers.safeMap { inBuffer =>
       closeOnExcept(DeviceMemoryBuffer.allocate(inBuffer.getLength)) { buffer =>
-        buffer.copyFromDeviceBufferAsync(0, inBuffer, 0, inBuffer.getLength, Cuda.DEFAULT_STREAM)
+        buffer.copyFromDeviceBufferAsync(0, inBuffer, 0, inBuffer.getLength, stream)
         buffer
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ContiguousTable, NvtxColor, NvtxRange, Table}
+import ai.rapids.cudf.{ContiguousTable, Cuda, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -125,7 +125,8 @@ trait GpuPartitioning extends Partitioning with Arm {
       outputBatches: ArrayBuffer[ColumnarBatch],
       codec: TableCompressionCodec,
       contiguousTables: Array[ContiguousTable]): Unit = {
-    withResource(codec.createBatchCompressor(maxCompressionBatchSize)) { compressor =>
+    withResource(codec.createBatchCompressor(maxCompressionBatchSize,
+        Cuda.DEFAULT_STREAM)) { compressor =>
       // tracks batches with no data and the corresponding output index for the batch
       val emptyBatches = new ArrayBuffer[(ColumnarBatch, Int)]
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{NvtxColor, NvtxRange, Table}
+import ai.rapids.cudf.{ContiguousTable, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -51,13 +51,7 @@ trait GpuPartitioning extends Partitioning with Arm {
         val contiguousTables = withResource(table)(t => t.contiguousSplit(parts: _*))
         GpuShuffleEnv.rapidsShuffleCodec match {
           case Some(codec) =>
-            withResource(codec.createBatchCompressor(maxCompressionBatchSize)) { compressor =>
-              // batchCompress takes ownership of the contiguous tables and will close
-              compressor.addTables(contiguousTables)
-              withResource(compressor.finish()) { compressedTables =>
-                compressedTables.foreach(ct => splits.append(GpuCompressedColumnVector.from(ct)))
-              }
-            }
+            compressSplits(splits, codec, contiguousTables)
           case None =>
             withResource(contiguousTables) { cts =>
               cts.foreach { ct => splits.append(GpuColumnVectorFromBuffer.from(ct)) }
@@ -117,6 +111,57 @@ trait GpuPartitioning extends Partitioning with Arm {
       }
     } finally {
       sliceRange.close()
+    }
+  }
+
+  /**
+   * Compress contiguous tables representing the splits into compressed columnar batches.
+   * Contiguous tables corresponding to splits with no data will not be compressed.
+   * @param outputBatches where to collect the corresponding columnar batches for the splits
+   * @param codec compression codec to use
+   * @param contiguousTables contiguous tables to compress
+   */
+  def compressSplits(
+      outputBatches: ArrayBuffer[ColumnarBatch],
+      codec: TableCompressionCodec,
+      contiguousTables: Array[ContiguousTable]): Unit = {
+    withResource(codec.createBatchCompressor(maxCompressionBatchSize)) { compressor =>
+      // tracks batches with no data and the corresponding output index for the batch
+      val emptyBatches = new ArrayBuffer[(ColumnarBatch, Int)]
+
+      // add each table either to the batch to be compressed or to the empty batch tracker
+      contiguousTables.zipWithIndex.foreach { case (ct, i) =>
+        if (ct.getTable.getRowCount == 0) {
+          withResource(ct) { _ =>
+            emptyBatches.append((GpuColumnVector.from(ct.getTable), i))
+          }
+        } else {
+          compressor.addTableToCompress(ct)
+        }
+      }
+
+      withResource(compressor.finish()) { compressedTables =>
+        var compressedTableIndex = 0
+        var outputIndex = 0
+        emptyBatches.foreach { case (emptyBatch, emptyOutputIndex) =>
+          require(emptyOutputIndex >= outputIndex)
+          // add any compressed batches that need to appear before the next empty batch
+          val numCompressedToAdd = emptyOutputIndex - outputIndex
+          (0 until numCompressedToAdd).foreach { _ =>
+            val compressedTable = compressedTables(compressedTableIndex)
+            outputBatches.append(GpuCompressedColumnVector.from(compressedTable))
+            compressedTableIndex += 1
+          }
+          outputBatches.append(emptyBatch)
+          outputIndex = emptyOutputIndex + 1
+        }
+
+        // add any compressed batches that remain after the last empty batch
+        (compressedTableIndex until compressedTables.length).foreach { i =>
+          val ct = compressedTables(i)
+          outputBatches.append(GpuCompressedColumnVector.from(ct))
+        }
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -28,9 +28,10 @@ class NvcompLZ4CompressionCodec extends TableCompressionCodec with Arm {
 
   override def compress(
       tableId: Int,
-      contigTable: ContiguousTable): CompressedTable = {
+      contigTable: ContiguousTable,
+      stream: Cuda.Stream): CompressedTable = {
     val tableBuffer = contigTable.getBuffer
-    val (compressedSize, oversizedBuffer) = NvcompLZ4CompressionCodec.compress(tableBuffer)
+    val (compressedSize, oversizedBuffer) = NvcompLZ4CompressionCodec.compress(tableBuffer, stream)
     closeOnExcept(oversizedBuffer) { oversizedBuffer =>
       val tableMeta = MetaUtils.buildTableMeta(
         tableId,
@@ -42,26 +43,31 @@ class NvcompLZ4CompressionCodec extends TableCompressionCodec with Arm {
     }
   }
 
-  override def decompressBuffer(
+  override def decompressBufferAsync(
       outputBuffer: DeviceMemoryBuffer,
       outputOffset: Long,
       outputLength: Long,
       inputBuffer: DeviceMemoryBuffer,
       inputOffset: Long,
-      inputLength: Long): Unit = {
+      inputLength: Long,
+      stream: Cuda.Stream): Unit = {
     withResource(outputBuffer.slice(outputOffset, outputLength)) { outSlice =>
       withResource(inputBuffer.slice(inputOffset, inputLength)) { inSlice =>
-        NvcompLZ4CompressionCodec.decompress(outSlice, inSlice)
+        NvcompLZ4CompressionCodec.decompressAsync(outSlice, inSlice, stream)
       }
     }
   }
 
-  override def createBatchCompressor(maxBatchMemoryBytes: Long): BatchedTableCompressor = {
-    new BatchedNvcompLZ4Compressor(maxBatchMemoryBytes)
+  override def createBatchCompressor(
+      maxBatchMemoryBytes: Long,
+      stream: Cuda.Stream): BatchedTableCompressor = {
+    new BatchedNvcompLZ4Compressor(maxBatchMemoryBytes, stream)
   }
 
-  override def createBatchDecompressor(maxBatchMemoryBytes: Long): BatchedBufferDecompressor = {
-    new BatchedNvcompLZ4Decompressor(maxBatchMemoryBytes)
+  override def createBatchDecompressor(
+      maxBatchMemoryBytes: Long,
+      stream: Cuda.Stream): BatchedBufferDecompressor = {
+    new BatchedNvcompLZ4Decompressor(maxBatchMemoryBytes, stream)
   }
 }
 
@@ -72,9 +78,10 @@ object NvcompLZ4CompressionCodec extends Arm {
   /**
    * Compress a data buffer.
    * @param input buffer containing data to compress
+   * @param stream CUDA stream to use
    * @return the size of the compressed data in bytes and the (probably oversized) output buffer
    */
-  def compress(input: DeviceMemoryBuffer): (Long, DeviceMemoryBuffer) = {
+  def compress(input: DeviceMemoryBuffer, stream: Cuda.Stream): (Long, DeviceMemoryBuffer) = {
     val tempSize = LZ4Compressor.getTempSize(input, CompressionType.CHAR, LZ4_CHUNK_SIZE)
     withResource(DeviceMemoryBuffer.allocate(tempSize)) { tempBuffer =>
       var compressedSize: Long = 0L
@@ -82,19 +89,23 @@ object NvcompLZ4CompressionCodec extends Arm {
         tempBuffer)
       closeOnExcept(DeviceMemoryBuffer.allocate(outputSize)) { outputBuffer =>
         compressedSize = LZ4Compressor.compress(input, CompressionType.CHAR, LZ4_CHUNK_SIZE,
-          tempBuffer, outputBuffer, Cuda.DEFAULT_STREAM)
+          tempBuffer, outputBuffer, stream)
         (compressedSize, outputBuffer)
       }
     }
   }
 
   /**
-   * Decompress data that was compressed with nvcomp's LZ4-GPU codec
+   * Decompress data asynchronously that was compressed with nvcomp's LZ4-GPU codec
    * @param outputBuffer where the uncompressed data will be written
    * @param inputBuffer buffer of compressed data to decompress
+   * @param stream CUDA stream to use
    */
-  def decompress(outputBuffer: DeviceMemoryBuffer, inputBuffer: DeviceMemoryBuffer): Unit = {
-    withResource(Decompressor.getMetadata(inputBuffer, Cuda.DEFAULT_STREAM)) { metadata =>
+  def decompressAsync(
+      outputBuffer: DeviceMemoryBuffer,
+      inputBuffer: DeviceMemoryBuffer,
+      stream: Cuda.Stream): Unit = {
+    withResource(Decompressor.getMetadata(inputBuffer, stream)) { metadata =>
       val outputSize = Decompressor.getOutputSize(metadata)
       if (outputSize != outputBuffer.getLength) {
         throw new IllegalStateException(
@@ -102,19 +113,20 @@ object NvcompLZ4CompressionCodec extends Arm {
       }
       val tempSize = Decompressor.getTempSize(metadata)
       withResource(DeviceMemoryBuffer.allocate(tempSize)) { tempBuffer =>
-        Decompressor.decompressAsync(inputBuffer, tempBuffer, metadata, outputBuffer,
-          Cuda.DEFAULT_STREAM)
+        Decompressor.decompressAsync(inputBuffer, tempBuffer, metadata, outputBuffer, stream)
       }
     }
   }
 }
 
-class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long)
-    extends BatchedTableCompressor(maxBatchMemorySize) {
-  override protected def compress(tables: Array[ContiguousTable]): Array[CompressedTable] = {
+class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long, stream: Cuda.Stream)
+    extends BatchedTableCompressor(maxBatchMemorySize, stream) {
+  override protected def compress(
+      tables: Array[ContiguousTable],
+      stream: Cuda.Stream): Array[CompressedTable] = {
     val inputBuffers: Array[BaseDeviceMemoryBuffer] = tables.map(_.getBuffer)
     val compressionResult = BatchedLZ4Compressor.compress(inputBuffers,
-      NvcompLZ4CompressionCodec.LZ4_CHUNK_SIZE, Cuda.DEFAULT_STREAM)
+      NvcompLZ4CompressionCodec.LZ4_CHUNK_SIZE, stream)
     val compressedTables = try {
       val buffers = compressionResult.getCompressedBuffers
       val compressedSizes = compressionResult.getCompressedSizes
@@ -141,15 +153,14 @@ class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long)
   }
 }
 
-class BatchedNvcompLZ4Decompressor(maxBatchMemory: Long)
-    extends BatchedBufferDecompressor(maxBatchMemory) {
+class BatchedNvcompLZ4Decompressor(maxBatchMemory: Long, stream: Cuda.Stream)
+    extends BatchedBufferDecompressor(maxBatchMemory, stream) {
   override val codecId: Byte = CodecType.NVCOMP_LZ4
 
-  // TODO: Need to pass stream as arg, make name async
-
-  override def decompress(
+  override def decompressAsync(
       inputBuffers: Array[BaseDeviceMemoryBuffer],
-      bufferMetas: Array[BufferMeta]): Array[DeviceMemoryBuffer] = {
-    BatchedLZ4Decompressor.decompressAsync(inputBuffers, Cuda.DEFAULT_STREAM)
+      bufferMetas: Array[BufferMeta],
+      stream: Cuda.Stream): Array[DeviceMemoryBuffer] = {
+    BatchedLZ4Decompressor.decompressAsync(inputBuffers, stream)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer}
+import ai.rapids.cudf.nvcomp.{BatchedLZ4Compressor, BatchedLZ4Decompressor, CompressionType, Decompressor, LZ4Compressor}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.format.{BufferMeta, CodecType}
+
+/** A table compression codec that uses nvcomp's LZ4-GPU codec */
+class NvcompLZ4CompressionCodec extends TableCompressionCodec with Arm {
+  override val name: String = "nvcomp-LZ4"
+  override val codecId: Byte = CodecType.NVCOMP_LZ4
+
+  override def compress(
+      tableId: Int,
+      contigTable: ContiguousTable): CompressedTable = {
+    val tableBuffer = contigTable.getBuffer
+    val (compressedSize, oversizedBuffer) = NvcompLZ4CompressionCodec.compress(tableBuffer)
+    closeOnExcept(oversizedBuffer) { oversizedBuffer =>
+      val tableMeta = MetaUtils.buildTableMeta(
+        tableId,
+        contigTable.getTable,
+        tableBuffer,
+        CodecType.NVCOMP_LZ4,
+        compressedSize)
+      CompressedTable(compressedSize, tableMeta, oversizedBuffer)
+    }
+  }
+
+  override def decompressBuffer(
+      outputBuffer: DeviceMemoryBuffer,
+      outputOffset: Long,
+      outputLength: Long,
+      inputBuffer: DeviceMemoryBuffer,
+      inputOffset: Long,
+      inputLength: Long): Unit = {
+    withResource(outputBuffer.slice(outputOffset, outputLength)) { outSlice =>
+      withResource(inputBuffer.slice(inputOffset, inputLength)) { inSlice =>
+        NvcompLZ4CompressionCodec.decompress(outSlice, inSlice)
+      }
+    }
+  }
+
+  override def createBatchCompressor(maxBatchMemoryBytes: Long): BatchedTableCompressor = {
+    new BatchedNvcompLZ4Compressor(maxBatchMemoryBytes)
+  }
+
+  override def createBatchDecompressor(maxBatchMemoryBytes: Long): BatchedBufferDecompressor = {
+    new BatchedNvcompLZ4Decompressor(maxBatchMemoryBytes)
+  }
+}
+
+object NvcompLZ4CompressionCodec extends Arm {
+  // TODO: Make this a config?
+  val LZ4_CHUNK_SIZE: Int = 64 * 1024
+
+  /**
+   * Compress a data buffer.
+   * @param input buffer containing data to compress
+   * @return the size of the compressed data in bytes and the (probably oversized) output buffer
+   */
+  def compress(input: DeviceMemoryBuffer): (Long, DeviceMemoryBuffer) = {
+    val tempSize = LZ4Compressor.getTempSize(input, CompressionType.CHAR, LZ4_CHUNK_SIZE)
+    withResource(DeviceMemoryBuffer.allocate(tempSize)) { tempBuffer =>
+      var compressedSize: Long = 0L
+      val outputSize = LZ4Compressor.getOutputSize(input, CompressionType.CHAR, LZ4_CHUNK_SIZE,
+        tempBuffer)
+      closeOnExcept(DeviceMemoryBuffer.allocate(outputSize)) { outputBuffer =>
+        compressedSize = LZ4Compressor.compress(input, CompressionType.CHAR, LZ4_CHUNK_SIZE,
+          tempBuffer, outputBuffer, Cuda.DEFAULT_STREAM)
+        (compressedSize, outputBuffer)
+      }
+    }
+  }
+
+  /**
+   * Decompress data that was compressed with nvcomp's LZ4-GPU codec
+   * @param outputBuffer where the uncompressed data will be written
+   * @param inputBuffer buffer of compressed data to decompress
+   */
+  def decompress(outputBuffer: DeviceMemoryBuffer, inputBuffer: DeviceMemoryBuffer): Unit = {
+    withResource(Decompressor.getMetadata(inputBuffer, Cuda.DEFAULT_STREAM)) { metadata =>
+      val outputSize = Decompressor.getOutputSize(metadata)
+      if (outputSize != outputBuffer.getLength) {
+        throw new IllegalStateException(
+          s"metadata uncompressed size is $outputSize, buffer size is ${outputBuffer.getLength}")
+      }
+      val tempSize = Decompressor.getTempSize(metadata)
+      withResource(DeviceMemoryBuffer.allocate(tempSize)) { tempBuffer =>
+        Decompressor.decompressAsync(inputBuffer, tempBuffer, metadata, outputBuffer,
+          Cuda.DEFAULT_STREAM)
+      }
+    }
+  }
+}
+
+class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long)
+    extends BatchedTableCompressor(maxBatchMemorySize) {
+  override protected def compress(tables: Array[ContiguousTable]): Array[CompressedTable] = {
+    val inputBuffers: Array[BaseDeviceMemoryBuffer] = tables.map(_.getBuffer)
+    val compressionResult = BatchedLZ4Compressor.compress(inputBuffers,
+      NvcompLZ4CompressionCodec.LZ4_CHUNK_SIZE, Cuda.DEFAULT_STREAM)
+    val compressedTables = try {
+      val buffers = compressionResult.getCompressedBuffers
+      val compressedSizes = compressionResult.getCompressedSizes
+      buffers.zipWithIndex.map { case (buffer, i) =>
+        val contigTable = tables(i)
+        val compressedSize = compressedSizes(i)
+        val meta = MetaUtils.buildTableMeta(
+          tableId = 0,
+          contigTable.getTable,
+          contigTable.getBuffer,
+          CodecType.NVCOMP_LZ4,
+          compressedSize)
+        CompressedTable(compressedSize, meta, buffer)
+      }
+    } catch {
+      case t: Throwable =>
+        compressionResult.getCompressedBuffers.safeClose()
+        throw t
+    }
+
+    // output buffer sizes were estimated and probably significantly oversized, so copy any
+    // oversized buffers to properly sized buffers in order to release the excess memory.
+    resizeOversizedOutputs(compressedTables)
+  }
+}
+
+class BatchedNvcompLZ4Decompressor(maxBatchMemory: Long)
+    extends BatchedBufferDecompressor(maxBatchMemory) {
+  override val codecId: Byte = CodecType.NVCOMP_LZ4
+
+  // TODO: Need to pass stream as arg, make name async
+
+  override def decompress(
+      inputBuffers: Array[BaseDeviceMemoryBuffer],
+      bufferMetas: Array[BufferMeta]): Array[DeviceMemoryBuffer] = {
+    BatchedLZ4Decompressor.decompressAsync(inputBuffers, Cuda.DEFAULT_STREAM)
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -668,7 +668,7 @@ object RapidsConf {
 
   val SHUFFLE_COMPRESSION_CODEC = conf("spark.rapids.shuffle.compression.codec")
       .doc("The GPU codec used to compress shuffle data when using RAPIDS shuffle. " +
-          "Supported codecs: copy, none")
+          "Supported codecs: lz4, copy, none")
       .internal()
       .stringConf
       .createWithDefault("none")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer, NvtxColor, NvtxRange}
+import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, CodecType, TableMeta}
 
@@ -26,7 +26,6 @@ import org.apache.spark.internal.Logging
 
 /**
  * Compressed table descriptor
- * @note the buffer may be significantly oversized for the amount of compressed data
  * @param compressedSize size of the compressed data in bytes
  * @param meta metadata describing the table layout when uncompressed
  * @param buffer buffer containing the compressed data
@@ -99,7 +98,8 @@ trait TableCompressionCodec {
 
 object TableCompressionCodec {
   private val codecNameToId = Map(
-    "copy" -> CodecType.COPY)
+    "copy" -> CodecType.COPY,
+    "lz4" -> CodecType.NVCOMP_LZ4)
 
   /** Get a compression codec by short name or fully qualified class name */
   def getCodec(name: String): TableCompressionCodec = {
@@ -111,6 +111,7 @@ object TableCompressionCodec {
   /** Get a compression codec by ID, using a cache. */
   def getCodec(codecId: Byte): TableCompressionCodec = {
     codecId match {
+      case CodecType.NVCOMP_LZ4 => new NvcompLZ4CompressionCodec
       case CodecType.COPY => new CopyCompressionCodec
       case _ => throw new IllegalArgumentException(s"Unknown codec ID: $codecId")
     }
@@ -119,21 +120,15 @@ object TableCompressionCodec {
 
 /**
  * Base class for batched compressors
- * @param maxBatchMemorySize The upper limit in bytes of temporary and output memory usage at
+ * @param maxBatchMemorySize The upper limit in bytes of estimated output memory usage at
  *                           which a batch should be compressed. A single table that requires
- *                           temporary and output memory above this limit is allowed but will
+ *                           estimated output memory above this limit is allowed but will
  *                           be compressed individually.
  */
 abstract class BatchedTableCompressor(maxBatchMemorySize: Long) extends AutoCloseable with Arm
     with Logging {
   // The tables that need to be compressed in the next batch
   private[this] val tables = new ArrayBuffer[ContiguousTable]
-
-  // The temporary compression buffers needed to compress each table in the next batch
-  private[this] val tempBuffers = new ArrayBuffer[DeviceMemoryBuffer]
-
-  // The estimate-sized output buffers to hold the compressed output in the next batch
-  private[this] val oversizedOutBuffers = new ArrayBuffer[DeviceMemoryBuffer]
 
   // The compressed outputs of all tables across all batches
   private[this] val results = new ArrayBuffer[CompressedTable]
@@ -148,33 +143,13 @@ abstract class BatchedTableCompressor(maxBatchMemorySize: Long) extends AutoClos
    */
   def addTableToCompress(contigTable: ContiguousTable): Unit = {
     closeOnExcept(contigTable) { contigTable =>
-      val tempSize = getTempSpaceNeeded(contigTable.getBuffer)
-      var memNeededToCompressThisBuffer = tempSize
+      // use original input size as a conservative estimate of compressed output size
+      val memNeededToCompressThisBuffer = contigTable.getBuffer.getLength
       if (batchMemUsed + memNeededToCompressThisBuffer > maxBatchMemorySize) {
         compressBatch()
       }
-      val tempBuffer = if (tempSize > 0) {
-        DeviceMemoryBuffer.allocate(memNeededToCompressThisBuffer)
-      } else {
-        null
-      }
-      try {
-        val outputSize = getOutputSpaceNeeded(contigTable.getBuffer, tempBuffer)
-        memNeededToCompressThisBuffer += outputSize
-        if (batchMemUsed + memNeededToCompressThisBuffer > maxBatchMemorySize) {
-          compressBatch()
-        }
-        oversizedOutBuffers += DeviceMemoryBuffer.allocate(outputSize)
-        tempBuffers += tempBuffer
-        tables += contigTable
-        batchMemUsed += memNeededToCompressThisBuffer
-      } catch {
-        case t: Throwable =>
-          if (tempBuffer != null) {
-            tempBuffer.safeClose()
-          }
-          throw t
-      }
+      tables += contigTable
+      batchMemUsed += memNeededToCompressThisBuffer
     }
   }
 
@@ -215,95 +190,82 @@ abstract class BatchedTableCompressor(maxBatchMemorySize: Long) extends AutoClos
   /** Must be closed to release the resources owned by the batch compressor */
   override def close(): Unit = {
     tables.safeClose()
-    tempBuffers.safeClose()
-    oversizedOutBuffers.safeClose()
+    tables.clear()
     results.safeClose()
+    results.clear()
   }
 
   private def compressBatch(): Unit = if (tables.nonEmpty) {
-    require(oversizedOutBuffers.length == tables.length)
-    require(tempBuffers.length == tables.length)
-    val startTime = System.nanoTime()
-    val metas = withResource(new NvtxRange("batch ompress", NvtxColor.ORANGE)) { _ =>
-      compress(oversizedOutBuffers.toArray, tables.toArray, tempBuffers.toArray)
-    }
-    require(metas.length == tables.length)
+    withResource(new NvtxRange("batch compress", NvtxColor.ORANGE)) { _ =>
+      val startTime = System.nanoTime()
+      val compressedTables = compress(tables.toArray)
+      results ++= compressedTables
+      require(compressedTables.length == tables.length)
 
-    val inputSize = tables.map(_.getBuffer.getLength).sum
-    var outputSize: Long = 0
-
-    // copy the output data into correctly-sized buffers
-    withResource(new NvtxRange("copy compressed buffers", NvtxColor.PURPLE)) { _ =>
-      metas.zipWithIndex.foreach { case (meta, i) =>
-        val oversizedBuffer = oversizedOutBuffers(i)
-        val compressedSize = meta.bufferMeta.size
-        outputSize += compressedSize
-        val buffer = if (oversizedBuffer.getLength > compressedSize) {
-          oversizedBuffer.sliceWithCopy(0, compressedSize)
-        } else {
-          // use this buffer as-is, don't close it at the end of this method
-          oversizedOutBuffers(i) = null
-          oversizedBuffer
-        }
-        results += CompressedTable(compressedSize, meta, buffer)
+      if (log.isDebugEnabled) {
+        val duration = (System.nanoTime() - startTime).toFloat
+        val inputSize = tables.map(_.getBuffer.getLength).sum
+        val outputSize = compressedTables.map(_.compressedSize).sum
+        logDebug(s"Compressed ${tables.length} tables from $inputSize to $outputSize " +
+            s"in ${duration / 1000000} msec rate=${inputSize / duration} GB/s " +
+            s"ratio=${outputSize.toFloat/inputSize}")
       }
+
+      // free the inputs to this batch
+      tables.safeClose()
+      tables.clear()
+      batchMemUsed = 0
     }
-
-    val duration = (System.nanoTime() - startTime).toFloat
-    logDebug(s"Compressed ${tables.length} tables from $inputSize to $outputSize " +
-        s"in ${duration / 1000000} msec rate=${inputSize / duration} GB/s " +
-        s"ratio=${outputSize.toFloat/inputSize}")
-
-    // free all the inputs to this batch
-    tables.safeClose()
-    tables.clear()
-    tempBuffers.safeClose()
-    tempBuffers.clear()
-    oversizedOutBuffers.safeClose()
-    oversizedOutBuffers.clear()
-    batchMemUsed = 0
   }
 
-  /** Return the amount of temporary space needed to compress this buffer */
-  protected def getTempSpaceNeeded(buffer: DeviceMemoryBuffer): Long
-
-  /** Return the amount of estimated output space needed to compress this buffer */
-  protected def getOutputSpaceNeeded(
-      dataBuffer: DeviceMemoryBuffer,
-      tempBuffer: DeviceMemoryBuffer): Long
+  /**
+   * Reallocates and copies data for oversized compressed data buffers due to inaccurate estimates
+   * of the compressed output size. If the buffer is already the appropriate size then no copy
+   * is performed.
+   * @note This method takes ownership of the tables and is responsible for closing them.
+   * @param tables compressed tables to resize
+   * @return right-sized compressed tables
+   */
+  protected def resizeOversizedOutputs(tables: Array[CompressedTable]): Array[CompressedTable] = {
+    withResource(new NvtxRange("copy compressed buffers", NvtxColor.PURPLE)) { _ =>
+      withResource(tables) { _ =>
+        tables.safeMap { ct =>
+          val newBuffer = if (ct.buffer.getLength > ct.compressedSize) {
+            closeOnExcept(DeviceMemoryBuffer.allocate(ct.compressedSize)) { buffer =>
+              buffer.copyFromDeviceBufferAsync(
+                0, ct.buffer, 0, ct.compressedSize, Cuda.DEFAULT_STREAM)
+              buffer
+            }
+          } else {
+            ct.buffer.slice(0, ct.buffer.getLength)
+          }
+          CompressedTable(ct.compressedSize, ct.meta, newBuffer)
+        }
+      }
+    }
+  }
 
   /**
    * Batch-compress contiguous tables
-   * @param outputBuffers output buffers allocated based on `getOutputSpaceNeeded` results
    * @param tables contiguous tables to compress
-   * @param tempBuffers temporary buffers allocated based on `getTempSpaceNeeded` results.
-   *                    If the temporary space needed was zero then the corresponding buffer
-   *                    entry may be null.
-   * @return table metadata for the compressed tables. Table IDs should be set to 0.
+   * @return compressed tables. Table IDs in the `TableMeta` should be set to 0.
    */
-  protected def compress(
-      outputBuffers: Array[DeviceMemoryBuffer],
-      tables: Array[ContiguousTable],
-      tempBuffers: Array[DeviceMemoryBuffer]): Array[TableMeta]
+  protected def compress(tables: Array[ContiguousTable]): Array[CompressedTable]
 }
 
 /**
  * Base class for batched decompressors
- * @param maxBatchMemorySize The upper limit in bytes of temporary and output memory usage at
- *                           which a batch should be compressed. A single table that requires
- *                           temporary and output memory above this limit is allowed but will
- *                           be compressed individually.
+ * @param maxBatchMemorySize The upper limit in bytes of output memory usage at which a batch
+ *                           should be decompressed. A single table that requires output memory
+ *                           above this limit is allowed but will be decompressed individually.
  */
 abstract class BatchedBufferDecompressor(maxBatchMemorySize: Long) extends AutoCloseable with Arm
     with Logging {
   // The buffers of compressed data that will be decompressed in the next batch
-  private[this] val inputBuffers = new ArrayBuffer[DeviceMemoryBuffer]
-
-  // The temporary buffers needed to be decompressed the next batch
-  private[this] val tempBuffers = new ArrayBuffer[DeviceMemoryBuffer]
+  private[this] val inputBuffers = new ArrayBuffer[BaseDeviceMemoryBuffer]
 
   // The output buffers that will contain the decompressed data in the next batch
-  private[this] val outputBuffers = new ArrayBuffer[DeviceMemoryBuffer]
+  private[this] val bufferMetas = new ArrayBuffer[BufferMeta]
 
   // The decompressed data results for all input buffers across all batches
   private[this] val results = new ArrayBuffer[DeviceMemoryBuffer]
@@ -314,7 +276,7 @@ abstract class BatchedBufferDecompressor(maxBatchMemorySize: Long) extends AutoC
   /** The codec ID corresponding to this decompressor */
   val codecId: Byte
 
-  def addBufferToDecompress(buffer: DeviceMemoryBuffer, meta: BufferMeta): Unit = {
+  def addBufferToDecompress(buffer: BaseDeviceMemoryBuffer, meta: BufferMeta): Unit = {
     closeOnExcept(buffer) { buffer =>
       // Only supports a single codec per buffer for now.
       require(meta.codecBufferDescrsLength == 1)
@@ -325,21 +287,13 @@ abstract class BatchedBufferDecompressor(maxBatchMemorySize: Long) extends AutoC
       require(descr.compressedOffset == 0)
       require(descr.compressedSize == buffer.getLength)
 
-      val tempNeeded = decompressTempSpaceNeeded(buffer)
       val outputNeeded = descr.uncompressedSize
-      if (batchMemUsed + tempNeeded + outputNeeded > maxBatchMemorySize) {
+      if (batchMemUsed + outputNeeded > maxBatchMemorySize) {
         decompressBatch()
       }
 
-      val tempBuffer = if (tempNeeded > 0) {
-        DeviceMemoryBuffer.allocate(tempNeeded)
-      } else {
-        null
-      }
-      val outputBuffer = DeviceMemoryBuffer.allocate(outputNeeded)
-      batchMemUsed += tempNeeded + outputNeeded
-      tempBuffers += tempBuffer
-      outputBuffers += outputBuffer
+      batchMemUsed += outputNeeded
+      bufferMetas += meta
       inputBuffers += buffer
     }
   }
@@ -359,54 +313,43 @@ abstract class BatchedBufferDecompressor(maxBatchMemorySize: Long) extends AutoC
 
   override def close(): Unit = {
     inputBuffers.safeClose()
-    tempBuffers.safeClose()
-    outputBuffers.safeClose()
+    inputBuffers.clear()
+    bufferMetas.clear()
     results.safeClose()
+    results.clear()
   }
 
   protected def decompressBatch(): Unit = {
     if (inputBuffers.nonEmpty) {
-      require(outputBuffers.length == inputBuffers.length)
-      require(tempBuffers.length == inputBuffers.length)
-      val startTime = System.nanoTime()
       withResource(new NvtxRange("batch decompress", NvtxColor.ORANGE)) { _ =>
-        decompress(outputBuffers.toArray, inputBuffers.toArray, tempBuffers.toArray)
+        val startTime = System.nanoTime()
+        val uncompressedBuffers = decompress(inputBuffers.toArray, bufferMetas.toArray)
+        results ++= uncompressedBuffers
+        require(uncompressedBuffers.length == inputBuffers.length)
+        if (log.isDebugEnabled) {
+          val duration = (System.nanoTime - startTime).toFloat
+          val inputSize = inputBuffers.map(_.getLength).sum
+          val outputSize = uncompressedBuffers.map(_.getLength).sum
+          logDebug(s"Decompressed ${inputBuffers.length} buffers from $inputSize " +
+              s"to $outputSize in ${duration / 1000000} msec rate=${outputSize / duration} GB/s")
+        }
+
+        // free all the inputs to this batch
+        inputBuffers.safeClose()
+        inputBuffers.clear()
+        bufferMetas.clear()
+        batchMemUsed = 0
       }
-      val duration = (System.nanoTime - startTime).toFloat
-      val inputSize = inputBuffers.map(_.getLength).sum
-      val outputSize = outputBuffers.map(_.getLength).sum
-
-      results ++= outputBuffers
-      outputBuffers.clear()
-
-      logDebug(s"Decompressed ${inputBuffers.length} buffers from $inputSize " +
-          s"to $outputSize in ${duration / 1000000} msec rate=${outputSize / duration} GB/s")
-
-      // free all the inputs to this batch
-      inputBuffers.safeClose()
-      inputBuffers.clear()
-      tempBuffers.safeClose()
-      tempBuffers.clear()
-      batchMemUsed = 0
     }
   }
 
   /**
-   * Compute the amount of temporary buffer space required to decompress a buffer
-   * @param inputBuffer buffer to decompress
-   * @return required temporary buffer space in bytes
-   */
-  protected def decompressTempSpaceNeeded(inputBuffer: DeviceMemoryBuffer): Long
-
-  /**
    * Decompress a batch of compressed buffers
-   * @param outputBuffers buffers that will contain the uncompressed output
    * @param inputBuffers buffers that contain the compressed input
-   * @param tempBuffers buffers to used for temporary space
+   * @param bufferMetas corresponding metadata for each compressed input buffer
+   * @return buffers that contain the uncompressed output
    */
   protected def decompress(
-      outputBuffers: Array[DeviceMemoryBuffer],
-      inputBuffers: Array[DeviceMemoryBuffer],
-      tempBuffers: Array[DeviceMemoryBuffer]): Unit
-
+      inputBuffers: Array[BaseDeviceMemoryBuffer],
+      bufferMetas: Array[BufferMeta]): Array[DeviceMemoryBuffer]
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -408,7 +408,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
   }
 
   private def buildCompressedBatch(start: Int, numRows: Int): ColumnarBatch = {
-    val codec = TableCompressionCodec.getCodec(CodecType.COPY)
+    val codec = TableCompressionCodec.getCodec(CodecType.NVCOMP_LZ4)
     withResource(codec.createBatchCompressor(0)) { compressor =>
       compressor.addTableToCompress(buildContiguousTable(start, numRows))
       GpuCompressedColumnVector.from(compressor.finish().head)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -21,7 +21,7 @@ import java.nio.file.Files
 
 import scala.collection.immutable.HashMap
 
-import ai.rapids.cudf.{ContiguousTable, HostColumnVector, Table}
+import ai.rapids.cudf.{ContiguousTable, Cuda, HostColumnVector, Table}
 import com.nvidia.spark.rapids.format.CodecType
 
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -409,7 +409,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
 
   private def buildCompressedBatch(start: Int, numRows: Int): ColumnarBatch = {
     val codec = TableCompressionCodec.getCodec(CodecType.NVCOMP_LZ4)
-    withResource(codec.createBatchCompressor(0)) { compressor =>
+    withResource(codec.createBatchCompressor(0, Cuda.DEFAULT_STREAM)) { compressor =>
       compressor.addTableToCompress(buildContiguousTable(start, numRows))
       GpuCompressedColumnVector.from(compressor.finish().head)
     }


### PR DESCRIPTION
This adds a table compression codec implementation backed by nvcomp LZ4.

This depends upon https://github.com/rapidsai/cudf/pull/6301.