### PR TITLE
Support for CalendarIntervalType and NullType

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/CacheTestSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/CacheTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/CacheTestSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/CacheTestSuite.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tests
+
+import com.nvidia.spark.rapids.FuzzerUtils._
+import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.types.{ArrayType, ByteType, CalendarIntervalType, DataType, IntegerType, LongType, MapType, NullType, StringType}
+
+class CacheTestSuite extends SparkQueryCompareTestSuite {
+  type DfGenerator = SparkSession => DataFrame
+
+  test("interval") {
+    testCache { spark: SparkSession =>
+      val schema = createSchema(CalendarIntervalType)
+      generateDataFrame(spark, schema)
+    }
+  }
+
+  test("map(interval)") {
+    testCache(getMapWithDataDF(CalendarIntervalType))
+  }
+
+  test("struct(interval)") {
+    testCache(getIntervalStructDF(CalendarIntervalType))
+    testCache(getIntervalStructDF1(CalendarIntervalType))
+  }
+
+  test("array(interval)") {
+    testCache(getArrayDF(CalendarIntervalType))
+  }
+
+  test("array(map(integer, struct(string, byte, interval)))") {
+    testCache(getDF(CalendarIntervalType))
+  }
+
+  test("array(array(map(array(long), struct(interval))))") {
+    testCache(getMultiNestedDF(CalendarIntervalType))
+  }
+
+  test("null") {
+    testCache { spark: SparkSession =>
+      val schema = createSchema(NullType)
+      generateDataFrame(spark, schema)
+    }
+  }
+
+  test("array(null)") {
+    testCache(getArrayDF(NullType))
+  }
+
+  test("map(null)") {
+    testCache(getMapWithDataDF(NullType))
+  }
+
+  test("struct(null)") {
+    testCache(getIntervalStructDF(NullType))
+    testCache(getIntervalStructDF1(NullType))
+  }
+
+  test("array(map(integer, struct(string, byte, null)))") {
+    testCache(getDF(NullType))
+  }
+
+  test("array(array(map(array(long), struct(null))))") {
+    testCache(getMultiNestedDF(NullType))
+  }
+
+/** Helper functions  */
+
+  def testCache(f: SparkSession => DataFrame): Unit = {
+    val df = withCpuSparkSession(f)
+    val regularValues = df.selectExpr("*").collect()
+    val cachedValues = df.selectExpr("*").cache().collect()
+    compare(regularValues, cachedValues)
+  }
+
+  def getArrayDF(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema = createSchema(ArrayType(dataType))
+      generateDataFrame(spark, schema)
+  }
+
+  def getMapWithDataDF(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema =
+        createSchema(StringType, ArrayType(
+          createSchema(StringType, StringType)),
+          MapType(StringType, StringType),
+          MapType(IntegerType, dataType))
+      generateDataFrame(spark, schema)
+  }
+
+  def getIntervalStructDF(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema =
+        createSchema(
+          createSchema(dataType, StringType, dataType))
+      generateDataFrame(spark, schema)
+  }
+
+  def getIntervalStructDF1(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema =
+        createSchema(createSchema(IntegerType, IntegerType), dataType)
+      generateDataFrame(spark, schema)
+  }
+
+  def getMultiNestedDF(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema =
+        createSchema(ArrayType(
+          createSchema(ArrayType(
+            createSchema(MapType(ArrayType(LongType),
+              createSchema(dataType)))))))
+      generateDataFrame(spark, schema)
+  }
+
+  def getDF(dataType: DataType): DfGenerator = {
+    spark: SparkSession =>
+      val schema =
+        createSchema(ArrayType(
+          createSchema(MapType(IntegerType,
+            createSchema(StringType, ByteType, dataType)))))
+      generateDataFrame(spark, schema)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -69,7 +69,8 @@ object SparkSessionHolder extends Logging {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     // Add Locale setting
     Locale.setDefault(Locale.US)
-    SparkSession.builder()
+
+    val builder = SparkSession.builder()
         .master("local[1]")
         .config("spark.sql.adaptive.enabled", "false")
         .config("spark.rapids.sql.enabled", "false")
@@ -79,7 +80,17 @@ object SparkSessionHolder extends Logging {
           "com.nvidia.spark.rapids.ExecutionPlanCaptureCallback")
         .config("spark.sql.warehouse.dir", sparkWarehouseDir.getAbsolutePath)
         .appName("rapids spark plugin integration tests (scala)")
-        .getOrCreate()
+
+    // comma separated config from command line
+    val commandLineVariables = System.getenv("SPARK_CONF")
+    if (commandLineVariables != null) {
+      commandLineVariables.split(",").foreach { s =>
+        val a = s.split("=")
+        builder.config(a(0), a(1))
+      }
+    }
+
+    builder.getOrCreate()
   }
 
   private def reinitSession(): Unit = {


### PR DESCRIPTION
Handle nested CalendarIntervalType and NullType

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

In addition to the changes to ParquetCachedBatchSerializer the following changes were made 
* Changed FuzzerUtils to handle nested types
* SPARK_CONF can be added on the command-line before running scala tests 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
