### PR TITLE
Compare partitioned files in order

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -126,6 +126,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+            </plugin>
             <!-- disable surefire as we are using scalatest only -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR builds on https://github.com/NVIDIA/spark-rapids/pull/823 and adds support to `CompareResults` for comparing data sources with multiple partitions when `ignoreOrdering=false` by introspecting the RDD to get the underlying filenames and then reading each partition in order.

I have tested this on the YARN cluster against HDFS sources, and locally on my desktop running in local mode.

This closes https://github.com/NVIDIA/spark-rapids/issues/852