### PR TITLE
when AQE enabled we fail to fix up exchanges properly and EMR

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -543,14 +543,16 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
     }
   }
 
-  // This has to handle adaptive execution and the fact that it splits and
-  // runs subqueries at shuffle boundaries. When we analyze the subquery
-  // we don't know what the other side of the join is so we have to ensure it
-  // gets marked properly the first time through. It also only sees see the
-  // children when doing the subquery so if any child can't be replaced
-  // when AQE is on we make sure to mark the exchange as can't be replaced.
-  // Otherwise we could get a mismatch like
+  // For adaptive execution we have to ensure we mark everything properly
+  // the first time through and that has to match what happens when AQE
+  // splits things up and does the subquery analysis at the shuffle boundaries.
+  // If the AQE subquery analysis changes the plan from what is originally
+  // marked we can end up with mismatches like happened in:
   // https://github.com/NVIDIA/spark-rapids/issues/1423
+  // AQE splits subqueries at shuffle boundaries which means that it only
+  // sees the children at that point. So in our fix up exchange we only
+  // look at the children and mark is at will not work on GPU if the
+  // child can't be replaced.
   private def fixUpExchangeOverhead(): Unit = {
     childPlans.foreach(_.fixUpExchangeOverhead())
     if (wrapped.isInstanceOf[ShuffleExchangeExec] &&

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -558,8 +558,8 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
     if (wrapped.isInstanceOf[ShuffleExchangeExec] &&
       ((parent.filter(_.canThisBeReplaced).isEmpty &&
         childPlans.filter(_.canThisBeReplaced).isEmpty) ||
-        plan.conf.adaptiveExecutionEnabled &&
-          childPlans.filter(_.canThisBeReplaced).isEmpty)) {
+        (plan.conf.adaptiveExecutionEnabled &&
+          childPlans.filter(_.canThisBeReplaced).isEmpty))) {
       willNotWorkOnGpu("Columnar exchange without columnar children is inefficient")
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -556,10 +556,9 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
   private def fixUpExchangeOverhead(): Unit = {
     childPlans.foreach(_.fixUpExchangeOverhead())
     if (wrapped.isInstanceOf[ShuffleExchangeExec] &&
-      ((parent.filter(_.canThisBeReplaced).isEmpty &&
-        childPlans.filter(_.canThisBeReplaced).isEmpty) ||
-        (plan.conf.adaptiveExecutionEnabled &&
-          childPlans.filter(_.canThisBeReplaced).isEmpty))) {
+      childPlans.filter(_.canThisBeReplaced).isEmpty &&
+        (plan.conf.adaptiveExecutionEnabled ||
+        parent.filter(_.canThisBeReplaced).isEmpty)) {
       willNotWorkOnGpu("Columnar exchange without columnar children is inefficient")
     }
   }


### PR DESCRIPTION
This is part of issue in https://github.com/NVIDIA/spark-rapids/issues/1423

The issue here is in the way that AQE does its subqueries at exchange boundaries and when we re-analyze the subqueries we only see the children of the exchange.  This can results in our fixUpExchangeOverhead marking the plan different initially from when the subquery is actually ran and we end up having one part of the join coming from CPU exchange and one part coming from GPU exchange and we blow up.

To handle this case we have to make sure we initially mark the plan the same as AQE will on its subqueries. This means in the fixUpExchangeOverhead when AQE is enabled we only look a the children in deciding if the exchange will run on the GPU or not.

there are more details in the issue.  

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
