### PR TITLE
Dataproc removed ANACONDA as an optional component in preview2

### DIFF
--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -50,7 +50,7 @@ gcloud dataproc clusters create $CLUSTER_NAME  \
     --worker-machine-type n1-highmem-32\
     --num-worker-local-ssds 4 \
     --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-${REGION}/rapids/rapids.sh \
-    --optional-components=ANACONDA,JUPYTER,ZEPPELIN \
+    --optional-components=JUPYTER,ZEPPELIN \
     --metadata gpu-driver-provider="NVIDIA" \
     --metadata rapids-runtime=SPARK \
     --bucket $GCS_BUCKET \


### PR DESCRIPTION
Dataproc removed ANACONDA, trying to install with ANACONDA fails.  Removing from the documentation.  

Ref: https://cloud.google.com/dataproc/docs/release-notes#September_30_2020

I will follow up with a PR to branch-0.3 with this and other doc fixes.  

This was already updated in the instructions in the Dataproc repo https://github.com/GoogleCloudDataproc/initialization-actions/blob/master/rapids/README.md#step-1-create-dataproc-cluster-with-spark-rapids-accelerator