### PR TITLE
Init scripts to install cuda11 runtime [skip ci]

### DIFF
--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -23,7 +23,7 @@ class ClusterUtils(object):
 
     @staticmethod
     def generate_create_templ(sshKey, cluster_name, runtime, idle_timeout,
-            num_workers, driver_node_type, worker_node_type, cloud_provider,
+            num_workers, driver_node_type, worker_node_type, cloud_provider, init_script,
             printLoc=sys.stdout):
         timeStr = str(int(time.time()))
         uniq_name = cluster_name + "-" + timeStr
@@ -46,13 +46,18 @@ class ClusterUtils(object):
         templ['driver_node_type_id'] = driver_node_type
         templ['ssh_public_keys'] = [ sshKey ]
         templ['num_workers'] = num_workers
-        templ['init_scripts'] = [
-            {
-                "dbfs": {
-                     "destination": "dbfs:/databricks/init_scripts/init_cudf_udf.sh"
-                }
-            }
-        ]
+        if (init_script != ''):
+            templ['init_scripts']=[]
+            path_list = init_script.split(',')
+            for path in path_list:
+                templ['init_scripts'].append(
+                    {
+                        'dbfs' : {
+                            'destination' : path
+                        }
+                    }
+                )
+
         return templ
 
 

--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -23,7 +23,7 @@ class ClusterUtils(object):
 
     @staticmethod
     def generate_create_templ(sshKey, cluster_name, runtime, idle_timeout,
-            num_workers, driver_node_type, worker_node_type, cloud_provider, init_script,
+            num_workers, driver_node_type, worker_node_type, cloud_provider, init_scripts,
             printLoc=sys.stdout):
         timeStr = str(int(time.time()))
         uniq_name = cluster_name + "-" + timeStr
@@ -46,9 +46,9 @@ class ClusterUtils(object):
         templ['driver_node_type_id'] = driver_node_type
         templ['ssh_public_keys'] = [ sshKey ]
         templ['num_workers'] = num_workers
-        if (init_script != ''):
+        if (init_scripts != ''):
             templ['init_scripts']=[]
