### PR TITLE
Xfail the collect_list tests for databricks

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -21,6 +21,7 @@ from marks import *
 from pyspark.sql.types import *
 from pyspark.sql.window import Window
 import pyspark.sql.functions as f
+from conftest import is_databricks_runtime
 
 _grpkey_longs_with_no_nulls = [
     ('a', RepeatSeqGen(LongGen(nullable=False), length=20)),
@@ -279,6 +280,8 @@ def test_window_aggs_for_rows_collect_list():
   Once native supports dropping nulls, will enable the tests above and remove this one.
 '''
 # SortExec does not support array type, so sort the result locally.
+@pytest.mark.xfail(condition=is_databricks_runtime(),
+        reason='https://github.com/NVIDIA/spark-rapids/issues/1680')
 @ignore_order(local=True)
 def test_window_aggs_for_rows_collect_list_no_nulls():
     assert_gpu_and_cpu_are_equal_sql(


### PR DESCRIPTION
The tests of collect_list are failing on databricks due to not finding the plan `RunningWindowFunctionExec`, which seems to
be specific for databricks.

Now xfail the tests on databricks to unblock the nightly build.

Error log snip:
```
[2021-02-07T03:07:38.289Z]                     �[94mraise�[39;49;00m Py4JJavaError(
[2021-02-07T03:07:38.289Z]                         �[33m"�[39;49;00m�[33mAn error occurred while calling �[39;49;00m�[33m{0}�[39;49;00m�[33m{1}�[39;49;00m�[33m{2}�[39;49;00m�[33m.�[39;49;00m�[33m\n�[39;49;00m�[33m"�[39;49;00m.
[2021-02-07T03:07:38.289Z] >                       �[96mformat�[39;49;00m(target_id, �[33m"�[39;49;00m�[33m.�[39;49;00m�[33m"�[39;49;00m, name), value)
[2021-02-07T03:07:38.289Z] �[1m�[31mE                   py4j.protocol.Py4JJavaError: An error occurred while calling o174965.collectToPython.�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                   : java.lang.IllegalStateException: Found an aggregation function in an unexpected context Some(!NOT_FOUND <RunningWindowFunctionExec> NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                     !Expression <Alias> collect_list(c_int#83071, 0, 0) windowspecdefinition(a#83069L, b#83070 ASC NULLS FIRST, c_int#83071 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS collect_int#83096 NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                       !Expression <WindowExpression> collect_list(c_int#83071, 0, 0) windowspecdefinition(a#83069L, b#83070 ASC NULLS FIRST, c_int#83071 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                         !Expression <AggregateExpression> collect_list(c_int#83071, 0, 0) NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                           *Expression <CollectList> collect_list(c_int#83071, 0, 0) will run on GPU�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                         !Expression <WindowSpecDefinition> windowspecdefinition(a#83069L, b#83070 ASC NULLS FIRST, c_int#83071 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                           !Expression <AttributeReference> a#83069L NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                           !Expression <SortOrder> b#83070 ASC NULLS FIRST NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                             !Expression <AttributeReference> b#83070 NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                           !Expression <SortOrder> c_int#83071 ASC NULLS FIRST NOT EVALUATED FOR GPU YET�[0m
[2021-02-07T03:07:38.289Z] �[1m�[31mE                             !Expression <AttributeReference> c_int#83071 NOT EVALUATED FOR GPU YET�[0m
```

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
