### PR TITLE
add validate_execs_in_gpu_plan to pytest.ini

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -23,3 +23,4 @@ markers =
     qarun: Mark qa test
     cudf_udf: Mark udf cudf test
     rapids_udf_example_native: test UDFs that require custom cuda compilation
+    validate_execs_in_gpu_plan([execs]): Exec class names to validate they exist in the GPU plan.


### PR DESCRIPTION
I forgot to register the mark so pytest was printing a warning.  It was still working though.

  /home/tgraves/workspace/spark-rapids/integration_tests/src/main/python/marks.py:19: PytestUnknownMarkWarning: Unknown pytest.mark.validate_execs_in_gpu_plan - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
