### PR TITLE
fix pandas 1.2 compatible issue

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.centos7
+++ b/jenkins/Dockerfile-blossom.integration.centos7
@@ -46,7 +46,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.7 cudatoolkit=${CUDA_VER} && \
+RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.ubuntu16
+++ b/jenkins/Dockerfile-blossom.ubuntu16
@@ -32,9 +32,10 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     apt-get install -y maven \
-    openjdk-8-jdk python3.6 python3-pip tzdata git
+    openjdk-8-jdk python3.8 python3.8-distutils python3-setuptools tzdata git
+RUN python3.8 -m easy_install pip
 
-RUN ln -s /usr/bin/python3.6 /usr/bin/python
+RUN ln -s /usr/bin/python3.8 /usr/bin/python
 RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist
 
 RUN apt install -y inetutils-ping expect

--- a/jenkins/Dockerfile.integration.ubuntu16
+++ b/jenkins/Dockerfile.integration.ubuntu16
@@ -29,7 +29,8 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     apt-get install -y maven \
-    openjdk-8-jdk python3.6 python3-pip
+    openjdk-8-jdk python3.8 python3.8-distutils python3-setuptools
+RUN python3.8 -m easy_install pip
 
-RUN ln -s /usr/bin/python3.6 /usr/bin/python
+RUN ln -s /usr/bin/python3.8 /usr/bin/python
 RUN python -m pip install pytest sre_yield

--- a/jenkins/Dockerfile.ubuntu16
+++ b/jenkins/Dockerfile.ubuntu16
@@ -32,12 +32,8 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     apt-get install -y maven \
-    openjdk-8-jdk python3.6 python3-pip tzdata git
+    openjdk-8-jdk python3.8 python3.8-distutils python3-setuptools tzdata git
+RUN python3.8 -m easy_install pip
 
-RUN ln -s /usr/bin/python3.6 /usr/bin/python
+RUN ln -s /usr/bin/python3.8 /usr/bin/python
 RUN python -m pip install pytest sre_yield requests pandas pyarrow
-
-RUN adduser --uid 26576 --gid 30 --shell /bin/bash svcngcc
-USER svcngcc
-
-# TODO: remove this file after nightly pipeline get removed on NGCC


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

CI pipelines failed due to https://pandas.pydata.org/docs/whatsnew/v1.2.0.html#increased-minimum-version-for-python newly released pandas 1.2 on 26 Dec.

Try resolve compatible issue by upgrading python to 3.8

pre-merge CI passed
nightly CI passed
integration CI passed