### PR TITLE
Add audit script to list commits from Spark

### DIFF
--- a/scripts/audit-spark-3.2.sh
+++ b/scripts/audit-spark-3.2.sh
@@ -23,12 +23,14 @@
 #   lastcommit - File which contains the latest commit hash when this script ran last.
 #   basebranch - branch in Apache Spark for which commits needs to be audited.
 #                Currently it's master as Spark-3.2 branch is not cut yet.
+#   tag        - tag until which the commits are audited 
 
 
 set -ex
 
 lastcommit=""
 basebranch="master"
+tag="v3.1.1-rc3"
 REF=${REF:-"main"}
 REF=main
 while getopts v:a: flag
@@ -36,66 +38,70 @@ do
   case "${flag}" in
       v) lastcommit=${OPTARG};;
       b) basebranch=${OPTARG};;
+      t) tag=${OPTARG};;
   esac
 done
 
-SPARK_TREE="$HOME/spark-3.2/spark"
-rm -rf $SPARK_TREE && git clone https://github.com/apache/spark.git $SPARK_TREE
-
-if [ -f "$lastcommit" ]; then
-    cd ${SPARK_TREE}
-    latestcommit=`cat ${lastcommit}`
-    git checkout $basebranch
-    git log --oneline HEAD...$latestcommit -- sql/core/src/main sql/catalyst/src/main | tee $COMMIT_DIFF_LOG
-    git log HEAD -n 1 --pretty="%h" > ${lastcommit}
-
-    cd $WORKSPACE
-    COMMIT_UPDATE=`git diff ${lastcommit}`
-    if [ -n "$COMMIT_UPDATE" ]; then
-        git config --global user.name blossom
-        git config --global user.email blossom@nvidia.com
-        git add ${lastcommit}
-        git commit -m "Update latest commit-id for org.apache.spark branch ${basebranch}"
-        git push origin HEAD:$REF
-    else
-        echo "No commit update"
-    fi
+SPARK_TREE=$SPARK_HOME
+if [ -z "$SPARK_TREE" ]; then
+  echo "SPARK_HOME IS NOT SET. CANNOT RUN THIS SCRIPT"
+  exit 1
 else
-  ## Below sequence of commands were used to get the initial list of commits to audit branch-3.2-SNAPSHOT(which is currently `master` branch)
-  ## It filters out all the commits that were audited until 3.1.1-rc3.
-  ## There wasn't easy way to get the list of commits to audit for branch-3.2-SNAPSHOT.
-  ## Spark release works in this way -  Once the release branch is cut, PR's are merged into master and then cherry-picked to release branches.
-  ## This causes different commit ids for the same PR in different branches(master & release branch).
-  ## We need to find the common parent before branch-3.1 was cut. In this case commit id 990bee9c58e is the one.
-  ## So we get all commits from master and branch-3.1 until the common parent commit and then filter it based on commit header message i.e
-  ## if the commit header is same, it means it is cherry-picked to branch-3.1(implying that commit is already audited).
-  echo "file $lastcommit not found"
-  cd ${SPARK_TREE}
+  if [ -f "$lastcommit" ]; then
+      cd ${SPARK_TREE}
+      latestcommit=`cat ${lastcommit}`
+      git checkout $basebranch
+      git log --oneline HEAD...$latestcommit -- sql/core/src/main sql/catalyst/src/main | tee $COMMIT_DIFF_LOG
+      git log HEAD -n 1 --pretty="%h" > ${lastcommit}
 
-  ## Get all the commits from TOT tagv3.1.1-rc3 to 990bee9c58e
-  git checkout v3.1.1-rc3
-  git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.1.1.log
+      cd $WORKSPACE
+      COMMIT_UPDATE=`git diff ${lastcommit}`
+      if [ -n "$COMMIT_UPDATE" ]; then
+          git config --global user.name blossom
+          git config --global user.email blossom@nvidia.com
+          git add ${lastcommit}
+          git commit -m "Update latest commit-id for org.apache.spark branch ${basebranch}"
+          git push origin HEAD:$REF
+      else
+          echo "No commit update"
+      fi
+  else
+    ## Below sequence of commands were used to get the initial list of commits to audit branch-3.2-SNAPSHOT(which is currently `master` branch)
+    ## It filters out all the commits that were audited until 3.1.1-rc3.
+    ## There wasn't easy way to get the list of commits to audit for branch-3.2-SNAPSHOT.
+    ## Spark release works in this way -  Once the release branch is cut, PR's are merged into master and then cherry-picked to release branches.
+    ## This causes different commit ids for the same PR in different branches(master & release branch).
+    ## We need to find the common parent before branch-3.1 was cut. In this case commit id 990bee9c58e is the one.
+    ## So we get all commits from master and branch-3.1 until the common parent commit and then filter it based on commit header message i.e
+    ## if the commit header is same, it means it is cherry-picked to branch-3.1(implying that commit is already audited).
+    echo "file $lastcommit not found"
+    cd ${SPARK_TREE}
 
