### PR TITLE
Spill metrics everywhere

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
+import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -337,125 +337,6 @@ abstract class AbstractGpuCoalesceIterator(
   }
 }
 
-// Remove this iterator when contiguous_split supports nested types
-class GpuCoalesceIteratorNoSpill(iter: Iterator[ColumnarBatch],
-  schema: StructType,
-  goal: CoalesceGoal,
-  maxDecompressBatchMemory: Long,
-  numInputRows: GpuMetric,
-  numInputBatches: GpuMetric,
-  numOutputRows: GpuMetric,
-  numOutputBatches: GpuMetric,
-  collectTime: GpuMetric,
-  concatTime: GpuMetric,
-  totalTime: GpuMetric,
-  peakDevMemory: GpuMetric,
-  opName: String)
-  extends AbstractGpuCoalesceIterator(iter,
-    goal,
-    numInputRows,
-    numInputBatches,
-    numOutputRows,
-    numOutputBatches,
-    collectTime,
-    concatTime,
-    totalTime,
-    opName) with Arm {
-
-  private val sparkTypes: Array[DataType] = GpuColumnVector.extractTypes(schema)
-  private var batches: ArrayBuffer[ColumnarBatch] = ArrayBuffer.empty
-  private var maxDeviceMemory: Long = 0
-
-  // batch indices that are compressed batches
-  private[this] var compressedBatchIndices: ArrayBuffer[Int] = ArrayBuffer.empty
-
-  private[this] var codec: TableCompressionCodec = _
-
-  override def initNewBatch(batch: ColumnarBatch): Unit = {
-    batches.clear()
-    compressedBatchIndices.clear()
-  }
-
-  override def addBatchToConcat(batch: ColumnarBatch): Unit = {
-    if (isBatchCompressed(batch)) {
-      compressedBatchIndices += batches.size
-    }
-    batches += batch
-  }
-
-  private def isBatchCompressed(batch: ColumnarBatch): Boolean = {
-    if (batch.numCols == 0) {
-      false
-    } else {
-      batch.column(0) match {
-        case _: GpuCompressedColumnVector => true
-        case _ => false
-      }
-    }
-  }
-
-  override def concatAllAndPutOnGPU(): ColumnarBatch = {
-    decompressBatches()
-    val tmp = batches.toArray
-    // Clear the buffer so we don't close it again (buildNonEmptyBatch closed it for us).
-    batches = ArrayBuffer.empty
-    val ret = ConcatAndConsumeAll.buildNonEmptyBatch(tmp, schema)
-    // sum of current batches and concatenating batches. Approximately sizeof(ret * 2).
-    maxDeviceMemory = GpuColumnVector.getTotalDeviceMemoryUsed(ret) * 2
-    ret
-  }
-
-  private def decompressBatches(): Unit = {
-    if (compressedBatchIndices.nonEmpty) {
-      val compressedVecs = compressedBatchIndices.map { batchIndex =>
-        batches(batchIndex).column(0).asInstanceOf[GpuCompressedColumnVector]
-      }
-      if (codec == null) {
-        val descr = compressedVecs.head.getTableMeta.bufferMeta.codecBufferDescrs(0)
-        codec = TableCompressionCodec.getCodec(descr.codec)
-      }
-      withResource(codec.createBatchDecompressor(maxDecompressBatchMemory,
-        Cuda.DEFAULT_STREAM)) { decompressor =>
-        compressedVecs.foreach { cv =>
-          val bufferMeta = cv.getTableMeta.bufferMeta
-          // don't currently support switching codecs when partitioning
-          val buffer = cv.getTableBuffer.slice(0, cv.getTableBuffer.getLength)
-          decompressor.addBufferToDecompress(buffer, bufferMeta)
-        }
-        withResource(decompressor.finishAsync()) { outputBuffers =>
-          outputBuffers.zipWithIndex.foreach { case (outputBuffer, outputIndex) =>
-            val cv = compressedVecs(outputIndex)
-            val batchIndex = compressedBatchIndices(outputIndex)
-            val compressedBatch = batches(batchIndex)
-            batches(batchIndex) =
-                MetaUtils.getBatchFromMeta(outputBuffer, cv.getTableMeta, sparkTypes)
-            compressedBatch.close()
-          }
-        }
-      }
-    }
-  }
-
-  override def cleanupConcatIsDone(): Unit = {
-    peakDevMemory.set(maxDeviceMemory)
-    batches.foreach(_.close())
-  }
-
-  private var onDeck: Option[ColumnarBatch] = None
-
-  override protected def hasOnDeck: Boolean = onDeck.isDefined
-  override protected def saveOnDeck(batch: ColumnarBatch): Unit = onDeck = Some(batch)
-  override protected def clearOnDeck(): Unit = {
-    onDeck.foreach(_.close())
-    onDeck = None
-  }
-  override protected def popOnDeck(): ColumnarBatch = {
-    val ret = onDeck.get
-    onDeck = None
-    ret
-  }
-}
-
 class GpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     schema: StructType,
     goal: CoalesceGoal,
