### PR TITLE
Replace whole-buffer slicing with direct refcounting

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuCompressedColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuCompressedColumnVector.java
@@ -94,8 +94,8 @@ public final class GpuCompressedColumnVector extends GpuColumnVectorBase {
         tableMeta.columnMetas(columnMeta, i);
         DType dtype = DType.fromNative(columnMeta.dtype());
         DataType type = GpuColumnVector.getSparkType(dtype);
-        DeviceMemoryBuffer slicedBuffer = compressedBuffer.slice(0, compressedBuffer.getLength());
-        columns[i] = new GpuCompressedColumnVector(type, slicedBuffer, tableMeta);
+        compressedBuffer.incRefCount();
+        columns[i] = new GpuCompressedColumnVector(type, compressedBuffer, tableMeta);
       }
     } catch (Throwable t) {
       for (int i = 0; i < numColumns; ++i) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -436,9 +436,10 @@ class GpuCoalesceIterator(iter: Iterator[ColumnarBatch],
         withResource(codec.createBatchDecompressor(maxDecompressBatchMemory,
             Cuda.DEFAULT_STREAM)) { decompressor =>
           compressedVecs.foreach { cv =>
+            val buffer = cv.getBuffer
             val bufferMeta = cv.getTableMeta.bufferMeta
             // don't currently support switching codecs when partitioning
-            val buffer = cv.getBuffer.slice(0, cv.getBuffer.getLength)
+            buffer.incRefCount()
             decompressor.addBufferToDecompress(buffer, bufferMeta)
           }
           withResource(decompressor.finishAsync()) { outputBuffers =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
@@ -134,7 +134,10 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
       table.foreach(_.close())
     }
 
-    override def getMemoryBuffer: MemoryBuffer = contigBuffer.slice(0, contigBuffer.getLength)
+    override def getMemoryBuffer: MemoryBuffer = {
+      contigBuffer.incRefCount()
+      contigBuffer
+    }
 
     override def getColumnarBatch: ColumnarBatch = {
       if (table.isDefined) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -104,7 +104,8 @@ class RapidsDiskStore(
         logDebug(s"Created mmap buffer for $path $fileOffset:$size")
         hostBuffer = Some(mappedBuffer)
       }
-      hostBuffer.map(b => b.slice(0, b.getLength)).get
+      hostBuffer.foreach(_.incRefCount())
+      hostBuffer.get
     }
 
     override def close(): Unit = synchronized {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -120,7 +120,10 @@ class RapidsHostMemoryStore(
       isInternalPoolAllocated: Boolean) extends RapidsBufferBase(id, size, meta, spillPriority) {
     override val storageTier: StorageTier = StorageTier.HOST
 
-    override def getMemoryBuffer: MemoryBuffer = buffer.slice(0, buffer.getLength)
+    override def getMemoryBuffer: MemoryBuffer = {
+      buffer.incRefCount()
+      buffer
+    }
 
     override protected def releaseResources(): Unit = {
       if (isInternalPoolAllocated) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
@@ -246,7 +246,8 @@ abstract class BatchedTableCompressor(maxBatchMemorySize: Long, stream: Cuda.Str
               buffer
             }
           } else {
-            ct.buffer.slice(0, ct.buffer.getLength)
+            ct.buffer.incRefCount()
+            ct.buffer
           }
           CompressedTable(ct.compressedSize, ct.meta, newBuffer)
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -106,7 +106,8 @@ class RapidsCachingWriter[K, V](
           // Add the table to the shuffle store
           batch.column(0) match {
             case c: GpuColumnVectorFromBuffer =>
-              val buffer = c.getBuffer.slice(0, c.getBuffer.getLength)
+              val buffer = c.getBuffer
+              buffer.incRefCount()
               partSize = buffer.getLength
               uncompressedMetric += partSize
               shuffleStorage.addTable(
@@ -115,7 +116,8 @@ class RapidsCachingWriter[K, V](
                 buffer,
                 SpillPriorities.OUTPUT_FOR_SHUFFLE_INITIAL_PRIORITY)
             case c: GpuCompressedColumnVector =>
-              val buffer = c.getBuffer.slice(0, c.getBuffer.getLength)
+              val buffer = c.getBuffer
+              buffer.incRefCount()
               partSize = buffer.getLength
               val tableMeta = c.getTableMeta
               // update the table metadata for the buffer ID generated above

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -138,7 +138,8 @@ class GpuPartitioningSuite extends FunSuite with Arm {
               if (GpuCompressedColumnVector.isBatchCompressed(partBatch)) {
                 val gccv = columns.head.asInstanceOf[GpuCompressedColumnVector]
                 val bufferId = MockRapidsBufferId(partIndex)
-                val devBuffer = gccv.getBuffer.slice(0, gccv.getBuffer.getLength)
+                val devBuffer = gccv.getBuffer
+                devBuffer.incRefCount()
                 deviceStore.addBuffer(bufferId, devBuffer, gccv.getTableMeta, spillPriority)
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
                   withResource(catalog.acquireBuffer(bufferId)) { buffer =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -127,9 +127,9 @@ class RapidsDiskStoreSuite extends FunSuite with BeforeAndAfterEach with Arm wit
           val expectedBuffer = withResource(catalog.acquireBuffer(bufferId)) { buffer =>
             assertResult(StorageTier.DEVICE)(buffer.storageTier)
             withResource(buffer.getMemoryBuffer) { devbuf =>
-              withResource(HostMemoryBuffer.allocate(devbuf.getLength)) { hostbuf =>
+              closeOnExcept(HostMemoryBuffer.allocate(devbuf.getLength)) { hostbuf =>
                 hostbuf.copyFromDeviceBuffer(devbuf.asInstanceOf[DeviceMemoryBuffer])
-                hostbuf.slice(0, hostbuf.getLength)
+                hostbuf
               }
             }
           }


### PR DESCRIPTION
Fixes #585.

This changes occurrences where we were slicing the range of an entire buffer with a more direct increment of the reference count and reuse of the same buffer object.  This cuts down on unnecessary object creation.