### PR TITLE
Fix race condition in batch creation

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -60,7 +60,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
       writeObject(oout)
       val barr = out.toByteArray
       val oin = new ObjectInputStream(new ByteArrayInputStream(barr))
-      batchInternal = readObject(oin)
+      readObject(oin)
     }
     batchInternal
   }
@@ -81,7 +81,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
     }
   }
 
-  private def readObject(in: ObjectInputStream): ColumnarBatch = {
+  private def readObject(in: ObjectInputStream): Unit = {
     val range = new NvtxRange("DeserializeBatch", NvtxColor.PURPLE)
     try {
       val tableInfo: JCudfSerialization.TableAndRowCountPair =
@@ -90,12 +90,12 @@ class SerializeConcatHostBuffersDeserializeBatch(
         val table = tableInfo.getTable
         if (table == null) {
           val numRows = tableInfo.getNumRows
-          new ColumnarBatch(new Array[ColumnVector](0), numRows.toInt)
+          this.batchInternal = new ColumnarBatch(new Array[ColumnVector](0), numRows.toInt)
         } else {
           val colDataTypes = in.readObject().asInstanceOf[Array[DataType]]
           // This is read as part of the broadcast join so we expect it to leak.
           (0 until table.getNumberOfColumns).foreach(table.getColumn(_).noWarnLeakExpected())
-          GpuColumnVector.from(table, colDataTypes)
+          this.batchInternal = GpuColumnVector.from(table, colDataTypes)
         }
       } finally {
         tableInfo.close()


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

In `GpuBroadcastNestedLoopJoinExecBase#doExecuteColumnar` the following code computes the number of rows the join will output by multiplying each batch row count by the `buildCount` which is the row-count of the broadcast side of the relation.

```scala
val counts = streamed.executeColumnar().map(getRowCountAndClose)
GpuNoColumnCrossJoin.divideIntoBatches(
  counts.map(s => s * buildCount),
  targetSizeBytes,
  numOutputRows,
  numOutputBatches)
```

`buildCount` is a lazy val, defined as follows:

```scala
lazy val buildCount: Int = computeBuildRowCount(broadcastRelation, buildTime, buildDataSize)
```

The method called when instantiating `buildCount` contains the following code:

```scala
broadcastRelation.value.batch.numRows()
```

This reference to `batch` calls code that will create the batch if it does not already exist. 

```scala
def batch: ColumnarBatch = {
  if (batchInternal == null) {
    .... 
    batchInternal = readObject(...)
  }
  batchInternal
}

```

Through adding some debug code I was able to prove that multiple threads are following the code path from `counts.map(s => s * buildCount)` and trying to instantiate an instance of the `lazy val` at the same time (note that they all have a distinct `lazy val` and are not referencing a shared instance because this `lazy val` is local within the code block).

The result is that multiple batches get created and references are lost to all but one of them and this will cause leaks.

This PR fixes the issue by synchronizing the batch creation logic.

This closes https://github.com/NVIDIA/spark-rapids/issues/1179