### PR TITLE
Chunking input before writing a ParquetCachedBatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
             <dependency>
               <groupId>org.mockito</groupId>
               <artifactId>mockito-core</artifactId>
-              <version>2.28.2</version>
+              <version>3.6.0</version>
               <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <spark301.version>3.0.1</spark301.version>
         <spark302.version>3.0.2-SNAPSHOT</spark302.version>
         <spark310.version>3.1.0-SNAPSHOT</spark310.version>
+        <mockito.version>3.6.0</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -319,7 +320,7 @@
             <dependency>
               <groupId>org.mockito</groupId>
               <artifactId>mockito-core</artifactId>
-              <version>3.6.0</version>
+              <version>${mockito.version}</version>
               <scope>test</scope>
             </dependency>
         </dependencies>

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
@@ -1249,8 +1249,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
         new RowToColumnarIterator(iter, structSchema, RequireSingleBatch, converters)
       })
       columnarBatchRdd.flatMap(cb => {
-        withResource(cb) { cb => compressColumnarBatchWithParquet(cb)
-        }
+        withResource(cb)(cb => compressColumnarBatchWithParquet(cb))
       })
     } else {
       val broadcastedHadoopConf = getBroadcastedHadoopConf(conf, parquetSchema)

--- a/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
+++ b/shims/spark310/src/main/scala/com/nvidia/spark/rapids/shims/spark310/ParquetCachedBatchSerializer.scala
@@ -351,7 +351,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
 
   private[rapids] def compressColumnarBatchWithParquet(
      gpuCB: ColumnarBatch): List[ParquetCachedBatch] = {
-    // NOTE: this doesn't take nulls into account so we could be over-estimating the acutal size
+    // NOTE: this doesn't take nulls into account so we could be over-estimating the actual size
     // but that's still better than under-estimating
     val estimatedRowSize = scala.Range(0, gpuCB.numCols()).map { index =>
       gpuCB.column(index).dataType().defaultSize
@@ -1331,4 +1331,3 @@ private object ParquetOutputFileFormat {
     memoryManager
   }
 }
-

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -104,7 +104,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.6.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -134,13 +134,13 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     }
   }
 
-  test("convert large columnar batch to cachedbatch on CPU single col table") {
+  test("convert large columnar batch to cachedbatch on single col table") {
     val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors()
     testCompressColBatch(Array(spyCol0), Array(spyGpuCol0))
     verify(spyCol0).split(2086912)
   }
 
-  test("convert large columnar batch to cachedbatch on CPU multi-col table") {
+  test("convert large columnar batch to cachedbatch on multi-col table") {
     val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors()
     val (spyCol1, spyGpuCol1) = getCudfAndGpuVectors()
     val (spyCol2, spyGpuCol2) = getCudfAndGpuVectors()
@@ -265,7 +265,7 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
 
 
   private var compressWithParquetMethod: Option[Method] = None
-  private var ref: Option[Any] = None
+  private var parquetSerializerInstance: Option[Any] = None
 
   private def testCompressColBatch(
      cudfCols: Array[ColumnVector],
@@ -294,14 +294,14 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
           val method = compressWithParquetMethod.getOrElse {
             val classOfSerializer = Class.forName(
               "com.nvidia.spark.rapids.shims.spark310.ParquetCachedBatchSerializer")
-            ref = Some(classOfSerializer.newInstance())
+            parquetSerializerInstance = Some(classOfSerializer.newInstance())
             val compressWithParquet =
               classOfSerializer.getMethod("compressColumnarBatchWithParquet",
                 classOf[ColumnarBatch])
             compressWithParquetMethod = Some(compressWithParquet)
             compressWithParquet
           }
-          method.invoke(ref.get, cb)
+          method.invoke(parquetSerializerInstance.get, cb)
         } finally {
           theTableMock.close()
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -21,16 +21,18 @@ import java.lang.reflect.Method
 import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
+
 import ai.rapids.cudf.{ColumnVector, DType, Table, TableWriter}
 import com.nvidia.spark.rapids.shims.spark310.{ParquetCachedBatchSerializer, ParquetOutputFileFormat}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.spark.{SparkConf, SparkException}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
+
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.internal.SQLConf
@@ -265,8 +267,9 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   private var compressWithParquetMethod: Option[Method] = None
   private var ref: Option[Any] = None
 
-  private def testCompressColBatch(cudfCols: Array[ColumnVector],
-                                   gpuCols: Array[org.apache.spark.sql.vectorized.ColumnVector]): Unit = {
+  private def testCompressColBatch(
+     cudfCols: Array[ColumnVector],
+     gpuCols: Array[org.apache.spark.sql.vectorized.ColumnVector]): Unit = {
     if (!withCpuSparkSession(s => s.version < "3.1.0")) {
 
       // mock static method for Table

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -20,22 +20,14 @@ import java.io.File
 import java.lang.reflect.Method
 import java.nio.charset.StandardCharsets
 
-import scala.collection.mutable
-
 import ai.rapids.cudf.{ColumnVector, DType, Table, TableWriter}
-import com.nvidia.spark.rapids.shims.spark310.{ParquetCachedBatchSerializer, ParquetOutputFileFormat}
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, DataType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 


### PR DESCRIPTION
This PR deals with breaking up the incoming batches before writing them to a ParquetCachedBatch to make sure the CachedBuffer never exceeds the Int max-value. 

I am still working on writing the tests to test the CPU writing. This PR so far only has tests for the `compressColumnarBatchWithParquet`

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
