### PR TITLE
Remove verbose log prints to make the build/test log clean

### DIFF
--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -37,8 +37,8 @@ if [[ -n $SPARKSRCTGZ ]]
 then
     rm -rf spark-rapids
     mkdir spark-rapids
-    echo  "tar -zxvf $SPARKSRCTGZ -C spark-rapids"
-    tar -zxvf $SPARKSRCTGZ -C spark-rapids
+    echo  "tar -zxf $SPARKSRCTGZ -C spark-rapids"
+    tar -zxf $SPARKSRCTGZ -C spark-rapids
     cd spark-rapids
 fi
 export WORKSPACE=`pwd`
@@ -104,4 +104,4 @@ mvn -B install:install-file \
 mvn -B -P${BUILD_PROFILES} clean package -DskipTests
 
 cd /home/ubuntu
-tar -zcvf spark-rapids-built.tgz spark-rapids
+tar -zcf spark-rapids-built.tgz spark-rapids

--- a/jenkins/databricks/deploy.sh
+++ b/jenkins/databricks/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/deploy.sh
+++ b/jenkins/databricks/deploy.sh
@@ -19,7 +19,7 @@ set -e
 rm -rf deploy
 mkdir -p deploy
 cd deploy
-tar -zxvf ../spark-rapids-built.tgz
+tar -zxf ../spark-rapids-built.tgz
 cd spark-rapids
 echo "Maven mirror is $MVN_URM_MIRROR"
 SERVER_ID='snapshots'

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -40,7 +40,7 @@ if [ "$DATABRICKS" == true ]; then
     rm -rf deploy
     mkdir -p deploy
     cd deploy
-    tar -zxvf ../spark-rapids-built.tgz
+    tar -zxf ../spark-rapids-built.tgz
     cd spark-rapids
 fi
 


### PR DESCRIPTION
Fixes issue https://github.com/NVIDIA/spark-rapids/issues/2098

Remove the below tar verbose log prints in Jenkins to make the build/test log clean

tar -zxvf /home/ubuntu/spark-rapids-ci.tgz -C spark-rapids
CHANGELOG.md
CODE_OF_CONDUCT.md
CONTRIBUTING.md
LICENSE
NOTICE
NOTICE-binary
README.md
api_validation/
api_validation/auditAllVersions.sh
api_validation/src/
api_validation/src/main/
api_validation/src/main/resources/