### PR TITLE
[BUG] broadcast exchange can fail when job group set

### DIFF
--- a/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
+++ b/shims/spark300/src/main/scala/com/nvidia/spark/rapids/shims/spark300/Spark300Shims.scala
@@ -48,7 +48,6 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleEx
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashJoin, SortMergeJoinExec}
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
 import org.apache.spark.sql.execution.python.WindowInPandasExec
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub, ShuffleManagerShimBase}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
 import org.apache.spark.sql.rapids.execution.python.GpuWindowInPandasExecMetaBase
@@ -400,9 +399,6 @@ class Spark300Shims extends SparkShims {
       filePartitions: Seq[FilePartition]): RDD[InternalRow] = {
     new FileScanRDD(sparkSession, readFunction, filePartitions)
   }
-
-  // Hardcoded for Spark-3.0.*
-  override def getFileSourceMaxMetadataValueLength(sqlConf: SQLConf): Int = 100
 
   override def createFilePartition(index: Int, files: Array[PartitionedFile]): FilePartition = {
     FilePartition(index, files)

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -96,9 +96,6 @@ class Spark311Shims extends Spark301Shims {
     }
   }
 
-  override def getFileSourceMaxMetadataValueLength(sqlConf: SQLConf): Int =
-    sqlConf.maxMetadataStringLength
-
   def exprs311: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[Cast](
         "Convert a column of one type of data into another type",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
 import org.apache.spark.sql.execution.datasources.{FileIndex, FilePartition, HadoopFsRelation, PartitionDirectory, PartitionedFile}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, ShuffleManagerShimBase}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
 import org.apache.spark.sql.types._
@@ -138,8 +137,6 @@ trait SparkShims {
     sparkSession: SparkSession,
     readFunction: (PartitionedFile) => Iterator[InternalRow],
     filePartitions: Seq[FilePartition]): RDD[InternalRow]
-
-  def getFileSourceMaxMetadataValueLength(sqlConf: SQLConf): Int
 
   def copyParquetBatchScanExec(
       batchScanExec: GpuBatchScanExec,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuDataSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuDataSourceScanExec.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.ShimLoader
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.fs.Path
 
@@ -41,8 +40,7 @@ trait GpuDataSourceScanExec extends LeafExecNode {
   // Metadata that describes more details of this scan.
   protected def metadata: Map[String, String]
 
-  protected val maxMetadataValueLength = ShimLoader.getSparkShims
-    .getFileSourceMaxMetadataValueLength(sqlContext.sessionState.conf)
+  protected val maxMetadataValueLength = 100
 
   override def simpleString(maxFields: Int): String = {
     val metadataEntries = metadata.toSeq.sorted.map {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -29,7 +29,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
-import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
@@ -265,10 +265,7 @@ abstract class GpuBroadcastExchangeExecBase(
   @transient
   private val timeout: Long = SQLConf.get.broadcastTimeout
 
-  // Cancelling a SQL statement from Spark ThriftServer needs to cancel
-  // its related broadcast sub-jobs. So set the run id to job group id if exists.
-  val _runId: UUID = Option(sparkContext.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID))
-    .map(UUID.fromString).getOrElse(UUID.randomUUID)
+  val _runId: UUID = UUID.randomUUID()
 
   @transient
   lazy val relationFuture: Future[Broadcast[Any]] = {


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/1985

Testing on databricks we found GpuBroadcastExchange can fail with:

```
21/03/22 19:52:46 WARN SQLExecution: Error executing delta metering
java.lang.IllegalArgumentException: Invalid UUID string: 3320679480415245416_7209383250436260265_04bc82aba7ea4f96acff45a04ded8ea8
	at java.util.UUID.fromString(UUID.java:194)
	at org.apache.spark.sql.rapids.execution.GpuBroadcastExchangeExecBase.$anonfun$_runId$1(GpuBroadcastExchangeExec.scala:271)
	at scala.Option.map(Option.scala:230)
```

It looks like we pulled in a change from 3.1.1 that got reverted but we missed it.

This will affect anyone using the job groups. API like sc.setJobGroup. This especially affects databricks because they seem to set the job group all the time, atleast with the interactive notebooks. On databricks just running the following code fails all the time:
df1 = df1.join(F.broadcast(df2), "key")

spark reverted under: https://github.com/apache/spark/commit/6cd009215074f0ca9eabf91b5ff641bfeee6fdfe

So here I just reverted our commit: https://github.com/NVIDIA/spark-rapids/commit/b4d996b8f29dcdc89f4da666a16511ac1731dc30

I manually tested this on a databricks notebook and wrote 1 unit test that sets the job group. We will need to followup with more extensive automated testing.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
