### PR TITLE
Update UCX license info in NOTIFY-binary for 1.9 and RAPIDS plugin copyright dates

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 RAPIDS plugin for Apache Spark
-Copyright (c) 2019, NVIDIA CORPORATION
+Copyright (c) 2019-2020, NVIDIA CORPORATION
 
 // ------------------------------------------------------------------
 // NOTICE file corresponding to the section 4d of The Apache License,

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -1,5 +1,5 @@
 RAPIDS plugin for Apache Spark
-Copyright (c) 2019, NVIDIA CORPORATION
+Copyright (c) 2019-2020, NVIDIA CORPORATION
 
 // ------------------------------------------------------------------
 // NOTICE file corresponding to the section 4d of The Apache License,

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -27,15 +27,17 @@ This product includes software developed by Hewlett-Packard:
 UCF Consortium - Unified Communication X (UCX)
 
 Copyright (c) 2014-2015      UT-Battelle, LLC. All rights reserved.
-Copyright (C) 2014-2015      Mellanox Technologies Ltd. All rights reserved.
+Copyright (C) 2014-2020      Mellanox Technologies Ltd. All rights reserved.
 Copyright (C) 2014-2015      The University of Houston System. All rights reserved.
 Copyright (C) 2015           The University of Tennessee and The University 
                              of Tennessee Research Foundation. All rights reserved.
-Copyright (C) 2016           ARM Ltd. All rights reserved.
+Copyright (C) 2016-2020      ARM Ltd. All rights reserved.
 Copyright (c) 2016           Los Alamos National Security, LLC. All rights reserved.
-Copyright (C) 2016-2017      Advanced Micro Devices, Inc.  All rights reserved.
+Copyright (C) 2016-2020      Advanced Micro Devices, Inc.  All rights reserved.
 Copyright (C) 2019           UChicago Argonne, LLC.  All rights reserved.
-Copyright (c) 2018-2019      NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2018-2020      NVIDIA CORPORATION. All rights reserved.
+Copyright (C) 2020           Huawei Technologies Co., Ltd. All rights reserved.
+Copyright (C) 2016-2020      Stony Brook University. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 


### PR DESCRIPTION
Updates UCX license text for 1.9 per: https://raw.githubusercontent.com/openucx/ucx/cd9efd3d80ec3e5df4eadd005b9cc38f6324919e/LICENSE.

