### PR TITLE
[BUG] Fix GHSL2020-239 [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Set blackduck project version
         id: blackduck-project-version
-        run: echo "${{ fromJson(steps.pull_request_data.outputs.data).head.ref }}-${{ github.run_id }}"
+        env:
+          REF: ${{ fromJson(steps.pull_request_data.outputs.data).head.ref }}
+        run: echo "$REF-${{ github.run_id }}"
 
       - name: Update status
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix for GHSL2020-239 which found that authorized user could add bash injection into our workflow w/ specific branch name.
The vulnerable step was required by blossom team, so we just keep it.

Tested on my forked repo.