### PR TITLE
Improve AQE transition logic

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -266,7 +266,8 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       HostColumnarToGpu(insertColumnarFromGpu(plan), TargetSize(conf.gpuTargetBatchSizeBytes))
     } else {
       plan.withNewChildren(plan.children.map(insertColumnarToGpu))
-    }  }
+    }
+  }
 
   private def insertHashOptimizeSorts(plan: SparkPlan): SparkPlan = {
     if (conf.enableHashOptimizeSort) {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

The `insertColumnarToGpu` method inserts a `HostColumnarToGpu` transition for plans that are columnar but not on the GPU. This logic was not working correctly for query stages when AQE is enabled because we don't (and cannot) replace query stages with a GPU version. They simply wrap a GPU plan. We had logic to later remove these `HostColumnarToGpu` transitions that were incorrectly inserted.

This PR fixes `insertColumnarToGpu` so that it does not insert unnecessary transitions for GPU query stages.