### PR TITLE
[WIP] First shot at making integration tests run faster

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -41,13 +41,15 @@ else
     RUN_DIR="$SCRIPTPATH"/target/run_dir
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
-    "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
-        --conf "spark.driver.extraJavaOptions=-Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
-        --conf 'spark.executor.extraJavaOptions=-Duser.timezone=GMT' \
-        --conf 'spark.sql.session.timeZone=UTC' \
-        --conf 'spark.sql.shuffle.partitions=12' \
-        $SPARK_SUBMIT_FLAGS \
-        "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
+    export EXTRA_CP="${ALL_JARS// /:}"
+    #"$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
+    #    --conf "spark.driver.extraJavaOptions=-Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
+    #    --conf 'spark.executor.extraJavaOptions=-Duser.timezone=GMT' \
+    #    --conf 'spark.sql.session.timeZone=UTC' \
+    #    --conf 'spark.sql.shuffle.partitions=12' \
+    #    $SPARK_SUBMIT_FLAGS \
+    python      "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
+          -n 4 \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
           "$TEST_ARGS" \

--- a/jenkins/Dockerfile-blossom.ubuntu16
+++ b/jenkins/Dockerfile-blossom.ubuntu16
@@ -35,6 +35,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     openjdk-8-jdk python3.6 python3-pip tzdata git
 
 RUN ln -s /usr/bin/python3.6 /usr/bin/python
-RUN python -m pip install pytest sre_yield requests pandas pyarrow
+RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist
 
 RUN apt install -y inetutils-ping expect


### PR DESCRIPTION
I had a bad experience the other day running tests on a databricks node that took about 2 hours to complete.  Our integration tests take about 52 mins right now for me to run and I know we have all wanted it to go a bit faster.

By using [findspark](https://github.com/minrk/findspark) and [pytest_xdist](https://github.com/pytest-dev/pytest-xdist) I have been able to run the full set of tests in 12 mins on a 16GB V100.

This patch is by no means ready to be merged in, but it a proof of concept that it is possible. I mostly putting this up to checkpoint the work I have done and then see if I should spend a day or so to get it fully ready that we can use in everywhere.

This works by restricting the amount of memory that is allocated on the GPU, so we can have multiple local mode clusters all running at the same time on the same GPU.  In theory we could do the same type of thing against a full on cluster, but we would need to then limit the number of executors launched on the cluster so we get the same kind of parallelism.

The one big downside to this approach is that xdist has a main controller process and then child processes that are told what tests to run by the controller.  This results in the controller launching it's own spark application too that never is used, so if I want to run with N parallelism I need the GPU/Cluster to be divided into N+1 pieces, with one of those pieces idle.

I am also happy if someone else wants to take over this work.
