### PR TITLE
Add an example RAPIDS-accelerated Hive UDF using native code

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -52,4 +52,8 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--cudf_udf", action='store_true', default=False, help="if true enable cudf_udf test"
+    )
+    parser.addoption(
+        "--rapids_udf_example_native", action='store_true', default=False,
+        help="if true enable tests for RAPIDS UDF examples with native code"
     )

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -395,3 +395,8 @@ def enable_cudf_udf(request):
     if not enable_udf_cudf:
         pytest.skip("cudf_udf not configured to run")
 
+@pytest.fixture(scope="session")
+def enable_rapids_udf_example_native(request):
+    native_enabled = request.config.getoption("rapids_udf_example_native")
+    if not native_enabled:
+        pytest.skip("rapids_udf_example_native not configured to run")

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,3 +21,4 @@ incompat = pytest.mark.incompat
 limit = pytest.mark.limit
 qarun = pytest.mark.qarun
 cudf_udf = pytest.mark.cudf_udf
+rapids_udf_example_native = pytest.mark.rapids_udf_example_native

--- a/udf-examples/Dockerfile
+++ b/udf-examples/Dockerfile
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A container that can be used to build UDF native code against libcudf
+ARG CUDA_VERSION=10.1
+ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
+ARG LINUX_VERSION=ubuntu18.04
+ARG CUDF_REPO=https://github.com/rapidsai/cudf
+ARG CUDF_TAG=branch-0.18
+ARG CC=7
+ARG CXX=7
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+# Needed for cudf.concat(), avoids "OSError: library nvvm not found"
+ENV NUMBAPRO_NVVM=/usr/local/cuda/nvvm/lib64/libnvvm.so
+ENV NUMBAPRO_LIBDEVICE=/usr/local/cuda/nvvm/libdevice/
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG CC
+ARG CXX
+RUN apt update -y --fix-missing && \
+    apt upgrade -y && \
+    apt install -y --no-install-recommends \
+      git \
+      gcc-${CC} \
+      g++-${CXX} \
+      libboost-all-dev \
+      openjdk-8-jdk \
+      maven \
+      tzdata && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install conda
+ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
+RUN sh /miniconda.sh -b -p /conda && /conda/bin/conda update -n base conda
+ENV PATH=${PATH}:/conda/bin
+# Enables "source activate conda"
+SHELL ["/bin/bash", "-c"]
+
+# Pull the cudf source at the specified branch or tag
+ARG CUDF_TAG
+RUN git clone --recurse-submodules --depth 1 --single-branch --branch ${CUDF_TAG} https://github.com/rapidsai/cudf.git /cudf
+
+# Create the cudf conda environment
+ARG CUDA_SHORT_VERSION
+RUN conda env create --name cudf --file /cudf/conda/environments/cudf_dev_cuda${CUDA_SHORT_VERSION}.yml
+
+# libcudf build/install
+ARG CC
+ARG CXX
+ENV CC=/usr/bin/gcc-${CC}
+ENV CXX=/usr/bin/g++-${CXX}
+RUN source activate cudf && \
+    mkdir -p /cudf/cpp/build && \
+    cd /cudf/cpp/build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
+    make -j"$(nproc)" install
+
+# Default to cudf conda environment
+RUN echo "source activate cudf" > /.bash-init.sh
+ENTRYPOINT /bin/bash --init-file /.bash-init.sh

--- a/udf-examples/pom.xml
+++ b/udf-examples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020, NVIDIA CORPORATION.
+  Copyright (c) 2020-2021, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,6 +32,15 @@
     for Apache Spark</description>
   <version>0.4.0-SNAPSHOT</version>
 
+  <properties>
+    <udf.native.build.path>${project.build.directory}/cpp-build</udf.native.build.path>
+    <CMAKE_CXX_FLAGS/>
+    <GPU_ARCHS>ALL</GPU_ARCHS>
+    <CUDA_STATIC_RUNTIME>ON</CUDA_STATIC_RUNTIME>
+    <PER_THREAD_DEFAULT_STREAM>ON</PER_THREAD_DEFAULT_STREAM>
+    <CUDF_CMAKE_BUILD_DIR>/cudf/cpp/build</CUDF_CMAKE_BUILD_DIR>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>ai.rapids</groupId>
@@ -49,6 +58,7 @@
       <artifactId>spark-hive_${scala.binary.version}</artifactId>
     </dependency>
   </dependencies>
