### PR TITLE
fix the bound row project empty issue in row frame

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
     val aggColumn = withResource(GpuProjectExec.project(cb, boundRowProjectList)) { projected =>
 
       // in case boundRowProjectList is empty
-      val finalCb = if (boundRowProjectList.length > 0) projected else cb
+      val finalCb = if (boundRowProjectList.nonEmpty) projected else cb
 
       withResource(GpuColumnVector.from(finalCb)) { table =>
         val bases = GpuColumnVector.extractBases(finalCb).zipWithIndex

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -185,8 +185,12 @@ case class GpuWindowExpression(windowFunction: Expression, windowSpec: GpuWindow
     val totalExtraColumns = numGroupingColumns
 
     val aggColumn = withResource(GpuProjectExec.project(cb, boundRowProjectList)) { projected =>
-      withResource(GpuColumnVector.from(projected)) { table =>
-        val bases = GpuColumnVector.extractBases(projected).zipWithIndex
+
+      // in case boundRowProjectList is empty
+      val finalCb = if (boundRowProjectList.length > 0) projected else cb
+
+      withResource(GpuColumnVector.from(finalCb)) { table =>
+        val bases = GpuColumnVector.extractBases(finalCb).zipWithIndex
             .slice(totalExtraColumns, boundRowProjectList.length)
 
         val agg = windowFunc.windowAggregation(bases)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -166,6 +166,15 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     rowNumberAggregationTesterForDecimal(rowsWindow, scale = 2)
   }
 
+  testSparkResultsAreEqual(
+    "[Window] [ROWS] [UNBOUNDED PRECEDING, CURRENT ROW] [ROW_NUMBER] [WITHOUT PARTITIONBY]",
+    windowTestDfOrc) {
+    val rowsWindow = Window.orderBy("dateLong")
+      .rowsBetween(Window.unboundedPreceding, 0)
+    rowNumberAggregationTester(rowsWindow)
+    rowNumberAggregationTesterForDecimal(rowsWindow, scale = 2)
+  }
+
   testSparkResultsAreEqual("[Window] [ROWS] [UNBOUNDED PRECEDING, UNBOUNDED FOLLOWING] ",
       windowTestDfOrc) {
     val rowsWindow = Window.partitionBy("uid")


### PR DESCRIPTION
spark allows no partitioned by clause for row_number window function,
in this case, boundRowProjectList(partitionSpec + windowInputProjection)
will be empty. which results in ColumnarBatch projected empty and causes
issues.

Signed-off-by: Bobby Wang <wbo4958@gmail.com>

Fixes #2079 