### PR TITLE
Build merged code of HEAD and BASE branch for pre-merge [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -104,13 +104,13 @@ pipeline {
                             changelog: false,
                             poll: true,
                             scm: [
-                                    $class: 'GitSCM', branches: [[name: "pr/" + githubHelper.getPRNumber()]],
+                                    $class: 'GitSCM', branches: [[name: githubHelper.getMergedSHA()]],
                                     doGenerateSubmoduleConfigurations: false,
                                     submoduleCfg: [],
                                     userRemoteConfigs: [[
                                         credentialsId: 'github-token',
                                         url: githubHelper.getCloneUrl(),
-                                        refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*']]
+                                        refspec: '+refs/pull/*/merge:refs/remotes/origin/pr/*']]
                             ]
                     )
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Change the pre-merge build logic, to use the merged code (from the HEAD into BASE) to test the pre-merge. This should avoid case that PR has no merge conflict, but the HEAD branch was actually based on an incorrect BASE branch.

Tested in my forked repo.