### PR TITLE
Increase row limit when doing count() for HostColumnarToGpu 

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -271,9 +271,9 @@ def assert_gpu_fallback_write(write_func,
         gpu_end - gpu_start, cpu_end - cpu_start))
 
     (cpu_bring_back, cpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, cpu_path), True)
+            lambda spark: read_func(spark, cpu_path), 'COLLECT')
     (gpu_bring_back, gpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, gpu_path), True)
+            lambda spark: read_func(spark, gpu_path), 'COLLECT')
 
     from_cpu = with_cpu_session(cpu_bring_back, conf=conf)
     from_gpu = with_cpu_session(gpu_bring_back, conf=conf)
@@ -286,7 +286,7 @@ def assert_gpu_fallback_write(write_func,
 def assert_gpu_fallback_collect(func,
         cpu_fallback_class_name,
         conf={}):
-    (bring_back, collect_type) = _prep_func_for_compare(func, True)
+    (bring_back, collect_type) = _prep_func_for_compare(func, 'COLLECT')
     conf = _prep_incompat_conf(conf)
 
     print('### CPU RUN ###')
@@ -340,15 +340,6 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}):
     """
     _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf)
 
-def assert_gpu_and_cpu_are_equal_count(func, conf={}):
-    """
-    Assert when running func on both the CPU and the GPU that the results are equal.
-    In this case count() is run on the dataframe and its collected back to the driver
-    and compared here.
-    """
-    _assert_gpu_and_cpu_are_equal(func, 'COUNT', conf=conf)
-
-
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.
@@ -357,6 +348,13 @@ def assert_gpu_and_cpu_are_equal_iterator(func, conf={}):
     """
     _assert_gpu_and_cpu_are_equal(func, 'ITERATOR', conf=conf)
 
+def assert_gpu_and_cpu_row_counts_equal(func, conf={}):
+    """
+    Assert that the row counts from running the func are the same on both the CPU and GPU.
+    This function runs count() to only get the number of rows and compares that count
+    between the CPU and GPU. It does NOT compare any underlying data.
+    """
+    _assert_gpu_and_cpu_are_equal(func, 'COUNT', conf=conf)
 
 def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None):
     """

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -154,7 +154,7 @@ class _RowCmp(object):
     def __ne__(self, other):
         return self.cmp(other) != 0
 
-def _prep_func_for_compare(func, should_collect):
+def _prep_func_for_compare(func, mode):
     sort_locally = should_sort_locally()
     if should_sort_on_spark():
         def with_sorted(spark):
@@ -174,9 +174,12 @@ def _prep_func_for_compare(func, should_collect):
     else:
         limit_func = sorted_func
 
-    if should_collect:
+    if mode == 'COLLECT':
         bring_back = lambda spark: limit_func(spark).collect()
         collect_type = 'COLLECT'
+    elif mode == 'COUNT':
+        bring_back = lambda spark: limit_func(spark).count()
+        collect_type = 'COUNT'
     else:
         bring_back = lambda spark: limit_func(spark).toLocalIterator()
         collect_type = 'ITERATOR'
@@ -196,7 +199,7 @@ def _assert_gpu_and_cpu_writes_are_equal(
         write_func,
         read_func,
         base_path,
-        should_collect,
+        mode,
         conf={}):
     conf = _prep_incompat_conf(conf)
 
@@ -214,9 +217,9 @@ def _assert_gpu_and_cpu_writes_are_equal(
         gpu_end - gpu_start, cpu_end - cpu_start))
 
     (cpu_bring_back, cpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, cpu_path), should_collect)
+            lambda spark: read_func(spark, cpu_path), mode)
     (gpu_bring_back, gpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, gpu_path), should_collect)
+            lambda spark: read_func(spark, gpu_path), mode)
 
     from_cpu = with_cpu_session(cpu_bring_back, conf=conf)
     from_gpu = with_cpu_session(gpu_bring_back, conf=conf)
@@ -233,7 +236,7 @@ def assert_gpu_and_cpu_writes_are_equal_collect(write_func, read_func, base_path
     In this case the data is collected back to the driver and compared here, so be
     careful about the amount of data returned.
     """
