### PR TITLE
Spark 3.1.1 shim no longer a snapshot shim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <spark301.version>3.0.1</spark301.version>
         <spark301db.version>3.0.1-databricks</spark301db.version>
         <spark302.version>3.0.2</spark302.version>
-        <spark311.version>3.1.1-SNAPSHOT</spark311.version>
+        <spark311.version>3.1.1</spark311.version>
         <mockito.version>3.6.0</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -62,12 +62,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark311_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>
@@ -100,6 +94,12 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark302_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark311_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -45,7 +45,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>spark311</module>
             </modules>
         </profile>
     </profiles>
@@ -56,6 +55,7 @@
         <module>spark301emr</module>
         <module>spark301</module>
         <module>spark302</module>
+        <module>spark311</module>
         <module>aggregator</module>
     </modules>
     <dependencies>

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimServiceProvider.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimServiceProvider.scala
@@ -20,9 +20,8 @@ import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
   // keep 3.1.0 snapshot version for now until 3.1.1 is released
-  val VERSION310 = SparkShimVersion(3, 1, 0)
   val VERSION = SparkShimVersion(3, 1, 1)
-  val VERSIONNAMES = Seq(s"$VERSION310-SNAPSHOT", s"$VERSION", s"$VERSION-SNAPSHOT")
+  val VERSIONNAMES = Seq(s"$VERSION")
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimServiceProvider.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimServiceProvider.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.shims.spark311
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  // keep 3.1.0 snapshot version for now until 3.1.1 is released
   val VERSION = SparkShimVersion(3, 1, 1)
   val VERSIONNAMES = Seq(s"$VERSION")
 }


### PR DESCRIPTION
Updating the Spark 3.1.1 shim to not be a snapshot shim so it is shipped as part of the 0.4 release.