### PR TITLE
Always use RAPIDS shuffle when running TPCH and Mortgage tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,6 @@
             </modules>
         </profile>
         <profile>
-            <id>alpha-features</id>
-            <properties>
-                <rapids.shuffle.manager.override>true</rapids.shuffle.manager.override>
-            </properties>
-        </profile>
-        <profile>
             <id>source-javadoc</id>
             <build>
                 <plugins>
@@ -161,7 +155,7 @@
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
         <test.exclude.tags></test.exclude.tags>
         <test.include.tags></test.include.tags>
-        <rapids.shuffle.manager.override>false</rapids.shuffle.manager.override>
+        <rapids.shuffle.manager.override>true</rapids.shuffle.manager.override>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
         <pytest.TEST_TAGS>not qarun</pytest.TEST_TAGS>


### PR DESCRIPTION
This removes the `alpha-features` profile which was originally intended to isolate the RAPIDS shuffle for unit tests.  Instead the `rapids.shuffle.manager.override` property that it would override to `true` now always defaults to `true`.  This causes a few tests that examine that property to start using the RAPIDS shuffle plugin by default.  The legacy shuffle can still be run for those tests by running the tests with `-Drapids.shuffle.manager.override=false`.

Fixes #989 
