### PR TITLE
Run Databricks IT with python-xdist parallel, includes test fixes and xfail

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -14,6 +14,7 @@
 
 [pytest]
 markers =
+    allow_non_gpu_databricks(any, [ops]): Allow the test to run anything not on the GPU in Databricks environment
     allow_non_gpu(any, [ops]): Allow the test to run anything not on the GPU
     approximate_float(rel, abs): float calculation is approximate instead of exact
     ignore_order(local): Ignores the order of the result in asserts. If local is true the results are sorted in python instead of using spark.

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -126,7 +126,18 @@ def pytest_runtest_setup(item):
 
     global _allow_any_non_gpu
     global _non_gpu_allowed
+    _non_gpu_allowed_databricks = []
+    _allow_any_non_gpu_databricks = False
+    non_gpu_databricks = item.get_closest_marker('allow_non_gpu_databricks')
     non_gpu = item.get_closest_marker('allow_non_gpu')
+    if non_gpu_databricks:
+        if is_databricks_runtime():
+            if non_gpu_databricks.kwargs and non_gpu_databricks.kwargs['any']:
+                _allow_any_non_gpu_databricks = True
+            elif non_gpu_databricks.args:
+                _non_gpu_allowed_databricks = non_gpu_databricks.args
+            else:
+                pytest.warn('allow_non_gpu_databricks marker without anything allowed')
     if non_gpu:
         if non_gpu.kwargs and non_gpu.kwargs['any']:
             _allow_any_non_gpu = True
@@ -141,6 +152,12 @@ def pytest_runtest_setup(item):
     else:
         _allow_any_non_gpu = False
         _non_gpu_allowed = []
+
+    _allow_any_non_gpu = _allow_any_non_gpu | _allow_any_non_gpu_databricks
+    if _non_gpu_allowed and _non_gpu_allowed_databricks:
+        _non_gpu_allowed = _non_gpu_allowed + _non_gpu_allowed_databricks
+    elif _non_gpu_allowed_databricks:
+        _non_gpu_allowed = _non_gpu_allowed_databricks
 
     global _limit
     limit_mrk = item.get_closest_marker('limit')

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+allow_non_gpu_databricks = pytest.mark.allow_non_gpu_databricks
 allow_non_gpu = pytest.mark.allow_non_gpu
 approximate_float = pytest.mark.approximate_float
 ignore_order = pytest.mark.ignore_order

--- a/integration_tests/src/main/python/tpch_test.py
+++ b/integration_tests/src/main/python/tpch_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/tpch_test.py
+++ b/integration_tests/src/main/python/tpch_test.py
@@ -15,17 +15,28 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
+from conftest import is_databricks_runtime
 from marks import approximate_float, incompat, ignore_order, allow_non_gpu
 from spark_session import with_spark_session, is_before_spark_310
 
 _base_conf = {'spark.rapids.sql.variableFloatAgg.enabled': 'true',
-        'spark.rapids.sql.hasNans': 'false'}
+        'spark.rapids.sql.hasNans': 'false',
+        'spark.sql.adaptive.enabled': 'false'}
 
 _adaptive_conf = _base_conf.copy()
 _adaptive_conf.update({'spark.sql.adaptive.enabled': 'true'})
 
