### PR TITLE
Add FAQ entries for executor-per-GPU questions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -266,6 +266,16 @@ There are multiple reasons why this a problematic configuration:
 - CUDA context switches between processes sharing a single GPU can be expensive
 - Each executor would have a fraction of the GPU memory available for processing
 
+### Is [Multi Instance GPU (MIG)](https://docs.nvidia.com/cuda/mig/index.html) supported?
+
+Yes, but it requires support from the underlying cluster manager to isolate the MIG GPU instance
+for each executor (e.g.: by setting `CUDA_VISIBLE_DEVICES` or other means).
+
+Note that MIG is not recommended for use with the RAPIDS Accelerator since it significantly
+reduces the amount of GPU memory that can be used by the Accelerator for each executor instance.
+If the cluster is purpose-built to run Spark with the RAPIDS Accelerator then we recommend running
+without MIG.
+
 ### How can I run custom expressions/UDFs on the GPU?
 
 The RAPIDS Accelerator provides the following solutions for running

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -250,13 +250,13 @@ can throw at it.
 ### Why are multiple GPUs per executor not supported?
 
 The RAPIDS Accelerator only supports a single GPU per executor because that was a limitation of
-[RAPIDS cudf](https://github.com/rapidsai/cudf), the foundation of the Accelerator.  Basic support
+[RAPIDS cudf](https://github.com/rapidsai/cudf), the foundation of the Accelerator. Basic support
 for working with multiple GPUs has only recently been added to RAPIDS cudf, and there are no plans
 for its individual operations to leverage multiple GPUs (e.g.: a single task's join operation
 processed by multiple GPUs).
 
 Many Spark setups avoid allocating too many concurrent tasks to the same executor, and often
-multiple executors are run per node on the cluster.  Therefore this feature has not been
+multiple executors are run per node on the cluster. Therefore this feature has not been
 prioritized, as there has not been a compelling use-case that requires it.
 
 ### Why are multiple executors per GPU not supported?
@@ -274,7 +274,9 @@ for each executor (e.g.: by setting `CUDA_VISIBLE_DEVICES` or other means).
 Note that MIG is not recommended for use with the RAPIDS Accelerator since it significantly
 reduces the amount of GPU memory that can be used by the Accelerator for each executor instance.
 If the cluster is purpose-built to run Spark with the RAPIDS Accelerator then we recommend running
-without MIG.
+without MIG. Also note that the UCX-based shuffle plugin will not work as well in this
+configuration because
+[MIG does not support direct GPU to GPU transfers](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#app-considerations).
 
 ### How can I run custom expressions/UDFs on the GPU?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -247,6 +247,25 @@ the I/O and starting the initial processing can suffer.  But if you have a lot o
 cannot be done on the GPU, like complex UDFs, the more tasks you have the more CPU processing you
 can throw at it.
 
+### Why are multiple GPUs per executor not supported?
+
+The RAPIDS Accelerator only supports a single GPU per executor because that was a limitation of
+[RAPIDS cudf](https://github.com/rapidsai/cudf), the foundation of the Accelerator.  Basic support
+for working with multiple GPUs has only recently been added to RAPIDS cudf, and there are no plans
+for its individual operations to leverage multiple GPUs (e.g.: a single task's join operation
+processed by multiple GPUs).
+
+Many Spark setups avoid allocating too many concurrent tasks to the same executor, and often
+multiple executors are run per node on the cluster.  Therefore this feature has not been
+prioritized, as there has not been a compelling use-case that requires it.
+
+### Why are multiple executors per GPU not supported?
+
+There are multiple reasons why this a problematic configuration:
+- Apache Spark does not support scheduling a fractional number of GPUs to an executor
+- CUDA context switches between processes sharing a single GPU can be expensive
+- Each executor would have a fraction of the GPU memory available for processing
+
 ### How can I run custom expressions/UDFs on the GPU?
 
 The RAPIDS Accelerator provides the following solutions for running


### PR DESCRIPTION
Per the request at https://github.com/NVIDIA/spark-rapids/issues/1667#issuecomment-773378209, this adds FAQ entries discussing multiple GPUs per executor and multiple executors per GPU.