### PR TITLE
Upgrade ScalaTest plugin to respect JAVA_HOME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,7 @@
         <mockito.version>3.6.0</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+        <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -486,7 +487,7 @@
                 <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
-                    <version>2.0.0</version>
+                    <version>${scalatest-maven-plugin.version}</version>
                     <configuration>
                         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                         <junitxml>.</junitxml>


### PR DESCRIPTION
Signed-off-by: Gera Shegalov <gera@apache.org>

Spark/RAPIDS plugin contains tests requiring special settings for Java 11. E.g., by default the test 
`test GpuArrowColumnarBatchBuilder retains reference of ArrowBuf` triggers an error with JDK11.

If we use JDK11 by default, setting `JAVA_HOME` to a JDK8 location does not fix the problem due to 
https://github.com/scalatest/scalatest-maven-plugin/pull/69. Upgrading to the ScalaTest plugin version
to consume the fix

