### PR TITLE
Turn off CollectLimitExec replacement by default

### DIFF
--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -23,6 +23,7 @@ from join_test import create_df
 from generate_expr_test import four_op_df
 from marks import incompat, allow_non_gpu, ignore_order
 
+@allow_non_gpu('CollectLimitExec')
 def test_passing_gpuExpr_as_Expr():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, string_gen)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1750,7 +1750,7 @@ object GpuOverrides {
       "Reduce to single partition and apply limit",
       (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r))
         .disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
-          "of rows in a batch it could help by limiting the number transfered from GPU to CPU"),
+          "of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU"),
     exec[FilterExec](
       "The backend for most filter statements",
       (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1748,7 +1748,9 @@ object GpuOverrides {
         }),
     exec[CollectLimitExec](
       "Reduce to single partition and apply limit",
-      (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r)),
+      (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r))
+        .disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
+          "of rows in a batch it could help by limiting the number transfered from GPU to CPU"),
     exec[FilterExec](
       "The backend for most filter statements",
       (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1750,7 +1750,8 @@ object GpuOverrides {
       "Reduce to single partition and apply limit",
       (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r))
         .disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
-          "of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU"),
+          "of rows in a batch it could help by limiting the number of rows transferred from " +
+          "GPU to CPU"),
     exec[FilterExec](
       "The backend for most filter statements",
       (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/LimitExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/LimitExecSuite.scala
@@ -16,38 +16,47 @@
 
 package com.nvidia.spark.rapids
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.DataTypes
 
 class LimitExecSuite extends SparkQueryCompareTestSuite {
 
-  testSparkResultsAreEqual("limit more than rows", intCsvDf) {
+ /** CollectLimitExec is off by default, turn it on for tests */
+  def enableCollectLimitExec(conf: SparkConf = new SparkConf()): SparkConf = {
+    conf.set("spark.rapids.sql.exec.CollectLimitExec", "true")
+  }
+
+  testSparkResultsAreEqual("limit more than rows", intCsvDf,
+      conf = enableCollectLimitExec()) {
       frame => frame.limit(10).repartition(2)
   }
 
   testSparkResultsAreEqual("limit less than rows equal to batchSize", intCsvDf,
-    conf = makeBatchedBytes(1)) {
+    conf = enableCollectLimitExec(makeBatchedBytes(1))) {
     frame => frame.limit(1).repartition(2)
   }
 
   testSparkResultsAreEqual("limit less than rows applied with batches pending", intCsvDf,
-    conf = makeBatchedBytes(3)) {
+    conf = enableCollectLimitExec(makeBatchedBytes(3))) {
     frame => frame.limit(2).repartition(2)
   }
 
   testSparkResultsAreEqual("limit with no real columns", intCsvDf,
-    conf = makeBatchedBytes(3), repart = 0) {
+    conf = enableCollectLimitExec(makeBatchedBytes(3)), repart = 0) {
     frame => frame.limit(2).selectExpr("pi()")
   }
 
-  testSparkResultsAreEqual("collect with limit", testData) {
+  testSparkResultsAreEqual("collect with limit", testData,
+    conf = enableCollectLimitExec()) {
     frame => {
       import frame.sparkSession.implicits._
       val results: Array[Row] = frame.limit(16).repartition(2).collect()
       results.map(row => if (row.isNullAt(0)) 0 else row.getInt(0)).toSeq.toDF("c0")
     }
   }
-  testSparkResultsAreEqual("collect with limit, repart=4", testData, repart = 4) {
+  testSparkResultsAreEqual("collect with limit, repart=4", testData,
+    conf = enableCollectLimitExec(), repart = 4) {
     frame => {
       import frame.sparkSession.implicits._
       val results: Array[Row] = frame.limit(16).collect()


### PR DESCRIPTION
Replacing CollectLimitExec is causing us to process all partitions in some cases where as the CPU side is able to just run it on a single partition. This in many cases I've seen a performance hit due to this. I also ran a few tests on bigger data with more complex query and turning it off showed the same timings as having it enabled.  So I haven't seen any benefit from it at this point.  There may be cases if we return millions or more rows in a single batch, so just turn it off by default for now and see if we hit any of those cases.

Much more detailed analysis is in the issue: https://github.com/NVIDIA/spark-rapids/issues/882

Note this is triggered when user runs show() or limit.collect(), or take(), etc.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
