### PR TITLE
Disable range partitioning if computation is needed

### DIFF
--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -67,3 +67,15 @@ orderable_gens_sort_without_neg_decimal = [n for n in orderable_gens_sort if not
 def test_multi_orderby_with_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).orderBy(f.col('a'), f.col('b').desc()).limit(100))
+
+# We are not trying all possabilities, just doing a few where the numbers should work out.
+@pytest.mark.parametrize('data_gen', [byte_gen, long_gen, float_gen], ids=idfn)
+def test_orderby_with_processing(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, data_gen).orderBy(f.lit(100) - f.col('a')))
+
+# We are not trying all possabilities, just doing a few where the numbers should work out.
+@pytest.mark.parametrize('data_gen', [byte_gen, long_gen, float_gen], ids=idfn)
+def test_orderby_with_processing_and_limit(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, data_gen).orderBy(f.lit(100) - f.col('a')).limit(100))

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -68,13 +68,13 @@ def test_multi_orderby_with_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).orderBy(f.col('a'), f.col('b').desc()).limit(100))
 
-# We are not trying all possabilities, just doing a few where the numbers should work out.
+# We are not trying all possibilities, just doing a few with numbers so the query works.
 @pytest.mark.parametrize('data_gen', [byte_gen, long_gen, float_gen], ids=idfn)
 def test_orderby_with_processing(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).orderBy(f.lit(100) - f.col('a')))
 
-# We are not trying all possabilities, just doing a few where the numbers should work out.
+# We are not trying all possibilities, just doing a few with numbers so the query works.
 @pytest.mark.parametrize('data_gen', [byte_gen, long_gen, float_gen], ids=idfn)
 def test_orderby_with_processing_and_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
This fixes #1730 for the 0.4 release, by falling back to the CPU we will try to fix this permanently as a part of #1727 .