### PR TITLE
Fix bug where rkey buffer is getting advanced after the first handshake

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -478,7 +478,7 @@ class UCX(executorId: Int, usingWakeupFeature: Boolean = true) extends AutoClose
   /**
    * Return rkeys (if we have registered memory)
    */
-  private lazy val localRkeys: Seq[ByteBuffer] = registeredMemory.synchronized {
+  private def localRkeys: Seq[ByteBuffer] = registeredMemory.synchronized {
     while (pendingRegistration) {
       registeredMemory.wait(100)
     }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/2014

The bug here is that the lazy val would get mutated per the `put` interface in `ByteBuffer`. I am not sure how I missed it but yeah, that's a big bug (introduced in 0.5 by me, see issue linked).

@rongou fyi, and thank you.