### PR TITLE
Detect task failures in benchmarks

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -168,7 +168,6 @@ object BenchUtils {
 
     var df: DataFrame = null
     val queryTimes = new ListBuffer[Long]()
-
     for (i <- 0 until iterations) {
       spark.sparkContext.setJobDescription(s"Benchmark Run: query=$queryDescription; iteration=$i")
       

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -254,8 +254,7 @@ object BenchUtils {
     }
 
     // write results to file
-    val suffix = if (exceptions.isEmpty) "" else "-failed"
-    val filename = s"$filenameStub-${queryStartTime.toEpochMilli}$suffix.json"
+    val filename = s"$filenameStub-${queryStartTime.toEpochMilli}.json"
     println(s"$logPrefix Saving benchmark report to $filename")
 
     // try not to leak secrets
@@ -323,7 +322,7 @@ object BenchUtils {
     if (generateDotGraph) {
       queryPlansWithMetrics.headOption match {
         case Some(plan) =>
-          val filename = s"$filenameStub-${queryStartTime.toEpochMilli}$suffix.dot"
+          val filename = s"$filenameStub-${queryStartTime.toEpochMilli}.dot"
           println(s"$logPrefix Saving query plan diagram to $filename")
           BenchUtils.generateDotGraph(plan, None, filename)
         case _ =>

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/common/BenchUtils.scala
@@ -211,13 +211,11 @@ object BenchUtils {
         val elapsed = NANOSECONDS.toMillis(end - start)
         queryTimes.append(elapsed)
 
-        val status = if (taskFailureListener.taskFailures.isEmpty) {
-          STATUS_COMPLETED
-        } else {
-          // add the first task failure to the list of exceptions in the report
-          exceptions.append(taskFailureListener.taskFailures.head.toString)
-          STATUS_COMPLETED_WITH_TASK_FAILURES
-        }
+        val failureOpt = taskFailureListener.taskFailures.headOption
+        val status = failureOpt.map(_ =>  STATUS_COMPLETED_WITH_TASK_FAILURES)
+            .getOrElse(STATUS_COMPLETED)
+        failureOpt.foreach(failure => exceptions.append(failure.toString))
+
         queryStatus.append(status)
         println(s"$logPrefix Iteration $i took $elapsed msec. Status: $status.")
 

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
@@ -53,6 +53,7 @@ class BenchUtilsSuite extends FunSuite with BeforeAndAfterEach {
       queryPlan = QueryPlan("logical", "physical"),
       Seq.empty,
       queryTimes = Seq(99, 88, 77),
+      queryStatus = Seq("Completed", "Completed", "Completed"),
       exceptions = Seq.empty)
 
     val filename = s"$TEST_FILES_ROOT/BenchUtilsSuite-${System.currentTimeMillis()}.json"


### PR DESCRIPTION
This is a **breaking change** to the JSON reporting of query times.

Previously, the `queryTime` field would contain `-1` if the query failed and `>= 0` if the query was successful.

With these changes, `queryTime` will always be the elapsed time and there is a new `queryStatus` field which will have one of the following values: `Completed`, `CompletedWithTaskFailures`, or `Failed`.
