### PR TITLE
Trigger reading and handling control data.

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -634,7 +634,9 @@ case class GpuArrowEvalPythonExec(
         // store the number of rows separate from the batch. That way we can get the target batch
         // size out without needing to grab the GpuSemaphore which we cannot do if we might block
         // on a read operation.
-        override def hasNext: Boolean = queue.hasNext
+        // Besides, when the queue is empty, need to call the `hasNext` of the out iterator to
+        // trigger reading and handling the control data followed with the stream data.
+        override def hasNext: Boolean = queue.hasNext || outputBatchIterator.hasNext
 
         private [this] def combine(
             origBatch: ColumnarBatch,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -547,7 +547,9 @@ trait GpuWindowInPandasExecBase extends UnaryExecNode with GpuExec {
         // store the number of rows separate from the batch. That way we can get the target batch
         // size out without needing to grab the GpuSemaphore which we cannot do if we might block
         // on a read operation.
-        override def hasNext: Boolean = queue.hasNext
+        // Besides, when the queue is empty, need to call the `hasNext` of the out iterator to
+        // trigger reading and handling the control data followed with the stream data.
+        override def hasNext: Boolean = queue.hasNext || outputBatchIterator.hasNext
 
         private [this] def combine(
             origBatch: ColumnarBatch,


### PR DESCRIPTION
Trigger reading and handling control data by calling the API `hasNext` of the output iterator from GPU python runner after the queue becomes empty.

Because per the protocol, there is some control data after the stream data from python processes. When the queue becomes empty, we only read all the stream data, but ignore the control data. Seems we did not shut down the stream correctly even it works.


Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
