### PR TITLE
Pass dirs to getBlockData for a wrapped shuffle resolver

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -56,7 +56,7 @@ class GpuShuffleBlockResolver(
     if (hasActiveShuffle) {
       throw new IllegalStateException(s"The block $blockId is being managed by the catalog")
     }
-    wrapped.getBlockData(blockId)
+    wrapped.getBlockData(blockId, dirs)
   }
 
   override def stop(): Unit = wrapped.stop()


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/2001.