### PR TITLE
fix pvc scheduling issue

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -46,6 +46,7 @@ spec:
       limits:
         cpu: 8
         memory: 16Gi
+        nvidia.com/gpu: 1
     env:
       - name: DOCKER_HOST
         value: tcp://localhost:2375


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Add gpu resource for docker build phase to avoid k8s schedule pod on no privileged (for kubelet) nodes which could cause `has no NodeID annotation` when attach PVC to pod