### PR TITLE
Fix race condition in SerializeConcatHostBuffersDeserializeBatch

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -90,8 +90,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
         val table = tableInfo.getTable
         if (table == null) {
           val numRows = tableInfo.getNumRows
-          this.batchInternal = new ColumnarBatch(new Array[ColumnVector](0))
-          batchInternal.setNumRows(numRows.toInt)
+          this.batchInternal = new ColumnarBatch(new Array[ColumnVector](0), numRows.toInt)
         } else {
           val colDataTypes = in.readObject().asInstanceOf[Array[DataType]]
           // This is read as part of the broadcast join so we expect it to leak.


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR fixes a race condition where a batch was created with a zero row count and then updated with the actual row count, but other threads were able to use this batch when it was in the intermediate state.

This is a smaller change than the PR yesterday that attempted to fix this, but also introduced a regression.