### PR TITLE
Add dynamic Spark configuration for Databricks

### DIFF
--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -26,19 +26,20 @@ base_spark_pom_version = '3.0.0'
 clusterid = ''
 build_profiles = 'databricks,!snapshot-shims'
 jar_path = ''
+spark_conf = ''
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:',
-                               ['workspace=', 'token=', 'clusterid=', 'private=', 'localscript=', 'dest=', 'sparktgz=', 'basesparkpomversion=', 'buildprofiles=', 'jarpath'])
+    opts, args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:',
+                               ['workspace=', 'token=', 'clusterid=', 'private=', 'localscript=', 'dest=', 'sparktgz=', 'basesparkpomversion=', 'buildprofiles=', 'jarpath', 'sparkconf'])
 except getopt.GetoptError:
     print(
-        'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -l <localscript> -d <scriptdestinatino> -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -j <jarpath>')
+        'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -l <localscript> -d <scriptdestinatino> -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -j <jarpath> -f <sparkconf>')
     sys.exit(2)
 
 for opt, arg in opts:
     if opt == '-h':
         print(
-            'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -n <skipstartingcluster> -l <localscript> -d <scriptdestinatino>, -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles>')
+            'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -n <skipstartingcluster> -l <localscript> -d <scriptdestinatino>, -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -f <sparkconf>')
         sys.exit()
     elif opt in ('-w', '--workspace'):
         workspace = arg
@@ -60,6 +61,8 @@ for opt, arg in opts:
         build_profiles = arg
     elif opt in ('-j', '--jarpath'):
         jar_path = arg
+    elif opt in ('-f', '--sparkconf'):
+        spark_conf = arg
 
 print('-w is ' + workspace)
 print('-c is ' + clusterid)
@@ -69,3 +72,4 @@ print('-d is ' + script_dest)
 print('-z is ' + source_tgz)
 print('-v is ' + base_spark_pom_version)
 print('-j is ' + jar_path)
+print('-f is ' + spark_conf)

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -62,7 +62,7 @@ for opt, arg in opts:
     elif opt in ('-j', '--jarpath'):
         jar_path = arg
     elif opt in ('-f', '--sparkconf'):
-        print('\'-f\' can take multiple comma seperated spark configurations, e.g., \'spark.foo=1,spark.bar=2\'')
+        print('can take comma seperated mutiple spark configurations, e.g., spark.foo=1,spark.bar=2,...')
         spark_conf = arg
 
 print('-w is ' + workspace)

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -62,6 +62,7 @@ for opt, arg in opts:
     elif opt in ('-j', '--jarpath'):
         jar_path = arg
     elif opt in ('-f', '--sparkconf'):
+        print('\'-f\' can take multiple comma seperated spark configurations, e.g., \'spark.foo=1,spark.bar=2\'')
         spark_conf = arg
 
 print('-w is ' + workspace)

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -26,6 +26,7 @@ base_spark_pom_version = '3.0.0'
 clusterid = ''
 build_profiles = 'databricks,!snapshot-shims'
 jar_path = ''
+# `spark_conf` can take comma seperated mutiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
 spark_conf = ''
 
 try:
@@ -62,7 +63,6 @@ for opt, arg in opts:
     elif opt in ('-j', '--jarpath'):
         jar_path = arg
     elif opt in ('-f', '--sparkconf'):
-        print('can take comma seperated mutiple spark configurations, e.g., spark.foo=1,spark.bar=2,...')
         spark_conf = arg
 
 print('-w is ' + workspace)

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -35,7 +35,7 @@ def main():
   print("rsync command: %s" % rsync_command)
   subprocess.check_call(rsync_command, shell = True)
 
-  ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s %s %s 2>&1 | tee testout; if [ `echo ${PIPESTATUS[0]}` -ne 0 ]; then false; else true; fi" % (master_addr, params.private_key_file, params.script_dest, params.jar_path)
+  ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s %s %s '%s' 2>&1 | tee testout; if [ `echo ${PIPESTATUS[0]}` -ne 0 ]; then false; else true; fi" % (master_addr, params.private_key_file, params.script_dest, params.jar_path, params.spark_conf)
   print("ssh command: %s" % ssh_command)
   subprocess.check_call(ssh_command, shell = True)
 

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -35,7 +35,7 @@ def main():
   print("rsync command: %s" % rsync_command)
   subprocess.check_call(rsync_command, shell = True)
 
-  ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s %s %s '%s' 2>&1 | tee testout; if [ `echo ${PIPESTATUS[0]}` -ne 0 ]; then false; else true; fi" % (master_addr, params.private_key_file, params.script_dest, params.jar_path, params.spark_conf)
+  ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s %s %s %s 2>&1 | tee testout; if [ `echo ${PIPESTATUS[0]}` -ne 0 ]; then false; else true; fi" % (master_addr, params.private_key_file, params.script_dest, params.jar_path, params.spark_conf)
   print("ssh command: %s" % ssh_command)
   subprocess.check_call(ssh_command, shell = True)
 

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -39,16 +39,19 @@ CUDF_UDF_TEST_ARGS="--conf spark.python.daemon.module=rapids.daemon_databricks \
     --conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
     --conf spark.rapids.python.concurrentPythonWorkers=2"
 
-## '--conf spark.xxx.xxx=xxx' to 'export PYSP_TEST_spark_xxx_xxx=xxx'
+## 'spark.foo=1,spar.bar=2,...' to 'export PYSP_TEST_spark_foo=1 export PYSP_TEST_spark_bar=2'
 if [ -n "$SPARK_CONF" ]; then
