### PR TITLE
Record row counts in benchmark runs that call collect

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/common/BenchUtilsSuite.scala
@@ -52,6 +52,7 @@ class BenchUtilsSuite extends FunSuite with BeforeAndAfterEach {
       query = "q1",
       queryPlan = QueryPlan("logical", "physical"),
       Seq.empty,
+      rowCounts = Seq(10, 10, 10),
       queryTimes = Seq(99, 88, 77),
       queryStatus = Seq("Completed", "Completed", "Completed"),
       exceptions = Seq.empty)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Updates benchmark runner to record row count for each query when running in `collect()` mode.