### PR TITLE
Update Alias SQL quoting and float-to-timestamp casting to match Spark 3.2

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -621,4 +621,8 @@ class Spark300Shims extends SparkShims {
   ): A = {
     attachTree(tree, msg)(f)
   }
+
+  override def hasAliasQuoteFix: Boolean = false
+
+  override def hasCastFloatTimestampUpcast: Boolean = false
 }

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
@@ -73,4 +73,8 @@ class Spark320Shims extends Spark311Shims {
   ): A = {
     identity(f)
   }
+
+  override def hasAliasQuoteFix: Boolean = true
+
+  override def hasCastFloatTimestampUpcast: Boolean = true
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -213,4 +213,8 @@ trait SparkShims {
     msg: String = "")(
     f: => A
   ): A
+
+  def hasAliasQuoteFix: Boolean
+
+  def hasCastFloatTimestampUpcast: Boolean
 }


### PR DESCRIPTION
Alias SQL quoting behavior changed in [SPARK-34626](https://issues.apache.org/jira/browse/SPARK-34626) and float-to-timestamp casting behavior changed in [SPARK-34727](https://issues.apache.org/jira/browse/SPARK-34727) to upcast to double first.

This adds shim-specific flags to know when to apply these changed behaviors so the plugin remains compatible with the behavior with older versions of Spark while also matching the new Spark 3.2 behavior.