### PR TITLE
Fix divide-by-zero in GpuAverage with ansi mode

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -204,6 +204,30 @@ def test_hash_grpby_avg(data_gen, conf):
         conf=conf
     )
 
+@ignore_order
+@pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+@pytest.mark.parametrize('ansi_enabled', ['true', 'false']) 
+def test_hash_grpby_avg_nulls(data_gen, conf, ansi_enabled):
+    conf.update({'spark.sql.ansi.enabled': ansi_enabled})
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, data_gen, length=100).groupby('a')
+          .agg(f.avg('c')),
+        conf=conf
+    )
+
+@ignore_order
+@pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+@pytest.mark.parametrize('ansi_enabled', ['true', 'false']) 
+def test_hash_reduction_avg_nulls(data_gen, conf, ansi_enabled):
+    conf.update({'spark.sql.ansi.enabled': ansi_enabled})
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, data_gen, length=100)
+          .agg(f.avg('c')),
+        conf=conf
+    )
+
 # tracks https://github.com/NVIDIA/spark-rapids/issues/154
 @approximate_float
 @ignore_order
@@ -301,7 +325,6 @@ def test_hash_query_max_with_multiple_distincts(data_gen, conf, parameterless):
         'count(),' +
         'count(distinct b) from hash_agg_table group by a',
         conf)
-
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -448,7 +448,7 @@ case class GpuAverage(child: Expression) extends GpuDeclarativeAggregate
   // This is to conform with Spark's behavior in the Average aggregate function.
   override lazy val evaluateExpression: GpuExpression = GpuDivide(
     GpuCast(cudfSum, DoubleType),
-    GpuCast(cudfCount, DoubleType), Some(false))
+    GpuCast(cudfCount, DoubleType), Option(false))
 
   override lazy val initialValues: Seq[GpuLiteral] = Seq(
     GpuLiteral(0.0, DoubleType),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -442,9 +442,13 @@ case class GpuAverage(child: Expression) extends GpuDeclarativeAggregate
   // average = (0 + 1) and not 2 which is the rowcount of the projected column.
   override lazy val updateExpressions: Seq[GpuExpression] = Seq(new CudfSum(cudfSum),
     new CudfSum(cudfCount))
+
+  // NOTE: this passes an optional boolean to `GpuDivide` to force it not to throw
+  // divide-by-zero exceptions, even when ansi mode is enabled in Spark. 
+  // This is to conform with Spark's behavior in the Average aggregate function.
   override lazy val evaluateExpression: GpuExpression = GpuDivide(
     GpuCast(cudfSum, DoubleType),
-    GpuCast(cudfCount, DoubleType))
+    GpuCast(cudfCount, DoubleType), Some(false))
 
   override lazy val initialValues: Seq[GpuLiteral] = Seq(
     GpuLiteral(0.0, DoubleType),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -443,12 +443,12 @@ case class GpuAverage(child: Expression) extends GpuDeclarativeAggregate
   override lazy val updateExpressions: Seq[GpuExpression] = Seq(new CudfSum(cudfSum),
     new CudfSum(cudfCount))
 
-  // NOTE: this passes an optional boolean to `GpuDivide` to force it not to throw
+  // NOTE: this sets `failOnErrorOverride=false` in `GpuDivide` to force it not to throw
   // divide-by-zero exceptions, even when ansi mode is enabled in Spark. 
   // This is to conform with Spark's behavior in the Average aggregate function.
   override lazy val evaluateExpression: GpuExpression = GpuDivide(
     GpuCast(cudfSum, DoubleType),
-    GpuCast(cudfCount, DoubleType), Option(false))
+    GpuCast(cudfCount, DoubleType), failOnErrorOverride = false)
 
   override lazy val initialValues: Seq[GpuLiteral] = Seq(
     GpuLiteral(0.0, DoubleType),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -269,7 +269,10 @@ object GpuDivModLike {
 }
 
 trait GpuDivModLike extends CudfBinaryArithmetic {
-  lazy val failOnError: Boolean = ShimLoader.getSparkShims.shouldFailDivByZero()
+  val failOnErrorOverride: Option[Boolean] = None
+
+  lazy val failOnError: Boolean =
+    failOnErrorOverride.getOrElse(ShimLoader.getSparkShims.shouldFailDivByZero())
 
   override def nullable: Boolean = true
 
@@ -330,7 +333,8 @@ object GpuDivideUtil {
 }
 
 // This is for doubles and floats...
-case class GpuDivide(left: Expression, right: Expression) extends GpuDivModLike {
+case class GpuDivide(left: Expression, right: Expression,
+    override val failOnErrorOverride: Option[Boolean] = None) extends GpuDivModLike {
   override def inputType: AbstractDataType = TypeCollection(DoubleType, DecimalType)
 
   override def symbol: String = "/"

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -366,7 +366,7 @@ case class GpuDivide(left: Expression, right: Expression,
     (left.dataType, right.dataType) match {
       case (_: DecimalType, r: DecimalType) => {
         val (upcastedLhs, upcastedRhs) = if (!DecimalType.is32BitDecimalType(dataType) &&
-            DecimalType.is32BitDecimalType(r)) {
+          DecimalType.is32BitDecimalType(r)) {
           // we are casting to the smallest 64-bit decimal so the answer doesn't exceed 64-bit
           val decimalType = createCudfDecimal(10, r.scale)
           (lhs.getBase.castTo(decimalType), rhs.getBase.castTo(decimalType))
@@ -392,12 +392,12 @@ case class GpuDivide(left: Expression, right: Expression,
     (left.dataType, right.dataType) match {
       case (_: DecimalType, r: DecimalType) => {
         val (upcastedLhs, upcastedRhs) = if (!DecimalType.is32BitDecimalType(dataType) &&
-            DecimalType.is32BitDecimalType(r)) {
+          DecimalType.is32BitDecimalType(r)) {
           // we are casting to the smallest 64-bit decimal so the answer doesn't overflow
           val sparkDecimalType = DecimalType(10, r.scale)
           val decimalType = GpuColumnVector.getNonNestedRapidsType(sparkDecimalType)
           (lhs.getBase.castTo(decimalType),
-              GpuScalar.from(rhs.getBigDecimal().intValue().toLong, sparkDecimalType))
+            GpuScalar.from(rhs.getBigDecimal().intValue().toLong, sparkDecimalType))
         } else {
           (lhs.getBase(), rhs)
         }
@@ -418,12 +418,12 @@ case class GpuDivide(left: Expression, right: Expression,
     (left.dataType, right.dataType) match {
       case (_: DecimalType, r: DecimalType) => {
         val (upcastedLhs, upcastedRhs) = if (!DecimalType.is32BitDecimalType(dataType) &&
-            DecimalType.is32BitDecimalType(r)) {
+          DecimalType.is32BitDecimalType(r)) {
           // we are casting to the smallest 64-bit decimal so the answer doesn't overflow
           val sparkDecimalType = DecimalType(10, r.scale)
           val decimalType = GpuColumnVector.getNonNestedRapidsType(sparkDecimalType)
           (GpuScalar.from(lhs.getBigDecimal().intValue().toLong, sparkDecimalType),
-              rhs.getBase.castTo(decimalType))
+            rhs.getBase.castTo(decimalType))
         } else {
           (lhs, rhs.getBase())
         }


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/spark-rapids/issues/2078