### PR TITLE
Add in support for null type

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -431,7 +431,7 @@ def test_columnar_pow(data_gen):
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
 def test_least(data_gen):
     num_cols = 20
-    s1 = gen_scalar(data_gen, force_no_nulls=True)
+    s1 = gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen))
     # we want lots of nulls
     gen = StructGen([('_c' + str(x), data_gen.copy_special_case(None, weight=100.0)) 
         for x in range(0, num_cols)], nullable=False)
@@ -446,7 +446,7 @@ def test_least(data_gen):
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
 def test_greatest(data_gen):
     num_cols = 20
-    s1 = gen_scalar(data_gen, force_no_nulls=True)
+    s1 = gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen))
     # we want lots of nulls
     gen = StructGen([('_c' + str(x), data_gen.copy_special_case(None, weight=100.0)) 
         for x in range(0, num_cols)], nullable=False)

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -23,7 +23,7 @@ import pyspark.sql.functions as f
 
 @pytest.mark.parametrize('data_gen', eq_gens, ids=idfn)
 def test_eq(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -35,7 +35,7 @@ def test_eq(data_gen):
 
 @pytest.mark.parametrize('data_gen', eq_gens, ids=idfn)
 def test_eq_ns(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -47,7 +47,7 @@ def test_eq_ns(data_gen):
 
 @pytest.mark.parametrize('data_gen', eq_gens, ids=idfn)
 def test_ne(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -59,7 +59,7 @@ def test_ne(data_gen):
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lt(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -71,7 +71,7 @@ def test_lt(data_gen):
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lte(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -83,7 +83,7 @@ def test_lte(data_gen):
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gt(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -95,7 +95,7 @@ def test_gt(data_gen):
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gte(data_gen):
-    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=True)
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).select(
@@ -105,7 +105,7 @@ def test_gte(data_gen):
                 f.col('b') >= f.lit(None).cast(data_type),
                 f.col('a') >= f.col('b')))
 
-@pytest.mark.parametrize('data_gen', eq_gens + array_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_isnull(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(
@@ -150,7 +150,7 @@ def test_filter_with_lit(expr):
 def test_in(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) - 1
-    scalars = list(gen_scalars(data_gen, num_entries, force_no_nulls=True))
+    scalars = list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen)))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)))
 
@@ -160,7 +160,7 @@ def test_in(data_gen):
 def test_in_set(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) + 1
-    scalars = list(gen_scalars(data_gen, num_entries, force_no_nulls=True))
+    scalars = list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen)))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)))
 

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -63,6 +63,16 @@ _grpkey_strings_with_nulls = [
     ('a', RepeatSeqGen(StringGen(pattern='[0-9]{0,30}'), length= 20)),
     ('b', IntegerGen()),
     ('c', LongGen())]
