### PR TITLE
Fall back to CPU when parsing two-digit years

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -279,6 +279,31 @@ Formats that contain any of the following words are unsupported and will fall ba
 "d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS"
 ```
 
+## Formatting dates and timestamps as strings
+
+When formatting dates and timestamps as strings using functions such as `from_unixtime`, only a
+subset of valid format strings are supported on the GPU.
+
+Formats that contain any of the following characters are unsupported and will fall back to CPU:
+
+```
+'k', 'K','z', 'V', 'c', 'F', 'W', 'Q', 'q', 'G', 'A', 'n', 'N',
+'O', 'X', 'p', '\'', '[', ']', '#', '{', '}', 'Z', 'w', 'e', 'E', 'x', 'Z', 'Y'
+```
+
+Formats that contain any of the following words are unsupported and will fall back to CPU:
+
+```
+"u", "uu", "uuu", "uuuu", "uuuuu", "uuuuuu", "uuuuuuu", "uuuuuuuu", "uuuuuuuuu", "uuuuuuuuuu",
+"y", yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
+"D", "DD", "DDD", "s", "m", "H", "h", "M", "MMM", "MMMM", "MMMMM", "L", "LLL", "LLLL", "LLLLL",
+"d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS"
+```
+
+Note that this list differs very slightly from the list given in the previous section for parsing
+strings to dates because the two-digit year format `"yy"` is supported when formatting dates as
+strings but not when parsing strings to dates.
+
 ## Casting between types
 
 In general, performing `cast` and `ansi_cast` operations on the GPU is compatible with the same

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -256,7 +256,6 @@ The formats which are supported on GPU and 100% compatible with Spark are :
 
 Examples of supported formats that may produce different results are:
 
-- Use of a two digit year, i.e.: `yy`, may use a different century on GPU compared to CPU
 - Trailing characters (including whitespace) may return a non-null value on GPU and Spark will 
   return null 
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -275,7 +275,7 @@ Formats that contain any of the following words are unsupported and will fall ba
 
 ```
 "u", "uu", "uuu", "uuuu", "uuuuu", "uuuuuu", "uuuuuuu", "uuuuuuuu", "uuuuuuuuu", "uuuuuuuuuu",
