### PR TITLE
Add the integration test resources to the test tarball

### DIFF
--- a/integration_tests/src/assembly/bin.xml
+++ b/integration_tests/src/assembly/bin.xml
@@ -54,9 +54,6 @@
         <fileSet>
             <directory>src/test/resources/</directory>
             <outputDirectory>integration_tests/src/test/resources</outputDirectory>
-            <includes>
-                <include>*</include>
-            </includes>
         </fileSet>
     </fileSets>
 </assembly>

--- a/integration_tests/src/assembly/bin.xml
+++ b/integration_tests/src/assembly/bin.xml
@@ -51,5 +51,12 @@
                 <include>*.py</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>src/test/resources/</directory>
+            <outputDirectory>integration_tests/src/test/resources</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Trying to change the databricks build to use run_pyspark_from_build.sh and discovered these were missing which caused csv and tpch tests to fail.  I ran through all the tests now on databricks and everything passed there now.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
