### PR TITLE
Exclude foldable expressions from GPU if constant folding is disabled

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -352,4 +352,10 @@ Casting from string to timestamp currently has the following limitations.
 - <a name="Footnote1"></a>[1] The timestamp portion must be complete in terms of hours, minutes, seconds, and
  milliseconds, with 2 digits each for hours, minutes, and seconds, and 6 digits for milliseconds. 
  Only timezone 'Z' (UTC) is supported. Casting unsupported formats will result in null values. 
- 
+
+### Constant Folding
+
+ConstantFolding is an operator optimization rule in Catalyst that replaces expressions that can
+be statically evaluated with their equivalent literal values. We don't support excluding the rule 
+`org.apache.spark.sql.catalyst.optimizer.ConstantFolding` as we rely on this rule internally 
+and excluding it will cause some of our assumptions to fail. 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -356,6 +356,6 @@ Casting from string to timestamp currently has the following limitations.
 ### Constant Folding
 
 ConstantFolding is an operator optimization rule in Catalyst that replaces expressions that can
-be statically evaluated with their equivalent literal values. The RAPIDS Accelerator doesn't
-support excluding the rule `org.apache.spark.sql.catalyst.optimizer.ConstantFolding` as we rely on 
-this rule internally and excluding it may cause the query to produce undesired results
+be statically evaluated with their equivalent literal values. The RAPIDS Accelerator relies
+on constant folding and parts of the query will not be accelerated if 
+`org.apache.spark.sql.catalyst.optimizer.ConstantFolding` is excluded as a rule

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -356,6 +356,6 @@ Casting from string to timestamp currently has the following limitations.
 ### Constant Folding
 
 ConstantFolding is an operator optimization rule in Catalyst that replaces expressions that can
-be statically evaluated with their equivalent literal values. We don't support excluding the rule 
-`org.apache.spark.sql.catalyst.optimizer.ConstantFolding` as we rely on this rule internally 
-and excluding it will cause some of our assumptions to fail. 
+be statically evaluated with their equivalent literal values. The RAPIDS Accelerator doesn't
+support excluding the rule `org.apache.spark.sql.catalyst.optimizer.ConstantFolding` as we rely on 
+this rule internally and excluding it may cause the query to produce undesired results

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -358,4 +358,4 @@ Casting from string to timestamp currently has the following limitations.
 ConstantFolding is an operator optimization rule in Catalyst that replaces expressions that can
 be statically evaluated with their equivalent literal values. The RAPIDS Accelerator relies
 on constant folding and parts of the query will not be accelerated if 
-`org.apache.spark.sql.catalyst.optimizer.ConstantFolding` is excluded as a rule
+`org.apache.spark.sql.catalyst.optimizer.ConstantFolding` is excluded as a rule.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1028,6 +1028,10 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     entry.get(conf)
   }
 
+  def getStringConf(key: String): Option[String] = {
+    conf.get(key)
+  }
+
   lazy val rapidsConfMap: util.Map[String, String] = conf.filterKeys(
     _.startsWith("spark.rapids.")).asJava
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1028,10 +1028,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     entry.get(conf)
   }
 
-  def getStringConf(key: String): Option[String] = {
-    conf.get(key)
-  }
-
   lazy val rapidsConfMap: util.Map[String, String] = conf.filterKeys(
     _.startsWith("spark.rapids.")).asJava
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -245,7 +245,6 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
       }
     }
 
-
     tagSelfForGpu()
   }
 
@@ -813,10 +812,9 @@ abstract class BaseExprMeta[INPUT <: Expression](
       SQLConf.get.optimizerExcludedRules
         .contains("org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
     if (isConstantFoldingOff) {
-      val exp = wrapped.asInstanceOf[Expression]
-      if (exp.foldable && !GpuOverrides.isLit(exp)) {
+      if (wrapped.foldable && !GpuOverrides.isLit(wrapped)) {
         willNotWorkOnGpu(s"Cannot run on GPU because constant folding is off and expression " +
-          s"${exp} is foldable and operates on non literals")
+          s"$wrapped is foldable and operates on non literals")
       }
     }
     rule.getChecks.foreach(_.tag(this))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -808,14 +808,9 @@ abstract class BaseExprMeta[INPUT <: Expression](
   }
 
   final override def tagSelfForGpu(): Unit = {
-    val isConstantFoldingOff =
-      SQLConf.get.optimizerExcludedRules
-        .contains("org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
-    if (isConstantFoldingOff) {
-      if (wrapped.foldable && !GpuOverrides.isLit(wrapped)) {
-        willNotWorkOnGpu(s"Cannot run on GPU because constant folding is off and expression " +
-          s"$wrapped is foldable and operates on non literals")
-      }
+    if (wrapped.foldable && !GpuOverrides.isLit(wrapped)) {
+      willNotWorkOnGpu(s"Cannot run on GPU. Is ConstantFolding excluded? Expression " +
+        s"$wrapped is foldable and operates on non literals")
     }
     rule.getChecks.foreach(_.tag(this))
     tagExprForGpu()


### PR DESCRIPTION
This PR adds documentation that we don't support excluding the rule `org.apache.spark.sql.catalyst.optimizer.ConstantFolding`

This came up as a result of trying to support #1736 which was because of a change in Spark 3.1

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
