### PR TITLE
Fix rounding error when casting timestamp to string for timestamps before 1970

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -506,10 +506,12 @@ case class GpuCast(
         }
       }
     }
-    withResource(adjustedMillis.castTo(DType.TIMESTAMP_MILLISECONDS)) { ms =>
-      withResource(ms.asStrings("%Y-%m-%d %H:%M:%S.%3f")) { cv =>
-        GpuColumnVector.from(cv.stringReplaceWithBackrefs(
-          GpuCast.TIMESTAMP_TRUNCATE_REGEX, "\\1\\2\\3"))
+    withResource(adjustedMillis) { adjustedMillis =>
+      withResource(adjustedMillis.castTo(DType.TIMESTAMP_MILLISECONDS)) { ms =>
+        withResource(ms.asStrings("%Y-%m-%d %H:%M:%S.%3f")) { cv =>
+          GpuColumnVector.from(cv.stringReplaceWithBackrefs(
+            GpuCast.TIMESTAMP_TRUNCATE_REGEX, "\\1\\2\\3"))
+        }
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -509,7 +509,7 @@ case class GpuCast(
     }
     withResource(adjustedTimestamp) { adjustedTimestamp =>
       withResource(adjustedTimestamp.castTo(DType.TIMESTAMP_MICROSECONDS)) { micros =>
-        withResource(micros.asStrings("%Y-%m-%d %H:%M:%S.%3f")) { cv =>
+        withResource(micros.asStrings("%Y-%m-%d %H:%M:%S.%6f")) { cv =>
           GpuColumnVector.from(cv.stringReplaceWithBackrefs(
             GpuCast.TIMESTAMP_TRUNCATE_REGEX, "\\1\\2\\3"))
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -493,23 +493,23 @@ case class GpuCast(
   private def castTimestampToString(input: GpuColumnVector) = {
     // https://github.com/rapidsai/cudf/issues/5166
     // The time is off by 1 second if the result is < 0
-    val adjustedMillis = withResource(input.getBase
+    val adjustedTimestamp = withResource(input.getBase
         .castTo(DType.TIMESTAMP_MICROSECONDS)) { micros =>
-      withResource(micros.castTo(DType.INT64)) { ms =>
+      withResource(micros.castTo(DType.INT64)) { micros =>
         withResource(Scalar.fromLong(1000000)) { oneSecond =>
-          withResource(ms.sub(oneSecond)) { plusOne =>
+          withResource(micros.sub(oneSecond)) { plusOne =>
             withResource(Scalar.fromLong(0)) { zero =>
-              withResource(ms.lessThan(zero)) { neg =>
-                neg.ifElse(plusOne, ms)
+              withResource(micros.lessThan(zero)) { neg =>
+                neg.ifElse(plusOne, micros)
               }
             }
           }
         }
       }
     }
-    withResource(adjustedMillis) { adjustedMillis =>
-      withResource(adjustedMillis.castTo(DType.TIMESTAMP_MICROSECONDS)) { ms =>
-        withResource(ms.asStrings("%Y-%m-%d %H:%M:%S.%3f")) { cv =>
+    withResource(adjustedTimestamp) { adjustedTimestamp =>
+      withResource(adjustedTimestamp.castTo(DType.TIMESTAMP_MICROSECONDS)) { micros =>
+        withResource(micros.asStrings("%Y-%m-%d %H:%M:%S.%3f")) { cv =>
           GpuColumnVector.from(cv.stringReplaceWithBackrefs(
             GpuCast.TIMESTAMP_TRUNCATE_REGEX, "\\1\\2\\3"))
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -495,6 +495,7 @@ case class GpuCast(
     // The time is off by 1 second if the result is < 0
     val adjustedTimestamp = withResource(input.getBase
         .castTo(DType.TIMESTAMP_MICROSECONDS)) { micros =>
+      withResource(micros.castTo(DType.INT64)) { micros =>
         withResource(Scalar.fromLong(1000000)) { oneSecond =>
           withResource(micros.sub(oneSecond)) { subOne =>
             withResource(Scalar.fromLong(0)) { zero =>
@@ -503,6 +504,7 @@ case class GpuCast(
               }
             }
           }
+        }
       }
     }
     withResource(adjustedTimestamp) { adjustedTimestamp =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -495,16 +495,14 @@ case class GpuCast(
     // The time is off by 1 second if the result is < 0
     val adjustedTimestamp = withResource(input.getBase
         .castTo(DType.TIMESTAMP_MICROSECONDS)) { micros =>
-      withResource(micros.castTo(DType.INT64)) { micros =>
         withResource(Scalar.fromLong(1000000)) { oneSecond =>
-          withResource(micros.sub(oneSecond)) { plusOne =>
+          withResource(micros.sub(oneSecond)) { subOne =>
             withResource(Scalar.fromLong(0)) { zero =>
               withResource(micros.lessThan(zero)) { neg =>
-                neg.ifElse(plusOne, micros)
+                neg.ifElse(subOne, micros)
               }
             }
           }
-        }
       }
     }
     withResource(adjustedTimestamp) { adjustedTimestamp =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import java.sql.Timestamp
-import java.text.SimpleDateFormat
+import java.time.LocalDateTime
 import java.util.TimeZone
 
 import org.apache.spark.SparkConf
@@ -690,12 +690,13 @@ object CastOpSuite {
 
   def validTimestamps(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
-    val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
     val timestampStrings = Seq(
       "1920-12-31T11:59:59.999",
       "1969-12-31T23:59:59.999",
+      "1969-12-31T23:59:59.999999",
       "1970-01-01T00:00:00.000",
       "1970-01-01T00:00:00.999",
+      "1970-01-01T00:00:00.999111",
       "2020-12-31T11:59:59.990",
       "2020-12-31T11:59:59.900",
       "2020-12-31T11:59:59.000",
@@ -705,8 +706,7 @@ object CastOpSuite {
       "2020-12-31T11:00:00.000"
     )
     val timestamps = timestampStrings
-      .map(s => df.parse(s))
-      .map(d => new Timestamp(d.getTime))
+      .map(s => Timestamp.valueOf(LocalDateTime.parse(s)))
 
     timestamps.toDF("c0")
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -692,7 +692,10 @@ object CastOpSuite {
     import session.sqlContext.implicits._
     val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS")
     val timestampStrings = Seq(
-      "2020-12-31T11:59:59.999",
+      "1920-12-31T11:59:59.999",
+      "1969-12-31T23:59:59.999",
+      "1970-01-01T00:00:00.000",
+      "1970-01-01T00:00:00.999",
       "2020-12-31T11:59:59.990",
       "2020-12-31T11:59:59.900",
       "2020-12-31T11:59:59.000",


### PR DESCRIPTION
This closes https://github.com/NVIDIA/spark-rapids/issues/868