### PR TITLE
Limit length of spark app name in BenchmarkRunner

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -56,7 +56,12 @@ object BenchmarkRunner {
 
     benchmarks.get(conf.benchmark().toLowerCase) match {
       case Some(bench) =>
-        val appName = s"${bench.name()} Like Bench ${conf.query().mkString(",")}"
+        // only include the query name in the app name if a single query is being run
+        val appName = if (conf.query().size == 1) {
+          s"${bench.name()} Like Bench ${conf.query().head}"
+        } else {
+          s"${bench.name()} Like Bench"
+        }
         val spark = SparkSession.builder.appName(appName).getOrCreate()
         spark.sparkContext.setJobDescription("Register input tables")
         conf.inputFormat().toLowerCase match {


### PR DESCRIPTION
Only include query name in spark app name when a single query is being run.

I needed this to resolve an issue when running automated benchmarks in Kubernetes, where the long app name exceeded the allowed length for pod names.