### PR TITLE
Add --use-decimals flag to TPC-DS ConvertFiles

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -4744,19 +4744,21 @@ object ConvertFiles {
       case "parquet" =>
         csvToParquet(
           spark,
-          conf.input(),
-          conf.output(),
-          conf.coalesce,
-          conf.repartition,
-          conf.withPartitioning())
+          baseInput = conf.input(),
+          baseOutput = conf.output(),
+          coalesce = conf.coalesce,
+          repartition = conf.repartition,
+          writePartitioning = conf.withPartitioning(),
+          useDecimalType = conf.useDecimals())
       case "orc" =>
         csvToOrc(
           spark,
-          conf.input(),
-          conf.output(),
-          conf.coalesce,
-          conf.repartition,
-          conf.withPartitioning())
+          baseInput = conf.input(),
+          baseOutput = conf.output(),
+          coalesce = conf.coalesce,
+          repartition = conf.repartition,
+          writePartitioning = conf.withPartitioning(),
+          useDecimalType = conf.useDecimals())
     }
   }
 }
@@ -4768,6 +4770,7 @@ class FileConversionConf(arguments: Seq[String]) extends ScallopConf(arguments) 
   val coalesce = propsLong[Int]("coalesce")
   val repartition = propsLong[Int]("repartition")
   val withPartitioning = opt[Boolean](default = Some(false))
+  val useDecimals = opt[Boolean](default = Some(false))
   verify()
   BenchUtils.validateCoalesceRepartition(coalesce, repartition)
 }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/tpcds/TpcdsLikeSpark.scala
@@ -4743,7 +4743,7 @@ object ConvertFiles {
     conf.outputFormat() match {
       case "parquet" =>
         csvToParquet(
-          spark,
+          spark = spark,
           baseInput = conf.input(),
           baseOutput = conf.output(),
           coalesce = conf.coalesce,
@@ -4752,7 +4752,7 @@ object ConvertFiles {
           useDecimalType = conf.useDecimals())
       case "orc" =>
         csvToOrc(
-          spark,
+          spark = spark,
           baseInput = conf.input(),
           baseOutput = conf.output(),
           coalesce = conf.coalesce,


### PR DESCRIPTION
This adds the ability to specify to use decimal types when converting TPC-DS data to Parquet when using spark-submit with the ConvertFiles utility,