### PR TITLE
Add option to upload benchmark summary JSON file

### DIFF
--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -91,8 +91,6 @@ def main():
                         help='Whether to call System.gc between iterations')
     parser.add_argument('--upload-uri', required=False,
                         help='Upload URI for summary output')
-    parser.add_argument('--upload-path', required=False,
-                        help='Upload path for summary output')
 
     args = parser.parse_args()
 
@@ -132,9 +130,6 @@ def main():
 
             if args.upload_uri is not None:
                 cmd.append("--upload-uri " + args.upload_uri)
-
-            if args.upload_path is not None:
-                cmd.append("--upload-path " + args.upload_path)
 
             if args.iterations is None:
                 cmd.append("--iterations 1")

--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -89,8 +89,6 @@ def main():
                         help='The number of iterations to run (defaults to 1)')
     parser.add_argument('--gc-between-runs', required=False, action='store_true',
                         help='Whether to call System.gc between iterations')
-    parser.add_argument('--s3-endpoint-url', required=False,
-                        help='S3 endpoint URL (optional)')
     parser.add_argument('--upload-uri', required=False,
                         help='Upload URI for summary output')
     parser.add_argument('--upload-path', required=False,

--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -89,6 +89,12 @@ def main():
                         help='The number of iterations to run (defaults to 1)')
     parser.add_argument('--gc-between-runs', required=False, action='store_true',
                         help='Whether to call System.gc between iterations')
+    parser.add_argument('--s3-endpoint-url', required=False,
+                        help='S3 endpoint URL (optional)')
+    parser.add_argument('--upload-uri', required=False,
+                        help='Upload URI for summary output')
+    parser.add_argument('--upload-path', required=False,
+                        help='Upload path for summary output')
 
     args = parser.parse_args()
 
@@ -125,6 +131,12 @@ def main():
 
             if args.gc_between_runs is True:
                 cmd.append("--gc-between-runs ")
+
+            if args.upload_uri is not None:
+                cmd.append("--upload-uri " + args.upload_uri)
+
+            if args.upload_path is not None:
+                cmd.append("--upload-path " + args.upload_path)
 
             if args.iterations is None:
                 cmd.append("--iterations 1")

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -112,7 +112,7 @@ object BenchmarkRunner {
               val fs = FileSystem.newInstance(new URI(conf.uploadUri()), hadoopConf)
               fs.copyFromLocalFile(
                 new Path(report.filename),
-                new Path(s"${conf.uploadUri()}/${report.filename}"))
+                new Path(conf.uploadUri(), report.filename))
             }
 
           case Failure(e) =>

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -104,15 +104,15 @@ object BenchmarkRunner {
 
         report match {
           case Success(report) =>
-            if (conf.uploadUri.isSupplied && conf.uploadPath.isSupplied) {
+            if (conf.uploadUri.isSupplied) {
               println(s"Uploading ${report.filename} to " +
-                  s"${conf.uploadUri()}/${conf.uploadPath()}/${report.filename}")
+                  s"${conf.uploadUri()}/${report.filename}")
 
               val hadoopConf = spark.sparkContext.hadoopConfiguration
               val fs = FileSystem.newInstance(new URI(conf.uploadUri()), hadoopConf)
               fs.copyFromLocalFile(
                 new Path(report.filename),
-                new Path(s"${conf.uploadPath()}/${report.filename}"))
+                new Path(s"${conf.uploadUri()}/${report.filename}"))
             }
 
           case Failure(e) =>
@@ -291,6 +291,5 @@ class BenchmarkConf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val summaryFilePrefix = opt[String](required = false)
   val gcBetweenRuns = opt[Boolean](required = false, default = Some(false))
   val uploadUri = opt[String](required = false)
-  val uploadPath = opt[String](required = false)
   verify()
 }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -106,7 +106,7 @@ object BenchmarkRunner {
           case Success(report) =>
             if (conf.uploadUri.isSupplied && conf.uploadPath.isSupplied) {
               println(s"Uploading ${report.filename} to " +
-                  s"s3://${conf.uploadUri()}/${conf.uploadPath()}/${report.filename}")
+                  s"${conf.uploadUri()}/${conf.uploadPath()}/${report.filename}")
 
               // because we are using the hadoop library directly, we need to convert the spark
               // hadoop configuration settings into plain hadoop settings

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -108,15 +108,7 @@ object BenchmarkRunner {
               println(s"Uploading ${report.filename} to " +
                   s"${conf.uploadUri()}/${conf.uploadPath()}/${report.filename}")
 
-              // because we are using the hadoop library directly, we need to convert the spark
-              // hadoop configuration settings into plain hadoop settings
-              val hadoopConf = new Configuration()
-              val sparkHadoopPrefix = "spark.hadoop."
-              spark.sqlContext.getAllConfs
-                  .filter(_._1.startsWith(sparkHadoopPrefix + "fs"))
-                  .foreach { entry =>
-                    hadoopConf.set(entry._1.substring(sparkHadoopPrefix.length), entry._2)
-                  }
+              val hadoopConf = spark.sparkContext.hadoopConfiguration
               val fs = FileSystem.newInstance(new URI(conf.uploadUri()), hadoopConf)
               fs.copyFromLocalFile(
                 new Path(report.filename),

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -46,7 +46,7 @@ object BenchUtils {
       filenameStub: String,
       iterations: Int,
       gcBetweenRuns: Boolean
-  ): Unit = {
+  ): BenchmarkReport = {
     runBench(
       spark,
       createDataFrame,
@@ -67,7 +67,7 @@ object BenchUtils {
       gcBetweenRuns: Boolean,
       path: String,
       mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty): Unit = {
+      writeOptions: Map[String, String] = Map.empty): BenchmarkReport = {
     runBench(
       spark,
       createDataFrame,
@@ -88,7 +88,7 @@ object BenchUtils {
       gcBetweenRuns: Boolean,
       path: String,
       mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty): Unit = {
+      writeOptions: Map[String, String] = Map.empty): BenchmarkReport = {
     runBench(
       spark,
       createDataFrame,
@@ -109,7 +109,7 @@ object BenchUtils {
       gcBetweenRuns: Boolean,
       path: String,
       mode: SaveMode = SaveMode.Overwrite,
-      writeOptions: Map[String, String] = Map.empty): Unit = {
+      writeOptions: Map[String, String] = Map.empty): BenchmarkReport = {
     runBench(
       spark,
       createDataFrame,
@@ -143,7 +143,7 @@ object BenchUtils {
       filenameStub: String,
       iterations: Int,
       gcBetweenRuns: Boolean
-  ): Unit = {
+  ): BenchmarkReport = {
 
     assert(iterations > 0)
 
@@ -297,6 +297,8 @@ object BenchUtils {
     }
 
     writeReport(report, filename)
+
+    report
   }
 
   def readReport(file: File): BenchmarkReport = {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Adds option to upload benchmark summary JSON file to any supported hadoop filesystem, such as s3.

It requires the appropriate `spark.hadoop.fs` configuration options to be set, and that credentials are available at runtime, such as by setting environment variables for AWS keys.

This partially addresses https://github.com/NVIDIA/spark-rapids/issues/1048