### PR TITLE
Skip post-clean if aborted before the image build stage in pre-merge [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -261,5 +261,8 @@ void uploadDocker(String IMAGE_NAME) {
 }
 
 void deleteDockerTempTag(String tag) {
+    if (!tag?.trim()) { // return if the tag is null or empty
+        return
+    }
     sh "curl -u $URM_CREDS_USR:$URM_CREDS_PSW -XDELETE https://${ARTIFACTORY_NAME}/artifactory/sw-spark-docker-local/plugin/${tag} || true"
 }


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Current setup doesn't hurt anything but could cause misunderstanding, so make it more clearly.
Tested in my forked repo.

TAG is null or empty,
![image](https://user-images.githubusercontent.com/8086184/96661385-7f734580-137e-11eb-8274-ffabef410e61.png)
Comparing to TAG is not null and not empty,
![image](https://user-images.githubusercontent.com/8086184/96661405-8bf79e00-137e-11eb-916a-c670aee8cf77.png)
