### PR TITLE
Fix label in documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -2,7 +2,7 @@
 name: Documentation request
 about: Report incorrect or needed documentation
 title: "[DOC]"
-labels: "? - Needs Triage, doc"
+labels: "? - Needs Triage, documentation"
 assignees: ''
 
 ---


### PR DESCRIPTION
Change label `doc` to `documentation` in issue template