### PR TITLE
Do not run UDFs when the partition is empty.

### DIFF
--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -45,7 +45,7 @@ _conf = {
 
 small_data = [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)]
 
-large_data = list(map(lambda i: (i, i/1.0), range(1, 5000))) * 2
+large_data = list(map(lambda i: (i, i/1.0), range(1, 512))) * 2
 
 
 def _create_df(spark, data=large_data):

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -526,54 +526,59 @@ trait GpuWindowInPandasExecBase extends UnaryExecNode with GpuExec {
         PythonWorkerSemaphore.acquireIfNecessary(TaskContext.get())
       }
 
-      val pyRunner = new GpuArrowPythonRunner(
-        pyFuncs,
-        PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF,
-        argOffsets,
-        pythonInputSchema,
-        sessionLocalTimeZone,
-        pythonRunnerConf,
-        /* The whole group data should be written in a single call, so here is unlimited */
-        Int.MaxValue,
-        () => queue.finish(),
-        pythonOutputSchema)
+      if (pyInputIterator.hasNext) {
+        val pyRunner = new GpuArrowPythonRunner(
+          pyFuncs,
+          PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF,
+          argOffsets,
+          pythonInputSchema,
+          sessionLocalTimeZone,
+          pythonRunnerConf,
+          /* The whole group data should be written in a single call, so here is unlimited */
+          Int.MaxValue,
+          () => queue.finish(),
+          pythonOutputSchema)
 
-      val outputBatchIterator = pyRunner.compute(pyInputIterator, context.partitionId(), context)
-      new Iterator[ColumnarBatch] {
-        // for hasNext we are waiting on the queue to have something inserted into it
-        // instead of waiting for a result to be ready from python. The reason for this
-        // is to let us know the target number of rows in the batch that we want when reading.
-        // It is a bit hacked up but it works. In the future when we support spilling we should
-        // store the number of rows separate from the batch. That way we can get the target batch
-        // size out without needing to grab the GpuSemaphore which we cannot do if we might block
-        // on a read operation.
-        // Besides, when the queue is empty, need to call the `hasNext` of the out iterator to
-        // trigger reading and handling the control data followed with the stream data.
-        override def hasNext: Boolean = queue.hasNext || outputBatchIterator.hasNext
+        val outputBatchIterator = pyRunner.compute(pyInputIterator, context.partitionId(), context)
+        new Iterator[ColumnarBatch] {
+          // for hasNext we are waiting on the queue to have something inserted into it
+          // instead of waiting for a result to be ready from python. The reason for this
+          // is to let us know the target number of rows in the batch that we want when reading.
+          // It is a bit hacked up but it works. In the future when we support spilling we should
+          // store the number of rows separate from the batch. That way we can get the target batch
+          // size out without needing to grab the GpuSemaphore which we cannot do if we might block
+          // on a read operation.
+          // Besides, when the queue is empty, need to call the `hasNext` of the out iterator to
+          // trigger reading and handling the control data followed with the stream data.
+          override def hasNext: Boolean = queue.hasNext || outputBatchIterator.hasNext
 
-        private [this] def combine(
-            origBatch: ColumnarBatch,
-            retBatch: ColumnarBatch): ColumnarBatch = {
-          val lColumns = GpuColumnVector.extractColumns(origBatch)
-          val rColumns = GpuColumnVector.extractColumns(retBatch)
-          new ColumnarBatch(lColumns.map(_.incRefCount()) ++ rColumns.map(_.incRefCount()),
-            origBatch.numRows())
-        }
+          private [this] def combine(
+                                      origBatch: ColumnarBatch,
+                                      retBatch: ColumnarBatch): ColumnarBatch = {
+            val lColumns = GpuColumnVector.extractColumns(origBatch)
+            val rColumns = GpuColumnVector.extractColumns(retBatch)
+            new ColumnarBatch(lColumns.map(_.incRefCount()) ++ rColumns.map(_.incRefCount()),
+              origBatch.numRows())
+          }
 
-        override def next(): ColumnarBatch = {
-          val numRows = queue.peekBatchSize
-          // Update the expected batch size for next read
-          pyRunner.minReadTargetBatchSize = numRows
-          withResource(outputBatchIterator.next()) { cbFromPython =>
-            assert(cbFromPython.numRows() == numRows)
-            withResource(queue.remove()) { origBatch =>
-              numOutputBatches += 1
-              numOutputRows += numRows
-              projectResult(combine(origBatch, cbFromPython))
+          override def next(): ColumnarBatch = {
+            val numRows = queue.peekBatchSize
+            // Update the expected batch size for next read
+            pyRunner.minReadTargetBatchSize = numRows
+            withResource(outputBatchIterator.next()) { cbFromPython =>
+              assert(cbFromPython.numRows() == numRows)
+              withResource(queue.remove()) { origBatch =>
+                numOutputBatches += 1
+                numOutputRows += numRows
+                projectResult(combine(origBatch, cbFromPython))
+              }
             }
           }
-        }
-      } // End of new Iterator
+        } // End of new Iterator
+      } else {
+        // Empty partition, return the input iterator directly
+        inputIter
+      }
 
     } // End of mapPartitions
   } // End of doExecuteColumnar


### PR DESCRIPTION
When the partition is empty, do not launch the Python runners and Python processes which are expensive and useless, and return the input iterator directly instead.

Filed this PR to fix the udf related failures in IT tests due to IPC error. This is not a fix for the root cause, but it still makes sense. 

It looks like the cuDF 'ArrowIPCTableWriter' does not handle the empty partiton case correctly. So the Python side reports the IPC error. 

The IPC error should have been there for a while, however we just ignored it due to not read the control data before. But now is exposed by the PR https://github.com/NVIDIA/spark-rapids/pull/1235. Anyway will continue investigating it.

Also reduce the data size for cudf tests to save running time.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
