### PR TITLE
broadcast exchange can fail when job group set

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -29,7 +29,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
-import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
@@ -265,10 +265,7 @@ abstract class GpuBroadcastExchangeExecBase(
   @transient
   private val timeout: Long = SQLConf.get.broadcastTimeout
 
-  // Cancelling a SQL statement from Spark ThriftServer needs to cancel
-  // its related broadcast sub-jobs. So set the run id to job group id if exists.
-  val _runId: UUID = Option(sparkContext.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID))
-    .map(UUID.fromString).getOrElse(UUID.randomUUID)
+  val _runId: UUID = UUID.randomUUID()
 
   @transient
   lazy val relationFuture: Future[Broadcast[Any]] = {


### PR DESCRIPTION
fixes #1985

Testing on databricks we found GpuBroadcastExchange can fail with:

```
21/03/22 19:52:46 WARN SQLExecution: Error executing delta metering
java.lang.IllegalArgumentException: Invalid UUID string: 3320679480415245416_7209383250436260265_04bc82aba7ea4f96acff45a04ded8ea8
	at java.util.UUID.fromString(UUID.java:194)
	at org.apache.spark.sql.rapids.execution.GpuBroadcastExchangeExecBase.$anonfun$_runId$1(GpuBroadcastExchangeExec.scala:271)
	at scala.Option.map(Option.scala:230)
```
It looks like we pulled in a change from 3.1.1 that got reverted but we missed it.

This will affect anyone using the job groups. API like sc.setJobGroup. This especially affects databricks because they seem to set the job group all the time, atleast with the interactive notebooks. On databricks just running the following code fails all the time:
df1 = df1.join(F.broadcast(df2), "key")

spark reverted under: https://github.com/apache/spark/commit/6cd009215074f0ca9eabf91b5ff641bfeee6fdfe

So here I just reverted that part of we made in https://github.com/NVIDIA/spark-rapids/commit/b4d996b8f29dcdc89f4da666a16511ac1731dc30

I manually tested this on a databricks notebook and wrote 1 unit test that sets the job group. We will need to followup with more extensive automated testing.


Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
