### PR TITLE
Spark 3.0.2 shim no longer a snapshot shim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
          please update the snapshot-shims profile as well so it is accurate -->
         <spark301.version>3.0.1</spark301.version>
         <spark301db.version>3.0.1-databricks</spark301db.version>
-        <spark302.version>3.0.2-SNAPSHOT</spark302.version>
+        <spark302.version>3.0.2</spark302.version>
         <spark311.version>3.1.1-SNAPSHOT</spark311.version>
         <mockito.version>3.6.0</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -68,12 +68,6 @@
                     <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark302_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>
@@ -100,6 +94,12 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark302_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -45,7 +45,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>spark302</module>
                 <module>spark311</module>
             </modules>
         </profile>
@@ -56,6 +55,7 @@
         <module>spark300emr</module>
         <module>spark301emr</module>
         <module>spark301</module>
+        <module>spark302</module>
         <module>aggregator</module>
     </modules>
     <dependencies>

--- a/shims/spark302/src/main/scala/com/nvidia/spark/rapids/shims/spark302/SparkShimServiceProvider.scala
+++ b/shims/spark302/src/main/scala/com/nvidia/spark/rapids/shims/spark302/SparkShimServiceProvider.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
   val VERSION = SparkShimVersion(3, 0, 2)
-  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+  val VERSIONNAMES = Seq(s"$VERSION")
 }
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 


### PR DESCRIPTION
Spark 3.0.2 has been released, so this updates the 3.0.2 shim to no longer be a snapshot shim so it will be shipped as part of the 0.4 release.