### PR TITLE
Remove get call on timeZoneId

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -258,6 +258,7 @@ class Spark300Shims extends SparkShims {
             a.timeZoneId.foreach {
               case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
                 willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+              case _ =>
             }
           }
 

--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -255,8 +255,9 @@ class Spark300Shims extends SparkShims {
                 }
               case _ =>
             }
-            if (ZoneId.of(a.timeZoneId.get).normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
-              willNotWorkOnGpu("Only UTC zone id is supported")
+            a.timeZoneId.foreach {
+              case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+                willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
             }
           }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1403,6 +1403,7 @@ object GpuOverrides {
           a.timeZoneId.foreach {
             case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
               willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+            case _ =>
           }
         }
 
@@ -1417,6 +1418,7 @@ object GpuOverrides {
           a.timeZoneId.foreach {
             case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
               willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+            case _ =>
           }
         }
 
@@ -1432,6 +1434,7 @@ object GpuOverrides {
           a.timeZoneId.foreach {
             case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
               willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+            case _ =>
           }
         }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1322,8 +1322,9 @@ object GpuOverrides {
               willNotWorkOnGpu("interval months isn't supported")
             }
           }
-          if (ZoneId.of(a.timeZoneId.get).normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
-            willNotWorkOnGpu("Only UTC zone id is supported")
+          a.timeZoneId.foreach {
+            case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+              willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
           }
         }
 
@@ -1399,8 +1400,9 @@ object GpuOverrides {
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (a, conf, p, r) => new UnaryExprMeta[Hour](a, conf, p, r) {
         override def tagExprForGpu(): Unit = {
-          if (ZoneId.of(a.timeZoneId.get).normalized() != UTC_TIMEZONE_ID) {
-            willNotWorkOnGpu("Only UTC zone id is supported")
+          a.timeZoneId.foreach {
+            case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+              willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
           }
         }
 
@@ -1412,8 +1414,9 @@ object GpuOverrides {
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (a, conf, p, r) => new UnaryExprMeta[Minute](a, conf, p, r) {
         override def tagExprForGpu(): Unit = {
-          if (ZoneId.of(a.timeZoneId.get).normalized() != UTC_TIMEZONE_ID) {
-            willNotWorkOnGpu("Only UTC zone id is supported")
+          a.timeZoneId.foreach {
+            case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+              willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
           }
         }
 
@@ -1426,9 +1429,10 @@ object GpuOverrides {
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (a, conf, p, r) => new UnaryExprMeta[Second](a, conf, p, r) {
         override def tagExprForGpu(): Unit = {
-            if (ZoneId.of(a.timeZoneId.get).normalized() != UTC_TIMEZONE_ID) {
-              willNotWorkOnGpu("Only UTC zone id is supported")
-            }
+          a.timeZoneId.foreach {
+            case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+              willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+          }
         }
 
         override def convertToGpu(expr: Expression): GpuExpression =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.time.ZoneId
+
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, ComplexTypeMergingExpression, Expression, LambdaFunction, String2TrimExpression, TernaryExpression, UnaryExpression, WindowExpression, WindowFunction}
@@ -322,6 +324,14 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
       }
     } else {
       "!"
+    }
+  }
+
+  protected def checkTimeZoneId(timeZoneId: Option[String]): Unit = {
+    timeZoneId.foreach { zoneId =>
+      if (ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
+        willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+      }
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -16,11 +16,10 @@
 
 package org.apache.spark.sql.rapids
 
-import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DType, Scalar}
-import com.nvidia.spark.rapids.{Arm, BinaryExprMeta, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuOverrides, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, TimeZoneCheck}
+import com.nvidia.spark.rapids.{Arm, BinaryExprMeta, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuOverrides, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
 import com.nvidia.spark.rapids.DateUtils.TimestampFormatConversionException
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -342,11 +341,11 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
    (expr: A, conf: RapidsConf,
    parent: Option[RapidsMeta[_, _, _]],
    rule: DataFromReplacementRule)
-  extends BinaryExprMeta[A](expr, conf, parent, rule) with TimeZoneCheck {
+  extends BinaryExprMeta[A](expr, conf, parent, rule) {
   var sparkFormat: String = _
   var strfFormat: String = _
   override def tagExprForGpu(): Unit = {
-    checkTimeZoneId(expr.timeZoneId, this)
+    checkTimeZoneId(expr.timeZoneId)
 
     // Date and Timestamp work too
     if (expr.right.dataType == StringType) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -345,8 +345,9 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
   var sparkFormat: String = _
   var strfFormat: String = _
   override def tagExprForGpu(): Unit = {
-    if (ZoneId.of(expr.timeZoneId.get).normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
-      willNotWorkOnGpu("Only UTC zone id is supported")
+    expr.timeZoneId.foreach {
+      case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
+        willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
     }
     // Date and Timestamp work too
     if (expr.right.dataType == StringType) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -348,6 +348,7 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
     expr.timeZoneId.foreach {
       case zoneId if ZoneId.of(zoneId).normalized() != GpuOverrides.UTC_TIMEZONE_ID =>
         willNotWorkOnGpu(s"Only UTC zone id is supported. Actual zone id: $zoneId")
+      case _ =>
     }
     // Date and Timestamp work too
     if (expr.right.dataType == StringType) {


### PR DESCRIPTION
This a follow on PR based on review comment https://github.com/NVIDIA/spark-rapids/pull/1841#discussion_r585206250 .
Updated the code where get is called on timeZoneId(Option).

Signed-off-by: Niranjan Artal <nartal@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
