### PR TITLE
Avoid issues where more scalars that expected show up in an expression

### DIFF
--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -93,6 +93,13 @@ def test_coalesce(data_gen):
             lambda spark : gen_df(spark, gen).select(
                 f.coalesce(*command_args)))
 
+def test_coalesce_constant_output():
+    # Coalesce can allow a constant value as output. Technically Spark should mark this
+    # as foldable and turn it into a constant, but it does not, so make sure our code
+    # can deal with it.  (This means something like + will get two constant scalar values)
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : spark.range(1, 100).selectExpr("4 + coalesce(5, id) as nine"))
+
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
 def test_nvl2(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=True)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -273,6 +273,12 @@ case class GpuNaNvl(left: Expression, right: Expression) extends GpuBinaryExpres
     }
   }
 
+  override def doColumnar(numRows: Int, lhs: Scalar, rhs: Scalar): ColumnVector = {
+    withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { expandedLhs =>
+      doColumnar(expandedLhs, rhs)
+    }
+  }
+
   override def dataType: DataType = left.dataType
 
   // Access to AbstractDataType is not allowed, and not really needed here

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
@@ -78,6 +78,12 @@ trait GpuShiftBase extends GpuBinaryExpression with ImplicitCastInputTypes {
       lBase.binaryOp(shiftOp, distance, lBase.getType)
     }
   }
+
+  override def doColumnar(numRows: Int, lhs: Scalar, rhs: Scalar): ColumnVector = {
+    withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { expandedLhs =>
+      doColumnar(expandedLhs, rhs)
+    }
+  }
 }
 
 case class GpuShiftLeft(left: Expression, right: Expression) extends GpuShiftBase {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -88,6 +88,12 @@ case class GpuGetArrayItem(child: Expression, ordinal: Expression)
       }
     }
   }
+
+  override def doColumnar(numRows: Int, lhs: Scalar, rhs: Scalar): ColumnVector = {
+    withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { expandedLhs =>
+      doColumnar(expandedLhs, rhs)
+    }
+  }
 }
 
 class GpuGetMapValueMeta(
@@ -139,6 +145,11 @@ case class GpuGetMapValue(child: Expression, key: Expression)
   override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector =
     lhs.getBase.getMapValue(rhs)
 
+  override def doColumnar(numRows: Int, lhs: Scalar, rhs: Scalar): ColumnVector = {
+    withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { expandedLhs =>
+      doColumnar(expandedLhs, rhs)
+    }
+  }
 
   override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("This is not supported yet")


### PR DESCRIPTION
This fixes #1073 
by removing the call to `nullSafeEval` and offering an alternative path to compute the result.  I am not 100% sure that I got all possible cases for this.  We could also look into supporting execution on the CPU in the future instead of converting the scalar to a column and doing the processing on the GPU.  But this was the fastest way to make this work for the case that we saw failing.

I am happy to file follow on issues if the reviewers think it would be beneficial.