### PR TITLE
Another round of fixes for mapping of DataType to DType

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuHashJoin.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuHashJoin.scala
@@ -315,10 +315,8 @@ trait GpuHashJoin extends GpuExec with HashJoin {
           s" supported")
     }
     try {
-      val result = joinIndices.zip(output).map { pair =>
-        val joinIndex = pair._1
-        val dataType = pair._2.dataType
-        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), dataType)
+      val result = joinIndices.zip(output).map { case (joinIndex, outAttr) =>
+        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), outAttr.dataType)
       }.toArray[ColumnVector]
 
       new ColumnarBatch(result, joinedTable.getRowCount.toInt)

--- a/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuHashJoin.scala
+++ b/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuHashJoin.scala
@@ -316,10 +316,8 @@ trait GpuHashJoin extends GpuExec with HashJoin {
           s" supported")
     }
     try {
-      val result = joinIndices.zip(output).map { pair =>
-        val joinIndex = pair._1
-        val dataType = pair._2.dataType
-        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), dataType)
+      val result = joinIndices.zip(output).map { case (joinIndex, outAttr) =>
+        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), outAttr.dataType)
       }.toArray[ColumnVector]
 
       new ColumnarBatch(result, joinedTable.getRowCount.toInt)

--- a/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuHashJoin.scala
+++ b/shims/spark300db/src/main/scala/com/nvidia/spark/rapids/shims/spark300db/GpuHashJoin.scala
@@ -176,8 +176,6 @@ trait GpuHashJoin extends GpuExec with HashJoin {
 
   /**
    * Filter the builtBatch if needed.  builtBatch will be closed.
-   * @param builtBatch
-   * @return
    */
   def filterBuiltTableIfNeeded(builtBatch: ColumnarBatch): ColumnarBatch =
     if (shouldFilterBuiltTableForNulls) {
@@ -318,9 +316,11 @@ trait GpuHashJoin extends GpuExec with HashJoin {
           s" supported")
     }
     try {
-      val result = joinIndices.map(joinIndex =>
-        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount()))
-        .toArray[ColumnVector]
+      val result = joinIndices.zip(output).map { pair =>
+        val joinIndex = pair._1
+        val dataType = pair._2.dataType
+        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), dataType)
+      }.toArray[ColumnVector]
 
       new ColumnarBatch(result, joinedTable.getRowCount.toInt)
     } finally {

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuHashJoin.scala
@@ -316,10 +316,8 @@ trait GpuHashJoin extends GpuExec with HashJoinWithoutCodegen {
           s" supported")
     }
     try {
-      val result = joinIndices.zip(output).map { pair =>
-        val joinIndex = pair._1
-        val dataType = pair._2.dataType
-        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), dataType)
+      val result = joinIndices.zip(output).map { case (joinIndex, outAttr) =>
+        GpuColumnVector.from(joinedTable.getColumn(joinIndex).incRefCount(), outAttr.dataType)
       }.toArray[ColumnVector]
 
       new ColumnarBatch(result, joinedTable.getRowCount.toInt)

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -233,8 +233,8 @@ public class GpuColumnVector extends GpuColumnVectorBase {
   }
 
   /**
-   * Convert a spark schema into a cudf schema
-   * @param input the spark schema to convert
+   * Convert a Spark schema into a cudf schema
+   * @param input the Spark schema to convert
    * @return the cudf schema
    */
   public static Schema from(StructType input) {
@@ -415,7 +415,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
   }
 
   /**
-   * Converts a cudf internal vector to a spark compatible vector. No reference counts
+   * Converts a cudf internal vector to a Spark compatible vector. No reference counts
    * are incremented so you need to either close the returned value or the input value,
    * but not both.
    */
@@ -444,7 +444,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
   }
 
   /**
-   * Get the underlying spark compatible columns from the batch.  This does not increment any
+   * Get the underlying Spark compatible columns from the batch.  This does not increment any
    * reference counts so if you want to use these columns after the batch is closed
    * you will need to do that on your own.
    */

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -463,12 +463,19 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     return new GpuColumnVector(getSparkTypeFrom(cudfCv), cudfCv);
   }
 
+  /**
+   * Converts a cudf internal vector to a spark compatible vector. No reference counts
+   * are incremented so you need to either close the returned value or the input value,
+   * but not both.
+   */
   public static GpuColumnVector from(ai.rapids.cudf.ColumnVector cudfCv, DataType type) {
+    assert typeConversionAllowed(cudfCv, type) : "Type conversion is not allowed from " + cudfCv +
+        " to " + type;
     return new GpuColumnVector(type, cudfCv);
   }
 
