### PR TITLE
Remove obsolete HiveStringType usage

### DIFF
--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
@@ -265,7 +265,6 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
     dataType match {
       case TimestampType | StringType | BooleanType | DateType | BinaryType |
            DoubleType | FloatType | ByteType | IntegerType | LongType | ShortType => true
-      case _: HiveStringType => true
       case _: DecimalType => true
       case _ => false
     }


### PR DESCRIPTION
Apache Spark 3.1.0 recently removed `HiveStringType` in https://issues.apache.org/jira/browse/SPARK-33480 which breaks the plugin build since it was referring to this type in ParquetCachedBatchSerializer.

Note this only removes the reference to `HiveStringType` but does not add support for `CharType` or `VarcharType`.  This PR is only focused on fixing the build against Spark 3.1.0-SNAPSHOT, and support for those can be tracked in a followup issue.