### PR TITLE
Improve AQE transitions for shuffle and coalesce batches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -64,10 +64,8 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       if (plan.supportsColumnar && plan.isInstanceOf[GpuExec]) {
         // coalesce after shuffle, unless there is a custom shuffle reader
         parent match {
-          case Some(_: GpuCustomShuffleReaderExec) =>
-            s
-          case _ =>
-            GpuCoalesceBatches(s, TargetSize(conf.gpuTargetBatchSizeBytes))
+          case Some(_: GpuCustomShuffleReaderExec) => s
+          case _ => GpuCoalesceBatches(s, TargetSize(conf.gpuTargetBatchSizeBytes))
         }
       } else {
         s


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR improves the logic for handling AQE transitions for shuffle and coalesce batches. The specific changes are:

- The `insertColumnarToGpu` method no longer incorrectly inserts a `HostColumnarToGpu` transition for query stages that wrap columnar GPU plans, and therefore it is no longer necessary to remove these incorrect  ``HostColumnarToGpu`` later when optimizing AQE transitions.
- The logic for removing the `GpuCoalesceBatchExec` step around shuffle exchanges when creating new query stages has been simplified slightly to only recurse into the children of the shuffle exchange and not attempt to optimize the shuffle exchange itself.
- Previously `GpuCoalesceBatchExec` was only inserted around custom shuffle readers but in some cases there is no custom shuffle reader in the plan so we had lost the coalesce step in this case (which was a potential performance regression and also caused bugs when UCX and compression were enabled).
- When inserting `GpuCoalesceBatchExec` around a custom shuffle reader, the  target size is now based on the configuration rather than hard-coded.

