### PR TITLE
cuda11.0 toolkit for the Databricks integrationt test

### DIFF
--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -22,6 +22,9 @@ SPARK_CONF=$2
 
 # tests
 export PATH=/databricks/conda/envs/databricks-ml-gpu/bin:/databricks/conda/condabin:$PATH
+## cuda toolkit has been installed into conda envs via 'init_cudf_udf.sh'
+export LD_LIBRARY_PATH=/databricks/conda/envs/databricks-ml-gpu/lib
+
 sudo /databricks/conda/envs/databricks-ml-gpu/bin/pip install pytest sre_yield requests pandas \
 	pyarrow findspark pytest-xdist
 


### PR DESCRIPTION
cuda11.0 toolkit has been installed via CONDA in the Databricks init script file: 'init_cudf_udf.sh'

We only need to export the cuda11.0 toolkit path using 'LD_LIBRARY_PATH'


Signed-off-by: Tim Liu <timl@nvidia.com>