### PR TITLE
Add simple retry for URM dependencies [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -253,11 +253,14 @@ pipeline {
 
 void uploadDocker(String IMAGE_NAME) {
     def DOCKER_CMD = "docker --config $WORKSPACE/.docker"
-    sh """
-        echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
-        $DOCKER_CMD push $IMAGE_NAME
-        $DOCKER_CMD logout $ARTIFACTORY_NAME
-    """
+    retry(3) {
+        sleep(time: 30, unit: "SECONDS")
+        sh """
+            echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
+            $DOCKER_CMD push $IMAGE_NAME
+            $DOCKER_CMD logout $ARTIFACTORY_NAME
+        """
+    }
 }
 
 void deleteDockerTempTag(String tag) {

--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -110,6 +110,7 @@ void uploadDocker(String IMAGE_NAME) {
             $DOCKER_CMD push $IMAGE_NAME
             $DOCKER_CMD logout $ARTIFACTORY_NAME
         """
+    }
 }
 
 void slack(Map params = [:], String channel, String message) {

--- a/jenkins/Jenkinsfile.integration
+++ b/jenkins/Jenkinsfile.integration
@@ -103,11 +103,13 @@ pipeline {
 
 void uploadDocker(String IMAGE_NAME) {
     def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-    sh """
-        echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
-        $DOCKER_CMD push $IMAGE_NAME
-        $DOCKER_CMD logout $ARTIFACTORY_NAME
-    """
+    retry(3) {
+        sleep(time: 30, unit: "SECONDS")
+        sh """
+            echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
+            $DOCKER_CMD push $IMAGE_NAME
+            $DOCKER_CMD logout $ARTIFACTORY_NAME
+        """
 }
 
 void slack(Map params = [:], String channel, String message) {

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -127,6 +127,7 @@ void uploadDocker(String IMAGE_NAME) {
             $DOCKER_CMD push $IMAGE_NAME
             $DOCKER_CMD logout $ARTIFACTORY_NAME
         """
+    }
 }
 
 void slack(Map params = [:], String channel, String message) {

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -120,11 +120,13 @@ pipeline {
 
 void uploadDocker(String IMAGE_NAME) {
     def DOCKER_CMD="docker --config $WORKSPACE/.docker"
-    sh """
-        echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
-        $DOCKER_CMD push $IMAGE_NAME
-        $DOCKER_CMD logout $ARTIFACTORY_NAME
-    """
+    retry(3) {
+        sleep(time: 30, unit: "SECONDS")
+        sh """
+            echo $URM_CREDS_PSW | $DOCKER_CMD login $ARTIFACTORY_NAME -u $URM_CREDS_USR --password-stdin
+            $DOCKER_CMD push $IMAGE_NAME
+            $DOCKER_CMD logout $ARTIFACTORY_NAME
+        """
 }
 
 void slack(Map params = [:], String channel, String message) {


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Was seeing ephemeral issue connecting to URM when doing pre-merge build, so add a simple retry to make it more stable.

Also added retries for 2 other pipelines, the `docker upload func` could a be a shareable func in the future, since we are migrating nightly and integration, let's just make it dup here.

Tested in my forked repo.
