### PR TITLE
Reuse gpu expression conversion rules when checking sort order

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -401,42 +401,51 @@ object GpuOverrides {
     !regexList.exists(pattern => s.contains(pattern))
   }
 
-  private def canonicalizeToCpuForSortOrder(exp: Expression): Expression = exp match {
-    case g: GpuLiteral => Literal(g.value, g.dataType).canonicalized
-    case g: GpuKnownFloatingPointNormalized =>
-      KnownFloatingPointNormalized(canonicalizeToCpuForSortOrder(g.child)).canonicalized
-    case g: GpuNormalizeNaNAndZero =>
-      NormalizeNaNAndZero(canonicalizeToCpuForSortOrder(g.child)).canonicalized
-    case g: GpuAlias =>
-      ShimLoader.getSparkShims.alias(canonicalizeToCpuForSortOrder(g.child), g.name)(
-        g.exprId,
-        g.qualifier,
-        g.explicitMetadata)
-          .canonicalized
-    case g: GpuSubstring =>
-      Substring(
-        canonicalizeToCpuForSortOrder(g.str),
-        canonicalizeToCpuForSortOrder(g.pos),
-        canonicalizeToCpuForSortOrder(g.len))
-          .canonicalized
-    case o: GpuExpression =>
-      throw new IllegalStateException(s"${o.getClass} is not expected to be a part of a SortOrder")
-    case other => other.canonicalized
+  private def convertExprToGpuIfPossible(expr: Expression, conf: RapidsConf): Option[Expression] = {
+    val wrapped = wrapExpr(expr, conf, None)
+    wrapped.tagForGpu()
+    if (wrapped.canExprTreeBeReplaced) {
+      Some(wrapped.convertToGpu())
+    } else {
+      None
+    }
   }
 
-  private def gpuOrderingSemanticEquals(found: Expression, required: Expression): Boolean = {
-    found.deterministic && required.deterministic &&
-        canonicalizeToCpuForSortOrder(found) == canonicalizeToCpuForSortOrder(required)
+  private def gpuOrderingSemanticEquals(
+      found: Expression,
+      required: Expression,
+      conf: RapidsConf): Boolean = {
+    if (found.deterministic && required.deterministic) {
+      val foundOnGpu = found.find(_.isInstanceOf[GpuExpression]).isDefined
+      val requiredOnGpu = required.find(_.isInstanceOf[GpuExpression]).isDefined
+      if (foundOnGpu == requiredOnGpu) {
+        found.canonicalized == required.canonicalized
+      } else if (foundOnGpu) {
+        convertExprToGpuIfPossible(required, conf)
+            .map(r => found.canonicalized == r.canonicalized).getOrElse(false)
+      } else {
+        convertExprToGpuIfPossible(found, conf)
+            .map(f => f.canonicalized == required.canonicalized).getOrElse(false)
+      }
+    } else {
+      false
+    }
   }
 
-  private def orderingSatisfies(found: SortOrder, required: SortOrder): Boolean = {
+  private def orderingSatisfies(
+      found: SortOrder,
+      required: SortOrder,
+      conf: RapidsConf): Boolean = {
     val foundChildren = ShimLoader.getSparkShims.sortOrderChildren(found)
-    foundChildren.exists(gpuOrderingSemanticEquals(_, required.child)) &&
-        found.direction == required.direction &&
-        found.nullOrdering == required.nullOrdering
+    found.direction == required.direction &&
+        found.nullOrdering == required.nullOrdering &&
+        foundChildren.exists(gpuOrderingSemanticEquals(_, required.child, conf))
   }
 
-  private def orderingSatisfies(ordering1: Seq[SortOrder], ordering2: Seq[SortOrder]): Boolean = {
+  private def orderingSatisfies(
+      ordering1: Seq[SortOrder],
+      ordering2: Seq[SortOrder],
+      conf: RapidsConf): Boolean = {
     // We cannot use SortOrder.orderingSatisfies because there is a corner case where
     // some operators like a Literal can be a part of SortOrder, which then results in errors
     // because we may have converted it over to a GpuLiteral at that point and a Literal
@@ -447,7 +456,7 @@ object GpuOverrides {
       false
     } else {
       ordering2.zip(ordering1).forall {
-        case (o2, o1) => orderingSatisfies(o1, o2)
+        case (o2, o1) => orderingSatisfies(o1, o2, conf)
       }
     }
   }
@@ -2306,7 +2315,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
     // Now that we've performed any necessary shuffles, add sorts to guarantee output orderings:
     children = children.zip(requiredChildOrderings).map { case (child, requiredOrdering) =>
       // If child.outputOrdering already satisfies the requiredOrdering, we do not need to sort.
-      if (GpuOverrides.orderingSatisfies(child.outputOrdering, requiredOrdering)) {
+      if (GpuOverrides.orderingSatisfies(child.outputOrdering, requiredOrdering, conf)) {
         child
       } else {
         val sort = SortExec(requiredOrdering, global = false, child = child)


### PR DESCRIPTION
This fixes #1305 

In this patch instead of trying to bring everything back to the CPU to check if a sort order is satisfied, we selectively decide if we need to bring them both to the GPU to do it.