### PR TITLE
Skip casting StringType to TimestampType for Spark 310

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -55,6 +55,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
     case (BooleanType, TimestampType | DateType) => true
     case (TimestampType | DateType, _: NumericType) => true
     case (TimestampType | DateType, BooleanType) => true
+    case (StringType, TimestampType) => true
     case _ => false
   }
 
@@ -77,7 +78,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
           // In 3.1.0 Cast.canCast was split with a separate ANSI version
           // Until we are on 3.1.0 or more we cannot call this easily so for now
           // We will check and skip a very specific one.
-          val shouldSkip = is310OrAfter && ansiEnabled && should310SkipAnsiCast(to, from)
+          val shouldSkip = is310OrAfter && ansiEnabled && should310SkipAnsiCast(from, to)
           // check if Spark supports this cast
           if (!shouldSkip && Cast.canCast(from, to)) {
             // check if plugin supports this cast


### PR DESCRIPTION
This PR fixes the build issue because of a change in Spark 310 with how they are handling ANSI cast

There also seemed to be a typo in a previous check-in, the tests are passing regardless of the order of the arguments, but I have fixed the order as I thought it should be. PTAL @revans2 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
