### PR TITLE
Update docs and tests for null CSV support

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -105,10 +105,6 @@ of issues surrounding it and they should be avoided.
 Escaped quote characters `'\"'` are not supported well as described by this
 [issue](https://github.com/NVIDIA/spark-rapids/issues/129).
 
-Null values are not respected as described
-[here](https://github.com/NVIDIA/spark-rapids/issues/127) even though they are
-supported for other types.
-
 ### CSV Dates
 Parsing a `timestamp` as a `date` does not work. The details are documented in this
 [issue](https://github.com/NVIDIA/spark-rapids/issues/869).

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -130,7 +130,7 @@ csv_supported_gens = [
         # Spark does not escape '\r' or '\n' even though it uses it to mark end of record
         # This would require multiLine reads to work correctly so we avoid these chars
         StringGen('(\\w| |\t|\ud720){0,10}', nullable=False),
-        pytest.param(StringGen('[aAbB ]{0,10}'), marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/127')),
+        StringGen('[aAbB ]{0,10}'),
         byte_gen, short_gen, int_gen, long_gen, boolean_gen, date_gen,
         DoubleGen(no_nans=True), # NaN, Inf, and -Inf are not supported
         # Once https://github.com/NVIDIA/spark-rapids/issues/125 and https://github.com/NVIDIA/spark-rapids/issues/124


### PR DESCRIPTION
This fixes #127 

Actually cudf fixed it and this just updates the tests and docs, but it lets github close the issue.