### PR TITLE
Decimal Support for writing Parquet

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -464,13 +464,13 @@ Accelerator supports are described below.
 <td>S</td>
 <td>S*</td>
 <td>S</td>
-<td>S*</td>
-<td>S</td>
+<td><em>PS* (Only supported for Parquet)</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
-<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
-<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -464,13 +464,13 @@ Accelerator supports are described below.
 <td>S</td>
 <td>S*</td>
 <td>S</td>
+<td>S*</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
+<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
+<td><em>PS* (missing nested BINARY, CALENDAR, UDT)</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -17640,7 +17640,7 @@ dates or timestamps, or for a lack of type coercion support.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td></td>
 <td><b>NS</b></td>
 <td></td>

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -220,7 +220,6 @@ class DecimalGen(DataGen):
             scale = 0
         DECIMAL_MIN = Decimal('-' + ('9' * precision) + 'e' + str(-scale))
         DECIMAL_MAX = Decimal(('9'* precision) + 'e' + str(-scale))
-        special_cases = [Decimal('0'), Decimal(DECIMAL_MIN), Decimal(DECIMAL_MAX)]
         super().__init__(DecimalType(precision, scale), nullable=nullable, special_cases=special_cases)
         self._scale = scale
         self._precision = precision

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -20,6 +20,7 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_310
+import random
 
 # test with original parquet file reader, the multi-file parallel reader for cloud, and coalesce file reader for
 # non-cloud
@@ -32,9 +33,22 @@ reader_opt_confs = [original_parquet_file_reader_conf, multithreaded_parquet_fil
 writer_confs={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
               'spark.sql.legacy.parquet.int96RebaseModeInWrite': 'CORRECTED'}
 
+# https://github.com/rapidsai/cudf/issues/7152
+# The above bug in cudf causes problem writing Decimals with precision < 10
+random.seed(23423)
 parquet_write_gens_list = [
-        [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
-            string_gen, boolean_gen, date_gen, timestamp_gen]]
+    [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
+     string_gen, boolean_gen, date_gen, timestamp_gen,
+     DecimalGen(precision=10, scale=random.randint(1,10)),
+     DecimalGen(precision=11, scale=random.randint(1,11)),
+     DecimalGen(precision=12, scale=random.randint(1,12)),
+     DecimalGen(precision=13, scale=random.randint(1,13)),
+     DecimalGen(precision=14, scale=random.randint(1,14)),
+     DecimalGen(precision=15, scale=random.randint(1,15)),
+     DecimalGen(precision=16, scale=random.randint(1,16)),
+     DecimalGen(precision=17, scale=random.randint(1,17)),
+     DecimalGen(precision=18, scale=random.randint(1,18))]
+]
 
 parquet_ts_write_options = ['INT96', 'TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS']
 