+# grouping strings with nulls present, and null value
+_grpkey_strings_with_extra_nulls = [
+    ('a', RepeatSeqGen(StringGen(pattern='[0-9]{0,30}'), length= 20)),
+    ('b', IntegerGen()),
+    ('c', NullGen())]
+# grouping NullType
+_grpkey_nulls = [
+    ('a', NullGen()),
+    ('b', IntegerGen()),
+    ('c', LongGen())]
 
 # grouping floats with other columns containing nans and nulls
 _grpkey_floats_with_nulls_and_nans = [
@@ -112,7 +122,9 @@ _init_list_no_nans = [
     _grpkey_longs_with_nulls,
     _grpkey_dbls_with_nulls,
     _grpkey_floats_with_nulls,
-    _grpkey_strings_with_nulls]
+    _grpkey_strings_with_nulls,
+    _grpkey_nulls,
+    _grpkey_strings_with_extra_nulls]
 
 # List of schemas with NaNs included
 _init_list_with_nans_and_no_nans = [

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -21,7 +21,7 @@ from marks import ignore_order, allow_non_gpu, incompat
 from spark_session import with_spark_session, is_before_spark_310
 
 all_gen = [StringGen(), ByteGen(), ShortGen(), IntegerGen(), LongGen(),
-           BooleanGen(), DateGen(), TimestampGen(),
+           BooleanGen(), DateGen(), TimestampGen(), null_gen,
            pytest.param(FloatGen(), marks=[incompat]),
            pytest.param(DoubleGen(), marks=[incompat])]
 

--- a/integration_tests/src/main/python/row_conversion_test.py
+++ b/integration_tests/src/main/python/row_conversion_test.py
@@ -36,6 +36,14 @@ def test_row_conversions():
             ["n", ArrayGen(boolean_gen)], ["o", ArrayGen(ArrayGen(short_gen))],
             ["p", StructGen([["c0", byte_gen], ["c1", ArrayGen(byte_gen)]])],
             ["q", simple_string_to_string_map_gen],
-            ["r", MapGen(BooleanGen(nullable=False), ArrayGen(boolean_gen), max_length=2)]]
+            ["r", MapGen(BooleanGen(nullable=False), ArrayGen(boolean_gen), max_length=2)],
+            ["s", null_gen]]
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))
+
+def test_row_conversions_fixed_width():
+    gens = [["a", byte_gen], ["b", short_gen], ["c", int_gen], ["d", long_gen],
+            ["e", float_gen], ["f", double_gen], ["g", string_gen], ["h", boolean_gen],
+            ["i", timestamp_gen], ["j", date_gen]]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuBroadcastHashJoinExec.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -50,6 +51,10 @@ class GpuBroadcastHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuShuffledHashJoinExec.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuShuffledHashJoinExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide, ShuffledHashJoinExec}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.GpuShuffledHashJoinBase
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object GpuJoinUtils {
@@ -58,6 +59,10 @@ class GpuShuffledHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuSortMergeJoinExec.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/GpuSortMergeJoinExec.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, SortMergeJoinExec}
+import org.apache.spark.sql.types.DataType
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -40,6 +41,10 @@ class GpuSortMergeJoinMeta(
     GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -233,6 +233,10 @@ class Spark300Shims extends SparkShims {
             GpuOverrides.wrapExpr(a.ignoreNullsExpr, conf, Some(this))
           override val childExprs: Seq[BaseExprMeta[_]] = Seq(child, ignoreNulls)
 
+          override def isSupportedType(t: DataType): Boolean =
+            GpuOverrides.isSupportedType(t,
+              allowNull = true)
+
           override def convertToGpu(): GpuExpression =
             GpuFirst(child.convertToGpu(), ignoreNulls.convertToGpu())
         }),
