### PR TITLE
Nulls out the dataframe if --gc-between-runs is set

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -155,6 +155,14 @@ object BenchUtils {
     var df: DataFrame = null
     val queryTimes = new ListBuffer[Long]()
     for (i <- 0 until iterations) {
+      // cause Spark to call unregisterShuffle
+      if (i > 0 && gcBetweenRuns) {
+        // we must null out the dataframe reference to allow
+        // GC to clean up the shuffle
+        df = null
+        System.gc()
+        System.gc()
+      }
 
       // capture spark plan metrics on the first run
       if (i == 0) {
@@ -189,15 +197,6 @@ object BenchUtils {
           queryTimes.append(-1)
           exceptions.append(BenchUtils.toString(e))
           e.printStackTrace()
-      }
-
-      // cause Spark to call unregisterShuffle
-      if (gcBetweenRuns) {
-        // we must null out the dataframe reference to allow
-        // GC to clean up the shuffle
-        df = null
-        System.gc()
-        System.gc()
       }
     }
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -193,6 +193,9 @@ object BenchUtils {
 
       // cause Spark to call unregisterShuffle
       if (gcBetweenRuns) {
+        // we must null out the dataframe reference to allow
+        // GC to clean up the shuffle
+        df = null
         System.gc()
         System.gc()
       }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Small fix to allow GC to clean up shuffles between runs.