### PR TITLE
Update task memory and disk spill metrics when buffer store spills

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -150,7 +150,7 @@ abstract class RapidsBufferStore(
     if (buffers.getTotalBytes > targetTotalSize) {
       val nvtx = new NvtxRange(nvtxSyncSpillName, NvtxColor.ORANGE)
       try {
-        logInfo(s"$name store spilling to reduce usage from " +
+        logDebug(s"$name store spilling to reduce usage from " +
             s"${buffers.getTotalBytes} to $targetTotalSize bytes")
         var waited = false
         var exhausted = false

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -133,17 +133,20 @@ abstract class RapidsBufferStore(
   /**
    * Free memory in this store by spilling buffers to the spill store synchronously.
    * @param targetTotalSize maximum total size of this store after spilling completes
+   * @return number of bytes that were spilled
    */
-  def synchronousSpill(targetTotalSize: Long): Unit = synchronousSpill(targetTotalSize, null)
+  def synchronousSpill(targetTotalSize: Long): Long = synchronousSpill(targetTotalSize, null)
 
   /**
    * Free memory in this store by spilling buffers to the spill store synchronously.
    * @param targetTotalSize maximum total size of this store after spilling completes
    * @param stream CUDA stream to use or null for default stream
+   * @return number of bytes that were spilled
    */
-  def synchronousSpill(targetTotalSize: Long, stream: Cuda.Stream): Unit = {
-    assert(targetTotalSize >= 0)
+  def synchronousSpill(targetTotalSize: Long, stream: Cuda.Stream): Long = {
+    require(targetTotalSize >= 0, s"Negative spill target size: $targetTotalSize")
 
+    var totalSpilled: Long = 0
     if (buffers.getTotalBytes > targetTotalSize) {
       val nvtx = new NvtxRange(nvtxSyncSpillName, NvtxColor.ORANGE)
       try {
@@ -152,7 +155,9 @@ abstract class RapidsBufferStore(
         var waited = false
         var exhausted = false
         while (!exhausted && buffers.getTotalBytes > targetTotalSize) {
-          if (trySpillAndFreeBuffer(stream)) {
+          val amountSpilled = trySpillAndFreeBuffer(stream)
+          if (amountSpilled != 0) {
+            totalSpilled += amountSpilled
             waited = false
           } else {
             if (!waited && pendingFreeBytes.get > 0) {
@@ -179,6 +184,8 @@ abstract class RapidsBufferStore(
         nvtx.close()
       }
     }
+
+    totalSpilled
   }
 
   /**
@@ -202,12 +209,12 @@ abstract class RapidsBufferStore(
     buffers.freeAll()
   }
 
-  private def trySpillAndFreeBuffer(stream: Cuda.Stream): Boolean = synchronized {
+  private def trySpillAndFreeBuffer(stream: Cuda.Stream): Long = synchronized {
     val bufferToSpill = buffers.nextSpillableBuffer()
     if (bufferToSpill != null) {
       spillAndFreeBuffer(bufferToSpill, stream)
     }
-    bufferToSpill != null
+    bufferToSpill.size
   }
 
   private def spillAndFreeBuffer(buffer: RapidsBufferBase, stream: Cuda.Stream): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -20,6 +20,8 @@ import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer,
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+
 /**
  * A buffer store using host memory.
  * @param catalog buffer catalog to use with this store
@@ -36,7 +38,10 @@ class RapidsHostMemoryStore(
   // Returns an allocated host buffer and whether the allocation is from the internal pool
   private def allocateHostBuffer(size: Long): (HostMemoryBuffer, Boolean) = {
     // spill to keep within the targeted size
-    synchronousSpill(math.max(maxSize - size, 0))
+    val amountSpilled = synchronousSpill(math.max(maxSize - size, 0))
+    if (amountSpilled != 0) {
+      TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
+    }
 
     var buffer: HostMemoryBuffer = null
     while (buffer == null) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -40,6 +40,7 @@ class RapidsHostMemoryStore(
     // spill to keep within the targeted size
     val amountSpilled = synchronousSpill(math.max(maxSize - size, 0))
     if (amountSpilled != 0) {
+      logInfo(s"Spilled $amountSpilled bytes from the host memory store")
       TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
     }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.rapids.execution
 
 import org.json4s.JsonAST
 
-import org.apache.spark.{SparkContext, SparkEnv, SparkUpgradeException}
+import org.apache.spark.{SparkContext, SparkEnv, SparkUpgradeException, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.sql.SparkSession
@@ -75,4 +75,22 @@ object TrampolineUtil {
   def cleanupAnyExistingSession(): Unit = SparkSession.cleanupAnyExistingSession()
 
   def asNullable(dt: DataType): DataType = dt.asNullable
+
+  /**
+   * Increment the task's memory bytes spilled metric. If the current thread does not
+   * correspond to a Spark task then this call does nothing.
+   * @param amountSpilled amount of memory spilled in bytes
+   */
+  def incTaskMetricsMemoryBytesSpilled(amountSpilled: Long): Unit = {
+    Option(TaskContext.get).foreach(_.taskMetrics().incMemoryBytesSpilled(amountSpilled))
+  }
+
+  /**
+   * Increment the task's disk bytes spilled metric. If the current thread does not
+   * correspond to a Spark task then this call does nothing.
+   * @param amountSpilled amount of memory spilled in bytes
+   */
+  def incTaskMetricsDiskBytesSpilled(amountSpilled: Long): Unit = {
+    Option(TaskContext.get).foreach(_.taskMetrics().incDiskBytesSpilled(amountSpilled))
+  }
 }


### PR DESCRIPTION
This connects the buffer store spill to task metrics.  When a spill occurs from the device store to the host memory store, it updates the memory spilled metric for the task corresponding to the current thread that triggered the spill.  Similarly when the host store spills to the disk store, it updates the disk spilled metric.

This is far from perfect, as tasks can be blocked on the memory store lock while another task is spilling and not have anything reported yet be stalled/slow because of spilling.  However it at least allows a user to see that host and disk spills are occurring in their queries.