### PR TITLE
Add --gc-between-run flag for TPC* benchmarks.

### DIFF
--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -85,6 +85,8 @@ def main():
                     help='Queries to run')
     parser.add_argument('--iterations', required=False,
                         help='The number of iterations to run (defaults to 1)')
+    parser.add_argument('--gc-between-runs', required=False, action='store_true',
+                        help='Whether to call System.gc between iterations')
 
     args = parser.parse_args()
 
@@ -115,6 +117,9 @@ def main():
                 cmd.append("--output-format {}".format(args.output_format))
 
             cmd.append("--summary-file-prefix " + summary_file_prefix)
+
+            if args.gc_between_runs is True:
+                cmd.append("--gc-between-runs ")
 
             if args.iterations is None:
                 cmd.append("--iterations 1")

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -59,21 +59,24 @@ object BenchmarkRunner {
                 conf.query(),
                 path,
                 iterations = conf.iterations(),
-                summaryFilePrefix = conf.summaryFilePrefix.toOption)
+                summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                gcBetweenRuns = conf.gcBetweenRuns())
             case "csv" =>
               runner.writeCsv(
                 spark,
                 conf.query(),
                 path,
                 iterations = conf.iterations(),
-                summaryFilePrefix = conf.summaryFilePrefix.toOption)
+                summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                gcBetweenRuns = conf.gcBetweenRuns())
             case "orc" =>
               runner.writeOrc(
                 spark,
                 conf.query(),
                 path,
                 iterations = conf.iterations(),
-                summaryFilePrefix = conf.summaryFilePrefix.toOption)
+                summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                gcBetweenRuns = conf.gcBetweenRuns())
             case other =>
               System.err.println(s"Invalid or unspecified output format: $other")
               System.exit(-1)
@@ -83,7 +86,8 @@ object BenchmarkRunner {
               spark,
               conf.query(),
               conf.iterations(),
-              summaryFilePrefix = conf.summaryFilePrefix.toOption)
+              summaryFilePrefix = conf.summaryFilePrefix.toOption,
+              gcBetweenRuns = conf.gcBetweenRuns())
         }
       case _ =>
         System.err.println(s"Invalid benchmark name: ${conf.benchmark()}. Supported benchmarks " +
@@ -254,5 +258,6 @@ class BenchmarkConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val output = opt[String](required = false)
   val outputFormat = opt[String](required = false)
   val summaryFilePrefix = opt[String](required = false)
+  val gcBetweenRuns = opt[Boolean](required = false, default = Some(false))
   verify()
 }


### PR DESCRIPTION
Signed-off-by: Peter Rudenko prudenko@nvidia.com

Add `--gc-between-runs` parameter when submitting benchmark with spark-submit. Useful to trigger unregister shuffle when running many iterations.