### PR TITLE
[BUG] To honor spark.rapids.memory.gpu.pool=NONE

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -186,12 +186,10 @@ object GpuDeviceManager extends Logging {
       initialAllocation = adjustedMaxAllocation
     }
 
-    // Currently a max limit only works in pooled mode.  Need a general limit resource wrapper
-    // as requested in https://github.com/rapidsai/rmm/issues/442 to support for all RMM modes.
-    if (conf.isPooledMemEnabled) {
-      (initialAllocation, adjustedMaxAllocation)
-    } else {
+    if (!conf.isPooledMemEnabled || "none".equalsIgnoreCase(conf.rmmPool)) {
       (initialAllocation, 0)
+    } else {
+      (initialAllocation, adjustedMaxAllocation)
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

If user set,
```bash
--conf spark.rapids.memory.gpu.pooling.enabled=true
--conf spark.rapids.memory.gpu.pool=NONE
```
The RMM will fail to init w/ `CUDA_DEFAULT` due to [GpuDeviceManager.scala#L191-L192](https://github.com/NVIDIA/spark-rapids/blob/branch-0.3/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala#L191-L192) 
which assigns non-zero value to `adjustedMaxAllocation`, and then except at [Rmm.java#L179-L182](https://github.com/rapidsai/cudf/blob/branch-0.17/java/src/main/java/ai/rapids/cudf/Rmm.java#L179-L182)

As `spark.rapids.memory.gpu.pooling.enabled` will be deprecated, so we make a simple workaround for now