### PR TITLE
Improve UX when running benchmarks from Spark shell

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -106,7 +106,7 @@ results to the driver.
 
 ```scala
 import com.nvidia.spark.rapids.tests._
-val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+val benchmark = new BenchmarkRunner(new TpcdsLikeBench())
 benchmark.collect(spark, "q5", iterations=3)
 ```
 
@@ -116,7 +116,7 @@ files.
 
 ```scala
 import com.nvidia.spark.rapids.tests._
-val benchmark = new BenchmarkRunner(TpcdsLikeBench)
+val benchmark = new BenchmarkRunner(new TpcdsLikeBench())
 benchmark.writeParquet(spark, "q5", "/data/output/tpcds/q5", iterations=3)
 ```
 
@@ -184,7 +184,7 @@ Example usage from spark-shell:
 val cpu = spark.read.parquet("/data/tpcxbb/q5-cpu")
 val gpu = spark.read.parquet("/data/tpcxbb/q5-gpu")
 import com.nvidia.spark.rapids.tests.common._
-BenchUtils.compareResults(cpu, gpu, ignoreOrdering=true, epsilon=0.0001)
+BenchUtils.compareResults(cpu, gpu, inputFormat="parquet", ignoreOrdering=true, epsilon=0.0001)
 ```
 
 This will report on any differences between the two dataframes.

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -45,8 +45,8 @@ object BenchmarkRunner {
 
     val benchmarks = Map(
       "tpcds" -> new TpcdsLikeBench(conf.appendDat()),
-      "tpch" -> TpchLikeBench,
-      "tpcxbb" -> TpcxbbLikeBench
+      "tpch" -> new TpchLikeBench(),
+      "tpcxbb" -> new TpcxbbLikeBench()
     )
 
     benchmarks.get(conf.benchmark().toLowerCase) match {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -512,11 +512,20 @@ object BenchUtils {
   def compareResults(
       df1: DataFrame,
       df2: DataFrame,
-      readPathAction: String => DataFrame,
+      inputFormat: String,
       ignoreOrdering: Boolean,
       useIterator: Boolean = false,
       maxErrors: Int = 10,
       epsilon: Double = 0.00001): Unit = {
+
+    val spark = df1.sparkSession
+
+    val readPathAction = inputFormat match {
+      case "csv" =>
+        path: String => spark.read.csv(path)
+      case "parquet" =>
+        path: String => spark.read.parquet(path)
+    }
 
     val count1 = df1.count()
     val count2 = df2.count()

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/CompareResults.scala
@@ -55,17 +55,10 @@ object CompareResults {
         (spark.read.parquet(conf.input1()), spark.read.parquet(conf.input2()))
     }
 
-    val readPathAction = conf.inputFormat() match {
-      case "csv" =>
-        path: String => spark.read.csv(path)
-      case "parquet" =>
-        path: String => spark.read.parquet(path)
-    }
-
     BenchUtils.compareResults(
       df1,
       df2,
-      readPathAction,
+      conf.inputFormat(),
       conf.ignoreOrdering(),
       conf.useIterator(),
       conf.maxErrors(),

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeBench.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-class TpcdsLikeBench(val appendDat: Boolean) extends BenchmarkSuite {
+class TpcdsLikeBench(val appendDat: Boolean = false) extends BenchmarkSuite {
   override def name(): String = "TPC-DS"
 
   override def shortName(): String = "tpcds"

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeBench.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpchLikeBench extends BenchmarkSuite {
+class TpchLikeBench extends BenchmarkSuite {
   override def name(): String = "TPC-H"
 
   override def shortName(): String = "tpch"

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpch/TpchLikeSpark.scala
@@ -39,8 +39,8 @@ object TpchLikeSpark {
       spark: SparkSession, 
       basePath: String, 
       baseOutput: String, 
-      coalesce: Map[String, Int],
-      repartition: Map[String, Int]): Unit = {
+      coalesce: Map[String, Int] = Map.empty,
+      repartition: Map[String, Int] = Map.empty): Unit = {
     setupWrite(readOrdersCSV(spark, basePath + "/orders.tbl"), "orders", coalesce, repartition).parquet(baseOutput + "/orders.tbl")
     setupWrite(readLineitemCSV(spark, basePath + "/lineitem.tbl"), "lineitem", coalesce, repartition).parquet(baseOutput + "/lineitem.tbl")
     setupWrite(readCustomerCSV(spark, basePath + "/customer.tbl"), "customers", coalesce, repartition).parquet(baseOutput + "/customer.tbl")
@@ -55,8 +55,8 @@ object TpchLikeSpark {
       spark: SparkSession, 
       basePath: String, 
       baseOutput: String,
-      coalesce: Map[String, Int],
-      repartition: Map[String, Int]): Unit = {
+      coalesce: Map[String, Int] = Map.empty,
+      repartition: Map[String, Int] = Map.empty): Unit = {
     setupWrite(readOrdersCSV(spark, basePath + "/orders.tbl"), "orders", coalesce, repartition).orc(baseOutput + "/orders.tbl")
     setupWrite(readLineitemCSV(spark, basePath + "/lineitem.tbl"), "lineitem", coalesce, repartition).orc(baseOutput + "/lineitem.tbl")
     setupWrite(readCustomerCSV(spark, basePath + "/customer.tbl"), "customers", coalesce, repartition).orc(baseOutput + "/customer.tbl")

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeBench.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.tests.common.BenchmarkSuite
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-object TpcxbbLikeBench  extends BenchmarkSuite {
+class TpcxbbLikeBench  extends BenchmarkSuite {
   override def name(): String = "TPCx-BB"
 
   override def shortName(): String = "Tpcxbb"

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcxbb/TpcxbbLikeSpark.scala
@@ -40,8 +40,8 @@ object TpcxbbLikeSpark {
       spark: SparkSession, 
       basePath: String, 
       baseOutput: String, 
-      coalesce: Map[String, Int],
-      repartition: Map[String, Int]): Unit = {
+      coalesce: Map[String, Int] = Map.empty,
+      repartition: Map[String, Int] = Map.empty): Unit = {
     setupWrite(readCustomerCSV(spark, basePath + "/customer/"), "customer", coalesce, repartition).parquet(baseOutput + "/customer/")
     setupWrite(readCustomerAddressCSV(spark, basePath + "/customer_address/"), "customer_address", coalesce, repartition).parquet(baseOutput + "/customer_address/")
     setupWrite(readItemCSV(spark, basePath + "/item/"), "item", coalesce, repartition).parquet(baseOutput + "/item/")
@@ -67,8 +67,8 @@ object TpcxbbLikeSpark {
       spark: SparkSession, 
       basePath: String, 
       baseOutput: String, 
-      coalesce: Map[String, Int],
-      repartition: Map[String, Int]): Unit = {
+      coalesce: Map[String, Int] = Map.empty,
+      repartition: Map[String, Int] = Map.empty): Unit = {
     setupWrite(readCustomerCSV(spark, basePath + "/customer/"), "customer", coalesce, repartition).orc(baseOutput + "/customer/")
     setupWrite(readCustomerAddressCSV(spark, basePath + "/customer_address/"), "customer_address", coalesce, repartition).orc(baseOutput + "/customer_address/")
     setupWrite(readItemCSV(spark, basePath + "/item/"), "item", coalesce, repartition).orc(baseOutput + "/item/")


### PR DESCRIPTION
This PR improves consistency and UX of running benchmarks from Spark shell and also fixes some documentation errors.

The changes are:

- `TpcdsLikeBench`, `TpchLikeBench`, and `TpcxbbLikeBench` are now all classes, rather than being a mix of object and class, for better consistency and concise documentation.
- Default values are now specified for the new `coalesce` and `repartition` arguments for `TpchLikeSpark` and `TpcxbbLikeSpark` for consistency with `TpcdsLikeSpark`.
- The signature for `BenchUtils.compareResults` is simplified to accept a file format string rather than a function.
- Unit tests are implemented based on the Spark shell code samples in `docs/benchmarks.md` so that we are more likely to catch regressions to this usage in the future.

Closes https://github.com/NVIDIA/spark-rapids/issues/1400 and https://github.com/NVIDIA/spark-rapids/issues/1379