-  public static GpuColumnVector from(Scalar scalar, int count) {
-    return from(ai.rapids.cudf.ColumnVector.fromScalar(scalar, count));
+  public static GpuColumnVector from(Scalar scalar, int count, DataType sparkType) {
+    return from(ai.rapids.cudf.ColumnVector.fromScalar(scalar, count), sparkType);
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -17,7 +17,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable
 
-import ai.rapids.cudf.{DType, NvtxColor, Scalar}
+import ai.rapids.cudf.{NvtxColor, Scalar}
 import com.nvidia.spark.rapids.GpuMetricNames._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.{ExpandExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuExpandExecMeta(
@@ -135,19 +136,20 @@ class GpuExpandIterator(
       "ExpandExec projections", NvtxColor.GREEN, totalTime)) { _ =>
 
       // ExpandExec typically produces many null columns so we re-use them where possible
-      val nullCVs = mutable.Map[DType,GpuColumnVector]()
+      val nullCVs = mutable.Map[DataType, GpuColumnVector]()
 
       /**
        * Create a null column vector for the specified data type, returning the vector and
        * a boolean indicating whether an existing vector was re-used.
        */
-      def getOrCreateNullCV(dataType: DType): (GpuColumnVector, Boolean) = {
+      def getOrCreateNullCV(dataType: DataType): (GpuColumnVector, Boolean) = {
+        val rapidsType = GpuColumnVector.getRapidsType(dataType)
         nullCVs.get(dataType) match {
           case Some(cv) =>
             (cv.incRefCount(), true)
           case None =>
-            val cv = withResource(Scalar.fromNull(dataType)) { scalar =>
-              GpuColumnVector.from(scalar, cb.numRows())
+            val cv = withResource(Scalar.fromNull(rapidsType)) { scalar =>
+              GpuColumnVector.from(scalar, cb.numRows(), dataType)
             }
             nullCVs.put(dataType, cv)
             (cv, false)
@@ -155,19 +157,19 @@ class GpuExpandIterator(
       }
 
       val projectedColumns = boundProjections(projectionIndex).safeMap(fn = expr => {
-        val rapidsType = GpuColumnVector.getRapidsType(expr.dataType)
+        val sparkType = expr.dataType
         val (cv, nullColumnReused) = expr.columnarEval(cb) match {
-          case null => getOrCreateNullCV(rapidsType)
-          case lit: GpuLiteral if lit.value == null => getOrCreateNullCV(rapidsType)
+          case null => getOrCreateNullCV(sparkType)
+          case lit: GpuLiteral if lit.value == null => getOrCreateNullCV(sparkType)
           case lit: GpuLiteral =>
             val cv = withResource(GpuScalar.from(lit.value, lit.dataType)) { scalar =>
-              GpuColumnVector.from(scalar, cb.numRows())
+              GpuColumnVector.from(scalar, cb.numRows(), sparkType)
             }
             (cv, false)
           case cv: GpuColumnVector => (cv, false)
           case other =>
-            val cv = withResource(GpuScalar.from(other, expr.dataType)) { scalar =>
-              GpuColumnVector.from(scalar, cb.numRows())
+            val cv = withResource(GpuScalar.from(other, sparkType)) { scalar =>
+              GpuColumnVector.from(scalar, cb.numRows(), sparkType)
             }
             (cv, false)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioning.scala
@@ -103,9 +103,7 @@ case class GpuHashPartitioning(expressions: Seq[Expression], numPartitions: Int)
       val partedTable = table.onColumns(keys: _*).hashPartition(numPartitions)
       table.close()
       val parts = partedTable.getPartitions
-      val columns = dataIndexes.zip(sparkTypes).map { pair =>
-        val idx = pair._1
-        val sparkType = pair._2
+      val columns = dataIndexes.zip(sparkTypes).map { case (idx, sparkType) =>
         GpuColumnVector.from(partedTable.getColumn(idx).incRefCount(), sparkType)
       }
       partedTable.close()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
@@ -33,9 +33,9 @@ case class GpuInSet(
 
   override def nullable: Boolean = child.nullable || list.contains(null)
 
-  override def doColumnar(haystack: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(haystack: GpuColumnVector): ColumnVector = {
     val needles = getNeedles
-    GpuColumnVector.from(haystack.getBase.contains(needles))
+    haystack.getBase.contains(needles)
   }
 
   private def getNeedles: ColumnVector = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMonotonicallyIncreasingID.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMonotonicallyIncreasingID.scala
@@ -59,7 +59,7 @@ case class GpuMonotonicallyIncreasingID() extends GpuLeafExpression {
       mask = Scalar.fromLong(partitionMask)
       sequence = ColumnVector.sequence(start, numRows)
       count += numRows
-      GpuColumnVector.from(sequence.add(mask))
+      GpuColumnVector.from(sequence.add(mask), dataType)
     } finally {
       if (start != null) {
         start.close()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -756,7 +756,8 @@ abstract class FileParquetPartitionReaderBase(
         val partitionScalars = ColumnarPartitionReaderWithPartitionValues
           .createPartitionValues(partitionValues, partitionSchema)
         withResource(partitionScalars) { scalars =>
-          ColumnarPartitionReaderWithPartitionValues.addPartitionValues(cb, scalars)
+          ColumnarPartitionReaderWithPartitionValues.addPartitionValues(cb, scalars,
+            GpuColumnVector.extractTypes(partitionSchema))
         }
       }
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -43,19 +43,17 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
     val sparkTypes = GpuColumnVector.extractTypes(batch)
     withResource(GpuColumnVector.from(batch)) { table =>
       if (numPartitions == 1) {
-        val columns = (0 until table.getNumberOfColumns).zip(sparkTypes).map { pair =>
-          val idx = pair._1
-          val sparkType = pair._2
-          GpuColumnVector.from(table.getColumn(idx).incRefCount(), sparkType)
+        val columns = (0 until table.getNumberOfColumns).zip(sparkTypes).map {
+          case(idx, sparkType) =>
+            GpuColumnVector.from(table.getColumn(idx).incRefCount(), sparkType)
         }.toArray
         return (Array(0), columns)
       }
       withResource(table.roundRobinPartition(numPartitions, getStartPartition)) { partedTable =>
         val parts = partedTable.getPartitions
-        val columns = (0 until partedTable.getNumberOfColumns.toInt).zip(sparkTypes).map { pair =>
-          val idx = pair._1
-          val sparkType = pair._2
-          GpuColumnVector.from(partedTable.getColumn(idx).incRefCount(), sparkType)
+        val columns = (0 until partedTable.getNumberOfColumns.toInt).zip(sparkTypes).map {
+          case(idx, sparkType) =>
+            GpuColumnVector.from(partedTable.getColumn(idx).incRefCount(), sparkType)
         }.toArray
         (parts, columns)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import java.util.Random
 
-import ai.rapids.cudf.{NvtxColor, NvtxRange, Table}
+import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -40,24 +40,25 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
   override def dataType: DataType = IntegerType
 
   def partitionInternal(batch: ColumnarBatch): (Array[Int], Array[GpuColumnVector]) = {
-    val table: Table = GpuColumnVector.from(batch)
-    try {
+    val sparkTypes = GpuColumnVector.extractTypes(batch)
+    withResource(GpuColumnVector.from(batch)) { table =>
       if (numPartitions == 1) {
-        val columns = (0 until table.getNumberOfColumns).map(
-          idx => GpuColumnVector.from(table.getColumn(idx).incRefCount())).toArray
+        val columns = (0 until table.getNumberOfColumns).zip(sparkTypes).map { pair =>
+          val idx = pair._1
+          val sparkType = pair._2
+          GpuColumnVector.from(table.getColumn(idx).incRefCount(), sparkType)
+        }.toArray
         return (Array(0), columns)
       }
-      val partedTable = table.roundRobinPartition(numPartitions, getStartPartition)
-      try {
+      withResource(table.roundRobinPartition(numPartitions, getStartPartition)) { partedTable =>
         val parts = partedTable.getPartitions
-        val columns = (0 until partedTable.getNumberOfColumns.toInt).map(
-          idx => GpuColumnVector.from(partedTable.getColumn(idx).incRefCount())).toArray
+        val columns = (0 until partedTable.getNumberOfColumns.toInt).zip(sparkTypes).map { pair =>
+          val idx = pair._1
+          val sparkType = pair._2
+          GpuColumnVector.from(partedTable.getColumn(idx).incRefCount(), sparkType)
+        }.toArray
         (parts, columns)
-      } finally {
-        partedTable.close()
       }
-    } finally {
-      table.close()
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
@@ -44,15 +44,9 @@ case class GpuSparkPartitionID() extends GpuLeafExpression {
       partitionId = TaskContext.getPartitionId()
       wasInitialized = true
     }
-    var part: Scalar = null
-    try {
-      val numRows = batch.numRows()
-      part = Scalar.fromInt(partitionId)
-      GpuColumnVector.from(ColumnVector.fromScalar(part, numRows))
-    } finally {
-      if (part != null) {
-        part.close()
-      }
+    val numRows = batch.numRows()
+    withResource(Scalar.fromInt(partitionId)) { part =>
+      GpuColumnVector.from(ColumnVector.fromScalar(part, numRows), dataType)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -239,10 +239,10 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
     val expectedType = GpuColumnVector.getRapidsType(windowFunc.dataType)
     if (expectedType != aggColumn.getDataType) {
       withResource(aggColumn) { aggColumn =>
-        GpuColumnVector.from(aggColumn.castTo(expectedType))
+        GpuColumnVector.from(aggColumn.castTo(expectedType), windowFunc.dataType)
       }
     } else {
-      GpuColumnVector.from(aggColumn)
+      GpuColumnVector.from(aggColumn, windowFunc.dataType)
     }
   }
 
@@ -270,10 +270,10 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
     val expectedType = GpuColumnVector.getRapidsType(windowFunc.dataType)
     if (expectedType != aggColumn.getDataType) {
       withResource(aggColumn) { aggColumn =>
-        GpuColumnVector.from(aggColumn.castTo(expectedType))
+        GpuColumnVector.from(aggColumn.castTo(expectedType), windowFunc.dataType)
       }
     } else {
-      GpuColumnVector.from(aggColumn)
+      GpuColumnVector.from(aggColumn, windowFunc.dataType)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -26,6 +26,7 @@ import com.google.flatbuffers.FlatBufferBuilder
 import com.nvidia.spark.rapids.format._
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.ShuffleBlockBatchId
 
@@ -213,23 +214,44 @@ object MetaUtils extends Arm {
   }
 
   /**
+   * Construct a table from a contiguous device buffer and a
+   * `TableMeta` message describing the schema of the buffer data.
+   * @param deviceBuffer contiguous buffer
+   * @param meta schema metadata
+   * @return table that must be closed by the caller
+   */
+  def getTableFromMeta(deviceBuffer: DeviceMemoryBuffer, meta: TableMeta): Table = {
+    closeOnExcept(new ArrayBuffer[ColumnVector](meta.columnMetasLength())) { columns =>
+      val columnMeta = new ColumnMeta
+      (0 until meta.columnMetasLength).foreach { i =>
+        columns.append(makeCudfColumn(deviceBuffer, meta.columnMetas(columnMeta, i)))
+      }
+      new Table(columns :_*)
+    }
+  }
+
+  /**
    * Construct a columnar batch from a contiguous device buffer and a
    * `TableMeta` message describing the schema of the buffer data.
    * @param deviceBuffer contiguous buffer
    * @param meta schema metadata
+   * @param sparkTypes the spark types that the `ColumnarBatch` should have.
    * @return columnar batch that must be closed by the caller
    */
-  def getBatchFromMeta(deviceBuffer: DeviceMemoryBuffer, meta: TableMeta): ColumnarBatch = {
+  def getBatchFromMeta(deviceBuffer: DeviceMemoryBuffer,
+      meta: TableMeta,
+      sparkTypes: Array[DataType]): ColumnarBatch = {
     closeOnExcept(new ArrayBuffer[GpuColumnVector](meta.columnMetasLength())) { columns =>
       val columnMeta = new ColumnMeta
       (0 until meta.columnMetasLength).foreach { i =>
-        columns.append(makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i)))
+        columns.append(makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i), sparkTypes(i)))
       }
       new ColumnarBatch(columns.toArray, meta.rowCount.toInt)
     }
   }
 
-  private def makeColumn(buffer: DeviceMemoryBuffer, meta: ColumnMeta): GpuColumnVector = {
+  private def makeCudfColumn(buffer: DeviceMemoryBuffer,
+      meta: ColumnMeta): ColumnVector = {
     def getSubBuffer(s: SubBufferMeta): DeviceMemoryBuffer =
       if (s != null) buffer.slice(s.offset, s.length) else null
 
@@ -243,9 +265,13 @@ object MetaUtils extends Arm {
     val dataBuffer = getSubBuffer(meta.data)
     val validBuffer = getSubBuffer(meta.validity)
     val offsetsBuffer = getSubBuffer(meta.offsets)
-    GpuColumnVector.from(new ColumnVector(dtype, meta.rowCount, nullCount,
-      dataBuffer, validBuffer, offsetsBuffer))
+    new ColumnVector(dtype, meta.rowCount, nullCount, dataBuffer, validBuffer, offsetsBuffer)
   }
+
+  private def makeColumn(buffer: DeviceMemoryBuffer,
+      meta: ColumnMeta,
+      sparkType: DataType): GpuColumnVector =
+    GpuColumnVector.from(makeCudfColumn(buffer, meta), sparkType)
 }
 
 class DirectByteBufferFactory extends FlatBufferBuilder.ByteBufferFactory {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -499,7 +499,7 @@ case class GpuHashAggregateExec(
             val vecs = defaultValues.map { ref =>
               val scalar = GpuScalar.from(ref.asInstanceOf[GpuLiteral].value, ref.dataType)
               try {
-                GpuColumnVector.from(scalar, 1)
+                GpuColumnVector.from(scalar, 1, ref.dataType)
               } finally {
                 scalar.close()
               }
@@ -542,11 +542,8 @@ case class GpuHashAggregateExec(
               result match {
                 case cv: ColumnVector => cv.asInstanceOf[GpuColumnVector]
                 case _ =>
-                  val scalar = GpuScalar.from(result, ref.dataType)
-                  try {
-                    GpuColumnVector.from(scalar, finalCb.numRows)
-                  } finally {
-                    scalar.close()
+                  withResource(GpuScalar.from(result, ref.dataType)) { scalar =>
+                    GpuColumnVector.from(scalar, finalCb.numRows, ref.dataType)
                   }
               }
             }
@@ -605,7 +602,7 @@ case class GpuHashAggregateExec(
         case cv: ColumnVector => cv.asInstanceOf[GpuColumnVector]
         case _ =>
           withResource(GpuScalar.from(in, ref.dataType)) { scalar =>
-            GpuColumnVector.from(scalar, batch.numRows)
+            GpuColumnVector.from(scalar, batch.numRows, ref.dataType)
           }
       }
       if (childCv.dataType == ref.dataType) {
@@ -613,7 +610,7 @@ case class GpuHashAggregateExec(
       } else {
         withResource(childCv) { childCv =>
           val rapidsType = GpuColumnVector.getRapidsType(ref.dataType)
-          GpuColumnVector.from(childCv.getBase.castTo(rapidsType))
+          GpuColumnVector.from(childCv.getBase.castTo(rapidsType), ref.dataType)
         }
       }
     }
@@ -626,27 +623,23 @@ case class GpuHashAggregateExec(
    * @param aggregatedCb this is a batch that was kept for concatenation
    * @return Seq[GpuColumnVector] with concatenated vectors
    */
-  private def concatenateBatches(aggregatedInputCb: ColumnarBatch, aggregatedCb: ColumnarBatch,
+  private def concatenateBatches(aggregatedInputCb: ColumnarBatch,
+      aggregatedCb: ColumnarBatch,
       concatTime: SQLMetric): Seq[GpuColumnVector] = {
-    val nvtxRange = new NvtxWithMetrics("concatenateBatches", NvtxColor.BLUE, concatTime)
-    try {
+    withResource(new NvtxWithMetrics("concatenateBatches", NvtxColor.BLUE, concatTime)) { _ =>
       // get tuples of columns to concatenate
 
       val zipped = (0 until aggregatedCb.numCols()).map { i =>
         (aggregatedInputCb.column(i), aggregatedCb.column(i))
       }
 
-      val concatCvs = zipped.map {
+      zipped.map {
         case (col1, col2) =>
           GpuColumnVector.from(
             cudf.ColumnVector.concatenate(
               col1.asInstanceOf[GpuColumnVector].getBase,
-              col2.asInstanceOf[GpuColumnVector].getBase))
+              col2.asInstanceOf[GpuColumnVector].getBase), col1.dataType())
       }
-
-      concatCvs
-    } finally {
-      nvtxRange.close()
     }
   }
 
@@ -862,15 +855,8 @@ case class GpuHashAggregateExec(
           for (i <- 0 until result.getNumberOfColumns) {
             val rapidsType = GpuColumnVector.getRapidsType(dataTypes(i))
             // cast will be cheap if type matches, only does refCount++ in that case
-            val castedCol = result.getColumn(i).castTo(rapidsType)
-            var success = false
-            try {
-              resCols += GpuColumnVector.from(castedCol)
-              success = true
-            } finally {
-              if (!success) {
-                castedCol.close()
-              }
+            closeOnExcept(result.getColumn(i).castTo(rapidsType)) { castedCol =>
+              resCols += GpuColumnVector.from(castedCol, dataTypes(i))
             }
           }
           new ColumnarBatch(resCols.toArray, result.getRowCount.toInt)
@@ -888,23 +874,20 @@ case class GpuHashAggregateExec(
         // reduction merge or update aggregates functions are
         val cvs = ArrayBuffer[GpuColumnVector]()
         aggModeCudfAggregates.foreach { case (mode, aggs) =>
-         aggs.foreach {agg =>
-           val aggFn = if (mode == Partial && !merge) {
-             agg.updateReductionAggregate
-           } else {
-             agg.mergeReductionAggregate
-           }
-           val res = aggFn(toAggregateCvs(agg.getOrdinal(agg.ref)).getBase)
-           try {
-             val rapidsType = GpuColumnVector.getRapidsType(agg.dataType)
-             withResource(cudf.ColumnVector.fromScalar(res, 1)) { cv =>
-               cvs += GpuColumnVector.from(cv.castTo(rapidsType))
-             }
-           } finally {
-             res.close()
-           }
-         }
-       }
+          aggs.foreach {agg =>
+            val aggFn = if (mode == Partial && !merge) {
+              agg.updateReductionAggregate
+            } else {
+              agg.mergeReductionAggregate
+            }
+            withResource(aggFn(toAggregateCvs(agg.getOrdinal(agg.ref)).getBase)) { res =>
+              val rapidsType = GpuColumnVector.getRapidsType(agg.dataType)
+              withResource(cudf.ColumnVector.fromScalar(res, 1)) { cv =>
+                cvs += GpuColumnVector.from(cv.castTo(rapidsType), agg.dataType)
+              }
+            }
+          }
+        }
         new ColumnarBatch(cvs.toArray, cvs.head.getBase.getRowCount.toInt)
       }
     } finally {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -83,14 +83,16 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec {
           try {
             if (numColumns > 0) {
               table = GpuColumnVector.from(batch)
-              (0 until numColumns).foreach(i => {
+              (0 until numColumns).zip(output).foreach{ pair =>
+                val i = pair._1
+                val sparkType = pair._2.dataType
                 val subVector = table.getColumn(i).subVector(0, remainingLimit)
                 assert(subVector != null)
-                resultCVs.append(GpuColumnVector.from(subVector))
+                resultCVs.append(GpuColumnVector.from(subVector, sparkType))
                 assert(subVector.getRowCount == remainingLimit,
                   s"result rowcount ${subVector.getRowCount} is not equal to the " +
                     s"remainingLimit $remainingLimit")
-              })
+              }
             }
             new ColumnarBatch(resultCVs.toArray, remainingLimit)
           } catch {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -83,12 +83,10 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec {
           try {
             if (numColumns > 0) {
               table = GpuColumnVector.from(batch)
-              (0 until numColumns).zip(output).foreach{ pair =>
-                val i = pair._1
-                val sparkType = pair._2.dataType
+              (0 until numColumns).zip(output).foreach{ case (i, attr) =>
                 val subVector = table.getColumn(i).subVector(0, remainingLimit)
                 assert(subVector != null)
-                resultCVs.append(GpuColumnVector.from(subVector, sparkType))
+                resultCVs.append(GpuColumnVector.from(subVector, attr.dataType))
                 assert(subVector.getRowCount == remainingLimit,
                   s"result rowcount ${subVector.getRowCount} is not equal to the " +
                     s"remainingLimit $remainingLimit")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import java.util.Objects
 
+import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -91,6 +92,6 @@ case class GpuAlias(child: Expression, name: String)(
   override def columnarEval(batch: ColumnarBatch): Any =
     child.columnarEval(batch)
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("GpuAlias should never have doColumnar called")
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -87,11 +87,9 @@ case class GpuCoalesce(children: Seq[Expression]) extends GpuExpression with
       if (runningResult != null) {
         GpuColumnVector.from(runningResult.incRefCount(), dataType)
       } else if (runningScalar != null) {
-        GpuColumnVector.from(runningScalar, batch.numRows(), dataType)
+        GpuScalar.extract(runningScalar)
       } else {
-        withResource(GpuScalar.from(null, dataType)) { nullScalar =>
-          GpuColumnVector.from(nullScalar, batch.numRows(), dataType)
-        }
+        null
       }
     } finally {
       if (runningResult != null) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -25,22 +25,16 @@ import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, 
 import org.apache.spark.sql.types.{DataType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object GpuNvl {
-  def apply(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
-    val isLhsNotNull = lhs.getBase.isNotNull
-    try {
-      GpuColumnVector.from(isLhsNotNull.ifElse(lhs.getBase, rhs.getBase))
-    } finally {
-      isLhsNotNull.close()
+object GpuNvl extends Arm {
+  def apply(lhs: ColumnVector, rhs: ColumnVector): ColumnVector = {
+    withResource(lhs.isNotNull) { isLhsNotNull =>
+      isLhsNotNull.ifElse(lhs, rhs)
     }
   }
 
-  def apply(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
-    val isLhsNotNull = lhs.getBase.isNotNull
-    try {
-      GpuColumnVector.from(isLhsNotNull.ifElse(lhs.getBase, rhs))
-    } finally {
-      isLhsNotNull.close()
+  def apply(lhs: ColumnVector, rhs: Scalar): ColumnVector = {
+    withResource(lhs.isNotNull) { isLhsNotNull =>
+      isLhsNotNull.ifElse(lhs, rhs)
     }
   }
 }
@@ -50,7 +44,7 @@ case class GpuCoalesce(children: Seq[Expression]) extends GpuExpression with
 
   override def columnarEval(batch: ColumnarBatch): Any = {
     // runningResult has precedence over runningScalar
-    var runningResult: GpuColumnVector = null
+    var runningResult: ColumnVector = null
     var runningScalar: Scalar = null
     try {
       children.reverse.foreach(expr => {
@@ -58,14 +52,14 @@ case class GpuCoalesce(children: Seq[Expression]) extends GpuExpression with
           case data: GpuColumnVector =>
             try {
               if (runningResult != null) {
-                val tmp = GpuNvl(data, runningResult)
+                val tmp = GpuNvl(data.getBase, runningResult)
                 runningResult.close()
                 runningResult = tmp
               } else if (runningScalar != null) {
-                runningResult = GpuNvl(data, runningScalar)
+                runningResult = GpuNvl(data.getBase, runningScalar)
               } else {
                 // They are both null
-                runningResult = data.incRefCount()
+                runningResult = data.getBase.incRefCount()
               }
             } finally {
               data.close()
@@ -91,11 +85,13 @@ case class GpuCoalesce(children: Seq[Expression]) extends GpuExpression with
       })
 
       if (runningResult != null) {
-        runningResult.incRefCount()
+        GpuColumnVector.from(runningResult.incRefCount(), dataType)
       } else if (runningScalar != null) {
-        GpuScalar.extract(runningScalar)
+        GpuColumnVector.from(runningScalar, batch.numRows(), dataType)
       } else {
-        null
+        withResource(GpuScalar.from(null, dataType)) { nullScalar =>
+          GpuColumnVector.from(nullScalar, batch.numRows(), dataType)
+        }
       }
     } finally {
       if (runningResult != null) {
@@ -124,8 +120,8 @@ case class GpuIsNull(child: Expression) extends GpuUnaryExpression with Predicat
 
   override def sql: String = s"(${child.sql} IS NULL)"
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.isNull)
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.isNull
 }
 
 case class GpuIsNotNull(child: Expression) extends GpuUnaryExpression with Predicate {
@@ -133,8 +129,8 @@ case class GpuIsNotNull(child: Expression) extends GpuUnaryExpression with Predi
 
   override def sql: String = s"(${child.sql} IS NOT NULL)"
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.isNotNull)
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.isNotNull
 }
 
 case class GpuIsNan(child: Expression) extends GpuUnaryExpression with Predicate {
@@ -142,8 +138,8 @@ case class GpuIsNan(child: Expression) extends GpuUnaryExpression with Predicate
 
   override def sql: String = s"(${child.sql} IS NAN)"
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.isNan)
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.isNan
 }
 
 /**
@@ -217,7 +213,7 @@ case class GpuAtLeastNNonNulls(
       addColumnVectorsQ(nonNullNanCounts)
       scalar = GpuScalar.from(n, IntegerType)
       if (nonNullNanCounts.nonEmpty) {
-        ret = GpuColumnVector.from(nonNullNanCounts.head.greaterOrEqualTo(scalar))
+        ret = GpuColumnVector.from(nonNullNanCounts.head.greaterOrEqualTo(scalar), dataType)
       }
     } finally {
       if (scalar != null) {
@@ -248,20 +244,15 @@ case class GpuAtLeastNNonNulls(
 }
 
 case class GpuNaNvl(left: Expression, right: Expression) extends GpuBinaryExpression {
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
-    var islhsNotNan: ColumnVector = null
-    try {
-      val lhsBase = lhs.getBase
-      islhsNotNan = lhsBase.isNotNan // By definition null is not nan
-      GpuColumnVector.from(islhsNotNan.ifElse(lhsBase, rhs.getBase))
-    } finally {
-      if (islhsNotNan != null) {
-        islhsNotNan.close()
-      }
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+    val lhsBase = lhs.getBase
+    // By definition null is not nan
+    withResource(lhsBase.isNotNan) { islhsNotNan =>
+      islhsNotNan.ifElse(lhsBase, rhs.getBase)
     }
   }
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
     val isNull = !lhs.isValid
     val isNan = lhs.getType match {
       case DType.FLOAT32 => lhs.getFloat.isNaN
@@ -270,22 +261,17 @@ case class GpuNaNvl(left: Expression, right: Expression) extends GpuBinaryExpres
         s"a scalar of type $t showed up when only floats and doubles are supported")
     }
     if (isNull || !isNan) {
-      GpuColumnVector.from(ColumnVector.fromScalar(lhs, rhs.getRowCount.toInt))
+      ColumnVector.fromScalar(lhs, rhs.getRowCount.toInt)
     } else {
-      rhs.incRefCount()
+      rhs.getBase.incRefCount()
     }
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
-    var islhsNotNan: ColumnVector = null
-    try {
-      val lhsBase = lhs.getBase
-      islhsNotNan = lhsBase.isNotNan // By definition null is not nan
-      GpuColumnVector.from(islhsNotNan.ifElse(lhsBase, rhs))
-    } finally {
-      if (islhsNotNan != null) {
-        islhsNotNan.close()
-      }
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
+    val lhsBase = lhs.getBase
+    // By definition null is not nan
+    withResource(lhsBase.isNotNan) { islhsNotNan =>
+      islhsNotNan.ifElse(lhsBase, rhs)
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -49,13 +49,13 @@ object GpuFileFormatWriter extends Logging {
   case class GpuEmpty2Null(child: Expression) extends GpuUnaryExpression {
     override def nullable: Boolean = true
 
-    override def doColumnar(input: GpuColumnVector): GpuColumnVector = {
+    override def doColumnar(input: GpuColumnVector): ColumnVector = {
       var from: ColumnVector = null
       var to: ColumnVector = null
       try {
         from = ColumnVector.fromStrings("")
         to = ColumnVector.fromStrings(null)
-        GpuColumnVector.from(input.getBase.findAndReplaceAll(from, to))
+        input.getBase.findAndReplaceAll(from, to)
       } finally {
         if (from != null) {
           from.close()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
@@ -44,11 +44,8 @@ case class GpuInputFileName() extends GpuLeafExpression {
   override def disableCoalesceUntilInput(): Boolean = true
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    val scalar = Scalar.fromString(InputFileBlockHolder.getInputFilePath.toString)
-    try {
-      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()))
-    } finally {
-      scalar.close()
+    withResource(Scalar.fromString(InputFileBlockHolder.getInputFilePath.toString)) { scalar =>
+      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }
   }
 }
@@ -80,11 +77,8 @@ case class GpuInputFileBlockStart() extends GpuLeafExpression {
   override def disableCoalesceUntilInput(): Boolean = true
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    val scalar = Scalar.fromLong(InputFileBlockHolder.getStartOffset)
-    try {
-      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()))
-    } finally {
-      scalar.close()
+    withResource(Scalar.fromLong(InputFileBlockHolder.getStartOffset)) { scalar =>
+      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }
   }
 }
@@ -110,11 +104,8 @@ case class GpuInputFileBlockLength() extends GpuLeafExpression {
   override def disableCoalesceUntilInput(): Boolean = true
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    val scalar = Scalar.fromLong(InputFileBlockHolder.getLength)
-    try {
-      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()))
-    } finally {
-      scalar.close()
+    withResource(Scalar.fromLong(InputFileBlockHolder.getLength)) { scalar =>
+      GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleDependency.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleDependency.scala
@@ -23,10 +23,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.ShuffleWriteProcessor
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.types.DataType
 
 class GpuShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     rdd: RDD[_ <: Product2[K, V]],
     partitioner: Partitioner,
+    val sparkTypes: Array[DataType],
     serializer: Serializer = SparkEnv.get.serializer,
     keyOrdering: Option[Ordering[K]] = None,
     aggregator: Option[Aggregator[K, V, C]] = None,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -28,12 +28,9 @@ case class GpuMd5(child: Expression)
   override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType)
   override def dataType: DataType = StringType
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector = {
-    val fullResult = ColumnVector.md5Hash(input.getBase)
-    try {
-      GpuColumnVector.from(fullResult.mergeAndSetValidity(BinaryOp.BITWISE_AND, input.getBase))
-    } finally {
-      fullResult.close()
+  override def doColumnar(input: GpuColumnVector): ColumnVector = {
+    withResource(ColumnVector.md5Hash(input.getBase)) { fullResult =>
+      fullResult.mergeAndSetValidity(BinaryOp.BITWISE_AND, input.getBase)
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/NormalizeFloatingNumbers.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/NormalizeFloatingNumbers.scala
@@ -16,11 +16,11 @@
 
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuUnaryExpression}
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuUnaryExpression}
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{AbstractDataType, DataType, DoubleType, FloatType, TypeCollection}
-import org.apache.spark.sql.vectorized.ColumnarBatch
 
 // This will ensure that:
 //  - input NaNs become Float.NaN, or Double.NaN
@@ -33,6 +33,6 @@ case class GpuNormalizeNaNAndZero(child: Expression) extends GpuUnaryExpression
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(FloatType, DoubleType))
 
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.normalizeNANsAndZeros())
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.normalizeNANsAndZeros()
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManager.scala
@@ -335,7 +335,8 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
           context,
           metrics,
           transport,
-          catalog)
+          catalog,
+          gpu.dependency.sparkTypes)
       case other => {
         val shuffleHandle = RapidsShuffleInternalManagerBase.unwrapHandle(other)
         wrapped.getReader(shuffleHandle, startPartition, endPartition, context, metrics)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -64,12 +64,9 @@ case class GpuRand(child: Expression) extends UnaryExpression with GpuExpression
       previousPartition = partId
     }
     val numRows = batch.numRows()
-    val builder = HostColumnVector.builder(DType.FLOAT64, numRows)
-    try {
+    withResource(HostColumnVector.builder(DType.FLOAT64, numRows)) { builder =>
       (0 until numRows).foreach(_ =>  builder.append(rng.nextDouble()))
-      GpuColumnVector.from(builder.buildAndPutOnDevice())
-    } finally {
-      builder.close()
+      GpuColumnVector.from(builder.buildAndPutOnDevice(), dataType)
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -72,20 +72,19 @@ case class GpuGetArrayItem(child: Expression, ordinal: Expression)
   override def nullable: Boolean = true
   override def dataType: DataType = child.dataType.asInstanceOf[ArrayType].elementType
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector =
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("This is not supported yet")
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector =
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("This is not supported yet")
 
-  override def doColumnar(lhs: GpuColumnVector, ordinal: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, ordinal: Scalar): ColumnVector = {
     // Need to handle negative indexes...
     if (ordinal.isValid && ordinal.getInt >= 0) {
-      GpuColumnVector.from(lhs.getBase.extractListElement(ordinal.getInt), lhs.dataType())
+      lhs.getBase.extractListElement(ordinal.getInt)
     } else {
       withResource(Scalar.fromNull(GpuColumnVector.getRapidsType(dataType))) { nullScalar =>
-        GpuColumnVector.from(
-          ColumnVector.fromScalar(nullScalar, lhs.getRowCount.toInt), lhs.dataType())
+        ColumnVector.fromScalar(nullScalar, lhs.getRowCount.toInt)
       }
     }
   }
@@ -137,17 +136,14 @@ case class GpuGetMapValue(child: Expression, key: Expression)
 
   override def prettyName: String = "getMapValue"
 
-  override def doColumnar(lhs: GpuColumnVector,
-    rhs: Scalar): GpuColumnVector = GpuColumnVector.from(
-    lhs.getBase.getMapValue(rhs), lhs.dataType())
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector =
+    lhs.getBase.getMapValue(rhs)
 
 
-  override def doColumnar(lhs: Scalar,
-    rhs: GpuColumnVector): GpuColumnVector =
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("This is not supported yet")
 
-  override def doColumnar(lhs: GpuColumnVector,
-    rhs: GpuColumnVector): GpuColumnVector =
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("This is not supported yet")
 
   override def left: Expression = child

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -51,10 +51,10 @@ trait GpuTimeUnaryExpression extends GpuUnaryExpression with TimeZoneAwareExpres
 case class GpuWeekDay(child: Expression)
     extends GpuDateUnaryExpression {
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = {
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector = {
     withResource(Scalar.fromShort(1.toShort)) { one =>
       withResource(input.getBase.weekDay()) { weekday => // We want Monday = 0, CUDF Monday = 1
-        GpuColumnVector.from(weekday.sub(one))
+        weekday.sub(one)
       }
     }
   }
@@ -63,7 +63,7 @@ case class GpuWeekDay(child: Expression)
 case class GpuDayOfWeek(child: Expression)
     extends GpuDateUnaryExpression {
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = {
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector = {
     // Cudf returns Monday = 1, ...
     // We want Sunday = 1, ..., so add a day before we extract the day of the week
     val nextInts = withResource(Scalar.fromInt(1)) { one =>
@@ -73,7 +73,7 @@ case class GpuDayOfWeek(child: Expression)
     }
     withResource(nextInts) { nextInts =>
       withResource(nextInts.asTimestampDays()) { daysAgain =>
-        GpuColumnVector.from(daysAgain.weekDay())
+        daysAgain.weekDay()
       }
     }
   }
@@ -85,9 +85,8 @@ case class GpuMinute(child: Expression, timeZoneId: Option[String] = None)
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = {
-    GpuColumnVector.from(input.getBase.minute())
-  }
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.minute()
 }
 
 case class GpuSecond(child: Expression, timeZoneId: Option[String] = None)
@@ -96,9 +95,8 @@ case class GpuSecond(child: Expression, timeZoneId: Option[String] = None)
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = {
-    GpuColumnVector.from(input.getBase.second())
-  }
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.second()
 }
 
 case class GpuHour(child: Expression, timeZoneId: Option[String] = None)
@@ -107,14 +105,13 @@ case class GpuHour(child: Expression, timeZoneId: Option[String] = None)
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector = {
-    GpuColumnVector.from(input.getBase.hour())
-  }
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.hour()
 }
 
 case class GpuYear(child: Expression) extends GpuDateUnaryExpression {
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.year())
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.year()
 }
 
 abstract class GpuTimeMath(
@@ -217,39 +214,39 @@ case class GpuDateDiff(endDate: Expression, startDate: Expression)
 
   override def dataType: DataType = IntegerType
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     withResource(lhs.getBase.asInts()) { lhsDays =>
       withResource(rhs.getBase.asInts()) { rhsDays =>
-        GpuColumnVector.from(lhsDays.sub(rhsDays))
+        lhsDays.sub(rhsDays)
       }
     }
   }
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
     // if one of the operands is a scalar, they have to be explicitly casted by the caller
     // before the operation can be run. This is an issue being tracked by
     // https://github.com/rapidsai/cudf/issues/4180
     withResource(GpuScalar.castDateScalarToInt(lhs)) { intScalar =>
       withResource(rhs.getBase.asInts()) { intVector =>
-        GpuColumnVector.from(intScalar.sub(intVector))
+        intScalar.sub(intVector)
       }
     }
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
     // if one of the operands is a scalar, they have to be explicitly casted by the caller
     // before the operation can be run. This is an issue being tracked by
     // https://github.com/rapidsai/cudf/issues/4180
     withResource(GpuScalar.castDateScalarToInt(rhs)) { intScalar =>
       withResource(lhs.getBase.asInts()) { intVector =>
-        GpuColumnVector.from(intVector.sub(intScalar))
+        intVector.sub(intScalar)
       }
     }
   }
 }
 
 case class GpuQuarter(child: Expression) extends GpuDateUnaryExpression {
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(input: GpuColumnVector): ColumnVector = {
     val tmp = withResource(Scalar.fromInt(2)) { two =>
       withResource(input.getBase.month()) { month =>
         month.add(two)
@@ -257,25 +254,25 @@ case class GpuQuarter(child: Expression) extends GpuDateUnaryExpression {
     }
     withResource(tmp) { tmp =>
       withResource(Scalar.fromInt(3)) { three =>
-        GpuColumnVector.from(tmp.div(three))
+        tmp.div(three)
       }
     }
   }
 }
 
 case class GpuMonth(child: Expression) extends GpuDateUnaryExpression {
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.month())
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.month()
 }
 
 case class GpuDayOfMonth(child: Expression) extends GpuDateUnaryExpression {
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.day())
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.day()
 }
 
 case class GpuDayOfYear(child: Expression) extends GpuDateUnaryExpression {
-  override def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.dayOfYear())
+  override def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.dayOfYear()
 }
 
 abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpression]
@@ -323,15 +320,15 @@ abstract class GpuToTimestamp
 
   override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     throw new IllegalArgumentException("rhs has to be a scalar for the unixtimestamp to work")
   }
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
     throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
       "the unixtimestamp to work")
   }
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
     val tmp = if (lhs.dataType == StringType) {
       // rhs is ignored we already parsed the format
       lhs.getBase.asTimestampMicroseconds(strfFormat)
@@ -342,7 +339,7 @@ abstract class GpuToTimestamp
       // The type we are returning is a long not an actual timestamp
       withResource(Scalar.fromInt(downScaleFactor)) { downScaleFactor =>
         withResource(tmp.asLongs()) { longMicroSecs =>
-          GpuColumnVector.from(longMicroSecs.div(downScaleFactor))
+          longMicroSecs.div(downScaleFactor)
         }
       }
     }
@@ -354,7 +351,7 @@ abstract class GpuToTimestamp
  * first converting to microseconds
  */
 abstract class GpuToTimestampImproved extends GpuToTimestamp {
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
     val tmp = if (lhs.dataType == StringType) {
       // rhs is ignored we already parsed the format
       lhs.getBase.asTimestampSeconds(strfFormat)
@@ -381,7 +378,7 @@ abstract class GpuToTimestampImproved extends GpuToTimestamp {
     }
     withResource(tmp) { r =>
       // The type we are returning is a long not an actual timestamp
-      GpuColumnVector.from(r.asLongs())
+      r.asLongs()
     }
   }
 }
@@ -448,27 +445,20 @@ case class GpuFromUnixTime(
     strfFormat: String,
     timeZoneId: Option[String] = None)
   extends GpuBinaryExpression with TimeZoneAwareExpression with ImplicitCastInputTypes {
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     throw new IllegalArgumentException("rhs has to be a scalar for the from_unixtime to work")
   }
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
     throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
       "the from_unixtime to work")
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
     // expressions map and passed down here as strfFormat
-    var tsVector: ColumnVector = null
-    try {
-      tsVector = lhs.getBase.asTimestampSeconds
-      val strVector = tsVector.asStrings(strfFormat)
-      GpuColumnVector.from(strVector)
-    } finally {
-      if (tsVector != null) {
-        tsVector.close()
-      }
+    withResource(lhs.getBase.asTimestampSeconds) { tsVector =>
+      tsVector.asStrings(strfFormat)
     }
   }
 
@@ -499,26 +489,26 @@ trait GpuDateMathBase extends GpuBinaryExpression with ExpectsInputTypes {
 
   override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     withResource(lhs.getBase.castTo(DType.INT32)) { daysSinceEpoch =>
       withResource(daysSinceEpoch.binaryOp(binaryOp, rhs.getBase, daysSinceEpoch.getType)) {
-        daysAsInts => GpuColumnVector.from(daysAsInts.castTo(DType.TIMESTAMP_DAYS))
+        daysAsInts => daysAsInts.castTo(DType.TIMESTAMP_DAYS)
       }
     }
   }
 
-  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): GpuColumnVector = {
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
     withResource(GpuScalar.castDateScalarToInt(lhs)) { daysAsInts =>
-     withResource(daysAsInts.binaryOp(binaryOp, rhs.getBase, daysAsInts.getType)) { ints =>
-       GpuColumnVector.from(ints.castTo(DType.TIMESTAMP_DAYS))
-     }
+      withResource(daysAsInts.binaryOp(binaryOp, rhs.getBase, daysAsInts.getType)) { ints =>
+        ints.castTo(DType.TIMESTAMP_DAYS)
+      }
     }
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): GpuColumnVector = {
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
     withResource(lhs.getBase.castTo(DType.INT32)) { daysSinceEpoch =>
       withResource(daysSinceEpoch.binaryOp(binaryOp, rhs, daysSinceEpoch.getType)) { daysAsInts =>
-        GpuColumnVector.from(daysAsInts.castTo(DType.TIMESTAMP_DAYS))
+        daysAsInts.castTo(DType.TIMESTAMP_DAYS)
       }
     }
   }
@@ -555,6 +545,6 @@ case class GpuLastDay(startDate: Expression)
 
   override def prettyName: String = "last_day"
 
-  override protected def doColumnar(input: GpuColumnVector): GpuColumnVector =
-    GpuColumnVector.from(input.getBase.lastDayOfMonth())
+  override protected def doColumnar(input: GpuColumnVector): ColumnVector =
+    input.getBase.lastDayOfMonth()
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -151,7 +151,7 @@ abstract class GpuTimeMath(
             withResource(Scalar.fromLong(usToSub)) { us_s =>
               withResource(l.getBase.castTo(DType.INT64)) { us =>
                 withResource(intervalMath(us_s, us)) { longResult =>
-                  GpuColumnVector.from(longResult.castTo(DType.TIMESTAMP_MICROSECONDS))
+                  GpuColumnVector.from(longResult.castTo(DType.TIMESTAMP_MICROSECONDS), dataType)
                 }
               }
             }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -41,7 +41,12 @@ class GpuPartitioningSuite extends FunSuite with Arm {
 
   private def buildSubBatch(batch: ColumnarBatch, startRow: Int, endRow: Int): ColumnarBatch = {
     val columns = GpuColumnVector.extractBases(batch)
-    val sliced = columns.safeMap(c => GpuColumnVector.from(c.subVector(startRow, endRow)))
+    val types = GpuColumnVector.extractTypes(batch)
+    val sliced = columns.zip(types).map { pair =>
+      val c = pair._1
+      val t = pair._2
+      GpuColumnVector.from(c.subVector(startRow, endRow), t)
+    }
     new ColumnarBatch(sliced.toArray, endRow - startRow)
   }
 
@@ -109,6 +114,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
         }
         withResource(buildBatch()) { batch =>
           val columns = GpuColumnVector.extractColumns(batch)
+          val sparkTypes = GpuColumnVector.extractTypes(batch)
           val numRows = batch.numRows
           withResource(gp.sliceInternalOnGpu(numRows, partitionIndices, columns)) { partitions =>
             partitions.zipWithIndex.foreach { case (partBatch, partIndex) =>
@@ -144,7 +150,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
                 deviceStore.addBuffer(bufferId, devBuffer, gccv.getTableMeta, spillPriority)
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
                   withResource(catalog.acquireBuffer(bufferId)) { buffer =>
-                    compareBatches(expectedBatch, buffer.getColumnarBatch)
+                    compareBatches(expectedBatch, buffer.getColumnarBatch(sparkTypes))
                   }
                 }
               }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -42,9 +42,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
   private def buildSubBatch(batch: ColumnarBatch, startRow: Int, endRow: Int): ColumnarBatch = {
     val columns = GpuColumnVector.extractBases(batch)
     val types = GpuColumnVector.extractTypes(batch)
-    val sliced = columns.zip(types).map { pair =>
-      val c = pair._1
-      val t = pair._2
+    val sliced = columns.zip(types).map { case (c, t) =>
       GpuColumnVector.from(c.subVector(startRow, endRow), t)
     }
     new ColumnarBatch(sliced.toArray, endRow - startRow)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
@@ -43,7 +43,7 @@ class GpuUnitTests extends SparkQueryCompareTestSuite {
       val cv = v.asInstanceOf[ColumnVector]
       // close the vector that was passed in and return a new vector
       withResource(cv) { cv =>
-        GpuColumnVector.from(cv.castTo(GpuColumnVector.getRapidsType(to)))
+        GpuColumnVector.from(cv.castTo(GpuColumnVector.getRapidsType(to)), to)
       }
     }
 
@@ -167,12 +167,5 @@ class GpuUnitTests extends SparkQueryCompareTestSuite {
      expected: GpuColumnVector,
      inputBatch: ColumnarBatch = EmptyBatch): Unit = {
     checkEvaluationWithoutCodegen(gpuExpression, expected, inputBatch)
-  }
-
-  /**
-   * This method is to circumvent the scala limitation of children not able to call a static method
-   */
-  protected def getSparkType(dType: DType): DataType = {
-    GpuColumnVector.getSparkType(dType)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ImplicitsTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ImplicitsTestSuite.scala
@@ -87,7 +87,7 @@ class ImplicitsTestSuite extends FlatSpec with Matchers {
     val batch = new ColumnarBatch((0 until 10).map { ix =>
       val scalar = GpuScalar.from(ix, IntegerType)
       val col = try {
-        GpuColumnVector.from(scalar, 5)
+        GpuColumnVector.from(scalar, 5, IntegerType)
       } finally {
         scalar.close()
       }
@@ -115,7 +115,7 @@ class ImplicitsTestSuite extends FlatSpec with Matchers {
     val batch = new ColumnarBatch((0 until 10).map { ix => {
       val scalar = GpuScalar.from(ix, IntegerType)
       val col = try {
-        GpuColumnVector.from(scalar, 5)
+        GpuColumnVector.from(scalar, 5, IntegerType)
       } finally {
         scalar.close()
       }
@@ -157,7 +157,7 @@ class ImplicitsTestSuite extends FlatSpec with Matchers {
     val batch = new ColumnarBatch((0 until 10).map { ix => {
       val scalar = GpuScalar.from(ix, IntegerType)
       val col = try {
-        GpuColumnVector.from(scalar, 5)
+        GpuColumnVector.from(scalar, 5, IntegerType)
       } finally {
         scalar.close()
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -20,7 +20,7 @@ import ai.rapids.cudf.{BufferType, ContiguousTable, DeviceMemoryBuffer, Table}
 import com.nvidia.spark.rapids.format.{CodecType, ColumnMeta}
 import org.scalatest.FunSuite
 
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, DoubleType, IntegerType, StringType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class MetaUtilsSuite extends FunSuite with Arm {
@@ -164,7 +164,8 @@ class MetaUtilsSuite extends FunSuite with Arm {
       val origBuffer = contigTable.getBuffer
       val meta = MetaUtils.buildTableMeta(10, table, origBuffer)
       withResource(origBuffer.sliceWithCopy(0, origBuffer.getLength)) { buffer =>
-        withResource(MetaUtils.getBatchFromMeta(buffer, meta)) { batch =>
+        withResource(MetaUtils.getBatchFromMeta(buffer, meta,
+          Array[DataType](IntegerType, StringType, DoubleType))) { batch =>
           assertResult(table.getRowCount)(batch.numRows)
           assertResult(table.getNumberOfColumns)(batch.numCols)
           (0 until table.getNumberOfColumns).foreach { i =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -34,6 +34,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
+      Array.empty,
       mockCatalog,
       123)
 
@@ -61,6 +62,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
         mockTransport,
         blocksByAddress,
         testMetricsUpdater,
+        Array.empty,
         mockCatalog,
         123))
 
@@ -94,6 +96,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
+      Array.empty,
       mockCatalog,
       123))
 
@@ -124,6 +127,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
       mockTransport,
       blocksByAddress,
       testMetricsUpdater,
+      Array.empty,
       mockCatalog,
       123)
 
@@ -135,9 +139,9 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
     val bufferId = ShuffleReceivedBufferId(1)
     val mockBuffer = mock[RapidsBuffer]
 
-    val cb = new ColumnarBatch(Seq[ColumnVector]().toArray, 10)
+    val cb = new ColumnarBatch(Array.empty, 10)
 
-    when(mockBuffer.getColumnarBatch).thenReturn(cb)
+    when(mockBuffer.getColumnarBatch(Array.empty)).thenReturn(cb)
     when(mockCatalog.acquireBuffer(any[ShuffleReceivedBufferId]())).thenReturn(mockBuffer)
     doNothing().when(mockCatalog).removeBuffer(any())
     cl.start()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
@@ -20,7 +20,7 @@ import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuLiteral, GpuUnitTests}
 
 import org.apache.spark.sql.rapids.{GpuDateAdd, GpuDateSub}
-import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.{DataTypes, DateType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class DateTimeUnitTest extends GpuUnitTests {
@@ -31,15 +31,16 @@ class DateTimeUnitTest extends GpuUnitTests {
 
   test("test date_add") {
     withResource(GpuColumnVector.from(ColumnVector.daysFromInts(-1498, 17746, 19412,
-      -13498, 1746))) { expected0 =>
+      -13498, 1746), DateType)) { expected0 =>
       withResource(GpuColumnVector.from(ColumnVector.daysFromInts(-1526, 17748, 19388,
-        -13519, 1722))) { expected1 =>
+        -13519, 1722), DateType)) { expected1 =>
         withResource(GpuColumnVector.from(ColumnVector.daysFromInts(17676, 17706, 17680,
-          17683, 17680))) { expected2 =>
+          17683, 17680), DateType)) { expected2 =>
 
-          withResource(GpuColumnVector.from(ColumnVector.daysFromInts(TIMES_DAY: _*))) {
+          withResource(GpuColumnVector.from(ColumnVector.daysFromInts(TIMES_DAY: _*), DateType)) {
             datesVector =>
-              withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6))) {
+              withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6),
+                IntegerType)) {
                 daysVector =>
                   val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType, false)
                   val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType, false)
@@ -66,15 +67,16 @@ class DateTimeUnitTest extends GpuUnitTests {
 
   test("test date_sub") {
     withResource(GpuColumnVector.from(ColumnVector.daysFromInts(-1558, 17686, 19352, -13558,
-      1686))) { expected0 =>
+      1686), DateType)) { expected0 =>
       withResource(GpuColumnVector.from(ColumnVector.daysFromInts(-1530, 17684, 19376,
-        -13537, 1710))) { expected1 =>
+        -13537, 1710), DateType)) { expected1 =>
         withResource(GpuColumnVector.from(ColumnVector.daysFromInts(17672, 17642, 17668,
-          17665, 17668))) { expected2 =>
+          17665, 17668), DateType)) { expected2 =>
 
-          withResource(GpuColumnVector.from(ColumnVector.daysFromInts(TIMES_DAY: _*))) {
+          withResource(GpuColumnVector.from(ColumnVector.daysFromInts(TIMES_DAY: _*), DateType)) {
             datesVector =>
-              withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6))) {
+              withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6),
+                IntegerType)) {
                 daysVector =>
                   val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType, false)
                   val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType, false)

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
@@ -24,6 +24,7 @@ import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 import org.scalatest.FunSuite
 
+import org.apache.spark.sql.types.{DataType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.TempLocalBlockId
 
@@ -35,7 +36,7 @@ class SpillableColumnarBatchSuite extends FunSuite with Arm {
     val oldBufferCount = catalog.numBuffers
     catalog.registerNewBuffer(mockBuffer)
     assertResult(oldBufferCount + 1)(catalog.numBuffers)
-    val spillableBatch = new SpillableColumnarBatchImpl(id, 5)
+    val spillableBatch = new SpillableColumnarBatchImpl(id, 5, Array[DataType](IntegerType))
     spillableBatch.close()
     assertResult(oldBufferCount)(catalog.numBuffers)
   }
@@ -44,12 +45,12 @@ class SpillableColumnarBatchSuite extends FunSuite with Arm {
     override val size: Long = 123
     override val meta: TableMeta = null
     override val storageTier: StorageTier = StorageTier.DEVICE
-    override def getColumnarBatch: ColumnarBatch = null
     override def getMemoryBuffer: MemoryBuffer = null
     override def addReference(): Boolean = true
     override def free(): Unit = {}
     override def getSpillPriority: Long = 0
     override def setSpillPriority(priority: Long): Unit = {}
     override def close(): Unit = {}
+    override def getColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = null
   }
 }


### PR DESCRIPTION
Getting closer, but there is still a lot more to do.

One thing to note is that for part of this I changed `Gpu{Unary,Binary,Trinary}Expression` to return a `ColumnVector` instead of a `GpuColumnVector` this let me put the conversion in a single location and also fixed some issues with some `UnaryExpressions` that couldn't know the right spark type to return because they were going to be cast to the final type shortly afterwards.

Actually with the last push this should completely fix the issues with not doing the conversion correctly in all cases.