### PR TITLE
[WIP] re-enable cast float to int tests with 3.1.0

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -478,7 +478,7 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   }
 
   testSparkResultsAreEqual("Write floats to int (values within range)", intsAsFloats,
-    sparkConf, assumeCondition = before3_1_0) {
+    sparkConf) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -56,7 +56,6 @@ class CastOpSuite extends GpuExpressionTestSuite {
     case (TimestampType | DateType, _: NumericType) => true
     case (TimestampType | DateType, BooleanType) => true
     case (StringType, TimestampType) => true
-    case (FloatType, IntegerType) => true
     case _ => false
   }
 
@@ -531,7 +530,10 @@ object CastOpSuite {
 
   def intsAsFloats(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
-    intValues.map(_.toFloat).toDF("c0")
+    // Spark 3.1.0 changed the range of floats that can be cast to integral types and this
+    // required the intsAsFloats to be updated to avoid using Int.MaxValue. The supported
+    // range is now `Math.floor(x) <= Int.MaxValue && Math.ceil(x) >= Int.MinValue`
+    Seq(Int.MinValue.toFloat, 2147483583.toFloat, 0, -0, -1, 1).toDF("c0")
   }
 
   def intsAsDoubles(session: SparkSession): DataFrame = {


### PR DESCRIPTION
We had previously disabled two tests for CAST float to int due to changes in 3.1.0 that caused these tests to fail.

This is the logic used starting with Spark 3.1.0 to determine the range of valid floats that can be cast to an int:

```scala
Math.floor(x) <= Int.MaxValue && Math.ceil(x) >= Int.MinValue
```

We can no longer cast `Int.MaxValue.toFloat` to an int so the tests are updated to use in-range values.

Closes https://github.com/NVIDIA/spark-rapids/issues/1271