### PR TITLE
Handle "MM[/-]dd" and "dd[/-]MM" datetime formats in UnixTimeExprMeta

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -185,6 +185,8 @@ def test_to_unix_timestamp_improved(data_gen):
 
 str_date_and_format_gen = [pytest.param(StringGen('[0-9]{4}/[01][0-9]'),'yyyy/MM', marks=pytest.mark.xfail(reason="cudf does no checks")),
         (StringGen('[0-9]{4}/[01][12]/[0-2][1-8]'),'yyyy/MM/dd'),
+        (StringGen('[01][12]/[0-2][1-8]'), 'MM/dd'),
+        (StringGen('[0-2][1-8]/[01][12]'), 'dd/MM'),
         (ConvertGen(DateGen(nullable=False), lambda d: d.strftime('%Y/%m').zfill(7), data_type=StringType()), 'yyyy/MM')]
 
 @pytest.mark.parametrize('data_gen,date_form', str_date_and_format_gen, ids=idfn)
@@ -196,5 +198,3 @@ def test_string_to_unix_timestamp(data_gen, date_form):
 def test_string_unix_timestamp(data_gen, date_form):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen, seed=1).select(f.unix_timestamp(f.col('a'), date_form)))
-
-

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -330,7 +330,11 @@ object GpuToTimestamp extends Arm {
     "yyyy/MM/dd",
     "yyyy/MM",
     "dd/MM/yyyy",
-    "yyyy-MM-dd HH:mm:ss"
+    "yyyy-MM-dd HH:mm:ss",
+    "MM-dd",
+    "MM/dd",
+    "dd-MM",
+    "dd/MM"
   )
 
   def daysScalarSeconds(name: String): Scalar = {


### PR DESCRIPTION
This PR adds the code to handle the datetime pattern "MM/dd" or "dd/MM" and closes #959. I spoke with @andygrove and he agrees that we should instead track the formats that we don't support instead of having an exhaustive list of patterns that we do support. 

That item is being tracked by #1381 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
