### PR TITLE
Refactor TPC benchmarks to reduce duplicate code

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -105,7 +105,7 @@ The benchmark can be executed with the following syntax to execute the query and
 results to the driver.
 
 ```scala
-import com.nvidia.spark.rapids.tests.common._
+import com.nvidia.spark.rapids.tests._
 val benchmark = new BenchmarkRunner(TpcdsLikeBench)
 benchmark.collect(spark, "q5", iterations=3)
 ```
@@ -115,7 +115,7 @@ to Parquet. There are also `writeCsv` and `writeOrc` methods for writing the out
 files.
 
 ```scala
-import com.nvidia.spark.rapids.tests.common._
+import com.nvidia.spark.rapids.tests._
 val benchmark = new BenchmarkRunner(TpcdsLikeBench)
 benchmark.writeParquet(spark, "q5", "/data/output/tpcds/q5", iterations=3)
 ```
@@ -134,7 +134,7 @@ have the benchmark call `collect()` on the results instead.
 $SPARK_HOME/bin/spark-submit \
     --master $SPARK_MASTER_URL \
     --jars $SPARK_RAPIDS_PLUGIN_JAR,$CUDF_JAR \
-    --class com.nvidia.spark.rapids.tests.common.BenchmarkRunner \
+    --class com.nvidia.spark.rapids.tests.BenchmarkRunner \
     $SPARK_RAPIDS_PLUGIN_INTEGRATION_TEST_JAR \
     --benchmark tpcds \
     --query q5 \

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -105,7 +105,9 @@ The benchmark can be executed with the following syntax to execute the query and
 results to the driver.
 
 ```scala
-TpcdsLikeBench.collect(spark, "q5", iterations=3)
+import com.nvidia.spark.rapids.tests.common._
+val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+benchmark.collect(spark, "q5", iterations=3)
 ```
 
 The benchmark can be executed with the following syntax to execute the query and write the results 
@@ -113,12 +115,14 @@ to Parquet. There are also `writeCsv` and `writeOrc` methods for writing the out
 files.
 
 ```scala
-TpcdsLikeBench.writeParquet(spark, "q5", "/data/output/tpcds/q5", iterations=3)
+import com.nvidia.spark.rapids.tests.common._
+val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+benchmark.writeParquet(spark, "q5", "/data/output/tpcds/q5", iterations=3)
 ```
 
 ## Running Benchmarks from spark-submit
 
-Each of the TPC-* derived benchmarks has a command-line interface, allowing it to be submitted 
+The benchmark runner has a command-line interface, allowing it to be submitted 
 to Spark using `spark-submit` which can be more practical than using the Spark shell when 
 running a series of benchmarks using automation.
 
@@ -130,13 +134,14 @@ have the benchmark call `collect()` on the results instead.
 $SPARK_HOME/bin/spark-submit \
     --master $SPARK_MASTER_URL \
     --jars $SPARK_RAPIDS_PLUGIN_JAR,$CUDF_JAR \
-    --class com.nvidia.spark.rapids.tests.tpcds.TpcdsLikeBench \
+    --class com.nvidia.spark.rapids.tests.common.BenchmarkRunner \
     $SPARK_RAPIDS_PLUGIN_INTEGRATION_TEST_JAR \
+    --benchmark tpcds \
+    --query q5 \
     --input /raid/tpcds-3TB-parquet-largefiles \
     --input-format parquet \
     --output /raid/tpcds-output/tpcds-q5-cpu \
     --output-format parquet \
