### PR TITLE
Close buffer catalog on device manager shutdown

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -127,6 +127,7 @@ object GpuDeviceManager extends Logging {
   }
 
   def shutdown(): Unit = synchronized {
+    RapidsBufferCatalog.close()
     Rmm.shutdown()
     singletonMemoryInitialized = false
   }


### PR DESCRIPTION
This fixes a leak seen during unit tests because the catalog stores are not being closed when the device manager is shut down.