### PR TITLE
support auto-merge for branch 0.5 [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-0.3
+    - branch-0.4
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-0.3 # force to fetch from latest upstream instead of PR ref
+          ref: branch-0.4 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-0.3
-          BASE: branch-0.4
+          HEAD: branch-0.4
+          BASE: branch-0.5
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

enable auto-merge from branch 0.4 to 0.5

Please help review but do not merge until branch 0.5 is going to be created.