### PR TITLE
enable auto-merge from 0.5 to 0.6 [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-0.4
+    - branch-0.5
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-0.4 # force to fetch from latest upstream instead of PR ref
+          ref: branch-0.5 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-0.4
-          BASE: branch-0.5
+          HEAD: branch-0.5
+          BASE: branch-0.6
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

This PR is waiting for https://github.com/NVIDIA/spark-rapids/pull/2124 to get merged, and also holding for 0.4.2 release
please help review but do not merge, thanks!