### PR TITLE
Fix unknown column name error when filtering ORC file with no names

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -840,7 +840,8 @@ class GpuOrcPartitionReader(
         if (debugDumpPrefix != null) {
           dumpOrcData(dataBuffer, dataSize)
         }
-        val includedColumns = ctx.updatedReadSchema.getFieldNames.asScala
+        val fieldNames = ctx.updatedReadSchema.getFieldNames.asScala.toArray
+        val includedColumns = requestedMapping.map(_.map(fieldNames(_))).getOrElse(fieldNames)
         val parseOpts = ORCOptions.builder()
           .withTimeUnit(DType.TIMESTAMP_MICROSECONDS)
           .withNumPyTypes(false)


### PR DESCRIPTION
https://github.com/rapidsai/cudf/pull/7624 recently exposed an issue in the plugin when handling an ORC file with no column names.  The plugin was filtering the stripes based on the columns being referenced but then asking for all columns in the original file schema.  After the recent cudf change, that caused an "Unknown column" exception to be thrown.

This updates the code to filter the requested columns to the referenced columns when dealing with a file that has no column names.  The existing no-column-name ORC test now passes with this change, so no new test was added.