### PR TITLE
Cleanup prior Spark sessions in tests consistently

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,12 @@ import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer}
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
 class GpuDeviceManagerSuite extends FunSuite with Arm {
 
   test("RMM pool limit") {
-    SparkSession.getActiveSession.foreach(_.close())
-    GpuDeviceManager.shutdown()
+    TrampolineUtil.cleanupAnyExistingSession()
     val totalGpuSize = Cuda.memGetInfo().total
     val initPoolFraction = 0.1
     val maxPoolFraction = 0.2
@@ -52,13 +51,12 @@ class GpuDeviceManagerSuite extends FunSuite with Arm {
         }
       }
     } finally {
-      GpuDeviceManager.shutdown()
+      TrampolineUtil.cleanupAnyExistingSession()
     }
   }
 
   test("RMM reserve larger than max") {
-    SparkSession.getActiveSession.foreach(_.close())
-    GpuDeviceManager.shutdown()
+    TrampolineUtil.cleanupAnyExistingSession()
     val rapidsConf = new RapidsConf(Map(RapidsConf.RMM_ALLOC_RESERVE.key -> "200g"))
     assertThrows[IllegalArgumentException] {
       GpuDeviceManager.initializeMemory(None, Some(rapidsConf))
@@ -66,8 +64,7 @@ class GpuDeviceManagerSuite extends FunSuite with Arm {
   }
 
   test("RMM init equals max") {
-    SparkSession.getActiveSession.foreach(_.close())
-    GpuDeviceManager.shutdown()
+    TrampolineUtil.cleanupAnyExistingSession()
     val rapidsConf = new RapidsConf(Map(
       RapidsConf.RMM_ALLOC_RESERVE.key -> "0",
       RapidsConf.RMM_ALLOC_FRACTION.key -> "0.3",

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -23,8 +23,8 @@ import ai.rapids.cudf.{ColumnVector, Cuda, DType, Table}
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -106,7 +106,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
   }
 
   test("GPU partition") {
-    SparkSession.getActiveSession.foreach(_.close())
+    TrampolineUtil.cleanupAnyExistingSession()
     val conf = new SparkConf().set(RapidsConf.SHUFFLE_COMPRESSION_CODEC.key, "none")
     TestUtils.withGpuSparkSession(conf) { _ =>
       GpuShuffleEnv.init(new RapidsConf(conf))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -66,6 +66,8 @@ object SparkSessionHolder extends Logging {
   }
 
   private def createSparkSession(): SparkSession = {
+    TrampolineUtil.cleanupAnyExistingSession()
+
     // Timezone is fixed to UTC to allow timestamps to work by default
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
     // Add Locale setting

--- a/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuShuffleEnv}
+import org.apache.spark.sql.rapids.GpuShuffleEnv
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /** A collection of utility methods useful in tests. */
@@ -123,7 +124,7 @@ object TestUtils extends Assertions with Arm {
   }
 
   def withGpuSparkSession(conf: SparkConf)(f: SparkSession => Unit): Unit = {
-    SparkSession.getActiveSession.foreach(_.close())
+    TrampolineUtil.cleanupAnyExistingSession()
     val spark = SparkSession.builder()
         .master("local[1]")
         .config(conf)


### PR DESCRIPTION
The tests are using multiple, different ways to shut down any prior Spark session before trying to start a new session.  This updates the code to consistently use `cleanupAnyExistingSession` which is the same cleanup code used in Spark's tests.