### PR TITLE
Avoid pinned memory for shuffle host buffers

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -156,7 +156,9 @@ private class GpuColumnarBatchSerializerInstance(dataSize: GpuMetric) extends Se
               val header = new SerializedTableHeader(dIn)
               if (header.wasInitialized) {
                 if (header.getNumColumns > 0) {
-                  closeOnExcept(HostMemoryBuffer.allocate(header.getDataLen)) { hostBuffer =>
+                  // This buffer will later be concatenated into another host buffer before being
+                  // sent to the GPU, so no need to use pinned memory for these buffers.
+                  closeOnExcept(HostMemoryBuffer.allocate(header.getDataLen, false)) { hostBuffer =>
                     JCudfSerialization.readTableIntoBuffer(dIn, header, hostBuffer)
                     Some(SerializedTableColumn.from(header, hostBuffer))
                   }


### PR DESCRIPTION
When using legacy Spark shuffle the buffers are first collected into host buffers that are later concatenated into one monolithic host buffer by `GpuShuffleCoalesceExec` that is sent to the GPU.  The intermediate buffers do not need to be allocated with pinned memory because they are not sent directly to the device. This reduces the load on the pinned memory pool.  Because the pinned memory pool allocator currently does not perform well with many allocations, see https://github.com/rapidsai/cudf/issues/7553, this change shows noticeable speedup on regular queries with the default 200 partitions.