### PR TITLE
Iterator to make it easier to work with a window of blocks in the RAPIDS shuffle

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
@@ -38,7 +38,7 @@ trait BlockWithSize {
 case class BlockRange[T <: BlockWithSize](
     block: T, rangeStart: Long, rangeEnd: Long) {
   require(rangeStart <= rangeEnd,
-    s"Instantiated a BlockRange with invalid ranges: $rangeStart to $rangeEnd")
+    s"Instantiated a BlockRange with invalid boundaries: $rangeStart to $rangeEnd")
 
   /**
    * Returns the size of this range in bytes

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import scala.collection.mutable.ArrayBuffer
+
+// Helper trait that callers can use to add blocks to the iterator
+// as long as they can provide a size
+trait BlockWithSize {
+  /**
+   * Abstract method to return the size in bytes of this block
+   * @return Long - size in bytes
+   */
+  def size: Long
+}
+
+/**
+ * Specifies a start and end range of byes for a block.
+ * @param block - a BlockWithSize instance
+ * @param rangeStart - byte offset for the start of the range
+ * @param rangeEnd - byte offset for the end of the range
+ * @tparam T - the specific type of `BlockWithSize`
+ */
+case class BlockRange[T <: BlockWithSize](
+    block: T, rangeStart: Long, rangeEnd: Long) {
+
+  /**
+   * Returns the size of this range in bytes
+   * @return - Long - size in bytes
+   */
+  def rangeSize(): Long = rangeEnd - rangeStart + 1
+
+  def isComplete(): Boolean = rangeEnd == block.size - 1
+}
+
+/**
+ * Given a set of blocks, this iterator returns BlockRanges
+ * of such blocks that fit `windowSize`.
+ *
+ * If a block is too large for the window, the block will be
+ * returned in `next()` until the full block could be covered.
+ *
+ * @param transferBlocks - sequence of blocks to manage
+ * @param windowSize - the size (in bytes) that block ranges should fit
+ * @tparam T - the specific type of `BlockWithSize`
+ * @note this class does not own `transferBlocks`
+ * @note this class is not thread safe
+ */
+class WindowedBlockIterator[T <: BlockWithSize](blocks: Seq[T], windowSize: Long)
+    extends Iterator[Seq[BlockRange[T]]] {
+
+  require(windowSize > 0, s"Invalid window size specified $windowSize")
+
+  case class BlockWindow(start: Long, size: Long) {
+    val end = start + size - 1
+    def move(): BlockWindow = {
+      val windowLength = size - start
+      BlockWindow(start + size, size)
+    }
+  }
+
+  // start the window at byte 0
+  private[this] var window = BlockWindow(0, windowSize)
+  private[this] var done = false
+
+  // helper class that captures the start/end byte offset
+  // for `block` on creation
+  case class BlockWithOffset[T <: BlockWithSize](
+      block: T, startOffset: Long, endOffset: Long)
+
+  private var lastOffset = 0L
+  private[this] val blocksWithOffsets = blocks.map { block =>
+    require(block.size > 0, "Invalid 0-byte block")
+    val startOffset = lastOffset
+    val endOffset = startOffset + block.size - 1
+    lastOffset = endOffset + 1 // for next block
+    BlockWithOffset(block, startOffset, endOffset)
+  }
+
+  case class BlocksForWindow(lastBlockIndex: Option[Int],
+      blockRanges: Seq[BlockRange[T]],
+      hasMoreBlocks: Boolean)
+
+  private def getBlocksForWindow(
+      window: BlockWindow,
+      startingBlock: Int = 0): BlocksForWindow = {
+    val blockRangesInWindow = new ArrayBuffer[BlockRange[T]]()
+    var continue = true
+    var thisBlock = startingBlock
+    var lastBlockIndex: Option[Int] = None
+    while (continue && thisBlock < blocksWithOffsets.size) {
+      val b = blocksWithOffsets(thisBlock)
+      // if at least 1 byte fits within the window, this block should be included
+      if (window.start <= b.endOffset && window.end >= b.startOffset) {
+        var rangeStart = window.start - b.startOffset
+        if (rangeStart < 0) {
+          rangeStart = 0
+        }
+        var rangeEnd = window.end - b.startOffset
+        if (window.end > b.endOffset) {
+          rangeEnd = b.endOffset - b.startOffset
+        }
+        blockRangesInWindow.append(BlockRange[T](b.block, rangeStart, rangeEnd))
+        lastBlockIndex = Some(thisBlock)
+      } else {
+        // skip this block, unless it's before our window starts
+        continue = b.endOffset < window.start
+      }
+      thisBlock = thisBlock + 1
+    }
+    val lastBlock = blockRangesInWindow.last
+    BlocksForWindow(lastBlockIndex,
+      blockRangesInWindow,
+      !continue || !lastBlock.isComplete())
+  }
+
+  private var lastSeenBlock = 0
+  def next(): Seq[BlockRange[T]] = {
+    if (!hasNext) {
+      throw new NoSuchElementException(s"BounceBufferWindow $window has been exhausted.")
+    }
+
+    val blocksForWindow = getBlocksForWindow(window, lastSeenBlock)
+    lastSeenBlock = blocksForWindow.lastBlockIndex.getOrElse(0)
+
+    if (blocksForWindow.hasMoreBlocks) {
+      window = window.move()
+    } else {
+      done = true
+    }
+
+    blocksForWindow.blockRanges
+  }
+
+  override def hasNext: Boolean = !done && blocksWithOffsets.nonEmpty
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
@@ -91,7 +91,7 @@ class WindowedBlockIterator[T <: BlockWithSize](blocks: Seq[T], windowSize: Long
   require(windowSize > 0, s"Invalid window size specified $windowSize")
 
   private case class BlockWindow(start: Long, size: Long) {
-    val end = start + size // non-exclusive end offset
+    val end = start + size // exclusive end offset
     def move(): BlockWindow = {
       BlockWindow(start + size, size)
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIterator.scala
@@ -117,6 +117,10 @@ class WindowedBlockIterator[T <: BlockWithSize](blocks: Seq[T], windowSize: Long
     }
   }
 
+  // the last block index that made it into a window, which
+  // is an index into the `blocksWithOffsets` sequence
+  private[this] var lastSeenBlock = 0
+
   case class BlocksForWindow(lastBlockIndex: Option[Int],
       blockRanges: Seq[BlockRange[T]],
       hasMoreBlocks: Boolean)
@@ -154,7 +158,6 @@ class WindowedBlockIterator[T <: BlockWithSize](blocks: Seq[T], windowSize: Long
       !continue || !lastBlock.isComplete())
   }
 
-  private var lastSeenBlock = 0
   def next(): Seq[BlockRange[T]] = {
     if (!hasNext) {
       throw new NoSuchElementException(s"BounceBufferWindow $window has been exhausted.")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
@@ -27,6 +27,13 @@ class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
     assertThrows[NoSuchElementException](wbi.next)
   }
 
+  test ("1-byte+ ranges are allowed, but 0-byte or negative ranges are not") {
+    assertResult(1)(BlockRange(null, 123, 123).rangeSize())
+    assertResult(2)(BlockRange(null, 123, 124).rangeSize())
+    assertThrows[IllegalArgumentException](BlockRange(null, 123, 122))
+    assertThrows[IllegalArgumentException](BlockRange(null, 123, 121))
+  }
+
   test ("0-byte blocks are not allowed") {
     val block = mock[BlockWithSize]
     when(block.size).thenReturn(0)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import java.util.NoSuchElementException
+
+import org.mockito.Mockito._
+
+class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
+  test ("empty iterator throws on next") {
+    val wbi = new WindowedBlockIterator[BlockWithSize](Seq.empty, 1024)
+    assertResult(false)(wbi.hasNext)
+    assertThrows[NoSuchElementException](wbi.next)
+  }
+
+  test ("0-byte blocks are not allowed") {
+    val block = mock[BlockWithSize]
+    when(block.size).thenReturn(0)
+    assertThrows[IllegalArgumentException](
+      new WindowedBlockIterator[BlockWithSize](Seq(block), 1024))
+  }
+
+  test ("1024 1-byte blocks all fit in 1 1024-byte window") {
+    val mockBlocks = (0 until 1024).map { i =>
+      val block = mock[BlockWithSize]
+      when(block.size).thenReturn(1)
+      block
+    }
+    val wbi = new WindowedBlockIterator[BlockWithSize](mockBlocks, 1024)
+    assertResult(true)(wbi.hasNext)
+    val blockRange = wbi.next()
+    assertResult(1024)(blockRange.size)
+    blockRange.foreach { br =>
+      assertResult(1)(br.rangeSize())
+      assertResult(0)(br.rangeStart)
+      assertResult(0)(br.rangeEnd)
+    }
+    assertResult(false)(wbi.hasNext)
+    assertThrows[NoSuchElementException](wbi.next)
+  }
+
+  test ("a block larger than the window is split between calls to next") {
+    val block = mock[BlockWithSize]
+    when(block.size).thenReturn(2049)
+
+    val wbi = new WindowedBlockIterator[BlockWithSize](Seq(block), 1024)
+    assertResult(true)(wbi.hasNext)
+    val blockRanges = wbi.next()
+    assertResult(1)(blockRanges.size)
+
+    val blockRange = blockRanges.head
+    assertResult(1024)(blockRange.rangeSize())
+    assertResult(0)(blockRange.rangeStart)
+    assertResult(1023)(blockRange.rangeEnd)
+    assertResult(true)(wbi.hasNext)
+
+    val blockRangesMiddle = wbi.next()
+    val blockRangeMiddle = blockRangesMiddle.head
+    assertResult(1024)(blockRangeMiddle.rangeSize())
+    assertResult(1024)(blockRangeMiddle.rangeStart)
+    assertResult(2047)(blockRangeMiddle.rangeEnd)
+    assertResult(true)(wbi.hasNext)
+
+    val blockRangesLastByte = wbi.next()
+    val blockRangeLastByte = blockRangesLastByte.head
+    assertResult(1)(blockRangeLastByte.rangeSize())
+    assertResult(2048)(blockRangeLastByte.rangeStart)
+    assertResult(2048)(blockRangeLastByte.rangeEnd)
+
+    assertResult(false)(wbi.hasNext)
+    assertThrows[NoSuchElementException](wbi.next)
+  }
+
+  test ("a block fits entirely, but a subsequent block doesn't") {
+    val block = mock[BlockWithSize]
+    when(block.size).thenReturn(1000)
+
+    val block2 = mock[BlockWithSize]
+    when(block2.size).thenReturn(1000)
+
+    val wbi = new WindowedBlockIterator[BlockWithSize](Seq(block, block2), 1024)
+    assertResult(true)(wbi.hasNext)
+    val blockRanges = wbi.next()
+    assertResult(2)(blockRanges.size)
+
+    val firstBlock = blockRanges(0)
+    val secondBlock = blockRanges(1)
+
+    assertResult(1000)(firstBlock.rangeSize())
+    assertResult(0)(firstBlock.rangeStart)
+    assertResult(999)(firstBlock.rangeEnd)
+    assertResult(true)(wbi.hasNext)
+
+    assertResult(24)(secondBlock.rangeSize())
+    assertResult(0)(secondBlock.rangeStart)
+    assertResult(23)(secondBlock.rangeEnd)
+    assertResult(true)(wbi.hasNext)
+
+    val blockRangesLastByte = wbi.next()
+    val blockRangeLastByte = blockRangesLastByte.head
+    assertResult(976)(blockRangeLastByte.rangeSize())
+    assertResult(24)(blockRangeLastByte.rangeStart)
+    assertResult(999)(blockRangeLastByte.rangeEnd)
+
+    assertResult(false)(wbi.hasNext)
+    assertThrows[NoSuchElementException](wbi.next)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/WindowedBlockIteratorSuite.scala
@@ -28,10 +28,10 @@ class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
   }
 
   test ("1-byte+ ranges are allowed, but 0-byte or negative ranges are not") {
-    assertResult(1)(BlockRange(null, 123, 123).rangeSize())
-    assertResult(2)(BlockRange(null, 123, 124).rangeSize())
+    assertResult(1)(BlockRange(null, 123, 124).rangeSize())
+    assertResult(2)(BlockRange(null, 123, 125).rangeSize())
+    assertThrows[IllegalArgumentException](BlockRange(null, 123, 123))
     assertThrows[IllegalArgumentException](BlockRange(null, 123, 122))
-    assertThrows[IllegalArgumentException](BlockRange(null, 123, 121))
   }
 
   test ("0-byte blocks are not allowed") {
@@ -54,7 +54,7 @@ class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
     blockRange.foreach { br =>
       assertResult(1)(br.rangeSize())
       assertResult(0)(br.rangeStart)
-      assertResult(0)(br.rangeEnd)
+      assertResult(1)(br.rangeEnd)
     }
     assertResult(false)(wbi.hasNext)
     assertThrows[NoSuchElementException](wbi.next)
@@ -72,21 +72,21 @@ class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
     val blockRange = blockRanges.head
     assertResult(1024)(blockRange.rangeSize())
     assertResult(0)(blockRange.rangeStart)
-    assertResult(1023)(blockRange.rangeEnd)
+    assertResult(1024)(blockRange.rangeEnd)
     assertResult(true)(wbi.hasNext)
 
     val blockRangesMiddle = wbi.next()
     val blockRangeMiddle = blockRangesMiddle.head
     assertResult(1024)(blockRangeMiddle.rangeSize())
     assertResult(1024)(blockRangeMiddle.rangeStart)
-    assertResult(2047)(blockRangeMiddle.rangeEnd)
+    assertResult(2048)(blockRangeMiddle.rangeEnd)
     assertResult(true)(wbi.hasNext)
 
     val blockRangesLastByte = wbi.next()
     val blockRangeLastByte = blockRangesLastByte.head
     assertResult(1)(blockRangeLastByte.rangeSize())
     assertResult(2048)(blockRangeLastByte.rangeStart)
-    assertResult(2048)(blockRangeLastByte.rangeEnd)
+    assertResult(2049)(blockRangeLastByte.rangeEnd)
 
     assertResult(false)(wbi.hasNext)
     assertThrows[NoSuchElementException](wbi.next)
@@ -109,19 +109,19 @@ class WindowedBlockIteratorSuite extends RapidsShuffleTestHelper {
 
     assertResult(1000)(firstBlock.rangeSize())
     assertResult(0)(firstBlock.rangeStart)
-    assertResult(999)(firstBlock.rangeEnd)
+    assertResult(1000)(firstBlock.rangeEnd)
     assertResult(true)(wbi.hasNext)
 
     assertResult(24)(secondBlock.rangeSize())
     assertResult(0)(secondBlock.rangeStart)
-    assertResult(23)(secondBlock.rangeEnd)
+    assertResult(24)(secondBlock.rangeEnd)
     assertResult(true)(wbi.hasNext)
 
     val blockRangesLastByte = wbi.next()
     val blockRangeLastByte = blockRangesLastByte.head
     assertResult(976)(blockRangeLastByte.rangeSize())
     assertResult(24)(blockRangeLastByte.rangeStart)
-    assertResult(999)(blockRangeLastByte.rangeEnd)
+    assertResult(1000)(blockRangeLastByte.rangeEnd)
 
     assertResult(false)(wbi.hasNext)
     assertThrows[NoSuchElementException](wbi.next)


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This introduces an iterator that will be used in subsequent commits for the rapids shuffle. Adding it separate from them to reduce the size of PRs. If reviewers want me to put up a bigger PR with the rest of this I can, but I am trying to keep it reviewable.

The iterator, given a set of blocks will return on `next()` ranges of blocks that pack a window (of bytes)

1. If you have blocks smaller than a window, this puts them back to back within such window (spark's overpartition case)
2. If you have blocks larger than a window, this works to split ranges given the window length (multiple calls to next).

The main advantage of the approach supported by this iterator is that we utilize bounce buffers more efficiently, and also reduce the amount of calls to the underlying protocol.