-  ## Get all the commits from TOT master to 990bee9c58e
-  git checkout master
-  git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.2.log
+    ## Get all the commits from TOT tagv3.1.1-rc3 to 990bee9c58e
+    git checkout $tag
+    git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.1.1.log
 
-  ## Below steps filter commit header messages, sorts and saves only uniq commits that needs to be audited in commits.to.audit.3.2 file
-  cat b3.1.1.log | awk '{$1 = "";print $0}' > b3.1.1.filter.log
-  cat b3.2.log | awk '{$1 = "";print $0}' > b3.2.filter.log
-  cat b3.2.filter.log b3.1.1.filter.log | sort | uniq -c | sort  | awk '/^[[:space:]]*1/{$1 = "";print $0}' > uniqcommits.log
-  cat ~/b3.1.1.filter.log | sort > b3.1.1.filter.sorted.log
-  cat ~/b3.2.filter.log | sort > b3.2.filter.sorted.log
-  cat ~/uniqcommits.log | sort > uniqcommits.sorted.log
-  comm -12 b3.1.1.filter.sorted.log uniqcommits.sorted.log | wc -l
-  comm -12 b3.2.filter.sorted.log uniqcommits.sorted.log > commits.to.audit.3.2
-  sed -i 's/\[/\\[/g' commits.to.audit.3.2
-  sed -i 's/\]/\\]/g' commits.to.audit.3.2
+    ## Get all the commits from TOT master to 990bee9c58e
+    git checkout $basebranch
+    git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.2.log
 
-  filename=commits.to.audit.3.2
+    ## Below steps filter commit header messages, sorts and saves only uniq commits that needs to be audited in commits.to.audit.3.2 file
+    cat b3.1.1.log | awk '{$1 = "";print $0}' > b3.1.1.filter.log
+    cat b3.2.log | awk '{$1 = "";print $0}' > b3.2.filter.log
+    cat b3.2.filter.log b3.1.1.filter.log | sort | uniq -c | sort  | awk '/^[[:space:]]*1/{$1 = "";print $0}' > uniqcommits.log
+    cat ~/b3.1.1.filter.log | sort > b3.1.1.filter.sorted.log
+    cat ~/b3.2.filter.log | sort > b3.2.filter.sorted.log
+    cat ~/uniqcommits.log | sort > uniqcommits.sorted.log
+    comm -12 b3.1.1.filter.sorted.log uniqcommits.sorted.log | wc -l
+    comm -12 b3.2.filter.sorted.log uniqcommits.sorted.log > commits.to.audit.3.2
+    sed -i 's/\[/\\[/g' commits.to.audit.3.2
+    sed -i 's/\]/\\]/g' commits.to.audit.3.2
 
-  while read -r line; do
-  git log --grep="$line" --pretty="%h - %s" >> hashCommitsWithMessage.log
-  done < $filename
-  git log HEAD -n 1 --pretty="%h" > $lastcommit
+    filename=commits.to.audit.3.2
+
+    while read -r line; do
+    git log --grep="$line" --pretty="%h - %s" >> hashCommitsWithMessage.log
+    done < $filename
+    git log HEAD -n 1 --pretty="%h" > $lastcommit
+  fi
 fi

