### PR TITLE
Add support of DateType and TimestampType for GetTimestamp expression

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -5873,8 +5873,8 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td> </td>
-<td> </td>
+<td>S</td>
+<td>S*</td>
 <td>S</td>
 <td> </td>
 <td> </td>
@@ -5937,8 +5937,8 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td> </td>
-<td> </td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 <td> </td>
 <td> </td>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -28,7 +28,9 @@ object TimeStamp {
     GpuOverrides.expr[GetTimestamp](
       "Gets timestamps from strings using given pattern.",
       ExprChecks.binaryProjectNotLambda(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
-        ("timeExp", TypeSig.STRING, TypeSig.STRING),
+        ("timeExp",
+            TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP,
+            TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP),
         ("format", TypeSig.lit(TypeEnum.STRING)
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.sql.{Date, Timestamp}
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, to_date, to_timestamp, unix_timestamp}
@@ -33,6 +35,18 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite {
       datesAsStrings,
       conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")) {
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yyyy"))
+  }
+
+  testSparkResultsAreEqual("to_date parse date",
+      dates,
+      conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")) {
+    df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
+  }
+
+  testSparkResultsAreEqual("to_date parse timestamp",
+      timestamps,
+      conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")) {
+    df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
@@ -132,6 +146,16 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite {
     assert(cpuNowSeconds <= gpuNowSeconds)
   }
 
+  private def dates(spark: SparkSession) = {
+    import spark.implicits._
+    dateValues.toDF("c0")
+  }
+
+  private def timestamps(spark: SparkSession) = {
+    import spark.implicits._
+    tsValues.toDF("c0")
+  }
+
   private def timestampsAsStrings(spark: SparkSession) = {
     import spark.implicits._
     timestampValues.toDF("c0")
@@ -179,6 +203,17 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite {
     "\t1999-12-31",
     "\n1999-12-31",
     "1999/12/31"
+  )
+
+  private val dateValues = Seq(
+    Date.valueOf("2020-07-24"),
+    Date.valueOf("2020-07-25"),
+    Date.valueOf("1999-12-31"))
+
+  private val tsValues = Seq(
+    Timestamp.valueOf("2015-07-24 10:00:00.3"),
+    Timestamp.valueOf("2015-07-25 02:02:02.2"),
+    Timestamp.valueOf("1999-12-31 11:59:59.999")
   )
 }
 


### PR DESCRIPTION
This is follow on PR for the review comment: https://github.com/NVIDIA/spark-rapids/pull/1742#discussion_r579487836

Signed-off-by: Niranjan Artal <nartal@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
