### PR TITLE
Packs bounce buffers for highly partitioned shuffles

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -418,6 +418,7 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
                   } else {
                     // TODO: make this a metric => "blocked while waiting on bounce buffers"
                     logTrace("Can't acquire bounce buffers for receive.")
+                    keepAttempting = false
                   }
                 } else {
                   // bounce buffers already acquired

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids.shuffle.ucx
 
 import java.nio.ByteBuffer
-import java.util.PriorityQueue
 import java.util.concurrent._
 
 import scala.collection.mutable

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -21,8 +21,9 @@ import java.util.PriorityQueue
 import java.util.concurrent._
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange}
+import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.{GpuDeviceManager, RapidsConf}
 import com.nvidia.spark.rapids.shuffle._
@@ -148,6 +149,15 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
         deviceNumBuffers,
         (size: Long) => DeviceMemoryBuffer.allocate(size))
 
+    // we need to hook onto the bounce buffer manager, since now frees are
+    // encapsulated in a `BounceBuffer`, but we need visibility to notify
+    // a monitor
+    deviceReceiveBuffMgr.onFree(() => {
+      inflightMonitor.synchronized {
+        inflightMonitor.notify()
+      }
+    })
+
     hostSendBuffMgr =
       new BounceBufferManager[HostMemoryBuffer](
         "host-send",
@@ -160,84 +170,43 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
     Seq(deviceSendBuffMgr, deviceReceiveBuffMgr, hostSendBuffMgr).foreach(_.close())
   }
 
-  def freeReceiveBounceBuffers(bounceBuffers: Seq[MemoryBuffer]): Unit = {
-    bounceBuffers.foreach(bb => {
-      deviceReceiveBuffMgr.freeBuffer(bb)
-    })
-
-    // let the throttle know some bounce buffers were freed, so we give it a chance to claim them
-    inflightMonitor.synchronized {
-      inflightMonitor.notify()
-    }
-  }
-
-  def freeSendBounceBuffers(bounceBuffers: Seq[MemoryBuffer]): Unit = {
-    bounceBuffers.foreach {
-      case hb: HostMemoryBuffer => hostSendBuffMgr.freeBuffer(hb)
-      case db: DeviceMemoryBuffer => deviceSendBuffMgr.freeBuffer(db)
-    }
-  }
-
   private def getNumBounceBuffers(remaining: Long, totalRequired: Int): Int = {
     val numBuffers = (remaining + bounceBufferSize - 1) / bounceBufferSize
     Math.min(numBuffers, totalRequired).toInt
   }
 
