### PR TITLE
Improve benchmark error handling

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -676,12 +676,21 @@ class BenchmarkListener(
     exceptions: ListBuffer[String]) extends QueryExecutionListener {
 
   override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
-    queryPlans += toJson(qe.executedPlan)
+    addQueryPlan(qe)
   }
 
   override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
-    queryPlans += toJson(qe.executedPlan)
+    addQueryPlan(qe)
     exceptions += BenchUtils.toString(exception)
+  }
+
+  private def addQueryPlan(qe: QueryExecution) = {
+    try {
+      queryPlans += toJson(qe.executedPlan)
+    } catch {
+      case e: Exception =>
+        println(s"Failed to convert plan to JSON: $e")
+    }
   }
 
   private def toJson(plan: SparkPlan): SparkPlanNode = {


### PR DESCRIPTION
Improve benchmark error handling when converting executed plan to JSON.

This closes https://github.com/NVIDIA/spark-rapids/issues/1270