### PR TITLE
Sonatype staging repo for cudf dependency

### DIFF
--- a/jenkins/settings.xml
+++ b/jenkins/settings.xml
@@ -50,17 +50,6 @@
           <name>sw-spark-maven</name>
           <url>${env.URM_URL}</url>
         </repository>
-        <!-- Add Sonatype staging repo for buiding rapids against pre-release jars  -->
-        <repository>
-           <id>sonatype-staging</id>
-           <url>https://oss.sonatype.org/content/repositories/staging</url>
-           <releases>
-             <enabled>true</enabled>
-           </releases>
-           <snapshots>
-             <enabled>false</enabled>
-           </snapshots>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
@@ -79,8 +68,14 @@
         </pluginRepository>
       </pluginRepositories>
       <id>artifactory</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
     </profile>
     <profile>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <id>mirror-apache-to-urm</id>
       <repositories>
         <repository>
@@ -92,14 +87,31 @@
     </profile>
     <profile>
       <id>deploy-to-urm</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
           <altDeploymentRepository>snapshots::default::${env.URM_URL}-local</altDeploymentRepository>
       </properties>
      </profile>
+     <!-- Add Sonatype staging repo for buiding rapids against pre-release jars  -->
+     <profile>
+      <id>sonatype-staging</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+           <id>sonatype.staging</id>
+           <url>https://oss.sonatype.org/content/repositories/staging</url>
+           <releases>
+             <enabled>true</enabled>
+           </releases>
+           <snapshots>
+             <enabled>false</enabled>
+           </snapshots>
+        </repository>
+      </repositories>
+     </profile>
   </profiles>
-  <activeProfiles>
-    <activeProfile>artifactory</activeProfile>
-    <activeProfile>mirror-apache-to-urm</activeProfile>
-    <activeProfile>deploy-to-urm</activeProfile>
-  </activeProfiles>
 </settings>

--- a/jenkins/settings.xml
+++ b/jenkins/settings.xml
@@ -50,6 +50,17 @@
           <name>sw-spark-maven</name>
           <url>${env.URM_URL}</url>
         </repository>
+        <!-- Add Sonatype staging repo for buiding rapids against pre-release jars  -->
+        <repository>
+           <id>sonatype-staging</id>
+           <url>https://oss.sonatype.org/content/repositories/staging</url>
+           <releases>
+             <enabled>true</enabled>
+           </releases>
+           <snapshots>
+             <enabled>false</enabled>
+           </snapshots>
+        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
Add dependency of cudf pre-release jars on Sonatype staging repo.
Sonatype staging repo is needed in the case:
    cudf and spark-rapids jars will to be released at the same time
    cudf jars are on the Sonatyp staging repo ready for release
    need to build spark-rapids with dependency of the staging cudf jars