### PR TITLE
Fix and edit docs for standalone mode

### DIFF
--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -134,7 +134,7 @@ Now for each worker node:
   - `cp $SPARK_HOME/conf/spark-env.sh.template $SPARK_HOME/conf/spark-env.sh`
   - Edit `$SPARK_HOME/conf/spark-env.sh` and add any worker options. The example below sets the
     number of GPUs per worker to 4 and points to the discovery script.  Change this for your setup.
-    - `SPARK_WORKER_OPTS="-Dspark.worker.resource.gpu.amount=1 -Dspark.worker.resource.gpu.discoveryScript=/opt/sparkRapidsPlugin/getGpusResources.sh"`
+    - `SPARK_WORKER_OPTS="-Dspark.worker.resource.gpu.amount=4 -Dspark.worker.resource.gpu.discoveryScript=/opt/sparkRapidsPlugin/getGpusResources.sh"`
 - Start the worker(s)
   - For multiple workers:
     - You can add each hostname to the file `$SPARK_HOME/conf/slaves` and use the scripts provided

--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -117,7 +117,7 @@ The first step is to [Install Spark](#install-spark), the
 After that choose one of the nodes to be your master node and start the master.  Note that the
 master process does **not** need a GPU to function properly.
 
-One the master node:
+On the master node:
   - Make sure `SPARK_HOME` is exported
   - run `$SPARK_HOME/sbin/start-master.sh`
     - This script will print a message saying starting Master and have a path to a log file.
@@ -134,7 +134,7 @@ Now for each worker node:
   - `cp $SPARK_HOME/conf/spark-env.sh.template $SPARK_HOME/conf/spark-env.sh`
   - Edit `$SPARK_HOME/conf/spark-env.sh` and add any worker options. The example below sets the
     number of GPUs per worker to 4 and points to the discovery script.  Change this for your setup.
-    - `SPARK_WORKER_OPTS="-Dspark.worker.resource.gpu.amount=4 -Dspark.worker.resource.gpu.discoveryScript=/opt/sparkRapidsPlugin/getGpusResources.sh"`
+    - `SPARK_WORKER_OPTS="-Dspark.worker.resource.gpu.amount=1 -Dspark.worker.resource.gpu.discoveryScript=/opt/sparkRapidsPlugin/getGpusResources.sh"`
 - Start the worker(s)
   - For multiple workers:
     - You can add each hostname to the file `$SPARK_HOME/conf/slaves` and use the scripts provided
@@ -167,6 +167,7 @@ $SPARK_HOME/bin/spark-shell \
        --conf spark.executor.memory=4G \
        --conf spark.executor.cores=4 \
        --conf spark.task.cpus=1 \
+       --conf spark.executor.resource.gpu.amount=1 \
        --conf spark.task.resource.gpu.amount=0.25 \
        --conf spark.rapids.memory.pinnedPool.size=2G \
        --conf spark.locality.wait=0s \


### PR DESCRIPTION
Signed-off-by: Sameer Raheja <sraheja@nvidia.com>

Fixed getting started on prem document for standalone mode to include `spark.executor.resource.gpu.amount` for the spark-shell example.  Modified number of GPUs for the worker in the example to 1 instead of 4.  
