### PR TITLE
Fix Github documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -2,7 +2,7 @@
 name: Documentation request
 about: Report incorrect or needed documentation
 title: "[DOC]"
-labels: "? - Needs Triage, doc"
+labels: "? - Needs Triage, documentation"
 assignees: ''
 
 ---


### PR DESCRIPTION
This should fix the Github issue template so the `documentation` label is correctly applied to documentation issues when they are created.