### PR TITLE
Replace only window expressions on databricks.

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -26,7 +26,6 @@ except Exception as e:
     pytestmark = pytest.mark.skip(reason=str(e))
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
-from conftest import is_databricks_runtime
 from data_gen import *
 from marks import incompat, approximate_float, allow_non_gpu, ignore_order
 from pyspark.sql import Window
@@ -165,7 +164,6 @@ def test_window_aggregate_udf(data_gen, window):
         conf=arrow_udf_conf)
 
 
-@pytest.mark.skipif(is_databricks_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/1184')
 @ignore_order
 @pytest.mark.parametrize('data_gen', [byte_gen, short_gen, int_gen], ids=idfn)
 @pytest.mark.parametrize('window', udf_windows, ids=window_ids)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
@@ -55,11 +55,12 @@ case class GpuWindowInPandasExec(
   }
 
   private val outReferences = {
-    val references = windowExpression.zipWithIndex.map { case (e, i) =>
+    val allExpressions = windowFramesWithExpressions.map(_._2).flatten
+    val references = allExpressions.zipWithIndex.map { case (e, i) =>
       // Results of window expressions will be on the right side of child's output
       GpuBoundReference(child.output.size + i, e.dataType, e.nullable)
     }
-    val unboundToRefMap = windowExpression.zip(references).toMap
+    val unboundToRefMap = allExpressions.zip(references).toMap
     // Bound the project list for GPU
     GpuBindReferences.bindGpuReferences(
       projectList.map(_.transform(unboundToRefMap)), child.output)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -242,7 +242,7 @@ trait GpuWindowInPandasExecBase extends UnaryExecNode with GpuExec {
 
   // Similar with WindowExecBase.windowFrameExpressionFactoryPairs
   // but the functions are not needed here.
-  private lazy val windowFramesWithExpressions = {
+  protected lazy val windowFramesWithExpressions = {
     type FrameKey = (String, GpuSpecifiedWindowFrame)
     type ExpressionBuffer = mutable.Buffer[Expression]
     val framedExpressions = mutable.Map.empty[FrameKey, ExpressionBuffer]


### PR DESCRIPTION
On Databricks, when pulling only one element from an array type column, Databricks will put the
`GetArrayItem` into the `GpuWindowInPandas`, instead of generating a new `ProjectExec`.

This PR is to fix the issue https://github.com/NVIDIA/spark-rapids/issues/1184 by replacing only window expressions instead of the whole expression tree to avoid removing the original parent expression unexpectedly,  e.g. `GetArrayItem` or `Cast ` or others.  



Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
