### PR TITLE
Add query number to Spark app name when running benchmarks

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -45,7 +45,8 @@ object BenchmarkRunner {
 
     benchmarks.get(conf.benchmark().toLowerCase) match {
       case Some(bench) =>
-        val spark = SparkSession.builder.appName(s"${bench.name()} Like Bench").getOrCreate()
+        val appName = s"${bench.name()} Like Bench ${conf.query()}"
+        val spark = SparkSession.builder.appName(appName).getOrCreate()
         conf.inputFormat().toLowerCase match {
           case "parquet" => bench.setupAllParquet(spark, conf.input())
           case "csv" => bench.setupAllCSV(spark, conf.input())


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

When viewing Spark event logs in history server from a benchmark suite run, every app currently has the same name, such as "TPC-DS Like Bench" which isn't very helpful.

This PR simply adds the query name to the app name. For example: "TPC-DS Lilke Bench q5".