### PR TITLE
Decimal DIV changes 

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -200,17 +200,15 @@ trait CudfBinaryExpression extends GpuBinaryExpression {
     }
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    val lBase = lhs.getBase
-    val rBase = rhs.getBase
+  def doColumnar(lhs: BinaryOperable, rhs: BinaryOperable): ColumnVector = {
     val outType = if (castOutputAtEnd) {
-      BinaryOperable.implicitConversion(binaryOp, lBase, rBase)
+      BinaryOperable.implicitConversion(binaryOp, lhs, rhs)
     } else {
-      outputType(lBase, rBase)
+      outputType(lhs, rhs)
     }
-    val tmp = lBase.binaryOp(binaryOp, rBase, outType)
+    val tmp = lhs.binaryOp(binaryOp, rhs, outType)
     // In some cases the output type is ignored
-    val castType = outputType(lBase, rBase)
+    val castType = outputType(lhs, rhs)
     if (!castType.equals(tmp.getType) && castOutputAtEnd) {
       withResource(tmp) { tmp =>
         tmp.castTo(castType)
@@ -218,44 +216,18 @@ trait CudfBinaryExpression extends GpuBinaryExpression {
     } else {
       tmp
     }
+  }
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+    doColumnar(lhs.getBase, rhs.getBase)
   }
 
   override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
-    val rBase = rhs.getBase
-    val outType = if (castOutputAtEnd) {
-      BinaryOperable.implicitConversion(binaryOp, lhs, rBase)
-    } else {
-      outputType(lhs, rBase)
-    }
-    val tmp = lhs.binaryOp(binaryOp, rBase, outType)
-    // In some cases the output type is ignored
-    val castType = outputType(lhs, rBase)
-    if (!castType.equals(tmp.getType) && castOutputAtEnd) {
-      withResource(tmp) { tmp =>
-        tmp.castTo(castType)
-      }
-    } else {
-      tmp
-    }
+    doColumnar(lhs, rhs.getBase)
   }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
