### PR TITLE
Update mortgage tests to support reading multiple dataset formats

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -422,6 +422,10 @@ object AggregatesWithJoin {
 
 object Main {
   def main(args: Array[String]): Unit = {
+    if (args.length < 4 || args.length > 5) {
+        System.err.println("Usage:<sparkverion> <perfpath> <acqpath> <outputpath> [csv|orc|parquet]")
+        System.exit(1)
+    }
     val perfPath = args(1)
     val acqPath = args(2)
     val output = args(3)
@@ -431,14 +435,14 @@ object Main {
       .getOrCreate()
 
     // extend args to support csv/orc/parquet dataset
-    if (args.length > 5) {
-        throw new IllegalArgumentException("Supports up to 5 arguments.")
-    }
     val format = args.lift(4).getOrElse("parquet")
     val runFun = format match {
       case "csv" => Run.csv(session, perfPath, acqPath)
       case "orc" => Run.orc(session, perfPath, acqPath)
-      case _ => Run.parquet(session, perfPath, acqPath)
+      case "parquet" => Run.parquet(session, perfPath, acqPath)
+      case _ =>
+        System.err.println(s"Invalid input format $format, expected one of csv, orc, parquet")
+        System.exit(1)
     }
 
     0.until(10).foreach( _ => runFun.write.mode("overwrite").parquet(output))

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -435,16 +435,17 @@ object Main {
       .getOrCreate()
 
     // extend args to support csv/orc/parquet dataset
+    val dataFrameFormatMap = Map(
+      "csv" -> Run.csv(session, perfPath, acqPath),
+      "orc" -> Run.orc(session, perfPath, acqPath),
+      "parquet" -> Run.parquet(session, perfPath, acqPath)
+    )
     val format = args.lift(4).getOrElse("parquet")
-    val runFun = format match {
-      case "csv" => Run.csv(session, perfPath, acqPath)
-      case "orc" => Run.orc(session, perfPath, acqPath)
-      case "parquet" => Run.parquet(session, perfPath, acqPath)
-      case _ =>
+    if (!dataFrameFormatMap.contains(format))
         System.err.println(s"Invalid input format $format, expected one of csv, orc, parquet")
         System.exit(1)
     }
 
-    0.until(10).foreach( _ => runFun.write.mode("overwrite").parquet(output))
+    0.until(10).foreach( _ => dataFrameFormatMap(format).write.mode("overwrite").parquet(output))
   }
 }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -426,12 +426,23 @@ object Main {
     val acqPath = args(2)
     val output = args(3)
 
+    // extend args to support csv/orc/parquet dataset
+    val format = if (args.length > 4) args(4) else "parquet"
+
     val session = SparkSession.builder
       .appName("MortgageJob")
       .getOrCreate()
 
-    0.until(10).foreach { _ =>
-      Run.parquet(session, perfPath, acqPath).write.mode("overwrite").parquet(output)
+    format match {
+      case "csv" => 0.until(10).foreach { _ =>
+        Run.csv(session, perfPath, acqPath).write.mode("overwrite").parquet(output)
+      }
+      case "orc" => 0.until(10).foreach { _ =>
+        Run.orc(session, perfPath, acqPath).write.mode("overwrite").parquet(output)
+      }
+      case _ => 0.until(10).foreach { _ =>
+        Run.parquet(session, perfPath, acqPath).write.mode("overwrite").parquet(output)
+      }
     }
   }
 }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -441,7 +441,7 @@ object Main {
       "parquet" -> Run.parquet(session, perfPath, acqPath)
     )
     val format = args.lift(4).getOrElse("parquet")
-    if (!dataFrameFormatMap.contains(format))
+    if (!dataFrameFormatMap.contains(format)) {
         System.err.println(s"Invalid input format $format, expected one of csv, orc, parquet")
         System.exit(1)
     }

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -423,7 +423,7 @@ object AggregatesWithJoin {
 object Main {
   def main(args: Array[String]): Unit = {
     if (args.length < 4 || args.length > 5) {
-        System.err.println("Usage:<sparkverion> <perfpath> <acqpath> <outputpath> [csv|orc|parquet]")
+        System.err.println("Usage:<sparkversion> <perfpath> <acqpath> <outputpath> [csv|orc|parquet]")
         System.exit(1)
     }
     val perfPath = args(1)


### PR DESCRIPTION
change mortgage sample class to support datasets format csv/orc/parquet

In the mortgage ETL sample test class, there are interfaces supporting the datasets format csv/orc/parquet.
The main entry only ran with parquet format before.
As we need to run mortgage ETL with the csv dataset, related issue: https://github.com/NVIDIA/spark-rapids/issues/1659, so extend it for the datasets format csv/orc/parquet.

The mortgage ETL test sample, seems do not need unit tests against it.
