### PR TITLE
Stop reporting totalTime metric for GpuShuffleExchangeExec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ShuffledBatchRDD.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ShuffledBatchRDD.scala
@@ -192,15 +192,7 @@ class ShuffledBatchRDD(
           context,
           sqlMetricsReporter)
     }
-    var ret : Iterator[ColumnarBatch] = null
-    val nvtxRange = new NvtxWithMetrics(
-      "Shuffle getPartitions", NvtxColor.DARK_GREEN, metrics(GpuMetricNames.TOTAL_TIME))
-    try {
-      ret = reader.read().asInstanceOf[Iterator[Product2[Int, ColumnarBatch]]].map(_._2)
-    } finally {
-      nvtxRange.close()
-    }
-    ret
+    reader.read().asInstanceOf[Iterator[Product2[Int, ColumnarBatch]]].map(_._2)
   }
 
   override def clearDependencies() {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Spark does not report a `totalTime` metric for shuffle exchanges and the metric we were reporting for the non AQE case was misleading/confusing, and we reported zero for the AQE case.

This PR removes the `totalTime` metric.

This closes https://github.com/NVIDIA/spark-rapids/issues/952