### PR TITLE
Enable ANSI mode for CAST string to timestamp

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -791,10 +791,7 @@ case class GpuCast(
       // When ANSI mode is enabled, we need to throw an exception if any values could not be
       // converted
       if (ansiMode) {
-        val wasNotNull = withResource(input.isNull()) { wasNull =>
-          wasNull.not()
-        }
-        withResource(wasNotNull) { wasNotNull =>
+        withResource(input.isNotNull) { wasNotNull =>
           withResource(finalResult.isNull) { isNull =>
             withResource(wasNotNull.and(isNull)) { notConverted =>
               if (notConverted.any().getBoolean) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -791,12 +791,14 @@ case class GpuCast(
       // When ANSI mode is enabled, we need to throw an exception if any values could not be
       // converted
       if (ansiMode) {
-        withResource(input.isNotNull) { wasNotNull =>
-          withResource(finalResult.isNull) { isNull =>
-            withResource(wasNotNull.and(isNull)) { notConverted =>
-              if (notConverted.any().getBoolean) {
-                throw new DateTimeException(
-                  "One or more values could not be converted to TimestampType")
+        closeOnExcept(finalResult) { finalResult =>
+          withResource(input.isNotNull) { wasNotNull =>
+            withResource(finalResult.isNull) { isNull =>
+              withResource(wasNotNull.and(isNull)) { notConverted =>
+                if (notConverted.any().getBoolean) {
+                  throw new DateTimeException(
+                    "One or more values could not be converted to TimestampType")
+                }
               }
             }
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import java.text.SimpleDateFormat
+import java.time.DateTimeException
 
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
 
@@ -784,8 +785,28 @@ case class GpuCast(
               convertTimestampOrNull(sanitizedInput, TIMESTAMP_REGEX_YYYY, "%Y"))))
 
       // handle special dates like "epoch", "now", etc.
-      specialDates.foldLeft(converted)((prev, specialDate) =>
+      val finalResult = specialDates.foldLeft(converted)((prev, specialDate) =>
         specialTimestampOr(sanitizedInput, specialDate._1, specialDate._2, prev))
+
+      // When ANSI mode is enabled, we need to throw an exception if any values could not be
+      // converted
+      if (ansiMode) {
+        val wasNotNull = withResource(input.isNull()) { wasNull =>
+          wasNull.not()
+        }
+        withResource(wasNotNull) { wasNotNull =>
+          withResource(finalResult.isNull) { isNull =>
+            withResource(wasNotNull.and(isNull)) { notConverted =>
+              if (notConverted.any().getBoolean) {
+                throw new DateTimeException(
+                  "One or more values could not be converted to TimestampType")
+              }
+            }
+          }
+        }
+      }
+
+      finalResult
     }
   }
 


### PR DESCRIPTION
This PR adds a check to the CAST from string to timestamp to detect if any non-null values were not converted successfully. This check only happens in ANSI mode and will throw a `DateTimeException` if there were values that could not be converted. This matches Spark's behavior.

Partially addresses https://github.com/NVIDIA/spark-rapids/issues/1517 - we have different code paths for `CAST` and other methods of converting string to timestamp (such as `to_date`, `to_timestamp`, `unix_timestamp`, and `to_unix_timestamp`). I filed https://github.com/NVIDIA/spark-rapids/issues/1556 for adding tests for these functions.