### PR TITLE
Change struct and array shuffle tests to work in distributed mode

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -63,8 +63,8 @@ def test_orderby_array(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : unary_op_df(spark, data_gen),
         'array_table',
-        'select arr[0], first_val from'
-        '(select array_table.a as arr, array_table.a[0] as first_val'
+        'select arr[0], first_val from '
+        '(select array_table.a as arr, array_table.a[0] as first_val '
         'from array_table order by first_val)',
         conf=allow_negative_scale_of_decimal_conf)
 
@@ -76,8 +76,8 @@ def test_orderby_array_of_arrays(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
     lambda spark : unary_op_df(spark, data_gen),
         'array_table',
-        'select arr[0][0], first_val from'
-        '(select array_table.a as arr, array_table.a[0][0] as first_val'
+        'select arr[0][0], first_val from '
+        '(select array_table.a as arr, array_table.a[0][0] as first_val '
         'from array_table order by first_val)')
 
 
@@ -91,7 +91,7 @@ def test_orderby_array_of_structs(data_gen):
         'array_table',
         'select struct_tbl.struct_val.child0  from '
         '(select tbl.arr[0] as struct_val, first_val from ('
-        'select array_table.a as arr, array_table.a[0].child0 as first_val from'
+        'select array_table.a as arr, array_table.a[0].child0 as first_val from '
         'array_table order by first_val) as tbl) as struct_tbl')
 
 


### PR DESCRIPTION
Signed-off-by: Kuhu Shukla <kuhus@nvidia.com>

Fixes https://github.com/NVIDIA/spark-rapids/issues/1541 

**I am not terribly happy with what we are doing to make this work but it is a conversation starter at least.**
The issue is when we have multiple executors / distributed mode, the null key based values after the sort can be scrambled even though the sort is not semantically wrong after the shuffle. Shown below : 
CPU 
```
[Row(a=None, first_val=None),
 Row(a=[None, 234332775, 1, 1213716675, 1480654027, 271807679, 1930674352, -2080086848], first_val=None),
 Row(a=[], first_val=None),
 Row(a=None, first_val=None),
 Row(a=[None, 960244105, 84216343, -1373438663], first_val=None),
 Row(a=None, first_val=None),
 Row(a=[None, -1, 1718684370, 367231360, 1106778379, -1839778244, 666610294, 240175002, -672665733, -1803941716, -207959582, 53255033, 1, -1637040765, -2049878346, -2065016803], first_val=None),
 Row(a=[], first_val=None),
 Row(a=[], first_val=None)
```
GPU:
```
[Row(a=None, first_val=None),
 Row(a=[None, -1, 1718684370, 367231360, 1106778379, -1839778244, 666610294, 240175002, -672665733, -1803941716, -207959582, 53255033, 1, -1637040765, -2049878346, -2065016803], first_val=None),
 Row(a=[], first_val=None), 
 Row(a=[], first_val=None),
 Row(a=None, first_val=None), 
 Row(a=[], first_val=None),
 Row(a=None, first_val=None),
 Row(a=[None, 960244105, 84216343, -1373438663], first_val=None),
 Row(a=[None, 234332775, 1, 1213716675, 1480654027, 271807679, 1930674352, -2080086848], first_val=None)
```
If we anticipate this being a bug we should handle this change differently and I invite suggestions on that. The current fix is based on the understanding that this output is ok, I have reworked the tests to ignore_order. The reason why the queries themselves were changed is that when we ignore order, we do an explicit sort which does not go on the GPU since the original tests were projecting a nested column, something we cannot sort _on_, using local sort doesn't work due to NoneType comparisons failing on it. Another way to handle this is not have nulls in the tests but I don't really advocate that approach. Also for the `array_of_structs` case , I use a couple selects as we don't support certain operators like `GetArrayStructFields` to do a simple lookup. Appreciate any improvements for the tests and initial comments. I verified that taking out the change for https://github.com/NVIDIA/spark-rapids/pull/1477 does fail these tests so we should be good there.