+
   <build>
     <resources>
       <resource>
@@ -68,4 +78,75 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>udf-native-examples</id>
+      <build>
+        <resources>
+          <resource>
+            <directory>${project.build.directory}/native-deps/</directory>
+          </resource>
+        </resources>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>cmake</id>
+                <phase>validate</phase>
+                <configuration>
+                  <tasks>
+                    <mkdir dir="${udf.native.build.path}"/>
+                    <exec dir="${udf.native.build.path}"
+                          failonerror="true"
+                          executable="cmake">
+                      <arg value="${basedir}/src/main/cpp"/>
+                      <arg value="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"/>
+                      <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
+                      <arg value="-DCUDA_STATIC_RUNTIME=${CUDA_STATIC_RUNTIME}"/>
+                      <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>
+                      <arg value="-DCUDF_CMAKE_BUILD_DIR=${CUDF_CMAKE_BUILD_DIR}"/>
+                    </exec>
+                    <exec dir="${udf.native.build.path}"
+                          failonerror="true"
+                          executable="make">
+                      <arg value="-j"/>
+                    </exec>
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-native-libs</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <overwrite>true</overwrite>
+                  <outputDirectory>${project.build.directory}/native-deps/${os.arch}/${os.name}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${udf.native.build.path}</directory>
+                      <includes>
+                        <include>libudfexamplesjni.so</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,236 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+project(UDFEXAMPLESJNI VERSION 0.4.0 LANGUAGES C CXX CUDA)
+
+###################################################################################################
+# - build type ------------------------------------------------------------------------------------
+
+# Set a default build type if none was specified
+set(DEFAULT_BUILD_TYPE "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' since none specified.")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+###################################################################################################
+# - compiler options ------------------------------------------------------------------------------
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
+if(CMAKE_CUDA_COMPILER_VERSION)
+  # Compute the version from CMAKE_CUDA_COMPILER_VERSION
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" CUDA_VERSION_MAJOR ${CMAKE_CUDA_COMPILER_VERSION})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" CUDA_VERSION_MINOR ${CMAKE_CUDA_COMPILER_VERSION})
+  set(CUDA_VERSION "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}" CACHE STRING "Version of CUDA as computed from nvcc.")
+  mark_as_advanced(CUDA_VERSION)
+endif()
+
+message(STATUS "CUDA_VERSION_MAJOR: ${CUDA_VERSION_MAJOR}")
+message(STATUS "CUDA_VERSION_MINOR: ${CUDA_VERSION_MINOR}")
+message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
+
+# Always set this convenience variable
+set(CUDA_VERSION_STRING "${CUDA_VERSION}")
+
+set(GPU_ARCHS "ALL" CACHE STRING
+  "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures.")
+
+if("${GPU_ARCHS}" STREQUAL "ALL")
+
+  # Check for embedded vs workstation architectures
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    # This is being built for Linux4Tegra or SBSA ARM64
+    set(GPU_ARCHS "62")
+    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
+      set(GPU_ARCHS "${GPU_ARCHS};72")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
+      set(GPU_ARCHS "${GPU_ARCHS};75;80")
+    endif()
+
+  else()
+    # This is being built for an x86 or x86_64 architecture
+    set(GPU_ARCHS "60")
+    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
+      set(GPU_ARCHS "${GPU_ARCHS};70")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 10) OR (CUDA_VERSION_MAJOR GREATER 10))
+      set(GPU_ARCHS "${GPU_ARCHS};75")
+    endif()
+    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
+      set(GPU_ARCHS "${GPU_ARCHS};80")
+    endif()
+
+  endif()
+
+endif()
+message("GPU_ARCHS = ${GPU_ARCHS}")
+
+foreach(arch ${GPU_ARCHS})
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_${arch},code=sm_${arch}")
+endforeach()
+
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")
+
+# set warnings as errors
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
+
+# Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
+option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler)" OFF)
+if (CMAKE_CUDA_LINEINFO)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")
+endif(CMAKE_CUDA_LINEINFO)
+
+# Debug options
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    message(STATUS "Building with debugging flags")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G -Xcompiler -rdynamic")
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" ON)
+
+if(CUDA_STATIC_RUNTIME)
+    message(STATUS "Enabling static linking of cudart")
+    set(CUDART_LIBRARY "cudart_static")
+else()
+    message(STATUS "Enabling dynamic linking of cudart")
+    set(CUDART_LIBRARY "cudart")
+endif(CUDA_STATIC_RUNTIME)
+
+###################################################################################################
+# - CUDF ------------------------------------------------------------------------------------------
+
+find_path(CUDF_INCLUDE "cudf"
+    HINTS "$ENV{CUDF_ROOT}"
+          "$ENV{CONDA_PREFIX}/include")
+
+find_library(CUDF_BASE_LIBRARY "cudf_base"
+    HINTS "$ENV{CUDF_ROOT}"
+          "$ENV{CUDF_ROOT}/lib"
+          "$ENV{CONDA_PREFIX}/lib")
+
+###################################################################################################
+# - RMM -------------------------------------------------------------------------------------------
+
+find_path(RMM_INCLUDE "rmm"
+          HINTS "$ENV{RMM_ROOT}/include"
+                "$ENV{CONDA_PREFIX}/include")
+
+###################################################################################################
+# - Thrust/CUB/libcudacxx ------------------------------------------------------------------------------------
+
+# path to libcudf cmake build directory
+if(NOT DEFINED CUDF_CMAKE_BUILD_DIR)
+  set(CUDF_CMAKE_BUILD_DIR "/cudf/cpp/build")
+endif(NOT DEFINED CUDF_CMAKE_BUILD_DIR)
+
+find_path(THRUST_INCLUDE "thrust"
+    HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
+          "${CUDF_CMAKE_BUILD_DIR}/_deps/thrust-src")
+
+find_path(CUB_INCLUDE "cub"
+    HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
+          "${CUDF_CMAKE_BUILD_DIR}/_deps/thrust-src")
+
+find_path(LIBCUDACXX_INCLUDE "cuda"
+    HINTS "$ENV{CUDF_ROOT}/_deps/libcudacxx-src/include"
+          "${CUDF_CMAKE_BUILD_DIR}/_deps/libcudacxx-src/include")
+
+###################################################################################################
+# - find JNI -------------------------------------------------------------------------------------
+
+find_package(JNI REQUIRED)
+if(JNI_FOUND)
+    message(STATUS "JDK with JNI in ${JNI_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "JDK with JNI not found, please check your settings.")
+endif(JNI_FOUND)
+
+###################################################################################################
+# - include paths ---------------------------------------------------------------------------------
+
+include_directories("${THRUST_INCLUDE}"
+                    "${CUB_INCLUDE}"
+                    "${LIBCUDACXX_INCLUDE}"
+                    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+                    "${CMAKE_SOURCE_DIR}/src"
+                    "${CUDF_INCLUDE}"
+                    "${RMM_INCLUDE}"
+                    "${JNI_INCLUDE_DIRS}")
+
+###################################################################################################
+# - library paths ---------------------------------------------------------------------------------
+
+# CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
+link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
+                 "${CMAKE_BINARY_DIR}/lib")
+
+
+###################################################################################################
+# - library targets -------------------------------------------------------------------------------
+
+set(SOURCE_FILES
+    "src/StringWordCountJni.cpp"
+    "src/string_word_count.cu")
+
+add_library(udfexamplesjni SHARED ${SOURCE_FILES})
+
+#Override RPATH for udfexamplesjni
+SET_TARGET_PROPERTIES(udfexamplesjni PROPERTIES BUILD_RPATH "\$ORIGIN")
+
+###################################################################################################
+# - build options ---------------------------------------------------------------------------------
+
+option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
+if(PER_THREAD_DEFAULT_STREAM)
+    message(STATUS "Using per-thread default stream")
+    add_compile_definitions(CUDA_API_PER_THREAD_DEFAULT_STREAM)
+endif(PER_THREAD_DEFAULT_STREAM)
+
+###################################################################################################
+# - rmm logging level -----------------------------------------------------------------------------
+
+set(RMM_LOGGING_LEVEL "INFO" CACHE STRING "Choose the logging level.")
+# Set the possible values of build type for cmake-gui
+set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS
+        "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+message(STATUS "RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
+
+target_compile_definitions(udfexamplesjni
+    PUBLIC SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL})
+
+###################################################################################################
+# - link libraries --------------------------------------------------------------------------------
+
+target_link_libraries(udfexamplesjni ${CUDF_BASE_LIBRARY} ${CUDART_LIBRARY} cuda)

