### PR TITLE
closeOnExcept -> withResources in MetaUtils

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -221,10 +221,10 @@ object MetaUtils extends Arm {
    * @return table that must be closed by the caller
    */
   def getTableFromMeta(deviceBuffer: DeviceMemoryBuffer, meta: TableMeta): Table = {
-    closeOnExcept(new ArrayBuffer[ColumnVector](meta.columnMetasLength())) { columns =>
+    withResource(new Array[ColumnVector](meta.columnMetasLength())) { columns =>
       val columnMeta = new ColumnMeta
       (0 until meta.columnMetasLength).foreach { i =>
-        columns.append(makeCudfColumn(deviceBuffer, meta.columnMetas(columnMeta, i)))
+        columns(i) = makeCudfColumn(deviceBuffer, meta.columnMetas(columnMeta, i))
       }
       new Table(columns :_*)
     }
@@ -241,10 +241,10 @@ object MetaUtils extends Arm {
   def getBatchFromMeta(deviceBuffer: DeviceMemoryBuffer,
       meta: TableMeta,
       sparkTypes: Array[DataType]): ColumnarBatch = {
-    closeOnExcept(new ArrayBuffer[GpuColumnVector](meta.columnMetasLength())) { columns =>
+    withResource(new Array[GpuColumnVector](meta.columnMetasLength())) { columns =>
       val columnMeta = new ColumnMeta
       (0 until meta.columnMetasLength).foreach { i =>
-        columns.append(makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i), sparkTypes(i)))
+        columns(i) = makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i), sparkTypes(i))
       }
       new ColumnarBatch(columns.toArray, meta.rowCount.toInt)
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -241,10 +241,10 @@ object MetaUtils extends Arm {
   def getBatchFromMeta(deviceBuffer: DeviceMemoryBuffer,
       meta: TableMeta,
       sparkTypes: Array[DataType]): ColumnarBatch = {
-    withResource(new Array[GpuColumnVector](meta.columnMetasLength())) { columns =>
+    closeOnExcept(new ArrayBuffer[GpuColumnVector](meta.columnMetasLength())) { columns =>
       val columnMeta = new ColumnMeta
       (0 until meta.columnMetasLength).foreach { i =>
-        columns(i) = makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i), sparkTypes(i))
+        columns.append(makeColumn(deviceBuffer, meta.columnMetas(columnMeta, i), sparkTypes(i)))
       }
       new ColumnarBatch(columns.toArray, meta.rowCount.toInt)
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This fixes a leak in MetaUtils. It also replaces the use of `ArrayBuffer` with `Array` such that the appropriate impl of `withResources` is picked.

Thanks to @jlowe to help triage this.