### PR TITLE
Add support for RAPIDS accelerated Java UDFs

### DIFF
--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -33,16 +33,20 @@ on the GPU.
 The RAPIDS Accelerator only supports RAPIDS accelerated forms of the
 following UDF types:
 - Scala UDFs implementing a `Function` interface and registered via `SparkSession.udf.register`
+- Java UDFs implementing
+  [one of the `org.apache.spark.sql.api.java.UDF` interfaces](https://github.com/apache/spark/tree/branch-3.0/sql/core/src/main/java/org/apache/spark/sql/api/java)
+  and registered either via `SparkSession.udf.register` or
+  `spark.udf.registerJavaFunction` in PySpark
 - [Simple](https://github.com/apache/hive/blob/cb213d88304034393d68cc31a95be24f5aac62b6/ql/src/java/org/apache/hadoop/hive/ql/exec/UDF.java)
   or
   [Generic](https://github.com/apache/hive/blob/cb213d88304034393d68cc31a95be24f5aac62b6/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDF.java)
   Hive UDFs
 
 Other forms of Spark UDFs are not supported, such as:
-- Spark Java UDFs (i.e.: derived from `org.apache.spark.sql.api.java.UDF`* interfaces)
+- Scala or Java User-Defined Aggregate Functions
 - Hive Aggregate Function (UDAF)
 - Hive Tabular Function (UDTF)
-- Lambda functions
+- Lambda Functions
 
 ## Adding GPU Implementations to UDFs
 
@@ -103,6 +107,15 @@ in the [udf-examples](../../udf-examples) project.
 decodes URL-encoded strings using the
 [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
 - [URLEncode](../../udf-examples/src/main/scala/com/nvidia/spark/rapids/udf/scala/URLEncode.scala)
+URL-encodes strings using the
+[Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+
+### Spark Java UDF Examples
+
+- [URLDecode](../../udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java)
+decodes URL-encoded strings using the
+[Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
+- [URLEncode](../../udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java)
 URL-encodes strings using the
 [Java APIs of RAPIDS cudf](https://docs.rapids.ai/api/cudf-java/stable)
 

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLDecode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF1;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * A Java user-defined function (UDF) that decodes URL-encoded strings.
+ * This class demonstrates how to implement a Java UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLDecode implements UDF1<String, String>, RapidsUDF {
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public String call(String s) {
+    String result = null;
+    if (s != null) {
+      try {
+        result = URLDecoder.decode(s, "utf-8");
+      } catch (IllegalArgumentException ignored) {
+        result = s;
+      } catch (UnsupportedEncodingException e) {
+        // utf-8 is a builtin, standard encoding, so this should never happen
+        throw new RuntimeException(e);
+      }
+    }
+    return result;
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.
+    // All intermediate results are closed to avoid leaking GPU resources.
+    try (Scalar plusScalar = Scalar.fromString("+");
+         Scalar spaceScalar = Scalar.fromString(" ");
+         ColumnVector replaced = input.stringReplace(plusScalar, spaceScalar)) {
+      return replaced.urlDecode();
+    }
+  }
+}

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/URLEncode.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import ai.rapids.cudf.DType;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF1;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * A Java user-defined function (UDF) that URL-encodes strings.
+ * This class demonstrates how to implement a Java UDF that also
+ * provides a RAPIDS implementation that can run on the GPU when the query
+ * is executed with the RAPIDS Accelerator for Apache Spark.
+ */
+public class URLEncode implements UDF1<String, String>, RapidsUDF {
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public String call(String s) {
+    if (s == null) {
+      return null;
+    }
+    try {
+      return URLEncoder.encode(s, "utf-8")
+          .replace("+", "%20")
+          .replace("*", "%2A")
+          .replace("%7E", "~");
+    } catch (UnsupportedEncodingException e) {
+      // utf-8 is a builtin, standard encoding, so this should never happen
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Columnar implementation that runs on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    // The CPU implementation takes a single string argument, so similarly
+    // there should only be one column argument of type STRING.
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+    ColumnVector input = args[0];
+    if (!input.getType().equals(DType.STRING)) {
+      throw new IllegalArgumentException("Argument type is not a string column: " +
+          input.getType());
+    }
+
+    return input.urlEncode();
+  }
+}


### PR DESCRIPTION
Fixes #1635.

This extends `GpuScalaUDF` to recognize RAPIDS accelerated Spark Java UDFs that are wrapped in a lambda function by Apache Spark by `UDFRegistration`.  This allows users to provide RAPIDS accelerated implementation of their Spark Java UDFs for use in Spark via `spark.udf.register` and PySpark via `spark.udf.registerJavaFunction`.

A working example of a RAPIDS accelerated Spark Scala UDF is also provided, which required adding the Scala version to the udf-examples jar (and everywhere it was referenced). A unit test was added to exercise it. It was not implemented as a Python test as was done for the Hive UDFs because PySpark does not support registering Scala UDFs (it uses the Java UDF interface instead).

The RAPIDS accelerated UDF documentation has also been updated to reflect the new functionality.