### PR TITLE
Enable nightly test checks for Apache Spark

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -434,4 +434,5 @@ def enable_cudf_udf(request):
 def enable_rapids_udf_example_native(request):
     native_enabled = request.config.getoption("rapids_udf_example_native")
     if not native_enabled:
-        skip_unless_nightly_tests("rapids_udf_example_native is not configured to run")
+        # udf_example_native tests are not required for any test runs
+        pytest.skip("rapids_udf_example_native is not configured to run")

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -21,7 +21,7 @@ set -ex
 
 ## export 'M2DIR' so that shims can get the correct cudf/spark dependency info
 export M2DIR="$WORKSPACE/.m2"
-mvn -U -B -Pinclude-databricks,snapshot-shims clean deploy $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR
+mvn -U -B -Pinclude-databricks,snapshot-shims clean deploy $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dpytest.TEST_TAGS='' -Dpytest.TEST_TYPE="nightly"
 # Run unit tests against other spark versions
 mvn -U -B -Pspark301tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR
 mvn -U -B -Pspark302tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR


### PR DESCRIPTION
This addresses part of #1421

The databricks tests will wait on #1549 
The EMR tests have not been touched yet and will likely need a bit of work as well.