### PR TITLE
[WIP] decimal meta adjustment for GPU runtime

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -532,6 +532,7 @@ object GpuOverrides {
         // There are so many of these that we don't need to print them out.
         override def print(append: StringBuilder, depth: Int, all: Boolean): Unit = {}
       }),
+    // TODO: maybe we should apply the conversion between decimal32 and decimal64 to promote precision?
     expr[PromotePrecision](
       "Eliminates unnecessary PromotePrecision expressions in GPU runtime",
       (a, conf, p, r) => new UnaryExprMeta[PromotePrecision](a, conf, p, r) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import scala.math.max
+
+import org.apache.spark.sql.catalyst.expressions.{CheckOverflow, Expression, PromotePrecision}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.{GpuAdd, GpuDivide, GpuIntegralDivide, GpuMultiply, GpuPmod, GpuRemainder, GpuSubtract}
+import org.apache.spark.sql.types.{DataType, DecimalType}
+
+/**
+ * A GPU substitution of CheckOverflow, serves as a placeholder.
+ */
+case class GpuCheckOverflow(child: Expression) extends GpuUnaryExpression {
+  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = input
+  override def dataType: DataType = child.dataType
+}
+
+/**
+ * A GPU substitution of PromotePrecision, serves as a placeholder.
+ */
+case class GpuPromotePrecision(child: Expression) extends GpuUnaryExpression {
+  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = input
+  override def dataType: DataType = child.dataType
+}
+
+/** Meta-data for checkOverflow */
+class CheckOverflowExprMeta(
+    expr: CheckOverflow,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: ConfKeysAndIncompat)
+  extends UnaryExprMeta[CheckOverflow](expr, conf, parent, rule) {
+  override def convertToGpu(child: Expression): GpuExpression = {
+    child match {
+      // For Add | Subtract | Remainder | Pmod | IntegralDivide,
+      // resultTypes have less or same precision compared with inputTypes.
+      // Since inputTypes are checked in PromotePrecisionExprMeta, resultTypes are also safe.
+      case _: GpuAdd =>
+      case _: GpuSubtract =>
+      case _: GpuRemainder =>
+      case _: GpuPmod =>
+      case _: GpuIntegralDivide =>
+      // For Multiply, we need to infer result's precision from inputs' precision.
+      case GpuMultiply(GpuPromotePrecision(lhs: GpuCast), _) =>
+        val dt = lhs.dataType.asInstanceOf[DecimalType]
+        if (dt.precision * 2 + 1 > DecimalExpressions.gpuMaxPrecision) {
+          throw new IllegalStateException("DecimalPrecision overflow may occur because " +
+            s"inferred result precision(${dt.precision * 2 + 1}) exceeds GpuMaxPrecision.")
+        }
+      // For Divide, we need to infer result's precision from inputs' precision and scale.
+      case GpuDivide(GpuPromotePrecision(lhs: GpuCast), _) =>
+        val dt = lhs.dataType.asInstanceOf[DecimalType]
+        val scale = max(DecimalType.MINIMUM_ADJUSTED_SCALE, dt.precision + dt.scale + 1)
+        if (dt.precision + scale > DecimalExpressions.gpuMaxPrecision) {
+          throw new IllegalStateException("DecimalPrecision overflow may occur because " +
+            s"inferred result precision(${dt.precision + scale}) exceeds GpuMaxPrecision.")
+        }
+      case c =>
+        throw new IllegalAccessException(
+          s"Unknown child expression of CheckOverflow ${c.prettyName}.")
+    }
+    GpuCheckOverflow(child)
+  }
+}
+
+/** Meta-data for promotePrecision */
+class PromotePrecisionExprMeta(
+    expr: PromotePrecision,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: ConfKeysAndIncompat)
+  extends UnaryExprMeta[PromotePrecision](expr, conf, parent, rule) {
+  override def convertToGpu(child: Expression): GpuExpression = {
+    child match {
+      case GpuCast(cc: Expression, dt: DecimalType, a: Boolean, t: Option[String]) =>
+        GpuPromotePrecision(GpuCast(cc, DecimalExpressions.gpuCheckPrecision(dt), a, t))
+      case c => throw new IllegalStateException(
+        s"Child expression of PromotePrecision should always be GpuCast with DecimalType, " +
+          s"but found ${c.prettyName}")
+    }
+  }
+}
+
+object DecimalExpressions {
+  // Underlying storage type of decimal data in cuDF is int64_t, whose max capacity is 19.
+  val gpuMaxPrecision: Int = 19
+
+  /**
+   * Check whether there exists Gpu precision overflow for given DecimalType.
+   * And try to shrink scale to avoid it if possible. Otherwise, an exception will be thrown.
+   *
+   * @return checked DecimalType
+   */
+  def gpuCheckPrecision(dt: DecimalType): DecimalType = {
+    if (dt.precision > DecimalExpressions.gpuMaxPrecision) {
+      if (!SQLConf.get.decimalOperationsAllowPrecisionLoss) {
+        throw new IllegalStateException(
+          "Failed to reduce scale of decimalType which exceeds GpuMaxPrecision, " +
+            "because SQLConf.get.decimalOperationsAllowPrecisionLoss is disabled.")
+      }
+      val scale = dt.scale - (dt.precision - DecimalExpressions.gpuMaxPrecision)
+      return DecimalType(DecimalExpressions.gpuMaxPrecision, scale)
+    }
+    dt
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -21,24 +21,49 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers.convertToAnyShouldWrapper
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.expressions.{Add, Cast, Expression, Literal, PromotePrecision}
-import org.apache.spark.sql.rapids.GpuAdd
-import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType}
+import org.apache.spark.sql.catalyst.expressions.{Add, Cast, CheckOverflow, Expression, Literal, Multiply, Pmod, PromotePrecision, Subtract}
+import org.apache.spark.sql.rapids._
+import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType}
 
 
 class DecimalUnitTest extends FunSuite with Arm {
-  test("PromotePrecision elimination test") {
+  test("GpuDecimalExpressionMeta") {
     val rapidsConf = new RapidsConf(Map[String, String]())
     val testWrapper = (input: Expression, expected: Expression) => {
       val output = GpuOverrides.wrapExpr(input, rapidsConf, None).convertToGpu()
       expected.semanticEquals(output) shouldBe true
     }
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val exp1 = PromotePrecision(Cast(Literal(12.345f), DoubleType))
-      testWrapper(exp1, GpuLiteral(12.345f, FloatType))
-      val exp2 = Add(exp1, Cast(Literal(123), DoubleType))
-      testWrapper(exp2,
-        GpuAdd(GpuLiteral(12.345f, FloatType), GpuCast(GpuLiteral(123, IntegerType), DoubleType)))
+    val sparkConf = new SparkConf()
+      .set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
+    TestUtils.withGpuSparkSession(sparkConf) { _ =>
+      testWrapper(
+        PromotePrecision(Cast(Literal(123.45), DecimalType(10, 3))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(123.45, DoubleType), DecimalType(10, 3))))
+      testWrapper(
+        PromotePrecision(Cast(Literal(1000.123456789), DecimalType(22, 10))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1000.123456789, DoubleType), DecimalType(19, 7))))
+      testWrapper(
+        PromotePrecision(Cast(Literal(123456789.123), DecimalType(24, 3))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(123456789.123, DoubleType), DecimalType(19, -2))))
+
+      var cpuPP = PromotePrecision(Cast(Literal(1), DecimalType(20, 3)))
+      var gpuPP = GpuPromotePrecision(GpuCast(GpuLiteral(1, IntegerType), DecimalType(19, 2)))
+      testWrapper(
+        CheckOverflow(Add(cpuPP, cpuPP), DecimalType(20, 3), false),
+        GpuCheckOverflow(GpuAdd(gpuPP, gpuPP)))
+      testWrapper(
+        CheckOverflow(Subtract(cpuPP, cpuPP), DecimalType(20, 3), false),
+        GpuCheckOverflow(GpuSubtract(gpuPP, gpuPP)))
+      testWrapper(
+        CheckOverflow(Pmod(cpuPP, cpuPP), DecimalType(20, 3), false),
+        GpuCheckOverflow(GpuPmod(gpuPP, gpuPP)))
+      cpuPP = PromotePrecision(Cast(Literal(1), DecimalType(10, 3)))
+      gpuPP = GpuPromotePrecision(GpuCast(GpuLiteral(1, IntegerType), DecimalType(10, 3)))
+      assertThrows[IllegalStateException] {
+        testWrapper(
+          CheckOverflow(Multiply(cpuPP, cpuPP), DecimalType(20, 6), false),
+          GpuCheckOverflow(GpuMultiply(gpuPP, gpuPP)))
+      }
     }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -1,0 +1,28 @@
