### PR TITLE
Rename ShuffleCoalesceExec to GpuShuffleCoalesceExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -42,8 +42,8 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * The serialization read path is notably different. The sequence of serialized bytes IS NOT
  * deserialized into a cudf `Table` but rather tracked in host memory by a `ColumnarBatch`
  * that contains a [[SerializedTableColumn]]. During query planning, each GPU columnar shuffle
- * exchange is followed by a [[ShuffleCoalesceExec]] that expects to receive only these
- * custom batches of [[SerializedTableColumn]]. [[ShuffleCoalesceExec]] coalesces the smaller
+ * exchange is followed by a [[GpuShuffleCoalesceExec]] that expects to receive only these
+ * custom batches of [[SerializedTableColumn]]. [[GpuShuffleCoalesceExec]] coalesces the smaller
  * shuffle partitions into larger tables before placing them on the GPU for further processing.
  *
  * @note The RAPIDS shuffle does not use this code.
@@ -233,7 +233,7 @@ private class GpuColumnarBatchSerializerInstance(
 
 /**
  * A special `ColumnVector` that describes a serialized table read from shuffle.
- * This appears in a `ColumnarBatch` to pass serialized tables to [[ShuffleCoalesceExec]]
+ * This appears in a `ColumnarBatch` to pass serialized tables to [[GpuShuffleCoalesceExec]]
  * which should always appear in the query plan immediately after a shuffle.
  */
 class SerializedTableColumn(
@@ -254,9 +254,10 @@ object SerializedTableColumn {
   /**
    * Build a `ColumnarBatch` consisting of a single [[SerializedTableColumn]] describing
    * the specified serialized table.
+   *
    * @param header header for the serialized table
    * @param hostBuffer host buffer containing the table data
-   * @return columnar batch to be passed to [[ShuffleCoalesceExec]]
+   * @return columnar batch to be passed to [[GpuShuffleCoalesceExec]]
    */
   def from(
       header: SerializedTableHeader,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * @note This should ALWAYS appear in the plan after a GPU shuffle when RAPIDS shuffle is
  *       not being used.
  */
-case class ShuffleCoalesceExec(child: SparkPlan, @transient rapidsConf: RapidsConf)
+case class GpuShuffleCoalesceExec(child: SparkPlan, @transient rapidsConf: RapidsConf)
     extends UnaryExecNode with GpuExec {
 
   import GpuMetricNames._
@@ -63,7 +63,7 @@ case class ShuffleCoalesceExec(child: SparkPlan, @transient rapidsConf: RapidsCo
     val sparkSchema = GpuColumnVector.extractTypes(schema)
 
     child.executeColumnar().mapPartitions { iter =>
-      new ShuffleCoalesceIterator(iter, targetBatchByteSize, sparkSchema, metricsMap)
+      new GpuShuffleCoalesceIterator(iter, targetBatchByteSize, sparkSchema, metricsMap)
     }
   }
 }
@@ -74,7 +74,7 @@ case class ShuffleCoalesceExec(child: SparkPlan, @transient rapidsConf: RapidsCo
  * to the target batch size and then concatenated on the host before the data
  * is transferred to the GPU.
  */
-class ShuffleCoalesceIterator(
+class GpuShuffleCoalesceIterator(
     batchIter: Iterator[ColumnarBatch],
     targetBatchByteSize: Long,
     sparkSchema: Array[DataType],

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -174,8 +174,8 @@ class AdaptiveQueryExecSuite
         _.isInstanceOf[GpuShuffledHashJoinBase]).get
       assert(shj.children.length == 2)
       assert(shj.children.forall {
-        case ShuffleCoalesceExec(_, _) => true
-        case GpuCoalesceBatches(ShuffleCoalesceExec(_, _), _) => true
+        case GpuShuffleCoalesceExec(_, _) => true
+        case GpuCoalesceBatches(GpuShuffleCoalesceExec(_, _), _) => true
         case _ => false
       })
 


### PR DESCRIPTION
@tgravescs pointed out that `ShuffleCoalesceExec` can appear to be something that isn't running on the GPU.  While this is technically true since it is coalescing on the host before putting the results on the GPU, it can be confusing to users who think there is something than could be on the GPU but currently isn't.  Since `ShuffleCoalesceExec` is all about coalescing shuffles intended for the GPU, this renames ShuffleCoalesceExec to GpuShuffleCoalesceExec to reduce that confusion.