### PR TITLE
Adjust images for integration tests

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -32,7 +32,6 @@ ARG URM_URL
 
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
-    yum install -y centos-release-scl || true && \
     yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect
 
 # The default mvn verision is 3.0.5 on centos7 docker container.

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -18,21 +18,24 @@
 #
 # Arguments:
 #    CUDA_VER=10.1, 10.2 or 11.0
+#    CENTOS_VER=7 or 8
 #    CUDF_VER=0.18 or 0.19
 #    URM_URL=<maven repo url>
 ###
+
 ARG CUDA_VER=10.1
-FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
+ARG CENTOS_VER=7
+FROM nvidia/cuda:${CUDA_VER}-runtime-centos${CENTOS_VER}
 ARG CUDA_VER
 ARG CUDF_VER
 ARG URM_URL
 
-#Install java-8, maven, docker image
+# Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
-    yum install -y centos-release-scl && \
-    yum install -y java-1.8.0-openjdk-devel wget expect
+    yum install -y centos-release-scl || true && \
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect
 
-# The default mvn verision is 3.05 on centos7 docker container.
+# The default mvn verision is 3.0.5 on centos7 docker container.
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"
 RUN wget ${URM_URL}/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz -P /usr/local && \
@@ -42,9 +45,7 @@ RUN wget ${URM_URL}/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.t
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
-
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
@@ -52,5 +53,5 @@ RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c
     conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 
-# Set ENV for mvn
+# Set default java as 1.8.0
 ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk"

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -39,7 +39,15 @@ RUN python3.8 -m easy_install pip
 # Set default jdk as 1.8.0
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
-RUN ln -s /usr/bin/python3.8 /usr/bin/python
-RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm -f ~/miniconda.sh
+ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
+# 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
+RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
+    conda install -y spacy && python -m spacy download en_core_web_sm && \
+    conda install -y -c anaconda pytest requests && \
+    conda install -y -c conda-forge sre_yield && \
+    conda clean -ay
 
 RUN apt install -y inetutils-ping expect


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

To support more test scenarios, we make our Dockerfiles more flexible to support different:
1. OS
2. CUDA version
3. JDK 8 + 11

Tested locally, all docker images will be maintained by docker manager service