### PR TITLE
Initial implementation of row count estimates in cost-based optimizer

### DIFF
--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastExchangeExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastExchangeExec.scala
@@ -17,6 +17,8 @@ package com.nvidia.spark.rapids.shims.spark301
 
 import java.util.UUID
 
+import com.nvidia.spark.rapids.GpuMetric
+
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.SparkPlan
@@ -30,8 +32,9 @@ case class GpuBroadcastExchangeExec(
   override def runId: UUID = _runId
 
   override def runtimeStatistics: Statistics = {
-    val dataSize = metrics("dataSize").value
-    Statistics(dataSize)
+    Statistics(
+      sizeInBytes = metrics("dataSize").value,
+      rowCount = Some(metrics(GpuMetric.NUM_OUTPUT_ROWS).value))
   }
 
   override def doCanonicalize(): SparkPlan = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -20,10 +20,11 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression}
-import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.CustomShuffleReaderExec
+import org.apache.spark.sql.catalyst.plans.{JoinType, LeftAnti, LeftSemi}
+import org.apache.spark.sql.execution.{GlobalLimitExec, LocalLimitExec, ProjectExec, SparkPlan, UnionExec}
+import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.internal.SQLConf
 
 class CostBasedOptimizer(conf: RapidsConf) extends Logging {
@@ -77,6 +78,8 @@ class CostBasedOptimizer(conf: RapidsConf) extends Logging {
     // calculate total (this operator + children)
     val totalCpuCost = operatorCpuCost + childCpuCosts.sum
     var totalGpuCost = operatorGpuCost + childGpuCosts.sum
+
+    plan.estimatedOutputRows = RowCountPlanVisitor.visit(plan)
 
     // determine how many transitions between CPU and GPU are taking place between
     // the child operators and this operator
@@ -268,6 +271,58 @@ class DefaultCostModel(conf: RapidsConf) extends CostModel {
     }
   }
 
+}
+
+/**
+ * Estimate the number of rows that an operator will output.
+ *
+ * Logic is based on Spark's SizeInBytesOnlyStatsPlanVisitor. which operates on logical plans
+ * and only computes data sizes, not row counts.
+ */
+object RowCountPlanVisitor {
+
+  def visit(plan: SparkPlanMeta[_]): Option[BigInt] = plan.wrapped match {
+    case p: QueryStageExec =>
+      ShimLoader.getSparkShims.getQueryStageRuntimeStatistics(p).rowCount
+    case GlobalLimitExec(limit, _) =>
+      visit(plan.childPlans.head).map(_.min(limit)).orElse(Some(limit))
+    case LocalLimitExec(limit, _) =>
+      visit(plan.childPlans.head).map(_.min(limit)).orElse(Some(limit))
+    case p: SortMergeJoinExec =>
+      estimateJoin(plan, p.joinType)
+    case p: ShuffledHashJoinExec =>
+      estimateJoin(plan, p.joinType)
+    case p: BroadcastHashJoinExec =>
+      estimateJoin(plan, p.joinType)
+    case _: UnionExec =>
+      Some(plan.childPlans.flatMap(c => visit(c)).sum)
+    case _ =>
+      default(plan)
+  }
+
+  private def estimateJoin(plan: SparkPlanMeta[_], joinType: JoinType): Option[BigInt] = {
+    joinType match {
+      case LeftAnti | LeftSemi =>
+        // LeftSemi and LeftAnti won't ever be bigger than left
+        visit(plan.childPlans.head)
+      case _ =>
+        default(plan)
+    }
+  }
+
+  private def default(p: SparkPlanMeta[_]): Option[BigInt] = {
+    val one = BigInt(1)
+    val product = p.childPlans.map(visit)
+        .filter(_.exists(_ > 0L))
+        .map(_.get)
+        .product
+    if (product == one) {
+      // product will be 1 when there are no child plans
+      None
+    } else {
+      Some(product)
+    }
+  }
 }
 
 sealed abstract class Optimization

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -540,6 +540,7 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
 
   var cpuCost: Double = 0
   var gpuCost: Double = 0
+  var estimatedOutputRows: Option[BigInt] = None
 
   override def convertToCpu(): SparkPlan = {
     wrapped.withNewChildren(childPlans.map(_.convertIfNeeded()))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -550,25 +550,6 @@ class AdaptiveQueryExecSuite
     }, conf)
   }
 
-  /** most of the AQE tests requires Spark 3.0.1 or later */
-  private def assumeSpark301orLater =
-    assume(cmpSparkVersion(3, 0, 1) >= 0)
-
-  private def assumePriorToSpark320 =
-    assume(cmpSparkVersion(3, 2, 0) < 0)
-
-  private def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
-    val sparkShimVersion = ShimLoader.getSparkShims.getSparkShimVersion
-    val (sparkMajor, sparkMinor, sparkBugfix) = sparkShimVersion match {
-      case SparkShimVersion(a, b, c) => (a, b, c)
-      case DatabricksShimVersion(a, b, c) => (a, b, c)
-      case EMRShimVersion(a, b, c) => (a, b, c)
-    }
-    val fullVersion = ((major.toLong * 1000) + minor) * 1000 + bugfix
-    val sparkFullVersion = ((sparkMajor.toLong * 1000) + sparkMinor) * 1000 + sparkBugfix
-    sparkFullVersion.compareTo(fullVersion)
-  }
-
   def checkSkewJoin(
       joins: Seq[GpuShuffledHashJoinBase],
       leftSkewNum: Int,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1811,4 +1811,24 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     }
   }
 
+  /** most of the AQE tests requires Spark 3.0.1 or later */
+  def assumeSpark301orLater =
+    assume(cmpSparkVersion(3, 0, 1) >= 0)
+
+  def assumePriorToSpark320 =
+    assume(cmpSparkVersion(3, 2, 0) < 0)
+
+  def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
+    val sparkShimVersion = ShimLoader.getSparkShims.getSparkShimVersion
+    val (sparkMajor, sparkMinor, sparkBugfix) = sparkShimVersion match {
+      case SparkShimVersion(a, b, c) => (a, b, c)
+      case DatabricksShimVersion(a, b, c) => (a, b, c)
+      case EMRShimVersion(a, b, c) => (a, b, c)
+    }
+    val fullVersion = ((major.toLong * 1000) + minor) * 1000 + bugfix
+    val sparkFullVersion = ((sparkMajor.toLong * 1000) + sparkMinor) * 1000 + sparkBugfix
+    sparkFullVersion.compareTo(fullVersion)
+  }
+
+
 }


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

First pass at making estimated row counts available to the cost-based optimizer.

Closes https://github.com/NVIDIA/spark-rapids/issues/2090



