### PR TITLE
Fix RapidsBufferStore NPE when no spillable buffers are available

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -213,8 +213,10 @@ abstract class RapidsBufferStore(
     val bufferToSpill = buffers.nextSpillableBuffer()
     if (bufferToSpill != null) {
       spillAndFreeBuffer(bufferToSpill, stream)
+      bufferToSpill.size
+    } else {
+      0
     }
-    bufferToSpill.size
   }
 
   private def spillAndFreeBuffer(buffer: RapidsBufferBase, stream: Cuda.Stream): Unit = {


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Small bug that I observed could cause an NPE on OOM.