### PR TITLE
fix refcount when materializing device buffer from GDS

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -82,7 +82,6 @@ class RapidsGdsStore(
       closeOnExcept(DeviceMemoryBuffer.allocate(size)) { buffer =>
         CuFile.readFileToDeviceBuffer(buffer, path, fileOffset)
         logDebug(s"Created device buffer for $path $fileOffset:$size via GDS")
-        buffer.incRefCount()
         buffer
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -82,6 +82,7 @@ class RapidsGdsStore(
       closeOnExcept(DeviceMemoryBuffer.allocate(size)) { buffer =>
         CuFile.readFileToDeviceBuffer(buffer, path, fileOffset)
         logDebug(s"Created device buffer for $path $fileOffset:$size via GDS")
+        buffer.incRefCount()
         buffer
       }
     }


### PR DESCRIPTION
Signed-off-by: Rong Ou <rong.ou@gmail.com>

Ideally this should be covered by a test, but right now we can't run GDS tests with the plugin. I added an action item in #1445 to add tests once the CI/CD pipeline is set up to run GDS tests.