### PR TITLE
Consistent Spark version for test and production

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -29,31 +29,31 @@
     <version>0.4.0-SNAPSHOT</version>
 
     <properties>
-        <spark.test.version>3.0.0</spark.test.version>
+        <spark.test.version>${spark300.version}</spark.test.version>
     </properties>
     <profiles>
         <profile>
             <id>spark301dbtests</id>
             <properties>
-                <spark.test.version>3.0.1-databricks</spark.test.version>
+                <spark.test.version>${spark301db.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark301tests</id>
             <properties>
-                <spark.test.version>3.0.1</spark.test.version>
+                <spark.test.version>${spark301.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark302tests</id>
             <properties>
-                <spark.test.version>3.0.2-SNAPSHOT</spark.test.version>
+                <spark.test.version>${spark302.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark311tests</id>
             <properties>
-                <spark.test.version>3.1.1-SNAPSHOT</spark.test.version>
+                <spark.test.version>${spark311.version}</spark.test.version>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spark.version>3.0.0</spark.version>
+        <spark.version>${spark300.version}</spark.version>
         <cuda.version>cuda10-1</cuda.version>
         <cudf.version>0.18-SNAPSHOT</cudf.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -174,6 +174,7 @@
          If you update a dependendy version so it is no longer a SNAPSHOT
          please update the snapshot-shims profile as well so it is accurate -->
         <spark301.version>3.0.1</spark301.version>
+        <spark301db.version>3.0.1-databricks</spark301db.version>
         <spark302.version>3.0.2-SNAPSHOT</spark302.version>
         <spark311.version>3.1.1-SNAPSHOT</spark311.version>
         <mockito.version>3.6.0</mockito.version>

--- a/tests-spark310+/pom.xml
+++ b/tests-spark310+/pom.xml
@@ -29,7 +29,7 @@
     <version>0.4.0-SNAPSHOT</version>
 
     <properties>
-        <spark.test.version>3.1.0-SNAPSHOT</spark.test.version>
+        <spark.test.version>${spark311.version}</spark.test.version>
     </properties>
 
     <dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -31,31 +31,31 @@
     <version>0.4.0-SNAPSHOT</version>
 
     <properties>
-        <spark.test.version>3.0.0</spark.test.version>
+        <spark.test.version>${spark300.version}</spark.test.version>
     </properties>
     <profiles>
         <profile>
             <id>spark301dbtests</id>
             <properties>
-                <spark.test.version>3.0.1-databricks</spark.test.version>
+                <spark.test.version>${spark301db.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark301tests</id>
             <properties>
-                <spark.test.version>3.0.1</spark.test.version>
+                <spark.test.version>${spark301.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark302tests</id>
             <properties>
-                <spark.test.version>3.0.2-SNAPSHOT</spark.test.version>
+                <spark.test.version>${spark302.version}</spark.test.version>
             </properties>
         </profile>
         <profile>
             <id>spark311tests</id>
             <properties>
-                <spark.test.version>3.1.1-SNAPSHOT</spark.test.version>
+                <spark.test.version>${spark311.version}</spark.test.version>
             </properties>
         </profile>
     </profiles>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-	    <version>${spark.test.version}</version>
+            <version>${spark.test.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
Signed-off-by: Gera Shegalov <gera@apache.org>

Currently spark version for production and test code are set twice allowing the values to potentially diverge. Some definitions occur more than twice.

This PR ensures a single source of truth for setting Spark versions. It's factored out of the two PR's #1744 #1704 taking more time 