### PR TITLE
BenchmarkRunner should produce JSON summary file even when queries fail

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -15,7 +15,7 @@
  */
 package com.nvidia.spark.rapids.tests.common
 
-import java.io.{File, FileOutputStream, FileWriter, PrintWriter}
+import java.io.{File, FileOutputStream, FileWriter, PrintWriter, StringWriter}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.NANOSECONDS
@@ -26,8 +26,8 @@ import scala.collection.mutable.ListBuffer
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.Serialization.writePretty
-
 import org.apache.spark.{SPARK_BUILD_USER, SPARK_VERSION}
+
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{InputAdapter, QueryExecution, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
@@ -187,7 +187,7 @@ object BenchUtils {
           val elapsed = NANOSECONDS.toMillis(end - start)
           println(s"*** Iteration $i failed after $elapsed msec.")
           queryTimes.append(-1)
-          exceptions.append(e.toString)
+          exceptions.append(BenchUtils.toString(e))
           e.printStackTrace()
       }
 
@@ -634,6 +634,14 @@ object BenchUtils {
       case (a, b) => a == b
     }
   }
+
+  def toString(e: Exception): String = {
+    val sw = new StringWriter()
+    val w = new PrintWriter(sw)
+    e.printStackTrace(w)
+    w.close()
+    sw.toString
+  }
 }
 
 class BenchmarkListener(
@@ -646,7 +654,7 @@ class BenchmarkListener(
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
     queryPlans += toJson(qe.executedPlan)
-    exceptions += exception.toString
+    exceptions += BenchUtils.toString(exception)
   }
 
   private def toJson(plan: SparkPlan): SparkPlanNode = {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -183,8 +183,11 @@ object BenchUtils {
 
       } catch {
         case e: Exception =>
-          println(s"*** Iteration $i failed.")
+          val end = System.nanoTime()
+          val elapsed = NANOSECONDS.toMillis(end - start)
+          println(s"*** Iteration $i failed after $elapsed msec.")
           queryTimes.append(-1)
+          exceptions.append(e.toString)
           e.printStackTrace()
       }
 
@@ -216,7 +219,8 @@ object BenchUtils {
     }
 
     // write results to file
-    val filename = s"$filenameStub-${queryStartTime.toEpochMilli}.json"
+    val suffix = if (exceptions.isEmpty) "" else "-failed"
+    val filename = s"$filenameStub-${queryStartTime.toEpochMilli}$suffix.json"
     println(s"Saving benchmark report to $filename")
 
     // try not to leak secrets

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -195,20 +195,24 @@ object BenchUtils {
       }
     }
 
-    // summarize all query times
-    for (i <- 0 until iterations) {
-      println(s"Iteration $i took ${queryTimes(i)} msec.")
-    }
+    // only show query times if there were no failed queries
+    if (!queryTimes.contains(-1)) {
 
-    // for multiple runs, summarize cold/hot timings
-    if (iterations > 1) {
-      println(s"Cold run: ${queryTimes(0)} msec.")
-      val hotRuns = queryTimes.drop(1)
-      val numHotRuns = hotRuns.length
-      println(s"Best of $numHotRuns hot run(s): ${hotRuns.min} msec.")
-      println(s"Worst of $numHotRuns hot run(s): ${hotRuns.max} msec.")
-      println(s"Average of $numHotRuns hot run(s): " +
-          s"${hotRuns.sum.toDouble / numHotRuns} msec.")
+      // summarize all query times
+      for (i <- 0 until iterations) {
+        println(s"Iteration $i took ${queryTimes(i)} msec.")
+      }
+
+      // for multiple runs, summarize cold/hot timings
+      if (iterations > 1) {
+        println(s"Cold run: ${queryTimes(0)} msec.")
+        val hotRuns = queryTimes.drop(1)
+        val numHotRuns = hotRuns.length
+        println(s"Best of $numHotRuns hot run(s): ${hotRuns.min} msec.")
+        println(s"Worst of $numHotRuns hot run(s): ${hotRuns.max} msec.")
+        println(s"Average of $numHotRuns hot run(s): " +
+            s"${hotRuns.sum.toDouble / numHotRuns} msec.")
+      }
     }
 
     // write results to file

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -26,8 +26,8 @@ import scala.collection.mutable.ListBuffer
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.Serialization.writePretty
-import org.apache.spark.{SPARK_BUILD_USER, SPARK_VERSION}
 
+import org.apache.spark.{SPARK_BUILD_USER, SPARK_VERSION}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.execution.{InputAdapter, QueryExecution, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
@@ -50,7 +50,8 @@ class BenchUtilsSuite extends FunSuite with BeforeAndAfterEach {
       query = "q1",
       queryPlan = QueryPlan("logical", "physical"),
       Seq.empty,
-      queryTimes = Seq(99, 88, 77))
+      queryTimes = Seq(99, 88, 77),
+      exceptions = Seq.empty)
 
     val filename = s"$TEST_FILES_ROOT/BenchUtilsSuite-${System.currentTimeMillis()}.json"
     BenchUtils.writeReport(report, filename)


### PR DESCRIPTION
This PR updates the benchmark runner to capture query plans even when query execution fails.

This closes https://github.com/NVIDIA/spark-rapids/issues/1027