### PR TITLE
Update Spark 3.1.2 shim for float upcast behavior

### DIFF
--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
@@ -27,4 +27,6 @@ class Spark312Shims extends Spark311Shims {
   override def getRapidsShuffleManagerClass: String = {
     classOf[RapidsShuffleManager].getCanonicalName
   }
+
+  override def hasCastFloatTimestampUpcast: Boolean = true
 }


### PR DESCRIPTION
[SPARK-34727](https://issues.apache.org/jira/browse/SPARK-34727) recently was cherry-picked to branch-3.1 in Apache Spark which requires updating the Spark 3.1.2 shim accordingly.