### PR TITLE
fix shuffle manager doc on ucx library path

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -272,7 +272,7 @@ In this section, we are using a docker container built using the sample dockerfi
 --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1 \
 --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
 --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
---conf spark.executorEnv.LD_LIBRARY_PATH=/usr/lib:/usr/lib/ucx \
+--conf spark.executorEnv.LD_LIBRARY_PATH=/usr/lib/ucx \
 --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
 ```
 

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -272,7 +272,6 @@ In this section, we are using a docker container built using the sample dockerfi
 --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1 \
 --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
 --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
---conf spark.executorEnv.LD_LIBRARY_PATH=/usr/lib/ucx \
 --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
 ```
 


### PR DESCRIPTION
Signed-off-by: Rong Ou <rong.ou@gmail.com>

The UCX 1.9.0 debian package puts `libjucx.so` in `/usr/lib`, which conflicts with the one in our jar file.