### PR TITLE
Support TakeOrderedAndProject

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,6 +17,33 @@ with `collect`, `show` or `write` a new `DataFrame` is constructed causing Spark
 query. This is why `spark.rapids.sql.enabled` is still respected when running, even if explain shows
 stale results.
 
+### Why does the plan for the GPU query look different from the CPU query?
+
+Typically, there is a one to one mapping between CPU stages in a plan and GPU stages.  There are a
+few places where this is not the case.
+
+* `WholeStageCodeGen` - The GPU plan typically does not do code generation, and does not support generating code for an
+entire stage in the plan. Code generation is typically used to reduce the cost of processing data
+one row at a time. The GPU plan processes the data in a columnar format, so the costs are different.
+
+* ColumnarToRow and RowToColumnar Transitions - The CPU version of Spark plans typically process data in a row based format. The main exception to
+this is reading some kinds of columnar data, like parquet. When transitioning between the CPU and
+the GPU require transitions between row and columnar formatted data.
+
+* `GpuCoalesceBatches` and `GpuShuffleCoalesce` - Processing data on the GPU often scales sublinerarly. That means doubling the data does takes less
+than half the time. Because of this we want to process larger batches of data when possible. These
+operators will try to build larger batches of data to process.
+
+* `SortMergeJoin` - The RAPIDS accelerator does not support sort merge joins yet. For now we
+translate sort merge joins into shuffled hash joins. Because of this there are times when
+Sorts may be removed or other sorts added to meet the ordering requirements of the query.
+
+* `TakeOrderedAndProject` - The `TakeOrderedAndProject` operator will take the top N entries in each task,
+shuffle the results to a single executor and then take the top N results from that. The GPU
+plan often has more metrics than the CPU versions do, and when we tried to combine all of these
+operations into a single stage the metrics where confusing to understand what was happening. Instead
+we split the single stage up into multiple smaller parts so the metrics are clearer.
+
 ### What versions of Apache Spark does the RAPIDS Accelerator for Apache Spark support?
 
 The RAPIDS Accelerator for Apache Spark requires version 3.0.0 or 3.0.1 of Apache Spark. Because the

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -271,6 +271,7 @@ Name | Description | Default Value | Notes
 <a name="sql.exec.ProjectExec"></a>spark.rapids.sql.exec.ProjectExec|The backend for most select, withColumn and dropColumn statements|true|None|
 <a name="sql.exec.RangeExec"></a>spark.rapids.sql.exec.RangeExec|The backend for range operator|true|None|
 <a name="sql.exec.SortExec"></a>spark.rapids.sql.exec.SortExec|The backend for the sort operator|true|None|
+<a name="sql.exec.TakeOrderedAndProjectExec"></a>spark.rapids.sql.exec.TakeOrderedAndProjectExec|Take the first limit elements as defined by the sortOrder, and do projection if needed.|true|None|
 <a name="sql.exec.UnionExec"></a>spark.rapids.sql.exec.UnionExec|The backend for the union operator|true|None|
 <a name="sql.exec.CustomShuffleReaderExec"></a>spark.rapids.sql.exec.CustomShuffleReaderExec|A wrapper of shuffle query stage|true|None|
 <a name="sql.exec.HashAggregateExec"></a>spark.rapids.sql.exec.HashAggregateExec|The backend for hash based aggregations|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -258,8 +258,8 @@ Accelerator supports are described below.
 <td>S</td>
 <td>S*</td>
 <td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S*</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -281,8 +281,8 @@ Accelerator supports are described below.
 <td>S</td>
 <td>S*</td>
 <td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S*</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -357,6 +357,29 @@ Accelerator supports are described below.
 <td><em>PS* (missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
 <td><b>NS</b></td>
 <td><em>PS* (missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>TakeOrderedAndProjectExec</td>
+<td>Take the first limit elements as defined by the sortOrder, and do projection if needed.</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S*</td>
+<td>S</td>
+<td>S*</td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -371,7 +371,7 @@ class TpcdsRunner:
     }
     if not self.tpcds_format in formats:
         raise RuntimeError("{} is not a supported tpcds input type".format(self.tpcds_format))
-    formats.get(self.tpcds_format)(jvm_session, self.tpcds_path, True)
+    formats.get(self.tpcds_format)(jvm_session, self.tpcds_path, True, True)
 
   def do_test_query(self, query):
     spark = get_spark_i_know_what_i_am_doing()

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -221,13 +221,13 @@ class DecimalGen(DataGen):
         DECIMAL_MIN = Decimal('-' + ('9' * precision) + 'e' + str(-scale))
         DECIMAL_MAX = Decimal(('9'* precision) + 'e' + str(-scale))
         super().__init__(DecimalType(precision, scale), nullable=nullable, special_cases=special_cases)
-        self._scale = scale
-        self._precision = precision
+        self.scale = scale
+        self.precision = precision
         pattern = "[0-9]{1,"+ str(precision) + "}e" + str(-scale)
         self.base_strs = sre_yield.AllStrings(pattern, flags=0, charset=sre_yield.CHARSET, max_count=_MAX_CHOICES)
 
     def __repr__(self):
-        return super().__repr__() + '(' + str(self._precision) + ',' + str(self._scale) + ')'
+        return super().__repr__() + '(' + str(self.precision) + ',' + str(self.scale) + ')'
 
     def start(self, rand):
         strs = self.base_strs

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -34,6 +34,14 @@ def test_single_orderby(data_gen, order):
             lambda spark : unary_op_df(spark, data_gen).orderBy(order),
             conf = allow_negative_scale_of_decimal_conf)
 
