### PR TITLE
Fix bug where cost-based optimizer was forcing GPU CustomShuffleReaderExec onto CPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2714,7 +2714,9 @@ object GpuOverrides {
       (exec, conf, p, r) =>
       new SparkPlanMeta[CustomShuffleReaderExec](exec, conf, p, r) {
         override def tagPlanForGpu(): Unit = {
-          if (!exec.child.supportsColumnar) {
+          if (exec.child.supportsColumnar) {
+            mustStayOnGpu("Reading from a GPU shuffle")
+          } else {
             willNotWorkOnGpu(
               "Unable to replace CustomShuffleReader due to child not being columnar")
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
@@ -113,6 +113,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
   def convertToCpu(): BASE = wrapped
 
   private var cannotBeReplacedReasons: Option[mutable.Set[String]] = None
+  private var mustBeReplacedReasons: Option[mutable.Set[String]] = None
   private var cannotReplaceAnyOfPlanReasons: Option[mutable.Set[String]] = None
   private var shouldBeRemovedReasons: Option[mutable.Set[String]] = None
   protected var cannotRunOnGpuBecauseOfSparkPlan: Boolean = false
@@ -125,13 +126,18 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
    * is reached that is already on CPU.
    */
   final def recursiveCostPreventsRunningOnGpu(): Unit = {
-    if (canThisBeReplaced) {
+    if (canThisBeReplaced && !mustThisBeReplaced) {
       costPreventsRunningOnGpu()
       childDataWriteCmds.foreach(_.recursiveCostPreventsRunningOnGpu())
     }
   }
 
   final def costPreventsRunningOnGpu(): Unit = {
+
+    if (wrapped.isInstanceOf[CustomShuffleReaderExec]) {
+      throw new IllegalStateException()
+    }
+
     cannotRunOnGpuBecauseOfCost = true
     willNotWorkOnGpu("Removed by cost-based optimizer")
     childExprs.foreach(_.recursiveCostPreventsRunningOnGpu())
@@ -171,6 +177,10 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     }
   }
 
+  final def mustStayOnGpu(because: String): Unit = {
+    mustBeReplacedReasons.get.add(because)
+  }
+
   /**
    * Call this if there is a condition found that the entire plan is not allowed
    * to run on the GPU.
@@ -191,6 +201,12 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
    * Returns true iff this could be replaced.
    */
   final def canThisBeReplaced: Boolean = cannotBeReplacedReasons.exists(_.isEmpty)
+
+  /**
+   * Returns true iff this must be replaced because its children have already been
+   * replaced and this needs to also be replaced for compatibility.
+   */
+  final def mustThisBeReplaced: Boolean = mustBeReplacedReasons.exists(_.nonEmpty)
 
   /**
    * Returns the list of reasons the entire plan can't be replaced. An empty
@@ -230,6 +246,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
 
   def initReasons(): Unit = {
     cannotBeReplacedReasons = Some(mutable.Set[String]())
+    mustBeReplacedReasons = Some(mutable.Set[String]())
     shouldBeRemovedReasons = Some(mutable.Set[String]())
     cannotReplaceAnyOfPlanReasons = Some(mutable.Set[String]())
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
@@ -133,11 +133,6 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
   }
 
   final def costPreventsRunningOnGpu(): Unit = {
-
-    if (wrapped.isInstanceOf[CustomShuffleReaderExec]) {
-      throw new IllegalStateException()
-    }
-
     cannotRunOnGpuBecauseOfCost = true
     willNotWorkOnGpu("Removed by cost-based optimizer")
     childExprs.foreach(_.recursiveCostPreventsRunningOnGpu())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -362,7 +362,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "1")
-        .set(SQLConf.PREFER_SORTMERGEJOIN.key, "false")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_EXPLAIN.key, "ALL")
         .set(RapidsConf.EXPLAIN.key, "ALL")
@@ -370,8 +369,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
         .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0")
         .set("spark.rapids.sql.optimizer.exec.CustomShuffleReaderExec", "99999999")
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortMergeJoinExec,SortExec," +
-              "Alias,Cast,LessThan")
+          "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan")
 
     withGpuSparkSession(spark => {
       val df1: DataFrame = createQuery(spark).alias("l")


### PR DESCRIPTION
The experimental cost-based optimizer determines CPU vs GPU costs per operator and forces sections of the plan back onto the CPU if there is no benefit in having that section on the GPU. Unfortunately, it was not taking into account the fact that some operators must run on GPU. For example, with AQE enabled we must have a GPU `CustomShuffleReaderExec` if the shuffle already ran on the GPU, and forcing it back onto the CPU results in an invalid plan.

This PR introduces yet another type of tag in `RapidsMeta` for tagging operators that must run on GPU and the optimizer is updated to respect this. I also added a unit test to reproduce the bug.

I'm not sure if adding another tag in `RapidsMeta` is the best solution so am looking for feedback on that. 

I tested the change locally with our benchmarks and it fixes the 13 queries that were previously failing at SF=100.