### PR TITLE
MetaUtils.getBatchFromMeta should return batches with GpuColumnVectorFromBuffer

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVectorFromBuffer.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVectorFromBuffer.java
@@ -100,7 +100,7 @@ public final class GpuColumnVectorFromBuffer extends GpuColumnVector {
    * @param cudfColumn a ColumnVector instance
    * @param buffer the buffer to hold
    */
-  private GpuColumnVectorFromBuffer(DataType type, ColumnVector cudfColumn,
+  public GpuColumnVectorFromBuffer(DataType type, ColumnVector cudfColumn,
       DeviceMemoryBuffer buffer) {
     super(type, cudfColumn);
     this.buffer = buffer;

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -260,7 +260,7 @@ object MetaUtils extends Arm {
       sparkType: DataType): GpuColumnVector = {
     val columnView = makeCudfColumnView(buffer, meta)
     val column = ColumnViewUtil.fromViewWithContiguousAllocation(columnView, buffer)
-    GpuColumnVector.from(column, sparkType)
+    new GpuColumnVectorFromBuffer(sparkType, column, buffer)
   }
 
   private def makeCudfColumn(buffer: DeviceMemoryBuffer, meta: ColumnMeta): ColumnVector = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -215,8 +215,10 @@ class MetaUtilsSuite extends FunSuite with Arm {
           assertResult(table.getRowCount)(batch.numRows)
           assertResult(table.getNumberOfColumns)(batch.numCols)
           (0 until table.getNumberOfColumns).foreach { i =>
+            val batchColumn = batch.column(i)
+            assert(batchColumn.isInstanceOf[GpuColumnVectorFromBuffer])
             TestUtils.compareColumns(table.getColumn(i),
-              batch.column(i).asInstanceOf[GpuColumnVector].getBase)
+              batchColumn.asInstanceOf[GpuColumnVector].getBase)
           }
         }
       }


### PR DESCRIPTION
When building a `ColumnarBatch` from a device buffer and shuffle metadata, `MetaUtils` is not returning a batch with `GpuColumnVectorFromBuffer` instances but rather normal `GpuColumnVector` instances.  When these batches are seen by the subsequent `GpuCoalesceBatches` node in the query plan, `GpuCoalesceBatches` mistakenly thinks the columns are not from a contiguous buffer and performs a redundant contiguous split on the batch.