-    CONF_LIST=${SPARK_CONF//'--conf'/}
+    CONF_LIST=${SPARK_CONF//','/' '}
     for CONF in ${CONF_LIST}; do
         KEY=${CONF%%=*}
         VALUE=${CONF#*=}
-        ## run_pyspark_from_build.sh requires 'exportPYSP_TEST_spark_xxx_xxx=xxx' as the spark configs
-        export PYSP_TEST_${KEY//./_}=$VALUE
+        ## run_pyspark_from_build.sh requires 'export PYSP_TEST_spark_foo=1' as the spark configs
+        export PYSP_TEST_${KEY//'.'/'_'}=$VALUE
     done
 fi
+
+## 'spark.foo=1,spar.bar=2,...' to '--conf spark.foo=1 --conf spar.bar=2 --conf ...'
+SPARK_CONF="--conf ${SPARK_CONF/','/' --conf '}"
 
 TEST_TYPE="nightly"
 if [ -d "$LOCAL_JAR_PATH" ]; then
@@ -57,7 +60,7 @@ if [ -d "$LOCAL_JAR_PATH" ]; then
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
-    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
+    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_ARGS $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
         bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
 else
     ## Run tests with jars building from the spark-rapids source code

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -15,9 +15,10 @@
 # limitations under the License.
 #
 
-set -e
+set -ex
 
 LOCAL_JAR_PATH=$1
+SPARK_CONF=$2
 
 # tests
 export PATH=/databricks/conda/envs/databricks-ml-gpu/bin:/databricks/conda/condabin:$PATH
@@ -38,6 +39,17 @@ CUDF_UDF_TEST_ARGS="--conf spark.python.daemon.module=rapids.daemon_databricks \
     --conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
     --conf spark.rapids.python.concurrentPythonWorkers=2"
 
+## '--conf spark.xxx.xxx=xxx' to 'export PYSP_TEST_spark_xxx_xxx=xxx'
+if [ -n "$SPARK_CONF" ]; then
+    CONF_LIST=${SPARK_CONF//'--conf'/}
+    for CONF in ${CONF_LIST}; do
+        KEY=${CONF%%=*}
+        VALUE=${CONF#*=}
+        ## run_pyspark_from_build.sh requires 'exportPYSP_TEST_spark_xxx_xxx=xxx' as the spark configs
+        export PYSP_TEST_${KEY//./_}=$VALUE
+    done
+fi
+
 TEST_TYPE="nightly"
 if [ -d "$LOCAL_JAR_PATH" ]; then
     ## Run tests with jars in the LOCAL_JAR_PATH dir downloading from the denpedency repo
@@ -45,7 +57,7 @@ if [ -d "$LOCAL_JAR_PATH" ]; then
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
-    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS=$CUDF_UDF_TEST_ARGS TEST_PARALLEL=1 \
+    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
         bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
 else
     ## Run tests with jars building from the spark-rapids source code
@@ -53,6 +65,6 @@ else
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls /home/ubuntu/spark-rapids/dist/target/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
-    SPARK_SUBMIT_FLAGS=$CUDF_UDF_TEST_ARGS TEST_PARALLEL=1 \
+    SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
         bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
 fi

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -39,7 +39,7 @@ CUDF_UDF_TEST_ARGS="--conf spark.python.daemon.module=rapids.daemon_databricks \
     --conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
     --conf spark.rapids.python.concurrentPythonWorkers=2"
 
-## 'spark.foo=1,spar.bar=2,...' to 'export PYSP_TEST_spark_foo=1 export PYSP_TEST_spark_bar=2'
+## 'spark.foo=1,spark.bar=2,...' to 'export PYSP_TEST_spark_foo=1 export PYSP_TEST_spark_bar=2'
 if [ -n "$SPARK_CONF" ]; then
     CONF_LIST=${SPARK_CONF//','/' '}
     for CONF in ${CONF_LIST}; do
@@ -50,7 +50,7 @@ if [ -n "$SPARK_CONF" ]; then
     done
 fi
 
-## 'spark.foo=1,spar.bar=2,...' to '--conf spark.foo=1 --conf spar.bar=2 --conf ...'
+## 'spark.foo=1,spark.bar=2,...' to '--conf spark.foo=1 --conf spark.bar=2 --conf ...'
 SPARK_CONF="--conf ${SPARK_CONF/','/' --conf '}"
 
 TEST_TYPE="nightly"
@@ -60,7 +60,7 @@ if [ -d "$LOCAL_JAR_PATH" ]; then
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
-    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_ARGS $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
+    LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
         bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
 else
     ## Run tests with jars building from the spark-rapids source code

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -48,10 +48,10 @@ if [ -n "$SPARK_CONF" ]; then
         ## run_pyspark_from_build.sh requires 'export PYSP_TEST_spark_foo=1' as the spark configs
         export PYSP_TEST_${KEY//'.'/'_'}=$VALUE
     done
-fi
 
-## 'spark.foo=1,spark.bar=2,...' to '--conf spark.foo=1 --conf spark.bar=2 --conf ...'
-SPARK_CONF="--conf ${SPARK_CONF/','/' --conf '}"
+    ## 'spark.foo=1,spark.bar=2,...' to '--conf spark.foo=1 --conf spark.bar=2 --conf ...'
+    SPARK_CONF="--conf ${SPARK_CONF/','/' --conf '}"
+fi
 
 TEST_TYPE="nightly"
 if [ -d "$LOCAL_JAR_PATH" ]; then


### PR DESCRIPTION
We need a way to set spark confs dynamically for the Databricks,
e.g., when we test cuDF sonatype release jars, we need to disable cudf-rapids version match by adding
"--conf spark.rapids.cudfVersionOverride=true", or enable/disable AQE, or anything else.

By adding the parameter `-f " spark.foo=1,spark.bar=2 ......"` for the script 'run-tests.py',
we can dynamically add whatever confs for the Databricks cluster.

Signed-off-by: Tim Liu <timl@nvidia.com>