### PR TITLE
Improve error message after failed RMM shutdown

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -29,9 +29,9 @@ import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.sql.rapids.GpuShuffleEnv
 
 sealed trait MemoryState
-case object Initialized extends MemoryState
-case object Uninitialized extends MemoryState
-case object Uninitializable extends MemoryState
+private case object Initialized extends MemoryState
+private case object Uninitialized extends MemoryState
+private case object Uninitializable extends MemoryState
 
 object GpuDeviceManager extends Logging {
   // This config controls whether RMM/Pinned memory are initialized from the task

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -33,7 +33,6 @@ case object Initialized extends MemoryState
 case object Uninitialized extends MemoryState
 case object Uninitializable extends MemoryState
 
-
 object GpuDeviceManager extends Logging {
   // This config controls whether RMM/Pinned memory are initialized from the task
   // or from the executor side plugin. The default is to initialize from the

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -132,17 +132,11 @@ object GpuDeviceManager extends Logging {
   }
 
   def shutdown(): Unit = synchronized {
-    try {
-      RapidsBufferCatalog.close()
-      Rmm.shutdown()
-      singletonMemoryInitialized = Uninitialized
-    } catch {
-      case e: Throwable =>
-        // flag as Uninitializable so that any future initialization attempts can throw
-        // a helpful error message
-        singletonMemoryInitialized = Uninitializable
-        throw e
-    }
+    // assume error during shutdown until we complete it
+    singletonMemoryInitialied = Uninitializable
+    RapidsBufferCatalog.close()
+    Rmm.shutdown()
+    singletonMemoryInitialized = Uninitialized
   }
 
   def getResourcesFromTaskContext: Map[String, ResourceInformation] = {


### PR DESCRIPTION
Exceptions during `GpuDeviceManager.shutdown` can lead to `GpuDeviceManager` and ` RapidsBufferCatalog` being left in an inconsistent state which results in `NullPointerException` when accessing uninitialized state.

This PR changes the `singletonMemoryInitialized` flag from a boolean to a `MemoryState` data type with possible values of `Initialized`, `Uninitialized`, and `Uninitializable`, with appropriate error checking added.

Signed-off-by: Andy Grove <andygrove@nvidia.com>