-  override def getSendBounceBuffers(
-      deviceMemory: Boolean,
-      remaining: Long,
-      totalRequired: Int): Seq[MemoryBuffer] = {
-
-    val numBuffs = getNumBounceBuffers(remaining, totalRequired)
-    if (!deviceMemory) {
-      acquireBounceBuffers(hostSendBuffMgr, numBuffs)
-    } else {
-      acquireBounceBuffers(deviceSendBuffMgr, numBuffs)
-    }
-  }
-
   override def tryGetSendBounceBuffers(
-      deviceMemory: Boolean,
       remaining: Long,
-      totalRequired: Int): Seq[MemoryBuffer] = {
-
+      totalRequired: Int): Seq[SendBounceBuffers] = {
     val numBuffs = getNumBounceBuffers(remaining, totalRequired)
-    if (!deviceMemory) {
-      tryAcquireBounceBuffers(hostSendBuffMgr, numBuffs)
+    val deviceBuffer = tryAcquireBounceBuffers(deviceSendBuffMgr, numBuffs)
+    if (deviceBuffer.nonEmpty) {
+      val hostBuffer = tryAcquireBounceBuffers(hostSendBuffMgr, numBuffs)
+      if (hostBuffer.nonEmpty) {
+        deviceBuffer.zip(hostBuffer).map { case (d, h) =>
+          SendBounceBuffers(d, Some(h))
+        }
+      } else {
+        deviceBuffer.map(d => SendBounceBuffers(d, None))
+      }
     } else {
-      tryAcquireBounceBuffers(deviceSendBuffMgr, numBuffs)
+      Seq.empty
     }
   }
 
-  override def getReceiveBounceBuffers(remaining: Long, totalRequired: Int): Seq[MemoryBuffer] = {
-    val numBuffs = getNumBounceBuffers(remaining, totalRequired)
-    acquireBounceBuffers(deviceReceiveBuffMgr, numBuffs)
-  }
-
-  def tryGetReceiveBounceBuffers(remaining: Long, totalRequired: Int): Seq[MemoryBuffer] = {
+  override def tryGetReceiveBounceBuffers(
+      remaining: Long, totalRequired: Int): Seq[BounceBuffer] = {
     val numBuffs = getNumBounceBuffers(remaining, totalRequired)
     tryAcquireBounceBuffers(deviceReceiveBuffMgr, numBuffs)
   }
 
-  private def acquireBounceBuffers[T <: MemoryBuffer](
-      bounceBuffMgr: BounceBufferManager[T],
-      numBuffs: Integer) : Seq[MemoryBuffer] = {
-    // if the # of buffers requested is more than what the pool has, we would deadlock
-    // this ensures we only get as many buffers as the pool could possibly give us.
-    val possibleNumBuffers = Math.min(bounceBuffMgr.numBuffers, numBuffs)
-    val bounceBuffers: Seq[MemoryBuffer] = bounceBuffMgr.acquireBuffersBlocking(possibleNumBuffers)
-    logTrace(s"Got ${bounceBuffers.size} bounce buffers from pool " +
-      s"out of ${numBuffs} requested.")
-    bounceBuffers
-  }
-
   private def tryAcquireBounceBuffers[T <: MemoryBuffer](
       bounceBuffMgr: BounceBufferManager[T],
-      numBuffs: Integer): Seq[MemoryBuffer] = {
+      numBuffs: Integer): Seq[BounceBuffer] = {
     // if the # of buffers requested is more than what the pool has, we would deadlock
     // this ensures we only get as many buffers as the pool could possibly give us.
     val possibleNumBuffers = Math.min(bounceBuffMgr.numBuffers, numBuffs)
-    val bounceBuffers: Seq[MemoryBuffer] =
+    val bounceBuffers =
       bounceBuffMgr.acquireBuffersNonBlocking(possibleNumBuffers)
     logTrace(s"Got ${bounceBuffers.size} bounce buffers from pool " +
       s"out of ${numBuffs} requested.")
@@ -355,39 +324,34 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
   }
 
   /**
-   * Returns a sequence of bounce buffers if the transport allows for [[neededAmount]] + its
-   * inflight tally to be inflight at this time, and bounce buffers are available.
-   *
+   * Updates the inflightSize by adding the `neededAmount`
    * @param neededAmount amount of bytes needed.
-   * @return optional bounce buffers to be used to for the client to receive if amount of bytes
-   *         needed was allowed into the inflight amount, None otherwise (caller should try again)
+   * @note This function is called only after a successful call to `wouldFit`. It also
+   *       calls `wouldFit` as a sanity check.
    */
-  private def markBytesInFlight(neededAmount: Long)
-      : Option[Seq[MemoryBuffer]] = inflightMonitor.synchronized {
-    // if it would fit, or we are sending nothing (protects against the buffer that is bigger
-    // than limit), go ahead and allow it
-    if (wouldFit(neededAmount)) {
-      val bbs = tryGetReceiveBounceBuffers(neededAmount, 2)
-      if (bbs.nonEmpty) {
-        inflightSize = inflightSize + neededAmount
-        logDebug(s"New inflight size ${inflightSize} after adding = ${neededAmount} " +
-          s"and ${bbs} bounce buffers.")
-        Some(bbs)
-      } else {
-        None
-      }
-    } else {
-      logTrace(s"Did not update inflight size ${inflightSize}: ${neededAmount} + " +
-        s"${inflightSize} > ${inflightLimit}")
-      None
-    }
+  private def markBytesInFlight(neededAmount: Long): Unit = {
+    require(wouldFit(neededAmount),
+      s"Inflight limit can't allow this size $neededAmount of request")
+    inflightSize = inflightSize + neededAmount
   }
 
-  // NOTE: this function is called from within monitor.synchronized blocks always
+  /**
+   * Returns true if the neededAmount fits within the throttle, or if the throttle is at 0.
+   * The "at 0" case helps in the case where we have buffer sizes that are greater than
+   * inflightLimit
+   * @param neededAmount amount of bytes needed
+   * @return true if `neededAmount` would be allowed in the throttle
+   */
   private def wouldFit(neededAmount: Long): Boolean = {
     inflightSize + neededAmount <= inflightLimit || inflightSize == 0
   }
 
+  /**
+   * Decreases the inflight size.
+   * @note We are holding onto the inflightMonitor lock here, which we use to update the limit
+   *       in all cases.
+   * @param bytesCompleted amount of bytes handled
+   */
   override def doneBytesInFlight(bytesCompleted: Long): Unit = inflightMonitor.synchronized {
     inflightSize = inflightSize - bytesCompleted
     logDebug(s"Done with ${bytesCompleted} bytes inflight, " +
@@ -414,14 +378,22 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
         .setDaemon(true)
         .build))
 
+  // helper class to hold transfer requests that have a bounce buffer
+  // and should be ready to be handled by a `BufferReceiveState`
+  class PerClientReadyRequests(val bounceBuffer: BounceBuffer) {
+    val transferRequests = new ArrayBuffer[PendingTransferRequest]()
+    def addRequest(req: PendingTransferRequest): Unit = {
+      transferRequests.append(req)
+    }
+  }
+
   exec.execute(() => {
+    import collection.JavaConverters._
     while (inflightStarted) {
       try {
-        var perClientReq = mutable.Map[RapidsShuffleClient, BufferReceiveState]()
-        var removed = false
+        var perClientReq = mutable.Map[RapidsShuffleClient, PerClientReadyRequests]()
         inflightMonitor.synchronized {
-          var head: PendingTransferRequest = altList.peek()
-          if (head == null) {
+          if (altList.isEmpty) {
             val waitRange = new NvtxRange("Transport throttling", NvtxColor.RED)
             try {
               inflightMonitor.wait(100)
@@ -429,40 +401,55 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
               waitRange.close()
             }
           } else {
+            var toRemove = Seq[PendingTransferRequest]()
             var keepAttempting = true
-            while (head != null && keepAttempting) {
-              val existingReq: Option[BufferReceiveState] = perClientReq.get(head.client)
-              if (existingReq.isEmpty) {
-                // need to get bounce buffers
-                val bounceBuffers = if (head != null) {
-                  markBytesInFlight(head.getLength)
+            val altListIter = altList.iterator()
+            var req = altListIter.next()
+            while (req != null && keepAttempting) {
+              if (wouldFit(req.getLength)) {
+                val existingReq =
+                  perClientReq.get(req.client)
+                if (existingReq.isEmpty) {
+                  // need to get bounce buffers
+                  val bbs = tryGetReceiveBounceBuffers(1, 1)
+                  if (bbs.nonEmpty) {
+                    markBytesInFlight(req.getLength)
+                    val perClientReadyRequests = new PerClientReadyRequests(bbs.head)
+                    perClientReadyRequests.addRequest(req)
+                    perClientReq += req.client -> perClientReadyRequests
+                    toRemove = toRemove :+ req
+                  } else {
+                    // TODO: make this a metric => "blocked while waiting on bounce buffers"
+                    logTrace("Can't acquire bounce buffers for receive.")
+                  }
                 } else {
-                  None
+                  // bounce buffers already acquired
+                  markBytesInFlight(req.getLength)
+                  existingReq.foreach(_.addRequest(req))
+                  toRemove = toRemove :+ req
                 }
-                if (bounceBuffers.isEmpty) {
-                  inflightMonitor.wait(100)
-                  keepAttempting = false
+                if (altListIter.hasNext) {
+                  req = altListIter.next()
                 } else {
-                  val brs = new BufferReceiveState(this, bounceBuffers.get)
-                  brs.addRequest(head)
-                  perClientReq += head.client -> brs
-                  altList.remove(head)
+                  keepAttempting = false // no more requests to handle
                 }
               } else {
-                // bounce buffers already acquired
-                existingReq.foreach(_.addRequest(head))
-                altList.remove(head)
+                // cannot fit anymore (reached inflight maximum)
+                keepAttempting = false
               }
-              head = altList.peek()
             }
+            altList.removeAll(toRemove.asJava)
+          }
+          if (perClientReq.nonEmpty) {
+            perClientReq.foreach { case (client, perClientRequests) =>
+              val brs = new BufferReceiveState(perClientRequests.bounceBuffer,
+                perClientRequests.transferRequests)
+              client.issueBufferReceives(brs)
+            }
+          } else {
+            inflightMonitor.wait(100)
           }
         }
-        if (perClientReq.nonEmpty) {
-          logDebug(s"Issuing client req ${perClientReq.size}")
-        }
-        perClientReq.foreach { case (client, brs) => {
-          client.issueBufferReceives(brs)
-        }}
       } catch {
         case t: Throwable =>
           logError("Error in the UCX throttle loop", t)

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -149,17 +149,6 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
         deviceNumBuffers,
         (size: Long) => DeviceMemoryBuffer.allocate(size))
 
-    // we need to hook onto the bounce buffer manager, since now frees are
-    // encapsulated in a `BounceBuffer`, but we need visibility to notify
-    // a monitor
-    deviceReceiveBuffMgr.onFree(() => {
-      // We are getting called within the `deviceReceiveBuffMgr` lock
-      // so we know that we have indeed freed a bounce buffer at this point.
-      // The notify would wake up the "inflight" thread as it could be waiting
-      // for a bounce buffer to be freed.
-      deviceReceiveBuffMgr.notifyAll()
-    })
-
     hostSendBuffMgr =
       new BounceBufferManager[HostMemoryBuffer](
         "host-send",

--- a/sql-plugin/src/main/scala/ai/rapids/cudf/CudaUtil.scala
+++ b/sql-plugin/src/main/scala/ai/rapids/cudf/CudaUtil.scala
@@ -35,4 +35,17 @@ object CudaUtil {
       length,
       CudaMemcpyKind.DEFAULT)
   }
+
+  /**
+   * Allocate a `size` buffer on the device using stream `stream`.
+   *
+   * This needs to be replaced by `DeviceMemoryBuffer.allocate(size, stream)`
+   *
+   * @param size - size of buffer to allocate
+   * @param stream - stream to use for the allocation
+   * @return - a `DeviceMemoryBuffer` instance
+   */
+  def deviceAllocateOnStream(size: Long, stream: Cuda.Stream): DeviceMemoryBuffer = {
+    Rmm.alloc(size, stream)
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
@@ -140,21 +140,19 @@ class BounceBufferManager[T <: MemoryBuffer](
    * Free a `BounceBuffer`, putting it back into the pool.
    * @param bounceBuffer the memory buffer to free
    */
-  def freeBuffer(bounceBuffer: BounceBuffer): Unit = {
-    synchronized {
-      val buffer = bounceBuffer.buffer
-      require(buffer.getAddress >= rootBuffer.getAddress
-          && (buffer.getAddress - rootBuffer.getAddress) % bufferSize == 0,
-        s"$poolName: foreign buffer being freed")
-      val bufferIndex = (buffer.getAddress - rootBuffer.getAddress) / bufferSize
-      require(bufferIndex < numBuffers,
-        s"$poolName: buffer index invalid $bufferIndex should be less than $numBuffers")
+  def freeBuffer(bounceBuffer: BounceBuffer): Unit = synchronized {
+    val buffer = bounceBuffer.buffer
+    require(buffer.getAddress >= rootBuffer.getAddress
+        && (buffer.getAddress - rootBuffer.getAddress) % bufferSize == 0,
+      s"$poolName: foreign buffer being freed")
+    val bufferIndex = (buffer.getAddress - rootBuffer.getAddress) / bufferSize
+    require(bufferIndex < numBuffers,
+      s"$poolName: buffer index invalid $bufferIndex should be less than $numBuffers")
 
-      logDebug(s"$poolName: Free buffer index ${bufferIndex}")
-      buffer.close()
-      freeBufferMap.set(bufferIndex.toInt)
-      notifyAll() // notify any waiters that are checking the state of this manager
-    }
+    logDebug(s"$poolName: Free buffer index ${bufferIndex}")
+    buffer.close()
+    freeBufferMap.set(bufferIndex.toInt)
+    notifyAll() // notify any waiters that are checking the state of this manager
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
@@ -117,7 +117,7 @@ class BounceBufferManager[T <: MemoryBuffer](
     new BounceBufferImpl(res)
   }
 
-  private def numFree(): Int = synchronized {
+  def numFree(): Int = synchronized {
     freeBufferMap.cardinality()
   }
 
@@ -155,8 +155,8 @@ class BounceBufferManager[T <: MemoryBuffer](
       logDebug(s"$poolName: Free buffer index ${bufferIndex}")
       buffer.close()
       freeBufferMap.set(bufferIndex.toInt)
+      onFreeCallback.foreach(fn => fn())
     }
-    onFreeCallback.foreach(fn => fn())
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BounceBufferManager.scala
@@ -23,6 +23,52 @@ import ai.rapids.cudf.MemoryBuffer
 import org.apache.spark.internal.Logging
 
 /**
+ * Class to hold a bounce buffer reference in `buffer`.
+ *
+ * It is `AutoCloseable`, where a call to `close` puts the bounce buffer
+ * back into the corresponding source `BounceBufferManager`
+ *
+ * @param buffer - cudf MemoryBuffer to be used as a bounce buffer
+ * @param freeFn - a function that can return the buffer to the manager
+ */
+class BounceBuffer(val buffer: MemoryBuffer,
+    freeFn: BounceBuffer => Unit) extends AutoCloseable {
+
+  var isClosed = false
+
+  override def close(): Unit = {
+    if (isClosed) {
+      throw new IllegalStateException("Bounce buffer closed too many times")
+    }
+    freeFn(this)
+    isClosed = true
+  }
+}
+
+/**
+ * This class can hold 1 or 2 `BounceBuffer`s and is only used in the send case.
+ *
+ * Ideally, the device buffer is used if most of the buffers to be sent are on
+ * the device. The host buffer is used in the opposite case.
+ *
+ * @param deviceBounceBuffer - device buffer to use for sends
+ * @param hostBounceBuffer - optional host buffer to use for sends
+ */
+case class SendBounceBuffers(
+    deviceBounceBuffer: BounceBuffer,
+    hostBounceBuffer: Option[BounceBuffer]) extends AutoCloseable {
+
+  def bounceBufferSize: Long = {
+    deviceBounceBuffer.buffer.getLength
+  }
+
+  override def close(): Unit = {
+    deviceBounceBuffer.close()
+    hostBounceBuffer.foreach(_.close())
+  }
+}
+
+/**
  * This classes manages a set of bounce buffers, that are instances of `MemoryBuffer`.
  * The size/quantity of buffers is configurable, and so is the allocator.
  * @param poolName a human-friendly name to use for debug logs
@@ -44,28 +90,26 @@ class BounceBufferManager[T <: MemoryBuffer](
 
   private[this] val rootBuffer = allocator(bufferSize * numBuffers)
 
+  private[this] var onFreeCallback: Option[() => Unit] = None
+
   freeBufferMap.set(0, numBuffers)
 
   /**
-   * Acquires a [[MemoryBuffer]] from the pool. Blocks if the pool is empty.
+   * Acquires a [[BounceBuffer]] from the pool. Blocks if the pool is empty.
    *
    * @note calls to this function should have a lock on this [[BounceBufferManager]]
-   * @return the acquired `MemoryBuffer`
+   * @return the acquired `BounceBuffer`
    */
-  private def acquireBuffer(): MemoryBuffer = {
-    val start = System.currentTimeMillis()
-    var bufferIndex = freeBufferMap.nextSetBit(0)
+  private def acquireBuffer(): BounceBuffer = {
+    val bufferIndex = freeBufferMap.nextSetBit(0)
     while (bufferIndex < 0) {
-      logDebug(s"Buffer pool $poolName exhausted. Waiting...")
-      wait()
-      bufferIndex = freeBufferMap.nextSetBit(0)
+      throw new IllegalStateException(s"Buffer pool $poolName has exhausted!")
     }
 
     logDebug(s"$poolName: Buffer index: ${bufferIndex}")
     freeBufferMap.clear(bufferIndex)
     val res = rootBuffer.slice(bufferIndex * bufferSize, bufferSize)
-    logDebug(s"It took ${System.currentTimeMillis() - start} ms to allocBuffer in $poolName")
-    res
+    new BounceBuffer(res, this.freeBuffer)
   }
 
   private def numFree(): Int = synchronized {
@@ -75,47 +119,39 @@ class BounceBufferManager[T <: MemoryBuffer](
   /**
    * Acquire `possibleNumBuffers` buffers from the pool. This method will not block.
    * @param possibleNumBuffers number of buffers to acquire
-   * @return a sequence of `MemoryBuffer`s, or empty if the request can't be satisfied
+   * @return a sequence of `BounceBuffer`s, or empty if the request can't be satisfied
    */
-  def acquireBuffersNonBlocking(possibleNumBuffers: Int): Seq[MemoryBuffer] = synchronized {
+  def acquireBuffersNonBlocking(possibleNumBuffers: Int): Seq[BounceBuffer] = synchronized {
     if (numFree < possibleNumBuffers) {
       // would block
       logTrace(s"$poolName at capacity. numFree: ${numFree}, " +
         s"buffers required ${possibleNumBuffers}")
       return Seq.empty
     }
-    // we won't block, and we are still holding the lock, so get the promised buffers
-    acquireBuffersBlocking(possibleNumBuffers)
-  }
-
-  /**
-   * Acquire `possibleNumBuffers` buffers from the pool. This method will block until
-   * it can get the buffers requested.
-   * @param possibleNumBuffers number of buffers to acquire
-   * @return a sequence of `MemoryBuffer`s
-   */
-  def acquireBuffersBlocking(possibleNumBuffers: Int): Seq[MemoryBuffer] = synchronized {
     val res = (0 until possibleNumBuffers).map(_ => acquireBuffer())
     logDebug(s"$poolName at acquire. Has numFree ${numFree}")
     res
   }
 
   /**
-   * Free a `MemoryBuffer`, putting it back into the pool.
-   * @param buffer the memory buffer to free
+   * Free a `BounceBuffer`, putting it back into the pool.
+   * @param bounceBuffer the memory buffer to free
    */
-  def freeBuffer(buffer: MemoryBuffer): Unit = synchronized {
-    require(buffer.getAddress >= rootBuffer.getAddress
-      && (buffer.getAddress - rootBuffer.getAddress) % bufferSize == 0,
-      s"$poolName: foreign buffer being freed")
-    val bufferIndex = (buffer.getAddress - rootBuffer.getAddress) / bufferSize
-    require(bufferIndex < numBuffers,
-      s"$poolName: buffer index invalid $bufferIndex should be less than $numBuffers")
+  def freeBuffer(bounceBuffer: BounceBuffer): Unit = {
+    synchronized {
+      val buffer = bounceBuffer.buffer
+      require(buffer.getAddress >= rootBuffer.getAddress
+          && (buffer.getAddress - rootBuffer.getAddress) % bufferSize == 0,
+        s"$poolName: foreign buffer being freed")
+      val bufferIndex = (buffer.getAddress - rootBuffer.getAddress) / bufferSize
+      require(bufferIndex < numBuffers,
+        s"$poolName: buffer index invalid $bufferIndex should be less than $numBuffers")
 
-    logDebug(s"$poolName: Free buffer index ${bufferIndex}")
-    buffer.close()
-    freeBufferMap.set(bufferIndex.toInt)
-    notifyAll()
+      logDebug(s"$poolName: Free buffer index ${bufferIndex}")
+      buffer.close()
+      freeBufferMap.set(bufferIndex.toInt)
+    }
+    onFreeCallback.foreach(fn => fn())
   }
 
   /**
@@ -126,4 +162,13 @@ class BounceBufferManager[T <: MemoryBuffer](
   def getRootBuffer(): MemoryBuffer = rootBuffer
 
   override def close(): Unit = rootBuffer.close()
+
+  /**
+   * Registers a callback to be used on free.
+   * @param fn - user-defined function
+   */
+  def onFree(fn: () => Unit): Unit = {
+    require(onFreeCallback.isEmpty, "Already registered a free callback")
+    onFreeCallback = Some(fn)
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import ai.rapids.cudf.{Cuda, CudaUtil, DeviceMemoryBuffer, NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.format.TableMeta
+
+import org.apache.spark.internal.Logging
+
+case class ConsumedBatchFromBounceBuffer(
+    contigBuffer: DeviceMemoryBuffer,
+    meta: TableMeta,
+    handler: RapidsShuffleFetchHandler)
+
+/**
+ * A helper case class to maintain the state associated with a transfer request to a peer.
+ *
+ * The class implements the Iterator interface.
+ *
+ * On next(), a bounce buffer is returned earmarked for a range "window". The window
+ * is composed of eventual target buffers that will be handed off to the catalog.
+ *
+ * By convention, the tag used is that of the first buffer contained in the payload. The
+ * server follows the same convention in `BufferSendState`.
+ *
+ * `consumeWindow` is called when data has arrived at the bounce buffer, copying
+ * onto the ranges the bytes received.
+ *
+ * It also is AutoCloseable. close() should be called to free bounce buffers.
+ *
+ * @param bounceBuffer - bounce buffer to use (device memory strictly)
+ * @param requests - collection of `PendingTransferRequest` as issued by iterators
+ *                 currently requesting
+ * @param stream - CUDA stream to use for allocations and copies
+ */
+class BufferReceiveState(
+    bounceBuffer: BounceBuffer,
+    requests: Seq[PendingTransferRequest],
+    stream: Cuda.Stream = Cuda.DEFAULT_STREAM)
+    extends Iterator[AddressLengthTag]
+        with AutoCloseable with Logging {
+
+  class ReceiveBlock(val request: PendingTransferRequest) extends BlockWithSize {
+    override def size: Long = request.getLength
+    def tag: Long = request.tag
+  }
+
+  // flags whether we need to populate a window, and if the client should send a
+  // transfer request
+  private[this] var firstTime = true
+
+  private[this] var markedAsDone = false
+
+  // block ranges we'll work on next
+  private[this] var nextBlocks: Seq[BlockRange[ReceiveBlock]] = Seq.empty
+
+  // ranges we are working on now
+  private[this] var currentBlocks: Seq[BlockRange[ReceiveBlock]] = Seq.empty
+
+  // if a block overshoots a window, it will be in `workingOn`. This happens if the
+  // block is larger than window also.
+  private[this] var workingOn: DeviceMemoryBuffer = null
+
+  // offset tracking
+  private[this] var workingOnSoFar: Long = 0L
+  private[this] var bounceBufferByteOffset = 0L
+
+  // get block ranges for us to work with
+  private[this] val windowedBlockIterator = new WindowedBlockIterator[ReceiveBlock](
+    requests.map(r => new ReceiveBlock(r)), bounceBuffer.buffer.getLength)
+
+  def getRequests: Seq[PendingTransferRequest] = requests
+
+  def isFirstTime: Boolean = synchronized { firstTime }
+
+  override def close(): Unit = synchronized {
+    if (bounceBuffer != null) {
+      bounceBuffer.close()
+    }
+    if (workingOn != null) {
+      throw new IllegalStateException(
+        s"BufferReceiveState closing, but there are unfinished batches")
+    }
+  }
+
+  /**
+   * Calls `transferError` on each `RapidsShuffleFetchHandler`
+   * @param errMsg - the message to pass onto the handlers
+   */
+  def errorOcurred(errMsg: String): Unit = {
+    // get handlers for blocks that are currently being worked
+    val currentHandlers = currentBlocks.map(_.block.request.handler)
+   // signal error to all handlers
+    currentHandlers.foreach(_.transferError(errMsg))
+  }
+
+  override def hasNext: Boolean = synchronized { !markedAsDone }
+
+  override def next(): AddressLengthTag = synchronized {
+    if (firstTime) {
+      nextBlocks = windowedBlockIterator.next()
+      firstTime = false
+    }
+    currentBlocks = nextBlocks
+
+    val firstTag = getFirstTag(currentBlocks)
+
+    val alt = AddressLengthTag.from(bounceBuffer.buffer, firstTag)
+    alt.resetLength(currentBlocks.map(_.rangeSize()).sum)
+
+    if (windowedBlockIterator.hasNext) {
+      nextBlocks = windowedBlockIterator.next()
+    } else {
+      nextBlocks = Seq.empty
+      markedAsDone = true
+    }
+    alt
+  }
+
+  private def getFirstTag(blockRanges: Seq[BlockRange[ReceiveBlock]]): Long =
+    blockRanges.head.block.tag
+
+  def consumeWindow(): Seq[ConsumedBatchFromBounceBuffer] = synchronized {
+    val windowRange = new NvtxRange("consumeWindow", NvtxColor.PURPLE)
+    try {
+      val results = currentBlocks.flatMap { case b =>
+        val pendingTransferRequest = b.block.request
+
+        val fullSize = pendingTransferRequest.tableMeta.bufferMeta().size()
+
+        var contigBuffer: DeviceMemoryBuffer = null
+        val deviceBounceBuffer = bounceBuffer.buffer.asInstanceOf[DeviceMemoryBuffer]
+
+        if (fullSize == b.rangeSize()) {
+          // we have the full buffer!
+          contigBuffer = CudaUtil.deviceAllocateOnStream(b.rangeSize(), stream)
+          contigBuffer.copyFromDeviceBufferAsync(0, deviceBounceBuffer,
+            bounceBufferByteOffset, b.rangeSize(), stream)
+        } else {
+          if (workingOn != null) {
+            workingOn.copyFromDeviceBufferAsync(workingOnSoFar, deviceBounceBuffer,
+              bounceBufferByteOffset, b.rangeSize(), stream)
+
+            workingOnSoFar += b.rangeSize()
+            if (workingOnSoFar == fullSize) {
+              contigBuffer = workingOn
+              workingOn = null
+              workingOnSoFar = 0
+            }
+          } else {
+            // need to keep it around
+            workingOn = CudaUtil.deviceAllocateOnStream(fullSize, stream)
+
+            workingOn.copyFromDeviceBufferAsync( 0, deviceBounceBuffer,
+              bounceBufferByteOffset, b.rangeSize(), stream)
+
+            workingOnSoFar += b.rangeSize()
+          }
+        }
+        bounceBufferByteOffset += b.rangeSize()
+        if (bounceBufferByteOffset >= deviceBounceBuffer.getLength) {
+          bounceBufferByteOffset = 0
+        }
+
+        if (contigBuffer != null) {
+          Some(ConsumedBatchFromBounceBuffer(
+            contigBuffer, pendingTransferRequest.tableMeta, pendingTransferRequest.handler))
+        } else {
+          None
+        }
+      }
+
+      // Sync once, instead of for each copy.
+      // We need to synchronize, because we can't ask ucx to overwrite our bounce buffer
+      // unless all that data has truly moved to our final buffer in our stream
+      stream.sync()
+
+      results
+    } finally {
+      windowRange.close()
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
@@ -19,9 +19,9 @@ package com.nvidia.spark.rapids.shuffle
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{Cuda, CudaUtil, DeviceMemoryBuffer, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.format.TableMeta
 import com.nvidia.spark.rapids.Arm
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.internal.Logging
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -68,7 +68,7 @@ class BufferSendState(
 
   private[this] val blocksToSend: Seq[SendBlock] = {
     val btr = new BufferTransferRequest() // for reuse
-    (0 until transferRequest.requestsLength()).map { case ix  =>
+    (0 until transferRequest.requestsLength()).map { ix  =>
       val bufferTransferRequest = transferRequest.requests(btr, ix)
       withResource(requestHandler.acquireShuffleBuffer(
         bufferTransferRequest.bufferId())) { table =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import ai.rapids.cudf.{Cuda, CudaUtil, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.{Arm, RapidsBuffer, ShuffleMetadata, StorageTier}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.format.{BufferMeta, BufferTransferRequest, TransferRequest}
+
+import org.apache.spark.internal.Logging
+
+/**
+ * A helper case class to maintain the server side state in responde to a transfer
+ * request initiated by a peer.
+ *
+ * The class implements the Iterator interface.
+ *
+ * On next(), a set of RapidsBuffer are copied onto a bounce buffer, and the
+ * `AddressLengthTag` of the bounce buffer is returned. By convention, the tag used
+ * is that of the first buffer contained in the payload. Buffers are copied to the bounce
+ * buffer in TransferRequest order. The receiver has the same conventions.
+ *
+ * It also is AutoCloseable. close() should be called to free bounce buffers.
+ *
+ * In terms of the lifecycle of this object, it begins with the client asking for transfers to
+ * start, it lasts through all buffers being transmitted, and ultimately finishes when a
+ * TransferResponse is sent back to the client.
+ *
+ * @param request a transfer request
+ * @param sendBounceBuffers - an object that contains a device and potentially a host
+ *                          buffer also
+ * @param requestHandler - impl of trait that interfaces to the catalog
+ * @param serverStream - CUDA stream to use for copies.
+ */
+class BufferSendState(
+    request: RefCountedDirectByteBuffer,
+    sendBounceBuffers: SendBounceBuffers,
+    requestHandler: RapidsShuffleRequestHandler,
+    serverStream: Cuda.Stream = Cuda.DEFAULT_STREAM)
+    extends Iterator[AddressLengthTag] with AutoCloseable with Logging with Arm {
+
+  class SendBlock(val bufferTransferRequest: BufferTransferRequest,
+      tableSize: Long) extends BlockWithSize {
+    override def size: Long = tableSize
+    def tag: Long = bufferTransferRequest.tag()
+  }
+
+  private[this] val transferRequest = ShuffleMetadata.getTransferRequest(request.getBuffer())
+  private[this] var bufferMetas = Seq[BufferMeta]()
+  private[this] var isClosed = false
+
+  private[this] val blocksToSend: Seq[SendBlock] =
+    (0 until transferRequest.requestsLength()).map { btr =>
+      val bufferTransferRequest = transferRequest.requests(btr)
+      withResource(requestHandler.acquireShuffleBuffer(
+          bufferTransferRequest.bufferId())) { table =>
+        bufferMetas = bufferMetas :+ table.meta.bufferMeta()
+        new SendBlock(bufferTransferRequest, table.size)
+      }
+  }
+
+  private[this] val windowedBlockIterator =
+    new WindowedBlockIterator[SendBlock](blocksToSend, sendBounceBuffers.bounceBufferSize)
+
+  // when the window has been exhausted
+  private[this] var markedDone = false
+
+  // take out the device and host bounce buffers from the `SendBounceBuffers` case class
+  private[this] val deviceBounceBuffer: BounceBuffer =
+    sendBounceBuffers.deviceBounceBuffer
+  private[this] val hostBounceBuffer: BounceBuffer =
+    sendBounceBuffers.hostBounceBuffer.orNull
+
+  // ranges that we currently copying from (initialize with the first range)
+  private[this] var blockRanges: Seq[BlockRange[SendBlock]] = windowedBlockIterator.next()
+
+  private[this] var acquiredBuffs: Seq[RangeBuffer] = Seq.empty
+
+  def getTransferRequest: TransferRequest = synchronized {
+    transferRequest
+  }
+
+  def hasNext: Boolean = synchronized { !markedDone }
+
+  private[this] def freeBounceBuffers(): Unit = {
+    sendBounceBuffers.close()
+  }
+
+  def getTransferResponse(): RefCountedDirectByteBuffer = synchronized {
+    new RefCountedDirectByteBuffer(
+      ShuffleMetadata.buildBufferTransferResponse(bufferMetas))
+  }
+
+  override def close(): Unit = synchronized {
+    require(markedDone)
+    if (isClosed){
+      throw new IllegalStateException("ALREADY CLOSED!")
+    }
+    isClosed = true
+    freeBounceBuffers()
+    request.close()
+  }
+
+  case class RangeBuffer(
+      range: BlockRange[SendBlock], rapidsBuffer: RapidsBuffer)
+      extends AutoCloseable {
+    override def close(): Unit = {
+      rapidsBuffer.close()
+    }
+  }
+
+  def next(): AddressLengthTag = synchronized {
+    require(acquiredBuffs.isEmpty,
+      "Called next without calling `releaseAcquiredToCatalog` first")
+
+    var bounceBuffToUse: MemoryBuffer = null
+    var buffOffset = 0L
+
+    val buffsToSend = try {
+      if (!markedDone) {
+        var deviceBuffs = 0L
+        var hostBuffs = 0L
+        acquiredBuffs = blockRanges.safeMap { blockRange =>
+          val transferRequest =
+            blockRange.block.bufferTransferRequest
+
+          // we acquire these buffers now, and keep them until the caller releases them
+          // using `releaseAcquiredToCatalog`
+          closeOnExcept(
+            requestHandler.acquireShuffleBuffer(transferRequest.bufferId())) { rapidsBuffer =>
+            //these are closed later, after we synchronize streams
+            rapidsBuffer.storageTier match {
+              case StorageTier.DEVICE =>
+                deviceBuffs += blockRange.rangeSize()
+              case _ => // host/disk
+                hostBuffs += blockRange.rangeSize()
+            }
+            RangeBuffer(blockRange, rapidsBuffer)
+          }
+        }
+
+        logDebug(s"Occupancy for bounce buffer is [device=${deviceBuffs}, host=${hostBuffs}] Bytes")
+
+        bounceBuffToUse = if (deviceBuffs >= hostBuffs || hostBounceBuffer == null) {
+          deviceBounceBuffer.buffer
+        } else {
+          hostBounceBuffer.buffer
+        }
+
+        acquiredBuffs.foreach { case RangeBuffer(blockRange, rapidsBuffer) =>
+          require(blockRange.rangeSize() <= bounceBuffToUse.getLength - buffOffset)
+          withResource(rapidsBuffer.getMemoryBuffer) { memBuff =>
+            bounceBuffToUse match {
+              case _: HostMemoryBuffer =>
+                //TODO: HostMemoryBuffer needs the same functionality that
+                // DeviceMemoryBuffer has to copy from/to device/host buffers
+                CudaUtil.copy(
+                  memBuff,
+                  blockRange.rangeStart,
+                  bounceBuffToUse,
+                  buffOffset,
+                  blockRange.rangeSize())
+              case d: DeviceMemoryBuffer =>
+                memBuff match {
+                  case mh: HostMemoryBuffer =>
+                    // host original => device bounce
+                    d.copyFromHostBufferAsync(buffOffset, mh, blockRange.rangeStart,
+                      blockRange.rangeSize(), serverStream)
+                  case md: DeviceMemoryBuffer =>
+                    // device original => device bounce
+                    d.copyFromDeviceBufferAsync(buffOffset, md, blockRange.rangeStart,
+                      blockRange.rangeSize(), serverStream)
+                  case _ => throw new IllegalStateException("What buffer is this")
+                }
+              case _ => throw new IllegalStateException("What buffer is this")
+            }
+          }
+          buffOffset += blockRange.rangeSize()
+        }
+
+        val alt = AddressLengthTag.from(bounceBuffToUse,
+          blockRanges.head.block.tag)
+
+        alt.resetLength(buffOffset)
+
+        if (windowedBlockIterator.hasNext) {
+          blockRanges = windowedBlockIterator.next()
+        } else {
+          blockRanges = Seq.empty
+          markedDone = true
+        }
+
+        alt
+      } else {
+        null
+      }
+    } catch {
+      case t: Throwable =>
+        logError("Error while copying to bounce buffers on send.", t)
+        throw t
+    }
+
+    logDebug(s"Sending ${buffsToSend} for transfer request, " +
+        s" [peer_executor_id=${transferRequest.executorId()}]")
+
+    buffsToSend
+  }
+
+  /**
+   * Called by the RapidsShuffleServer when it has synchronized with its stream,
+   * allowing us to safely return buffers to the catalog to be potentially freed if spilling.
+   */
+  def releaseAcquiredToCatalog(): Unit = synchronized {
+    require(acquiredBuffs.nonEmpty, "Told to close rapids buffers, but nothing was acquired")
+    acquiredBuffs.foreach(_.close())
+    acquiredBuffs = Seq.empty
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -228,7 +228,9 @@ class BufferSendState(
    * allowing us to safely return buffers to the catalog to be potentially freed if spilling.
    */
   def releaseAcquiredToCatalog(): Unit = synchronized {
-    logWarning("Told to close rapids buffers, but nothing was acquired")
+    if (acquiredBuffs.isEmpty) {
+      logWarning("Told to close rapids buffers, but nothing was acquired")
+    }
     acquiredBuffs.foreach(_.close())
     acquiredBuffs = Seq.empty
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -67,7 +67,7 @@ case class PendingTransferRequest(client: RapidsShuffleClient,
                                   tableMeta: TableMeta,
                                   tag: Long,
                                   handler: RapidsShuffleFetchHandler) {
-  def getLength: Long = tableMeta.bufferMeta.size()
+  val getLength: Long = tableMeta.bufferMeta.size()
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -67,287 +67,7 @@ case class PendingTransferRequest(client: RapidsShuffleClient,
                                   tableMeta: TableMeta,
                                   tag: Long,
                                   handler: RapidsShuffleFetchHandler) {
-  def getLength: Long = tableMeta.bufferMeta.size
-}
-
-/**
- * Class describing the state of a set of [[PendingTransferRequest]]s.
- *
- * This class is *not thread safe*. The way the code is currently designed, bounce buffers being
- * used to receive, or copied from, are acted on a sequential basis, in time and in space.
- *
- * Callers use this class, like so:
- *
- * 1. [[getRequest]]
- *    - first call:
- *       - Initializes the state tracking the progress of `currentRequest` and our place in
- *          `requests` (e.g. offset, bytes remaining)
- *
- *    - subsequent calls:
- *       - if `currentRequest` is not done, it will return the current request. And perform
- *          sanity checks.
- *       - if `currentRequest` is done, it will perform sanity checks, and advance to the next
- *          request in `requests`
- *
- * 2. [[consumeBuffers]]
- *     - first call:
- *       - The first time around for `currentRequest` it will allocate the actual full device
- *         buffer that we will copy to, copy data sequentially from the bounce buffer to the 
- *         target buffer.
- *     - subsequent calls:
- *       - continue copy data sequentially from the bounce buffers passed in.
- *       - When `currentRequest` has been fully received, an optional `DeviceMemoryBuffer` is 
- *         set, and returned.
- *
- * 3. [[close]]
- *     - once the caller calls close, the bounce buffers are returned to the pool.
- *
- * @param transport a transport, which in this case is used to free bounce buffers
- * @param bounceMemoryBuffers a sequence of `MemoryBuffer` buffers to use for receives
- */
-class BufferReceiveState(
-    transport: RapidsShuffleTransport,
-    val bounceMemoryBuffers: Seq[MemoryBuffer])
-  extends AutoCloseable
-  with Logging {
-
-  private[this] var bounceBuffers: Seq[AddressLengthTag] = null
-  private[this] val requests = new ArrayBuffer[PendingTransferRequest]()
-
-  /**
-   * Use by the transport to add to this [[BufferReceiveState]] requests it needs to handle.
-   * @param pendingTransferRequest request to add to this [[BufferReceiveState]]
-   */
-  def addRequest(pendingTransferRequest: PendingTransferRequest): Unit = synchronized {
-    requests.append(pendingTransferRequest)
-  }
-
-  /**
-   * Holds the target device memory buffer. It is allocated at [[consumeBuffers]] when the first
-   * bounce buffer resolves, and it is also handed off to the caller in the same function.
-   */
-  private[this] var buff: DeviceMemoryBuffer = null
-
-  /**
-   * This is the address/length/tag object for the target buffer. It is used only to access a cuda
-   * synchronous copy method. We should do a regular copy from [[buff]] once we use the async
-   * method and add the cuda event synchronization.
-   */
-  private[this] var alt: AddressLengthTag = null
-
-  /**
-   * True iff this is the last request we are handling. It is used in [[isDone]] to find the
-   * stopping point.
-   */
-  private[this] var lastRequest: Boolean = false
-
-  /**
-   * The index into the [[requests]] sequence pointing to the current request we are handling.
-   * We handle requests sequentially.
-   */
-  private[this] var currentRequestIndex = -1
-
-  /**
-   * Amount of bytes left in the current request.
-   */
-  private[this] var currentRequestRemaining: Long = 0L
-
-  /**
-   * Byte offset we are currently at. [[getRequest]] uses and resets it, and [[consumeBuffers]]
-   * updates it.
-   */
-  private[this] var currentRequestOffset: Long = 0L
-
-  /**
-   * The current request (TableMeta, Handler (iterator))
-   */
-  private[this] var currentRequest: PendingTransferRequest = null
-
-  /**
-   * To help debug "closed multiple times" issues
-   */
-  private[this] var isClosed = false
-
-  /**
-   * Becomes true when there is an error detected, allowing the client to close this
-   * [[BufferReceiveState]] prematurely.
-   */
-  private[this] var errorOcurred = false
-
-  override def toString: String = {
-    s"BufferReceiveState(isDone=$isDone, currentRequestDone=$currentRequestDone, " +
-      s"requests=${requests.size}, currentReqIx=$currentRequestIndex, " +
-      s"currentReqOffset=$currentRequestOffset, currentReqRemaining=$currentRequestRemaining" +
-      s"bounceBuffers=$bounceBuffers)"
-  }
-
-  /**
-   * When a receive transaction is successful, this function is called to consume the bounce
-   * buffers received.
-   *
-   * @note If the target device buffer is not allocated, this function does so.
-   * @param bounceBuffers sequence of buffers that have been received
-   * @return if the current request is complete, returns a shallow copy of the target
-   *         device buffer as an `Option`. Callers will need to close the buffer.
-   */
-  def consumeBuffers(
-      bounceBuffers: Seq[AddressLengthTag]): Option[DeviceMemoryBuffer] = synchronized {
-    var needsCleanup = true
-
-    try {
-      if (buff == null) {
-        buff = DeviceMemoryBuffer.allocate(currentRequest.getLength)
-        alt = AddressLengthTag.from(buff, currentRequest.tag)
-      }
-
-      bounceBuffers.foreach(bb => {
-        currentRequestOffset = currentRequestOffset +
-          alt.cudaCopyFrom(bb, currentRequestOffset)
-      })
-
-      // buffers are sent in sequential order, so the length check is all we need (at the moment)
-      // to determine if we are done.
-      if (currentRequestDone) {
-        require(currentRequestOffset == currentRequest.getLength,
-          "Current request marked as done, but not all bounce buffers were consumed?")
-        logDebug(s"Done copying ${TransportUtils.formatTag(currentRequest.tag)}")
-        val res = buff
-        // The buffer [[buff]] is being handed off to the caller.
-        // It is the job of the caller to close it.
-        buff = null
-        needsCleanup = false
-        Some(res)
-      } else {
-        logDebug(s"More copying left for ${TransportUtils.formatTag(currentRequest.tag)}, " +
-           s"current offset is ${currentRequestOffset} out of ${currentRequest.getLength}")
-        needsCleanup = false
-        None
-      }
-    } finally {
-      if (needsCleanup) {
-        if (buff != null) {
-          buff.close()
-          buff = null
-        }
-      }
-    }
-  }
-
-  private[this] def currentRequestDone: Boolean = {
-    currentRequestRemaining == 0
-  }
-
-  /**
-   * Signals whether this [[BufferReceiveState]] is complete.
-   * @return boolean when at the last request, and that request is fully received
-   */
-  def isDone: Boolean = synchronized {
-    lastRequest && currentRequestDone
-  }
-
-  /**
-   * Return the current (making the next request current, if we are done) request and
-   * whether we advanced (want to kick off a transfer request to the server)
-   *
-   * @return returns the currently working transfer request, and
-   *         true if this is a new request we should be asking the server to trigger
-   */
-  def getRequest: (PendingTransferRequest, Boolean) = synchronized {
-    require(currentRequestIndex < requests.size,
-      "Something went wrong while handling buffer receives. Asking for more buffers than expected")
-
-    if (currentRequestRemaining > 0) {
-      require(currentRequest != null,
-        "Attempted to get the current request, but it was null")
-      (currentRequest, false)
-    } else {
-      if (currentRequest != null) {
-        logDebug(s"Done with ${currentRequest}, advancing.")
-        require(currentRequestDone,
-          s"Attempted to move on to the next buffer receive, but the prior buffer wasn't fully " +
-            s"transmitted, offset ${currentRequestOffset} == ${currentRequest.getLength}")
-        currentRequestOffset = 0L
-        currentRequest = null
-      }
-
-      // advance to the next request
-      currentRequestIndex = currentRequestIndex + 1
-
-      require(currentRequestIndex < requests.size,
-        s"getRequest was called too many times, looking for $currentRequestIndex out of " +
-          s"${requests.size}")
-
-      currentRequest = requests(currentRequestIndex)
-
-      currentRequestRemaining = currentRequest.getLength
-
-      // track if we are at the last request
-      lastRequest = currentRequestIndex == requests.size - 1
-
-      prepareBounceBuffers() // need to prepare these before returning the new request
-
-      (currentRequest, true)
-    }
-  }
-
-  private[this] def prepareBounceBuffers(): Unit = {
-    bounceBuffers = bounceMemoryBuffers.map(bmb => AddressLengthTag.from(bmb, currentRequest.tag))
-  }
-
-  private[this] def advance(bounceBufferLength: Long): Long = {
-    val lengthToRecv = Math.min(bounceBufferLength, currentRequestRemaining)
-    currentRequestRemaining = currentRequestRemaining - lengthToRecv
-    lengthToRecv
-  }
-
-  /**
-   * Used to cut the subset of bounce buffers the client will need to issue receives with.
-   *
-   * This is a subset, because at the moment, the full target length worth of bounce buffers
-   * could have been acquired. If we are at the tail end of receive, and it could be fulfilled
-   * with 1 bounce buffer, for example, we would return 1 bounce buffer here, rather than the
-   * number of buffers in acquired.
-   *
-   * @note that these extra buffers should really just be freed as soon as we realize
-   *       they are of no use.
-   *
-   * @return sequence of [[AddressLengthTag]] pointing to the receive bounce buffers.
-   */
-  def getBounceBuffersForReceive(): Seq[AddressLengthTag] = synchronized {
-    var bounceBufferIx = 0
-    var bounceBuffersForTransfer = Seq[AddressLengthTag]()
-    // we may have more bounce buffers than required for this send
-    while (bounceBufferIx < bounceBuffers.size && !currentRequestDone) {
-      val bb = bounceBuffers(bounceBufferIx)
-      val lengthToRecv = advance(bb.length)
-      bb.resetLength(lengthToRecv)
-
-      logDebug(s"Buffer for ${currentRequest}: ${bb}")
-      bounceBufferIx = bounceBufferIx + 1
-
-      // at the very end, we may have a smaller set of buffers, than those we acquired
-      bounceBuffersForTransfer = bounceBuffersForTransfer :+ bb
-    }
-    bounceBuffersForTransfer
-  }
-
-  // helpers used in logging
-  def getCurrentRequestRemaining: Long = currentRequestRemaining
-  def getCurrentRequestOffset : Long = currentRequestOffset
-
-  def closeWithError(): Unit = synchronized {
-    errorOcurred = true
-    close()
-  }
-
-  override def close(): Unit = synchronized {
-    require(isDone || errorOcurred)
-    if (isClosed) {
-      throw new IllegalStateException("ALREADY CLOSED")
-    }
-    isClosed = true
-    transport.freeReceiveBounceBuffers(bounceMemoryBuffers)
-  }
+  def getLength: Long = tableMeta.bufferMeta.size()
 }
 
 /**
@@ -424,13 +144,9 @@ class RapidsShuffleClient(
      *
      * @param tx live transaction for the buffer, to be closed after the buffer is handled
      * @param bufferReceiveState the object maintaining state for receives
-     * @param currentRequest the request these bounce buffers belong to
-     * @param bounceBuffers buffers used in the transfer, which contain the fragment of the data
      */
     case class HandleBounceBufferReceive(tx: Transaction,
-                                         bufferReceiveState: BufferReceiveState,
-                                         currentRequest: PendingTransferRequest,
-                                         bounceBuffers: Seq[AddressLengthTag])
+                                         bufferReceiveState: BufferReceiveState)
   }
 
   import ShuffleClientOps._
@@ -444,8 +160,8 @@ class RapidsShuffleClient(
           doFetch(shuffleRequests, rapidsShuffleFetchHandler, fullResponseSize)
         case IssueBufferReceives(bufferReceiveState) =>
           doIssueBufferReceives(bufferReceiveState)
-        case HandleBounceBufferReceive(tx, bufferReceiveState, currentRequest, bounceBuffers) =>
-          doHandleBounceBufferReceive(tx, bufferReceiveState, currentRequest, bounceBuffers)
+        case HandleBounceBufferReceive(tx, bufferReceiveState) =>
+          doHandleBounceBufferReceive(tx, bufferReceiveState)
       }
     } catch {
       case t: Throwable => {
@@ -550,10 +266,6 @@ class RapidsShuffleClient(
             // signal to the handler how many batches are expected
             handler.start(metadataResponse.tableMetasLength())
 
-            //TODO: nothing is preventing us from issuing transfers later, still letting
-            //  the metadata requests through early on, but doing the transfer requests later
-            //  (on iterator.next) saving connection/handshake time.
-
             // queue up the receives
             queueTransferRequests(metadataResponse, handler)
           } else {
@@ -590,48 +302,31 @@ class RapidsShuffleClient(
    *                           the transport's throttle logic.
    */
   private[shuffle] def doIssueBufferReceives(bufferReceiveState: BufferReceiveState): Unit = {
-    logDebug(s"At issue for ${bufferReceiveState}, " +
-      s"remaining: ${bufferReceiveState.getCurrentRequestRemaining}, " +
-      s"offset: ${bufferReceiveState.getCurrentRequestOffset}")
-
-    val (currentRequest, advanced) = bufferReceiveState.getRequest
-
-    if (advanced) {
-      // note this sends 1 at a time... need to experiment with `getRequest` returning more than
-      // 1 buffer if there are bounce buffers available
-      receiveBuffers(currentRequest, bufferReceiveState)
-      sendTransferRequest(Seq(currentRequest))
-    } else {
-      logDebug(s"Not the first time around for ${currentRequest}, NOT sending transfer request.")
-      receiveBuffers(currentRequest, bufferReceiveState)
+    if (bufferReceiveState.isFirstTime) {
+      sendTransferRequest(bufferReceiveState)
     }
+    receiveBuffers(bufferReceiveState)
   }
 
-  private def receiveBuffers(
-      currentRequest: PendingTransferRequest,
-      bufferReceiveState: BufferReceiveState): Transaction = {
-    val buffersToReceive = bufferReceiveState.getBounceBuffersForReceive()
+  private def receiveBuffers(bufferReceiveState: BufferReceiveState): Transaction = {
+    val buffersToReceive = bufferReceiveState.next()
 
-    logDebug(s"Issuing receive for ${TransportUtils.formatTag(currentRequest.tag)} at " +
-      s"startingOffset ${bufferReceiveState.getCurrentRequestOffset} with " +
-      s"${buffersToReceive.size} bounce buffers, and ${currentRequest.getLength} total length. " +
-      s"buffers = ${buffersToReceive.map(_.length).mkString(",")}")
+    logDebug(s"Issuing receive for ${TransportUtils.formatTag(buffersToReceive.tag)}")
 
-    connection.receive(buffersToReceive,
+    // TODO: make this use the single-receive version
+    connection.receive(Seq(buffersToReceive),
       tx => {
         tx.getStatus match {
           case TransactionStatus.Success =>
-            // TODO: during code review we agreed to make this receive per buffer, s.t.
-            //  buffers could be freed earlier and likely out of order.
-            asyncOnCopyThread(HandleBounceBufferReceive(tx, bufferReceiveState,
-              currentRequest, buffersToReceive))
+            logDebug(s"Handling response for ${TransportUtils.formatTag(buffersToReceive.tag)}")
+            asyncOnCopyThread(HandleBounceBufferReceive(tx, bufferReceiveState))
           case _ => try {
             val errMsg = s"Unsuccessful buffer receive ${tx}"
             logError(errMsg)
-            currentRequest.handler.transferError(errMsg)
+            bufferReceiveState.errorOcurred(errMsg)
           } finally {
             tx.close()
-            bufferReceiveState.closeWithError()
+            bufferReceiveState.close()
           }
         }
       })
@@ -643,16 +338,17 @@ class RapidsShuffleClient(
    * @param toIssue sequence of [[PendingTransferRequest]] we want included in the server
    *                transfers
    */
-  private[this] def sendTransferRequest(toIssue: Seq[PendingTransferRequest]): Unit = {
+  private[this] def sendTransferRequest(toIssue: BufferReceiveState): Unit = {
+    val requestsToIssue = toIssue.getRequests
     logDebug(s"Sending a transfer request for " +
-      s"${toIssue.map(r => TransportUtils.formatTag(r.tag)).mkString(",")}")
+        s"${requestsToIssue.map(r => TransportUtils.formatTag(r.tag)).mkString(",")}")
 
     // get a tag that the server can use to send its reply
     val responseTag = connection.assignResponseTag
 
     val transferReq = new RefCountedDirectByteBuffer(
       ShuffleMetadata.buildTransferRequest(localExecutorId, responseTag,
-        toIssue.map(i => (i.tableMeta, i.tag))))
+        requestsToIssue.map(i => (i.tableMeta, i.tag))))
 
     if (transferReq.getBuffer().remaining() > maximumMetadataSize) {
       throw new IllegalStateException("Trying to send a transfer request metadata buffer that " +
@@ -707,10 +403,11 @@ class RapidsShuffleClient(
     (0 until allTables).foreach { i =>
       val tableMeta = ShuffleMetadata.copyTableMetaToHeap(metaResponse.tableMetas(i))
       if (tableMeta.bufferMeta() != null) {
+        val tag = connection.assignBufferTag(tableMeta.bufferMeta().id)
         ptrs += PendingTransferRequest(
           this,
           tableMeta,
-          connection.assignBufferTag(tableMeta.bufferMeta().id),
+          tag,
           handler)
       } else {
         // Degenerate buffer (no device data) so no more data to request.
@@ -730,46 +427,35 @@ class RapidsShuffleClient(
    * state (consumeBuffers)
    * @param tx live transaction for these bounce buffers, it should be closed in this function
    * @param bufferReceiveState state management objects for live transfer requests
-   * @param currentRequest current transfer request being worked on
-   * @param bounceBuffers bounce buffers (just received) containing data to be consumed
    */
-  def doHandleBounceBufferReceive(tx: Transaction,
-                                  bufferReceiveState: BufferReceiveState,
-                                  currentRequest: PendingTransferRequest,
-                                  bounceBuffers: Seq[AddressLengthTag]): Unit = {
-    logDebug(s"At issue receive async with bounce buffers ${bounceBuffers} and ${currentRequest}" +
-      s" and starting offset ${bufferReceiveState.getCurrentRequestOffset}")
+  def doHandleBounceBufferReceive(tx: Transaction, 
+      bufferReceiveState: BufferReceiveState): Unit = {
     val nvtxRange = new NvtxRange("Buffer Callback", NvtxColor.RED)
     try {
-      // consume buffers, which will return true if done for the current request
-      val buff = bufferReceiveState.consumeBuffers(bounceBuffers)
-
-      if (buff.isDefined) {
-        logDebug(s"Done with receive [tag=${TransportUtils.formatTag(currentRequest.tag)}, " +
-          s"tx=${tx}]")
-
-        // release the bytes in flight
-        transport.doneBytesInFlight(currentRequest.getLength)
-
-        // hand buffer off to the catalog
-        val rapidsBufferId = track(buff.get, currentRequest.tableMeta)
-
-        // tell the iterator the batch has arrived, and is ready for processing
-        currentRequest.handler.batchReceived(
-          rapidsBufferId.asInstanceOf[ShuffleReceivedBufferId])
-      } else {
-        logDebug(s"Not done with: " +
-          s"[tag=${TransportUtils.formatTag(currentRequest.tag)}, tx=${tx}, " +
-          s"current_offset=${bufferReceiveState.getCurrentRequestOffset}, " +
-          s"total_length=${currentRequest.getLength}]")
-      }
+      // consume buffers, which will non empty for batches that are ready
+      // to be handed off to the catalog
+      val buffMetas = bufferReceiveState.consumeWindow()
 
       val stats = tx.getStats
+
+      // hand buffer off to the catalog
+      buffMetas.foreach { consumed: ConsumedBatchFromBounceBuffer =>
+        try {
+          val bId = track(consumed.contigBuffer, consumed.meta)
+          consumed.handler.batchReceived(bId.asInstanceOf[ShuffleReceivedBufferId])
+          transport.doneBytesInFlight(consumed.contigBuffer.getLength)
+        } catch {
+          case e: Throwable => {
+            logError(s"Error while handling: $consumed", e)
+            throw e
+          }
+        }
+      }
 
       logDebug(s"Received buffer size ${stats.receiveSize} in" +
         s" ${stats.txTimeMs} ms @ bw: [recv: ${stats.recvThroughput}] GB/sec")
 
-      if (!bufferReceiveState.isDone) {
+      if (bufferReceiveState.hasNext) {
         logDebug(s"${bufferReceiveState} is not done.")
         asyncOnCopyThread(IssueBufferReceives(bufferReceiveState))
       } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -18,9 +18,9 @@ package com.nvidia.spark.rapids.shuffle
 
 import java.util.concurrent.{ConcurrentLinkedQueue, Executor}
 
-import ai.rapids.cudf.{MemoryBuffer, NvtxColor, NvtxRange}
+import ai.rapids.cudf.{Cuda, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.format.{BufferMeta, TableMeta}
+import com.nvidia.spark.rapids.format.{TableMeta, TransferRequest}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.{BlockManagerId, ShuffleBlockBatchId}
@@ -94,7 +94,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
      * in order to handle the request fully.
      * @param sendState instance of [[BufferSendState]] used to complete a transfer request.
      */
-    case class HandleTransferRequest(sendState: BufferSendState)
+    case class HandleTransferRequest(sendState: Seq[BufferSendState])
   }
 
   import ShuffleServerOps._
@@ -128,7 +128,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
       serverTask match {
         case HandleMeta(tx, metaRequestBuffer) =>
           doHandleMeta(tx, metaRequestBuffer)
-        case HandleTransferRequest(wt: BufferSendState) =>
+        case HandleTransferRequest(wt: Seq[BufferSendState]) =>
           doHandleTransferRequest(wt)
       }
     } catch {
@@ -164,7 +164,8 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
   /**
    * Keep a list of BufferSendState that are waiting for bounce buffers.
    */
-  private[this] val bssQueue = new ConcurrentLinkedQueue[BufferSendState]()
+  private[this] val pendingTransfersQueue = new ConcurrentLinkedQueue[PendingTransferResponse]()
+  private[this] val bssContinueQueue = new ConcurrentLinkedQueue[BufferSendState]()
 
   /**
    * Executor that loops until it finds bounce buffers for [[BufferSendState]],
@@ -172,36 +173,74 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
    */
   bssExec.execute(() => {
     while (started) {
-      var bss: BufferSendState = null
+      var bssContinue: BufferSendState = null
+      var bssToIssue = Seq[BufferSendState]()
       try {
-        bss = bssQueue.peek()
-        if (bss != null) {
+        bssContinue = bssContinueQueue.peek()
+        while (bssContinue != null) {
           bssExec.synchronized {
-            if (bss.acquireBounceBuffersNonBlocking) {
-              bssQueue.remove(bss)
-              asyncOnCopyThread(HandleTransferRequest(bss))
-            } else {
-              bssExec.synchronized {
-                bssExec.wait(100)
-              }
-            }
-          }
-        } else {
-          bssExec.synchronized {
-            bssExec.wait(100)
+            bssContinueQueue.remove(bssContinue)
+            bssToIssue = bssToIssue :+ bssContinue
+            bssContinue = bssContinueQueue.peek()
           }
         }
       } catch {
         case t: Throwable => {
           logError("Error while handling BufferSendState", t)
-          if (bss != null) {
-            bss.close()
-            bss = null
+          if (bssContinue != null) {
+            bssContinue.close()
+            bssContinue = null
           }
         }
       }
+
+      var pendingTransfer: PendingTransferResponse = null
+      pendingTransfer = pendingTransfersQueue.peek()
+      var continue = true
+      while (pendingTransfer != null && continue) {
+        // TODO: throttle on too big a send total so we don't acquire the world (in flight limit)
+        bssExec.synchronized {
+          val sendBounceBuffers =
+            transport.tryGetSendBounceBuffers(1, 1)
+          try {
+            if (sendBounceBuffers.nonEmpty) {
+              pendingTransfersQueue.remove(pendingTransfer)
+              bssToIssue = bssToIssue :+ new BufferSendState(
+                pendingTransfer.metaRequest,
+                sendBounceBuffers.head, // there's only one bounce buffer here for now
+                pendingTransfer.requestHandler,
+                serverStream)
+              pendingTransfer = pendingTransfersQueue.peek()
+            } else {
+              // TODO: make this a metric => "blocked while waiting on bounce buffers"
+              logTrace(s"Can't acquire send bounce buffers")
+              continue = false
+            }
+          } catch {
+            case t: Throwable => {
+              logError("Error while handling BufferSendState", t)
+              if (pendingTransfer != null) {
+                sendBounceBuffers.foreach(_.close())
+                pendingTransfer = null
+              }
+            }
+          }
+        }
+      }
+
+      if (bssToIssue.nonEmpty) {
+        asyncOnCopyThread(HandleTransferRequest(bssToIssue))
+      }
+
+      bssExec.synchronized {
+        bssExec.wait(100)
+      }
     }
   })
+
+  // NOTE: this stream will likely move to its own non-blocking stream in the future
+  val serverStream = Cuda.DEFAULT_STREAM
+
   /**
    * Handler for a metadata request. It queues request handlers for either
    * [[RequestType.MetadataRequest]] or [[RequestType.TransferRequest]], and re-issues
@@ -227,22 +266,28 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
             doIssueReceive(RequestType.MetadataRequest)
             doHandleMeta(tx, metaRequest)
           } else {
-            val bss = new BufferSendState(tx, metaRequest)
-            bssQueue.add(bss)
+            val pendingTransfer = PendingTransferResponse(metaRequest, requestHandler)
+            pendingTransfersQueue.add(pendingTransfer)
 
             // tell the bssExec to wake up to try to handle the new BufferSendState
             bssExec.synchronized {
               bssExec.notifyAll()
             }
-            logDebug(s"Got a transfer request ${bss} from ${tx}. " +
-              s"I now have ${bssQueue.size} BSSs")
+            logDebug(s"Got a transfer request ${pendingTransfer} from ${tx}. " +
+              s"Pending requests [new=${pendingTransfersQueue.size}, " +
+                s"continuing=${bssContinueQueue.size}]")
             doIssueReceive(RequestType.TransferRequest)
           }
         } finally {
           handleMetaRange.close()
+          tx.close()
         }
       })
   }
+
+  case class PendingTransferResponse(
+      metaRequest: RefCountedDirectByteBuffer,
+      requestHandler: RapidsShuffleRequestHandler)
 
   /**
    * Function to handle `MetadataRequest`s. It will populate and issue a
@@ -273,7 +318,6 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
     } finally {
       logDebug(s"Metadata request handled in ${TransportUtils.timeDiffMs(start)} ms")
       doHandleMetaRange.close()
-      tx.close()
     }
   }
 
@@ -340,325 +384,85 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
   }
 
   /**
-   * A helper case class to maintain the state associated with a transfer request initiated by
-   * a `TransferRequest` metadata message.
-   *
-   * This class is *not thread safe*. The way the code is currently designed, bounce buffers
-   * being used to send, or copied to, are acted on a sequential basis, in time and in space.
-   *
-   * Callers use this class, like so:
-   *
-   * 1) [[getBuffersToSend]]: is used to get bounce buffers that the server should .send on.
-   *    -- first time:
-   *          a) the corresponding catalog table is acquired,
-   *          b) bounce buffers are acquired,
-   *          c) data is copied from the original catalog table into the bounce buffers available
-   *          d) the length of the last bounce buffer is adjusted if it would satisfy the full
-   *             length of the catalog-backed buffer.
-   *          e) bounce buffers are returned
-   *
-   *    -- subsequent times:
-   *      if we are not done sending the acquired table:
-   *          a) data is copied from the original catalog table into the bounce buffers available
-   *             at sequentially incrementing offsets.
-   *          b) the length of the last bounce buffer is adjusted if it would satisfy the full
-   *             length of the catalog-backed buffer.
-   *          c) bounce buffers are returned
-   *
-   * 2) [[freeBounceBuffersIfNecessary]]: called  when a send finishes, in order to free bounce
-   *    buffers, if the current table is done sending.
-   *
-   * 3) [[close]]: used to free state as the [[BufferSendState]] object is no longer needed
-   *
-   * In terms of the lifecycle of this object, it begins with the client asking for transfers to
-   * start, it lasts through all buffers being transmitted, and ultimately finishes when a
-   * `TransferResponse` is sent back to the client.
-   *
-   * @param tx the original `Transaction` from the `TransferRequest`.
-   * @param request a transfer request
-   */
-  class BufferSendState(tx: Transaction, request: RefCountedDirectByteBuffer)
-      extends AutoCloseable {
-    private[this] var currentTableIndex = -1
-    private[this] var lastTable = false
-    private[this] var currentTableRemaining: Long = 0L
-    private[this] var currentTableOffset: Long = 0L
-    private[this] var currentAlt: AddressLengthTag = null
-    private[this] val transferRequest = ShuffleMetadata.getTransferRequest(request.getBuffer())
-    private[this] var bufferMetas = Seq[BufferMeta]()
-    private[this] var isClosed = false
-
-    def getTransferRequest() = synchronized { 
-      transferRequest 
-    }
-
-
-    case class TableIdTag(tableId: Int, tag: Long)
-
-    // this is the complete amount of buffers we need to send
-    private[this] val tableIdAndTags: Seq[TableIdTag] =
-      (0 until transferRequest.requestsLength()).map { btr =>
-        val bufferTransferRequest = transferRequest.requests(btr)
-        TableIdTag(bufferTransferRequest.bufferId(),
-          bufferTransferRequest.tag())
-      }
-
-    require(tableIdAndTags.nonEmpty)
-
-    def isDone: Boolean = synchronized {
-      lastTable &&
-        currentTableRemaining == 0
-    }
-
-    // while we acquire a table from the catalog, this value is non-null
-    private[this] var acquiredTable: RapidsBuffer = null
-    private[this] var acquiredBuffer: MemoryBuffer = null
-
-    // the set of buffers we will acquire and use to work the entirety of this transfer.
-    private[this] var bounceBuffers = Seq[AddressLengthTag]()
-
-    override def toString: String = {
-      s"BufferSendState(isDone=$isDone, currentTableRemaining=$currentTableRemaining, " +
-        s"requests=$tableIdAndTags, currentTableOffset=$currentTableIndex, " +
-        s"currentTableOffset=$currentTableOffset, bounceBuffers=$bounceBuffers)"
-    }
-
-    /**
-     * Used to pop a [[BufferSendState]] from its queue if and only if there are bounce
-     * buffers available
-     * @return true if bounce buffers are available to proceed
-     */
-    def acquireBounceBuffersNonBlocking: Boolean = {
-      // we need to secure the table we are about to send, in order to get the correct flavor of
-      // bounce buffer
-      acquireTable()
-
-      if (bounceBuffers.isEmpty) {
-        bounceBuffers = transport.tryGetSendBounceBuffers(
-          currentAlt.isDeviceBuffer(),
-          currentTableRemaining,
-          // TODO: currently we have 2 buffers here, but this value could change and should
-          //  perhaps be configurable, if we find that it should vary depending on the user's job
-          2).map(buff => AddressLengthTag.from(buff, currentAlt.tag))
-      }
-      // else, we may want to make acquisition of the table and state separate so
-      // the act of acquiring the table from the catalog and getting the bounce buffer
-      // doesn't affect the state in [[BufferSendState]], this is in the case where we are at
-      // the limit, and we want to spill everything in a tier (including the one buffer
-      // we are trying to pop from the [[BufferSendState]] queue)
-      bounceBuffers.nonEmpty
-    }
-
-    private[this] def getBounceBuffers(): Seq[AddressLengthTag] = {
-      bounceBuffers.foreach(b => b.resetLength())
-      bounceBuffers
-    }
-
-    private[this] def acquireTable(): AddressLengthTag = {
-      if (currentTableRemaining > 0) {
-        require(currentAlt != null)
-        currentAlt
-      } else {
-        currentTableIndex = currentTableIndex + 1
-
-        require(currentTableIndex < tableIdAndTags.size,
-          "Something went wrong while handling a transfer request. " +
-            "Asking for more tables than expected.")
-
-        if (acquiredBuffer != null) {
-          acquiredBuffer.close()
-          acquiredBuffer = null
-        }
-        if (acquiredTable != null) {
-          acquiredTable.close()
-          acquiredTable = null
-          currentTableOffset = 0L
-        }
-
-        val TableIdTag(tableId, tag) = tableIdAndTags(currentTableIndex)
-
-        logDebug(s"Handling buffer transfer request " +
-          s"[peer_executor_id=${transferRequest.executorId()}, " +
-          s"table_id=$tableId, tag=${TransportUtils.formatTag(tag)}]")
-
-        // acquire the buffer, adding a reference to it, it will not be freed under us
-        acquiredTable = requestHandler.acquireShuffleBuffer(tableId)
-        acquiredBuffer = acquiredTable.getMemoryBuffer
-
-        currentAlt = AddressLengthTag.from(acquiredBuffer, tag)
-
-        currentTableRemaining = acquiredTable.size
-
-        val bufferMeta = acquiredTable.meta.bufferMeta()
-
-        bufferMetas = bufferMetas :+ bufferMeta
-
-        lastTable = currentTableIndex == tableIdAndTags.size - 1
-
-        currentAlt
-      }
-    }
-
-    private[this] def freeBounceBuffers(): Unit = {
-      if (bounceBuffers.nonEmpty) {
-        transport.freeSendBounceBuffers(bounceBuffers.flatMap(_.memoryBuffer))
-        bounceBuffers = Seq.empty
-
-        // wake up the bssExec since bounce buffers became available
-        bssExec.synchronized {
-          bssExec.notifyAll()
-        }
-      }
-    }
-
-
-    def getTransferResponse(): RefCountedDirectByteBuffer = synchronized {
-      new RefCountedDirectByteBuffer(ShuffleMetadata.buildBufferTransferResponse(bufferMetas))
-    }
-
-    private def advance(toCopy: Long): Boolean = {
-      currentTableRemaining = currentTableRemaining - toCopy
-      currentTableOffset = currentTableOffset + toCopy
-      currentTableRemaining == 0
-    }
-
-    override def close(): Unit = synchronized {
-      require(isDone)
-      if (isClosed){
-        throw new IllegalStateException("ALREADY CLOSED!")
-      }
-      isClosed = true
-      freeBounceBuffers()
-      tx.close()
-      request.close()
-      if (acquiredBuffer != null) {
-        acquiredBuffer.close()
-        acquiredBuffer = null
-      }
-      if (acquiredTable != null) {
-        acquiredTable.close()
-        acquiredTable = null
-      }
-    }
-
-    /**
-     * This function returns bounce buffers that are ready to be sent. To get there,
-     * it will:
-     *   1) acquire the bounce buffers in the first place (if it hasn't already)
-     *   2) copy data from the source buffer to the bounce buffers, updating the offset accordingly
-     *   3) return either the full set of bounce buffers, or a subset, depending on how much is
-     *      left to send.
-     * @return bounce buffers ready to be sent.
-     */
-    def getBuffersToSend(): Seq[AddressLengthTag] = synchronized {
-      val alt = acquireTable()
-
-      logDebug(s"Handling transfer request for ${alt}")
-
-      logDebug(s"${currentTableRemaining} remaining, getting bounce buffers for tr ${alt}")
-
-      // get bounce buffers, note we may block
-      val bounceBuffers = getBounceBuffers()
-
-      logDebug(s"${bounceBuffers} got, for tr ${alt}")
-
-      var buffersToSend = Seq[AddressLengthTag]()
-
-      try {
-        // copy to the bounce buffer
-        var bounceBufferIx = 0
-        var done = false
-        while (bounceBufferIx < bounceBuffers.size && !done) {
-          val bb = bounceBuffers(bounceBufferIx)
-          val toCopy = Math.min(currentTableRemaining, bb.length)
-          alt.cudaCopyTo(bb, currentTableOffset, toCopy)
-          done = advance(toCopy)
-          if (done) {
-            // got to the end, that last buffer needs the correct length
-            bb.resetLength(toCopy)
-          }
-          buffersToSend = buffersToSend :+ bb
-          bounceBufferIx = bounceBufferIx + 1
-        }
-      } catch {
-        case t: Throwable =>
-          logError("Error while copying to bounce buffers on send.", t)
-          close()
-          throw t
-      }
-
-      logDebug(s"Sending ${buffersToSend} for transfer request, with " +
-        s"${currentTableRemaining} left [peer_executor_id=${transferRequest.executorId()}, " +
-        s"table_id=${acquiredTable.id}, tag=${TransportUtils.formatTag(alt.tag)}]")
-
-      buffersToSend
-    }
-
-    def freeBounceBuffersIfNecessary(): Unit = synchronized {
-      // let go of the buffers, we'll be acquiring them again on the next table we want to transfer
-      if (currentTableRemaining <= 0) {
-        logDebug(s"Freeing bounce buffers ${bounceBuffers}")
-        freeBounceBuffers()
-      }
-    }
-  }
-
-  /**
    * This will kick off, or continue to work, a [[BufferSendState]] object
    * until all tables are fully transmitted.
    *
-   * @param bufferSendState state object tracking sends needed to fulfill a TransferRequest
+   * @param bufferSendStates state objects tracking sends needed to fulfill a TransferRequest
    */
-  def doHandleTransferRequest(bufferSendState: BufferSendState): Unit = {
-    val doHandleTransferRequest = new NvtxRange("doHandleTransferRequest", NvtxColor.CYAN)
-    val start = System.currentTimeMillis()
-    try {
-      require(!bufferSendState.isDone, "Attempting to handle a complete transfer request.")
+  def doHandleTransferRequest(bufferSendStates: Seq[BufferSendState]): Unit = {
+    val bssBuffers = bufferSendStates.map { bufferSendState =>
+      val doHandleTransferRequest =
+        new NvtxRange(s"doHandleTransferRequest", NvtxColor.CYAN)
 
-      // [[BufferSendState]] will continue to return buffers to send, as long as there
-      // is work to be done.
-      val buffersToSend = bufferSendState.getBuffersToSend()
+      try {
+        require(bufferSendState.hasNext, "Attempting to handle a complete transfer request.")
 
-      val transferRequest = bufferSendState.getTransferRequest()
+        // For each `BufferSendState` we ask for a bounce buffer fill up
+        // so the server is servicing N (`bufferSendStates`) requests
+        val buffersToSend = bufferSendState.next()
 
-      logDebug(s"Handling transfer request for ${transferRequest.executorId()} " +
-        s"with ${buffersToSend}")
+        (bufferSendState, buffersToSend)
+      } catch {
+        case t: Throwable =>
+          logError("Error handling shuffle send", t)
+          bufferSendState.close()
+          throw t
+      } finally {
+        doHandleTransferRequest.close()
+      }
+    }
 
-      serverConnection.send(transferRequest.executorId(), buffersToSend, new TransactionCallback {
+    serverStream.sync()
+
+    // need to release at this point, we do this after the sync so
+    // we are sure we actually copied everything to the bounce buffer
+    bufferSendStates.foreach(_.releaseAcquiredToCatalog())
+
+    bssBuffers.foreach {
+      case (bufferSendState, buffersToSend) =>
+        val transferRequest = bufferSendState.getTransferRequest
+        serverConnection.send(transferRequest.executorId(), buffersToSend, new TransactionCallback {
         override def apply(bufferTx: Transaction): Unit = {
           try {
             logDebug(s"Done with the send for ${bufferSendState} with ${buffersToSend}")
 
-            if (!bufferSendState.isDone) {
+            if (bufferSendState.hasNext) {
               // continue issuing sends.
               logDebug(s"Buffer send state ${bufferSendState} is NOT done. " +
-                s"I now have ${bssQueue.size} BSSs")
-              asyncOnCopyThread(HandleTransferRequest(bufferSendState))
+                  s"Still pending: ${pendingTransfersQueue.size}.")
+              bssExec.synchronized {
+                bssContinueQueue.add(bufferSendState)
+                bssExec.notifyAll()
+              }
             } else {
               val transferResponse = bufferSendState.getTransferResponse()
 
+              logDebug(s"Handling transfer request for ${transferRequest.executorId()} " +
+                  s"with ${buffersToSend}")
+
               // send the transfer response
               serverConnection.send(
-                transferRequest.executorId(),
+                transferRequest.executorId,
                 AddressLengthTag.from(transferResponse.acquire(), transferRequest.responseTag()),
                 transferResponseTx => {
                   transferResponse.close()
                   transferResponseTx.close()
                 })
 
-              // close up the [[BufferSendState]] instance
-              logDebug(s"Buffer send state ${bufferSendState} is done. Closing. " +
-                s"I now have ${bssQueue.size} BSSs")
+              logDebug(s"Buffer send state ${buffersToSend.tag} is done. Closing. " +
+                  s"Still pending: ${pendingTransfersQueue.size}.")
               bufferSendState.close()
+
+              // wake up the bssExec since bounce buffers became available
+              bssExec.synchronized {
+                bssExec.notifyAll()
+              }
             }
           } finally {
             bufferTx.close()
           }
         }
       })
-    } finally {
-      logDebug(s"Transfer request handled in ${TransportUtils.timeDiffMs(start)} ms")
-      doHandleTransferRequest.close()
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -408,7 +408,7 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
   def checkBuffer(
       source: HostMemoryBuffer,
       mockTable: TableMeta,
-      consumed: ConsumedBatchFromBounceBuffer) = {
+      consumed: ConsumedBatchFromBounceBuffer): Unit = {
     assertResult(mockTable.bufferMeta().size())(consumed.contigBuffer.getLength)
     assertResult(true)(
       areBuffersEqual(source, consumed.contigBuffer))
@@ -428,7 +428,7 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
   def endToEndTest(buff: BounceBuffer,
       expected: Seq[ExpectedTagAndMaterialized],
       ptrBuffs: Seq[(PendingTransferRequest, HostMemoryBuffer, TableMeta)]): Unit = {
-    withResource(ptrBuffs.map(_._2)) { case sources =>
+    withResource(ptrBuffs.map(_._2)) { sources =>
       withResource(new BufferReceiveState(buff, ptrBuffs.map(_._1))) { br =>
         val blocks = sources.map(x => new MockBlock(x))
         val sendWindow = new WindowedBlockIterator[MockBlock](blocks, 1000)
@@ -452,10 +452,9 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
             val consumed = br.consumeWindow()
             assertResult(materialized)(consumed.size)
             ranges.zip(consumed).foreach {
-              case (range: BlockRange[MockBlock], c: ConsumedBatchFromBounceBuffer) => {
+              case (range: BlockRange[MockBlock], c: ConsumedBatchFromBounceBuffer) =>
                 checkBuffer(range.block.hmb, c.meta, c)
                 c.contigBuffer.close()
-              }
             }
             assertResult(!isLast)(br.hasNext)
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -16,7 +16,9 @@
 
 package com.nvidia.spark.rapids.shuffle
 
-import ai.rapids.cudf.{DeviceMemoryBuffer, MemoryBuffer}
+import scala.collection.mutable.ArrayBuffer
+
+import ai.rapids.cudf.{DeviceMemoryBuffer, HostMemoryBuffer}
 import com.nvidia.spark.rapids.format.{BufferMeta, TableMeta}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers._
@@ -25,14 +27,23 @@ import org.mockito.Mockito._
 class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
   def prepareBufferReceiveState(
       tableMeta: TableMeta,
-      bounceBuffers: Seq[MemoryBuffer]): BufferReceiveState = {
-    val brs = spy(new BufferReceiveState(mockTransport, bounceBuffers))
-    val tag = 123
-    val ptr = PendingTransferRequest(client, tableMeta, tag, mockHandler)
-    val targetAlt = mock[AddressLengthTag]
-    when(targetAlt.cudaCopyFrom(any(), any())).thenReturn(bounceBuffers.head.getLength)
-    brs.addRequest(ptr)
-    brs
+      bounceBuffer: BounceBuffer): BufferReceiveState = {
+    val ptr = PendingTransferRequest(client, tableMeta, 123L, mockHandler)
+    spy(new BufferReceiveState(bounceBuffer, Seq(ptr)))
+  }
+
+  def prepareBufferReceiveState(
+      tableMetas: Seq[TableMeta],
+      bounceBuffer: BounceBuffer): BufferReceiveState = {
+
+    var tag = 123
+    val ptrs = tableMetas.map { tm =>
+      val ptr = PendingTransferRequest(client, tm, tag, mockHandler)
+      tag = tag + 1
+      ptr
+    }
+
+    spy(new BufferReceiveState(bounceBuffer, ptrs))
   }
 
   def verifyTableMeta(expected: TableMeta, actual: TableMeta): Unit = {
@@ -148,32 +159,42 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
     val tableMeta =
       RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
 
-    // assume we obtained 2 bounce buffers for reuse
-    val numBuffers = 2
     // 10000 in bytes ~ 2500 rows (minus validity/offset buffers) worth of contiguous
     // single column int table, so we need 10 buffer-lengths to receive all of 25000 rows,
-    // the extra one adds 1 receive. Note that each receive is 2 buffers (except for the last one),
-    // so that is 6 receives expected.
+    // the extra one adds 1 receive. Note that each receive is 1 buffer, so that is
+    // 11 receives expected.
     val sizePerBuffer = 10000
     // 5 receives (each with 2 buffers) makes for 100000 bytes + 1 receive for the remaining byte
-    val expectedReceives = 6
-    val bbs = (0 until numBuffers).map( _ => DeviceMemoryBuffer.allocate(sizePerBuffer))
+    val expectedReceives = 11
 
-    withResource(bbs) { bounceBuffers =>
-      val brs = prepareBufferReceiveState(tableMeta, bounceBuffers)
+    val refHostBuffer = HostMemoryBuffer.allocate(100032)
+    var count = 0
+    (0 until refHostBuffer.getLength.toInt)
+        .foreach { off =>
+          refHostBuffer.setByte(off, count.toByte)
+          count = count + 1
+          if (count >= sizePerBuffer) {
+            count = 0
+          }
+        }
 
-      assert(!brs.isDone)
+    closeOnExcept(getBounceBuffer(sizePerBuffer)) { bounceBuffer =>
+      val db = bounceBuffer.buffer.asInstanceOf[DeviceMemoryBuffer]
+      db.copyFromHostBuffer(refHostBuffer.slice(0, sizePerBuffer))
+      val brs = prepareBufferReceiveState(tableMeta, bounceBuffer)
+
+      assert(brs.hasNext)
 
       // Kick off receives
       client.doIssueBufferReceives(brs)
 
       // If transactions are successful, we should have completed the receive
-      assert(brs.isDone)
+      assert(!brs.hasNext)
 
       // we would issue as many requests as required in order to get the full contiguous
       // buffer
       verify(mockConnection, times(expectedReceives))
-        .receive(any[Seq[AddressLengthTag]](), any[TransactionCallback]())
+          .receive(any[Seq[AddressLengthTag]](), any[TransactionCallback]())
 
       // the mock connection keeps track of every receive length
       val totalReceived = mockConnection.receiveLengths.sum
@@ -193,17 +214,141 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
       verify(mockStorage, times(1))
           .addBuffer(any(), dmbCaptor.capture(), any(), any())
 
-      assertResult(tableMeta.bufferMeta().size())(
-        dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer].getLength)
+      val receivedBuff = dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer]
+      assertResult(tableMeta.bufferMeta().size())(receivedBuff.getLength)
+
+      withResource(HostMemoryBuffer.allocate(receivedBuff.getLength)) { hostBuff =>
+        hostBuff.copyFromDeviceBuffer(receivedBuff)
+        (0 until numRows).foreach { r =>
+          assertResult(refHostBuffer.getByte(r))(hostBuff.getByte(r))
+        }
+      }
 
       // after closing, we should have freed our bounce buffers.
-      val capturedBuffers: ArgumentCaptor[Seq[MemoryBuffer]] =
-        ArgumentCaptor.forClass(classOf[Seq[MemoryBuffer]])
-      verify(mockTransport, times(1))
-        .freeReceiveBounceBuffers(capturedBuffers.capture())
+      assertResult(true)(bounceBuffer.isClosed)
+    }
+  }
 
-      val freedBuffers = capturedBuffers.getValue
-      assertResult(bounceBuffers)(freedBuffers)
+  test("successful buffer fetch multi-buffer") {
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Success)
+
+    val numRows = 500
+    val tableMetas =
+      (0 until 5).map {
+        _ => RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
+      }
+
+    // 20000 in bytes ~ 5000 rows (minus validity/offset buffers) worth of contiguous
+    // single column int table, so we can pack 5 device receives into a single bounce buffer
+    val sizePerBuffer = 20000
+    // 5 receives (each with 2 buffers) makes for 100000 bytes + 1 receive for the remaining byte
+    val expectedReceives = 1
+
+    closeOnExcept(getBounceBuffer(sizePerBuffer)) { bounceBuffer =>
+      val brs = prepareBufferReceiveState(tableMetas, bounceBuffer)
+
+      assert(brs.hasNext)
+
+      // Kick off receives
+      client.doIssueBufferReceives(brs)
+
+      // If transactions are successful, we should have completed the receive
+      assert(!brs.hasNext)
+
+      // we would issue as many requests as required in order to get the full contiguous
+      // buffer
+      verify(mockConnection, times(expectedReceives))
+          .receive(any[Seq[AddressLengthTag]](), any[TransactionCallback]())
+
+      // the mock connection keeps track of every receive length
+      val totalReceived = mockConnection.receiveLengths.sum
+      val numBuffersUsed = mockConnection.receiveLengths.size
+
+      val totalExpectedSize = tableMetas.map(tm => tm.bufferMeta().size()).sum
+      assertResult(totalExpectedSize)(totalReceived)
+      assertResult(1)(numBuffersUsed)
+
+      // we would perform 1 request to issue a `TransferRequest`, so the server can start.
+      verify(mockConnection, times(1)).request(any(), any(), any[TransactionCallback]())
+
+      // we will hand off a `DeviceMemoryBuffer` to the catalog
+      val dmbCaptor = ArgumentCaptor.forClass(classOf[DeviceMemoryBuffer])
+      val tmCaptor = ArgumentCaptor.forClass(classOf[TableMeta])
+      verify(client, times(5)).track(any[DeviceMemoryBuffer](), tmCaptor.capture())
+      tableMetas.zipWithIndex.foreach { case (tm, ix) =>
+        verifyTableMeta(tm, tmCaptor.getAllValues().get(ix).asInstanceOf[TableMeta])
+      }
+
+      verify(mockStorage, times(5))
+          .addBuffer(any(), dmbCaptor.capture(), any(), any())
+
+      assertResult(totalExpectedSize)(
+        dmbCaptor.getAllValues().toArray().map(_.asInstanceOf[DeviceMemoryBuffer].getLength).sum)
+
+      // after closing, we should have freed our bounce buffers.
+      assertResult(true)(bounceBuffer.isClosed)
+    }
+  }
+
+  test("successful buffer fetch multi-buffer, larger than a single bounce buffer") {
+    when(mockTransaction.getStatus).thenReturn(TransactionStatus.Success)
+
+    val numRows = 500
+    val tableMetas =
+      (0 until 20).map {
+        _ => RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
+      }
+
+    // 20000 in bytes ~ 5000 rows (minus validity/offset buffers) worth of contiguous
+    // single column int table, so we can pack 5 device receives into a single bounce buffer
+    // we have 20 bounce buffers, so we expect in this case 3 receives.
+    val sizePerBuffer = 20000
+    // 5 receives (each with 2 buffers) makes for 100000 bytes + 1 receive for the remaining byte
+    val expectedReceives = 3
+
+    closeOnExcept(getBounceBuffer(sizePerBuffer)) { bounceBuffer =>
+      val brs = prepareBufferReceiveState(tableMetas, bounceBuffer)
+
+      assert(brs.hasNext)
+
+      // Kick off receives
+      client.doIssueBufferReceives(brs)
+
+      // If transactions are successful, we should have completed the receive
+      assert(!brs.hasNext)
+
+      // we would issue as many requests as required in order to get the full contiguous
+      // buffer
+      verify(mockConnection, times(expectedReceives))
+          .receive(any[Seq[AddressLengthTag]](), any[TransactionCallback]())
+
+      // the mock connection keeps track of every receive length
+      val totalReceived = mockConnection.receiveLengths.sum
+      val numBuffersUsed = mockConnection.receiveLengths.size
+
+      val totalExpectedSize = tableMetas.map(tm => tm.bufferMeta().size()).sum
+      assertResult(totalExpectedSize)(totalReceived)
+      assertResult(3)(numBuffersUsed)
+
+      // we would perform 1 request to issue a `TransferRequest`, so the server can start.
+      verify(mockConnection, times(1)).request(any(), any(), any[TransactionCallback]())
+
+      // we will hand off a `DeviceMemoryBuffer` to the catalog
+      val dmbCaptor = ArgumentCaptor.forClass(classOf[DeviceMemoryBuffer])
+      val tmCaptor = ArgumentCaptor.forClass(classOf[TableMeta])
+      verify(client, times(20)).track(any[DeviceMemoryBuffer](), tmCaptor.capture())
+      tableMetas.zipWithIndex.foreach { case (tm, ix) =>
+        verifyTableMeta(tm, tmCaptor.getAllValues().get(ix).asInstanceOf[TableMeta])
+      }
+
+      verify(mockStorage, times(20))
+          .addBuffer(any(), dmbCaptor.capture(), any(), any())
+
+      assertResult(totalExpectedSize)(
+        dmbCaptor.getAllValues().toArray().map(_.asInstanceOf[DeviceMemoryBuffer].getLength).sum)
+
+      // after closing, we should have freed our bounce buffers.
+      assertResult(true)(bounceBuffer.isClosed)
     }
   }
 
@@ -216,23 +361,19 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
       val tableMeta =
         RapidsShuffleTestHelper.prepareMetaTransferResponse(mockTransport, numRows)
 
-      // assume we obtained 2 bounce buffers, for reuse
-      val numBuffers = 2
-
       // error condition, so it doesn't matter much what we set here, only the first
       // receive will happen
       val sizePerBuffer = numRows * 4 / 10
-      val bbs = (0 until numBuffers).map(_ => DeviceMemoryBuffer.allocate(sizePerBuffer))
-      withResource(bbs) { bounceBuffers =>
-        val brs = prepareBufferReceiveState(tableMeta, bounceBuffers)
+      closeOnExcept(getBounceBuffer(sizePerBuffer)) { bounceBuffer =>
+        val brs = prepareBufferReceiveState(tableMeta, bounceBuffer)
 
-        assert(!brs.isDone)
+        assert(brs.hasNext)
 
         // Kick off receives
         client.doIssueBufferReceives(brs)
 
         // Errored transaction. Therefore we should not be done
-        assert(!brs.isDone)
+        assert(brs.hasNext)
 
         // We should have called `transferError` in the `RapidsShuffleFetchHandler`
         verify(mockHandler, times(1)).transferError(any())
@@ -244,16 +385,202 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
         verify(mockConnection, times(1)).request(any(), any(), any())
 
         // ensure we closed the BufferReceiveState => releasing the bounce buffers
-        val capturedBuffers: ArgumentCaptor[Seq[MemoryBuffer]] =
-          ArgumentCaptor.forClass(classOf[Seq[MemoryBuffer]])
-        verify(mockTransport, times(1))
-            .freeReceiveBounceBuffers(capturedBuffers.capture())
-
-        val freedBuffers = capturedBuffers.getValue
-        assertResult(bounceBuffers)(freedBuffers)
+        assertResult(true)(bounceBuffer.isClosed)
       }
 
       newMocks()
     }
+  }
+
+
+  def makeRequest(
+      tag: Long, numRows: Long): (PendingTransferRequest, HostMemoryBuffer, TableMeta) = {
+    val ptr = mock[PendingTransferRequest]
+    val mockTable = RapidsShuffleTestHelper.mockTableMeta(numRows)
+    when(ptr.getLength).thenReturn(mockTable.bufferMeta().size())
+    when(ptr.tag).thenReturn(tag)
+    when(ptr.tableMeta).thenReturn(mockTable)
+    val buff = HostMemoryBuffer.allocate(mockTable.bufferMeta().size())
+    fillBuffer(buff)
+    (ptr, buff, mockTable)
+  }
+
+  def checkBuffer(
+      source: HostMemoryBuffer,
+      mockTable: TableMeta,
+      consumed: ConsumedBatchFromBounceBuffer) = {
+    assertResult(mockTable.bufferMeta().size())(consumed.contigBuffer.getLength)
+    assertResult(true)(
+      areBuffersEqual(source, consumed.contigBuffer))
+  }
+
+  class MockBlock(val hmb: HostMemoryBuffer) extends BlockWithSize {
+    override def size: Long = hmb.getLength
+  }
+
+  case class ExpectedTagAndMaterialized(
+      tag: Long,
+      blocksInWindow: Int,
+      materializedBatches: Int,
+      bytesInWindow: Long,
+      isLast: Boolean)
+
+  def endToEndTest(buff: BounceBuffer,
+      expected: Seq[ExpectedTagAndMaterialized],
+      ptrBuffs: Seq[(PendingTransferRequest, HostMemoryBuffer, TableMeta)]): Unit = {
+    withResource(ptrBuffs.map(_._2)) { case sources =>
+      withResource(new BufferReceiveState(buff, ptrBuffs.map(_._1))) { br =>
+        val blocks = sources.map(x => new MockBlock(x))
+        val sendWindow = new WindowedBlockIterator[MockBlock](blocks, 1000)
+
+        expected.foreach {
+          case ExpectedTagAndMaterialized(tag, inWindow, materialized, bytesInWindow, isLast) =>
+            val state = br.next()
+            assertResult(state.length)(bytesInWindow)
+            assertResult(state.tag)(tag)
+
+            val bb = state.memoryBuffer.get.asInstanceOf[DeviceMemoryBuffer]
+            val ranges = sendWindow.next()
+            assertResult(inWindow)(ranges.size)
+            var offset = 0L
+
+            ranges.foreach(r => {
+              bb.copyFromHostBuffer(offset, r.block.hmb, r.rangeStart, r.rangeSize())
+              offset = offset + r.rangeSize()
+            })
+
+            val consumed = br.consumeWindow()
+            assertResult(materialized)(consumed.size)
+            ranges.zip(consumed).foreach {
+              case (range: BlockRange[MockBlock], c: ConsumedBatchFromBounceBuffer) => {
+                checkBuffer(range.block.hmb, c.meta, c)
+                c.contigBuffer.close()
+              }
+            }
+            assertResult(!isLast)(br.hasNext)
+        }
+      }
+    }
+  }
+
+  test("one request spanning several bounce buffer lengths") {
+    val bb = closeOnExcept(getBounceBuffer(1000)) { buff =>
+      val rowCounts = Seq(1000)
+      val ptrBuffs = rowCounts.zipWithIndex.map { case (c, ix) => makeRequest(ix + 1, c) }
+      var remaining = ptrBuffs.map(_._2.getLength).sum
+      val expected = new ArrayBuffer[ExpectedTagAndMaterialized]()
+
+      // 4 buffer lengths
+      (0 until 4).foreach { _ =>
+        expected.append(
+          ExpectedTagAndMaterialized(
+            tag = 1,
+            blocksInWindow = 1,
+            materializedBatches = 0,
+            bytesInWindow = math.min(1000, remaining),
+            isLast = false))
+        remaining = remaining - 1000
+      }
+
+      // then a last one to finish it off
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 1,
+          blocksInWindow = 1,
+          materializedBatches = 1,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = true))
+
+      endToEndTest(buff, expected, ptrBuffs)
+      buff
+    }
+    assert(bb.isClosed)
+  }
+
+  test ("three requests within a bounce buffer") {
+    val bb = closeOnExcept(getBounceBuffer(1000)) { buff =>
+      val rowCounts = Seq(40, 50, 60)
+      val ptrBuffs = rowCounts.zipWithIndex.map { case (c, ix) => makeRequest(ix + 1, c) }
+      val remaining = ptrBuffs.map(_._2.getLength).sum
+      val expected = new ArrayBuffer[ExpectedTagAndMaterialized]()
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 1,
+          blocksInWindow = 3,
+          materializedBatches = 3,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = true))
+
+      endToEndTest(buff, expected, ptrBuffs)
+      buff
+    }
+    assert(bb.isClosed)
+  }
+
+  test ("three requests spanning two bounce buffer lengths") {
+    val bb = closeOnExcept(getBounceBuffer(1000)) { buff =>
+      val rowCounts = Seq(40, 180, 100)
+      val ptrBuffs = rowCounts.zipWithIndex.map { case (c, ix) => makeRequest(ix + 1, c) }
+      var remaining = ptrBuffs.map(_._2.getLength).sum
+      val expected = new ArrayBuffer[ExpectedTagAndMaterialized]()
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 1,
+          blocksInWindow = 3,
+          materializedBatches = 2,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = false))
+      remaining = remaining - 1000
+
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 3,
+          blocksInWindow = 1,
+          materializedBatches = 1,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = true))
+
+      endToEndTest(buff, expected, ptrBuffs)
+      buff
+    }
+    assert(bb.isClosed)
+  }
+
+  test ("two requests larger than the bounce buffer length") {
+    val bb = closeOnExcept(getBounceBuffer(1000)) { buff =>
+      val rowCounts = Seq(300, 300)
+      val ptrBuffs = rowCounts.zipWithIndex.map { case (c, ix) => makeRequest(ix + 1, c) }
+      var remaining = ptrBuffs.map(_._2.getLength).sum
+      val expected = new ArrayBuffer[ExpectedTagAndMaterialized]()
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 1,
+          blocksInWindow = 1,
+          materializedBatches = 0,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = false))
+      remaining = remaining - 1000
+
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 1,
+          blocksInWindow = 2,
+          materializedBatches = 1,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = false))
+      remaining = remaining - 1000
+
+      expected.append(
+        ExpectedTagAndMaterialized(
+          tag = 2,
+          blocksInWindow = 1,
+          materializedBatches = 1,
+          bytesInWindow = math.min(1000, remaining),
+          isLast = true))
+
+      endToEndTest(buff, expected, ptrBuffs)
+      buff
+    }
+    assert(bb.isClosed)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shuffle
+
+import ai.rapids.cudf.{DeviceMemoryBuffer, HostMemoryBuffer}
+import com.nvidia.spark.rapids.RapidsBuffer
+import com.nvidia.spark.rapids.format.TableMeta
+import java.util
+import org.mockito.Mockito._
+
+import org.apache.spark.storage.ShuffleBlockBatchId
+
+class RapidsShuffleServerSuite extends RapidsShuffleTestHelper {
+
+  def setupMocks(
+      deviceBuffers: Seq[DeviceMemoryBuffer],
+      numRows: Long): (RapidsShuffleRequestHandler,
+      Seq[RapidsBuffer], util.HashMap[RapidsBuffer, Int]) = {
+
+    val numCloses = new util.HashMap[RapidsBuffer, Int]()
+    val mockBuffers = deviceBuffers.map { deviceBuffer =>
+      withResource(HostMemoryBuffer.allocate(deviceBuffer.getLength)) { hostBuff =>
+        fillBuffer(hostBuff)
+        deviceBuffer.copyFromHostBuffer(hostBuff)
+        val mockBuffer = mock[RapidsBuffer]
+        val mockMeta = RapidsShuffleTestHelper.mockTableMeta(100000)
+        when(mockBuffer.getMemoryBuffer).thenAnswer { _ =>
+          deviceBuffer.incRefCount()
+          // start at 1 close, since we'll need to close at refcount 0 too
+          val newNumCloses = numCloses.getOrDefault(mockBuffer, 1) + 1
+          numCloses.put(mockBuffer, newNumCloses)
+          deviceBuffer
+        }
+        when(mockBuffer.size).thenReturn(deviceBuffer.getLength)
+        when(mockBuffer.meta).thenReturn(mockMeta)
+        mockBuffer
+      }
+    }
+
+    val handler = new RapidsShuffleRequestHandler {
+      var acquiredTables = Seq[Int]()
+      override def getShuffleBufferMetas(
+          shuffleBlockBatchId: ShuffleBlockBatchId): Seq[TableMeta] = {
+        throw new NotImplementedError("getShuffleBufferMetas")
+      }
+
+      override def acquireShuffleBuffer(tableId: Int): RapidsBuffer = {
+        acquiredTables = acquiredTables :+ tableId
+        mockBuffers(tableId)
+      }
+    }
+    (handler, mockBuffers, numCloses)
+  }
+
+  class MockBlockWithSize(val b: DeviceMemoryBuffer) extends BlockWithSize {
+    override def size: Long = b.getLength
+  }
+
+  def compareRanges(
+      bounceBuffer: SendBounceBuffers,
+      receiveBlocks: Seq[BlockRange[MockBlockWithSize]]): Unit = {
+    var bounceBuffOffset = 0L
+    receiveBlocks.foreach { range =>
+      val deviceBuff = range.block.b
+      val deviceBounceBuff = bounceBuffer.deviceBounceBuffer.buffer
+      withResource(deviceBounceBuff.slice(bounceBuffOffset, range.rangeSize())) { bbSlice =>
+        bounceBuffOffset = bounceBuffOffset + range.rangeSize()
+        withResource(HostMemoryBuffer.allocate(bbSlice.getLength)) { hostCopy =>
+          hostCopy.copyFromDeviceBuffer(bbSlice.asInstanceOf[DeviceMemoryBuffer])
+          withResource(deviceBuff.slice(range.rangeStart, range.rangeSize())) { origSlice =>
+            assert(areBuffersEqual(hostCopy, origSlice))
+          }
+        }
+      }
+    }
+  }
+
+  test("sending tables that fit within one bounce buffer") {
+    val mockTransferRequest =
+      RapidsShuffleTestHelper.prepareMetaTransferRequest(10, 1000)
+
+    val bb = closeOnExcept(getSendBounceBuffer(10000)) { bounceBuffer =>
+      withResource((0 until 10).map(_ => DeviceMemoryBuffer.allocate(1000))) { deviceBuffers =>
+        val receiveSide = deviceBuffers.map(b => new MockBlockWithSize(b))
+        val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
+        val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers, 100000)
+        withResource(new BufferSendState(mockTransferRequest, bounceBuffer, handler)) { bss =>
+          assert(bss.hasNext)
+          val alt = bss.next()
+          val receiveBlocks = receiveWindow.next()
+          compareRanges(bounceBuffer, receiveBlocks)
+          assertResult(10000)(alt.length)
+          assert(!bss.hasNext)
+          bss.releaseAcquiredToCatalog()
+          mockBuffers.foreach { b: RapidsBuffer =>
+            // should have seen 2 closes, one for BufferSendState acquiring for metadata
+            // and the second acquisition for copying
+            verify(b, times(numCloses.get(b))).close()
+          }
+        }
+      }
+      bounceBuffer
+    }
+    assertResult(true)(bb.deviceBounceBuffer.isClosed)
+    newMocks()
+  }
+
+  test("sending tables that require two bounce buffer lengths") {
+    val mockTransferRequest = RapidsShuffleTestHelper.prepareMetaTransferRequest(20, 1000)
+
+    val bb = closeOnExcept(getSendBounceBuffer(10000)) { bounceBuffer =>
+      withResource((0 until 20).map(_ => DeviceMemoryBuffer.allocate(1000))) { deviceBuffers =>
+        val receiveSide = deviceBuffers.map(b => new MockBlockWithSize(b))
+        val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
+        val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers, 100000)
+        withResource(new BufferSendState(mockTransferRequest, bounceBuffer, handler)) { bss =>
+          var buffs = bss.next()
+          var receiveBlocks = receiveWindow.next()
+          compareRanges(bounceBuffer, receiveBlocks)
+          assert(bss.hasNext)
+          bss.releaseAcquiredToCatalog()
+
+          buffs = bss.next()
+          receiveBlocks = receiveWindow.next()
+          compareRanges(bounceBuffer, receiveBlocks)
+          assert(!bss.hasNext)
+          bss.releaseAcquiredToCatalog()
+
+          mockBuffers.foreach { b: RapidsBuffer =>
+            // should have seen 2 closes, one for BufferSendState acquiring for metadata
+            // and the second acquisition for copying
+            verify(b, times(numCloses.get(b))).close()
+          }
+        }
+      }
+      bounceBuffer
+    }
+    assertResult(true)(bb.deviceBounceBuffer.isClosed)
+  }
+
+  test("sending buffers larger than bounce buffer") {
+    val mockTransferRequest = RapidsShuffleTestHelper.prepareMetaTransferRequest(20, 10000)
+
+    val bb = closeOnExcept(getSendBounceBuffer(10000)) { bounceBuffer =>
+      withResource((0 until 20).map(_ => DeviceMemoryBuffer.allocate(123000))) { deviceBuffers =>
+        val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers, 100000)
+
+        val receiveSide = deviceBuffers.map(b => new MockBlockWithSize(b))
+        val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
+        withResource(new BufferSendState(mockTransferRequest, bounceBuffer, handler)) { bss =>
+          (0 until 246).foreach { i =>
+            try {
+              bss.next()
+              val receiveBlocks = receiveWindow.next()
+              compareRanges(bounceBuffer, receiveBlocks)
+              bss.releaseAcquiredToCatalog()
+            } catch {
+              case t: Throwable => println(t)
+            }
+          }
+          assert(!bss.hasNext)
+        }
+        mockBuffers.foreach { b: RapidsBuffer =>
+          verify(b, times(numCloses.get(b))).close()
+        }
+      }
+      bounceBuffer
+    }
+    assertResult(true)(bb.deviceBounceBuffer.isClosed)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
@@ -161,14 +161,10 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         withResource(new BufferSendState(mockTransferRequest, bounceBuffer, handler)) { bss =>
           (0 until 246).foreach { _ =>
-            try {
-              bss.next()
-              val receiveBlocks = receiveWindow.next()
-              compareRanges(bounceBuffer, receiveBlocks)
-              bss.releaseAcquiredToCatalog()
-            } catch {
-              case t: Throwable => println(t)
-            }
+            bss.next()
+            val receiveBlocks = receiveWindow.next()
+            compareRanges(bounceBuffer, receiveBlocks)
+            bss.releaseAcquiredToCatalog()
           }
           assert(!bss.hasNext)
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.Executor
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ColumnVector, ContiguousTable}
+import ai.rapids.cudf.{ColumnVector, ContiguousTable, DeviceMemoryBuffer, HostMemoryBuffer}
 import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsConf, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentMatchers.any
@@ -64,12 +64,56 @@ class RapidsShuffleTestHelper extends FunSuite
   var testMetricsUpdater: TestShuffleMetricsUpdater = _
   var client: RapidsShuffleClient = _
 
+  def getBounceBuffer(size: Long): BounceBuffer = {
+    withResource(HostMemoryBuffer.allocate(size)) { hmb =>
+      fillBuffer(hmb)
+      val db = DeviceMemoryBuffer.allocate(size)
+      db.copyFromHostBuffer(hmb)
+      new BounceBuffer(db, _ => {
+        db.close()
+      })
+    }
+  }
+
+  def fillBuffer(hmb: HostMemoryBuffer): Unit = {
+    (0 until hmb.getLength.toInt by 4).foreach { b =>
+      hmb.setInt(b, b)
+    }
+  }
+
+  def areBuffersEqual(orig: HostMemoryBuffer, buff: DeviceMemoryBuffer): Boolean = {
+    var areEqual = orig.getLength == buff.getLength
+    if (areEqual) {
+      val len = orig.getLength.toInt
+      withResource(HostMemoryBuffer.allocate(len)) { hmb =>
+        hmb.copyFromDeviceBuffer(buff)
+        (0 until len by 4).foreach { b =>
+          areEqual = areEqual && hmb.getInt(b) == orig.getInt(b)
+          if (!areEqual) {
+            println(s"not equal at offset ${b} ${hmb.getInt(b)} -- ${orig.getInt(b)}")
+          }
+        }
+      }
+    } else {
+      println(s"NOT EQUAL LENGTH ${orig} vs ${buff}")
+    }
+    areEqual
+  }
+
+  def getSendBounceBuffer(size: Long): SendBounceBuffers = {
+    val db = DeviceMemoryBuffer.allocate(size)
+    SendBounceBuffers(new BounceBuffer(db, _ => {
+      db.close()
+    }), None)
+  }
+
   override def beforeEach(): Unit = {
     newMocks()
   }
 
   def newMocks(): Unit = {
     mockTransaction = mock[Transaction]
+    when(mockTransaction.getStats).thenReturn(mock[TransactionStats])
     mockConnection = spy(new MockConnection(mockTransaction))
     mockTransport = mock[RapidsShuffleTransport]
     mockExecutor = new ImmediateExecutor
@@ -143,6 +187,23 @@ object RapidsShuffleTestHelper extends MockitoSugar with Arm {
     tableMetas
   }
 
+  def prepareMetaTransferRequest(numTables: Int, numRows: Long): RefCountedDirectByteBuffer =
+    withMockContiguousTable(numRows) { ct =>
+      val tableMetaTags = (0 until numTables).map { t =>
+        (buildMockTableMeta(t, ct), t.toLong)
+      }
+      val trBuffer = ShuffleMetadata.buildTransferRequest(1, 123, tableMetaTags)
+      val refCountedRes = new RefCountedDirectByteBuffer(trBuffer)
+      refCountedRes
+    }
+
+  def mockTableMeta(numRows: Long): TableMeta =
+    withMockContiguousTable(numRows) { ct =>
+      val tableMeta = buildMockTableMeta(1, ct)
+      val bufferMeta = tableMeta.bufferMeta()
+      tableMeta
+    }
+
   def prepareMetaTransferResponse(
       mockTransport: RapidsShuffleTransport,
       numRows: Long): TableMeta =
@@ -209,8 +270,7 @@ class MockConnection(mockTransaction: Transaction) extends ClientConnection {
     mockTransaction
   }
 
-  override def getPeerExecutorId: Long =
-    throw new UnsupportedOperationException
+  override def getPeerExecutorId: Long = 0
 
   override def assignResponseTag: Long = 1L
   override def assignBufferTag(msgId: Int): Long = 2L


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

I affectionately refer to this as the "delivery truck packing" PR. 

Before this change: 

- Given a set of requests for a peer, we'd get a bounce buffer and put a single batch in this bounce buffer for the transmission. A process which we'd have to repeat per batch (contig buffer). This means if we have small batches, we run out of bounce buffers quickly, synchronize many times, and we call into the transport many times. This is akin to us getting many delivery orders, finding a big truck, and sending the truck many times round trip with a single package.

After this change:

- We use the `WindowedBlockIterator` to copy into and out of a bounce buffer, packing the bounce buffer with many batches in the highly partitioned case. This means we reduce the calls to the transport, synchronize less (at the bounce buffer granularity), and we send bigger buffers that the transport can more efficiently transmit. This is akin to us getting that big delivery truck, but packing it fully with as many packages as they would fit, and sending it far less times in the highly contended highway.

A big change is how tags work in this PR. Since a send/recv can have many batches, only the tag for the first batch is taken into account. This is a convention that the server and client follow.
