### PR TITLE
add doc for nsight systems bundled with cuda toolkit

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -246,6 +246,12 @@ added to the profile via NVTX ranges.  See
 [the NVTX profiling guide](nvtx_profiling.md) for additional information on
 setting up the build for profiling and adding NVTX ranges.
 
+> Note: The Nsight Systems GUI is installed as part of the CUDA Toolkit, but is
+> under a slightly different name depending on the CUDA version:
+> * `/usr/local/cuda-10.1/nsight-systems-2019.3.7.5/Host-x86_64/nsight-sys`
+> * `/usr/local/cuda-10.2/nsight-systems-2019.5.2/host-linux-x64/nsight-sys`
+> * `/usr/local/cuda-11.0/nsight-systems-2020.3.2/host-linux-x64/nsight-sys`
+
 ## Code Coverage
 
 We use [jacoco](https://www.jacoco.org/jacoco/trunk/doc/) for code coverage because it lets

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -246,11 +246,13 @@ added to the profile via NVTX ranges.  See
 [the NVTX profiling guide](nvtx_profiling.md) for additional information on
 setting up the build for profiling and adding NVTX ranges.
 
-> Note: The Nsight Systems GUI is installed as part of the CUDA Toolkit, but is
-> under a slightly different name depending on the CUDA version:
-> * `/usr/local/cuda-10.1/nsight-systems-2019.3.7.5/Host-x86_64/nsight-sys`
-> * `/usr/local/cuda-10.2/nsight-systems-2019.5.2/host-linux-x64/nsight-sys`
-> * `/usr/local/cuda-11.0/nsight-systems-2020.3.2/host-linux-x64/nsight-sys`
+Note: Nsight Systems can be downloaded from its
+[product page](https://developer.nvidia.com/nsight-systems) directly.
+It is also installed as part of the CUDA Toolkit. To launch the GUI, run the following
+executable, depending on your CUDA Toolkit version:
+* `/usr/local/cuda-10.1/nsight-systems-2019.3.7.5/Host-x86_64/nsight-sys`
+* `/usr/local/cuda-10.2/nsight-systems-2019.5.2/host-linux-x64/nsight-sys`
+* `/usr/local/cuda-11.0/nsight-systems-2020.3.2/host-linux-x64/nsight-sys`
 
 ## Code Coverage
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -246,13 +246,9 @@ added to the profile via NVTX ranges.  See
 [the NVTX profiling guide](nvtx_profiling.md) for additional information on
 setting up the build for profiling and adding NVTX ranges.
 
-Note: Nsight Systems can be downloaded from its
+Note: Nsight Systems is installed as part of the CUDA Toolkit.
+However, it is recommended that you download the latest release from the
 [product page](https://developer.nvidia.com/nsight-systems) directly.
-It is also installed as part of the CUDA Toolkit. To launch the GUI, run the following
-executable, depending on your CUDA Toolkit version:
-* `/usr/local/cuda-10.1/nsight-systems-2019.3.7.5/Host-x86_64/nsight-sys`
-* `/usr/local/cuda-10.2/nsight-systems-2019.5.2/host-linux-x64/nsight-sys`
-* `/usr/local/cuda-11.0/nsight-systems-2020.3.2/host-linux-x64/nsight-sys`
 
 ## Code Coverage
 


### PR DESCRIPTION
Signed-off-by: Rong Ou <rong.ou@gmail.com>

This is messier than I thought. There is a shell script in the cuda bin directory, but it doesn't work. In CUDA 11.2 they renamed the binary to `nsys-ui`. Anyway, I only listed the 3 versions we currently support.

@sameerz @gerashegalov 