### PR TITLE
update getting-started-gcp.md with new component list

### DIFF
--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -50,7 +50,7 @@ gcloud dataproc clusters create $CLUSTER_NAME  \
     --worker-machine-type n1-highmem-32\
     --num-worker-local-ssds 4 \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-${REGION}/rapids/rapids.sh \
-    --optional-components=ANACONDA,JUPYTER,ZEPPELIN \
+    --optional-components=JUPYTER,ZEPPELIN \
     --metadata gpu-driver-provider="NVIDIA" \
     --metadata rapids-runtime=SPARK \
     --bucket $GCS_BUCKET \


### PR DESCRIPTION
The `preview-ubuntu` image now points to an image that does not contain Anaconda; however, it also does not require Anaconda in order to run Jupyter.  The command line in the current getting started guide will thus fail.