### PR TITLE
Run parallelism pytests on spark local mode

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -204,6 +204,7 @@
                                 <TEST>${test}</TEST>
 				<COVERAGE_SUBMIT_FLAGS>${argLine}</COVERAGE_SUBMIT_FLAGS>
 				<TEST_TAGS>${pytest.TEST_TAGS}</TEST_TAGS>
+                                <RAP_TEST_PARALLEL>${pytest.RAP_TEST_PARALLEL}</RAP_TEST_PARALLEL>
                             </environmentVariables>
                         </configuration>
                     </execution>

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -41,7 +41,7 @@ else
     RUN_DIR="$SCRIPTPATH"/target/run_dir
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
-    export EXTRA_CP="${ALL_JARS// /:}"
+    export RAP_TEST_EXTRA_CP="${ALL_JARS// /:}"
     #"$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
     #    --conf "spark.driver.extraJavaOptions=-Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
     #    --conf 'spark.executor.extraJavaOptions=-Duser.timezone=GMT' \
@@ -49,9 +49,8 @@ else
     #    --conf 'spark.sql.shuffle.partitions=12' \
     #    $SPARK_SUBMIT_FLAGS \
 
-    export RUN_PARALLEL=${RUN_PARALLEL:-4}
-    python      "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
-          -n $RUN_PARALLEL \
+    python "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
+          -n $RAP_TEST_PARALLEL \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
           "$TEST_ARGS" \

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -41,13 +41,15 @@ else
     RUN_DIR="$SCRIPTPATH"/target/run_dir
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
-    "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
-        --conf "spark.driver.extraJavaOptions=-ea -Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
-        --conf 'spark.executor.extraJavaOptions=-ea -Duser.timezone=GMT' \
-        --conf 'spark.sql.session.timeZone=UTC' \
-        --conf 'spark.sql.shuffle.partitions=12' \
-        $SPARK_SUBMIT_FLAGS \
-        "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
+    export EXTRA_CP="${ALL_JARS// /:}"
+    #"$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
+    #    --conf "spark.driver.extraJavaOptions=-Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
+    #    --conf 'spark.executor.extraJavaOptions=-Duser.timezone=GMT' \
+    #    --conf 'spark.sql.session.timeZone=UTC' \
+    #    --conf 'spark.sql.shuffle.partitions=12' \
+    #    $SPARK_SUBMIT_FLAGS \
+    python      "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
+          -n 4 \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
           "$TEST_ARGS" \

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -48,8 +48,10 @@ else
     #    --conf 'spark.sql.session.timeZone=UTC' \
     #    --conf 'spark.sql.shuffle.partitions=12' \
     #    $SPARK_SUBMIT_FLAGS \
+
+    export RUN_PARALLEL=${RUN_PARALLEL:-4}
     python      "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
-          -n 4 \
+          -n $RUN_PARALLEL \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
           "$TEST_ARGS" \

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -199,7 +199,7 @@ class TmpTableFactory:
 
 @pytest.fixture
 def spark_tmp_table_factory(request):
-    base_id = 'tmp_table_{}'.format(random.randint(0, 1000000))
+    base_id = 'tmp_{}_table'.format(random.randint(0, 1000000))
     yield TmpTableFactory(base_id)
     sp = get_spark_i_know_what_i_am_doing()
     tables = sp.sql("SHOW TABLES".format(base_id)).collect()

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -412,11 +412,10 @@ def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 # this test would be better if we could ensure exchanges didn't exist - ie used buckets
-def test_buckets(spark_tmp_path, v1_enabled_list, reader_confs):
+def test_buckets(spark_tmp_path, v1_enabled_list, reader_confs, spark_tmp_table_factory):
     all_confs = reader_confs.copy()
     all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
           "spark.sql.autoBroadcastJoinThreshold": '-1'})
-def test_buckets(spark_tmp_path, mt_opt, v1_enabled_list, spark_tmp_table_factory):
     def do_it(spark):
         return createBucketedTableAndJoin(spark, spark_tmp_table_factory.get(),
             spark_tmp_table_factory.get())

