### PR TITLE
[BUG] fix IT dockerfile args ordering [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.centos7
+++ b/jenkins/Dockerfile-blossom.integration.centos7
@@ -22,10 +22,9 @@
 #    URM_URL=<maven repo url>
 ###
 ARG CUDA_VER=10.1
+FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 ARG CUDF_VER
 ARG URM_URL
-
-FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 
 #Install java-8, maven, docker image
 RUN yum update -y && \

--- a/jenkins/Dockerfile.integration.centos7
+++ b/jenkins/Dockerfile.integration.centos7
@@ -22,10 +22,9 @@
 #    URM_URL=<maven repo url>
 ###
 ARG CUDA_VER=10.1
+FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 ARG CUDF_VER
 ARG URM_URL
-
-FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 
 #Install java-8, maven, docker image
 RUN yum update -y && \


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

According to the official doc `An ARG declared before a FROM is outside of a build stage, so it can't be used in any instruction after a FROM.` I didn't notice that before.

So make the ordering correct, tested locally.