-            path_list = init_script.split(',')
+            path_list = init_scripts.split(',')
             for path in path_list:
                 templ['init_scripts'].append(
                     {

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -34,14 +34,17 @@ def main():
   worker_type = 'g4dn.xlarge'
   driver_type = 'g4dn.xlarge'
   cloud_provider = 'aws'
+  # comma seperated init scritps, e.g., dbfs:/foo,dbfs:/bar,...
+  init_script = ''
+
 
   try:
-      opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:',
+      opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:f:',
                                  ['workspace=', 'token=', 'sshkey=', 'clustername=', 'idletime=',
-                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider='])
+                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=, initscript='])
   except getopt.GetoptError:
       print(
-          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider>')
+          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscript>')
       sys.exit(2)
 
   for opt, arg in opts:
@@ -69,6 +72,8 @@ def main():
           num_workers = arg
       elif opt in ('-s', '--cloudprovider'):
           cloud_provider = arg
+      elif opt in ('-f', '--initscript'):
+          init_script = arg
 
   print('-w is ' + workspace, file=sys.stderr)
   print('-k is ' + sshkey, file=sys.stderr)
@@ -79,6 +84,7 @@ def main():
   print('-d is ' + driver_type, file=sys.stderr)
   print('-e is ' + str(num_workers), file=sys.stderr)
   print('-s is ' + cloud_provider, file=sys.stderr)
+  print('-f is ' + init_script, file=sys.stderr)
 
   if not sshkey:
       print("You must specify an sshkey!", file=sys.stderr)
@@ -89,7 +95,7 @@ def main():
       sys.exit(2)
 
   templ = ClusterUtils.generate_create_templ(sshkey, cluster_name, runtime, idletime,
-          num_workers, driver_type, worker_type, cloud_provider, printLoc=sys.stderr)
+          num_workers, driver_type, worker_type, cloud_provider, init_script, printLoc=sys.stderr)
   clusterid = ClusterUtils.create_cluster(workspace, templ, token, printLoc=sys.stderr)
   ClusterUtils.wait_for_cluster_start(workspace, clusterid, token, printLoc=sys.stderr)
 

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -41,7 +41,7 @@ def main():
   try:
       opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:f:',
                                  ['workspace=', 'token=', 'sshkey=', 'clustername=', 'idletime=',
-                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=, initscripts='])
+                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=', 'initscripts='])
   except getopt.GetoptError:
       print(
           'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscripts>')

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -35,16 +35,16 @@ def main():
   driver_type = 'g4dn.xlarge'
   cloud_provider = 'aws'
   # comma seperated init scritps, e.g., dbfs:/foo,dbfs:/bar,...
-  init_script = ''
+  init_scripts = ''
 
 
   try:
       opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:f:',
                                  ['workspace=', 'token=', 'sshkey=', 'clustername=', 'idletime=',
-                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=, initscript='])
+                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=, initscripts='])
   except getopt.GetoptError:
       print(
-          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscript>')
+          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscripts>')
       sys.exit(2)
 
   for opt, arg in opts:
@@ -72,8 +72,8 @@ def main():
           num_workers = arg
       elif opt in ('-s', '--cloudprovider'):
           cloud_provider = arg
-      elif opt in ('-f', '--initscript'):
-          init_script = arg
+      elif opt in ('-f', '--initscripts'):
+          init_scripts = arg
 
   print('-w is ' + workspace, file=sys.stderr)
   print('-k is ' + sshkey, file=sys.stderr)
@@ -84,7 +84,7 @@ def main():
   print('-d is ' + driver_type, file=sys.stderr)
   print('-e is ' + str(num_workers), file=sys.stderr)
   print('-s is ' + cloud_provider, file=sys.stderr)
-  print('-f is ' + init_script, file=sys.stderr)
+  print('-f is ' + init_scripts, file=sys.stderr)
 
   if not sshkey:
       print("You must specify an sshkey!", file=sys.stderr)
@@ -95,7 +95,7 @@ def main():
       sys.exit(2)
 
   templ = ClusterUtils.generate_create_templ(sshkey, cluster_name, runtime, idletime,
-          num_workers, driver_type, worker_type, cloud_provider, init_script, printLoc=sys.stderr)
+          num_workers, driver_type, worker_type, cloud_provider, init_scripts, printLoc=sys.stderr)
   clusterid = ClusterUtils.create_cluster(workspace, templ, token, printLoc=sys.stderr)
   ClusterUtils.wait_for_cluster_start(workspace, clusterid, token, printLoc=sys.stderr)
 

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -34,7 +34,7 @@ def main():
   worker_type = 'g4dn.xlarge'
   driver_type = 'g4dn.xlarge'
   cloud_provider = 'aws'
-  # comma seperated init scritps, e.g., dbfs:/foo,dbfs:/bar,...
+  # comma separated init scripts, e.g. dbfs:/foo,dbfs:/bar,...
   init_scripts = ''
 
 

--- a/jenkins/databricks/init_cuda11_runtime.sh
+++ b/jenkins/databricks/init_cuda11_runtime.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The init script to install cuda11.0 toolkit
+# Will be automatically pushed into the dbfs:/databricks/init_scripts once it is updated.
+
+wget http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run
+
+sudo sh cuda_11.0.2_450.51.05_linux.run --toolkit --silent
+
+rm cuda_11.0.2_450.51.05_linux.run

--- a/jenkins/databricks/init_cuda11_runtime.sh
+++ b/jenkins/databricks/init_cuda11_runtime.sh
@@ -20,6 +20,6 @@
 
 wget http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run
 
-sudo sh cuda_11.0.2_450.51.05_linux.run --toolkit --silent
+sh cuda_11.0.2_450.51.05_linux.run --toolkit --silent
 
 rm cuda_11.0.2_450.51.05_linux.run


### PR DESCRIPTION
Add the parameter 'init_script' to make init scripts common for Databricks.

Add the 'init_cuda11_runtime.sh' to install cuda11 toolkit on Databricks.

Signed-off-by: Tim Liu <timl@nvidia.com>