### PR TITLE
Shrink detect scope to compile only [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -92,6 +92,7 @@ jobs:
             --blackduck.url="https://${{ secrets.BLACKDUCK_URL }}"
             --blackduck.api.token="${{ secrets.BLACKDUCK_API_TOKEN }}"
             --detect.maven.build.command="-pl='$PROJECTS -am'"
+            --detect.maven.included.scopes=compile
             --detect.force.success=false
             --detect.parallel.processors=0
             --detect.project.name="${{ github.repository }}"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

take `compile` only which excludes scope `test` and `provided` to save us from https://github.com/NVIDIA/spark-rapids/pull/879#issuecomment-700956386

Passed on forked repo https://github.com/pxLi/spark-rapids/runs/1186488321?check_suite_focus=true