### PR TITLE
Move SortOrder creation to shims

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -415,4 +415,17 @@ class Spark300Shims extends SparkShims {
       resolver: Resolver): Unit = {
     GpuSchemaUtils.checkColumnNameDuplication(schema, colType, resolver)
   }
+
+  override def sortOrderChildren(s: SortOrder): Seq[Expression] = {
+    (s.sameOrderExpressions + s.child).toSeq
+  }
+
+  override def sortOrder(
+      child: Expression,
+      direction: SortDirection,
+      nullOrdering: NullOrdering): SortOrder = SortOrder(child, direction, nullOrdering, Set.empty)
+
+  override def copySortOrderWithNewChild(s: SortOrder, child: Expression): SortOrder = {
+    s.copy(child = child)
+  }
 }

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/Spark310Shims.scala
@@ -298,4 +298,15 @@ class Spark310Shims extends Spark301Shims {
     val shuffleOrigin = cpuShuffle.map(_.shuffleOrigin).getOrElse(ENSURE_REQUIREMENTS)
     GpuShuffleExchangeExec(outputPartitioning, child, shuffleOrigin)
   }
+
+  override def sortOrderChildren(s: SortOrder): Seq[Expression] = s.children
+
+  override def sortOrder(
+      child: Expression,
+      direction: SortDirection,
+      nullOrdering: NullOrdering): SortOrder = SortOrder(child, direction, nullOrdering, Seq.empty)
+
+  override def copySortOrderWithNewChild(s: SortOrder, child: Expression) = {
+    s.copy(child = child)
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -424,8 +424,8 @@ object GpuOverrides {
   }
 
   private def orderingSatisfies(found: SortOrder, required: SortOrder): Boolean = {
-    (found.sameOrderExpressions + found.child).exists(
-      gpuOrderingSemanticEquals(_, required.child)) &&
+    val foundChildren = ShimLoader.getSparkShims.sortOrderChildren(found)
+    foundChildren.exists(gpuOrderingSemanticEquals(_, required.child)) &&
         found.direction == required.direction &&
         found.nullOrdering == required.nullOrdering
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -372,12 +372,10 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       val wrapped = GpuOverrides.wrapExpr(expr, conf, None)
       wrapped.tagForGpu()
       assert(wrapped.canThisBeReplaced)
-      SortOrder(
+      ShimLoader.getSparkShims.sortOrder(
         wrapped.convertToGpu(),
         Ascending,
-        Ascending.defaultNullOrdering,
-        Set.empty
-      )
+        Ascending.defaultNullOrdering)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -114,8 +114,10 @@ case class GpuWindowExec(
 
   override def childrenCoalesceGoal: Seq[CoalesceGoal] = Seq(RequireSingleBatch)
 
-  override def requiredChildOrdering: Seq[Seq[SortOrder]] =
-    Seq(partitionSpec.map(SortOrder(_, Ascending)) ++ orderSpec)
+  override def requiredChildOrdering: Seq[Seq[SortOrder]] = {
+    val shims = ShimLoader.getSparkShims
+    Seq(partitionSpec.map(shims.sortOrder(_, Ascending)) ++ orderSpec)
+  }
 
   override def outputOrdering: Seq[SortOrder] = child.outputOrdering
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, NullOrdering, SortDirection, SortOrder}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -146,5 +146,17 @@ trait SparkShims {
       schema: StructType,
       colType: String,
       resolver: Resolver): Unit
-}
 
+  def sortOrderChildren(s: SortOrder): Seq[Expression]
+
+  def sortOrder(child: Expression, direction: SortDirection): SortOrder = {
+    sortOrder(child, direction, direction.defaultNullOrdering)
+  }
+
+  def sortOrder(
+      child: Expression,
+      direction: SortDirection,
+      nullOrdering: NullOrdering): SortOrder
+
+  def copySortOrderWithNewChild(s: SortOrder, child: Expression): SortOrder
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -33,7 +33,7 @@ import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, Expression}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{WriteJobStatsTracker, WriteTaskResult, WriteTaskStats}
@@ -196,9 +196,10 @@ object GpuFileFormatWriter extends Logging {
         // SPARK-21165: the `requiredOrdering` is based on the attributes from analyzed plan, and
         // the physical plan may have different attribute ids due to optimizer removing some
         // aliases. Here we bind the expression ahead to avoid potential attribute ids mismatch.
+        val sparkShims = ShimLoader.getSparkShims
         val orderingExpr = GpuBindReferences.bindReferences(
           requiredOrdering
-            .map(attr => SortOrder(attr, Ascending)), outputSpec.outputColumns)
+            .map(attr => sparkShims.sortOrder(attr, Ascending)), outputSpec.outputColumns)
         GpuSortExec(
           orderingExpr,
           global = false,


### PR DESCRIPTION
Apache Spark 3.1 changed `SortOrder` in https://issues.apache.org/jira/browse/SPARK-33503 so that the `sameOrderExpressions` field is no longer a `Set` but is now a `Seq`.  This requires moving `SortOrder` creation to the shims, otherwise when running against Spark 3.1 the plugin will try to call a `SortOrder` constructor that does not exist.