--- a/udf-examples/src/main/cpp/src/StringWordCountJni.cpp
+++ b/udf-examples/src/main/cpp/src/StringWordCountJni.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+
+#include <memory>
+#include <jni.h>
+
+#include "string_word_count.hpp"
+
+namespace {
+
+constexpr char const* RUNTIME_ERROR_CLASS = "java/lang/RuntimeException";
+
+/**
+ * @brief Throw a Java exception
+ *
+ * @param env The Java environment
+ * @param class_name The fully qualified Java class name of the exception
+ * @param msg The message string to associate with the exception
+ */
+void throw_java_exception(JNIEnv* env, char const* class_name, char const* msg) {
+  jclass ex_class = env->FindClass(class_name);
+  if (ex_class != NULL) {
+    env->ThrowNew(ex_class, msg);
+  }
+}
+
+}  // anonymous namespace
+
+extern "C" {
+
+/**
+ * @brief The native implementation of StringWordCount.countWords which counts the
+ * number of words per string in a string column.
+ *
+ * @param env The Java environment
+ * @param j_strings The address of the cudf column view of the strings column
+ * @return The address of the cudf column containing the word counts
+ */
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_udf_StringWordCount_countWords(JNIEnv* env, jclass,
+                                                            jlong j_strings) {
+  // Use a try block to translate C++ exceptions into Java exceptions to avoid
+  // crashing the JVM if a C++ exception occurs.
+  try {
+    // turn the addresses into column_view pointers
+    auto strs = reinterpret_cast<cudf::column_view const*>(j_strings);
+
+    // run the GPU kernel to compute the word counts
+    std::unique_ptr<cudf::column> result = string_word_count(*strs);
+
+    // take ownership of the column and return the column address to Java
+    return reinterpret_cast<jlong>(result.release());
+  } catch (std::bad_alloc const& e) {
+    auto msg = std::string("Unable to allocate native memory: ") +
+        (e.what() == nullptr ? "" : e.what());
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg.c_str());
+    return 0;
+  } catch (std::exception const& e) {
+    auto msg = e.what() == nullptr ? "" : e.what();
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg);
+  }
+}
+
+}

