### PR TITLE
Fix build warnings

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -112,6 +112,9 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                     <descriptors>
                         <descriptor>src/assembly/bin.xml</descriptor>
                     </descriptors>
@@ -125,26 +128,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
             <!-- disable surefire as we are using scalatest only -->
             <plugin>
@@ -165,6 +148,9 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+		</configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala
@@ -28,10 +28,10 @@ import org.apache.spark.sql.SparkSession
  * Example usage:
  *
  * <pre>
- * $SPARK_HOME/bin/spark-submit --jars $SPARK_RAPIDS_PLUGIN_JAR,$CUDF_JAR \
+ * \$SPARK_HOME/bin/spark-submit --jars \$SPARK_RAPIDS_PLUGIN_JAR,\$CUDF_JAR \
  *   --master local[*] \
  *   --class com.nvidia.spark.rapids.tests.common.CompareResults \
- *   $SPARK_RAPIDS_PLUGIN_INTEGRATION_TEST_JAR \
+ *   \$SPARK_RAPIDS_PLUGIN_INTEGRATION_TEST_JAR \
  *   --input1 /path/to/result1 \
  *   --input2 /path/to/result2 \
  *   --input-format parquet

--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
                     <configuration>
                         <verbose>false</verbose>
                         <failOnViolation>true</failOnViolation>
-                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        <includeTestSourceDirectory>false</includeTestSourceDirectory>
                         <failOnWarning>false</failOnWarning>
                         <sourceDirectory>${basedir}/src/main/scala</sourceDirectory>
                         <testSourceDirectory>${basedir}/src/test/scala</testSourceDirectory>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -78,10 +78,6 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.scalastyle</groupId>
-                <artifactId>scalastyle-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/shims/spark300/pom.xml
+++ b/shims/spark300/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark300/pom.xml
+++ b/shims/spark300/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark300db/pom.xml
+++ b/shims/spark300db/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark300db/pom.xml
+++ b/shims/spark300db/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark300emr/pom.xml
+++ b/shims/spark300emr/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark300emr/pom.xml
+++ b/shims/spark300emr/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark301/pom.xml
+++ b/shims/spark301/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark301/pom.xml
+++ b/shims/spark301/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark301emr/pom.xml
+++ b/shims/spark301emr/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark301emr/pom.xml
+++ b/shims/spark301emr/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark302/pom.xml
+++ b/shims/spark302/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark302/pom.xml
+++ b/shims/spark302/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/shims/spark310/pom.xml
+++ b/shims/spark310/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-		<configuration>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-		</configuration>
             </plugin>
         </plugins>
 

--- a/shims/spark310/pom.xml
+++ b/shims/spark310/pom.xml
@@ -58,6 +58,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+		</configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -310,6 +310,7 @@ trait GpuGreatestLeastBase extends ComplexTypeMergingExpression with GpuExpressi
       r.binaryOp(binaryOp, c, dtype)
     case (r: Scalar, c: ColumnVector) =>
       r.binaryOp(binaryOp, c, dtype)
+    case _ => throw new IllegalStateException(s"Unexpected inputs: $r, $c")
   }
 
   private[this] def makeNanWin(checkForNans: ColumnVector, result: ColumnVector): ColumnVector = {
@@ -395,6 +396,7 @@ trait GpuGreatestLeastBase extends ComplexTypeMergingExpression with GpuExpressi
           }
         }
       }
+    case _ => throw new IllegalStateException(s"Unexpected inputs: $r, $c")
   }
 
   override def columnarEval(batch: ColumnarBatch): Any = {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -129,7 +129,6 @@
                 <artifactId>scalastyle-maven-plugin</artifactId>
                 <configuration>
                   <sourceDirectory>${project.basedir}/src/test/scala</sourceDirectory>
-                  <includeTestSourceDirectory>false</includeTestSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -127,6 +127,10 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
+                <configuration>
+                  <sourceDirectory>${project.basedir}/src/test/scala</sourceDirectory>
+                  <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -131,6 +131,9 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
+		<configuration>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+		</configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This fixes a number of warnings in the build that have accumulated recently.  Specifically these warnings are addressed:
```
[WARNING] Some problems were encountered while building the effective model for com.nvidia:rapids-4-spark-integration-tests_2.12:jar:0.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-assembly-plugin @ line 129, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[...]
[WARNING] /home/jlowe/src/rapids-plugin-4-spark/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala:306: match may not be exhaustive.
It would fail on the following inputs: (??, _), (ColumnVector(), _), (Scalar(), Scalar()), (Scalar(), _), (_, ??), (_, ColumnVector()), (_, Scalar()), (_, _)
[WARNING]   private[this] def combineButNoClose(r: Any, c: Any): Any = (r, c) match {
[WARNING]                                                              ^
[WARNING] /home/jlowe/src/rapids-plugin-4-spark/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala:361: match may not be exhaustive.
It would fail on the following inputs: (??, _), (ColumnVector(), _), (Scalar(), Scalar()), (Scalar(), _), (_, ??), (_, ColumnVector()), (_, Scalar()), (_, _)
[WARNING]   private[this] def combineButNoCloseFp(r: Any, c: Any): Any = (r, c) match {
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/sql-plugin/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shuffle-plugin/src/test/scala
[...]
[WARNING] sourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/src/main/scala
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark300/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark300emr/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark301/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark301emr/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark310/src/test/scala
[...]
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/spark302/src/test/scala
[...]
[WARNING] sourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/aggregator/src/main/scala
[WARNING] testSourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/shims/aggregator/src/test/scala
[...]
[WARNING] sourceDirectory is not specified or does not exist value=/home/jlowe/src/rapids-plugin-4-spark/tests/src/main/scala
[...]
/home/jlowe/src/rapids-plugin-4-spark/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala:31: warning: Variable SPARK undefined in comment for object CompareResults in object CompareResults
/home/jlowe/src/rapids-plugin-4-spark/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala:31: warning: Variable SPARK undefined in comment for object CompareResults in object CompareResults
/home/jlowe/src/rapids-plugin-4-spark/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala:31: warning: Variable CUDF undefined in comment for object CompareResults in object CompareResults
/home/jlowe/src/rapids-plugin-4-spark/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala:34: warning: Variable SPARK undefined in comment for object CompareResults in object CompareResults
```
