### PR TITLE
Additional functionality docs

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Frequently Asked Questions
-nav_order: 10
+nav_order: 11
 ---
 # Frequently Asked Questions
 
@@ -205,7 +205,7 @@ user-defined functions on the GPU:
 #### RAPIDS-Accelerated UDFs
 
 UDFs can provide a RAPIDS-accelerated implementation which allows the RAPIDS Accelerator to perform
-the operation on the GPU.  See the [RAPIDS-accelerated UDF documentation](../docs/rapids-udfs.md)
+the operation on the GPU.  See the [RAPIDS-accelerated UDF documentation](additional-functionality/rapids-udfs.md)
 for details.
 
 #### Automatic Translation of Scala UDFs to Apache Spark Operations

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@
 #
 
 
-remote_theme: pmarsceill/just-the-docs
+theme: just-the-docs
 
 aux_links:
   "Spark Rapids Plugin on Github":

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,7 +15,7 @@
 #
 
 
-theme: just-the-docs
+remote_theme: pmarsceill/just-the-docs
 
 aux_links:
   "Spark Rapids Plugin on Github":

--- a/docs/additional-functionality/README.md
+++ b/docs/additional-functionality/README.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Additional Functionality
+nav_order: 9
+has_children: true
+permalink: /additional-functionality/
+---

--- a/docs/additional-functionality/cache-serializer.md
+++ b/docs/additional-functionality/cache-serializer.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: RAPIDS Cache Serializer
-nav_order: 12
+parent: Additional Functionality
+nav_order: 2
 ---
 # RAPIDS Cache Serializer  
   Apache Spark provides an important feature to cache intermediate data and provide

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: ML Integration
-nav_order: 8
+parent: Additional Functionality
+nav_order: 1
 ---
 # RAPIDS Accelerator for Apache Spark ML Library Integration
 

--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: RAPIDS-Accelerated User-Defined Functions
-nav_order: 9
+parent: Additional Functionality
+nav_order: 3
 ---
 # RAPIDS-Accelerated User-Defined Functions
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Benchmarks
-nav_exclude: true
+nav_order: 8
 ---
 # Benchmarks
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Developer Overview
-nav_order: 12
+nav_order: 10
 has_children: true
 permalink: /developer-overview/
 ---

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -7,4 +7,3 @@ parent: Developer Overview
 An overview of testing can be found within the repository at:
 * [Unit tests](https://github.com/NVIDIA/spark-rapids/tree/branch-0.3/tests)
 * [Integration testing](https://github.com/NVIDIA/spark-rapids/tree/branch-0.3/integration_tests)
-* [Benchmarks](../benchmarks.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: Demos
-nav_order: 11
+title: Examples
+nav_order: 12
 ---
 # Demos
 

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -42,7 +42,7 @@ called [RMM](https://github.com/rapidsai/rmm) to mitigate this overhead. By defa
 the plugin will allocate `90%` (`0.9`) of the memory on the GPU and keep it as a pool that can
 be allocated from. If the pool is exhausted more memory will be allocated and added to the pool.
 Most of the time this is a huge win, but if you need to share the GPU with other 
-[libraries](ml-integration.md) that are not aware of RMM this can lead to memory issues, and you
+[libraries](additional-functionality/ml-integration.md) that are not aware of RMM this can lead to memory issues, and you
 may need to disable pooling.
 
 ## Pinned Memory


### PR DESCRIPTION
Documentation changes in this PR: 
* Created a new navigation section for `Additional Functionality`.  Moved documentation related to ML Integration, Cached Batch Serializer and RAPIDS Accelerated UDFs to this folder.  
* Promoted `Benchmarks` to a top level navigation page
* Renamed `Demos` to `Examples`.  

@jlowe do you mind if we change `RAPIDS-Accelerated User-Defined Functions` to `RAPIDS Accelerated User-Defined Functions`?  We are not hyphenating after RAPIDS in other places in our documentation.  If that is ok I can make the change as part of this update.  