### PR TITLE
Disable float round/bround by default

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1916,8 +1916,8 @@ Accelerator support is described below.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td>S</td>
-<td>S</td>
+<td><em>PS (result may round slightly differently)</em></td>
+<td><em>PS (result may round slightly differently)</em></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -10803,8 +10803,8 @@ Accelerator support is described below.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td>S</td>
-<td>S</td>
+<td><em>PS (result may round slightly differently)</em></td>
+<td><em>PS (result may round slightly differently)</em></td>
 <td> </td>
 <td> </td>
 <td> </td>

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -221,6 +221,7 @@ def test_decimal_bround(data_gen):
                 'bround(a)',
                 'bround(a, -1)',
                 'bround(a, 1)',
+                'bround(a, 2)',
                 'bround(a, 10)'),
                 conf=allow_negative_scale_of_decimal_conf)
 
@@ -233,6 +234,7 @@ def test_decimal_round(data_gen):
                 'round(a)',
                 'round(a, -1)',
                 'round(a, 1)',
+                'round(a, 2)',
                 'round(a, 10)'),
                conf=allow_negative_scale_of_decimal_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1807,9 +1807,20 @@ object GpuOverrides {
       "Round an expression to d decimal places using HALF_EVEN rounding mode",
       ExprChecks.binaryProjectNotLambda(
         TypeSig.numeric, TypeSig.numeric,
-        ("value", TypeSig.numeric, TypeSig.numeric),
+        ("value", TypeSig.numeric +
+            TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
+            TypeSig.psNote(TypeEnum.DOUBLE, "result may round slightly differently"),
+            TypeSig.numeric),
         ("scale", TypeSig.lit(TypeEnum.INT), TypeSig.lit(TypeEnum.INT))),
       (a, conf, p, r) => new BinaryExprMeta[BRound](a, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          a.child.dataType match {
+            case FloatType | DoubleType if !conf.isIncompatEnabled =>
+              willNotWorkOnGpu("rounding floating point numbers may be slightly off " +
+                  "compared to Spark's result")
+            case _ => // NOOP
+          }
+        }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuBRound(lhs, rhs)
       }),
@@ -1817,9 +1828,20 @@ object GpuOverrides {
       "Round an expression to d decimal places using HALF_UP rounding mode",
       ExprChecks.binaryProjectNotLambda(
         TypeSig.numeric, TypeSig.numeric,
-        ("value", TypeSig.numeric, TypeSig.numeric),
+        ("value", TypeSig.numeric +
+            TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
+            TypeSig.psNote(TypeEnum.DOUBLE, "result may round slightly differently"),
+            TypeSig.numeric),
         ("scale", TypeSig.lit(TypeEnum.INT), TypeSig.lit(TypeEnum.INT))),
       (a, conf, p, r) => new BinaryExprMeta[Round](a, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          a.child.dataType match {
+            case FloatType | DoubleType if !conf.isIncompatEnabled =>
+              willNotWorkOnGpu("rounding floating point numbers may be slightly off " +
+                  "compared to Spark's result")
+            case _ => // NOOP
+          }
+        }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuRound(lhs, rhs)
       }),


### PR DESCRIPTION
This is related to #1573. It does not fix the underlying problem, but it disables the problematic operators by default.

I decided to reuse the incompat config for these instead of creating a new config. I can change that if we feel it would be better.