### PR TITLE
Shuffle/better error handling

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
@@ -105,8 +105,8 @@ class BufferReceiveState(
    * Calls `transferError` on each `RapidsShuffleFetchHandler`
    * @param errMsg - the message to pass onto the handlers
    */
-  def errorOcurred(errMsg: String): Unit = {
-    currentBlocks.foreach(_.block.request.handler.transferError(errMsg))
+  def errorOcurred(errMsg: String, throwable: Throwable = null): Unit = {
+    currentBlocks.foreach(_.block.request.handler.transferError(errMsg, throwable))
   }
 
   override def hasNext: Boolean = synchronized { hasMoreBuffers }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -121,6 +121,7 @@ class BufferSendState(
     isClosed = true
     freeBounceBuffers()
     request.close()
+    releaseAcquiredToCatalog()
   }
 
   case class RangeBuffer(
@@ -228,9 +229,6 @@ class BufferSendState(
    * allowing us to safely return buffers to the catalog to be potentially freed if spilling.
    */
   def releaseAcquiredToCatalog(): Unit = synchronized {
-    if (acquiredBuffs.isEmpty) {
-      logWarning("Told to close rapids buffers, but nothing was acquired")
-    }
     acquiredBuffs.foreach(_.close())
     acquiredBuffs = Seq.empty
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -282,14 +282,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
         throw new IllegalStateException(s"Error occurred while while handling metadata $tx")
       } else {
         logDebug(s"Received metadata request: $tx => $metaRequest")
-        try {
-          handleMetadataRequest(metaRequest)
-        } catch {
-          case e: Throwable => {
-            logError(s"Exception while handling metadata request from $tx: ", e)
-            throw e
-          }
-        }
+        handleMetadataRequest(metaRequest)
       }
     } finally {
       logDebug(s"Metadata request handled in ${TransportUtils.timeDiffMs(start)} ms")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -279,7 +279,6 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
       if (tx.getStatus == TransactionStatus.Error) {
         logError("error getting metadata request: " + tx)
         metaRequest.close() // the buffer is not going to be handed anywhere else, so lets close it
-        throw new IllegalStateException(s"Error occurred while while handling metadata $tx")
       } else {
         logDebug(s"Received metadata request: $tx => $metaRequest")
         handleMetadataRequest(metaRequest)
@@ -335,8 +334,6 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
         try {
           if (tx.getStatus == TransactionStatus.Error) {
             logError(s"Error sending metadata response in tx $tx")
-            throw new IllegalStateException(
-              s"Error while handling a metadata response send for $tx")
           } else {
             val stats = tx.getStats
             logDebug(s"Sent metadata ${stats.sendSize} in ${stats.txTimeMs} ms")
@@ -359,9 +356,9 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
    * @param bufferSendStates state objects tracking sends needed to fulfill a TransferRequest
    */
   def doHandleTransferRequest(bufferSendStates: Seq[BufferSendState]): Unit = {
-    val bssBuffers = bufferSendStates.map { bufferSendState =>
-      withResource(new NvtxRange(s"doHandleTransferRequest", NvtxColor.CYAN)) { _ =>
-        try {
+    try {
+      val bssBuffers = bufferSendStates.map { bufferSendState =>
+        withResource(new NvtxRange(s"doHandleTransferRequest", NvtxColor.CYAN)) { _ =>
           require(bufferSendState.hasNext, "Attempting to handle a complete transfer request.")
 
           // For each `BufferSendState` we ask for a bounce buffer fill up
@@ -369,64 +366,61 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
           val buffersToSend = bufferSendState.next()
 
           (bufferSendState, buffersToSend)
-        } catch {
-          case t: Throwable =>
-            bufferSendState.close()
-            throw t
         }
       }
-    }
 
-    serverStream.sync()
+      serverStream.sync()
 
-    // need to release at this point, we do this after the sync so
-    // we are sure we actually copied everything to the bounce buffer
-    bufferSendStates.foreach(_.releaseAcquiredToCatalog())
+      // need to release at this point, we do this after the sync so
+      // we are sure we actually copied everything to the bounce buffer
+      bufferSendStates.foreach(_.releaseAcquiredToCatalog())
 
-    bssBuffers.foreach {
-      case (bufferSendState, buffersToSend) =>
-        val transferRequest = bufferSendState.getTransferRequest
-        serverConnection.send(transferRequest.executorId(), buffersToSend, new TransactionCallback {
-        override def apply(bufferTx: Transaction): Unit = {
-          try {
-            logDebug(s"Done with the send for ${bufferSendState} with ${buffersToSend}")
+      bssBuffers.foreach {
+        case (bufferSendState, buffersToSend) =>
+          val transferRequest = bufferSendState.getTransferRequest
+          serverConnection.send(transferRequest.executorId(), buffersToSend, bufferTx =>
+            try {
+              logDebug(s"Done with the send for ${bufferSendState} with ${buffersToSend}")
 
-            if (bufferSendState.hasNext) {
-              // continue issuing sends.
-              logDebug(s"Buffer send state ${bufferSendState} is NOT done. " +
-                  s"Still pending: ${pendingTransfersQueue.size}.")
-              bssExec.synchronized {
-                bssContinueQueue.add(bufferSendState)
-                bssExec.notifyAll()
+              if (bufferSendState.hasNext) {
+                // continue issuing sends.
+                logDebug(s"Buffer send state ${bufferSendState} is NOT done. " +
+                    s"Still pending: ${pendingTransfersQueue.size}.")
+                bssExec.synchronized {
+                  bssContinueQueue.add(bufferSendState)
+                  bssExec.notifyAll()
+                }
+              } else {
+                val transferResponse = bufferSendState.getTransferResponse()
+
+                logDebug(s"Handling transfer request for ${transferRequest.executorId()} " +
+                    s"with ${buffersToSend}")
+
+                // send the transfer response
+                serverConnection.send(
+                  transferRequest.executorId,
+                  AddressLengthTag.from(transferResponse.acquire(), transferRequest.responseTag()),
+                  transferResponseTx => {
+                    transferResponse.close()
+                    transferResponseTx.close()
+                  })
+
+                // wake up the bssExec since bounce buffers became available
+                logDebug(s"Buffer send state ${buffersToSend.tag} is done. Closing. " +
+                    s"Still pending: ${pendingTransfersQueue.size}.")
+                bssExec.synchronized {
+                  bufferSendState.close()
+                  bssExec.notifyAll()
+                }
               }
-            } else {
-              val transferResponse = bufferSendState.getTransferResponse()
-
-              logDebug(s"Handling transfer request for ${transferRequest.executorId()} " +
-                  s"with ${buffersToSend}")
-
-              // send the transfer response
-              serverConnection.send(
-                transferRequest.executorId,
-                AddressLengthTag.from(transferResponse.acquire(), transferRequest.responseTag()),
-                transferResponseTx => {
-                  transferResponse.close()
-                  transferResponseTx.close()
-                })
-
-              // wake up the bssExec since bounce buffers became available
-              logDebug(s"Buffer send state ${buffersToSend.tag} is done. Closing. " +
-                  s"Still pending: ${pendingTransfersQueue.size}.")
-              bssExec.synchronized {
-                bufferSendState.close()
-                bssExec.notifyAll()
-              }
-            }
-          } finally {
-            bufferTx.close()
-          }
-        }
-      })
+            } finally {
+              bufferTx.close()
+            })
+      }
+    } catch {
+      case t: Throwable =>
+        bufferSendStates.safeClose(t)
+        throw t
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -356,7 +356,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
    * @param bufferSendStates state objects tracking sends needed to fulfill a TransferRequest
    */
   def doHandleTransferRequest(bufferSendStates: Seq[BufferSendState]): Unit = {
-    try {
+    closeOnExcept(bufferSendStates) { _ =>
       val bssBuffers = bufferSendStates.map { bufferSendState =>
         withResource(new NvtxRange(s"doHandleTransferRequest", NvtxColor.CYAN)) { _ =>
           require(bufferSendState.hasNext, "Attempting to handle a complete transfer request.")
@@ -417,10 +417,6 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
               bufferTx.close()
             })
       }
-    } catch {
-      case t: Throwable =>
-        bufferSendStates.safeClose(t)
-        throw t
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
@@ -24,9 +24,10 @@ class RapidsShuffleFetchFailedException(
     mapId: Long,
     mapIndex: Int,
     reduceId: Int,
-    message: String)
+    message: String,
+    cause: Throwable)
     extends FetchFailedException(
-      bmAddress, shuffleId, mapId, mapIndex, reduceId, message) {
+      bmAddress, shuffleId, mapId, mapIndex, reduceId, message, cause) {
 }
 
 class RapidsShuffleTimeoutException(message: String) extends Exception(message)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -87,7 +87,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
     }
   }
 
-  test("a transport exception raises a fetch failure with the suppressed exception") {
+  test("a transport exception raises a fetch failure with the cause exception") {
     val blocksByAddress = RapidsShuffleTestHelper.getBlocksByAddress
 
     val cl = spy(new RapidsShuffleIterator(
@@ -106,8 +106,8 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
     cl.start()
 
     val handler = ac.getValue.asInstanceOf[RapidsShuffleFetchHandler]
-    val exceptionToSuppress = new RuntimeException("Exception to suppress")
-    handler.transferError("Test", exceptionToSuppress)
+    val causeException = new RuntimeException("Exception to suppress")
+    handler.transferError("Test", causeException)
 
     assert(cl.hasNext)
     assertThrows[RapidsShuffleFetchFailedException] {
@@ -115,9 +115,8 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
         cl.next()
       } catch {
         case rsffe: RapidsShuffleFetchFailedException =>
-          val suppressed = rsffe.getSuppressed
-          assertResult(suppressed.size)(1)
-          assertResult(suppressed.head)(exceptionToSuppress)
+          val cause = rsffe.getCause
+          assertResult(cause)(causeException)
           throw rsffe
         case _ =>
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -106,7 +106,7 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
     cl.start()
 
     val handler = ac.getValue.asInstanceOf[RapidsShuffleFetchHandler]
-    val causeException = new RuntimeException("Exception to suppress")
+    val causeException = new RuntimeException("some exception")
     handler.transferError("Test", causeException)
 
     assert(cl.hasNext)


### PR DESCRIPTION
Mostly on the client side, this removes the global try/catch in `handleOp` and instead pipes errors into the `handleError` function in the fetch handler (shuffle iterator). This, in turn, creates `FetchFailed` exceptions that Spark will use when the task fails.

Removes a log-then-throw anti-pattern in the server. The server still has a global catch-all that logs then forgets an exception. The main issue on the server is there isn't really a good sink for the errors. I can add a follow up issue to add some logic to handle this, but would like to hear what people think. I think the best approach is a side-band message that the client can be waiting for, causing it to cancel any pending receives.

On the server side I was not safeClosing the `BufferSendStates` in one case, so I fixed that. This in turn will release buffers to the catalog, and frees send bounce buffers.

Follow up from: https://github.com/NVIDIA/spark-rapids/pull/994