### PR TITLE
Fix copying GpuFileSourceScanExec node

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -71,6 +71,8 @@ case class GpuFileSourceScanExec(
   private val isParquetFileFormat: Boolean = relation.fileFormat.isInstanceOf[ParquetFileFormat]
   private val isPerFileReadEnabled = rapidsConf.isParquetPerFileReadEnabled || !isParquetFileFormat
 
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
   override val nodeName: String = {
     s"GpuScan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
   }


### PR DESCRIPTION
#1310 added a separate parameter list to `GpuFileSourceScanExec` but did not override the `otherCopyArgs` method which can lead to a crash like this:
```
Caused by: org.apache.spark.sql.catalyst.errors.package$TreeNodeException:
Failed to copy node.
Is otherCopyArgs specified correctly for GpuScan parquet .
Exception message: wrong number of arguments
ctor: public org.apache.spark.sql.rapids.GpuFileSourceScanExec(org.apache.spark.sql.execution.datasources.HadoopFsRelation,scala.collection.Seq,org.apache.spark.sql.types.StructType,scala.collection.Seq,scala.Option,scala.Option,scala.collection.Seq,scala.Option,boolean,com.nvidia.spark.rapids.RapidsConf)?
types: class org.apache.spark.sql.execution.datasources.HadoopFsRelation, class scala.collection.immutable.$colon$colon, class org.apache.spark.sql.types.StructType, class scala.collection.immutable.Vector, class scala.None$, class scala.None$, class scala.collection.immutable.$colon$colon, class scala.None$, class java.lang.Boolean
```

This adds the necessary override to allow `GpuFileSourceScanExec` to be copied.