--- a/udf-examples/src/main/cpp/src/string_word_count.cu
+++ b/udf-examples/src/main/cpp/src/string_word_count.cu
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "string_word_count.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/strings/string_view.cuh>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/transform.h>
+
+namespace {
+
+// count the words separated by whitespace characters
+__device__ cudf::size_type count_words(cudf::column_device_view const& d_strings,
+                                       cudf::size_type idx) {
+  if (d_strings.is_null(idx)) return 0;
+  cudf::string_view const d_str = d_strings.element<cudf::string_view>(idx);
+  cudf::size_type word_count    = 0;
+  // run of whitespace is considered a single delimiter
+  bool spaces = true;
+  auto itr    = d_str.begin();
+  while (itr != d_str.end()) {
+    cudf::char_utf8 ch = *itr;
+    if (spaces == (ch <= ' ')) {
+      itr++;
+    } else {
+      word_count += static_cast<cudf::size_type>(spaces);
+      spaces = !spaces;
+    }
+  }
+
+  return word_count;
+}
+
+
+} // anonymous namespace
+
+/**
+ * @brief Count the words in a string using whitespace as word boundaries
+ *
+ * @param strs The column containing the strings
+ * @param stream The CUDA stream to use
+ * @return The INT32 column containing the word count results per string
+ */
+std::unique_ptr<cudf::column> string_word_count(cudf::column_view const& strs) {
+  auto strings_count = strs.size();
+  if (strings_count == 0) {
+    return cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32});
+  }
+
+  // the validity of the output matches the validity of the input
+  rmm::device_buffer null_mask = cudf::copy_bitmask(strs);
+
+  // allocate the column that will contain the word count results
+  std::unique_ptr<cudf::column> result =
+    cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT32},
+      strs.size(),
+      std::move(null_mask),
+      strs.null_count());
+
+  // compute the word counts, writing into the result column data buffer
+  auto stream = rmm::cuda_stream_default;
+  auto strs_device_view = cudf::column_device_view::create(strs, stream);
+  auto d_strs_view = *strs_device_view;
+  thrust::transform(
+    rmm::exec_policy(stream),
+    thrust::make_counting_iterator<cudf::size_type>(0),
+    thrust::make_counting_iterator<cudf::size_type>(strings_count),
+    result->mutable_view().data<cudf::size_type>(),
+    [d_strs_view] __device__(cudf::size_type idx) { return count_words(d_strs_view, idx); });
+
+  return result;
+}

