### PR TITLE
Add --append-dat flag for TPC-DS benchmark

### DIFF
--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -75,6 +75,8 @@ def main():
                     help='Path to source data set')
     parser.add_argument('--input-format', required=True,
                         help='Format of input data set (parquet or csv)')
+    parser.add_argument('--append-dat', required=False, action='store_true',
+                        help='Append .dat to path (for tpcds only)')
     parser.add_argument('--output', required=False,
                     help='Path to write query output to')
     parser.add_argument('--output-format', required=False,
@@ -107,6 +109,9 @@ def main():
             cmd.append("--query " + query)
             cmd.append("--input " + args.input)
             cmd.append("--input-format {}".format(args.input_format))
+
+            if args.append_dat is True:
+                cmd.append("--append-dat ")
 
             if args.output is not None:
                 cmd.append("--output " + args.output + "/" + config_name + "/" + query)

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -31,8 +31,14 @@ object BenchmarkRunner {
   def main(args: Array[String]): Unit = {
     val conf = new BenchmarkConf(args)
 
+    if (conf.appendDat() && !conf.benchmark().equalsIgnoreCase("tpcds")) {
+      System.err.println(
+        s"The --append-dat flag is not supported for benchmark ${conf.benchmark()}")
+      System.exit(-1)
+    }
+
     val benchmarks = Map(
-      "tpcds" -> TpcdsLikeBench,
+      "tpcds" -> new TpcdsLikeBench(conf.appendDat()),
       "tpch" -> TpchLikeBench,
       "tpcxbb" -> TpcxbbLikeBench
     )
@@ -249,6 +255,7 @@ class BenchmarkConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val benchmark = opt[String](required = true)
   val input = opt[String](required = true)
   val inputFormat = opt[String](required = true)
+  val appendDat = opt[Boolean](required = false, default = Some(false))
   val query = opt[String](required = true)
   val iterations = opt[Int](default = Some(3))
   val output = opt[String](required = false)

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
@@ -20,21 +20,21 @@ import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpcdsLikeBench extends BenchmarkSuite {
+class TpcdsLikeBench(val appendDat: Boolean) extends BenchmarkSuite {
   override def name(): String = "TPC-DS"
 
   override def shortName(): String = "tpcds"
 
   override def setupAllParquet(spark: SparkSession, path: String): Unit = {
-    TpcdsLikeSpark.setupAllParquet(spark, path)
+    TpcdsLikeSpark.setupAllParquet(spark, path, appendDat)
   }
 
   override def setupAllCSV(spark: SparkSession, path: String): Unit = {
-    TpcdsLikeSpark.setupAllCSV(spark, path)
+    TpcdsLikeSpark.setupAllCSV(spark, path, appendDat)
   }
 
   override def setupAllOrc(spark: SparkSession, path: String): Unit = {
-    TpcdsLikeSpark.setupAllOrc(spark, path)
+    TpcdsLikeSpark.setupAllOrc(spark, path, appendDat)
   }
 
   override def createDataFrame(spark: SparkSession, query: String): DataFrame = {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -28,7 +28,7 @@ case class Table(
     partitionColumns: Seq[String],
     schema: StructType) {
 
-  private[this] def path(basePath: String, appendDat: Boolean = true) = {
+  private[this] def path(basePath: String, appendDat: Boolean) = {
     val rest = if (appendDat) {
       ".dat"
     } else {
@@ -37,25 +37,25 @@ case class Table(
     basePath + "/" + name + rest
   }
 
-  def readCSV(spark: SparkSession, basePath: String, appendDat: Boolean = true): DataFrame =
+  def readCSV(spark: SparkSession, basePath: String, appendDat: Boolean): DataFrame =
     spark.read.option("delimiter", "|")
         .schema(schema)
         .csv(path(basePath, appendDat))
 
-  def setupCSV(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit =
+  def setupCSV(spark: SparkSession, basePath: String, appendDat: Boolean): Unit =
     readCSV(spark, basePath, appendDat).createOrReplaceTempView(name)
 
-  def setupParquet(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit =
+  def setupParquet(spark: SparkSession, basePath: String, appendDat: Boolean): Unit =
     spark.read.parquet(path(basePath, appendDat)).createOrReplaceTempView(name)
 
-  def setupOrc(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit =
+  def setupOrc(spark: SparkSession, basePath: String, appendDat: Boolean): Unit =
     spark.read.orc(path(basePath, appendDat)).createOrReplaceTempView(name)
 
   def setup(
       spark: SparkSession,
       basePath: String,
       format: String,
-      appendDat: Boolean = true): Unit = {
+      appendDat: Boolean): Unit = {
     spark.read.format(format).load(path(basePath, appendDat)).createOrReplaceTempView(name)
   }
 
@@ -66,7 +66,7 @@ case class Table(
       coalesce: Map[String, Int],
       repartition: Map[String, Int],
       writePartitioning: Boolean): DataFrameWriter[Row] = {
-    val df = readCSV(spark, inputBase)
+    val df = readCSV(spark, inputBase, appendDat = true)
     val repart = BenchUtils.applyCoalesceRepartition(name, df, coalesce, repartition)
     val tmp = repart.write.mode("overwrite")
     if (writePartitioning && partitionColumns.nonEmpty) {
@@ -82,9 +82,10 @@ case class Table(
       outputBase: String,
       coalesce: Map[String, Int],
       repartition: Map[String, Int],
-      writePartitioning: Boolean): Unit =
+      writePartitioning: Boolean,
+      appendDat: Boolean): Unit =
     setupWrite(spark, name, inputBase, coalesce, repartition, writePartitioning)
-        .parquet(path(outputBase))
+        .parquet(path(outputBase, appendDat))
 
   def csvToOrc(
       spark: SparkSession,
@@ -92,9 +93,10 @@ case class Table(
       outputBase: String,
       coalesce: Map[String, Int],
       repartition: Map[String, Int],
-      writePartitioning: Boolean): Unit =
+      writePartitioning: Boolean,
+      appendDat: Boolean): Unit =
     setupWrite(spark, name, inputBase, coalesce, repartition, writePartitioning)
-        .orc(path(outputBase))
+        .orc(path(outputBase, appendDat))
 }
 
 case class Query(name: String, query: String) {
@@ -114,14 +116,16 @@ object TpcdsLikeSpark {
       baseOutput: String,
       coalesce: Map[String, Int] = Map.empty,
       repartition: Map[String, Int] = Map.empty,
-      writePartitioning: Boolean = false): Unit = {
+      writePartitioning: Boolean = false,
+      appendDat: Boolean = true): Unit = {
     tables.foreach(_.csvToParquet(
       spark,
       baseInput,
       baseOutput,
       coalesce,
       repartition,
-      writePartitioning))
+      writePartitioning,
+      appendDat))
   }
 
   def csvToOrc(
@@ -130,25 +134,27 @@ object TpcdsLikeSpark {
       baseOutput: String,
       coalesce: Map[String, Int] = Map.empty,
       repartition: Map[String, Int] = Map.empty,
-      writePartitioning: Boolean = false): Unit = {
+      writePartitioning: Boolean = false,
+      appendDat: Boolean = true): Unit = {
     tables.foreach(_.csvToOrc(
       spark,
       baseInput,
       baseOutput,
       coalesce,
       repartition,
-      writePartitioning))
+      writePartitioning,
+      appendDat))
   }
 
-  def setupAllCSV(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
+  def setupAllCSV(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
     tables.foreach(_.setupCSV(spark, basePath, appendDat))
   }
 
-  def setupAllParquet(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
+  def setupAllParquet(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
     tables.foreach(_.setupParquet(spark, basePath, appendDat))
   }
 
-  def setupAllOrc(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
+  def setupAllOrc(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
     tables.foreach(_.setupOrc(spark, basePath, appendDat))
   }
 
@@ -156,7 +162,7 @@ object TpcdsLikeSpark {
       spark: SparkSession,
       basePath: String,
       format: String,
-      appendDat: Boolean = true): Unit = {
+      appendDat: Boolean): Unit = {
     tables.foreach(_.setup(spark, basePath, format, appendDat))
   }
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -146,15 +146,15 @@ object TpcdsLikeSpark {
       appendDat))
   }
 
-  def setupAllCSV(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
+  def setupAllCSV(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
     tables.foreach(_.setupCSV(spark, basePath, appendDat))
   }
 
-  def setupAllParquet(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
+  def setupAllParquet(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
     tables.foreach(_.setupParquet(spark, basePath, appendDat))
   }
 
-  def setupAllOrc(spark: SparkSession, basePath: String, appendDat: Boolean): Unit = {
+  def setupAllOrc(spark: SparkSession, basePath: String, appendDat: Boolean = true): Unit = {
     tables.foreach(_.setupOrc(spark, basePath, appendDat))
   }
 
@@ -162,7 +162,7 @@ object TpcdsLikeSpark {
       spark: SparkSession,
       basePath: String,
       format: String,
-      appendDat: Boolean): Unit = {
+      appendDat: Boolean = true): Unit = {
     tables.foreach(_.setup(spark, basePath, format, appendDat))
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Within the TPC-DS code, the `appendDat` parameter had a default value in a number of places but the parameter wasn't always propagated, so it was not possible to override in some cases. This PR is essentially just a refactor so that the only place default values are used are when calling the top-level `TpcdsLikeSpark.csvTo*` and `TpcdsLikeSpark.setupAll*` methods and the default value here is still true so that this isn't a breaking change to that API when called from spark-shell. Also, appendDat is hard-coded to true when reading CSV during these conversions because the generated CSV files do have that extension.

The benchmark CLI is also updated to add an `--append-dat` flag so that the user can specify whether the input parquet or orc files have the `.dat` extension, meaning that the benchmark tool can now be used with the parquet files generated by `spark-sql-perf`.

I tested these changes by performing the csv to parquet conversion with and without the `.dat` extension and then used the benchmark runner against both datasets.

This closes https://github.com/NVIDIA/spark-rapids/issues/996