### PR TITLE
[WIP] Record input metadata when running TPC-* benchmarks

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -41,6 +41,7 @@ object BenchUtils {
   /** Perform benchmark of calling collect */
   def collect(
       spark: SparkSession,
+      input: InputSpecification,
       createDataFrame: SparkSession => DataFrame,
       queryDescription: String,
       filenameStub: String,
@@ -49,6 +50,7 @@ object BenchUtils {
   ): Unit = {
     runBench(
       spark,
+      input,
       createDataFrame,
       Collect(),
       queryDescription,
@@ -60,6 +62,7 @@ object BenchUtils {
   /** Perform benchmark of writing results to CSV */
   def writeCsv(
       spark: SparkSession,
+      input: InputSpecification,
       createDataFrame: SparkSession => DataFrame,
       queryDescription: String,
       filenameStub: String,
@@ -70,6 +73,7 @@ object BenchUtils {
       writeOptions: Map[String, String] = Map.empty): Unit = {
     runBench(
       spark,
+      input,
       createDataFrame,
       WriteCsv(path, mode, writeOptions),
       queryDescription,
@@ -81,6 +85,7 @@ object BenchUtils {
   /** Perform benchmark of writing results to ORC */
   def writeOrc(
       spark: SparkSession,
+      input: InputSpecification,
       createDataFrame: SparkSession => DataFrame,
       queryDescription: String,
       filenameStub: String,
@@ -91,6 +96,7 @@ object BenchUtils {
       writeOptions: Map[String, String] = Map.empty): Unit = {
     runBench(
       spark,
+      input,
       createDataFrame,
       WriteOrc(path, mode, writeOptions),
       queryDescription,
@@ -102,6 +108,7 @@ object BenchUtils {
   /** Perform benchmark of writing results to Parquet */
   def writeParquet(
       spark: SparkSession,
+      input: InputSpecification,
       createDataFrame: SparkSession => DataFrame,
       queryDescription: String,
       filenameStub: String,
@@ -112,6 +119,7 @@ object BenchUtils {
       writeOptions: Map[String, String] = Map.empty): Unit = {
     runBench(
       spark,
+      input,
       createDataFrame,
       WriteParquet(path, mode, writeOptions),
       queryDescription,
@@ -126,6 +134,7 @@ object BenchUtils {
    * variables.
    *
    * @param spark           The Spark session
+   * @param input           Metadata about the input data set.
    * @param createDataFrame Function to create a DataFrame from the Spark session.
    * @param resultsAction   Optional action to perform after creating the DataFrame, with default
    *                        behavior of calling df.collect() but user could provide function to
@@ -137,6 +146,7 @@ object BenchUtils {
    */
   def runBench(
       spark: SparkSession,
+      input: InputSpecification,
       createDataFrame: SparkSession => DataFrame,
       resultsAction: ResultsAction,
       queryDescription: String,
@@ -231,6 +241,7 @@ object BenchUtils {
         queryStartTime.toEpochMilli,
         environment,
         testConfiguration,
+        input,
         "collect",
         Map.empty,
         queryDescription,
@@ -243,6 +254,7 @@ object BenchUtils {
         queryStartTime.toEpochMilli,
         environment,
         testConfiguration,
+        input,
         "csv",
         w.writeOptions,
         queryDescription,
@@ -255,6 +267,7 @@ object BenchUtils {
         queryStartTime.toEpochMilli,
         environment,
         testConfiguration,
+        input,
         "orc",
         w.writeOptions,
         queryDescription,
@@ -267,6 +280,7 @@ object BenchUtils {
         queryStartTime.toEpochMilli,
         environment,
         testConfiguration,
+        input,
         "parquet",
         w.writeOptions,
         queryDescription,
@@ -627,6 +641,7 @@ case class BenchmarkReport(
     startTime: Long,
     env: Environment,
     testConfiguration: TestConfiguration,
+    input: InputSpecification,
     action: String,
     writeOptions: Map[String, String],
     query: String,
@@ -661,6 +676,11 @@ case class Environment(
     envVars: Map[String, String],
     sparkConf: Map[String, String],
     sparkVersion: String)
+
+case class InputSpecification(
+    path: String,
+    format: String,
+    partitions: Map[String, Seq[String]])
 
 sealed trait ResultsAction
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -157,7 +157,7 @@ object TpcdsLikeSpark {
     tables.foreach(_.setup(spark, basePath, format, appendDat))
   }
 
-  private val tables = Array(
+  val tables = Array(
     Table(
       "catalog_sales",
       Seq("cs_sold_date_sk"),

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
@@ -44,6 +44,7 @@ object TpchLikeBench {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.collect(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpch-$query-collect"),
@@ -78,6 +79,7 @@ object TpchLikeBench {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeCsv(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpch-$query-csv"),
@@ -115,6 +117,7 @@ object TpchLikeBench {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeOrc(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpch-$query-csv"),
@@ -152,6 +155,7 @@ object TpchLikeBench {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeParquet(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpch-$query-parquet"),

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeSpark.scala
@@ -24,6 +24,18 @@ import org.apache.spark.sql.types._
 // scalastyle:off line.size.limit
 
 object TpchLikeSpark {
+
+  val tables = Seq(
+    "orders",
+    "lineitem",
+    "customer",
+    "nation",
+    "part",
+    "partsupp",
+    "region",
+    "supplier"
+  )
+
   def csvToParquet(spark: SparkSession, basePath: String, baseOutput: String): Unit = {
     readOrdersCSV(spark, basePath + "/orders.tbl").write.parquet(baseOutput + "/orders.tbl")
     readLineitemCSV(spark, basePath + "/lineitem.tbl").write.parquet(baseOutput + "/lineitem.tbl")

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
@@ -44,6 +44,7 @@ object TpcxbbLikeBench extends Logging {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.collect(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpcxbb-$query-collect"),
@@ -78,6 +79,7 @@ object TpcxbbLikeBench extends Logging {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeCsv(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpcxbb-$query-csv"),
@@ -115,6 +117,7 @@ object TpcxbbLikeBench extends Logging {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeOrc(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpcxbb-$query-csv"),
@@ -152,6 +155,7 @@ object TpcxbbLikeBench extends Logging {
       gcBetweenRuns: Boolean = false): Unit = {
     BenchUtils.writeParquet(
       spark,
+      null,
       spark => getQuery(query)(spark),
       query,
       summaryFilePrefix.getOrElse(s"tpcxbb-$query-parquet"),

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeSpark.scala
@@ -23,6 +23,28 @@ import org.apache.spark.sql.types._
 
 // DecimalType to DoubleType, bigint to LongType
 object TpcxbbLikeSpark {
+
+  val tables = Seq(
+    "customer",
+    "customer_address",
+    "item",
+    "store_sales",
+    "date_dim",
+    "store",
+    "customer_demographics",
+    "product_reviews",
+    "web_sales",
+    "web_clickstreams",
+    "household_demographics",
+    "web_page",
+    "time_dim",
+    "web_returns",
+    "warehouse",
+    "promotion",
+    "store_returns",
+    "inventory",
+    "item_marketprices")
+
   def csvToParquet(spark: SparkSession, basePath: String, baseOutput: String): Unit = {
     readCustomerCSV(spark, basePath + "/customer/").write.parquet(baseOutput + "/customer/")
     readCustomerAddressCSV(spark, basePath + "/customer_address/").write.parquet(baseOutput + "/customer_address/")

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
@@ -45,6 +45,7 @@ class BenchUtilsSuite extends FunSuite with BeforeAndAfterEach {
         Map("spark.sql.adaptive.enabled" -> "true"),
         "3.0.1"),
       testConfiguration = TestConfiguration(gcBetweenRuns = false),
+      input = InputSpecification("", "", Map.empty),
       action = "csv",
       writeOptions = Map("header" -> "true"),
       query = "q1",


### PR DESCRIPTION
The purpose of this PR is to record the following information about the TPC-* input data set in the benchmark summary output JSON file:

- Path to input dataset (which typically indicates the size of the dataset e.g. `/raid/tpcds-3TB-parquet`)
- File format (parquet, csv, orc)
- List of input partition files per table so that we know how many partitions we were running against and also so that we can compare two runs and see if they ran against the same files or not, although I'm not sure how useful that is yet.

One implication of this change is that it changes the UX a little when running from spark-shell. Rather than calling a method like `setupAllParquet` once and then calling `TpcdsLikeBench.runBench` multiple times, `TpcdsLikeBench.runBench` now delegates to `setupAllParquet`. This is simpler UX but could be annoying when running multiple benchmarks from spark-shell, so I'm still thinking about what to do about this.

TODO:

- Consider having `setupAllParquet` check first to see if tables are registered to avoid the cost of re-registering when used from spark-shell.
- Update Benchmark Guide
- Futher testing
