### PR TITLE
Mark reduction corner case tests as xfail on databricks until they can be fixed

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -15,6 +15,7 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql
+from conftest import is_databricks_runtime
 from data_gen import *
 from pyspark.sql.types import *
 from marks import *
@@ -358,6 +359,7 @@ non_nan_all_basic_gens = [byte_gen, short_gen, int_gen, long_gen,
         string_gen, boolean_gen, date_gen, timestamp_gen]
 
 
+@pytest.mark.xfail(is_databricks_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/898')
 @pytest.mark.parametrize('data_gen', non_nan_all_basic_gens, ids=idfn)
 def test_generic_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Just marks the tests as xfail pointing to the issue to fix them.  This way we can avoid failed tests until next week when we can find time to fix the problem.