--- a/integration_tests/src/main/python/rap_conf.py
+++ b/integration_tests/src/main/python/rap_conf.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+confMap = {
+  'spark.master':                               'local',
+  'spark.ui.showConsoleProgress':               'false',
+  'spark.sql.session.timeZone':                 'UTC',
+  'spark.sql.shuffle.partitions':               '12',
+  'spark.executor.extraJavaOptions':            '-Duser.timezone=GMT',
+}
+
+def update_conf_map():
+    # 'RAP_TEST_PARALLEL' is num of parallelism for spark pytests, only valid for spark local mode
+    # We need to divide GPU mem to RAP_TEST_PARALLEL+1 parts for running num of parallelism
+    allowFraction = 1 / (int(os.getenv('RAP_TEST_PARALLEL')) + 2)
+    maxFraction = 1 / (int(os.getenv('RAP_TEST_PARALLEL')) + 1)
+    confMap['spark.rapids.memory.gpu.allocFraction'] = str(round(allowFraction, 3))
+    confMap['spark.rapids.memory.gpu.maxAllocFraction'] = str(round(maxFraction, 3))
+
+    if ('RAP_TEST_EXTRA_CP' in os.environ):
+        confMap['spark.driver.extraClassPath'] = os.environ['RAP_TEST_EXTRA_CP']
+
+    _javaOption = '-Duser.timezone=GMT ' + str(os.getenv('COVERAGE_SUBMIT_FLAGS'))
+    if ('PYTEST_XDIST_WORKER' in os.environ):
+        wid = os.environ['PYTEST_XDIST_WORKER']
+        d = "./derby_{}".format(wid)
+        if not os.path.exists(d):
+            os.makedirs(d)
+        confMap['spark.driver.extraJavaOptions'] = _javaOption + ' -Dderby.system.home={}'.format(d)
+    else:
+        confMap['spark.driver.extraJavaOptions'] = _javaOption

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -27,14 +27,16 @@ def _spark__init():
     # enableHiveSupport() is needed for parquet bucket tests
     #TODO need to figure out a better way to do this optionally
     import os
+    ALLOW_FRACTION = 1 / (int(os.getenv('RUN_PARALLEL')) + 2)
+    MAX_FRACTION = 1 / (int(os.getenv('RUN_PARALLEL')) + 1)
     _sb = SparkSession.builder
     _sb.config('spark.master', 'local') \
             .config('spark.ui.showConsoleProgress', 'false') \
             .config('spark.driver.extraClassPath', os.environ['EXTRA_CP']) \
             .config('spark.sql.session.timeZone', 'UTC') \
             .config('spark.sql.shuffle.partitions', '12') \
-            .config('spark.rapids.memory.gpu.allocFraction', '0.125')\
-            .config('spark.rapids.memory.gpu.maxAllocFraction', '0.2')\
+            .config('spark.rapids.memory.gpu.allocFraction', str(ALLOW_FRACTION))\
+            .config('spark.rapids.memory.gpu.maxAllocFraction', str(MAX_FRACTION))\
             .config('spark.plugins', 'com.nvidia.spark.SQLPlugin') \
             .config('spark.sql.queryExecutionListeners', 'com.nvidia.spark.rapids.ExecutionPlanCaptureCallback')
 
@@ -43,10 +45,10 @@ def _spark__init():
         d = "./derby_{}".format(wid)
         if not os.path.exists(d):
             os.makedirs(d)
-        _sb.config('spark.driver.extraJavaOptions', '-Duser.timezone=GMT -Dderby.system.home={}'.format(d)) \
+        _sb.config('spark.driver.extraJavaOptions', '-Duser.timezone=GMT -Dderby.system.home={} '.format(d) + str(os.getenv('COVERAGE_SUBMIT_FLAGS'))) \
                 .config('spark.executor.extraJavaOptions', '-Duser.timezone=GMT')
     else:
-        _sb.config('spark.driver.extraJavaOptions', '-Duser.timezone=GMT') \
+        _sb.config('spark.driver.extraJavaOptions', '-Duser.timezone=GMT ' + str(os.getenv('COVERAGE_SUBMIT_FLAGS'))) \
                 .config('spark.executor.extraJavaOptions', '-Duser.timezone=GMT')
  
     _s = _sb.enableHiveSupport() \

--- a/jenkins/Dockerfile-blossom.ubuntu16
+++ b/jenkins/Dockerfile-blossom.ubuntu16
@@ -35,6 +35,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     openjdk-8-jdk python3.6 python3-pip tzdata git
 
 RUN ln -s /usr/bin/python3.6 /usr/bin/python
-RUN python -m pip install pytest sre_yield requests pandas pyarrow
+RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist
 
 RUN apt install -y inetutils-ping expect

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -37,7 +37,7 @@ export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
 
-mvn -U -B $MVN_URM_MIRROR '-P!snapshot-shims' clean verify -Dpytest.TEST_TAGS=''
+mvn -U -B $MVN_URM_MIRROR '-P!snapshot-shims' clean verify -Dpytest.TEST_TAGS='' -Dpytest.RAP_TEST_PARALLEL=4
 # Run the unit tests for other Spark versions but dont run full python integration tests
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark301tests,snapshot-shims test -Dpytest.TEST_TAGS=''
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark310tests,snapshot-shims test -Dpytest.TEST_TAGS=''

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,8 @@
         <spark301.version>3.0.1</spark301.version>
         <spark302.version>3.0.2-SNAPSHOT</spark302.version>
         <spark310.version>3.1.0-SNAPSHOT</spark310.version>
+        <!-- Number of pytest parallelism  -->
+        <pytest.RAP_TEST_PARALLEL>1</pytest.RAP_TEST_PARALLEL>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Refer to https://github.com/NVIDIA/spark-rapids/pull/966

Shot at making integration tests run faster by running parallelism pytests for spark local mode.

Move spark local mode conf of pytest parallelism into confMap

Add maven parameter '-Dpytest.RAP_TEST_PARALLEL=xx' to override the parallelism
