### PR TITLE
Fix warning introduced in iterator suite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala
@@ -118,7 +118,6 @@ class RapidsShuffleIteratorSuite extends RapidsShuffleTestHelper {
           val cause = rsffe.getCause
           assertResult(cause)(causeException)
           throw rsffe
-        case _ =>
       }
     }
     verify(testMetricsUpdater, times(1))


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Removes new warning introduced by https://github.com/NVIDIA/spark-rapids/pull/994 in the tests:
```
[WARNING] /home/abellina/work/rapids-plugin-4-spark/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIteratorSuite.scala:121: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
[WARNING]         case _ =>
```