### PR TITLE
fix github action env setup [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -76,8 +76,7 @@ jobs:
           java-version: 1.8
 
       - name: Get project data (maven)
-        run: |
-          echo ::set-env name=projects::$(mvn -am dependency:tree | grep maven-dependency-plugin | awk '{ out="com.nvidia:"$(NF-1);print out }' | grep rapids | xargs | sed -e 's/ /,/g')
+        run: echo "PROJECTS=$(mvn -am dependency:tree | grep maven-dependency-plugin | awk '{ out="com.nvidia:"$(NF-1);print out }' | grep rapids | xargs | sed -e 's/ /,/g')" >> $GITHUB_ENV
 
       - name: Add mask
         run: echo "::add-mask::${{ secrets.BLACKDUCK_URL }}"
@@ -85,8 +84,6 @@ jobs:
       - name: Run synopsys detect
         id: scan_result
         uses: blackducksoftware/github-action@2.0.1
-        env:
-          PROJECTS: ${{ env.projects }}
         with:
           args: >
             --blackduck.url="https://${{ secrets.BLACKDUCK_URL }}"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Seeing warning from github actions about,
```
The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: 
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Update workflow to support new way as [setting-an-environment-variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)

Tested and passed on my forked repo :)