--- a/udf-examples/src/main/cpp/src/string_word_count.hpp
+++ b/udf-examples/src/main/cpp/src/string_word_count.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+
+/**
+ * @brief Count the words in a string separated by whitespace
+ *
+ * @param strs The column containing the strings to be examined
+ * @return The INT32 column containing the word count results for each string
+ */
+std::unique_ptr<cudf::column> string_word_count(cudf::column_view const& strs);

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/StringWordCount.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/StringWordCount.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.NativeDepsLoader;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+import java.io.IOException;
+
+/**
+ * A user-defined function (UDF) that counts the words in a string.
+ * This avoids the manifestation of intermediate results required when
+ * splitting the string on whitespace and counting the split results.
+ * <p>
+ * This class demonstrates how to implement a Hive UDF with a RAPIDS
+ * implementation that uses custom native code.
+ */
+public class StringWordCount extends UDF implements RapidsUDF {
+  private volatile boolean isNativeCodeLoaded = false;
+
+  /** Row-by-row implementation that executes on the CPU */
+  public Integer evaluate(String str) {
+    if (str == null) {
+      return null;
+    }
+
+    int numWords = 0;
+    // run of whitespace is considered a single delimiter
+    boolean spaces = true;
+    for (int idx = 0; idx < str.length(); idx++) {
+      char ch = str.charAt(idx);
+      if (spaces != (ch <= ' ')) {
+        if (spaces) {
+          numWords++;
+        }
+        spaces = !spaces;
+      }
+    }
+    return numWords;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector strs = args[0];
+    if (!strs.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("type mismatch, expected strings but found " +
+          strs.getType());
+    }
+
+    // Load the native code if it has not been already loaded. This is done here
+    // rather than in a static code block since the driver may not have the
+    // required CUDA environment.
+    ensureNativeCodeLoaded();
+
+    return new ColumnVector(countWords(strs.getNativeView()));
+  }
+
+  private void ensureNativeCodeLoaded() {
+    if (!isNativeCodeLoaded) {
+      synchronized(StringWordCount.class) {
+        if (!isNativeCodeLoaded) {
+          try {
+            NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
+            isNativeCodeLoaded = true;
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    }
+  }
+
+  private static native long countWords(long stringsView);
+}


### PR DESCRIPTION
Closes #1353

This adds an example of a Hive UDF that leverages native CUDA code to implement a RAPIDS-accelerated version.  A Dockerfile is provided to show how to setup an environment for compiling the native UDF code against libcudf and the version of cub, thrust, and libcudacxx used by libcudf.

An integration test is provided, but the user must supply the `--rapids_udf_example_native` flag in order to enable the test, as most nightly builds will not bother to perform the extra steps necessary to build the native code required by the new example.

Documentation that covers this native example and implementing RAPIDS-acclerated Hive UDFs in general will be covered in #1354.