### PR TITLE
Temporarily disable more CAST tests for Spark 3.1.0

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -478,7 +478,7 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   }
 
   testSparkResultsAreEqual("Write floats to int (values within range)", intsAsFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_1_0) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -531,7 +531,6 @@ object CastOpSuite {
 
   def intsAsFloats(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
-
     intValues.map(_.toFloat).toDF("c0")
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -56,6 +56,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
     case (TimestampType | DateType, _: NumericType) => true
     case (TimestampType | DateType, BooleanType) => true
     case (StringType, TimestampType) => true
+    case (FloatType, IntegerType) => true
     case _ => false
   }
 
@@ -530,6 +531,7 @@ object CastOpSuite {
 
   def intsAsFloats(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
+
     intValues.map(_.toFloat).toDF("c0")
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Temporarily disable more CAST tests for Spark 3.1.0 due to recent changes causing test failures.

Follow-up issue is https://github.com/NVIDIA/spark-rapids/issues/1271