### PR TITLE
Mark test as xfail until we can get a fix in

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -185,6 +185,7 @@ def test_ts_read_fails_datetime_legacy(gen, spark_tmp_path, ts_write, ts_rebase,
     with_cpu_session(
             lambda spark : unary_op_df(spark, gen).write.parquet(data_path),
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
+                'spark.sql.legacy.parquet.int96RebaseModeInWrite': ts_rebase,
                 'spark.sql.parquet.outputTimestampType': ts_write})
     all_confs = reader_confs.copy()
     all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -14,10 +14,11 @@
 
 import pytest
 
+from spark_session import is_before_spark_310
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql
 from data_gen import *
-from pyspark.sql.types import *
 from marks import *
+from pyspark.sql.types import *
 from pyspark.sql.window import Window
 import pyspark.sql.functions as f
 
@@ -78,6 +79,7 @@ def meta_idfn(meta):
         return meta + idfn(something)
     return tmp
 
+@pytest.mark.xfail(condition=not(is_before_spark_310()), reason='https://github.com/NVIDIA/spark-rapids/issues/999')
 @ignore_order
 @approximate_float
 @pytest.mark.parametrize('c_gen', lead_lag_data_gens, ids=idfn)


### PR DESCRIPTION
This marks some of the window tests related to #999 as xfail, but it does not fix all of the failures in 3.1.0 

```
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[-reader_confs0-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[-reader_confs1-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[-reader_confs2-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[parquet-reader_confs0-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[parquet-reader_confs1-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/parquet_test.py::test_ts_read_fails_datetime_legacy[parquet-reader_confs2-LEGACY-INT96-Timestamp]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[No_Partition-Byte][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[No_Partition-Short][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[No_Partition-Integer][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Following-Integer][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded-Byte][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Preceding-Byte][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Lower_Upper-Short][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded-Short][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Preceding-Short][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded-Integer][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Lower_Upper-Integer][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Following-Byte][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Preceding-Integer][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Lower_Upper-Byte][IGNORE_ORDER]
FAILED ../../src/main/python/udf_test.py::test_window_aggregate_udf[Unbounded_Following-Short][IGNORE_ORDER]
```

`test_window_aggregate_udf` are showing part of the query not being on the GPU. I believe that the 3.1.0 shim layer is not implemented.  I can file another issue for them and mark them as xfail too if we want to.

The `test_ts_read_fails_datetime_legacy` tests are failing with spark saying that it cannot write some of the dates in legacy mode.

```
  Caused by: org.apache.spark.SparkUpgradeException: You may get a different result due to the upgrading of Spark 3.0: writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z into Parquet INT96 files can be dangerous, as the files may be read by Spark 2.x or legacy versions of Hive later, which uses a legacy hybrid calendar that is different from Spark 3.0+'s Proleptic Gregorian calendar. See more details in SPARK-31404. You can set spark.sql.legacy.parquet.int96RebaseModeInWrite to 'LEGACY' to rebase the datetime values w.r.t. the calendar difference during writing, to get maximum interoperability. Or set spark.sql.legacy.parquet.int96RebaseModeInWrite to 'CORRECTED' to write the datetime values as it is, if you are 100% sure that the written files will only be read by Spark 3.0+ or other systems that use Proleptic Gregorian calendar.
```

I am happy to set that config in the tests too, to work around this issue.