### PR TITLE
[REVIEW] Support decimal type for GpuProjectExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -648,7 +648,7 @@ object GpuOverrides {
         }
 
         override def isSupportedType(t: DataType): Boolean =
-          GpuOverrides.isSupportedType(t, allowCalendarInterval = true)
+          GpuOverrides.isSupportedType(t, allowCalendarInterval = true, allowDecimal = true)
       }),
     expr[Signum](
       "Returns -1.0, 0.0 or 1.0 as expr is negative, 0 or positive",
@@ -663,7 +663,8 @@ object GpuOverrides {
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
-            allowNesting = true)
+            allowNesting = true,
+            allowDecimal = true)
 
         override def convertToGpu(child: Expression): GpuExpression =
           GpuAlias(child, a.name)(a.exprId, a.qualifier, a.explicitMetadata)
@@ -676,7 +677,8 @@ object GpuOverrides {
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
-            allowNesting = true)
+            allowNesting = true,
+            allowDecimal = true)
 
         // This is the only NOOP operator.  It goes away when things are bound
         override def convertToGpu(): Expression = att
@@ -873,7 +875,8 @@ object GpuOverrides {
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
-            allowNesting = true)
+            allowNesting = true,
+            allowDecimal = true)
 
         override def convertToGpu(child: Expression): GpuExpression = GpuIsNull(child)
       }),
@@ -885,7 +888,8 @@ object GpuOverrides {
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
-            allowNesting = true)
+            allowNesting = true,
+            allowDecimal = true)
 
         override def convertToGpu(child: Expression): GpuExpression = GpuIsNotNull(child)
       }),
@@ -1894,7 +1898,8 @@ object GpuOverrides {
               allowMaps = true,
               allowArray = true,
               allowStruct = true,
-              allowNesting = true)
+              allowNesting = true,
+              allowDecimal = true)
 
           override def convertToGpu(): GpuExec =
             GpuProjectExec(childExprs.map(_.convertToGpu()), childPlans(0).convertIfNeeded())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -111,9 +111,10 @@ private object GpuRowToColumnConverter {
         StructConverter(st.fields.map(getConverterFor))
       case (st: StructType, false) =>
         NotNullStructConverter(st.fields.map(getConverterFor))
-      // NOT SUPPORTED YET
-      // case dt: DecimalType => new DecimalConverter(dt)
-      //       NOT SUPPORTED YET
+      case (dt: DecimalType, true) =>
+        new DecimalConverter(dt.precision, dt.scale)
+      case (dt: DecimalType, false) =>
+        new NotNullDecimalConverter(dt.precision, dt.scale)
       case (MapType(k, v, vcn), true) =>
         MapConverter(getConverterForType(k, nullable = false),
           getConverterForType(v, vcn))
@@ -480,27 +481,34 @@ private object GpuRowToColumnConverter {
     override def getNullSize: Double = childConverters.map(_.getNullSize).sum + VALIDITY
   }
 
-  //  private case class DecimalConverter(dt: DecimalType) extends TypeConverter {
-  //    override def append(row: SpecializedGetters,
-  //    column: Int,
-  //    builder: ai.rapids.cudf.HostColumnVector.Builder): Unit = {
-  //      if (row.isNullAt(column)) {
-  //        builder.appendNull()
-  //      } else {
-  //        val d = row.getDecimal(column, dt.precision, dt.scale)
-  //        if (dt.precision <= Decimal.MAX_INT_DIGITS) {
-  //          cv.appendInt(d.toUnscaledLong.toInt)
-  //        } else if (dt.precision <= Decimal.MAX_LONG_DIGITS) {
-  //          cv.appendLong(d.toUnscaledLong)
-  //        } else {
-  //          val integer = d.toJavaBigDecimal.unscaledValue
-  //          val bytes = integer.toByteArray
-  //          cv.appendByteArray(bytes, 0, bytes.length)
-  //        }
-  //      }
-  //    }
-  //  }
-  //
+  private class DecimalConverter(
+    precision: Int, scale: Int) extends NotNullDecimalConverter(precision, scale) {
+    override def append(
+      row: SpecializedGetters,
+      column: Int,
+      builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
+      if (row.isNullAt(column)) {
+        builder.appendNull()
+      } else {
+        super.append(row, column, builder)
+      }
+      8 + VALIDITY
+    }
+  }
+
+  private class NotNullDecimalConverter(precision: Int, scale: Int) extends TypeConverter {
+    override def append(
+      row: SpecializedGetters,
+      column: Int,
+      builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
+      // Because DECIMAL64 is the only supported decimal DType, we can
+      // append unscaledLongValue instead of BigDecimal itself to speedup this conversion.
+      builder.append(row.getDecimal(column, precision, scale).toUnscaledLong)
+      8
+    }
+
+    override def getNullSize: Double = 8 + VALIDITY
+  }
 }
 
 class RowToColumnarIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import ai.rapids.cudf.DType