@@ -578,29 +459,15 @@ case class GpuCoalesceBatches(child: SparkPlan, goal: CoalesceGoal)
   private[this] val maxDecompressBatchMemory =
     new RapidsConf(child.conf).shuffleCompressionMaxBatchMemory
 
-  private[this] lazy val cannotSpill = child.schema.fields.exists { f =>
-    f.dataType match {
-      case MapType(_, _, _) | ArrayType(_, _) | StructType(_) => true
-      case _ => false
-    }
-  }
-
   protected override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL
   protected override val outputBatchesLevel: MetricsLevel = MODERATE_LEVEL
-  override lazy val additionalMetrics: Map[String, GpuMetric] = {
-    val tmp = Map(
-      NUM_INPUT_ROWS -> createMetric(DEBUG_LEVEL, DESCRIPTION_NUM_INPUT_ROWS),
-      NUM_INPUT_BATCHES -> createMetric(DEBUG_LEVEL, DESCRIPTION_NUM_INPUT_BATCHES),
-      COLLECT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_COLLECT_TIME),
-      CONCAT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_CONCAT_TIME),
-      PEAK_DEVICE_MEMORY -> createSizeMetric(MODERATE_LEVEL, DESCRIPTION_PEAK_DEVICE_MEMORY)
-    )
-    if (cannotSpill) {
-      tmp
-    } else {
-      tmp ++ spillMetrics
-    }
-  }
+  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    NUM_INPUT_ROWS -> createMetric(DEBUG_LEVEL, DESCRIPTION_NUM_INPUT_ROWS),
+    NUM_INPUT_BATCHES -> createMetric(DEBUG_LEVEL, DESCRIPTION_NUM_INPUT_BATCHES),
+    COLLECT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_COLLECT_TIME),
+    CONCAT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_CONCAT_TIME),
+    PEAK_DEVICE_MEMORY -> createSizeMetric(MODERATE_LEVEL, DESCRIPTION_PEAK_DEVICE_MEMORY)
+  ) ++ spillMetrics
 
   override protected def doExecute(): RDD[InternalRow] = {
     throw new IllegalStateException("ROW BASED PROCESSING IS NOT SUPPORTED")
@@ -632,10 +499,6 @@ case class GpuCoalesceBatches(child: SparkPlan, goal: CoalesceGoal)
         val numRows = iter.map(_.numRows).sum
         val combinedCb = new ColumnarBatch(Array.empty, numRows)
         Iterator.single(combinedCb)
-      } else if (cannotSpill) {
-        new GpuCoalesceIteratorNoSpill(iter, outputSchema, goal, decompressMemoryTarget,
-          numInputRows, numInputBatches, numOutputRows, numOutputBatches, collectTime,
-          concatTime, totalTime, peakDevMemory, "GpuCoalesceBatches")
       } else {
         val callback = GpuMetric.makeSpillCallback(allMetrics)
         new GpuCoalesceIterator(iter, outputSchema, goal, decompressMemoryTarget,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -16,8 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import com.nvidia.spark.rapids.StorageTier.StorageTier
-
 import org.apache.spark.sql.rapids.TempSpillBufferId
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -134,8 +132,7 @@ object SpillableColumnarBatch extends Arm {
    */
   def apply(batch: ColumnarBatch,
       priority: Long,
-      spillCallback: RapidsBuffer.SpillCallback = RapidsBuffer.defaultSpillCallback)
-  : SpillableColumnarBatch = {
+      spillCallback: RapidsBuffer.SpillCallback): SpillableColumnarBatch = {
     val numRows = batch.numRows()
     if (batch.numCols() <= 0) {
       // We consumed it

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -165,7 +165,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     val vector3 = toArrowField("array", ArrayType(IntegerType), nullable = true, null)
       .createVector(allocator).asInstanceOf[ListVector]
     vector3.allocateNew()
-    val elementVector = vector3.getDataVector().asInstanceOf[IntVector]
+    val elementVector = vector3.getDataVector.asInstanceOf[IntVector]
 
     (0 until 10).foreach { i =>
       vector1.setSafe(i, i)
@@ -404,6 +404,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
       dummyMetric,
       dummyMetric,
       dummyMetric,
+      RapidsBuffer.defaultSpillCallback,
       "test concat")
 
     var expected = 0
@@ -485,6 +486,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
       dummyMetric,
       dummyMetric,
       dummyMetric,
+      RapidsBuffer.defaultSpillCallback,
       "test concat")
 
     var expected = 0


### PR DESCRIPTION
This enables spill metrics for all parts of the GPU plan (except UCX shuffle) that can spill. It also removes some old code there was there when cudf contiguous split did not work with nested types.

Right now it changes the API in a non-backwards compatible way to force all of the operators that can spill to report metrics on spilling. I am OK with keeping it backwards compatible for now, but eventually I want to make the change permanent.