+# SPARK CPU itself has issue with negative scale for take ordered and project
+orderable_without_neg_decimal = [n for n in (orderable_gens + orderable_not_null_gen) if not (isinstance(n, DecimalGen) and n.scale < 0)]
+@pytest.mark.parametrize('data_gen', orderable_without_neg_decimal, ids=idfn)
+@pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
+def test_single_orderby_with_limit(data_gen, order):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, data_gen).orderBy(order).limit(100))
+
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
@@ -52,3 +60,10 @@ def test_multi_orderby(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).orderBy(f.col('a'), f.col('b').desc()),
             conf = allow_negative_scale_of_decimal_conf)
+
+# SPARK CPU itself has issue with negative scale for take ordered and project
+orderable_gens_sort_without_neg_decimal = [n for n in orderable_gens_sort if not (isinstance(n, DecimalGen) and n.scale < 0)]
+@pytest.mark.parametrize('data_gen', orderable_gens_sort_without_neg_decimal, ids=idfn)
+def test_multi_orderby_with_limit(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : binary_op_df(spark, data_gen).orderBy(f.col('a'), f.col('b').desc()).limit(100))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -19,15 +19,19 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{NvtxColor, Table}
+import ai.rapids.cudf
 import com.nvidia.spark.rapids.GpuMetricNames._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning}