@@ -243,6 +247,10 @@ class Spark300Shims extends SparkShims {
           val ignoreNulls: BaseExprMeta[_] =
             GpuOverrides.wrapExpr(a.ignoreNullsExpr, conf, Some(this))
           override val childExprs: Seq[BaseExprMeta[_]] = Seq(child, ignoreNulls)
+
+          override def isSupportedType(t: DataType): Boolean =
+            GpuOverrides.isSupportedType(t,
+              allowNull = true)
 
           override def convertToGpu(): GpuExpression =
             GpuLast(child.convertToGpu(), ignoreNulls.convertToGpu())

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BuildLeft, BuildRight, BuildSide, HashedRelationBroadcastMode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.SerializeConcatHostBuffersDeserializeBatch
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -47,6 +48,10 @@ class GpuBroadcastHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.SerializeConcatHostBuffersDeserializeBatch
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -47,6 +48,10 @@ class GpuBroadcastHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
@@ -18,8 +18,8 @@ package com.nvidia.spark.rapids.shims.spark301db
 
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuMetricNames._
-
 import org.apache.spark.TaskContext
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{Distribution, HashClustered
 import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object GpuJoinUtils {
@@ -58,6 +59,10 @@ class GpuShuffledHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
@@ -18,8 +18,8 @@ package com.nvidia.spark.rapids.shims.spark301db
 
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuMetricNames._
-import org.apache.spark.TaskContext
 
+import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuBroadcastHashJoinExec.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode}
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -52,6 +53,10 @@ class GpuBroadcastHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuShuffledHashJoinExec.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/GpuShuffledHashJoinExec.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.rapids.execution.GpuShuffledHashJoinBase
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object GpuJoinUtils {
@@ -59,6 +60,10 @@ class GpuShuffledHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
+
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
@@ -270,7 +270,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
   }
 
   def isSupportedByCudf(schema: Seq[Attribute]): Boolean = {
-    schema.forall(a => GpuColumnVector.isSupportedType(a.dataType))
+    schema.forall(a => GpuColumnVector.isNonNestedSupportedType(a.dataType))
   }
 
   def isTypeSupportedByParquet(dataType: DataType): Boolean = {

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuCompressedColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuCompressedColumnVector.java
@@ -87,7 +87,7 @@ public final class GpuCompressedColumnVector extends GpuColumnVectorBase {
   private static boolean typeConversionAllowed(ColumnMeta columnMeta, DataType colType) {
     DType dt = DType.fromNative(columnMeta.dtypeId(), columnMeta.dtypeScale());
     if (!dt.isNestedType()) {
-      return GpuColumnVector.getRapidsType(colType).equals(dt);
+      return GpuColumnVector.getNonNestedRapidsType(colType).equals(dt);
     }
     if (colType instanceof MapType) {
       MapType mType = (MapType) colType;

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/UnsafeRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/UnsafeRowToColumnarBatchIterator.java
@@ -72,7 +72,7 @@ public abstract class UnsafeRowToColumnarBatchIterator implements Iterator<Colum
     outputTypes = new DataType[schema.length];
 
     for (int i = 0; i < schema.length; i++) {
-      rapidsTypes[i] = GpuColumnVector.getRapidsType(schema[i].dataType());
+      rapidsTypes[i] = GpuColumnVector.getNonNestedRapidsType(schema[i].dataType());
       outputTypes[i] = schema[i].dataType();
     }
     this.totalTime = totalTime;

--- a/sql-plugin/src/main/java/org/apache/spark/sql/catalyst/CudfUnsafeRow.java
+++ b/sql-plugin/src/main/java/org/apache/spark/sql/catalyst/CudfUnsafeRow.java
@@ -56,7 +56,7 @@ public final class CudfUnsafeRow extends InternalRow {
     // This needs to match what is in cudf and what is in the constructor.
     int offset = 0;
     for (Attribute attr : attributes) {
-      int length = GpuColumnVector.getRapidsType(attr.dataType()).getSizeInBytes();
+      int length = GpuColumnVector.getNonNestedRapidsType(attr.dataType()).getSizeInBytes();
       offset = alignOffset(offset, length);
       offset += length;
     }
@@ -135,7 +135,7 @@ public final class CudfUnsafeRow extends InternalRow {
     startOffsets = new int[attributes.length];
     for (int i = 0; i < attributes.length; i++) {
       Attribute attr = attributes[i];
-      int length = GpuColumnVector.getRapidsType(attr.dataType()).getSizeInBytes();
+      int length = GpuColumnVector.getNonNestedRapidsType(attr.dataType()).getSizeInBytes();
       assert length > 0 : "Only fixed width types are currently supported.";
       offset = alignOffset(offset, length);
       startOffsets[i] = offset;

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -46,6 +46,10 @@ class GpuExpandExecMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = gpuProjections.flatten ++ outputAttributes
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
+
   /**
    * Convert what this wraps to a GPU enabled version.
    */
@@ -147,7 +151,7 @@ class GpuExpandIterator(
        * a boolean indicating whether an existing vector was re-used.
        */
       def getOrCreateNullCV(dataType: DataType): (GpuColumnVector, Boolean) = {
-        val rapidsType = GpuColumnVector.getRapidsType(dataType)
+        val rapidsType = GpuColumnVector.getNonNestedRapidsType(dataType)
         nullCVs.get(dataType) match {
           case Some(cv) =>
             (cv.incRefCount(), true)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -113,7 +113,7 @@ object GpuOrcScanBase {
       meta.willNotWorkOnGpu("mergeSchema and schema evolution is not supported yet")
     }
     schema.foreach { field =>
-      if (!GpuColumnVector.isSupportedType(field.dataType)) {
+      if (!GpuColumnVector.isNonNestedSupportedType(field.dataType)) {
         meta.willNotWorkOnGpu(s"GpuOrcScan does not support fields of type ${field.dataType}")
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -648,7 +648,10 @@ object GpuOverrides {
         }
 
         override def isSupportedType(t: DataType): Boolean =
-          GpuOverrides.isSupportedType(t, allowCalendarInterval = true, allowDecimal = true)
+          GpuOverrides.isSupportedType(t,
+            allowNull = true,
+            allowDecimal = true,
+            allowCalendarInterval = true)
       }),
     expr[Signum](
       "Returns -1.0, 0.0 or 1.0 as expr is negative, 0 or positive",
@@ -660,6 +663,7 @@ object GpuOverrides {
       (a, conf, p, r) => new UnaryExprMeta[Alias](a, conf, p, r) {
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -674,6 +678,7 @@ object GpuOverrides {
       (att, conf, p, r) => new BaseExprMeta[AttributeReference](att, conf, p, r) {
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -694,10 +699,7 @@ object GpuOverrides {
     expr[Cast](
       "Convert a column of one type of data into another type",
       (cast, conf, p, r) => new CastExprMeta[Cast](cast, SparkSession.active.sessionState.conf
-        .ansiEnabled, conf, p, r) {
-        override def isSupportedType(t: DataType): Boolean =
-          GpuOverrides.isSupportedType(t, allowBinary = true)
-      }),
+        .ansiEnabled, conf, p, r)),
     expr[AnsiCast](
       "Convert a column of one type of data into another type",
       (cast, conf, p, r) => new CastExprMeta[AnsiCast](cast, true, conf, p, r)),
@@ -872,6 +874,7 @@ object GpuOverrides {
       (a, conf, p, r) => new UnaryExprMeta[IsNull](a, conf, p, r) {
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -885,6 +888,7 @@ object GpuOverrides {
       (a, conf, p, r) => new UnaryExprMeta[IsNotNull](a, conf, p, r) {
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -918,6 +922,7 @@ object GpuOverrides {
 
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -990,18 +995,30 @@ object GpuOverrides {
     expr[Coalesce] (
       "Returns the first non-null argument if exists. Otherwise, null",
       (a, conf, p, r) => new ExprMeta[Coalesce](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(): GpuExpression = GpuCoalesce(childExprs.map(_.convertToGpu()))
       }
     ),
     expr[Least] (
       "Returns the least value of all parameters, skipping null values",
       (a, conf, p, r) => new ExprMeta[Least](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(): GpuExpression = GpuLeast(childExprs.map(_.convertToGpu()))
       }
     ),
     expr[Greatest] (
       "Returns the greatest value of all parameters, skipping null values",
       (a, conf, p, r) => new ExprMeta[Greatest](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(): GpuExpression = GpuGreatest(childExprs.map(_.convertToGpu()))
       }
     ),
@@ -1266,30 +1283,50 @@ object GpuOverrides {
     expr[EqualNullSafe](
       "Check if the values are equal including nulls <=>",
       (a, conf, p, r) => new BinaryExprMeta[EqualNullSafe](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuEqualNullSafe(lhs, rhs)
       }),
     expr[EqualTo](
       "Check if the values are equal",
       (a, conf, p, r) => new BinaryExprMeta[EqualTo](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuEqualTo(lhs, rhs)
       }),
     expr[GreaterThan](
       "> operator",
       (a, conf, p, r) => new BinaryExprMeta[GreaterThan](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuGreaterThan(lhs, rhs)
       }),
     expr[GreaterThanOrEqual](
       ">= operator",
       (a, conf, p, r) => new BinaryExprMeta[GreaterThanOrEqual](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuGreaterThanOrEqual(lhs, rhs)
       }),
     expr[In](
       "IN operator",
       (in, conf, p, r) => new ExprMeta[In](in, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def tagExprForGpu(): Unit = {
           val unaliased = in.list.map(extractLit)
           if (!unaliased.forall(_.isDefined)) {
@@ -1309,6 +1346,10 @@ object GpuOverrides {
     expr[InSet](
       "INSET operator",
       (in, conf, p, r) => new ExprMeta[InSet](in, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def tagExprForGpu(): Unit = {
           if (in.hset.contains(null)) {
             willNotWorkOnGpu("nulls are not supported")
@@ -1325,18 +1366,30 @@ object GpuOverrides {
     expr[LessThan](
       "< operator",
       (a, conf, p, r) => new BinaryExprMeta[LessThan](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuLessThan(lhs, rhs)
       }),
     expr[LessThanOrEqual](
       "<= operator",
       (a, conf, p, r) => new BinaryExprMeta[LessThanOrEqual](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuLessThanOrEqual(lhs, rhs)
       }),
     expr[CaseWhen](
       "CASE WHEN expression",
       (a, conf, p, r) => new ExprMeta[CaseWhen](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def tagExprForGpu(): Unit = {
           val anyLit = a.branches.exists { case (predicate, _) => isLit(predicate) }
           if (anyLit) {
@@ -1359,6 +1412,10 @@ object GpuOverrides {
     expr[If](
       "IF expression",
       (a, conf, p, r) => new ExprMeta[If](a, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def tagExprForGpu(): Unit = {
           if (isLit(a.predicate)) {
             willNotWorkOnGpu(s"literal predicate ${a.predicate} is not supported")
@@ -1405,10 +1462,13 @@ object GpuOverrides {
         } else {
           childrenExprMeta
         }
-       override def convertToGpu(): GpuExpression = {
-         // handle the case AggregateExpression has the resultIds parameter where its
-         // Seq[ExprIds] instead of single ExprId.
-         val resultId = try {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+        override def convertToGpu(): GpuExpression = {
+          // handle the case AggregateExpression has the resultIds parameter where its
+          // Seq[ExprIds] instead of single ExprId.
+          val resultId = try {
             val resultMethod = a.getClass.getMethod("resultId")
             resultMethod.invoke(a).asInstanceOf[ExprId]
           } catch {
@@ -1418,7 +1478,7 @@ object GpuOverrides {
           }
           GpuAggregateExpression(childExprs(0).convertToGpu().asInstanceOf[GpuAggregateFunction],
             a.mode, a.isDistinct, filter.map(_.convertToGpu()), resultId)
-       }
+        }
       }),
     expr[SortOrder](
       "Sort order",
@@ -1426,6 +1486,9 @@ object GpuOverrides {
         // One of the few expressions that are not replaced with a GPU version
         override def convertToGpu(): Expression =
           a.withNewChildren(childExprs.map(_.convertToGpu()))
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t, allowNull = true)
       }),
     expr[Count](
       "Count aggregate operator",
@@ -1435,6 +1498,10 @@ object GpuOverrides {
             willNotWorkOnGpu("count of multiple columns not supported")
           }
         }
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
 
         override def convertToGpu(): GpuExpression = GpuCount(childExprs.map(_.convertToGpu()))
       }),
@@ -1449,6 +1516,11 @@ object GpuOverrides {
               s" ${RapidsConf.HAS_NANS} to false.")
           }
         }
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(child: Expression): GpuExpression = GpuMax(child)
       }),
     expr[Min](
@@ -1462,6 +1534,11 @@ object GpuOverrides {
               s" ${RapidsConf.HAS_NANS} to false.")
           }
         }
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(child: Expression): GpuExpression = GpuMin(child)
       }),
     expr[Sum](
@@ -1818,6 +1895,9 @@ object GpuOverrides {
         override val childExprs: Seq[BaseExprMeta[_]] =
           hp.expressions.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t, allowNull = true)
+
         override def convertToGpu(): GpuPartitioning =
           GpuHashPartitioning(childExprs.map(_.convertToGpu()), hp.numPartitions)
       }),
@@ -1826,6 +1906,10 @@ object GpuOverrides {
       (rp, conf, p, r) => new PartMeta[RangePartitioning](rp, conf, p, r) {
         override val childExprs: Seq[BaseExprMeta[_]] =
           rp.ordering.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t, allowNull = true)
+
         override def convertToGpu(): GpuPartitioning = {
           if (rp.numPartitions > 1) {
             val gpuOrdering = childExprs.map(_.convertToGpu()).asInstanceOf[Seq[SortOrder]]
@@ -1845,6 +1929,9 @@ object GpuOverrides {
     part[RoundRobinPartitioning](
       "Round robin partitioning",
       (rrp, conf, p, r) => new PartMeta[RoundRobinPartitioning](rrp, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t, allowNull = true)
+
         override def convertToGpu(): GpuPartitioning = {
           GpuRoundRobinPartitioning(rrp.numPartitions)
         }
@@ -1853,6 +1940,10 @@ object GpuOverrides {
       "Single partitioning",
       (sp, conf, p, r) => new PartMeta[SinglePartition.type](sp, conf, p, r) {
         override val childExprs: Seq[ExprMeta[_]] = Seq.empty[ExprMeta[_]]
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t, allowNull = true)
+
         override def convertToGpu(): GpuPartitioning = {
           GpuSinglePartitioning(childExprs.map(_.convertToGpu()))
         }
@@ -1895,6 +1986,7 @@ object GpuOverrides {
         new SparkPlanMeta[ProjectExec](proj, conf, p, r) {
           override def isSupportedType(t: DataType): Boolean =
             GpuOverrides.isSupportedType(t,
+              allowNull = true,
               allowMaps = true,
               allowArray = true,
               allowStruct = true,
@@ -1932,6 +2024,10 @@ object GpuOverrides {
     exec[CoalesceExec](
       "The backend for the dataframe coalesce method",
       (coalesce, conf, parent, r) => new SparkPlanMeta[CoalesceExec](coalesce, conf, parent, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(): GpuExec =
           GpuCoalesceExec(coalesce.numPartitions, childPlans.head.convertIfNeeded())
       }),
@@ -1992,6 +2088,7 @@ object GpuOverrides {
       (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {
         override def isSupportedType(t: DataType): Boolean =
           GpuOverrides.isSupportedType(t,
+            allowNull = true,
             allowMaps = true,
             allowArray = true,
             allowStruct = true,
@@ -2006,6 +2103,10 @@ object GpuOverrides {
     exec[UnionExec](
       "The backend for the union operator",
       (union, conf, p, r) => new SparkPlanMeta[UnionExec](union, conf, p, r) {
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
+
         override def convertToGpu(): GpuExec =
           GpuUnionExec(childPlans.map(_.convertIfNeeded()))
       }),
@@ -2023,6 +2124,10 @@ object GpuOverrides {
           join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
         override val childExprs: Seq[BaseExprMeta[_]] = condition.toSeq
+
+        override def isSupportedType(t: DataType): Boolean =
+          GpuOverrides.isSupportedType(t,
+            allowNull = true)
 
         override def convertToGpu(): GpuExec =
           GpuCartesianProductExec(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -121,9 +121,22 @@ private object GpuRowToColumnConverter {
       case (MapType(k, v, vcn), false) =>
         NotNullMapConverter(getConverterForType(k, nullable = false),
           getConverterForType(v, vcn))
+      case (NullType, true) =>
+        NullConverter
       case (unknown, _) => throw new UnsupportedOperationException(
         s"Type $unknown not supported")
     }
+  }
+
+  private object NullConverter extends TypeConverter {
+    override def append(row: SpecializedGetters,
+        column: Int,
+        builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
+      builder.appendNull()
+      1 + VALIDITY
+    }
+
+    override def getNullSize: Double = 1 + VALIDITY
   }
 
   private object BooleanConverter extends TypeConverter {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -41,6 +41,10 @@ class GpuSortMeta(
       sort.global,
       childPlans(0).convertIfNeeded())
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
+
   override def tagPlanForGpu(): Unit = {
     if (GpuOverrides.isAnyStringLit(sort.sortOrder)) {
       willNotWorkOnGpu("string literal values are not supported in a sort")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -240,7 +240,7 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
         }
       }
     }
-    val expectedType = GpuColumnVector.getRapidsType(windowFunc.dataType)
+    val expectedType = GpuColumnVector.getNonNestedRapidsType(windowFunc.dataType)
     if (expectedType != aggColumn.getType) {
       withResource(aggColumn) { aggColumn =>
         GpuColumnVector.from(aggColumn.castTo(expectedType), windowFunc.dataType)
@@ -271,7 +271,7 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
         }
       }
     }
-    val expectedType = GpuColumnVector.getRapidsType(windowFunc.dataType)
+    val expectedType = GpuColumnVector.getNonNestedRapidsType(windowFunc.dataType)
     if (expectedType != aggColumn.getType) {
       withResource(aggColumn) { aggColumn =>
         GpuColumnVector.from(aggColumn.castTo(expectedType), windowFunc.dataType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -115,6 +115,10 @@ object HostColumnarToGpu {
         for (i <- 0 until rows) {
           b.appendUTF8String(cv.getUTF8String(i).getBytes)
         }
+      case (NullType, true) =>
+        for (_ <- 0 until rows) {
+          b.appendNull()
+        }
       case (dt: DecimalType, nullable) =>
         // Because DECIMAL64 is the only supported decimal DType, we can
         // append unscaledLongValue instead of BigDecimal itself to speedup this conversion.
@@ -131,8 +135,8 @@ object HostColumnarToGpu {
             b.append(cv.getDecimal(i, DType.DECIMAL64_MAX_PRECISION, dt.scale).toUnscaledLong)
           }
         }
-      case (t, n) =>
-        throw new UnsupportedOperationException(s"Converting to GPU for ${t} is not currently " +
+      case (t, _) =>
+        throw new UnsupportedOperationException(s"Converting to GPU for $t is not currently " +
           s"supported")
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -99,7 +99,7 @@ object GpuScalar {
   }
 
   def from(v: Any, t: DataType): Scalar = v match {
-    case _ if v == null => Scalar.fromNull(GpuColumnVector.getRapidsType(t))
+    case _ if v == null => Scalar.fromNull(GpuColumnVector.getNonNestedRapidsType(t))
     case _ if t.isInstanceOf[DecimalType] =>
       var bigDec = v match {
         case vv: Decimal => vv.toBigDecimal.bigDecimal

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -236,7 +236,7 @@ trait GpuGreatestLeastBase extends ComplexTypeMergingExpression with GpuExpressi
 
   private[this] def isFp = dataType == FloatType || dataType == DoubleType
   // TODO need a better way to do this for nested types
-  protected lazy val dtype: DType = GpuColumnVector.getRapidsType(dataType)
+  protected lazy val dtype: DType = GpuColumnVector.getNonNestedRapidsType(dataType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (children.length <= 1) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -94,6 +94,7 @@ class GpuGetArrayItemMeta(
 
   override def isSupportedType(t: DataType): Boolean =
     GpuOverrides.isSupportedType(t,
+      allowNull = true,
       allowArray = true,
       allowStruct = true,
       allowNesting = true)
@@ -131,7 +132,8 @@ case class GpuGetArrayItem(child: Expression, ordinal: Expression)
     if (ordinal.isValid && ordinal.getInt >= 0) {
       lhs.getBase.extractListElement(ordinal.getInt)
     } else {
-      withResource(Scalar.fromNull(GpuColumnVector.getRapidsType(dataType))) { nullScalar =>
+      withResource(Scalar.fromNull(
+        GpuColumnVector.getNonNestedRapidsType(dataType))) { nullScalar =>
         ColumnVector.fromScalar(nullScalar, lhs.getRowCount.toInt)
       }
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -207,6 +207,10 @@ class GpuBroadcastMeta(
     rule: ConfKeysAndIncompat) extends
   SparkPlanMeta[BroadcastExchangeExec](exchange, conf, parent, rule) {
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
+
   override def tagPlanForGpu(): Unit = {
     if (!TrampolineUtil.isSupportedRelation(exchange.mode)) {
       willNotWorkOnGpu(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -48,6 +48,10 @@ class GpuBroadcastNestedLoopJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = condition.toSeq
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
+
   override def tagPlanForGpu(): Unit = {
     join.joinType match {
       case Inner =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -57,6 +57,10 @@ class GpuShuffleMeta(
     wrapped.getTagValue(gpuSupportedTag).foreach(_.foreach(willNotWorkOnGpu))
   }
 
+  override def isSupportedType(t: DataType): Boolean =
+    GpuOverrides.isSupportedType(t,
+      allowNull = true)
+
   override def convertToGpu(): GpuExec =
     ShimLoader.getSparkShims.getGpuShuffleExchangeExec(
       childParts(0).convertToGpu(),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -41,7 +41,8 @@ class CastOpSuite extends GpuExpressionTestSuite {
     DataTypes.FloatType, DataTypes.DoubleType,
     DataTypes.DateType,
     DataTypes.TimestampType,
-    DataTypes.StringType
+    DataTypes.StringType,
+    DataTypes.NullType
   )
 
   /** Produces a matrix of all possible casts. */
@@ -98,7 +99,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
 
               } catch {
                 case e: Exception =>
-                  fail(s"Cast from $from to $to failed; ansi=$ansiEnabled", e)
+                  fail(s"Cast from $from to $to failed; ansi=$ansiEnabled $e", e)
               }
             }
           } else if (!shouldSkip) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/FuzzerUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FuzzerUtils.scala
@@ -183,6 +183,7 @@ object FuzzerUtils {
           case DataTypes.StringType => r.nextString()
           case DataTypes.TimestampType => r.nextTimestamp()
           case DataTypes.DateType => r.nextDate()
+          case DataTypes.NullType => null
           case _ => throw new IllegalStateException(
             s"fuzzer does not support data type ${field.dataType}")
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
@@ -43,7 +43,7 @@ class GpuUnitTests extends SparkQueryCompareTestSuite {
       val cv = v.asInstanceOf[ColumnVector]
       // close the vector that was passed in and return a new vector
       withResource(cv) { cv =>
-        GpuColumnVector.from(cv.castTo(GpuColumnVector.getRapidsType(to)), to)
+        GpuColumnVector.from(cv.castTo(GpuColumnVector.getNonNestedRapidsType(to)), to)
       }
     }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -71,7 +71,7 @@ class DecimalUnitTest extends GpuUnitTests {
   test("test decimal as column vector") {
     val dt32 = DecimalType(DType.DECIMAL64_MAX_PRECISION, 5)
     val dt64 = DecimalType(DType.DECIMAL64_MAX_PRECISION, 9)
-    val cudfCV = ColumnVector.decimalFromDoubles(GpuColumnVector.getRapidsType(dt32),
+    val cudfCV = ColumnVector.decimalFromDoubles(GpuColumnVector.getNonNestedRapidsType(dt32),
       RoundingMode.UNNECESSARY, dec32Data.map(_.toDouble): _*)
     withResource(GpuColumnVector.from(cudfCV, dt32)) { cv: GpuColumnVector =>
       assertResult(dec32Data.length)(cv.getRowCount)
@@ -193,7 +193,8 @@ class DecimalUnitTest extends GpuUnitTests {
     withResource(
       GpuColumnVector.from(ColumnVector.fromDecimals(dec64Data.map(_.toJavaBigDecimal): _*),
         DecimalType(DType.DECIMAL64_MAX_PRECISION, 9))) { cv =>
-      val dt = new HostColumnVector.BasicType(false, GpuColumnVector.getRapidsType(cv.dataType()))
+      val dt = new HostColumnVector.BasicType(false,
+        GpuColumnVector.getNonNestedRapidsType(cv.dataType()))
       val builder = new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)
       withResource(cv.copyToHost()) { hostCV =>
         HostColumnarToGpu.columnarCopy(hostCV, builder, false, cv.getRowCount.toInt)
@@ -214,7 +215,8 @@ class DecimalUnitTest extends GpuUnitTests {
     withResource(
       GpuColumnVector.from(ColumnVector.fromDecimals(dec64WithNull: _*),
         DecimalType(DType.DECIMAL64_MAX_PRECISION, 9))) { cv =>
-      val dt = new HostColumnVector.BasicType(true, GpuColumnVector.getRapidsType(cv.dataType()))
+      val dt = new HostColumnVector.BasicType(true,
+        GpuColumnVector.getNonNestedRapidsType(cv.dataType()))
       val builder = new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)
       withResource(cv.copyToHost()) { hostCV =>
         HostColumnarToGpu.columnarCopy(hostCV, builder, true, cv.getRowCount.toInt)


### PR DESCRIPTION
This adds in null type support for almost all operators. The only operators that are missing is python UDF support and window operations.  I didn't consider these critical right now.  Window support is likely to work, but there have been issues with nulls in the past.  I am not sure what the conversion to arrow would look like so I avoided it in the first take on this.