### PR TITLE
Fix race condition in SerializeConcatHostBuffersDeserializeBatch

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -50,7 +50,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
   extends Serializable with Arm with AutoCloseable {
   @transient private val headers = data.map(_.header)
   @transient private val buffers = data.map(_.buffer)
-  @transient private var batchInternal: ColumnarBatch = null
+  @transient @volatile private var batchInternal: ColumnarBatch = _
 
   def batch: ColumnarBatch = {
     if (batchInternal == null) {
@@ -60,7 +60,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
       writeObject(oout)
       val barr = out.toByteArray
       val oin = new ObjectInputStream(new ByteArrayInputStream(barr))
-      readObject(oin)
+      batchInternal = readObject(oin)
     }
     batchInternal
   }
@@ -81,7 +81,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
     }
   }
 
-  private def readObject(in: ObjectInputStream): Unit = {
+  private def readObject(in: ObjectInputStream): ColumnarBatch = {
     val range = new NvtxRange("DeserializeBatch", NvtxColor.PURPLE)
     try {
       val tableInfo: JCudfSerialization.TableAndRowCountPair =
@@ -90,13 +90,12 @@ class SerializeConcatHostBuffersDeserializeBatch(
         val table = tableInfo.getTable
         if (table == null) {
           val numRows = tableInfo.getNumRows
-          this.batchInternal = new ColumnarBatch(new Array[ColumnVector](0))
-          batchInternal.setNumRows(numRows.toInt)
+          new ColumnarBatch(new Array[ColumnVector](0), numRows.toInt)
         } else {
           val colDataTypes = in.readObject().asInstanceOf[Array[DataType]]
           // This is read as part of the broadcast join so we expect it to leak.
           (0 until table.getNumberOfColumns).foreach(table.getColumn(_).noWarnLeakExpected())
-          this.batchInternal = GpuColumnVector.from(table, colDataTypes)
+          GpuColumnVector.from(table, colDataTypes)
         }
       } finally {
         tableInfo.close()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -50,22 +50,20 @@ class SerializeConcatHostBuffersDeserializeBatch(
   extends Serializable with Arm with AutoCloseable {
   @transient private val headers = data.map(_.header)
   @transient private val buffers = data.map(_.buffer)
-  @transient @volatile private var batchInternalRef: ColumnarBatch = _
+  @transient @volatile private var batchInternal: ColumnarBatch = _
 
   def batch: ColumnarBatch = this.synchronized {
-    if (batchInternalRef == null) {
+    if (batchInternal == null) {
       // TODO we should come up with a better way for this to happen directly...
       val out = new ByteArrayOutputStream()
       val oout = new ObjectOutputStream(out)
       writeObject(oout)
       val barr = out.toByteArray
       val oin = new ObjectInputStream(new ByteArrayInputStream(barr))
-      batchInternalRef = readObject(oin)
+      batchInternal = readObject(oin)
     }
-    batchInternalRef
+    batchInternal
   }
-
-  def batchInternal = this.synchronized { batchInternalRef }
 
   private def writeObject(out: ObjectOutputStream): Unit = {
     if (headers.length == 0) {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

The following code had a race condition. The object was created with numRows = 0 and then updated. Another thread could access the object before the row count was set.

```scala
this.batchInternal = new ColumnarBatch(new Array[ColumnVector](0))
batchInternal.setNumRows(numRows.toInt)
```

I also changed `readObject` to return an object rather than set the shared object as a side-effect.

This closes https://github.com/NVIDIA/spark-rapids/issues/724