-import org.apache.spark.sql.execution.{CollectLimitExec, LimitExec, SparkPlan}
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression, NullsFirst, NullsLast, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, Distribution, Partitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.execution.{CollectLimitExec, LimitExec, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 /**
  * Helper trait which defines methods that are shared by both
@@ -137,4 +141,220 @@ class GpuCollectLimitMeta(
       ShimLoader.getSparkShims.getGpuShuffleExchangeExec(GpuSinglePartitioning(Seq.empty),
         GpuLocalLimitExec(collectLimit.limit, childPlans(0).convertIfNeeded())))
 
+}
+
+object GpuTopN extends Arm {
+  private[this] def getOrderArgs(
+      sortOrder: Seq[SortOrder],
+      inputTbl: Table): Seq[Table.OrderByArg] = {
+    val orderByArgs = if (sortOrder.nonEmpty) {
+      sortOrder.zipWithIndex.map { case (order, index) =>
+        if (order.isAscending) {
+          Table.asc(index, order.nullOrdering == NullsFirst)
+        } else {
+          Table.desc(index, order.nullOrdering == NullsLast)
+        }
+      }
+    } else {
+      (0 until inputTbl.getNumberOfColumns).map { index =>
+        Table.asc(index, true)
+      }
+    }
+    orderByArgs
+  }
+
+  private def doGpuSort(
+      inputTbl: Table,
+      sortOrder: Seq[SortOrder],
+      types: Seq[DataType]): ColumnarBatch = {
+    val orderByArgs = getOrderArgs(sortOrder, inputTbl)
+    val numSortCols = sortOrder.length
+    withResource(inputTbl.orderBy(orderByArgs: _*)) { resultTbl =>
+      GpuColumnVector.from(resultTbl, types.toArray, numSortCols, resultTbl.getNumberOfColumns)
+    }
+  }
+
+  private[this] def sortBatch(
+      sortOrder: Seq[SortOrder],
+      inputBatch: ColumnarBatch,
+      sortTime: SQLMetric): ColumnarBatch = {
+    withResource(new NvtxWithMetrics("sort", NvtxColor.DARK_GREEN, sortTime)) { _ =>
+      var outputTypes: Seq[DataType] = Nil
+      var inputTbl: Table = null
+      var inputCvs: Seq[GpuColumnVector] = Nil
+      try {
+        if (sortOrder.nonEmpty) {
+          inputCvs = SortUtils.getGpuColVectorsAndBindReferences(inputBatch, sortOrder)
+          inputTbl = new cudf.Table(inputCvs.map(_.getBase): _*)
+          outputTypes = sortOrder.map(_.child.dataType) ++
+              GpuColumnVector.extractTypes(inputBatch)
+        } else if (inputBatch.numCols() > 0) {
+          inputTbl = GpuColumnVector.from(inputBatch)
+          outputTypes = GpuColumnVector.extractTypes(inputBatch)
+        }
+        doGpuSort(inputTbl, sortOrder, outputTypes)
+      } finally {
+        inputCvs.safeClose()
+        if (inputTbl != null) {
+          inputTbl.close()
+        }
+      }
+    }
+  }
+
+  private[this] def concatAndClose(a: SpillableColumnarBatch, b: ColumnarBatch): ColumnarBatch = {
+    val dataTypes = GpuColumnVector.extractTypes(b)
+    val aTable = withResource(a) { a =>
+      withResource(a.getColumnarBatch()) { aBatch =>
+        GpuColumnVector.from(aBatch)
+      }
+    }
+    val ret = withResource(aTable) { aTable =>
+      withResource(b) { b =>
+        withResource(GpuColumnVector.from(b)) { bTable =>
+          Table.concatenate(aTable, bTable)
+        }
+      }
+    }
+    withResource(ret) { ret =>
+      GpuColumnVector.from(ret, dataTypes)
+    }
+  }
+
+  private[this] def takeN(batch: ColumnarBatch, count: Int): ColumnarBatch = {
+    val end = Math.min(count, batch.numRows())
+    val numColumns = batch.numCols()
+    closeOnExcept(new Array[ColumnVector](numColumns)) { columns =>
+      val bases = GpuColumnVector.extractBases(batch)
+      (0 until numColumns).foreach { i =>
+        columns(i) = GpuColumnVector.from(bases(i).subVector(0, end), batch.column(i).dataType())
+      }
+      new ColumnarBatch(columns, end)
+    }
+  }
+
+  def apply(limit: Int,
+      sortOrder: Seq[SortOrder],
+      batch: ColumnarBatch,
+      sortTime: SQLMetric): ColumnarBatch = {
+    withResource(sortBatch(sortOrder, batch, sortTime)) { sorted =>
+      takeN(sorted, limit)
+    }
+  }
+
+  def apply(limit: Int,
+      sortOrder: Seq[SortOrder],
+      iter: Iterator[ColumnarBatch],
+      totalTime: SQLMetric,
+      sortTime: SQLMetric,
+      inputBatches: SQLMetric,
+      inputRows: SQLMetric,
+      outputBatches: SQLMetric,
+      outputRows: SQLMetric): Iterator[ColumnarBatch] =
+    new Iterator[ColumnarBatch]() {
+      override def hasNext: Boolean = iter.hasNext
+
+      private[this] var pending: Option[SpillableColumnarBatch] = None
+
+      override def next(): ColumnarBatch = {
+        while (iter.hasNext) {
+          withResource(new NvtxWithMetrics("TOP N", NvtxColor.ORANGE, totalTime)) { _ =>
+            val input = iter.next()
+            inputBatches += 1
+            inputRows += input.numRows()
+            lazy val totalSize = GpuColumnVector.getTotalDeviceMemoryUsed(input) +
+                pending.map(_.sizeInBytes).getOrElse(0L)
+
+            val runningResult = if (pending.isEmpty) {
+              withResource(input) { input =>
+                apply(limit, sortOrder, input, sortTime)
+              }
+            } else if (totalSize > Integer.MAX_VALUE) {
+              // The intermediate size is likely big enough we don't want to risk an overflow,
+              // so sort/slice before we concat and sort/slice again.
+              val tmp = withResource(input) { input =>
+                apply(limit, sortOrder, input, sortTime)
+              }
+              withResource(concatAndClose(pending.get, tmp)) { concat =>
+                apply(limit, sortOrder, concat, sortTime)
+              }
+            } else {
+              // The intermediate size looks like we could never overflow the indexes so
+              // do it the more efficient way and concat first followed by the sort/slice
+              withResource(concatAndClose(pending.get, input)) { concat =>
+                apply(limit, sortOrder, concat, sortTime)
+              }
+            }
+            pending =
+                Some(SpillableColumnarBatch(runningResult, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
+          }
+        }
+        val ret = pending.get.getColumnarBatch()
+        pending.get.close()
+        pending = None
+        outputBatches += 1
+        outputRows += ret.numRows()
+        ret
+      }
+    }
+}
+
+/**
+ * Take the first limit elements as defined by the sortOrder, and do projection if needed.
+ * This is logically equivalent to having a Limit operator after a `SortExec` operator,
+ * or having a `ProjectExec` operator between them.
+ * This could have been named TopK, but Spark's top operator does the opposite in ordering
+ * so we name it TakeOrdered to avoid confusion.
+ */
+case class GpuTopN(
+    limit: Int,
+    sortOrder: Seq[SortOrder],
+    projectList: Seq[NamedExpression],
+    child: SparkPlan) extends GpuExec with UnaryExecNode {
+
+  override def output: Seq[Attribute] = {
+    projectList.map(_.toAttribute)
+  }
+
+  override lazy val additionalMetrics: Map[String, SQLMetric] = Map(
+    NUM_INPUT_ROWS -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_INPUT_ROWS),
+    NUM_INPUT_BATCHES -> SQLMetrics.createMetric(sparkContext, DESCRIPTION_NUM_INPUT_BATCHES),
+    "sortTime" -> SQLMetrics.createNanoTimingMetric(sparkContext, "sort time")
+  )
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val boundSortExprs = GpuBindReferences.bindReferences(sortOrder, child.output)
+    val boundProjectExprs = GpuBindReferences.bindGpuReferences(projectList, child.output)
+    val totalTime = metrics(TOTAL_TIME)
+    val inputBatches = metrics(NUM_INPUT_BATCHES)
+    val inputRows = metrics(NUM_INPUT_ROWS)
+    val outputBatches = metrics(NUM_OUTPUT_BATCHES)
+    val outputRows = metrics(NUM_OUTPUT_ROWS)
+    val sortTime = metrics("sortTime")
+    child.executeColumnar().mapPartitions { iter =>
+      val topN = GpuTopN(limit, boundSortExprs, iter, totalTime, sortTime,
+        inputBatches, inputRows, outputBatches, outputRows)
+      if (projectList != child.output) {
+        topN.map { batch =>
+          GpuProjectExec.projectAndClose(batch, boundProjectExprs, totalTime)
+        }
+      } else {
+        topN
+      }
+    }
+  }
+
+  protected override def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+
+  override def outputOrdering: Seq[SortOrder] = sortOrder
+
+  override def outputPartitioning: Partitioning = SinglePartition
+
+  override def simpleString(maxFields: Int): String = {
+    val orderByString = truncatedString(sortOrder, "[", ",", "]", maxFields)
+    val outputString = truncatedString(output, "[", ",", "]", maxFields)
+
+    s"GpuTopN(limit=$limit, orderBy=$orderByString, output=$outputString)"
+  }
 }


### PR DESCRIPTION
This fixes #1575 and fixes #103

I did not test topN with nested types going along for the ride (not being sorted on, but in the table that is being sorted), so I didn't turn them on.  They should work, but it was not a requirement.

My initial performance tests showed a little bit of a performance gain over not supporting take ordered and project, but it was not a huge amount of data so it is hard to tell.