### PR TITLE
Change in Spark caused the 3.1.0 CI to fail

### DIFF
--- a/shims/spark310/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetMaterializer.scala
+++ b/shims/spark310/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetMaterializer.scala
@@ -29,14 +29,21 @@ import org.apache.spark.sql.types.StructType
 /**
  * This class exposes the ParquetRecordMaterializer
  */
-class ParquetRecordMaterializer(parquetSchema: MessageType,
+class ParquetRecordMaterializer(
+   parquetSchema: MessageType,
    catalystSchema: StructType,
    schemaConverter: ParquetToSparkSchemaConverter,
    convertTz: Option[ZoneId],
    datetimeRebaseMode: LegacyBehaviorPolicy.Value) extends RecordMaterializer[InternalRow] {
 
   private val rootConverter = new ParquetRowConverter(
-    schemaConverter, parquetSchema, catalystSchema, convertTz, datetimeRebaseMode, NoopUpdater)
+    schemaConverter,
+    parquetSchema,
+    catalystSchema,
+    convertTz,
+    datetimeRebaseMode,
+    LegacyBehaviorPolicy.EXCEPTION,
+    NoopUpdater)
 
   override def getCurrentRecord: InternalRow = rootConverter.currentRecord
 


### PR DESCRIPTION
Hard coding the value for rebasing INT96 to EXCEPTION since we don't use INT96 in writing cache

Here is the offending commit https://github.com/apache/spark/commit/a44e008de3ae5aecad9e0f1a7af6a1e8b0d97f4e

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
