### PR TITLE
Increase the Databricks cluster's timeout [skip ci]

### DIFF
--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -28,7 +28,7 @@ def main():
   token = ''
   sshkey = ''
   cluster_name = 'CI-GPU-databricks-0.4.0-SNAPSHOT'
-  idletime = 240
+  idletime = 360
   runtime = '7.0.x-gpu-ml-scala2.12'
   num_workers = 1
   worker_type = 'g4dn.xlarge'


### PR DESCRIPTION
    Increase the Databricks cluster's timeout.

    As more test cases are added, the timeout of Databricks cluster needs to be increased to run all the tests.