### PR TITLE
Allow for GPUCoalesceBatch to deal with Map

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -42,8 +42,8 @@ else
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
     "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
-        --conf "spark.driver.extraJavaOptions=-Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
-        --conf 'spark.executor.extraJavaOptions=-Duser.timezone=GMT' \
+        --conf "spark.driver.extraJavaOptions=-ea -Duser.timezone=GMT $COVERAGE_SUBMIT_FLAGS" \
+        --conf 'spark.executor.extraJavaOptions=-ea -Duser.timezone=GMT' \
         --conf 'spark.sql.session.timeZone=UTC' \
         --conf 'spark.sql.shuffle.partitions=12' \
         $SPARK_SUBMIT_FLAGS \

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -979,8 +979,8 @@ class MultiFileParquetPartitionReader(
       } else {
         val table = readToTable(seqPathsAndBlocks, clippedSchema, isCorrectRebaseMode)
         try {
-          val colTypes = readDataSchema.fields.map(f => f.dataType).toList
-          val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes.asJava))
+          val colTypes = readDataSchema.fields.map(f => f.dataType)
+          val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes))
           maybeBatch.foreach { batch =>
             logDebug(s"GPU batch size: ${GpuColumnVector.getTotalDeviceMemoryUsed(batch)} bytes")
           }
@@ -1416,8 +1416,8 @@ class MultiFileCloudParquetPartitionReader(
       Some(evolveSchemaIfNeededAndClose(table, fileName, clippedSchema))
     }
     try {
-      val colTypes = readDataSchema.fields.map(f => f.dataType).toList
-      val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes.asJava))
+      val colTypes = readDataSchema.fields.map(f => f.dataType)
+      val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes))
       maybeBatch.foreach { batch =>
         logDebug(s"GPU batch size: ${GpuColumnVector.getTotalDeviceMemoryUsed(batch)} bytes")
       }
@@ -1498,8 +1498,8 @@ class ParquetPartitionReader(
       } else {
         val table = readToTable(currentChunkedBlocks)
         try {
-          val colTypes = readDataSchema.fields.map(f => f.dataType).toList
-          val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes.asJava))
+          val colTypes = readDataSchema.fields.map(f => f.dataType)
+          val maybeBatch = table.map(t => GpuColumnVector.from(t, colTypes))
           maybeBatch.foreach { batch =>
             logDebug(s"GPU batch size: ${GpuColumnVector.getTotalDeviceMemoryUsed(batch)} bytes")
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioning.scala
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.JavaConverters.{asScalaBufferConverter, seqAsJavaListConverter}
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, Table}
@@ -121,8 +120,8 @@ case class GpuRangePartitioning(
       slicedSortedTbl = new Table(sortColumns: _*)
       //get the final column batch, remove the sort order sortColumns
       val outputTypes = gpuOrdering.map(_.child.dataType) ++
-          GpuColumnVector.extractTypes(batch).asScala
-      finalSortedCb = GpuColumnVector.from(sortedTbl, outputTypes.asJava,
+          GpuColumnVector.extractTypes(batch)
+      finalSortedCb = GpuColumnVector.from(sortedTbl, outputTypes.toArray,
         numSortCols, sortedTbl.getNumberOfColumns)
       val numRows = finalSortedCb.numRows
       partitionColumns = GpuColumnVector.extractColumns(finalSortedCb)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -16,8 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.JavaConverters.{asScalaBufferConverter, seqAsJavaListConverter}
-
 import ai.rapids.cudf
 import ai.rapids.cudf.{NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids.GpuMetricNames._
@@ -171,10 +169,10 @@ class GpuColumnarBatchSorter(
               inputCvs = SortUtils.getGpuColVectorsAndBindReferences(inputBatch, sortOrder)
               inputTbl = new cudf.Table(inputCvs.map(_.getBase): _*)
               outputTypes = sortOrder.map(_.child.dataType) ++
-                  GpuColumnVector.extractTypes(inputBatch).asScala
+                  GpuColumnVector.extractTypes(inputBatch)
             } else if (inputBatch.numCols() > 0) {
               inputTbl = GpuColumnVector.from(inputBatch)
-              outputTypes = GpuColumnVector.extractTypes(inputBatch).asScala
+              outputTypes = GpuColumnVector.extractTypes(inputBatch)
             }
             val orderByArgs = getOrderArgs(inputTbl)
             val startTimestamp = System.nanoTime()
@@ -256,7 +254,7 @@ class GpuColumnarBatchSorter(
     var resultTbl: cudf.Table = null
     try {
       resultTbl = tbl.orderBy(orderByArgs: _*)
-      GpuColumnVector.from(resultTbl, types.asJava, numSortCols, resultTbl.getNumberOfColumns)
+      GpuColumnVector.from(resultTbl, types.toArray, numSortCols, resultTbl.getNumberOfColumns)
     } finally {
       if (resultTbl != null) {
         resultTbl.close()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -119,13 +119,12 @@ object GpuFilter extends Arm {
     var tbl: cudf.Table = null
     var filtered: cudf.Table = null
     try {
-      import collection.JavaConverters._
       filterConditionCv = boundCondition.columnarEval(batch).asInstanceOf[GpuColumnVector]
       tbl = GpuColumnVector.from(batch)
       val colTypes =
         (0 until batch.numCols()).map(i => batch.column(i).dataType())
       filtered = tbl.filter(filterConditionCv.getBase)
-      GpuColumnVector.from(filtered, colTypes.asJava)
+      GpuColumnVector.from(filtered, colTypes.toArray)
     } finally {
       Seq(filtered, tbl, filterConditionCv, batch).safeClose()
     }


### PR DESCRIPTION
This allows GPUCoalesceBatch to work on Maps that have been explicitly allowed in other parts of the code.  This is just the first step of several to allow nested types.  This is because Spark has more data types than cudf does so there is not a clear one to one mapping, which we have relied on prior to this.