### PR TITLE
More fixes for conversion to ColumnarBatch

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuShuffledHashJoinExec.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuShuffledHashJoinExec.scala
@@ -137,11 +137,10 @@ case class GpuShuffledHashJoinExec(
           buildIter, localBuildOutput)) { buildBatch: ColumnarBatch =>
           withResource(GpuProjectExec.project(buildBatch, gpuBuildKeys)) { keys =>
             val combined = GpuHashJoin.incRefCount(combine(keys, buildBatch))
-            val filtered = filterBuiltTableIfNeeded(combined)
-            combinedSize =
-                GpuColumnVector.extractColumns(filtered)
-                    .map(_.getBase.getDeviceMemorySize).sum.toInt
-            withResource(filtered) { filtered =>
+            withResource(filterBuiltTableIfNeeded(combined)) { filtered =>
+              combinedSize =
+                  GpuColumnVector.extractColumns(filtered)
+                      .map(_.getBase.getDeviceMemorySize).sum.toInt
               GpuColumnVector.from(filtered)
             }
           }

--- a/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuShuffledHashJoinExec.scala
@@ -126,11 +126,10 @@ case class GpuShuffledHashJoinExec(
           buildIter, localBuildOutput)) { buildBatch: ColumnarBatch =>
           withResource(GpuProjectExec.project(buildBatch, gpuBuildKeys)) { keys =>
             val combined = GpuHashJoin.incRefCount(combine(keys, buildBatch))
-            val filtered = filterBuiltTableIfNeeded(combined)
-            combinedSize =
-                GpuColumnVector.extractColumns(filtered)
-                    .map(_.getBase.getDeviceMemorySize).sum.toInt
-            withResource(filtered) { filtered =>
+            withResource(filterBuiltTableIfNeeded(combined)) { filtered =>
+              combinedSize =
+                  GpuColumnVector.extractColumns(filtered)
+                      .map(_.getBase.getDeviceMemorySize).sum.toInt
               GpuColumnVector.from(filtered)
             }
           }

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuShuffledHashJoinExec.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuShuffledHashJoinExec.scala
@@ -138,11 +138,10 @@ case class GpuShuffledHashJoinExec(
           buildIter, localBuildOutput)) { buildBatch: ColumnarBatch =>
           withResource(GpuProjectExec.project(buildBatch, gpuBuildKeys)) { keys =>
             val combined = GpuHashJoin.incRefCount(combine(keys, buildBatch))
-            val filtered = filterBuiltTableIfNeeded(combined)
-            combinedSize =
-                GpuColumnVector.extractColumns(filtered)
-                    .map(_.getBase.getDeviceMemorySize).sum.toInt
-            withResource(filtered) { filtered =>
+            withResource(filterBuiltTableIfNeeded(combined)) { filtered =>
+              combinedSize =
+                  GpuColumnVector.extractColumns(filtered)
+                      .map(_.getBase.getDeviceMemorySize).sum.toInt
               GpuColumnVector.from(filtered)
             }
           }

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
@@ -362,7 +362,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
           .includeColumn(requestedColumnNames.asJavaCollection).build()
         withResource(Table.readParquet(parquetOptions, parquetCB.buffer, 0,
           parquetCB.sizeInBytes)) { table =>
-          GpuColumnVector.from(table)
+          GpuColumnVector.from(table, selectedAttributes.map(_.dataType).toArray)
         }
       } else {
         throw new IllegalStateException("I don't know how to convert this batch")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBatchScanExec.scala
@@ -432,7 +432,7 @@ class CSVPartitionReader(
         if (readDataSchema.isEmpty) {
           table.map(t => new ColumnarBatch(Array.empty, t.getRowCount.toInt))
         } else {
-          table.map(GpuColumnVector.from)
+          table.map(GpuColumnVector.from(_, readDataSchema.toArray.map(_.dataType)))
         }
       } finally {
         metrics(NUM_OUTPUT_BATCHES) += 1

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -127,6 +127,7 @@ case class GpuGenerateExec(
     val numOtherColumns = boundOthersProjectList.length
     val numExplodeColumns = if (includePos) 2 else 1
 
+    val outputSchema = output.map(_.dataType).toArray
     child.executeColumnar().mapPartitions { it =>
       new Iterator[ColumnarBatch] {
         var currentBatch: ColumnarBatch = _
@@ -181,7 +182,7 @@ case class GpuGenerateExec(
                 indexIntoData += 1
                 numOutputBatches += 1
                 numOutputRows += table.getRowCount
-                GpuColumnVector.from(table)
+                GpuColumnVector.from(table, outputSchema)
               }
             } finally {
               result.safeClose()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -284,7 +284,7 @@ class GpuOrcPartitionReader(
       } else {
         val table = readToTable(currentStripes)
         try {
-          table.map(GpuColumnVector.from)
+          table.map(GpuColumnVector.from(_, readDataSchema.toArray.map(_.dataType)))
         } finally {
           table.foreach(_.close())
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.GpuPredicateHelper
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.types.{DataType, LongType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 object GpuProjectExec {
@@ -281,7 +282,7 @@ case class GpuRangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range
                         ai.rapids.cudf.ColumnVector.sequence(
                           startScalar, stepScalar, rowsThisBatch.toInt)) { vec =>
                         withResource(new Table(vec)) { tab =>
-                          GpuColumnVector.from(tab)
+                          GpuColumnVector.from(tab, Array[DataType](LongType))
                         }
                       }
                     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -104,7 +104,11 @@ abstract class GpuShuffleExchangeExecBase(
     throw new IllegalStateException()
   }
 
-  private val serializer: Serializer = new GpuColumnarBatchSerializer(longMetric("dataSize"))
+  // This value must be lazy because the child's output may not have been resolved
+  // yet in all cases.
+  private lazy val serializer: Serializer = new GpuColumnarBatchSerializer(
+    child.output.map(_.dataType).toArray,
+    longMetric("dataSize"))
 
   @transient lazy val inputBatchRDD: RDD[ColumnarBatch] = child.executeColumnar()
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -19,14 +19,12 @@ package com.nvidia.spark.rapids
 import java.io.File
 import java.nio.file.Files
 
-import scala.collection.immutable.HashMap
-
 import ai.rapids.cudf.{ContiguousTable, Cuda, HostColumnVector, Table}
 import com.nvidia.spark.rapids.format.CodecType
 
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.metrics.source.MockTaskContext
-import org.apache.spark.sql.types.{DataTypes, LongType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, DataTypes, LongType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
@@ -403,7 +401,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
 
   private def buildUncompressedBatch(start: Int, numRows: Int): ColumnarBatch = {
     withResource(buildContiguousTable(start, numRows)) { ct =>
-      GpuColumnVector.from(ct.getTable)
+      GpuColumnVector.from(ct.getTable, Array[DataType](LongType))
     }
   }
 
@@ -411,7 +409,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     val codec = TableCompressionCodec.getCodec(CodecType.NVCOMP_LZ4)
     withResource(codec.createBatchCompressor(0, Cuda.DEFAULT_STREAM)) { compressor =>
       compressor.addTableToCompress(buildContiguousTable(start, numRows))
-      GpuCompressedColumnVector.from(compressor.finish().head)
+      GpuCompressedColumnVector.from(compressor.finish().head, Array[DataType](LongType))
     }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -18,13 +18,14 @@ package com.nvidia.spark.rapids
 
 import java.io.File
 
-import ai.rapids.cudf.{Cuda, Table}
+import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuPartitioningSuite extends FunSuite with Arm {
@@ -34,7 +35,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
         .column("five", "two", null, null, "one", "one", "one", "one", "one", "one")
         .column(5.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
         .build()) { table =>
-      GpuColumnVector.from(table)
+      GpuColumnVector.from(table, Array(IntegerType, StringType, DoubleType))
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -16,11 +16,12 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{Cuda, Table}
+import ai.rapids.cudf.Table
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.rapids.GpuShuffleEnv
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuSinglePartitioningSuite extends FunSuite with Arm {
@@ -30,7 +31,7 @@ class GpuSinglePartitioningSuite extends FunSuite with Arm {
         .column("five", "two", null, null, "one", "one", "one", "one", "one", "one")
         .column(5.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
         .build()) { table =>
-      GpuColumnVector.from(table)
+      GpuColumnVector.from(table, Array(IntegerType, StringType, DoubleType))
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -135,7 +135,8 @@ class MetaUtilsSuite extends FunSuite with Arm {
       val uncompressedMeta = MetaUtils.buildDegenerateTableMeta(uncompressedBatch)
       withResource(DeviceMemoryBuffer.allocate(0)) { buffer =>
         val compressedTable = CompressedTable(0, uncompressedMeta, buffer)
-        withResource(GpuCompressedColumnVector.from(compressedTable)) { batch =>
+        withResource(GpuCompressedColumnVector.from(compressedTable,
+            GpuColumnVector.extractTypes(schema))) { batch =>
           val meta = MetaUtils.buildDegenerateTableMeta(batch)
           assertResult(null)(meta.bufferMeta)
           assertResult(0)(meta.rowCount)


### PR DESCRIPTION
This is getting to be a rather large change and there is a lot more on the way, so I am putting in some of the changes now and will keep working on more of them as this is reviewed.

The issue is that there is a many to one mapping of Spark Types to CUDF types. So we can no longer take a `cudf.Table` and turn it into a `ColumnarBatch`, or a `cudf.ColumnVector` and turn it into a `GpuColumnVector`.

The is going through API by API to try and replace them with versions that take the Spark DataType.