### PR TITLE
Upgrade Scala Maven Plugin to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
         <spark302.version>3.0.2-SNAPSHOT</spark302.version>
         <spark310.version>3.1.0-SNAPSHOT</spark310.version>
         <mockito.version>3.6.0</mockito.version>
+        <scala.plugin.version>4.3.0</scala.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -357,7 +358,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.4.4</version>
+                    <version>${scala.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>eclipse-add-source</id>


### PR DESCRIPTION
Fixes the issue with `JAVA_HOME` resolution described in https://github.com/davidB/scala-maven-plugin/issues/221.
Encountered when building using IntelliJ's maven plugin

Signed-off-by: Gera Shegalov <gshegalov@nvidia.com>
