### PR TITLE
Fix resource leaks with new shuffle optimization

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -167,6 +167,8 @@ private class GpuColumnarBatchSerializerInstance(
                   Some(SerializedTableColumn.from(header))
                 }
               } else {
+                // at EOF
+                dIn.close()
                 None
               }
             }


### PR DESCRIPTION
#1116 accidentally dropped a fix for leaking Netty shuffle buffers, and that can result in warning messages like the following:
```
20/11/16 16:13:58 ERROR ResourceLeakDetector: LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
```

In addition the `ShuffleCoalesceIterator` can buffer `HostMemoryBuffer` objects yet was not installing a task completion listener to guarantee the buffers are closed even if the iterator is not drained (e.g.: in a limit query).