### PR TITLE
enable sum as a window aggregation operator for decimal

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -16451,7 +16451,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S*</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -16472,7 +16472,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S*</td>
 <td> </td>
 <td> </td>
 <td> </td>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1716,9 +1716,18 @@ object GpuOverrides {
       }),
     expr[Sum](
       "Sum aggregate operator",
-      ExprChecks.fullAgg(
-        TypeSig.LONG + TypeSig.DOUBLE, TypeSig.LONG + TypeSig.DOUBLE + TypeSig.DECIMAL,
-        Seq(ParamCheck("input", TypeSig.integral + TypeSig.fp, TypeSig.numeric))),
+      ExprChecksImpl(
+        ExprChecks.fullAgg(
+          TypeSig.LONG + TypeSig.DOUBLE, TypeSig.LONG + TypeSig.DOUBLE + TypeSig.DECIMAL,
+          Seq(ParamCheck("input", TypeSig.integral + TypeSig.fp, TypeSig.numeric))
+        ).asInstanceOf[ExprChecksImpl].contexts
+          ++
+          ExprChecks.windowOnly(
+            TypeSig.LONG + TypeSig.DOUBLE + TypeSig.DECIMAL,
+            TypeSig.LONG + TypeSig.DOUBLE + TypeSig.DECIMAL,
+            Seq(ParamCheck("input", TypeSig.numeric, TypeSig.numeric))
+          ).asInstanceOf[ExprChecksImpl].contexts
+      ),
       (a, conf, p, r) => new AggExprMeta[Sum](a, conf, p, r) {
         override def tagExprForGpu(): Unit = {
           val dataType = a.child.dataType

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -45,14 +45,15 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     windowSpec: WindowSpec, scale: Int = 0): DataFrame => DataFrame =
     (df: DataFrame) => {
       val decimalType = DecimalType(precision = 18, scale = scale)
+      val sumDecimalType = DecimalType(precision = 8, scale = 0)
       df.select(
         col("uid").cast(decimalType),
         col("dollars"),
         col("dateLong").cast(decimalType)
       ).withColumn("decimalDollars", col("dollars").cast(decimalType)
+      ).withColumn("sumDecimalDollars", col("dollars").cast(sumDecimalType)
       ).select(
-        // TODO: test sum on decimal columns when underlying cuDF implementation is ready
-        sum("dollars").over(windowSpec),
+        sum("sumDecimalDollars").over(windowSpec),
         min("decimalDollars").over(windowSpec),
         max("decimalDollars").over(windowSpec),
         count("decimalDollars").over(windowSpec)
@@ -63,14 +64,15 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     windowSpec: WindowSpec, scale: Int = 0): DataFrame => DataFrame =
     (df: DataFrame) => {
       val decimalType = DecimalType(precision = 18, scale = scale)
+      val sumDecimalType = DecimalType(precision = 8, scale = 0)
       df.select(
         col("uid").cast(decimalType),
         col("dollars"),
         col("dateLong").cast(decimalType)
       ).withColumn("decimalDollars", col("dollars").cast(decimalType)
+      ).withColumn("sumDecimalDollars", col("dollars").cast(sumDecimalType)
       ).select(
-        // TODO: test sum on decimal columns when underlying cuDF implementation is ready
-        sum("dollars").over(windowSpec),
+        sum("sumDecimalDollars").over(windowSpec),
         min("decimalDollars").over(windowSpec),
         max("decimalDollars").over(windowSpec),
         row_number().over(windowSpec),


### PR DESCRIPTION
This pull request is to enable sum as a window aggregation operator for decimal columns, which is one of tasks listed in #1333.
NOTICE:  Due to hard-code precision promotion in the result type of sum expression, we can only support sum with decimal data whose precision not greater than 8.