### PR TITLE
Aggregate reductions in Complete mode should use updateExpressions

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -371,7 +371,6 @@ non_nan_all_basic_gens = [byte_gen, short_gen, int_gen, long_gen,
         string_gen, boolean_gen, date_gen, timestamp_gen]
 
 
-@pytest.mark.xfail(is_databricks_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/898')
 @pytest.mark.parametrize('data_gen', non_nan_all_basic_gens, ids=idfn)
 def test_generic_reductions(data_gen):
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -881,7 +881,7 @@ case class GpuHashAggregateExec(
         val cvs = ArrayBuffer[GpuColumnVector]()
         aggModeCudfAggregates.foreach { case (mode, aggs) =>
           aggs.foreach {agg =>
-            val aggFn = if (mode == Partial && !merge) {
+            val aggFn = if ((mode == Partial || mode == Complete) && !merge) {
               agg.updateReductionAggregate
             } else {
               agg.mergeReductionAggregate


### PR DESCRIPTION
Fixes #898 
Signed-off-by: Kuhu Shukla <kuhus@nvidia.com>

This fixes the reduction aggregates to work in complete mode. We already had some of this covered for when we have grouping keys. This change merely extends that change to reductions.