-    _assert_gpu_and_cpu_writes_are_equal(write_func, read_func, base_path, True, conf=conf)
+    _assert_gpu_and_cpu_writes_are_equal(write_func, read_func, base_path, 'COLLECT', conf=conf)
 
 def assert_gpu_and_cpu_writes_are_equal_iterator(write_func, read_func, base_path, conf={}):
     """
@@ -242,7 +245,7 @@ def assert_gpu_and_cpu_writes_are_equal_iterator(write_func, read_func, base_pat
     In this case the data is pulled back to the driver in chunks and compared here
     so any amount of data can work, just be careful about how long it might take.
     """
-    _assert_gpu_and_cpu_writes_are_equal(write_func, read_func, base_path, False, conf=conf)
+    _assert_gpu_and_cpu_writes_are_equal(write_func, read_func, base_path, 'ITERATOR', conf=conf)
 
 def assert_gpu_fallback_write(write_func,
         read_func,
@@ -307,9 +310,9 @@ def assert_gpu_fallback_collect(func,
     assert_equal(from_cpu, from_gpu)
 
 def _assert_gpu_and_cpu_are_equal(func,
-        should_collect,
+        mode,
         conf={}):
-    (bring_back, collect_type) = _prep_func_for_compare(func, should_collect)
+    (bring_back, collect_type) = _prep_func_for_compare(func, mode)
     conf = _prep_incompat_conf(conf)
 
     print('### CPU RUN ###')
@@ -335,7 +338,16 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}):
     In this case the data is collected back to the driver and compared here, so be
     careful about the amount of data returned.
     """
-    _assert_gpu_and_cpu_are_equal(func, True, conf=conf)
+    _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf)
+
+def assert_gpu_and_cpu_are_equal_count(func, conf={}):
+    """
+    Assert when running func on both the CPU and the GPU that the results are equal.
+    In this case the data is collected back to the driver and compared here, so be
+    careful about the amount of data returned.
+    """
+    _assert_gpu_and_cpu_are_equal(func, 'COUNT', conf=conf)
+
 
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}):
     """
@@ -343,7 +355,7 @@ def assert_gpu_and_cpu_are_equal_iterator(func, conf={}):
     In this case the data is pulled back to the driver in chunks and compared here
     so any amount of data can work, just be careful about how long it might take.
     """
-    _assert_gpu_and_cpu_are_equal(func, False, conf=conf)
+    _assert_gpu_and_cpu_are_equal(func, 'ITERATOR', conf=conf)
 
 
 def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -343,8 +343,8 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}):
 def assert_gpu_and_cpu_are_equal_count(func, conf={}):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.
-    In this case the data is collected back to the driver and compared here, so be
-    careful about the amount of data returned.
+    In this case count() is run on the dataframe and its collected back to the driver
+    and compared here.
     """
     _assert_gpu_and_cpu_are_equal(func, 'COUNT', conf=conf)
 

--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -25,7 +25,6 @@ def readTable(types, classToUse):
         .format(classToUse).load()\
         .orderBy("col1")
 
-
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_int():
     assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
