### PR TITLE
Cleaned up tests and documentation for csv timestamp parsing

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -99,7 +99,7 @@ supported for other types.
 
 ### CSV Dates
 Parsing a `timestamp` as a `date` does not work. The details are documented in this
-[issue](https://github.com/NVIDIA/spark-rapids/issues/122).
+[issue](https://github.com/NVIDIA/spark-rapids/issues/869).
 
 Only a limited set of formats are supported when parsing dates.
 
@@ -115,10 +115,9 @@ Only a limited set of formats are supported when parsing dates.
 The reality is that all of these formats are supported at the same time. The plugin
 will only disable itself if you set a format that it does not support.
 
-### CSV Timestamps
-The CSV parser only works for timestamps that are after 1902 and before the end of 2038.
-This is documented in this [issue](https://github.com/NVIDIA/spark-rapids/issues/122).
+As a work around you can parse the column as a timestamp and then cast it to a date.
 
+### CSV Timestamps
 The CSV parser does not support time zones.  It will ignore any trailing time zone
 information, despite the format asking for a `XXX` or `[XXX]`. As such it is off by
 default and you can enable it by setting 

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -113,7 +113,7 @@ def read_csv_sql(data_path, schema, header, sep):
 @pytest.mark.parametrize('name,schema,sep,header', [
     ('Acquisition_2007Q3.txt', _acq_schema, '|', False),
     ('Performance_2007Q3.txt_0', _perf_schema, '|', False),
-    pytest.param('ts.csv', _date_schema, ',', False, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/122')),
+    pytest.param('ts.csv', _date_schema, ',', False, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/869')),
     ('ts.csv', _ts_schema, ',', False),
     ('str.csv', _bad_str_schema, ',', True),
     ('str.csv', _good_str_schema, ',', True)
@@ -138,9 +138,7 @@ csv_supported_gens = [
         pytest.param(double_gen, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/125')),
         pytest.param(FloatGen(no_nans=True), marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/124')),
         pytest.param(float_gen, marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/125')),
-        # Once https://github.com/NVIDIA/spark-rapids/issues/122 is fixed the reduced range ts gen should be removed
-        TimestampGen(start=datetime(1902, 1, 1, tzinfo=timezone.utc), end=datetime(2038, 1, 1, tzinfo=timezone.utc)),
-        pytest.param(TimestampGen(), marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/122'))]
+        TimestampGen()]
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', csv_supported_gens, ids=idfn)
@@ -211,9 +209,7 @@ csv_supported_ts_parts = ['', # Just the date
 @pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
 def test_ts_formats_round_trip(spark_tmp_path, date_format, ts_part, v1_enabled_list):
     full_format = date_format + ts_part
-    # Once https://github.com/NVIDIA/spark-rapids/issues/122 is fixed the full range should be used
-    data_gen = TimestampGen(start=datetime(1902, 1, 1, tzinfo=timezone.utc),
-            end=datetime(2038, 1, 1, tzinfo=timezone.utc))
+    data_gen = TimestampGen()
     gen = StructGen([('a', data_gen)], nullable=False)
     data_path = spark_tmp_path + '/CSV_DATA'
     schema = gen.data_type


### PR DESCRIPTION
This fixes #122 

Actually cudf fixed the underlying issues.  This just updates the tests and the documentation to reflect what really happened.