--- a/scripts/audit-spark-3.2.sh
+++ b/scripts/audit-spark-3.2.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script generates the commits that went in Apache Spark for audit.
+# Audit is required to evaluate if the code needs to be updated based
+# on new commits merged in Apache Spark. This currently audits changes for
+# Spark-3.2 (master branch).
+# Arguments:
+#   lastcommit - File which contains the latest commit hash when this script ran last.
+#   basebranch - branch in Apache Spark for which commits needs to be audited.
+#                Currently it's master as Spark-3.2 branch is not cut yet.
+
+
+set -ex
+
+lastcommit=""
+basebranch="master"
+REF=${REF:-"main"}
+REF=main
+while getopts v:a: flag
+do
+  case "${flag}" in
+      v) lastcommit=${OPTARG};;
+      b) basebranch=${OPTARG};;
+  esac
+done
+
+SPARK_TREE="$HOME/spark-3.2/spark"
+rm -rf $SPARK_TREE && git clone https://github.com/apache/spark.git $SPARK_TREE
+
+if [ -f "$lastcommit" ]; then
+    cd ${SPARK_TREE}
+    latestcommit=`cat ${lastcommit}`
+    git checkout $basebranch
+    git log --oneline HEAD...$latestcommit -- sql/core/src/main sql/catalyst/src/main | tee $COMMIT_DIFF_LOG
+    git log HEAD -n 1 --pretty="%h" > ${lastcommit}
+
+    cd $WORKSPACE
+    COMMIT_UPDATE=`git diff ${lastcommit}`
+    if [ -n "$COMMIT_UPDATE" ]; then
+        git config --global user.name blossom
+        git config --global user.email blossom@nvidia.com
+        git add ${lastcommit}
+        git commit -m "Update latest commit-id for org.apache.spark branch ${basebranch}"
+        git push origin HEAD:$REF
+    else
+        echo "No commit update"
+    fi
+else
+  ## Below sequence of commands were used to get the initial list of commits to audit branch-3.2-SNAPSHOT(which is currently `master` branch)
+  ## It filters out all the commits that were audited until 3.1.1-rc3.
+  ## There wasn't easy way to get the list of commits to audit for branch-3.2-SNAPSHOT.
+  ## Spark release works in this way -  Once the release branch is cut, PR's are merged into master and then cherry-picked to release branches.
+  ## This causes different commit ids for the same PR in different branches(master & release branch).
+  ## We need to find the common parent before branch-3.1 was cut. In this case commit id 990bee9c58e is the one.
+  ## So we get all commits from master and branch-3.1 until the common parent commit and then filter it based on commit header message i.e
+  ## if the commit header is same, it means it is cherry-picked to branch-3.1(implying that commit is already audited).
+  echo "file $lastcommit not found"
+  cd ${SPARK_TREE}
+
+  ## Get all the commits from TOT tagv3.1.1-rc3 to 990bee9c58e
+  git checkout v3.1.1-rc3
+  git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.1.1.log
+
+  ## Get all the commits from TOT master to 990bee9c58e
+  git checkout master
+  git log --oneline HEAD...990bee9c58e -- sql/core/src/main sql/catalyst/src/main  > b3.2.log
+
+  ## Below steps filter commit header messages, sorts and saves only uniq commits that needs to be audited in commits.to.audit.3.2 file
+  cat b3.1.1.log | awk '{$1 = "";print $0}' > b3.1.1.filter.log
+  cat b3.2.log | awk '{$1 = "";print $0}' > b3.2.filter.log
+  cat b3.2.filter.log b3.1.1.filter.log | sort | uniq -c | sort  | awk '/^[[:space:]]*1/{$1 = "";print $0}' > uniqcommits.log
+  cat ~/b3.1.1.filter.log | sort > b3.1.1.filter.sorted.log
+  cat ~/b3.2.filter.log | sort > b3.2.filter.sorted.log
+  cat ~/uniqcommits.log | sort > uniqcommits.sorted.log
+  comm -12 b3.1.1.filter.sorted.log uniqcommits.sorted.log | wc -l
+  comm -12 b3.2.filter.sorted.log uniqcommits.sorted.log > commits.to.audit.3.2
+  sed -i 's/\[/\\[/g' commits.to.audit.3.2
+  sed -i 's/\]/\\]/g' commits.to.audit.3.2
+
+  filename=commits.to.audit.3.2
+
+  while read -r line; do
+  git log --grep="$line" --pretty="%h - %s" >> hashCommitsWithMessage.log
+  done < $filename
+  git log HEAD -n 1 --pretty="%h" > $lastcommit
+fi


### PR DESCRIPTION
Adding audit script which is used to get the commits from Apache Spark. Currently we are auditing Spark-3.2 which is the master branch in Spark. New scripts can be added/modified if we want to track and get the list for other branches as well. 
This fixes https://github.com/NVIDIA/spark-rapids/issues/1136

Signed-off-by: Niranjan Artal <nartal@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
