### PR TITLE
Accelerated columnar to row/row to columnar for decimal

### DIFF
--- a/integration_tests/src/main/python/row_conversion_test.py
+++ b/integration_tests/src/main/python/row_conversion_test.py
@@ -37,13 +37,14 @@ def test_row_conversions():
             ["p", StructGen([["c0", byte_gen], ["c1", ArrayGen(byte_gen)]])],
             ["q", simple_string_to_string_map_gen],
             ["r", MapGen(BooleanGen(nullable=False), ArrayGen(boolean_gen), max_length=2)],
-            ["s", null_gen]]
+            ["s", null_gen], ["t", decimal_gen_64bit], ["u", decimal_gen_scale_precision]]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))
 
 def test_row_conversions_fixed_width():
     gens = [["a", byte_gen], ["b", short_gen], ["c", int_gen], ["d", long_gen],
             ["e", float_gen], ["f", double_gen], ["g", string_gen], ["h", boolean_gen],
-            ["i", timestamp_gen], ["j", date_gen]]
+            ["i", timestamp_gen], ["j", date_gen], ["k", decimal_gen_64bit],
+            ["l", decimal_gen_scale_precision]]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))

--- a/sql-plugin/src/main/java/org/apache/spark/sql/catalyst/CudfUnsafeRow.java
+++ b/sql-plugin/src/main/java/org/apache/spark/sql/catalyst/CudfUnsafeRow.java
@@ -235,18 +235,19 @@ public final class CudfUnsafeRow extends InternalRow {
 
   @Override
   public Decimal getDecimal(int ordinal, int precision, int scale) {
-//    if (isNullAt(ordinal)) {
-//      return null;
-//    }
-//    if (precision <= Decimal.MAX_LONG_DIGITS()) {
-//      return Decimal.createUnsafe(getLong(ordinal), precision, scale);
-//    } else {
+    if (isNullAt(ordinal)) {
+      return null;
+    }
+    // TODO when DECIMAL32 is supported a special case will need to be added here
+    if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      return Decimal.createUnsafe(getLong(ordinal), precision, scale);
+    } else {
+      throw new IllegalArgumentException("NOT IMPLEMENTED YET");
 //      byte[] bytes = getBinary(ordinal);
 //      BigInteger bigInteger = new BigInteger(bytes);
 //      BigDecimal javaDecimal = new BigDecimal(bigInteger, scale);
 //      return Decimal.apply(javaDecimal, precision, scale);
-//    }
-    throw new IllegalArgumentException("NOT IMPLEMENTED YET");
+    }
   }
 
   @Override

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -51,6 +51,8 @@ class AcceleratedColumnarToRowIterator(
 
   // for packMap the nth entry is the index of the original input column that we want at
   // the nth entry.
+  // TODO When we support DECIMAL32 we will need to add in a special case here
+  //  because defaultSize of DecimalType does not take that into account.
   private val packMap: Array[Int] = schema
       .zipWithIndex
       .sortWith(_._1.dataType.defaultSize > _._1.dataType.defaultSize)
@@ -242,7 +244,7 @@ object CudfRowTransitions {
   def isSupportedType(dataType: DataType): Boolean = dataType match {
     // Only fixed width for now...
     case ByteType | ShortType | IntegerType | LongType |
-         FloatType | DoubleType | BooleanType | DateType | TimestampType => true
+         FloatType | DoubleType | BooleanType | DateType | TimestampType | _: DecimalType => true
     case _ => false
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -655,6 +655,7 @@ object GeneratedUnsafeRowToCudfRowIterator extends Logging {
       val attr = pair._1
       val colIndex = pair._2
       // This only works on fixed width types
+      // TODO once we support DECIMAL32 we will need a special case in here for it.
       val length = attr.dataType.defaultSize
       cudfOffset = CudfUnsafeRow.alignOffset(cudfOffset, length)
       val ret = length match {


### PR DESCRIPTION
This turns on accelerated DECIMAL64 transitions and adds in comments where we would need to update the code for DECIMAL32 support.

I ran through all of TPC-DS with decimal enabled to verify that all of the tests are still passing.

I did a quick measurement and this saved about 10 ms out of 1500 ms on TPC-DS Q1 Scale factor 1 with decimal support enabled.  Not a lot but enough to be helpful, but for this query it looks it was really only two small transitions that were improved.