### PR TITLE
Fix fails on the mortgage ETL test

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSpark.scala
@@ -436,16 +436,18 @@ object Main {
 
     // extend args to support csv/orc/parquet dataset
     val dataFrameFormatMap = Map(
-      "csv" -> Run.csv(session, perfPath, acqPath),
-      "orc" -> Run.orc(session, perfPath, acqPath),
-      "parquet" -> Run.parquet(session, perfPath, acqPath)
+      "csv" -> { () => Run.csv(session, perfPath, acqPath) },
+      "orc" -> { () => Run.orc(session, perfPath, acqPath) },
+      "parquet" -> { () => Run.parquet(session, perfPath, acqPath) }
     )
     val format = args.lift(4).getOrElse("parquet")
-    if (!dataFrameFormatMap.contains(format)) {
+    val contains = dataFrameFormatMap.contains(format)
+    if (!contains) {
         System.err.println(s"Invalid input format $format, expected one of csv, orc, parquet")
         System.exit(1)
     }
 
-    0.until(10).foreach( _ => dataFrameFormatMap(format).write.mode("overwrite").parquet(output))
+    val runFunc = dataFrameFormatMap(format)
+    0.until(10).foreach( _ => runFunc().write.mode("overwrite").parquet(output))
   }
 }


### PR DESCRIPTION
Issue: https://github.com/NVIDIA/spark-rapids/issues/1844

In the 'Map' of dataset-format, the function of 'Run.csv()/Run.orc()/Run.parquet' will be executed one by one, then it causes the dataset format error, because the dataset format in the current test is 'parquet'

Change 'Run.csv()/Run.orc()/Run.parquet' into the lambda expressions, to avoid running the 'Run.xxx()' functions in the dataFrameFormatMap

