### PR TITLE
Temp fix for parquet write changes

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -391,7 +391,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
      schema: StructType): ParquetBufferConsumer = {
     val buffer = new ParquetBufferConsumer(table.getRowCount.toInt)
     val options = ParquetWriterOptions.builder()
-      .withPrecisionValues(GpuParquetFileFormat.getFlatPrecisionList(schema):_*)
+      .withDecimalPrecisions(GpuParquetFileFormat.getPrecisionList(schema):_*)
       .withStatisticsFrequency(StatisticsFrequency.ROWGROUP)
       .withTimestampInt96(false)
       .build()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -304,7 +304,10 @@ class GpuParquetWriter(
       if (entry.nullable) {
         builder.withColumnNames(entry.name)
       } else {
-        builder.withNotNullableColumnNames(entry.name)
+        builder.withColumnNames(entry.name)
+        // TODO once https://github.com/rapidsai/cudf/issues/7654 is fixed go back to actually
+        // setting if the output is nullable or not.
+        //builder.withNotNullableColumnNames(entry.name)
       }
     })
     val options = builder.build()


### PR DESCRIPTION
This depends on https://github.com/rapidsai/cudf/pull/7655 and is a temporary work around to changes made to the parquet writer. At some point soon we are going to need to redo the parquet writer configuration API to make this work properly for structs and the like.