### PR TITLE
support truncate cuda version for image build [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -46,7 +46,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN export CUDF_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -19,7 +19,7 @@
 # Arguments:
 #    CUDA_VER=11.0, 11.1 or 11.2.2
 #    CENTOS_VER=7 or 8
-#    CUDF_VER=0.19 or 0.20
+#    CUDF_VER=0.20
 #    URM_URL=<maven repo url>
 ###
 
@@ -46,7 +46,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
+RUN export CUDF_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -17,7 +17,7 @@
 ###
 #
 # Arguments:
-#    CUDA_VER=11.0, 11.1 or 11.2.2
+#    CUDA_VER=11.0, 11.1 or 11.2.x
 #    CENTOS_VER=7 or 8
 #    CUDF_VER=0.20
 #    URM_URL=<maven repo url>

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -47,7 +47,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -19,13 +19,16 @@
 # Build the image for rapids-plugin development environment
 #
 # Arguments:
-#       CUDA_VER=11.0, 11.1 or 11.2.2
-#       UBUNTU_VER=18.04 or 20.04
+#    CUDA_VER=11.0, 11.1 or 11.2.2
+#    UBUNTU_VER=18.04 or 20.04
+#    CUDF_VER=0.20
 ###
 
 ARG CUDA_VER=11.0
 ARG UBUNTU_VER=18.04
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
+ARG CUDA_VER
+ARG CUDF_VER
 
 # Install jdk-8, jdk-11, maven, docker image
 RUN apt-get update -y && \
@@ -44,7 +47,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
+RUN RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.8 cudatoolkit=${CUDA_VER} && \
     conda install -y spacy && python -m spacy download en_core_web_sm && \
     conda install -y -c anaconda pytest requests && \
     conda install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -19,7 +19,7 @@
 # Build the image for rapids-plugin development environment
 #
 # Arguments:
-#    CUDA_VER=11.0, 11.1 or 11.2.2
+#    CUDA_VER=11.0, 11.1 or 11.2.x
 #    UBUNTU_VER=18.04 or 20.04
 #    CUDF_VER=0.20
 ###

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -19,7 +19,7 @@
 # Build the image for rapids-plugin development environment
 #
 # Arguments:
-#       CUDA_VER=11.0, 11.1 or 11.2.2
+#       CUDA_VER=11.0, 11.1 or 11.2.x
 #       UBUNTU_VER=18.04 or 20.04
 ###
 


### PR DESCRIPTION
cuda image has add the update version to image tag since 11.2+, e.g.
11.2.<update_version>-runtime-ubuntu18.04 

Since cudf + cudatoolkit do not care about the update's version, we need to truncate it.

Tested locally.