@@ -45,7 +44,6 @@ def test_read_all_types_count():
     assert_gpu_and_cpu_are_equal_count(
        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
             conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
-
 
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_arrow_off():

--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_count
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal
 from marks import *
 
 columnarClass = 'com.nvidia.spark.rapids.tests.datasourcev2.parquet.ArrowColumnarDataSourceV2'
@@ -41,7 +41,7 @@ def test_read_all_types():
 
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_all_types_count():
-    assert_gpu_and_cpu_are_equal_count(
+    assert_gpu_and_cpu_row_counts_equal(
        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
             conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
 

--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -16,34 +16,40 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_count
 from marks import *
-from data_gen import debug_df
 
 columnarClass = 'com.nvidia.spark.rapids.tests.datasourcev2.parquet.ArrowColumnarDataSourceV2'
 
 def readTable(types, classToUse):
-    return lambda spark: debug_df(spark.read\
+    return lambda spark: spark.read\
         .option("arrowTypes", types)\
         .format(classToUse).load()\
-        .orderBy("col1"))
+        .orderBy("col1")
 
 
-#@validate_execs_in_gpu_plan('HostColumnarToGpu')
-#def test_read_int():
-#    assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
+@validate_execs_in_gpu_plan('HostColumnarToGpu')
+def test_read_int():
+    assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
 
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_strings():
-    assert_gpu_and_cpu_are_equal_count(readTable("string", columnarClass))
+    assert_gpu_and_cpu_are_equal_collect(readTable("string", columnarClass))
 
-#@validate_execs_in_gpu_plan('HostColumnarToGpu')
-#def test_read_all_types():
-#    assert_gpu_and_cpu_are_equal_collect(
-#       readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
-#            conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
-#
-#@validate_execs_in_gpu_plan('HostColumnarToGpu')
-#def test_read_arrow_off():
-#    assert_gpu_and_cpu_are_equal_collect(
-#        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
-##            conf={'spark.rapids.arrowCopyOptmizationEnabled': 'false',
-#                  'spark.rapids.sql.castFloatToString.enabled': 'true'})
+@validate_execs_in_gpu_plan('HostColumnarToGpu')
+def test_read_all_types():
+    assert_gpu_and_cpu_are_equal_collect(
+       readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
+            conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
+
+@validate_execs_in_gpu_plan('HostColumnarToGpu')
+def test_read_all_types_count():
+    assert_gpu_and_cpu_are_equal_count(
+       readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
+            conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
+
+
+@validate_execs_in_gpu_plan('HostColumnarToGpu')
+def test_read_arrow_off():
+    assert_gpu_and_cpu_are_equal_collect(
+        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
+            conf={'spark.rapids.arrowCopyOptmizationEnabled': 'false',
+                  'spark.rapids.sql.castFloatToString.enabled': 'true'})

--- a/integration_tests/src/main/python/datasourcev2_read_test.py
+++ b/integration_tests/src/main/python/datasourcev2_read_test.py
@@ -14,34 +14,36 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
-from marks import validate_execs_in_gpu_plan
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_count
+from marks import *
+from data_gen import debug_df
 
 columnarClass = 'com.nvidia.spark.rapids.tests.datasourcev2.parquet.ArrowColumnarDataSourceV2'
 
 def readTable(types, classToUse):
-    return lambda spark: spark.read\
+    return lambda spark: debug_df(spark.read\
         .option("arrowTypes", types)\
         .format(classToUse).load()\
-        .orderBy("col1")
+        .orderBy("col1"))
 
-@validate_execs_in_gpu_plan('HostColumnarToGpu')
-def test_read_int():
-    assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
+
+#@validate_execs_in_gpu_plan('HostColumnarToGpu')
+#def test_read_int():
+#    assert_gpu_and_cpu_are_equal_collect(readTable("int", columnarClass))
 
 @validate_execs_in_gpu_plan('HostColumnarToGpu')
 def test_read_strings():
-    assert_gpu_and_cpu_are_equal_collect(readTable("string", columnarClass))
+    assert_gpu_and_cpu_are_equal_count(readTable("string", columnarClass))
 
-@validate_execs_in_gpu_plan('HostColumnarToGpu')
-def test_read_all_types():
-    assert_gpu_and_cpu_are_equal_collect(
-       readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
-            conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
-
-@validate_execs_in_gpu_plan('HostColumnarToGpu')
-def test_read_arrow_off():
-    assert_gpu_and_cpu_are_equal_collect(
-        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
-            conf={'spark.rapids.arrowCopyOptmizationEnabled': 'false',
-                  'spark.rapids.sql.castFloatToString.enabled': 'true'})
+#@validate_execs_in_gpu_plan('HostColumnarToGpu')
+#def test_read_all_types():
+#    assert_gpu_and_cpu_are_equal_collect(
+#       readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
+#            conf={'spark.rapids.sql.castFloatToString.enabled': 'true'})
+#
+#@validate_execs_in_gpu_plan('HostColumnarToGpu')
+#def test_read_arrow_off():
+#    assert_gpu_and_cpu_are_equal_collect(
+#        readTable("int,bool,byte,short,long,string,float,double,date,timestamp", columnarClass),
+##            conf={'spark.rapids.arrowCopyOptmizationEnabled': 'false',
+#                  'spark.rapids.sql.castFloatToString.enabled': 'true'})

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -279,8 +279,8 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     // schema and desired batch size
     batchRowLimit = GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
       GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
-    // when no columns generally mean count and we don't need to limit batch size because
-    // there isn't any actual data
+    // when there aren't any columns, it generally means user is doing a count() and we don't
+    // need to limit batch size because there isn't any actual data
     if (batch.numCols() == 0) {
       batchRowLimit = Integer.MAX_VALUE
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -280,8 +280,7 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     batchRowLimit = GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
       GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
     if (batch.numCols() == 0) {
-      // batchRowLimit = Integer.MAX_VALUE
-      batchRowLimit = 512
+      batchRowLimit = Integer.MAX_VALUE
     }
 
     // if no columns then probably a count operation so doesn't matter which builder we use
@@ -294,7 +293,7 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
       logDebug("Using GpuArrowColumnarBatchBuilder")
       batchBuilder = new GpuColumnVector.GpuArrowColumnarBatchBuilder(schema, batchRowLimit, batch)
     } else {
-      logWarning("Using GpuColumnarBatchBuilder type is: " + schema)
+      logDebug("Using GpuColumnarBatchBuilder")
       batchBuilder = new GpuColumnVector.GpuColumnarBatchBuilder(schema, batchRowLimit, null)
     }
     totalRows = 0

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -279,6 +279,8 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     // schema and desired batch size
     batchRowLimit = GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
       GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
+    // when no columns generally mean count and we don't need to limit batch size because
+    // there isn't any actual data
     if (batch.numCols() == 0) {
       batchRowLimit = Integer.MAX_VALUE
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -279,6 +279,10 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     // schema and desired batch size
     batchRowLimit = GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
       GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
+    if (batch.numCols() == 0) {
+      // batchRowLimit = Integer.MAX_VALUE
+      batchRowLimit = 512
+    }
 
     // if no columns then probably a count operation so doesn't matter which builder we use
     // as we won't actually copy any data and we can't tell what type of data it is without
@@ -290,7 +294,7 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
       logDebug("Using GpuArrowColumnarBatchBuilder")
       batchBuilder = new GpuColumnVector.GpuArrowColumnarBatchBuilder(schema, batchRowLimit, batch)
     } else {
-      logDebug("Using GpuColumnarBatchBuilder")
+      logWarning("Using GpuColumnarBatchBuilder type is: " + schema)
       batchBuilder = new GpuColumnVector.GpuColumnarBatchBuilder(schema, batchRowLimit, null)
     }
     totalRows = 0

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -277,12 +277,13 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     // when reading host batches it is essential to read the data immediately and pass to a
     // builder and we need to determine how many rows to allocate in the builder based on the
     // schema and desired batch size
-    batchRowLimit = GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
-      GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
-    // when there aren't any columns, it generally means user is doing a count() and we don't
-    // need to limit batch size because there isn't any actual data
-    if (batch.numCols() == 0) {
-      batchRowLimit = Integer.MAX_VALUE
+    batchRowLimit = if (batch.numCols() > 0) {
+       GpuBatchUtils.estimateRowCount(goal.targetSizeBytes,
+         GpuBatchUtils.estimateGpuMemory(schema, 512), 512)
+    } else {
+      // when there aren't any columns, it generally means user is doing a count() and we don't
+      // need to limit batch size because there isn't any actual data
+      Integer.MAX_VALUE
     }
 
     // if no columns then probably a count operation so doesn't matter which builder we use


### PR DESCRIPTION
If doing a count() with HostcolumnToGPU which ends up doing a coalesce, the row limit is currently set at 512. This can be very inefficient for larger data.  So when there aren't any columns specified just set the row limit to max integer.

This improved one query from 2 minutes down to 6 seconds.

I also added a new testing function assert_gpu_and_cpu_are_equal_count to be able to easily test count() calls.

fixes https://github.com/NVIDIA/spark-rapids/issues/1864

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