-    val lBase = lhs.getBase
-    val outType = if (castOutputAtEnd) {
-      BinaryOperable.implicitConversion(binaryOp, lBase, rhs)
-    } else {
-      outputType(lBase, rhs)
-    }
-    val tmp = lBase.binaryOp(binaryOp, rhs, outType)
-    // In some cases the output type is ignored
-    val castType = outputType(lBase, rhs)
-    if (!castType.equals(tmp.getType) && castOutputAtEnd) {
-      withResource(tmp) { tmp =>
-        tmp.castTo(castType)
-      }
-    } else {
-      tmp
-    }
+    doColumnar(lhs.getBase, rhs)
   }
 
   override def doColumnar(numRows: Int, lhs: Scalar, rhs: Scalar): ColumnVector = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1733,7 +1733,25 @@ object GpuOverrides {
           // decimal place so we can round it in GpuCheckOverflow
           (childExprs.head.dataType, childExprs(1).dataType) match {
             case (l: DecimalType, r: DecimalType) =>
-              val intermediateResult = GpuDivideUtil.decimalDataType(l, r)
+              val outputType = GpuDivideUtil.decimalDataType(l, r)
+              // We will never hit a case where outputType.precision < outputType.scale + r.scale.
+              // So there is no need to protect against that.
+              // The only two cases in which there is a possibility of the intermediary scale
+              // exceeding the intermediary precision is when l.precision < l.scale or l
+              // .precision < 0, both of which aren't possible.
+              // Proof:
+              // case 1:
+              // outputType.precision = p1 - s1 + s2 + s1 + p2 + 1 + 1
+              // outputType.scale = p1 + s2 + p2 + 1 + 1
+              // To find out if outputType.precision < outputType.scale simplifies to p1 < s1,
+              // which is never possible
+              //
+              // case 2:
+              // outputType.precision = p1 - s1 + s2 + 6 + 1
+              // outputType.scale = 6 + 1
+              // To find out if outputType.precision < outputType.scale simplifies to p1 < 0
+              // which is never possible
+              val intermediateResult = DecimalType(outputType.precision, outputType.scale + r.scale)
               if (intermediateResult.precision > DType.DECIMAL64_MAX_PRECISION) {
                 willNotWorkOnGpu("The actual output precision of the divide is too large" +
                     s" to fit on the GPU $intermediateResult")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1751,6 +1751,8 @@ object GpuOverrides {
               // outputType.scale = 6 + 1
               // To find out if outputType.precision < outputType.scale simplifies to p1 < 0
               // which is never possible
+              //
+              // TODO We should revisit the proof one more time after we support 128-bit decimals
               val intermediateResult = DecimalType(outputType.precision, outputType.scale + r.scale)
               if (intermediateResult.precision > DType.DECIMAL64_MAX_PRECISION) {
                 willNotWorkOnGpu("The actual output precision of the divide is too large" +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -243,7 +243,7 @@ abstract class GpuDecimalDivide(left: Expression, right: Expression) extends Gpu
   Serializable {
   // Override the output type as a special case for decimal
   override def dataType: DataType = (left.dataType, right.dataType) match {
-    case (l: DecimalType, r: DecimalType) =>  GpuDivideUtil.decimalDataType(l, r)
+    case (l: DecimalType, r: DecimalType) => GpuDivideUtil.decimalDataType(l, r)
     case _ => super.dataType
   }
 
@@ -253,11 +253,10 @@ abstract class GpuDecimalDivide(left: Expression, right: Expression) extends Gpu
     } else {
       l.scale - outputScale
     }
-    val newType = DecimalType(Math.min(18, l.precision + newScale), Math.min(18, newScale))
+    val newType = DecimalType(Math.min(Decimal.MAX_LONG_DIGITS, l.precision + newScale),
+      Math.min(Decimal.MAX_LONG_DIGITS, newScale))
     val raise = newScale - l.scale
-    if (raise > Decimal.MAX_LONG_DIGITS) {
-      throw new IllegalArgumentException(s"$newType  is not supported for GPU processing yet.")
-    }
+    require(raise <= Decimal.MAX_LONG_DIGITS, s"$newType  is not supported for GPU processing yet.")
     newType
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -239,22 +239,99 @@ object GpuDivideUtil {
   }
 }
 
-// This is for doubles and floats...
-case class GpuDivide(left: Expression, right: Expression) extends GpuDivModLike {
-  override def inputType: AbstractDataType = TypeCollection(DoubleType, DecimalType)
-
-  override def symbol: String = "/"
-
-  override def binaryOp: BinaryOp = BinaryOp.TRUE_DIV
-
-  override def outputTypeOverride: DType =
-    GpuColumnVector.getNonNestedRapidsType(dataType)
-
+abstract class GpuDecimalDivide(left: Expression, right: Expression) extends GpuDivModLike with
+  Serializable {
   // Override the output type as a special case for decimal
   override def dataType: DataType = (left.dataType, right.dataType) match {
     case (l: DecimalType, r: DecimalType) =>  GpuDivideUtil.decimalDataType(l, r)
     case _ => super.dataType
   }
+
+  def getNewDecimalType(outputScale: Int, l: DecimalType, r: DecimalType): DecimalType = {
+    val newScale = if (outputScale + r.scale > l.scale) {
+      outputScale + r.scale
+    } else {
+      l.scale - outputScale
+    }
+    val newType = DecimalType(Math.min(18, l.precision + newScale), Math.min(18, newScale))
+    val raise = newScale - l.scale
+    if (raise > Decimal.MAX_LONG_DIGITS) {
+      throw new IllegalArgumentException(s"$newType  is not supported for GPU processing yet.")
+    }
+    newType
+  }
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+    (left.dataType, right.dataType) match {
+      case (l: DecimalType, r: DecimalType) => {
+        val outputScale = dataType.asInstanceOf[DecimalType].scale
+        val newType = getNewDecimalType(outputScale, l, r)
+        if (outputScale + r.scale > l.scale) {
+          withResource(lhs.getBase.castTo(GpuColumnVector.getNonNestedRapidsType(newType))) {
+            modLhs => super.doColumnar(GpuColumnVector.from(modLhs, newType), rhs)
+          }
+        } else {
+          withResource(rhs.getBase.castTo(GpuColumnVector.getNonNestedRapidsType(newType))) {
+            modRhs => super.doColumnar(lhs, GpuColumnVector.from(modRhs, newType))
+          }
+        }
+      }
+      case _ => super.doColumnar(lhs, rhs)
+    }
+  }
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: Scalar): ColumnVector = {
+    (left.dataType, right.dataType) match {
+      case (l: DecimalType, r: DecimalType) => {
+        val outputScale = dataType.asInstanceOf[DecimalType].scale
+        val newType = getNewDecimalType(outputScale, l, r)
+        if (outputScale + r.scale > l.scale) {
+          withResource(lhs.getBase.castTo(GpuColumnVector.getNonNestedRapidsType(newType))) {
+            modLhs => super.doColumnar(GpuColumnVector.from(modLhs, newType), rhs)
+          }
+        } else {
+          withResource(GpuScalar.from(rhs.getBigDecimal.longValue(), newType)) { modRhs =>
+            super.doColumnar(lhs, modRhs)
+          }
+        }
+      }
+      case _ => super.doColumnar(lhs, rhs)
+    }
+  }
+
+  override def doColumnar(lhs: Scalar, rhs: GpuColumnVector): ColumnVector = {
+    (left.dataType, right.dataType) match {
+      case (l: DecimalType, r: DecimalType) => {
+        val outputScale = dataType.asInstanceOf[DecimalType].scale
+        val newType = getNewDecimalType(outputScale, l, r)
+        if (outputScale + r.scale > l.scale) {
+          withResource(GpuScalar.from(lhs.getBigDecimal.longValue(), newType)) { modLhs =>
+            super.doColumnar(modLhs, rhs)
+          }
+        } else {
+          withResource(rhs.getBase.castTo(GpuColumnVector.getNonNestedRapidsType(newType))) {
+            modRhs => super.doColumnar(lhs, GpuColumnVector.from(modRhs, newType))
+          }
+        }
+      }
+      case _ => super.doColumnar(lhs, rhs)
+    }
+  }
+}
+
+// This is for doubles and floats...
+case class GpuDivide(left: Expression, right: Expression) extends GpuDecimalDivide(left, right) {
+  override def inputType: AbstractDataType = TypeCollection(DoubleType, DecimalType)
+
+  override def symbol: String = "/"
+
+  override def binaryOp: BinaryOp = (left.dataType, right.dataType) match {
+    case (_: DecimalType, _: DecimalType) =>  BinaryOp.DIV
+    case _ => BinaryOp.TRUE_DIV
+  }
+
+  override def outputTypeOverride: DType =
+    GpuColumnVector.getNonNestedRapidsType(dataType)
 }
 
 case class GpuIntegralDivide(left: Expression, right: Expression) extends GpuDivModLike {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -262,7 +262,7 @@ case class GpuDivide(left: Expression, right: Expression) extends GpuDivModLike 
   private def getIntermediaryType(r: DecimalType): DecimalType = {
     val outType = dataType.asInstanceOf[DecimalType]
     // We should never hit a case where the newType hits precision > Decimal.MAX_LONG_DIGITS
-    // as we have check for it in tagExprForGpu
+    // as we have check for it in tagExprForGpu.
     DecimalType(outType.precision, outType.scale + r.scale)
   }
 


### PR DESCRIPTION
This PR deals with the changes to the Decimal `DIV` in cudf.

There is a bug in rapidsai/cudf#7435 where it's returning a Decimal col when a BOOL8 col is expected. I have commented on the PR https://github.com/rapidsai/cudf/pull/7435#issuecomment-792217382

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
