### PR TITLE
Disable Spark 3.2 shim by default

### DIFF
--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -56,18 +56,23 @@
                 </dependency>
             </dependencies>
         </profile>
+       <profile>
+           <id>spark320</id>
+           <dependencies>
+               <dependency>
+                   <groupId>com.nvidia</groupId>
+                   <artifactId>rapids-4-spark-shims-spark320_${scala.binary.version}</artifactId>
+                   <version>${project.version}</version>
+                   <scope>compile</scope>
+               </dependency>
+           </dependencies>
+       </profile>
         <profile>
             <id>snapshot-shims</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark320_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
                 <dependency>
                     <groupId>com.nvidia</groupId>
                     <artifactId>rapids-4-spark-shims-spark303_${scala.binary.version}</artifactId>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -40,6 +40,12 @@
             </modules>
         </profile>
         <profile>
+            <id>spark320</id>
+            <modules>
+                <module>spark320</module>
+            </modules>
+        </profile>
+        <profile>
             <id>snapshot-shims</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -47,7 +53,6 @@
             <modules>
                 <module>spark303</module>
                 <module>spark312</module>
-                <module>spark320</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
The fix for #2052 is going to take a long time, so in the meantime this disables the Spark 3.2 shim build by default.  It can still be built with the `spark320` profile.