+    #pytest.param(_adaptive_conf, marks=pytest.mark.xfail(is_databricks_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/1059'))
+
+_test_confs = [_base_conf]
+
+# don't run the AQE tests on databricks - https://github.com/NVIDIA/spark-rapids/issues/1059
+# for some reaosn xfail doesn't work, it causes other issues when those tests run and fail
+if not is_databricks_runtime():
+    _test_confs.append(_adaptive_conf)
+
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q1(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q1"), conf=conf)
@@ -33,49 +44,49 @@ def test_tpch_q1(tpch, conf):
 @approximate_float
 @incompat
 @allow_non_gpu('TakeOrderedAndProjectExec', 'SortOrder', 'AttributeReference')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q2(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q2"), conf=conf)
 
 @approximate_float
 @allow_non_gpu('TakeOrderedAndProjectExec', 'SortOrder', 'AttributeReference')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q3(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q3"), conf=conf)
 
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q4(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q4"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q5(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q5"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q6(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q6"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q7(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q7"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q8(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q8"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q9(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q9"), conf=conf)
@@ -83,30 +94,30 @@ def test_tpch_q9(tpch, conf):
 @incompat
 @approximate_float
 @allow_non_gpu('TakeOrderedAndProjectExec', 'SortOrder', 'AttributeReference')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q10(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q10"), conf=conf)
 
 @approximate_float
 @allow_non_gpu('FilterExec', 'And', 'IsNotNull', 'GreaterThan', 'AttributeReference', 'ScalarSubquery')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q11(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q11"), conf=conf)
 
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q12(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q12"), conf=conf)
 
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q13(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q13"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q14(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q14"), conf=conf)
@@ -114,19 +125,19 @@ def test_tpch_q14(tpch, conf):
 @approximate_float
 #fp sum does not work on Q15
 @allow_non_gpu(any=True)
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q15(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q15"))
 
 @allow_non_gpu('BroadcastNestedLoopJoinExec', 'Or', 'IsNull', 'EqualTo', 'AttributeReference', 'BroadcastExchangeExec')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q16(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q16"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q17(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q17"), conf=conf)
@@ -134,18 +145,18 @@ def test_tpch_q17(tpch, conf):
 @incompat
 @approximate_float
 @allow_non_gpu('TakeOrderedAndProjectExec', 'SortOrder', 'AttributeReference')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q18(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q18"), conf=conf)
 
 @approximate_float
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q19(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q19"), conf=conf)
 
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q20(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q20"), conf=conf)
@@ -153,7 +164,7 @@ def test_tpch_q20(tpch, conf):
 @allow_non_gpu('TakeOrderedAndProjectExec', 'SortOrder', 'AttributeReference',
         'SortMergeJoinExec', 'BroadcastHashJoinExec', 'BroadcastExchangeExec',
         'Alias', 'Not', 'EqualTo')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q21(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q21"), conf=conf)
@@ -161,7 +172,7 @@ def test_tpch_q21(tpch, conf):
 @approximate_float
 #Once ScalarSubqery if fixed the rest should just work
 @allow_non_gpu('FilterExec', 'And', 'AttributeReference', 'IsNotNull', 'In', 'Substring', 'Literal', 'GreaterThan', 'ScalarSubquery')
-@pytest.mark.parametrize('conf', [_base_conf, _adaptive_conf])
+@pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q22(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q22"), conf=conf)

--- a/integration_tests/src/main/python/tpch_test.py
+++ b/integration_tests/src/main/python/tpch_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from conftest import is_databricks_runtime
-from marks import approximate_float, incompat, ignore_order, allow_non_gpu
+from marks import approximate_float, incompat, ignore_order, allow_non_gpu, allow_non_gpu_databricks
 from spark_session import with_spark_session, is_before_spark_310
 
 _base_conf = {'spark.rapids.sql.variableFloatAgg.enabled': 'true',
@@ -25,8 +25,6 @@ _base_conf = {'spark.rapids.sql.variableFloatAgg.enabled': 'true',
 
 _adaptive_conf = _base_conf.copy()
 _adaptive_conf.update({'spark.sql.adaptive.enabled': 'true'})
-
-    #pytest.param(_adaptive_conf, marks=pytest.mark.xfail(is_databricks_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/1059'))
 
 _test_confs = [_base_conf]
 
@@ -157,6 +155,7 @@ def test_tpch_q19(tpch, conf):
           lambda spark : tpch.do_test_query("q19"), conf=conf)
 
 @pytest.mark.parametrize('conf', _test_confs)
+@allow_non_gpu_databricks('BroadcastHashJoinExec', 'BroadcastExchangeExec', 'GreaterThan', 'Cast')
 def test_tpch_q20(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(
           lambda spark : tpch.do_test_query("q20"), conf=conf)
@@ -172,6 +171,7 @@ def test_tpch_q21(tpch, conf):
 @approximate_float
 #Once ScalarSubqery if fixed the rest should just work
 @allow_non_gpu('FilterExec', 'And', 'AttributeReference', 'IsNotNull', 'In', 'Substring', 'Literal', 'GreaterThan', 'ScalarSubquery')
+@allow_non_gpu_databricks('EphemeralSubstring')
 @pytest.mark.parametrize('conf', _test_confs)
 def test_tpch_q22(tpch, conf):
   assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from conftest import is_at_least_precommit_run
+from conftest import is_at_least_precommit_run, is_databricks_runtime
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
 try:
@@ -170,6 +170,8 @@ def test_window_aggregate_udf(data_gen, window):
         conf=arrow_udf_conf)
 
 
+@pytest.mark.xfail(condition=is_databricks_runtime(),
+        reason='https://github.com/NVIDIA/spark-rapids/issues/1644')
 @ignore_order
 @pytest.mark.parametrize('data_gen', [byte_gen, short_gen, int_gen], ids=idfn)
 @pytest.mark.parametrize('window', udf_windows, ids=window_ids)

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -107,7 +107,8 @@ sudo cp $CUDF_JAR $DB_JAR_LOC
 
 # tests
 export PATH=/databricks/conda/envs/databricks-ml-gpu/bin:/databricks/conda/condabin:$PATH
-sudo /databricks/conda/envs/databricks-ml-gpu/bin/pip install pytest sre_yield
+sudo /databricks/conda/envs/databricks-ml-gpu/bin/pip install pytest sre_yield requests pandas \
+	pyarrow findspark pytest-xdist
 cd /home/ubuntu/spark-rapids/integration_tests
 export SPARK_HOME=/databricks/spark
 # change to not point at databricks confs so we don't conflict with their settings
@@ -127,6 +128,6 @@ if [ `ls $DB_JAR_LOC/cudf* | wc -l` -gt 1 ]; then
     ls $DB_JAR_LOC/cudf*
     exit 1
 fi
-$SPARK_HOME/bin/spark-submit ./runtests.py --runtime_env="databricks"
+bash run_pyspark_from_build.sh --runtime_env="databricks"
 cd /home/ubuntu
 tar -zcvf spark-rapids-built.tgz spark-rapids

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We want databricks to run all the tests and run them in parallel.  When enabling that a few were failing.

tpch - we can't run with AQE due to known databricks issues with it. After that there were a few operators running on CPU due to differences in databricks so added code to handle that
test_window_aggregate_udf_array_from_python failing - xfail it for now and filed https://github.com/NVIDIA/spark-rapids/issues/1644 to root cause it.

Note this was started by Tim with https://github.com/NVIDIA/spark-rapids/pull/1549/files

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
