### PR TITLE
Remove nodeAffinity from premerge pipeline

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -84,14 +84,7 @@ spec:
     tty: true
   nodeSelector:
     kubernetes.io/os: linux
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: nvidia.com/gpu_type
-            operator: In
-            values: GPU_TYPES
+    nvidia.com/gpu_type: GPU_TYPE
 """
 
 def githubHelper // blossom github helper
@@ -123,7 +116,7 @@ pipeline {
         GITHUB_TOKEN = credentials("github-token")
         URM_CREDS = credentials("urm_creds")
         URM_URL = "https://${ArtifactoryConstants.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
-        GPU_TYPES = credentials("pre-merge_gpu_types")
+        GPU_TYPE = credentials("pre-merge_gpu_type")
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
     }
@@ -197,7 +190,7 @@ pipeline {
                         uploadDocker(IMAGE_PREMERGE)
 
                         pluginPremerge = pluginPremerge.replace("IMAGE_PREMERGE", "$IMAGE_PREMERGE")
-                        pluginPremerge = pluginPremerge.replace("GPU_TYPES", "$GPU_TYPES")
+                        pluginPremerge = pluginPremerge.replace("GPU_TYPE", "$GPU_TYPE")
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

We were seeing premerge job got scheduled to invalid node w/ GPU, like quadro, on blossom. After talked to them, they have disabled support for custom nodeAffinity in user's pod definition. So we have to use the nodeSelector and only specify a single GPU type. Use TITAN_RTX for now (7 available in public pool)

FYI pipeline tested in forked repo