### PR TITLE
Add in support for filtering ArrayType

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -94,6 +94,7 @@ else
           $TEST_PARALLEL_OPTS \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
+          --color=yes \
           "$TEST_ARGS" \
           $RUN_TEST_PARAMS \
           "$@"
@@ -107,6 +108,7 @@ else
           "$SCRIPTPATH"/runtests.py --rootdir "$SCRIPTPATH" "$SCRIPTPATH"/src/main/python \
           -v -rfExXs "$TEST_TAGS" \
           --std_input_path="$SCRIPTPATH"/src/test/resources/ \
+          --color=yes \
           "$TEST_ARGS" \
           $RUN_TEST_PARAMS \
           "$@"

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -482,7 +482,7 @@ class TimestampGen(DataGen):
 
 class ArrayGen(DataGen):
     """Generate Arrays of data."""
-    def __init__(self, child_gen, min_length=0, max_length=100, nullable=True):
+    def __init__(self, child_gen, min_length=0, max_length=20, nullable=True):
         super().__init__(ArrayType(child_gen.data_type, containsNull=child_gen.nullable), nullable=nullable)
         self._min_length = min_length
         self._max_length = max_length

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -197,6 +197,9 @@ class Spark300Shims extends SparkShims {
             }
           }
 
+          override def isSupportedType(t: DataType): Boolean =
+            GpuOverrides.isSupportedType(t, allowCalendarInterval = true)
+
           override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
             GpuTimeSub(lhs, rhs)
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -485,6 +485,11 @@ class GpuSpecifiedWindowFrameMeta(
   // SpecifiedWindowFrame has no associated dataType.
   override val ignoreUnsetDataTypes: Boolean = true
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true,
+      allowCalendarInterval = true)
+
   override def tagExprForGpu(): Unit = {
     if (windowFrame.frameType.equals(RangeFrame)) {
       // Expect either SpecialFrame (UNBOUNDED PRECEDING/FOLLOWING, or CURRENT ROW),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -54,8 +54,7 @@ class GpuGetArrayItemMeta(
     GpuGetArrayItem(arr, ordinal)
 
   override def isSupportedType(t: DataType): Boolean =
-    // For expressions it is only the output that is checked, not the input types.
-    GpuOverrides.isSupportedType(t, allowArray = true)
+    GpuOverrides.isSupportedType(t, allowArray = true, allowNesting = true)
 }
 
 /**
@@ -114,10 +113,6 @@ class GpuGetMapValueMeta(
   override def tagExprForGpu(): Unit = {
     if (!isStringLit(expr.key)) {
       willNotWorkOnGpu("Only String literal keys are supported")
-    }
-    expr.child.dataType match {
-      case MapType(StringType, StringType, _) => // works
-      case _ => willNotWorkOnGpu("Only a Map[String, String] is supported")
     }
   }
 


### PR DESCRIPTION
This adds in support for filtering ArrayType columns.

One big change kind of related change is that ExprBaseMeta now checks both input and output types.  A lot of the code assumed that it was doing this already, but it was not.  This made some checks a lot simpler for operators that support only specific inputs, not outputs.

I also dropped the default max size of generated arrays in the tests because it was starting to take a while to generate some of the columns.