+package com.nvidia.spark.rapids.unit
+
+import com.nvidia.spark.rapids._
+import org.scalatest.FunSuite
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.expressions.{Add, Cast, Expression, Literal, PromotePrecision}
+import org.apache.spark.sql.rapids.GpuAdd
+import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType}
+
+
+class DecimalUnitTest extends FunSuite with Arm {
+  test("PromotePrecision elimination test") {
+    val rapidsConf = new RapidsConf(Map[String, String]())
+    val testWrapper = (input: Expression, expected: Expression) => {
+      val output = GpuOverrides.wrapExpr(input, rapidsConf, None).convertToGpu()
+      expected.semanticEquals(output) shouldBe true
+    }
+    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+      val exp1 = PromotePrecision(Cast(Literal(12.345f), DoubleType))
+      testWrapper(exp1, GpuLiteral(12.345f, FloatType))
+      val exp2 = Add(exp1, Cast(Literal(123), DoubleType))
+      testWrapper(exp2,
+        GpuAdd(GpuLiteral(12.345f, FloatType), GpuCast(GpuLiteral(123, IntegerType), DoubleType)))
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.nvidia.spark.rapids.unit
 
 import com.nvidia.spark.rapids._

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -31,23 +31,34 @@ class DecimalUnitTest extends FunSuite with Arm {
     val rapidsConf = new RapidsConf(Map[String, String]())
     val testWrapper = (input: Expression, expected: Expression) => {
       val output = GpuOverrides.wrapExpr(input, rapidsConf, None).convertToGpu()
+      println(output.sql)
+      println(expected.sql)
       expected.semanticEquals(output) shouldBe true
     }
-    val sparkConf = new SparkConf()
-      .set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
+    val sparkConf = new SparkConf().set("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
     TestUtils.withGpuSparkSession(sparkConf) { _ =>
+      // no need to adjust
       testWrapper(
-        PromotePrecision(Cast(Literal(123.45), DecimalType(10, 3))),
-        GpuPromotePrecision(GpuCast(GpuLiteral(123.45, DoubleType), DecimalType(10, 3))))
+        PromotePrecision(Cast(Literal(1.0), DecimalType(10, 3))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1.0, DoubleType), DecimalType(10, 3))))
+      // GPU_MAX_PRECISION - intDigits = 19 - (22 - 10) = 7
+      // minScaleValue = min(10, GPU_MINIMUM_ADJUSTED_SCALE) = 6
+      // adjustedScale = max(7, 6) = 7
       testWrapper(
-        PromotePrecision(Cast(Literal(1000.123456789), DecimalType(22, 10))),
-        GpuPromotePrecision(GpuCast(GpuLiteral(1000.123456789, DoubleType), DecimalType(19, 7))))
+        PromotePrecision(Cast(Literal(1.0), DecimalType(22, 10))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1.0, DoubleType), DecimalType(19, 7))))
+      // GPU_MAX_PRECISION - intDigits = 19 - (20 - 5) = 4
+      // minScaleValue = min(5, GPU_MINIMUM_ADJUSTED_SCALE) = 5
+      // adjustedScale = max(4, 5) = 5
       testWrapper(
-        PromotePrecision(Cast(Literal(123456789.123), DecimalType(24, 3))),
-        GpuPromotePrecision(GpuCast(GpuLiteral(123456789.123, DoubleType), DecimalType(19, -2))))
+        PromotePrecision(Cast(Literal(1.0), DecimalType(20, 5))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1.0, DoubleType), DecimalType(19, 5))))
 
