### PR TITLE
Remove isGpuBroadcastNestedLoopJoin from shims

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -118,13 +118,6 @@ class Spark300Shims extends SparkShims {
     }
   }
 
-  override def isGpuBroadcastNestedLoopJoin(plan: SparkPlan): Boolean = {
-    plan match {
-      case _: GpuBroadcastNestedLoopJoinExecBase => true
-      case _ => false
-    }
-  }
-
   override def isGpuShuffledHashJoin(plan: SparkPlan): Boolean = {
     plan match {
       case _: GpuShuffledHashJoinExec => true

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -62,7 +62,6 @@ trait SparkShims {
   def getSparkShimVersion: ShimVersion
   def isGpuHashJoin(plan: SparkPlan): Boolean
   def isGpuBroadcastHashJoin(plan: SparkPlan): Boolean
-  def isGpuBroadcastNestedLoopJoin(plan: SparkPlan): Boolean
   def isGpuShuffledHashJoin(plan: SparkPlan): Boolean
   def isBroadcastExchangeLike(plan: SparkPlan): Boolean
   def isShuffleExchangeLike(plan: SparkPlan): Boolean

--- a/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.TestUtils.findOperators
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions.broadcast
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.execution.GpuBroadcastNestedLoopJoinExecBase
 
 class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
 
@@ -36,7 +37,7 @@ class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
       df3.collect()
       val plan = df3.queryExecution.executedPlan
 
-      val nljCount = findOperators(plan, ShimLoader.getSparkShims.isGpuBroadcastNestedLoopJoin)
+      val nljCount = findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExecBase])
       assert(nljCount.size === 1)
     }, conf)
   }
@@ -53,7 +54,7 @@ class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
       df3.collect()
       val plan = df3.queryExecution.executedPlan
 
-      val nljCount = findOperators(plan, ShimLoader.getSparkShims.isGpuBroadcastNestedLoopJoin)
+      val nljCount = findOperators(plan, _.isInstanceOf[GpuBroadcastNestedLoopJoinExecBase])
 
       ShimLoader.getSparkShims.getSparkShimVersion match {
         case SparkShimVersion(3, 0, 0) =>


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This is a follow-up to a review comment on the recent PR to fix an issue with joins and AQE and simply removes a method that was added to the shim layer that wasn't really necessary.
