### PR TITLE
Update to note support for 3.0.2

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,10 +10,10 @@ nav_order: 11
 
 ### What versions of Apache Spark does the RAPIDS Accelerator for Apache Spark support?
 
-The RAPIDS Accelerator for Apache Spark requires version 3.0.0 or 3.0.1 of Apache Spark. Because the
-plugin replaces parts of the physical plan that Apache Spark considers to be internal the code for
-those plans can change even between bug fix releases. As a part of our process, we try to stay on
-top of these changes and release updates as quickly as possible.
+The RAPIDS Accelerator for Apache Spark requires version 3.0.0, 3.0.1, 3.0.2 or 3.1.1 of Apache
+Spark. Because the plugin replaces parts of the physical plan that Apache Spark considers to be
+internal the code for those plans can change even between bug fix releases. As a part of our
+process, we try to stay on top of these changes and release updates as quickly as possible.
 
 ### Which distributions are supported?
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -21,8 +21,8 @@ This release includes additional performance improvements, including
 * Instructions on how to use [Alluxio caching](get-started/getting-started-alluxio.md) with Spark to
   leverage caching.
 
-The release is supported on Apache Spark 3.0.0, 3.0.1, 3.1.1, Databricks 7.3 ML LTS and Google Cloud
-Platform Dataproc 2.0.
+The release is supported on Apache Spark 3.0.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS and
+Google Cloud Platform Dataproc 2.0.
 
 The list of all supported operations is provided [here](supported_ops.md).
 


### PR DESCRIPTION
Missed a line where we should say we support 3.0.2 for the 0.4 release.  