-    --query q5 \
     --summary-file-prefix tpcds-q5-cpu \
     --iterations 1
 ```

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -34,7 +34,7 @@ object BenchmarkRunner {
     val benchmarks = Map(
       "tpcds" -> TpcdsLikeBench,
       "tpch" -> TpchLikeBench,
-      "tpcxbb" -> TpcxbbLikeBench,
+      "tpcxbb" -> TpcxbbLikeBench
     )
 
     benchmarks.get(conf.benchmark().toLowerCase) match {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.nvidia.spark.rapids.tests.common
+package com.nvidia.spark.rapids.tests
 
+import com.nvidia.spark.rapids.tests.common.{BenchmarkSuite, BenchUtils}
 import com.nvidia.spark.rapids.tests.tpcds.TpcdsLikeBench
 import com.nvidia.spark.rapids.tests.tpch.TpchLikeBench
 import com.nvidia.spark.rapids.tests.tpcxbb.TpcxbbLikeBench

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -648,6 +648,15 @@ class BenchmarkListener(list: ListBuffer[SparkPlanNode]) extends QueryExecutionL
   }
 }
 
+trait BenchmarkSuite {
+  def name(): String
+  def shortName(): String
+  def setupAllParquet(spark: SparkSession, path: String)
+  def setupAllCSV(spark: SparkSession, path: String)
+  def setupAllOrc(spark: SparkSession, path: String)
+  def createDataFrame(spark: SparkSession, query: String): DataFrame
+}
+
 /** Top level benchmark report class */
 case class BenchmarkReport(
     filename: String,

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchmarkRunner.scala
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tests.common
+
+import com.nvidia.spark.rapids.tests.tpcds.TpcdsLikeBench
+import com.nvidia.spark.rapids.tests.tpch.TpchLikeBench
+import com.nvidia.spark.rapids.tests.tpcxbb.TpcxbbLikeBench
+import org.rogach.scallop.ScallopConf
+
+import org.apache.spark.sql.{SaveMode, SparkSession}
+
+/**
+ * The BenchmarkRunner can be submitted using spark-submit to run any of the TPC-* benchmarks.
+ */
+object BenchmarkRunner {
+
+  def main(args: Array[String]): Unit = {
+    val conf = new BenchmarkConf(args)
+
+    val bench: BenchmarkSuite = conf.benchmark() match {
+      case "tpcds" => TpcdsLikeBench
+      case "tpch" => TpchLikeBench
+      case "tpcxbb" => TpcxbbLikeBench
+      case other => throw new IllegalArgumentException(s"Invalid benchmark name: $other")
+    }
+
+    val spark = SparkSession.builder.appName(s"${bench.name()} Like Bench").getOrCreate()
+    conf.inputFormat().toLowerCase match {
+      case "parquet" => bench.setupAllParquet(spark, conf.input())
+      case "csv" => bench.setupAllCSV(spark, conf.input())
+      case "orc" => bench.setupAllOrc(spark, conf.input())
+      case other =>
+        println(s"Invalid input format: $other")
+        System.exit(-1)
+    }
+
+    val runner = new BenchmarkRunner(bench)
+
+    println(s"*** RUNNING ${bench.name()} QUERY ${conf.query()}")
+    conf.output.toOption match {
+      case Some(path) => conf.outputFormat().toLowerCase match {
+        case "parquet" =>
+          runner.writeParquet(
+            spark,
+            conf.query(),
+            path,
+            iterations = conf.iterations(),
+            summaryFilePrefix = conf.summaryFilePrefix.toOption)
+        case "csv" =>
+          runner.writeCsv(
+            spark,
+            conf.query(),
+            path,
+            iterations = conf.iterations(),
+            summaryFilePrefix = conf.summaryFilePrefix.toOption)
+        case "orc" =>
+          runner.writeOrc(
+            spark,
+            conf.query(),
+            path,
+            iterations = conf.iterations(),
+            summaryFilePrefix = conf.summaryFilePrefix.toOption)
+        case _ =>
+          println("Invalid or unspecified output format")
+          System.exit(-1)
+      }
+      case _ =>
+        runner.collect(
+          spark,
+          conf.query(),
+          conf.iterations(),
+          summaryFilePrefix = conf.summaryFilePrefix.toOption)
+    }
+  }
+
+}
+
+/**
+ * This is a wrapper for a specific benchmark suite that provides methods for executing queries
+ * and collecting the results, or writing the results to one of the supported output formats.
+ *
+ * @param bench Benchmark suite (TpcdsLikeBench, TpcxbbLikeBench, or TpchLikeBench).
+ */
+class BenchmarkRunner(val bench: BenchmarkSuite) {
+
+  /**
+   * This method performs a benchmark by executing a query and collecting the results to the
+   * driver and can be called from Spark shell using the following syntax:
+   *
+   * val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+   * benchmark.collect(spark, "q5", 3)
+   *
+   * @param spark The Spark session
+   * @param query The name of the query to run e.g. "q5"
+   * @param iterations The number of times to run the query.
+   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
+   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
+   *                      call `unregisterShuffle`
+   */
+  def collect(
+      spark: SparkSession,
+      query: String,
+      iterations: Int = 3,
+      summaryFilePrefix: Option[String] = None,
+      gcBetweenRuns: Boolean = false): Unit = {
+    BenchUtils.collect(
+      spark,
+      spark => bench.createDataFrame(spark, query),
+      query,
+      summaryFilePrefix.getOrElse(s"${bench.shortName()}-$query-collect"),
+      iterations,
+      gcBetweenRuns)
+  }
+
+  /**
+   * This method performs a benchmark of executing a query and writing the results to CSV files
+   * and can be called from Spark shell using the following syntax:
+   *
+   * val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+   * benchmark.writeCsv(spark, "q5", 3, "/path/to/write")
+   *
+   * @param spark The Spark session
+   * @param query The name of the query to run e.g. "q5"
+   * @param path The path to write the results to
+   * @param mode The SaveMode to use when writing the results
+   * @param writeOptions Write options
+   * @param iterations The number of times to run the query.
+   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
+   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
+   *                      call `unregisterShuffle`
+   */
+  def writeCsv(
+      spark: SparkSession,
+      query: String,
+      path: String,
+      mode: SaveMode = SaveMode.Overwrite,
+      writeOptions: Map[String, String] = Map.empty,
+      iterations: Int = 3,
+      summaryFilePrefix: Option[String] = None,
+      gcBetweenRuns: Boolean = false): Unit = {
+    BenchUtils.writeCsv(
+      spark,
+      spark => bench.createDataFrame(spark, query),
+      query,
+      summaryFilePrefix.getOrElse(s"${bench.shortName()}-$query-csv"),
+      iterations,
+      gcBetweenRuns,
+      path,
+      mode,
+      writeOptions)
+  }
+
+  /**
+   * This method performs a benchmark of executing a query and writing the results to ORC files
+   * and can be called from Spark shell using the following syntax:
+   *
+   * val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+   * benchmark.writeOrc(spark, "q5", 3, "/path/to/write")
+   *
+   * @param spark The Spark session
+   * @param query The name of the query to run e.g. "q5"
+   * @param path The path to write the results to
+   * @param mode The SaveMode to use when writing the results
+   * @param writeOptions Write options
+   * @param iterations The number of times to run the query.
+   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
+   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
+   *                      call `unregisterShuffle`
+   */
+  def writeOrc(
+      spark: SparkSession,
+      query: String,
+      path: String,
+      mode: SaveMode = SaveMode.Overwrite,
+      writeOptions: Map[String, String] = Map.empty,
+      iterations: Int = 3,
+      summaryFilePrefix: Option[String] = None,
+      gcBetweenRuns: Boolean = false): Unit = {
+    BenchUtils.writeOrc(
+      spark,
+      spark => bench.createDataFrame(spark, query),
+      query,
+      summaryFilePrefix.getOrElse(s"${bench.shortName()}-$query-csv"),
+      iterations,
+      gcBetweenRuns,
+      path,
+      mode,
+      writeOptions)
+  }
+
+  /**
+   * This method performs a benchmark of executing a query and writing the results to Parquet files
+   * and can be called from Spark shell using the following syntax:
+   *
+   * val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+   * benchmark.writeParquet(spark, "q5", 3, "/path/to/write")
+   *
+   * @param spark The Spark session
+   * @param query The name of the query to run e.g. "q5"
+   * @param path The path to write the results to
+   * @param mode The SaveMode to use when writing the results
+   * @param writeOptions Write options
+   * @param iterations The number of times to run the query
+   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
+   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
+   *                      call `unregisterShuffle`
+   */
+  def writeParquet(
+      spark: SparkSession,
+      query: String,
+      path: String,
+      mode: SaveMode = SaveMode.Overwrite,
+      writeOptions: Map[String, String] = Map.empty,
+      iterations: Int = 3,
+      summaryFilePrefix: Option[String] = None,
+      gcBetweenRuns: Boolean = false): Unit = {
+    BenchUtils.writeParquet(
+      spark,
+      spark => bench.createDataFrame(spark, query),
+      query,
+      summaryFilePrefix.getOrElse(s"${bench.shortName()}-$query-parquet"),
+      iterations,
+      gcBetweenRuns,
+      path,
+      mode,
+      writeOptions)
+  }
+}
+
+class BenchmarkConf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val benchmark = opt[String](required = true)
+  val input = opt[String](required = true)
+  val inputFormat = opt[String](required = true)
+  val query = opt[String](required = true)
+  val iterations = opt[Int](default = Some(3))
+  val output = opt[String](required = false)
+  val outputFormat = opt[String](required = false)
+  val summaryFilePrefix = opt[String](required = false)
+  verify()
+}

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tests.tpcds
 
-import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
+import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
@@ -16,214 +16,29 @@
 
 package com.nvidia.spark.rapids.tests.tpcds
 
-import com.nvidia.spark.rapids.tests.common.BenchUtils
-import org.rogach.scallop.ScallopConf
+import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
 
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpcdsLikeBench extends Logging {
+object TpcdsLikeBench extends BenchmarkSuite {
+  override def name(): String = "TPC-DS"
 
-  /**
-   * This method performs a benchmark of executing a query and collecting the results to the
-   * driver and can be called from Spark shell using the following syntax:
-   *
-   * TpcdsLikeBench.collect(spark, "q5", 3)
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def collect(
-      spark: SparkSession,
-      query: String,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.collect(
-      spark,
-      spark => TpcdsLikeSpark.query(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcds-$query-collect"),
-      iterations,
-      gcBetweenRuns)
+  override def shortName(): String = "tpcds"
+
+  override def setupAllParquet(spark: SparkSession, path: String): Unit = {
+    TpcdsLikeSpark.setupAllParquet(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to CSV files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcdsLikeBench.writeCsv(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeCsv(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeCsv(
-      spark,
-      spark => TpcdsLikeSpark.query(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcds-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllCSV(spark: SparkSession, path: String): Unit = {
+    TpcdsLikeSpark.setupAllCSV(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to ORC files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcdsLikeBench.writeOrc(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeOrc(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeOrc(
-      spark,
-      spark => TpcdsLikeSpark.query(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcds-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllOrc(spark: SparkSession, path: String): Unit = {
+    TpcdsLikeSpark.setupAllOrc(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to Parquet files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcdsLikeBench.writeParquet(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeParquet(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeParquet(
-      spark,
-      spark => TpcdsLikeSpark.query(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcds-$query-parquet"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def createDataFrame(spark: SparkSession, query: String): DataFrame = {
+    TpcdsLikeSpark.run(spark, query)
   }
-
-  /**
-   * The main method can be invoked by using spark-submit.
-   */
-  def main(args: Array[String]): Unit = {
-    val conf = new Conf(args)
-
-    val spark = SparkSession.builder.appName("TPC-DS Like Bench").getOrCreate()
-    conf.inputFormat().toLowerCase match {
-      case "parquet" => TpcdsLikeSpark.setupAllParquet(spark, conf.input())
-      case "csv" => TpcdsLikeSpark.setupAllCSV(spark, conf.input())
-      case other =>
-        println(s"Invalid input format: $other")
-        System.exit(-1)
-    }
-
-    println(s"*** RUNNING TPC-DS QUERY ${conf.query()}")
-    conf.output.toOption match {
-      case Some(path) => conf.outputFormat().toLowerCase match {
-        case "parquet" =>
-          writeParquet(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "csv" =>
-          writeCsv(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "orc" =>
-          writeOrc(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case _ =>
-          println("Invalid or unspecified output format")
-          System.exit(-1)
-      }
-      case _ =>
-        collect(
-          spark,
-          conf.query(),
-          conf.iterations(),
-          summaryFilePrefix = conf.summaryFilePrefix.toOption)
-    }
-  }
-}
-
-class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val input = opt[String](required = true)
-  val inputFormat = opt[String](required = true)
-  val query = opt[String](required = true)
-  val iterations = opt[Int](default = Some(3))
-  val output = opt[String](required = false)
-  val outputFormat = opt[String](required = false)
-  val summaryFilePrefix = opt[String](required = false)
-  verify()
 }
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
@@ -16,202 +16,29 @@
 
 package com.nvidia.spark.rapids.tests.tpch
 
-import com.nvidia.spark.rapids.tests.common.BenchUtils
-import org.rogach.scallop.ScallopConf
+import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
 
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpchLikeBench {
+object TpchLikeBench extends BenchmarkSuite {
+  override def name(): String = "TPC-H"
 
-  /**
-   * This method performs a benchmark of executing a query and collecting the results to the
-   * driver and can be called from Spark shell using the following syntax:
-   *
-   * TpchLikeBench.collect(spark, "q5", 3)
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def collect(
-      spark: SparkSession,
-      query: String,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.collect(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpch-$query-collect"),
-      iterations,
-      gcBetweenRuns)
+  override def shortName(): String = "tpch"
+
+  override def setupAllParquet(spark: SparkSession, path: String): Unit = {
+    TpchLikeSpark.setupAllParquet(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to CSV files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpchLikeBench.writeCsv(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeCsv(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeCsv(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpch-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllCSV(spark: SparkSession, path: String): Unit = {
+    TpchLikeSpark.setupAllCSV(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to ORC files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpchLikeBench.writeOrc(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeOrc(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeOrc(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpch-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllOrc(spark: SparkSession, path: String): Unit = {
+    TpchLikeSpark.setupAllOrc(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to Parquet files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpchLikeBench.writeParquet(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeParquet(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeParquet(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpch-$query-parquet"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
-  }
-
-  /**
-   * The main method can be invoked by using spark-submit.
-   */
-  def main(args: Array[String]): Unit = {
-    val conf = new Conf(args)
-
-    val spark = SparkSession.builder.appName("TPC-H Like Bench").getOrCreate()
-    conf.inputFormat().toLowerCase match {
-      case "parquet" => TpchLikeSpark.setupAllParquet(spark, conf.input())
-      case "csv" => TpchLikeSpark.setupAllCSV(spark, conf.input())
-      case other =>
-        println(s"Invalid input format: $other")
-        System.exit(-1)
-    }
-
-    println(s"*** RUNNING TPC-H QUERY ${conf.query()}")
-    conf.output.toOption match {
-      case Some(path) => conf.outputFormat().toLowerCase match {
-        case "parquet" =>
-          writeParquet(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "csv" =>
-          writeCsv(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "orc" =>
-          writeOrc(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case _ =>
-          println("Invalid or unspecified output format")
-          System.exit(-1)
-      }
-      case _ =>
-        collect(
-          spark,
-          conf.query(),
-          conf.iterations(),
-          summaryFilePrefix = conf.summaryFilePrefix.toOption)
-    }
+  override def createDataFrame(spark: SparkSession, query: String): DataFrame = {
+    getQuery(query)(spark)
   }
 
   private def getQuery(query: String)(spark: SparkSession) = {
@@ -240,15 +67,4 @@ object TpchLikeBench {
       case "q22" => Q22Like(spark)
     }
   }
-}
-
-class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val input = opt[String](required = true)
-  val inputFormat = opt[String](required = true)
-  val query = opt[String](required = true)
-  val iterations = opt[Int](default = Some(3))
-  val output = opt[String](required = false)
-  val outputFormat = opt[String](required = false)
-  val summaryFilePrefix = opt[String](required = false)
-  verify()
 }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tests.tpch
 
-import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
+import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.tests.tpcxbb
 
-import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
+import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
@@ -16,200 +16,29 @@
 
 package com.nvidia.spark.rapids.tests.tpcxbb
 
-import com.nvidia.spark.rapids.tests.common.BenchUtils
-import org.rogach.scallop.ScallopConf
+import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
 
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpcxbbLikeBench extends Logging {
+object TpcxbbLikeBench  extends BenchmarkSuite {
+  override def name(): String = "TPC-xBB"
 
-  /**
-   * This method performs a benchmark of executing a query and collecting the results to the
-   * driver and can be called from Spark shell using the following syntax:
-   *
-   * TpcxbbLikeBench.collect(spark, "q5", 3)
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def collect(
-      spark: SparkSession,
-      query: String,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.collect(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcxbb-$query-collect"),
-      iterations,
-      gcBetweenRuns)
+  override def shortName(): String = "Tpcxbb"
+
+  override def setupAllParquet(spark: SparkSession, path: String): Unit = {
+    TpcxbbLikeSpark.setupAllParquet(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to CSV files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcxbbLikeBench.writeCsv(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeCsv(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeCsv(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcxbb-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllCSV(spark: SparkSession, path: String): Unit = {
+    TpcxbbLikeSpark.setupAllCSV(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to ORC files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcxbbLikeBench.writeOrc(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeOrc(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeOrc(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcxbb-$query-csv"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
+  override def setupAllOrc(spark: SparkSession, path: String): Unit = {
+    TpcxbbLikeSpark.setupAllOrc(spark, path)
   }
 
-  /**
-   * This method performs a benchmark of executing a query and writing the results to Parquet files
-   * and can be called from Spark shell using the following syntax:
-   *
-   * TpcxbbLikeBench.writeParquet(spark, "q5", 3, "/path/to/write")
-   *
-   * @param spark The Spark session
-   * @param query The name of the query to run e.g. "q5"
-   * @param path The path to write the results to
-   * @param mode The SaveMode to use when writing the results
-   * @param writeOptions Write options
-   * @param iterations The number of times to run the query.
-   * @param summaryFilePrefix Optional prefix for the generated JSON summary file.
-   * @param gcBetweenRuns Whether to call `System.gc` between iterations to cause Spark to
-   *                      call `unregisterShuffle`
-   */
-  def writeParquet(
-      spark: SparkSession,
-      query: String,
-      path: String,
-      mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty,
-      iterations: Int = 3,
-      summaryFilePrefix: Option[String] = None,
-      gcBetweenRuns: Boolean = false): Unit = {
-    BenchUtils.writeParquet(
-      spark,
-      spark => getQuery(query)(spark),
-      query,
-      summaryFilePrefix.getOrElse(s"tpcxbb-$query-parquet"),
-      iterations,
-      gcBetweenRuns,
-      path,
-      mode,
-      writeOptions)
-  }
-
-  def main(args: Array[String]): Unit = {
-    val conf = new Conf(args)
-
-    val spark = SparkSession.builder.appName("TPCxBB Bench").getOrCreate()
-
-    conf.inputFormat().toLowerCase match {
-      case "parquet" => TpcxbbLikeSpark.setupAllParquet(spark, conf.input())
-      case "csv" => TpcxbbLikeSpark.setupAllCSV(spark, conf.input())
-      case other =>
-        println(s"Invalid input format: $other")
-        System.exit(-1)
-    }
-
-    println(s"*** RUNNING TPCx-BB QUERY ${conf.query()}")
-    conf.output.toOption match {
-      case Some(path) => conf.outputFormat().toLowerCase match {
-        case "parquet" =>
-          writeParquet(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "csv" =>
-          writeCsv(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case "orc" =>
-          writeOrc(
-            spark,
-            conf.query(),
-            path,
-            iterations = conf.iterations(),
-            summaryFilePrefix = conf.summaryFilePrefix.toOption)
-        case _ =>
-          println("Invalid or unspecified output format")
-          System.exit(-1)
-      }
-      case _ =>
-        collect(
-          spark,
-          conf.query(),
-          conf.iterations(),
-          summaryFilePrefix = conf.summaryFilePrefix.toOption)
-    }
+  override def createDataFrame(spark: SparkSession, query: String): DataFrame = {
+    getQuery(query)(spark)
   }
 
   def getQuery(query: String): SparkSession => DataFrame = {
@@ -256,13 +85,3 @@ object TpcxbbLikeBench extends Logging {
   }
 }
 
-class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val input = opt[String](required = true)
-  val inputFormat = opt[String](required = true)
-  val query = opt[String](required = true)
-  val iterations = opt[Int](default = Some(3))
-  val output = opt[String](required = false)
-  val outputFormat = opt[String](required = false)
-  val summaryFilePrefix = opt[String](required = false)
-  verify()
-}

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids.tests.common.{BenchmarkRunner, BenchmarkSuite}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 object TpcxbbLikeBench  extends BenchmarkSuite {
-  override def name(): String = "TPC-xBB"
+  override def name(): String = "TPCx-BB"
 
   override def shortName(): String = "Tpcxbb"
 
@@ -84,4 +84,3 @@ object TpcxbbLikeBench  extends BenchmarkSuite {
     }
   }
 }
-


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR refactors the TPC-* benchmarks to move the duplicate code that was implemented in each one into a new `BenchmarkRunner` object and class. The benchmark runner has a main method and can therefore be submitted to spark-submit with the specific benchmark chosen by a `--benchmark` argument.

There are no functional changes in this PR but it does change the UX a little when running benchmarks from the Spark shell. Data sources can still be registered in the same way as before by calling the `TpcdsLikeSpark.setupAll*` methods but queries must now be executed by creating a benchmark runner, as follows:

```scala
import com.nvidia.spark.rapids.tests.common._
val benchmark = new BenchmarkRunner(TpcdsLikeBench)
benchmark.writeParquet(spark, "q5", "/data/output/tpcds/q5", iterations=3)
```





