### PR TITLE
Fix typo in arrow optimized config name - spark.rapids.arrowCopyOptimizationEnabled

### DIFF
--- a/integration_tests/src/main/python/datasourcev2_read.py
+++ b/integration_tests/src/main/python/datasourcev2_read.py
@@ -98,7 +98,7 @@ def test_read_round_trip_no_partitioned_arrow_off(std_input_path, csv, spark_tmp
     columnarTableNameNoPart = catalogName + "." + tableNameNoPart
     with_cpu_session(lambda spark : setupInMemoryTableNoPartitioning(spark, csvPath, tableNameNoPart, columnarTableNameNoPart),
             conf={'spark.sql.catalog.columnar': columnarClass,
-                  'spark.rapids.arrowCopyOptmizationEnabled': 'false'})
+                  'spark.rapids.arrowCopyOptimizationEnabled': 'false'})
     assert_gpu_and_cpu_are_equal_collect(readTable(csvPath, columnarTableNameNoPart),
             conf={'spark.sql.catalog.columnar': columnarClass,
-                  'spark.rapids.arrowCopyOptmizationEnabled': 'false'})
+                  'spark.rapids.arrowCopyOptimizationEnabled': 'false'})

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -832,7 +832,7 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(true)
 
-  val USE_ARROW_OPT = conf("spark.rapids.arrowCopyOptmizationEnabled")
+  val USE_ARROW_OPT = conf("spark.rapids.arrowCopyOptimizationEnabled")
     .doc("Option to turn off using the optimized Arrow copy code when reading from " +
       "ArrowColumnVector in HostColumnarToGpu. Left as internal as user shouldn't " +
       "have to turn it off, but its convenient for testing.")


### PR DESCRIPTION
have a typo in the config name that should be spark.rapids.arrowCopyOptimizationEnabled

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