-      var cpuPP = PromotePrecision(Cast(Literal(1), DecimalType(20, 3)))
-      var gpuPP = GpuPromotePrecision(GpuCast(GpuLiteral(1, IntegerType), DecimalType(19, 2)))
+      // GPU_MAX_PRECISION - intDigits = 19 - (30 - 15) = 4
+      // minScaleValue = min(15, GPU_MINIMUM_ADJUSTED_SCALE) = 6
+      // adjustedScale = max(4, 6) = 6
+      var cpuPP = PromotePrecision(Cast(Literal(1), DecimalType(30, 15)))
+      var gpuPP = GpuPromotePrecision(GpuCast(GpuLiteral(1, IntegerType), DecimalType(19, 6)))
       testWrapper(
         CheckOverflow(Add(cpuPP, cpuPP), DecimalType(20, 3), false),
         GpuCheckOverflow(GpuAdd(gpuPP, gpuPP)))
@@ -57,6 +68,7 @@ class DecimalUnitTest extends FunSuite with Arm {
       testWrapper(
         CheckOverflow(Pmod(cpuPP, cpuPP), DecimalType(20, 3), false),
         GpuCheckOverflow(GpuPmod(gpuPP, gpuPP)))
+
       cpuPP = PromotePrecision(Cast(Literal(1), DecimalType(10, 3)))
       gpuPP = GpuPromotePrecision(GpuCast(GpuLiteral(1, IntegerType), DecimalType(10, 3)))
       assertThrows[IllegalStateException] {
@@ -64,6 +76,16 @@ class DecimalUnitTest extends FunSuite with Arm {
           CheckOverflow(Multiply(cpuPP, cpuPP), DecimalType(20, 6), false),
           GpuCheckOverflow(GpuMultiply(gpuPP, gpuPP)))
       }
+    }
+
+    sparkConf.set("spark.sql.decimalOperations.allowPrecisionLoss", "false")
+    TestUtils.withGpuSparkSession(sparkConf) { _ =>
+      testWrapper(
+        PromotePrecision(Cast(Literal(1.0), DecimalType(22, 10))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1.0, DoubleType), DecimalType(19, 10))))
+      testWrapper(
+        PromotePrecision(Cast(Literal(1.0), DecimalType(30, 20))),
+        GpuPromotePrecision(GpuCast(GpuLiteral(1.0, DoubleType), DecimalType(19, 19))))
     }
   }
 }


### PR DESCRIPTION
Catalyst analyzer will apply `promotePrecision` and `checkOverflow` on binary arithmetic expressions if data in both sides of expressions are decimal types (refer to [link](https://github.com/apache/spark/blob/branch-3.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecision.scala#L94)).

Considering GPU_MAX_PRECISION of decimal type can only be up to 19 (half of MAX_PRECISION in spark),  we need to reapply precision and scale adjustment with GPU constraints. To achieve this, we introduce two new expression-rules `PromotePrecisionExprMeta` and `CheckOverflowExprMeta` into GpuOverrides.  

In order to keep align with decimal overflow controlling behavior of spark, we follow the same strategy as catalyst with GPU constraints replacement. But in spark catalyst runtime, overflow decimal value will be replaced by null. (Otherwise, overflow exception will be thrown.)  In cuDF runtime, overflow check for decimal operations is still missing.     