### PR TITLE
[BUG] fix jvm crash during UT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>
                         <filereports>scala-test-output.txt</filereports>
-                        <argLine>${argLine} -ea -Xmx4g -Xss4m</argLine>
+                        <argLine>${argLine} -ea -Xmx8g -Xss8m</argLine>
                         <stderr/>
                         <systemProperties>
                             <rapids.shuffle.manager.override>${rapids.shuffle.manager.override}</rapids.shuffle.manager.override>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

jvm crash in nightly build during UT intermittently, try increase jvm heap size

```
OutOfMemory and StackOverflow Exception counts:
OutOfMemoryError java_heap_errors=1
```

[hs_err_pid2506.log](https://github.com/NVIDIA/spark-rapids/files/6048311/hs_err_pid2506.log)