@@ -42,6 +56,7 @@ parquet_ts_write_options = ['INT96', 'TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS']
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 @pytest.mark.parametrize('ts_type', parquet_ts_write_options)
+@allow_non_gpu("CoalesceExec")
 def test_write_round_trip(spark_tmp_path, parquet_gens, v1_enabled_list, ts_type, reader_confs):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -112,6 +127,7 @@ def test_compress_write_round_trip(spark_tmp_path, compress, v1_enabled_list, re
 
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
 @pytest.mark.parametrize('ts_type', parquet_ts_write_options)
+@allow_non_gpu("CoalesceExec")
 def test_write_save_table(spark_tmp_path, parquet_gens, ts_type, spark_tmp_table_factory):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -47,7 +47,7 @@ parquet_ts_write_options = ['INT96', 'TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS']
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 @pytest.mark.parametrize('ts_type', parquet_ts_write_options)
-def test_parquet_write_round_trip(spark_tmp_path, parquet_gens, v1_enabled_list, ts_type,
+def test_write_round_trip(spark_tmp_path, parquet_gens, v1_enabled_list, ts_type,
                                   reader_confs):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -118,7 +118,6 @@ def test_compress_write_round_trip(spark_tmp_path, compress, v1_enabled_list, re
 
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
 @pytest.mark.parametrize('ts_type', parquet_ts_write_options)
-@allow_non_gpu("CoalesceExec")
 def test_write_save_table(spark_tmp_path, parquet_gens, ts_type, spark_tmp_table_factory):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2293,8 +2293,9 @@ object GpuOverrides {
       }),
     exec[DataWritingCommandExec](
       "Writing data",
-      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
-        TypeSig.ARRAY + TypeSig.DECIMAL).nested(), TypeSig.all),
+      ExecChecks((TypeSig.commonCudfTypes +
+        TypeSig.DECIMAL.withPsNote(TypeEnum.DECIMAL, "Only supported for Parquet")).nested(),
+        TypeSig.all),
       (p, conf, parent, r) => new SparkPlanMeta[DataWritingCommandExec](p, conf, parent, r) {
         override val childDataWriteCmds: scala.Seq[DataWritingCommandMeta[_]] =
           Seq(GpuOverrides.wrapDataWriteCmds(p.cmd, conf, Some(this)))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -1312,7 +1312,7 @@ object SupportedOpsDocs {
     println("<td>S</td>") // DATE
     println("<td>S</td>") // TIMESTAMP
     println("<td>S</td>") // STRING
-    println("<td><b>NS</b></td>") // DECIMAL
+    println("<td>S</td>") // DECIMAL
     println("<td></td>") // NULL
     println("<td><b>NS</b></td>") // BINARY
     println("<td></td>") // CALENDAR

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -44,7 +44,13 @@ object GpuOrcFileFormat extends Logging {
 
   def tagGpuSupport(meta: RapidsMeta[_, _, _],
                     spark: SparkSession,
-                    options: Map[String, String]): Option[GpuOrcFileFormat] = {
+                    options: Map[String, String],
+                    schema: StructType): Option[GpuOrcFileFormat] = {
+
+
+    if(!schema.forall(field => GpuOverrides.isSupportedType(field.dataType))) {
+      meta.willNotWorkOnGpu("Not all datatypes are supported")
+    }
 
     if (!meta.conf.isOrcEnabled) {
       meta.willNotWorkOnGpu("ORC input and output has been disabled. To enable set" +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -47,8 +47,8 @@ object GpuOrcFileFormat extends Logging {
                     options: Map[String, String],
                     schema: StructType): Option[GpuOrcFileFormat] = {
 
-    val unSupportedTypes = schema.filter(field => !GpuOverrides.isSupportedType(field.dataType))
-    if (!unSupportedTypes.isEmpty) {
+    val unSupportedTypes = schema.filterNot(field => GpuOverrides.isSupportedType(field.dataType))
+    if (unSupportedTypes.nonEmpty) {
       meta.willNotWorkOnGpu(s"These types aren't supported for orc $unSupportedTypes")
     }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,9 +47,9 @@ object GpuOrcFileFormat extends Logging {
                     options: Map[String, String],
                     schema: StructType): Option[GpuOrcFileFormat] = {
 
-
-    if(!schema.forall(field => GpuOverrides.isSupportedType(field.dataType))) {
-      meta.willNotWorkOnGpu("Not all datatypes are supported")
+    val unSupportedTypes = schema.filter(field => !GpuOverrides.isSupportedType(field.dataType))
+    if (!unSupportedTypes.isEmpty) {
+      meta.willNotWorkOnGpu(s"These types aren't supported for orc $unSupportedTypes")
     }
 
     if (!meta.conf.isOrcEnabled) {


### PR DESCRIPTION
This PR adds support for writing Decimal types to Parquet file. 

There is an issue in cudf at the time of writing this PR (rapidsai/cudf#7152) i.e. Decimals with precision < 10 are not able to be read back using Spark-cpu. 

This depends on rapidsai/cudf#7153

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
