### PR TITLE
update blossom-ci for security updates [skip ci]

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,102 +12,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A workflow to trigger blossom-CI on self-hosted runner
+# A workflow to trigger ci on hybrid infra (github + self hosted runner)
 name: Blossom-CI
 on:
   issue_comment:
     types: [created]
-
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'runs-on argument'
+        required: false
+      args:
+        description: 'argument'
+        required: false
 jobs:
-  authorization:
+  Authorization:
     name: Authorization
-    # trigger on pre-defined text
-    if: github.event.comment.body == 'build'
-    runs-on: [self-hosted, linux, blossom]
+    runs-on: blossom
+    outputs:
+      args: ${{ env.args }}
+
+    # This job only runs for pull request comments
+    if: contains( '\
+      abellina,\
+      andygrove,\
+      anfeng,\
+      firestarman,\
+      GaryShen2008,\
+      jlowe,\
+      krajendrannv,\
+      kuhushukla,\
+      mythrocks,\
+      nartal1,\
+      nvdbaranec,\
+      NvTimLiu,\
+      razajafri,\
+      revans2,\
+      rongou,\
+      rwlee,\
+      sameerz,\
+      shotai,\
+      sriramch,\
+      tgravescs,\
+      wbo4958,\
+      wjxiz1992,\
+      yuange98,\
+      sperlingxx,\
+      pxLi,\
+      hyperbolic2346,\
+      gerashegalov,\
+      ttnghia,\
+      ', format('{0},', github.actor)) && github.event.comment.body == 'build'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci
         env:
           OPERATION: 'AUTH'
-          VERSION: '1'
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_KEY_DATA: ${{ secrets.BLOSSOM_KEY }}
 
-  vulnerability-scan-job:
-    name: Vulnerability scan job
-    needs: [authorization]
+  Vulnerability-scan:
+    name: Vulnerability scan
+    needs: [Authorization]
     runs-on: ubuntu-latest
     steps:
-      - name: Get pull request data
-        id: pull_request_data
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/${{ github.repository }}/pulls/{issue_id}
-          issue_id: ${{ github.event.issue.number }}
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Set blackduck project version
-        id: blackduck-project-version
-        env:
-          REF: ${{ fromJson(steps.pull_request_data.outputs.data).head.ref }}
-        run: echo "$REF-${{ github.run_id }}"
-
-      - name: Update status
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/${{ github.repository }}/statuses/{sha}
-          sha: ${{ fromJson(steps.pull_request_data.outputs.data).head.sha }}
-          target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          description: "vulnerability scan running"
-          state: "pending"
-          context: "blossom-ci"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          repository: ${{ fromJson(steps.pull_request_data.outputs.data).head.repo.full_name }}
-          ref: ${{ fromJson(steps.pull_request_data.outputs.data).head.ref }}
+          repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
+          ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}
           lfs: 'true'
 
+      # repo specific steps
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
 
-      - name: Get project data (maven)
-        run: echo "PROJECTS=$(mvn -am dependency:tree | grep maven-dependency-plugin | awk '{ out="com.nvidia:"$(NF-1);print out }' | grep rapids | xargs | sed -e 's/ /,/g')" >> $GITHUB_ENV
+      # add blackduck properties https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/631308372/Methods+for+Configuring+Analysis#Using-a-configuration-file
+      - name: Setup blackduck properties
+        run: |
+          PROJECTS=$(mvn -am dependency:tree | grep maven-dependency-plugin | awk '{ out="com.nvidia:"$(NF-1);print out }' | grep rapids | xargs | sed -e 's/ /,/g')
+          echo detect.maven.build.command="-pl=$PROJECTS -am" >> application.properties
+          echo detect.maven.included.scopes=compile >> application.properties
 
-      - name: Add mask
-        run: echo "::add-mask::${{ secrets.BLACKDUCK_URL }}"
-
-      - name: Run synopsys detect
-        id: scan_result
-        uses: blackducksoftware/github-action@2.0.1
+      - name: Run blossom action
+        uses: ravitestgit/blossom-action@main
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_KEY_DATA: ${{ secrets.BLOSSOM_KEY }}
         with:
-          args: >
-            --blackduck.url="https://${{ secrets.BLACKDUCK_URL }}"
-            --blackduck.api.token="${{ secrets.BLACKDUCK_API_TOKEN }}"
-            --detect.maven.build.command="-pl='$PROJECTS -am'"
-            --detect.maven.included.scopes=compile
-            --detect.force.success=false
-            --detect.tools.excluded=SIGNATURE_SCAN
-            --detect.parallel.processors=0
-            --detect.project.name="${{ github.repository }}"
-            --detect.project.version.name="${{ github.run_id }}"
+          args1: ${{ fromJson(needs.Authorization.outputs.args).args1 }}
+          args2: ${{ fromJson(needs.Authorization.outputs.args).args2 }}
+          args3: ${{ fromJson(needs.Authorization.outputs.args).args3 }}
 
-  vulnerability-check-trigger:
-    name: Vulnerability check & start ci job
-    needs: [vulnerability-scan-job]
-    runs-on: [self-hosted, linux, blossom]
+  Job-trigger:
+    name: Start ci job
+    needs: [Vulnerability-scan]
+    runs-on: blossom
     steps:
-      - name: Check for new issue in vulnerability scan & start ci job
+      - name: Start ci job
         run: blossom-ci
         env:
-          OPERATION: 'SCAN-CHECK-CI-JOB-START'
-          VERSION: '1'
-          BLACKDUCK_TOKEN: "${{ secrets.BLACKDUCK_API_TOKEN }}"
-          BLACKDUCK_URL: "${{ secrets.BLACKDUCK_URL }}"
-          BLACKDUCK_PROJECT_VERSION: "${{ github.run_id }}"
+          OPERATION: 'START-CI-JOB'
+          CI_SERVER: ${{ secrets.CI_SERVER }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  Post-processing:
+    name: Post processing
+    runs-on: blossom
+    if : github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Start post processing
+        run: blossom-ci
+        env:
+          OPERATION: 'POST-PROCESSING'
           CI_SERVER: ${{ secrets.CI_SERVER }}
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

To fullfill security updates from blossom and prodsec,
1. this file has to be the same as internal yaml file except the user list and java version steps, otherwise it will fail the check
2. it hides most of the code from external repo
3. it resolved the project version limit issue
4. it added better DDoS defense
5. it support the log upload from internal to external repo. we haven't enabled this

We have tested this in my forked repo for days. And this will be doc in confluence later.

**NOTE:** This has to be merged at the specific period. Please help review and DO NOT MERGE. 
I will merge this after the new self-hosted runner get deployed, and will validate the workflow after merge. Thanks!