+
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -113,8 +115,24 @@ object HostColumnarToGpu {
         for (i <- 0 until rows) {
           b.appendUTF8String(cv.getUTF8String(i).getBytes)
         }
-      case (t, _) =>
-        throw new UnsupportedOperationException(s"Converting to GPU for $t is not currently " +
+      case (dt: DecimalType, nullable) =>
+        // Because DECIMAL64 is the only supported decimal DType, we can
+        // append unscaledLongValue instead of BigDecimal itself to speedup this conversion.
+        if (nullable) {
+          for (i <- 0 until rows) {
+            if (cv.isNullAt(i)) {
+              b.appendNull()
+            } else {
+              b.append(cv.getDecimal(i, DType.DECIMAL64_MAX_PRECISION, dt.scale).toUnscaledLong)
+            }
+          }
+        } else {
+          for (i <- 0 until rows) {
+            b.append(cv.getDecimal(i, DType.DECIMAL64_MAX_PRECISION, dt.scale).toUnscaledLong)
+          }
+        }
+      case (t, n) =>
+        throw new UnsupportedOperationException(s"Converting to GPU for ${t} is not currently " +
           s"supported")
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -65,6 +65,7 @@ object GpuScalar {
     case DType.TIMESTAMP_DAYS => v.getInt
     case DType.TIMESTAMP_MICROSECONDS => v.getLong
     case DType.STRING => v.getJavaString
+    case dt: DType if dt.isDecimalType && dt.isBackedByLong => Decimal(v.getBigDecimal)
     case t => throw new IllegalStateException(s"$t is not a supported rapids scalar type yet")
   }
 
@@ -88,12 +89,36 @@ object GpuScalar {
     case b: Boolean => Scalar.fromBool(b)
     case s: String => Scalar.fromString(s)
     case s: UTF8String => Scalar.fromString(s.toString)
+    // make sure all scalars created are backed by DECIMAL64
+    case dec: Decimal =>
+      Scalar.fromDecimal(-dec.scale, dec.toUnscaledLong)
+    case dec: BigDecimal =>
+      Scalar.fromDecimal(-dec.scale, dec.bigDecimal.unscaledValue().longValueExact())
     case _ =>
       throw new IllegalStateException(s"${v.getClass} '${v}' is not supported as a scalar yet")
   }
 
   def from(v: Any, t: DataType): Scalar = v match {
     case _ if v == null => Scalar.fromNull(GpuColumnVector.getRapidsType(t))
+    case _ if t.isInstanceOf[DecimalType] =>
+      var bigDec = v match {
+        case vv: Decimal => vv.toBigDecimal.bigDecimal
+        case vv: BigDecimal => vv.bigDecimal
+        case vv: Double => BigDecimal(vv).bigDecimal
+        case vv: Float => BigDecimal(vv).bigDecimal
+        case vv: String => BigDecimal(vv).bigDecimal
+        case vv: Double => BigDecimal(vv).bigDecimal
+        case vv: Long => BigDecimal(vv).bigDecimal
+        case vv: Int => BigDecimal(vv).bigDecimal
+        case vv => throw new IllegalStateException(
+          s"${vv.getClass} '${vv}' is not supported as a scalar yet")
+      }
+      bigDec = bigDec.setScale(t.asInstanceOf[DecimalType].scale)
+      if (bigDec.precision() > t.asInstanceOf[DecimalType].precision) {
+        throw new IllegalArgumentException(s"BigDecimal $bigDec exceeds precision constraint of $t")
+      }
+      // make sure all scalars created are backed by DECIMAL64
+      Scalar.fromDecimal(-bigDec.scale(), bigDec.unscaledValue().longValueExact())
     case l: Long => t match {
       case LongType => Scalar.fromLong(l)
       case TimestampType => Scalar.timestampFromLong(DType.TIMESTAMP_MICROSECONDS, l)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -937,24 +937,28 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     ).toDF("ints", "longs", "doubles", "strings", "bucket_1", "bucket_2")
   }
 
-  def mixedDf(session: SparkSession): DataFrame = {
-    import session.sqlContext.implicits._
-    Seq[(java.lang.Integer, java.lang.Long, java.lang.Double, java.lang.String)](
-      (99, 100L, 1.0, "A"),
-      (98, 200L, 2.0, "B"),
-      (97,300L, 3.0, "C"),
-      (99, 400L, 4.0, "D"),
-      (98, 500L, 5.0, "E"),
-      (97, -100L, 6.0, "F"),
-      (96, -500L, 0.0, "G"),
-      (95, -700L, 8.0, "E\u0480\u0481"),
-      (Int.MaxValue, Long.MinValue, Double.PositiveInfinity, "\u0000"),
-      (Int.MinValue, Long.MaxValue, Double.NaN, "\u0000"),
-      (null, null, null, "actions are judged by intentions"),
-      (94, -900L, 9.0, "g\nH"),
-      (92, -1200L, 12.0, "IJ\"\u0100\u0101\u0500\u0501"),
-      (90, 1500L, 15.0, "\ud720\ud721")
-    ).toDF("ints", "longs", "doubles", "strings")
+  def mixedDf(session: SparkSession, numSlices: Int = 2): DataFrame = {
+    val rows = Seq[Row](Row(99, 100L, 1.0, "A", Decimal("1.2")),
+      Row(98, 200L, 2.0, "B", Decimal("1.3")),
+      Row(97, 300L, 3.0, "C", Decimal("1.4")),
+      Row(99, 400L, 4.0, "D", Decimal("1.5")),
+      Row(98, 500L, 5.0, "E", Decimal("1.6")),
+      Row(97, -100L, 6.0, "F", Decimal("1.7")),
+      Row(96, -500L, 0.0, "G", Decimal("1.8")),
+      Row(95, -700L, 8.0, "E\u0480\u0481", Decimal("1.9")),
+      Row(Int.MaxValue, Long.MinValue, Double.PositiveInfinity, "\u0000", Decimal("2.0")),
+      Row(Int.MinValue, Long.MaxValue, Double.NaN, "\u0000", Decimal("100.123")),
+      Row(null, null, null, "actions are judged by intentions", Decimal("200.246")),
+      Row(94, -900L, 9.0, "g\nH", Decimal("300.369")),
+      Row(92, -1200L, 12.0, "IJ\"\u0100\u0101\u0500\u0501", Decimal("-1.47e3")),
+      Row(90, 1500L, 15.0, "\ud720\ud721", Decimal("-22.2345")))
+    val structType = StructType(Seq(StructField("ints", IntegerType),
+        StructField("longs", LongType),
+        StructField("doubles", DoubleType),
+        StructField("strings", StringType),
+        StructField("decimals", DecimalType(15, 5))))
+    session.createDataFrame(
+      session.sparkContext.parallelize(rows, numSlices), structType)
   }
 
   def likeDf(session: SparkSession): DataFrame = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.unit
+
+import java.math.RoundingMode
+
+import scala.util.Random
+
+import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
+import com.nvidia.spark.rapids.{GpuAlias, GpuColumnVector, GpuIsNotNull, GpuIsNull, GpuLiteral, GpuOverrides, GpuScalar, GpuUnitTests, HostColumnarToGpu, RapidsConf, RapidsHostColumnVector}
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
+import org.apache.spark.sql.types.{Decimal, DecimalType}
+
+class DecimalUnitTest extends GpuUnitTests {
+  Random.setSeed(1234L)
+
+  private val dec32Data = Array.fill[Decimal](10)(
+    Decimal.fromDecimal(BigDecimal(Random.nextInt() / 1000, 3 + Random.nextInt(3))))
+  private val dec64Data = Array.fill[Decimal](10)(
+    Decimal.fromDecimal(BigDecimal(Random.nextLong() / 1000, 7 + Random.nextInt(3))))
+
+  test("test decimal as scalar") {
+    Array(dec32Data, dec64Data).flatten.foreach { dec =>
+      // test GpuScalar.from(v: Any)
+      withResource(GpuScalar.from(dec)) { s =>
+        assertResult(-dec.scale)(s.getType.getScale)
+        assertResult(dec)(GpuScalar.extract(s).asInstanceOf[Decimal])
+      }
+      // test GpuScalar.from(v: Any, t: DataType)
+      val dt = DecimalType(DType.DECIMAL64_MAX_PRECISION, dec.scale)
+      withResource(GpuScalar.from(dec.toDouble, dt)) { s =>
+        assertResult(-dt.scale)(s.getType.getScale)
+        assertResult(dec.toDouble)(GpuScalar.extract(s).asInstanceOf[Decimal].toDouble)
+      }
+      withResource(GpuScalar.from(dec.toString(), dt)) { s =>
+        assertResult(-dt.scale)(s.getType.getScale)
+        assertResult(dec.toString)(GpuScalar.extract(s).asInstanceOf[Decimal].toString)
+      }
+      val long = dec.toLong
+      withResource(GpuScalar.from(long, DecimalType(dec.precision, 0))) { s =>
+        assertResult(0)(s.getType.getScale)
+        assertResult(long)(GpuScalar.extract(s).asInstanceOf[Decimal].toLong)
+      }
+    }
+    // test exception throwing due to unsupported type
+    assertThrows[IllegalStateException] {
+      withResource(GpuScalar.from(true, DecimalType(10, 1))) { _ => }
+    }
+    // test exception throwing due to exceeded precision
+    assertThrows[IllegalArgumentException] {
+      val bigDec = Decimal(BigDecimal(Long.MaxValue / 100, 0))
+      withResource(GpuScalar.from(bigDec, DecimalType(15, 1))) { _ => }
+    }
+  }
+
+  test("test decimal as column vector") {
+    val dt32 = DecimalType(DType.DECIMAL64_MAX_PRECISION, 5)
+    val dt64 = DecimalType(DType.DECIMAL64_MAX_PRECISION, 9)
+    val cudfCV = ColumnVector.decimalFromDoubles(GpuColumnVector.getRapidsType(dt32),
+      RoundingMode.UNNECESSARY, dec32Data.map(_.toDouble): _*)
+    withResource(GpuColumnVector.from(cudfCV, dt32)) { cv: GpuColumnVector =>
+      assertResult(dec32Data.length)(cv.getRowCount)
+      val (precision, scale) = cv.dataType() match {
+        case dt: DecimalType => (dt.precision, dt.scale)
+      }
+      withResource(cv.copyToHost()) { hostCv: RapidsHostColumnVector =>
+        dec32Data.zipWithIndex.foreach { case (dec, i) =>
+          val rescaled = dec.toJavaBigDecimal.setScale(scale)
+          assertResult(rescaled.unscaledValue().longValueExact())(hostCv.getLong(i))
+          assertResult(Decimal(rescaled))(hostCv.getDecimal(i, precision, scale))
+        }
+      }
+    }
+    val dec64WithNull = Array(null) ++ dec64Data.map(_.toJavaBigDecimal) ++ Array(null, null)
+    withResource(GpuColumnVector.from(ColumnVector.fromDecimals(dec64WithNull: _*), dt64)) { cv =>
+      assertResult(dec64WithNull.length)(cv.getRowCount)
+      assertResult(true)(cv.hasNull)
+      assertResult(3)(cv.numNulls)
+      val (precision, scale) = cv.dataType() match {
+        case dt: DecimalType => (dt.precision, dt.scale)
+      }
+      withResource(cv.copyToHost()) { hostCv: RapidsHostColumnVector =>
+        dec64WithNull.zipWithIndex.foreach {
+          case (dec, i) if dec == null =>
+            assertResult(true)(hostCv.getBase.isNull(i))
+          case (dec, i) =>
+            val rescaled = dec.setScale(scale)
+            assertResult(rescaled.unscaledValue().longValueExact())(hostCv.getLong(i))
+            assertResult(Decimal(rescaled))(hostCv.getDecimal(i, precision, scale))
+        }
+      }
+    }
+    // assertion error throws because of precision overflow
+    assertThrows[AssertionError] {
+      withResource(GpuColumnVector.from(ColumnVector.decimalFromLongs(0, 1L),
+        DecimalType(DType.DECIMAL64_MAX_PRECISION + 1, 0))) { _ => }
+    }
+    // assertion error throws because of unsupported DType DECIMAL32
+    assertThrows[AssertionError] {
+      withResource(GpuColumnVector.from(ColumnVector.decimalFromInts(0, 1),
+        DecimalType(1, 0))) { _ => }
+    }
+    withResource(GpuScalar.from(dec64Data(0), dt64)) { scalar =>
+      withResource(GpuColumnVector.from(scalar, 10, dt64)) { cv =>
+        assertResult(10)(cv.getRowCount)
+        withResource(cv.copyToHost()) { hcv =>
+          (0 until 10).foreach { i =>
+            assertResult(scalar.getLong)(hcv.getLong(i))
+            assertResult(scalar.getBigDecimal)(
+              hcv.getDecimal(i, dt64.precision, dt64.scale).toJavaBigDecimal)
+          }
+        }
+      }
+    }
+  }
+
+  private val rapidsConf = new RapidsConf(Map[String, String]())
+  private val lit = Literal(dec32Data(0), DecimalType(dec32Data(0).precision, dec32Data(0).scale))
+
+  test("test Literal with decimal") {
+    val wrapperLit = GpuOverrides.wrapExpr(lit, rapidsConf, None)
+    wrapperLit.tagForGpu()
+    assertResult(true)(wrapperLit.canExprTreeBeReplaced)
+    val gpuLit = wrapperLit.convertToGpu().asInstanceOf[GpuLiteral]
+    assertResult(lit.eval(null))(gpuLit.columnarEval(null))
+    assertResult(lit.sql)(gpuLit.sql)
+
+    // inconvertible because of precision overflow
+    val wrp = GpuOverrides.wrapExpr(Literal(Decimal(12345L), DecimalType(38, 10)), rapidsConf, None)
+    wrp.tagForGpu()
+    assertResult(false)(wrp.canExprTreeBeReplaced)
+  }
+
+  test("test Alias with decimal") {
+    val cpuAlias = Alias(lit, "A")()
+    val wrapperAlias = GpuOverrides.wrapExpr(cpuAlias, rapidsConf, None)
+    wrapperAlias.tagForGpu()
+    assertResult(true)(wrapperAlias.canExprTreeBeReplaced)
+    val gpuAlias = wrapperAlias.convertToGpu().asInstanceOf[GpuAlias]
+    assertResult(cpuAlias.dataType)(gpuAlias.dataType)
+    assertResult(cpuAlias.sql)(gpuAlias.sql)
+    assertResult(cpuAlias.eval(null))(gpuAlias.columnarEval(null))
+  }
+
+  test("test AttributeReference with decimal") {
+    val cpuAttrRef = AttributeReference("test123", lit.dataType)()
+    val wrapperAttrRef = GpuOverrides.wrapExpr(cpuAttrRef, rapidsConf, None)
+    wrapperAttrRef.tagForGpu()
+    assertResult(true)(wrapperAttrRef.canExprTreeBeReplaced)
+    val gpuAttrRef = wrapperAttrRef.convertToGpu().asInstanceOf[AttributeReference]
+    assertResult(cpuAttrRef.sql)(gpuAttrRef.sql)
+    assertResult(true)(gpuAttrRef.sameRef(cpuAttrRef))
+  }
+
+  test("test IsNull/IsNotNull with decimal") {
+    val decArray = Array(BigDecimal(1234567890L).bigDecimal, null,
+      BigDecimal(-123L).bigDecimal, null, null)
+    withResource(GpuColumnVector.from(ColumnVector.fromDecimals(decArray: _*), DecimalType(10, 0))
+    ) { cv =>
+      withResource(GpuIsNull(null).doColumnar(cv).copyToHost()) { ret =>
+        assertResult(false)(ret.getBoolean(0))
+        assertResult(true)(ret.getBoolean(1))
+        assertResult(false)(ret.getBoolean(2))
+        assertResult(true)(ret.getBoolean(3))
+        assertResult(true)(ret.getBoolean(4))
+      }
+      withResource(GpuIsNotNull(null).doColumnar(cv).copyToHost()) { ret =>
+        assertResult(true)(ret.getBoolean(0))
+        assertResult(false)(ret.getBoolean(1))
+        assertResult(true)(ret.getBoolean(2))
+        assertResult(false)(ret.getBoolean(3))
+        assertResult(false)(ret.getBoolean(4))
+      }
+    }
+  }
+
+  test("test HostColumnarToGpu.columnarCopy") {
+    withResource(
+      GpuColumnVector.from(ColumnVector.fromDecimals(dec64Data.map(_.toJavaBigDecimal): _*),
+        DecimalType(DType.DECIMAL64_MAX_PRECISION, 9))) { cv =>
+      val dt = new HostColumnVector.BasicType(false, GpuColumnVector.getRapidsType(cv.dataType()))
+      val builder = new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)
+      withResource(cv.copyToHost()) { hostCV =>
+        HostColumnarToGpu.columnarCopy(hostCV, builder, false, cv.getRowCount.toInt)
+        val actual = builder.build()
+        val expected = hostCV.getBase
+        assertResult(expected.getType)(actual.getType)
+        assertResult(expected.getRowCount)(actual.getRowCount)
+        (0 until actual.getRowCount.toInt).foreach { i =>
+          assertResult(expected.getBigDecimal(i))(actual.getBigDecimal(i))
+        }
+      }
+    }
+    val dec64WithNull = dec64Data.splitAt(5) match {
+      case (left, right) =>
+        Array(null) ++ left.map(_.toJavaBigDecimal) ++ Array(null) ++
+          right.map(_.toJavaBigDecimal) ++ Array(null)
+    }
+    withResource(
+      GpuColumnVector.from(ColumnVector.fromDecimals(dec64WithNull: _*),
+        DecimalType(DType.DECIMAL64_MAX_PRECISION, 9))) { cv =>
+      val dt = new HostColumnVector.BasicType(true, GpuColumnVector.getRapidsType(cv.dataType()))
+      val builder = new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)
+      withResource(cv.copyToHost()) { hostCV =>
+        HostColumnarToGpu.columnarCopy(hostCV, builder, true, cv.getRowCount.toInt)
+        val actual = builder.build()
+        val expected = hostCV.getBase
+        assertResult(DType.create(DType.DTypeEnum.DECIMAL64, expected.getType.getScale)
+        )(actual.getType)
+        assertResult(expected.getRowCount)(actual.getRowCount)
+        (0 until actual.getRowCount.toInt).foreach { i =>
+          assertResult(expected.isNull(i))(actual.isNull(i))
+          if (!actual.isNull(i)) {
+            assertResult(expected.getBigDecimal(i))(actual.getBigDecimal(i))
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The target of current PR is to support decimal type for `GpuProjectExec`.  There are several prerequisites for this target:
* support decimal data in `GpuColumnVector`
* support decimal data in `GpuScalar`
* decimal data transmission between cpu and gpu 
   * `GpuRowToColumnarExec`
   * `GpuColumnarToRowExec`
   * `HostColumnarToGpu`

The PR also enables decimal type in some basic expressions (Literal/Alias/AttributeReference/IsNull/IsNotNull).

In addition, `DECIMAL64` is the only supported `DType.ID` for decimal column vectors and scalars in terms of spark-rapids. This restriction is to ensure one to one mapping relation between `DataType` and `DType`, in case of DType transaction caused by precision promotion.