-"y", "yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
+"y", "yy", yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
 "D", "DD", "DDD", "s", "m", "H", "h", "M", "MMM", "MMMM", "MMMMM", "L", "LLL", "LLLL", "LLLLL",
 "d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS"
 ```

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
@@ -33,13 +33,17 @@ object DateUtils {
 
   val unsupportedWord = Set(
     "u", "uu", "uuu", "uuuu", "uuuuu", "uuuuuu", "uuuuuuu", "uuuuuuuu", "uuuuuuuuu", "uuuuuuuuuu",
-    "y", "yy", "yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
+    "y", "yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
     "D", "DD", "DDD", "s", "m", "H", "h", "M", "MMM", "MMMM", "MMMMM", "L", "LLL", "LLLL", "LLLLL",
     "d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS")
 
+  // we support "yy" in some cases, but not when parsing strings
+  // https://github.com/NVIDIA/spark-rapids/issues/2118
+  val unsupportedWordParseFromString = unsupportedWord ++ Set("yy")
+
   val conversionMap = Map(
     "MM" -> "%m", "LL" -> "%m", "dd" -> "%d", "mm" -> "%M", "ss" -> "%S", "HH" -> "%H",
-    "yyyy" -> "%Y", "SSSSSS" -> "%f")
+    "yy" -> "%y", "yyyy" -> "%Y", "SSSSSS" -> "%f")
 
   val ONE_SECOND_MICROSECONDS = 1000000
 
@@ -110,9 +114,13 @@ object DateUtils {
    * "hh" -> "%I" (12 hour clock)
    * "a" -> "%p" ('AM', 'PM')
    * "DDD" -> "%j" (Day of the year)
+   *
+   * @param format Java time format string
+   * @param parseString True if we're parsing a string
    */
-  def toStrf(format: String): String = {
-    val javaPatternsToReplace = identifySupportedFormatsToReplaceElseThrow(format)
+  def toStrf(format: String, parseString: Boolean): String = {
+    val javaPatternsToReplace = identifySupportedFormatsToReplaceElseThrow(
+      format, parseString)
     replaceFormats(format, javaPatternsToReplace)
   }
 
@@ -129,7 +137,14 @@ object DateUtils {
   }
 
   def identifySupportedFormatsToReplaceElseThrow(
-      format: String): ListBuffer[FormatKeywordToReplace] = {
+      format: String,
+      parseString: Boolean): ListBuffer[FormatKeywordToReplace] = {
+
+    val unsupportedWordContextAware = if (parseString) {
+      unsupportedWordParseFromString
+    } else {
+      unsupportedWord
+    }
     var sb = new StringBuilder()
     var index = 0;
     val patterns = new ListBuffer[FormatKeywordToReplace]
@@ -145,7 +160,7 @@ object DateUtils {
         // its a new pattern, check if the previous pattern was supported. If its supported,
         // add it to the groups and add this char as a start of a new pattern else throw exception
         val word = sb.toString
-        if (unsupportedWord(word)) {
+        if (unsupportedWordContextAware(word)) {
           throw TimestampFormatConversionException(s"Unsupported word: $word")
         }
         val startIndex = index - word.length
@@ -160,7 +175,7 @@ object DateUtils {
     })
     if (sb.length > 0) {
       val word = sb.toString()
-      if (unsupportedWord(word)) {
+      if (unsupportedWordContextAware(word)) {
         throw TimestampFormatConversionException(s"Unsupported word: $word")
       }
       val startIndex = format.length - word.length

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
@@ -33,13 +33,13 @@ object DateUtils {
 
   val unsupportedWord = Set(
     "u", "uu", "uuu", "uuuu", "uuuuu", "uuuuuu", "uuuuuuu", "uuuuuuuu", "uuuuuuuuu", "uuuuuuuuuu",
-    "y", "yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
+    "y", "yy", "yyy", "yyyyy", "yyyyyy", "yyyyyyy", "yyyyyyyy", "yyyyyyyyy", "yyyyyyyyyy",
     "D", "DD", "DDD", "s", "m", "H", "h", "M", "MMM", "MMMM", "MMMMM", "L", "LLL", "LLLL", "LLLLL",
     "d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS")
 
   val conversionMap = Map(
     "MM" -> "%m", "LL" -> "%m", "dd" -> "%d", "mm" -> "%M", "ss" -> "%S", "HH" -> "%H",
-    "yy" -> "%y", "yyyy" -> "%Y", "SSSSSS" -> "%f")
+    "yyyy" -> "%Y", "SSSSSS" -> "%f")
 
   val ONE_SECOND_MICROSECONDS = 1000000
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -348,7 +348,8 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
               willNotWorkOnGpu("legacyTimeParserPolicy LEGACY is not supported")
             } else if (GpuToTimestamp.COMPATIBLE_FORMATS.contains(sparkFormat) ||
                 conf.incompatDateFormats) {
-              strfFormat = DateUtils.toStrf(sparkFormat)
+              strfFormat = DateUtils.toStrf(sparkFormat,
+                expr.left.dataType == DataTypes.StringType)
             } else {
               willNotWorkOnGpu(s"incompatible format '$sparkFormat'. Set " +
                   s"spark.rapids.sql.incompatibleDateFormats.enabled=true to force onto GPU.")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -25,6 +25,16 @@ import org.apache.spark.sql.internal.SQLConf
 
 class ParseDateTimeSuite extends SparkQueryCompareTestSuite {
 
+  testSparkResultsAreEqual("to_date dd/MM/yy",
+    datesAsStrings,
+    conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")
+        .set(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key, "true")
+        // until we fix https://github.com/NVIDIA/spark-rapids/issues/2118 we need to fall
+        // back to CPU when parsing two-digit years
+        .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "ProjectExec,Alias,Cast,GetTimestamp,Literal")) {
+    df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yy"))
+  }
+
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
       conf = new SparkConf().set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "CORRECTED")) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -31,7 +31,8 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite {
         .set(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key, "true")
         // until we fix https://github.com/NVIDIA/spark-rapids/issues/2118 we need to fall
         // back to CPU when parsing two-digit years
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "ProjectExec,Alias,Cast,GetTimestamp,Literal")) {
+        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+          "ProjectExec,Alias,Cast,GetTimestamp,UnixTimestamp,Literal")) {
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yy"))
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/2127