### PR TITLE
Filter nulls for left semi and left anti join to work around cudf

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,6 +268,9 @@ trait GpuHashJoin extends GpuExec {
     }
   }
 
+  // This is a work around added in response to https://github.com/NVIDIA/spark-rapids/issues/1643.
+  // to deal with slowness arising from many nulls in the build-side of the join. The work around
+  // should be removed when https://github.com/rapidsai/cudf/issues/7300 is addressed.
   private[this] def filterNulls(table: Table, joinKeyIndices: Range, closeTable: Boolean): Table = {
     var mask: ai.rapids.cudf.ColumnVector = null
     try {


### PR DESCRIPTION
performance issues

Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes #1643

This is only targetting `leftSemi` and `leftAnti` because these are based on `cudf::left_semi_anti_join`, and this path was not sped up in 0.18 (specifically building the hash table for the join is slow with many nulls). 

This passes the tests locally, and I fixed some leaks I had but I need to run performance tests at scale, so I am posting it as draft for now.