### PR TITLE
Fix resource leaks in unit tests

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -409,7 +409,9 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     val codec = TableCompressionCodec.getCodec(CodecType.NVCOMP_LZ4)
     withResource(codec.createBatchCompressor(0, Cuda.DEFAULT_STREAM)) { compressor =>
       compressor.addTableToCompress(buildContiguousTable(start, numRows))
-      GpuCompressedColumnVector.from(compressor.finish().head, Array[DataType](LongType))
+      withResource(compressor.finish()) { compressedResults =>
+        GpuCompressedColumnVector.from(compressedResults.head, Array[DataType](LongType))
+      }
     }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -105,7 +105,9 @@ class RapidsDiskStoreSuite extends FunSuite with BeforeAndAfterEach with Arm wit
             hostStore.synchronousSpill(0)
             withResource(catalog.acquireBuffer(bufferId)) { buffer =>
               assertResult(StorageTier.DISK)(buffer.storageTier)
-              TestUtils.compareBatches(expectedBatch, buffer.getColumnarBatch(sparkTypes))
+              withResource(buffer.getColumnarBatch(sparkTypes)) { actualBatch =>
+                TestUtils.compareBatches(expectedBatch, actualBatch)
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes a number of leaks in the unit tests.

This is dependent upon the `ColumnBuilder` close fix in https://github.com/rapidsai/cudf/pull/6826 being published in cudf.