### PR TITLE
Fix extraneous shuffles added by AQE

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -49,7 +49,7 @@ import org.apache.spark.sql.hive.rapids.GpuHiveOverrides
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastMeta, GpuBroadcastNestedLoopJoinMeta, GpuCustomShuffleReaderExec, GpuShuffleMeta}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastMeta, GpuBroadcastNestedLoopJoinMeta, GpuCustomShuffleReaderExec, GpuShuffleExchangeExecBase, GpuShuffleMeta}
 import org.apache.spark.sql.rapids.execution.python._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -465,6 +465,45 @@ object GpuOverrides {
       ordering2.zip(ordering1).forall {
         case (o2, o1) => orderingSatisfies(o1, o2, conf)
       }
+    }
+  }
+
+  private def convertPartToGpuIfPossible(part: Partitioning, conf: RapidsConf): Partitioning = {
+    part match {
+      case _: GpuPartitioning => part
+      case _ =>
+        val wrapped = wrapPart(part, conf, None)
+        wrapped.tagForGpu()
+        if (wrapped.canThisBeReplaced) {
+          wrapped.convertToGpu()
+        } else {
+          part
+        }
+    }
+  }
+
+  /**
+   * Removes unnecessary CPU shuffles that Spark can add to the plan when it does not realize
+   * a GPU partitioning satisfies a CPU distribution because CPU and GPU expressions are not
+   * semantically equal.
+   */
+  def removeExtraneousShuffles(plan: SparkPlan, conf: RapidsConf): SparkPlan = {
+    plan.transformUp {
+      case cpuShuffle: ShuffleExchangeExec =>
+        cpuShuffle.child match {
+          case sqse: ShuffleQueryStageExec =>
+            GpuTransitionOverrides.getNonQueryStagePlan(sqse) match {
+              case gpuShuffle: GpuShuffleExchangeExecBase =>
+                val converted = convertPartToGpuIfPossible(cpuShuffle.outputPartitioning, conf)
+                if (converted == gpuShuffle.outputPartitioning) {
+                  sqse
+                } else {
+                  plan
+                }
+              case _ => plan
+            }
+          case _ => plan
+        }
     }
   }
 
@@ -2647,33 +2686,44 @@ case class GpuQueryStagePrepOverrides() extends Rule[SparkPlan] with Logging {
 }
 
 case class GpuOverrides() extends Rule[SparkPlan] with Logging {
-  override def apply(plan: SparkPlan) :SparkPlan = {
+  override def apply(plan: SparkPlan): SparkPlan = {
     val conf = new RapidsConf(plan.conf)
     if (conf.isSqlEnabled) {
-      val wrap = GpuOverrides.wrapPlan(plan, conf, None)
-      wrap.tagForGpu()
-      val reasonsToNotReplaceEntirePlan = wrap.getReasonsNotToReplaceEntirePlan
-      val exp = conf.explain
-      if (conf.allowDisableEntirePlan && reasonsToNotReplaceEntirePlan.nonEmpty) {
-        if (!exp.equalsIgnoreCase("NONE")) {
-          logWarning("Can't replace any part of this plan due to: " +
-            s"${reasonsToNotReplaceEntirePlan.mkString(",")}")
-        }
-        plan
+      val updatedPlan = if (plan.conf.adaptiveExecutionEnabled) {
+        // AQE can cause Spark to inject undesired CPU shuffles into the plan because GPU and CPU
+        // distribution expressions are not semantically equal.
+        GpuOverrides.removeExtraneousShuffles(plan, conf)
       } else {
-        wrap.runAfterTagRules()
-        if (!exp.equalsIgnoreCase("NONE")) {
-          wrap.tagForExplain()
-          val explain = wrap.explain(exp.equalsIgnoreCase("ALL"))
-          if (!explain.isEmpty) {
-            logWarning(s"\n$explain")
-          }
-        }
-        val convertedPlan = wrap.convertIfNeeded()
-        addSortsIfNeeded(convertedPlan, conf)
+        plan
       }
+      applyOverrides(updatedPlan, conf)
     } else {
       plan
+    }
+  }
+
+  private def applyOverrides(plan: SparkPlan, conf: RapidsConf): SparkPlan = {
+    val wrap = GpuOverrides.wrapPlan(plan, conf, None)
+    wrap.tagForGpu()
+    val reasonsToNotReplaceEntirePlan = wrap.getReasonsNotToReplaceEntirePlan
+    val exp = conf.explain
+    if (conf.allowDisableEntirePlan && reasonsToNotReplaceEntirePlan.nonEmpty) {
+      if (!exp.equalsIgnoreCase("NONE")) {
+        logWarning("Can't replace any part of this plan due to: " +
+            s"${reasonsToNotReplaceEntirePlan.mkString(",")}")
+      }
+      plan
+    } else {
+      wrap.runAfterTagRules()
+      if (!exp.equalsIgnoreCase("NONE")) {
+        wrap.tagForExplain()
+        val explain = wrap.explain(exp.equalsIgnoreCase("ALL"))
+        if (!explain.isEmpty) {
+          logWarning(s"\n$explain")
+        }
+      }
+      val convertedPlan = wrap.convertIfNeeded()
+      addSortsIfNeeded(convertedPlan, conf)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -498,11 +498,11 @@ object GpuOverrides {
                 if (converted == gpuShuffle.outputPartitioning) {
                   sqse
                 } else {
-                  plan
+                  cpuShuffle
                 }
-              case _ => plan
+              case _ => cpuShuffle
             }
-          case _ => plan
+          case _ => cpuShuffle
         }
     }
   }


### PR DESCRIPTION
Fixes #1654 

Adaptive Query Execution re-planning can cause Spark to inject undesired, extraneous CPU shuffles into the plan because it does not realize that a GPU shuffle satisfies the required distribution of the next node in the plan.  It examines the distribution from a stage that ends in a GpuShuffleExchangeExec and calls `semanticEquals` on the expressions found in the partitioning vs. the required distribution expressions.  Unfortunately there are cases where the required distribution expressions are not simple attribute references (which will match) but instead contain an expression tree.  In that case the GPU version will have GPU expression operators (e.g.: `GpuAdd`, `GpuSubtract`, etc.) while the CPU will have non-GPU expression operators, and they do not compare as equal.

This updates the main override rules to do a "prepass" when AQE is enabled to search for these extraneous shuffles and remove them.