### PR TITLE
Fix databricks build since Arrow code added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,12 @@
               <type>test-jar</type>
               <scope>test</scope>
             </dependency>
+	    <dependency>
+              <groupId>org.apache.arrow</groupId>
+              <artifactId>arrow-vector</artifactId>
+              <version>0.15.1</version>
+	      <scope>provided</scope>
+            </dependency>
             <dependency>
               <groupId>org.apache.orc</groupId>
               <artifactId>orc-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -230,12 +230,6 @@
               <type>test-jar</type>
               <scope>test</scope>
             </dependency>
-	    <dependency>
-              <groupId>org.apache.arrow</groupId>
-              <artifactId>arrow-vector</artifactId>
-              <version>0.15.1</version>
-	      <scope>provided</scope>
-            </dependency>
             <dependency>
               <groupId>org.apache.orc</groupId>
               <artifactId>orc-core</artifactId>

--- a/shims/spark301db/pom.xml
+++ b/shims/spark301db/pom.xml
@@ -23,7 +23,7 @@
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-shims_2.12</artifactId>
         <version>0.4.0-SNAPSHOT</version>
-	<relativePath>../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-shims-spark301-databricks_2.12</artifactId>
@@ -74,6 +74,7 @@
     <properties>
         <parquet.version>1.10.1</parquet.version>
         <spark301db.version>3.0.1-databricks</spark301db.version>
+        <arrow.version>0.15.1</arrow.version>
     </properties>
 
     <dependencies>
@@ -82,29 +83,29 @@
             <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
-	<dependency>
+        <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
-            <version>0.15.1</version>
-	    <scope>provided</scope>
+            <version>${arrow.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-	    <version>${spark301db.version}</version>
-	    <scope>provided</scope>
+            <version>${spark301db.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-	    <version>${spark301db.version}</version>
-	    <scope>provided</scope>
+            <version>${spark301db.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-	    <version>${spark301db.version}</version>
-	    <scope>provided</scope>
+            <version>${spark301db.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/shims/spark301db/pom.xml
+++ b/shims/spark301db/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020, NVIDIA CORPORATION.
+  Copyright (c) 2020-2021, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/shims/spark301db/pom.xml
+++ b/shims/spark301db/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
+	<dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>0.15.1</version>
+	    <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>


### PR DESCRIPTION
Databricks for some reason isn't picking up the Arrow dependency from Spark so we need to explicitly add it for it build.  After that I tested it and it works fine for reading datasource v2 Arrow data.

I also fixed some tabs being in the file.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
