### PR TITLE
Set job descriptions in benchmark runner

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -47,6 +47,7 @@ object BenchmarkRunner {
       case Some(bench) =>
         val appName = s"${bench.name()} Like Bench ${conf.query()}"
         val spark = SparkSession.builder.appName(appName).getOrCreate()
+        spark.sparkContext.setJobDescription("Register input tables")
         conf.inputFormat().toLowerCase match {
           case "parquet" => bench.setupAllParquet(spark, conf.input())
           case "csv" => bench.setupAllCSV(spark, conf.input())

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -155,6 +155,7 @@ object BenchUtils {
     var df: DataFrame = null
     val queryTimes = new ListBuffer[Long]()
     for (i <- 0 until iterations) {
+      spark.sparkContext.setJobDescription(s"Benchmark Run: query=$queryDescription; iteration=$i")
 
       // capture spark plan metrics on the first run
       if (i == 0) {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

The benchmark runner causes multiple jobs to run to set up the input files as tables, and potentially multiple jobs can run to execute the query being benchmarked. This makes it difficult to collect metrics from the Spark event log during benchmark runs because it isn't obvious which jobs and stages are for setup rather than query execution.

This PR sets job descriptions so that it is easier to parse the Spark event logs for benchmark runs. 

Example output:

```
{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart",
  "executionId":0,
  "description":"Register input tables"

{"Event":"org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart",
  "executionId":24,
  "description":"Benchmark Run: query=q16; iteration=0"
```

This closes https://github.com/NVIDIA/spark-rapids/issues/1118