### PR TITLE
BenchmarkRunner - Include query name in JSON summary filename

### DIFF
--- a/integration_tests/src/main/python/benchmark.py
+++ b/integration_tests/src/main/python/benchmark.py
@@ -100,7 +100,7 @@ def main():
     for config_name in args.configs:
         config = load_properties(config_name + ".properties")
         for query in args.query:
-            summary_file_prefix = "{}-{}-{}".format(args.benchmark, query, config_name)
+            summary_file_prefix = "{}-{}".format(args.benchmark, config_name)
 
             cmd = ['--conf spark.app.name="' + summary_file_prefix + '"']
             for k, v in config.items():

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -113,7 +113,7 @@ object BenchmarkRunner {
                 spark,
                 query,
                 conf.iterations(),
-                summaryFilePrefix = summaryFilePrefixWithQuery,
+                summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
                 gcBetweenRuns = conf.gcBetweenRuns())
           })
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -78,10 +78,7 @@ object BenchmarkRunner {
         conf.query().foreach { query =>
 
           println(s"*** RUNNING ${bench.name()} QUERY $query")
-          val summaryFilePrefixWithQuery = conf.summaryFilePrefix.toOption match {
-            case Some(t) => Some(t + s"-$query")
-            case _ => None
-          }
+          val summaryFilePrefixWithQuery = conf.summaryFilePrefix.map(prefix => s"$prefix-$query")
           val report = Try(conf.output.toOption match {
             case Some(path) => conf.outputFormat().toLowerCase match {
               case "parquet" =>
@@ -90,7 +87,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery,
+                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "csv" =>
                 runner.writeCsv(
@@ -98,7 +95,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery,
+                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "orc" =>
                 runner.writeOrc(
@@ -106,7 +103,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery,
+                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case other =>
                 throw new IllegalArgumentException(s"Invalid or unspecified output format: $other")

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -78,7 +78,8 @@ object BenchmarkRunner {
         conf.query().foreach { query =>
 
           println(s"*** RUNNING ${bench.name()} QUERY $query")
-          val summaryFilePrefixWithQuery = conf.summaryFilePrefix.map(prefix => s"$prefix-$query")
+          val summaryFilePrefixWithQuery = conf.summaryFilePrefix.toOption
+              .map(prefix => s"$prefix-$query")
           val report = Try(conf.output.toOption match {
             case Some(path) => conf.outputFormat().toLowerCase match {
               case "parquet" =>
@@ -87,7 +88,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "csv" =>
                 runner.writeCsv(
@@ -95,7 +96,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "orc" =>
                 runner.writeOrc(
@@ -103,7 +104,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case other =>
                 throw new IllegalArgumentException(s"Invalid or unspecified output format: $other")
@@ -113,7 +114,7 @@ object BenchmarkRunner {
                 spark,
                 query,
                 conf.iterations(),
-                summaryFilePrefix = summaryFilePrefixWithQuery.toOption,
+                summaryFilePrefix = summaryFilePrefixWithQuery,
                 gcBetweenRuns = conf.gcBetweenRuns())
           })
 

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/BenchmarkRunner.scala
@@ -78,6 +78,10 @@ object BenchmarkRunner {
         conf.query().foreach { query =>
 
           println(s"*** RUNNING ${bench.name()} QUERY $query")
+          val summaryFilePrefixWithQuery = conf.summaryFilePrefix.toOption match {
+            case Some(t) => Some(t + s"-$query")
+            case _ => None
+          }
           val report = Try(conf.output.toOption match {
             case Some(path) => conf.outputFormat().toLowerCase match {
               case "parquet" =>
@@ -86,7 +90,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "csv" =>
                 runner.writeCsv(
@@ -94,7 +98,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case "orc" =>
                 runner.writeOrc(
@@ -102,7 +106,7 @@ object BenchmarkRunner {
                   query,
                   path,
                   iterations = conf.iterations(),
-                  summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                  summaryFilePrefix = summaryFilePrefixWithQuery,
                   gcBetweenRuns = conf.gcBetweenRuns())
               case other =>
                 throw new IllegalArgumentException(s"Invalid or unspecified output format: $other")
@@ -112,7 +116,7 @@ object BenchmarkRunner {
                 spark,
                 query,
                 conf.iterations(),
-                summaryFilePrefix = conf.summaryFilePrefix.toOption,
+                summaryFilePrefix = summaryFilePrefixWithQuery,
                 gcBetweenRuns = conf.gcBetweenRuns())
           })
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/1650. 
Signed-off-by: Niranjan Artal <nartal@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
