### PR TITLE
Pick a default tableId to use that is non 0 so that flatbuffers allow…

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
@@ -33,7 +33,7 @@ class CopyCompressionCodec extends TableCompressionCodec with Arm {
     closeOnExcept(DeviceMemoryBuffer.allocate(buffer.getLength)) { outputBuffer =>
       outputBuffer.copyFromDeviceBufferAsync(0, buffer, 0, buffer.getLength, stream)
       val meta = MetaUtils.buildTableMeta(
-        tableId,
+        Some(tableId),
         contigTable.getTable,
         buffer,
         codecId,
@@ -81,7 +81,7 @@ class BatchedCopyCompressor(maxBatchMemory: Long, stream: Cuda.Stream)
       closeOnExcept(DeviceMemoryBuffer.allocate(inBuffer.getLength)) { outBuffer =>
         outBuffer.copyFromDeviceBufferAsync(0, inBuffer, 0, inBuffer.getLength, stream)
         val meta = MetaUtils.buildTableMeta(
-          0,
+          None,
           ct.getTable,
           inBuffer,
           CodecType.COPY,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -30,6 +30,12 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.ShuffleBlockBatchId
 
 object MetaUtils extends Arm {
+  // Used in cases where the `tableId` is not known at meta creation. 
+  // We pick a non-zero integer since FlatBuffers prevent mutating the 
+  // field if originally set to the default value as specified in the 
+  // FlatBuffer (0 by default).
+  val TableIdDefaultValue: Int = -1
+
   /**
    * Build a TableMeta message from a Table in contiguous memory
    *
@@ -79,7 +85,7 @@ object MetaUtils extends Arm {
    * @return heap-based flatbuffer message
    */
   def buildTableMeta(
-      tableId: Int,
+      tableId: Option[Int],
       table: Table,
       uncompressedBuffer: DeviceMemoryBuffer,
       codecId: Byte,
@@ -95,7 +101,7 @@ object MetaUtils extends Arm {
     val codecDescrArrayOffset =
       BufferMeta.createCodecBufferDescrsVector(fbb, Array(codecDescrOffset))
     BufferMeta.startBufferMeta(fbb)
-    BufferMeta.addId(fbb, tableId)
+    BufferMeta.addId(fbb, tableId.getOrElse(MetaUtils.TableIdDefaultValue))
     BufferMeta.addSize(fbb, compressedSize)
     BufferMeta.addUncompressedSize(fbb, uncompressedBuffer.getLength)
     BufferMeta.addCodecBufferDescrs(fbb, codecDescrArrayOffset)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -35,7 +35,7 @@ class NvcompLZ4CompressionCodec extends TableCompressionCodec with Arm {
     closeOnExcept(oversizedBuffer) { oversizedBuffer =>
       require(compressedSize <= oversizedBuffer.getLength, "compressed buffer overrun")
       val tableMeta = MetaUtils.buildTableMeta(
-        tableId,
+        Some(tableId),
         contigTable.getTable,
         tableBuffer,
         CodecType.NVCOMP_LZ4,
@@ -137,7 +137,7 @@ class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long, stream: Cuda.Stream)
         val compressedSize = compressedSizes(i)
         require(compressedSize <= buffer.getLength, "compressed buffer overrun")
         val meta = MetaUtils.buildTableMeta(
-          tableId = 0,
+          None,
           contigTable.getTable,
           contigTable.getBuffer,
           CodecType.NVCOMP_LZ4,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -83,7 +83,7 @@ class MetaUtilsSuite extends FunSuite with Arm {
       val compressedSize: Long = 123
       val table = contigTable.getTable
       val buffer = contigTable.getBuffer
-      val meta = MetaUtils.buildTableMeta(tableId, table, buffer, codecType, compressedSize)
+      val meta = MetaUtils.buildTableMeta(Some(tableId), table, buffer, codecType, compressedSize)
 
       val bufferMeta = meta.bufferMeta
       assertResult(tableId)(bufferMeta.id)


### PR DESCRIPTION
…s for mutation later on

Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This fixes a small bug that prevents compression to work with the UCX shuffle, since table ids need to be mutated, and FlatBuffer `mutate` methods don't actually set values if default values are used at construction time. 