### PR TITLE
Fix a bug with the support for java.lang.StringBuilder.append.

### DIFF
--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CatalystExpressionBuilder.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CatalystExpressionBuilder.scala
@@ -417,6 +417,7 @@ object CatalystExpressionBuilder extends Logging {
             simplifyExpr(Cast(t, BooleanType, tz)),
             simplifyExpr(Cast(f, BooleanType, tz))))
         case If(c, Repr.ArrayBuffer(t), Repr.ArrayBuffer(f)) => Repr.ArrayBuffer(If(c, t, f))
+        case If(c, Repr.StringBuilder(t), Repr.StringBuilder(f)) => Repr.StringBuilder(If(c, t, f))
         case _ => expr
       }
       logDebug(s"[CatalystExpressionBuilder] simplify: ${expr} ==> ${res}")

--- a/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
+++ b/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
@@ -1432,6 +1432,29 @@ class OpcodeSuite extends FunSuite {
   }
 
   // Tests for string ops
+  test("java lang string builder test - append") {
+    // We do not support java.lang.StringBuilder officially in the udf compiler,
+    // but string + string in Scala generates some code with
+    // java.lang.StringBuilder. For that reason, we have some tests with
+    // java.lang.StringBuilder.
+    val myudf: (String, String, Boolean) => String = (a,b,c) => {
+      val sb = new java.lang.StringBuilder()
+      if (c) {
+        sb.append(a)
+        sb.toString + " true"
+      } else {
+        sb.append(b)
+        sb.toString + " false"
+      }
+    }
+    val u = makeUdf(myudf)
+    val dataset = List(("Hello", "World", false),
+                       ("Oh", "Hello", true)).toDF("x","y","z").repartition(1)
+    val result = dataset.withColumn("new", u(col("x"),col("y"),col("z")))
+    val ref = List(("Hello", "World", false, "World false"),
+                   ("Oh", "Hello", true, "Oh true")).toDF
+    checkEquiv(result, ref)
+  }
 
   test("string test - + concat") {
     val myudf: (String, String) => String = (a,b) => {

--- a/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
+++ b/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
@@ -1441,18 +1441,22 @@ class OpcodeSuite extends FunSuite {
       val sb = new java.lang.StringBuilder()
       if (c) {
         sb.append(a)
-        sb.toString + " true"
+        sb.append(" ")
+        sb.append(b)
+        sb.toString + "@@@" + " true"
       } else {
         sb.append(b)
-        sb.toString + " false"
+        sb.append(" ")
+        sb.append(a)
+        sb.toString + "!!!" + " false"
       }
     }
     val u = makeUdf(myudf)
     val dataset = List(("Hello", "World", false),
                        ("Oh", "Hello", true)).toDF("x","y","z").repartition(1)
     val result = dataset.withColumn("new", u(col("x"),col("y"),col("z")))
-    val ref = List(("Hello", "World", false, "World false"),
-                   ("Oh", "Hello", true, "Oh true")).toDF
+    val ref = List(("Hello", "World", false, "World Hello!!! false"),
+                   ("Oh", "Hello", true, "Oh Hello@@@ true")).toDF
     checkEquiv(result, ref)
   }
 


### PR DESCRIPTION
As java.lang.StringBuilder.append is a mutable operation, when this
method is called with a string builder object, all the references of
this object needs to be updated in locals and stack.