### PR TITLE
abstract multi-file clouder reader and apply to parquet

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -242,7 +242,7 @@ abstract class MultiFileCloudPartitionReaderBase(
 
     // this shouldn't happen but if somehow the batch is None and we still
     // have work left skip to the next file
-    if (!batch.isDefined && filesToRead > 0 && !isDone) {
+    if (batch.isEmpty && filesToRead > 0 && !isDone) {
       next()
     }
 
@@ -263,7 +263,7 @@ abstract class MultiFileCloudPartitionReaderBase(
   }
 
   private def addNextTaskIfNeeded(): Unit = {
-    if (tasksToRun.size > 0 && !isDone) {
+    if (tasksToRun.nonEmpty && !isDone) {
       val runner = tasksToRun.dequeue()
       tasks.add(getThreadPool(numThreads).submit(runner))
     }
@@ -274,7 +274,7 @@ abstract class MultiFileCloudPartitionReaderBase(
     // in cases close got called early for like limit() calls
     isDone = true
     currentFileHostBuffers.foreach { current =>
-      current.memBuffersAndSizes.foreach { case (buf, size) =>
+      current.memBuffersAndSizes.foreach { case (buf, _) =>
         if (buf != null) {
           buf.close()
         }
@@ -285,7 +285,7 @@ abstract class MultiFileCloudPartitionReaderBase(
     batch = None
     tasks.asScala.foreach { task =>
       if (task.isDone()) {
-        task.get.memBuffersAndSizes.foreach { case (buf, size) =>
+        task.get.memBuffersAndSizes.foreach { case (buf, _) =>
           if (buf != null) {
             buf.close()
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Future}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.Queue
+
+import ai.rapids.cudf.{HostMemoryBuffer, NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.GpuMetric.PEAK_DEVICE_MEMORY
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.execution.datasources.PartitionedFile
+import org.apache.spark.sql.rapids.InputFileUtils
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * The base HostMemoryBuffer information read from a single file.
+ */
+trait HostMemoryBuffersWithMetaDataBase {
+  // PartitionedFile to be read
+  def partitionedFile: PartitionedFile
+  // An array of BlockChunk (HostMemoryBuffer and its size)
+  def memBuffersAndSizes: Array[(HostMemoryBuffer, Long)]
+  def bytesRead: Long
+}
+
+trait MultiFileReaderFunctions extends Arm {
+  protected def addPartitionValues(
+      batch: Option[ColumnarBatch],
+      inPartitionValues: InternalRow,
+      partitionSchema: StructType): Option[ColumnarBatch] = {
+    if (partitionSchema.nonEmpty) {
+      batch.map { cb =>
+        val partitionValues = inPartitionValues.toSeq(partitionSchema)
+        val partitionScalars = ColumnarPartitionReaderWithPartitionValues
+          .createPartitionValues(partitionValues, partitionSchema)
+        withResource(partitionScalars) { scalars =>
+          ColumnarPartitionReaderWithPartitionValues.addPartitionValues(cb, scalars,
+            GpuColumnVector.extractTypes(partitionSchema))
+        }
+      }
+    } else {
+      batch
+    }
+  }
+
+  protected def fileSystemBytesRead(): Long = {
+    FileSystem.getAllStatistics.asScala.map(_.getThreadStatistics.getBytesRead).sum
+  }
+}
+
+/**
+ * The Abstract base class working as multi-file cloud reading framework
+ * @param conf
+ * @param files PartitionFiles to be read
+ * @param numThreads the number of threads to parallelly read files.
+ * @param maxNumFileProcessed
+ * @param filters push down filters
+ * @param execMetrics
+ */
+abstract class MultiFileCloudPartitionReaderBase(
+    conf: Configuration,
+    files: Array[PartitionedFile],
+    numThreads: Int,
+    maxNumFileProcessed: Int,
+    filters: Array[Filter],
+    execMetrics: Map[String, GpuMetric]) extends PartitionReader[ColumnarBatch] with Logging
+  with ScanWithMetrics with Arm {
+
+  metrics = execMetrics
+
+  protected var maxDeviceMemory: Long = 0
+
+  protected var batch: Option[ColumnarBatch] = None
+  protected var isDone: Boolean = false
+
+  private var filesToRead = 0
+  protected var currentFileHostBuffers: Option[HostMemoryBuffersWithMetaDataBase] = None
+  private var isInitted = false
+  private val tasks = new ConcurrentLinkedQueue[Future[HostMemoryBuffersWithMetaDataBase]]()
+  private val tasksToRun = new Queue[Callable[HostMemoryBuffersWithMetaDataBase]]()
+  private[this] val inputMetrics = TaskContext.get.taskMetrics().inputMetrics
+
+  private def initAndStartReaders(): Unit = {
+    // limit the number we submit at once according to the config if set
+    val limit = math.min(maxNumFileProcessed, files.length)
+    for (i <- 0 until limit) {
+      val file = files(i)
+      // Add these in the order as we got them so that we can make sure
+      // we process them in the same order as CPU would.
+      tasks.add(MultiFileThreadPoolFactory.submitToThreadPool(
+        getBatchRunner(file, conf, filters), numThreads))
+    }
+    // queue up any left to add once others finish
+    for (i <- limit until files.length) {
+      val file = files(i)
+      tasksToRun.enqueue(getBatchRunner(file, conf, filters))
+    }
+    isInitted = true
+    filesToRead = files.length
+  }
+
+  /**
+   * file reading logic in a Callable which will be running in a thread pool
+   *
+   * @param file file to be read
+   * @param conf
+   * @param filters push down filters
+   * @return Callable[HostMemoryBuffersWithMetaDataBase]
+   */
+  def getBatchRunner(
+    file: PartitionedFile,
+    conf: Configuration,
+    filters: Array[Filter]): Callable[HostMemoryBuffersWithMetaDataBase]
+
+  /**
+   * decode HostMemoryBuffers by GPU
+   * @param fileBufsAndMeta
+   * @return
+   */
+  def readBatch(
+    fileBufsAndMeta: HostMemoryBuffersWithMetaDataBase): Option[ColumnarBatch]
+
+  def getLogTag: String
+
+  override def next(): Boolean = {
+    withResource(new NvtxRange(getLogTag + " readBatch", NvtxColor.GREEN)) { _ =>
+      if (isInitted == false) {
+        initAndStartReaders()
+      }
+      batch.foreach(_.close())
+      batch = None
+      // if we have batch left from the last file read return it
+      if (currentFileHostBuffers.isDefined) {
+        if (getSizeOfHostBuffers(currentFileHostBuffers.get) == 0) {
+          next()
+        }
+        batch = readBatch(currentFileHostBuffers.get)
+      } else {
+        currentFileHostBuffers = None
+        if (filesToRead > 0 && !isDone) {
+          val fileBufsAndMeta = tasks.poll.get()
+          filesToRead -= 1
+          TrampolineUtil.incBytesRead(inputMetrics, fileBufsAndMeta.bytesRead)
+          InputFileUtils.setInputFileBlock(
+            fileBufsAndMeta.partitionedFile.filePath,
+            fileBufsAndMeta.partitionedFile.start,
+            fileBufsAndMeta.partitionedFile.length)
+
+          if (getSizeOfHostBuffers(fileBufsAndMeta) == 0) {
+            // if sizes are 0 means no rows and no data so skip to next file
+            // file data was empty so submit another task if any were waiting
+            addNextTaskIfNeeded()
+            next()
+          } else {
+            batch = readBatch(fileBufsAndMeta)
+            // the data is copied to GPU so submit another task if we were limited
+            addNextTaskIfNeeded()
+          }
+        } else {
+          isDone = true
+          metrics(PEAK_DEVICE_MEMORY) += maxDeviceMemory
+        }
+      }
+    }
+
+    // this shouldn't happen but if somehow the batch is None and we still
+    // have work left skip to the next file
+    if (!batch.isDefined && filesToRead > 0 && !isDone) {
+      next()
+    }
+
+    // This is odd, but some operators return data even when there is no input so we need to
+    // be sure that we grab the GPU
+    GpuSemaphore.acquireIfNecessary(TaskContext.get())
+    batch.isDefined
+  }
+
+  override def get(): ColumnarBatch = {
+    val ret = batch.getOrElse(throw new NoSuchElementException)
+    batch = None
+    ret
+  }
+
+  private def getSizeOfHostBuffers(fileInfo: HostMemoryBuffersWithMetaDataBase): Long = {
+    fileInfo.memBuffersAndSizes.map(_._2).sum
+  }
+
+  private def addNextTaskIfNeeded(): Unit = {
+    if (tasksToRun.size > 0 && !isDone) {
+      val runner = tasksToRun.dequeue()
+      tasks.add(MultiFileThreadPoolFactory.submitToThreadPool(runner, numThreads))
+    }
+  }
+
+  override def close(): Unit = {
+    // this is more complicated because threads might still be processing files
+    // in cases close got called early for like limit() calls
+    isDone = true
+    currentFileHostBuffers.foreach { current =>
+      current.memBuffersAndSizes.foreach { case (buf, size) =>
+        if (buf != null) {
+          buf.close()
+        }
+      }
+    }
+    currentFileHostBuffers = None
+    batch.foreach(_.close())
+    batch = None
+    tasks.asScala.foreach { task =>
+      if (task.isDone()) {
+        task.get.memBuffersAndSizes.foreach { case (buf, size) =>
+          if (buf != null) {
+            buf.close()
+          }
+        }
+      } else {
+        // Note we are not interrupting thread here so it
+        // will finish reading and then just discard. If we
+        // interrupt HDFS logs warnings about being interrupted.
+        task.cancel(false)
+      }
+    }
+  }
+
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -46,14 +46,14 @@ trait HostMemoryBuffersWithMetaDataBase {
   def partitionedFile: PartitionedFile
   // An array of BlockChunk(HostMemoryBuffer and its data size) read from PartitionedFile
   def memBuffersAndSizes: Array[(HostMemoryBuffer, Long)]
-  // total bytes read
+  // Total bytes read
   def bytesRead: Long
 }
 
-// this is a common trait for all kind of file formats
+// This is a common trait for all kind of file formats
 trait MultiFileReaderFunctions extends Arm {
 
-  // add partitioned columns into the batch
+  // Add partitioned columns into the batch
   protected def addPartitionValues(
       batch: Option[ColumnarBatch],
       inPartitionValues: InternalRow,
@@ -82,7 +82,6 @@ trait MultiFileReaderFunctions extends Arm {
 // Please note that the TaskContext is not set in these threads and should not be used.
 object MultiFileThreadPoolUtil {
 
-  // create a thread pool
   def createThreadPool(
       threadTag: String,
       maxThreads: Int = 20,
@@ -175,27 +174,28 @@ abstract class MultiFileCloudPartitionReaderBase(
     filters: Array[Filter]): Callable[HostMemoryBuffersWithMetaDataBase]
 
   /**
-   * get ThreadPoolExecutor to run the Callable.
+   * Get ThreadPoolExecutor to run the Callable.
    *
-   * the rules:
-   * 1. same ThreadPoolExecutor for cloud and coalescing for the same file format
-   * 2. different file formats have different ThreadPoolExecutors
+   * There're two rules:
+   * 1. Same ThreadPoolExecutor for cloud and coalescing for the same file format
+   * 2. Different file formats have different ThreadPoolExecutors
    *
-   * @return
+   * @param numThreads  max number of threads to create
+   * @return A ThreadPoolExecutors to used
    */
   def getThreadPool(numThreads: Int): ThreadPoolExecutor
 
   /**
-   * decode HostMemoryBuffers in GPU
+   * Decode HostMemoryBuffers in GPU
    * @param fileBufsAndMeta the file HostMemoryBuffer read from a PartitionedFile
-   * @return
+   * @return Option[ColumnarBatch] which has been decoded by GPU
    */
   def readBatch(
     fileBufsAndMeta: HostMemoryBuffersWithMetaDataBase): Option[ColumnarBatch]
 
   /**
-   * get the log tag
-   * @return
+   * Get the log prefix to form a new log tag in Logger and NVTX.
+   * @return the log tag
    */
   def getLogTag: String
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -194,13 +194,15 @@ abstract class MultiFileCloudPartitionReaderBase(
     fileBufsAndMeta: HostMemoryBuffersWithMetaDataBase): Option[ColumnarBatch]
 
   /**
-   * Get the log prefix to form a new log tag in Logger and NVTX.
-   * @return the log tag
+   * File format short name used for logging and other things to uniquely identity
+   * which file format is being used.
+   *
+   * @return the file format short name
    */
-  def getLogTag: String
+  def getFileFormatShortName: String
 
   override def next(): Boolean = {
-    withResource(new NvtxRange(getLogTag + " readBatch", NvtxColor.GREEN)) { _ =>
+    withResource(new NvtxRange(getFileFormatShortName + " readBatch", NvtxColor.GREEN)) { _ =>
       if (isInitted == false) {
         initAndStartReaders()
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1475,14 +1475,16 @@ class MultiFileCloudParquetPartitionReader(
    * @return ThreadPoolExecutor
    */
   override def getThreadPool(numThreads: Int): ThreadPoolExecutor = {
-    ParquetMultiFileThreadPoolFactory.getThreadPool(getLogTag, numThreads)
+    ParquetMultiFileThreadPoolFactory.getThreadPool(getFileFormatShortName, numThreads)
   }
 
   /**
-   * Get the log prefix
-   *  @return "Parquet"
+   * File format short name used for logging and other things to uniquely identity
+   * which file format is being used.
+   *
+   * @return the file format short name
    */
-  override def getLogTag: String = "Parquet"
+  override def getFileFormatShortName: String = "Parquet"
 
   /**
    * Decode HostMemoryBuffers by GPU

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -21,23 +21,24 @@ import java.net.{URI, URISyntaxException}
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Locale, Optional}
 import java.util.concurrent._
+
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.HashSet
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, LinkedHashMap, ListBuffer, Queue}
 import scala.math.max
+
 import ai.rapids.cudf._
 import ai.rapids.cudf.DType.DTypeEnum
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.nvidia.spark.RebaseHelper
 import com.nvidia.spark.rapids.GpuMetric._
-import com.nvidia.spark.rapids.MultiFileThreadPoolFactory.{initThreadPool, threadPool}
 import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FSDataInputStream, FileSystem, Path}
+import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 import org.apache.parquet.bytes.BytesUtils
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.filter2.predicate.FilterApi
@@ -57,7 +58,6 @@ import org.apache.spark.sql.execution.datasources.parquet.{ParquetFilters, Parqu
 import org.apache.spark.sql.execution.datasources.v2.FilePartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.InputFileUtils
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{ArrayType, DataType, DateType, Decimal, DecimalType, MapType, StringType, StructType, TimestampType}
@@ -1388,7 +1388,6 @@ class MultiFileCloudParquetPartitionReader(
     filters: Array[Filter])
   extends MultiFileCloudPartitionReaderBase(conf, files, numThreads, maxNumFileProcessed, filters,
     execMetrics) with ParquetPartitionReaderBase with MultiFileReaderFunctions {
-
 
   case class HostMemoryBuffersWithMetaData(
     override val partitionedFile: PartitionedFile,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -21,24 +21,23 @@ import java.net.{URI, URISyntaxException}
 import java.nio.charset.StandardCharsets
 import java.util.{Collections, Locale, Optional}
 import java.util.concurrent._
-
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.HashSet
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, LinkedHashMap, ListBuffer, Queue}
 import scala.math.max
-
 import ai.rapids.cudf._
 import ai.rapids.cudf.DType.DTypeEnum
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.nvidia.spark.RebaseHelper
 import com.nvidia.spark.rapids.GpuMetric._
+import com.nvidia.spark.rapids.MultiFileThreadPoolFactory.{initThreadPool, threadPool}
 import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
+import org.apache.hadoop.fs.{FSDataInputStream, FileSystem, Path}
 import org.apache.parquet.bytes.BytesUtils
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.filter2.predicate.FilterApi
@@ -46,7 +45,6 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
 import org.apache.parquet.hadoop.metadata._
 import org.apache.parquet.schema.{GroupType, MessageType, OriginalType, Type, Types}
-
 import org.apache.spark.TaskContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
@@ -883,6 +881,25 @@ abstract class FileParquetPartitionReaderBase(
 
 // Singleton threadpool that is used across all the tasks.
 // Please note that the TaskContext is not set in these threads and should not be used.
+object ParquetMultiFileThreadPoolFactory {
+  private var threadPool: Option[ThreadPoolExecutor] = None
+
+  private def initThreadPool(
+      threadTag: String,
+      numThreads: Int): ThreadPoolExecutor = synchronized {
+    if (!threadPool.isDefined) {
+      threadPool = Some(MultiFileThreadPoolUtil.createThreadPool(threadTag, numThreads))
+    }
+    threadPool.get
+  }
+
+  def getThreadPool(threadTag: String, numThreads: Int): ThreadPoolExecutor = {
+    threadPool.getOrElse(initThreadPool(threadTag, numThreads))
+  }
+}
+
+// Singleton threadpool that is used across all the tasks.
+// Please note that the TaskContext is not set in these threads and should not be used.
 object MultiFileThreadPoolFactory {
 
   private var threadPool: Option[ThreadPoolExecutor] = None
@@ -1459,7 +1476,19 @@ class MultiFileCloudParquetPartitionReader(
     new ReadBatchRunner(filterHandler, file, conf, filters)
   }
 
-  override def getLogTag: String = "Parquet read"
+  /**
+   * get ThreadPoolExecutor to run the Callable.
+   *
+   * same ThreadPoolExecutor for cloud and coalescing for same file format
+   * different ThreadPoolExecutors for different file formats
+   *
+   * @return
+   */
+  override def getThreadPool(numThreads: Int): ThreadPoolExecutor = {
+    ParquetMultiFileThreadPoolFactory.getThreadPool(getLogTag, numThreads)
+  }
+
+  override def getLogTag: String = "Parquet"
 
   /**
    * decode HostMemoryBuffers by GPU

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1456,10 +1456,10 @@ class MultiFileCloudParquetPartitionReader(
   }
 
   /**
-   * file reading logic in a Callable which will be running in a thread pool
+   * File reading logic in a Callable which will be running in a thread pool
    *
    * @param file    file to be read
-   * @param conf
+   * @param conf    configuration
    * @param filters push down filters
    * @return Callable[HostMemoryBuffersWithMetaDataBase]
    */
@@ -1469,24 +1469,26 @@ class MultiFileCloudParquetPartitionReader(
   }
 
   /**
-   * get ThreadPoolExecutor to run the Callable.
+   * Get ThreadPoolExecutor to run the Callable.
    *
-   * same ThreadPoolExecutor for cloud and coalescing for same file format
-   * different ThreadPoolExecutors for different file formats
-   *
-   * @return
+   * @param  numThreads  max number of threads to create
+   * @return ThreadPoolExecutor
    */
   override def getThreadPool(numThreads: Int): ThreadPoolExecutor = {
     ParquetMultiFileThreadPoolFactory.getThreadPool(getLogTag, numThreads)
   }
 
+  /**
+   * Get the log prefix
+   *  @return "Parquet"
+   */
   override def getLogTag: String = "Parquet"
 
   /**
-   * decode HostMemoryBuffers by GPU
+   * Decode HostMemoryBuffers by GPU
    *
-   * @param fileBufsAndMeta
-   * @return
+   * @param fileBufsAndMeta the file HostMemoryBuffer read from a PartitionedFile
+   * @return Option[ColumnarBatch]
    */
   override def readBatch(fileBufsAndMeta: HostMemoryBuffersWithMetaDataBase):
       Option[ColumnarBatch] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -880,7 +880,7 @@ object ParquetMultiFileThreadPoolFactory {
   private def initThreadPool(
       threadTag: String,
       numThreads: Int): ThreadPoolExecutor = synchronized {
-    if (!threadPool.isDefined) {
+    if (threadPool.isEmpty) {
       threadPool = Some(MultiFileThreadPoolUtil.createThreadPool(threadTag, numThreads))
     }
     threadPool.get


### PR DESCRIPTION
This PR first abstracted the basic logic of multi-files cloud reader to be the common class that should be applied for different file formats, eg. Parquet, ORC, CSV, and so on.

Second, reformed the existing parquet multi-files cloud reader which extends the common class abstracted 

The initialization design doc can be found at https://docs.google.com/document/d/10sIOPMesnSNPvbb_SGnbE1C4gQv-G4ISorgYK8jQQns/edit#heading=h.ykdv684u0rnx

