### PR TITLE
Use contiguous table when deserializing columnar batch

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -151,13 +151,13 @@ private class GpuColumnarBatchSerializerInstance(
             try {
               val tableInfo = JCudfSerialization.readTableFrom(dIn)
               try {
-                val table = tableInfo.getTable
-                if (table == null && tableInfo.getNumRows == 0) {
+                val contigTable = tableInfo.getContiguousTable
+                if (contigTable == null && tableInfo.getNumRows == 0) {
                   dIn.close()
                   None
                 } else {
-                  if (table != null) {
-                    Some(GpuColumnVector.from(table))
+                  if (contigTable != null) {
+                    Some(GpuColumnVectorFromBuffer.from(contigTable))
                   } else {
                     Some(new ColumnarBatch(Array.empty, tableInfo.getNumRows))
                   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -34,17 +34,13 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * Serializer for serializing `ColumnarBatch`s during shuffle.
  * The batches will be stored in an internal format specific to rapids.
  */
-class GpuColumnarBatchSerializer(
-      numFields: Int,
-      dataSize: SQLMetric = null) extends Serializer with Serializable {
+class GpuColumnarBatchSerializer(dataSize: SQLMetric = null) extends Serializer with Serializable {
   override def newInstance(): SerializerInstance =
-    new GpuColumnarBatchSerializerInstance(numFields, dataSize)
+    new GpuColumnarBatchSerializerInstance(dataSize)
   override def supportsRelocationOfSerializedObjects: Boolean = true
 }
 
-private class GpuColumnarBatchSerializerInstance(
-    numFields: Int,
-    dataSize: SQLMetric) extends SerializerInstance {
+private class GpuColumnarBatchSerializerInstance(dataSize: SQLMetric) extends SerializerInstance {
 
   override def serializeStream(out: OutputStream): SerializationStream = new SerializationStream {
     private[this] val dOut: DataOutputStream =

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.rapids
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
 import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange, Table}
-import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnarBatchSerializer, GpuColumnVector, GpuExec, GpuExpression, GpuSemaphore}
+import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuExpression, GpuSemaphore}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.{Dependency, NarrowDependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.execution.{BinaryExecNode, ExplainUtils, SparkPlan}
@@ -243,9 +242,6 @@ case class GpuCartesianProductExec(
     "joinOutputRows" -> SQLMetrics.createMetric(sparkContext, "join output rows"),
     "filterTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "filter time"),
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "size of shuffled data"))
-
-  private val serializer: Serializer =
-    new GpuColumnarBatchSerializer(output.size, longMetric("dataSize"))
 
   protected override def doExecute(): RDD[InternalRow] =
     throw new IllegalStateException("This should only be called from columnar")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -97,8 +97,7 @@ abstract class GpuShuffleExchangeExecBase(
     throw new IllegalStateException()
   }
 
-  private val serializer: Serializer =
-    new GpuColumnarBatchSerializer(child.output.size, longMetric("dataSize"))
+  private val serializer: Serializer = new GpuColumnarBatchSerializer(longMetric("dataSize"))
 
   @transient lazy val inputBatchRDD: RDD[ColumnarBatch] = child.executeColumnar()
 


### PR DESCRIPTION
Fixes #849.

This was straightforward to implement, as @revans2 detailed it so excellently in the feature request.

I verified with a profile on a query that the contig splits have been removed after a shuffle.  This cut the wall-clock time on a test query in local mode from over 32 seconds to under 25.

This also removes the unused `numFields` parameter from `GpuColumnarBatchSerializer` since I stumbled across it while doing this PR.  Happy to move that to a separate PR if desired.