### PR TITLE
Use CPM to fetch libcudf dependency for native UDF example build

### DIFF
--- a/udf-examples/Dockerfile
+++ b/udf-examples/Dockerfile
@@ -16,62 +16,55 @@
 
 # A container that can be used to build UDF native code against libcudf
 ARG CUDA_VERSION=11.0
-ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
 ARG LINUX_VERSION=ubuntu18.04
-ARG CUDF_REPO=https://github.com/rapidsai/cudf
-ARG CUDF_TAG=branch-0.20
-ARG CC=7
-ARG CXX=7
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
-# Needed for cudf.concat(), avoids "OSError: library nvvm not found"
-ENV NUMBAPRO_NVVM=/usr/local/cuda/nvvm/lib64/libnvvm.so
-ENV NUMBAPRO_LIBDEVICE=/usr/local/cuda/nvvm/libdevice/
-ENV DEBIAN_FRONTEND=noninteractive
 
-ARG CC
-ARG CXX
-RUN apt update -y --fix-missing && \
-    apt upgrade -y && \
-    apt install -y --no-install-recommends \
-      git \
-      gcc-${CC} \
-      g++-${CXX} \
-      libboost-all-dev \
-      openjdk-8-jdk \
-      maven \
-      tzdata && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PARALLEL_LEVEL=10
+ENV PARALLEL_LEVEL=10
 
-# Install conda
-ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh /miniconda.sh
-RUN sh /miniconda.sh -b -p /conda && /conda/bin/conda update -n base conda
-ENV PATH=${PATH}:/conda/bin
-# Enables "source activate conda"
-SHELL ["/bin/bash", "-c"]
+RUN GCC_VERSION=$(bash -c '\
+CUDA_VERSION=$(nvcc --version | head -n4 | tail -n1 | cut -d" " -f5 | cut -d"," -f1); \
+CUDA_VERSION_MAJOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 1-2); \
+CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
+  if [[ "$CUDA_VERSION_MAJOR" == 9 ]]; then echo "7"; \
+  elif [[ "$CUDA_VERSION_MAJOR" == 10 ]]; then echo "8"; \
+  elif [[ "$CUDA_VERSION_MAJOR" == 11 ]]; then echo "9"; \
+  else echo "10"; \
+  fi') \
+&& apt update -y \
+&& apt install -y software-properties-common \
+&& add-apt-repository -y ppa:git-core/ppa \
+&& add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+&& add-apt-repository ppa:deadsnakes/ppa \
+&& apt update -y \
+&& apt install -y \
+   build-essential git wget \
+   gcc-${GCC_VERSION} g++-${GCC_VERSION} \
+   openjdk-8-jdk maven tzdata \
+   # CMake dependencies
+   curl libssl-dev libcurl4-openssl-dev zlib1g-dev \
+   # cuDF dependencies
+   libboost-filesystem-dev \
+&& apt autoremove -y \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+&& update-alternatives \
+   --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+# Set gcc-${GCC_VERSION} as the default gcc
+&& update-alternatives --set gcc /usr/bin/gcc-${GCC_VERSION}  \
+# Set JDK8 as the default Java
+&& update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-# Pull the cudf source at the specified branch or tag
-ARG CUDF_TAG
-RUN git clone --recurse-submodules --depth 1 --single-branch --branch ${CUDF_TAG} https://github.com/rapidsai/cudf.git /cudf
+ARG CMAKE_VERSION=3.18.5
 
-# Create the cudf conda environment
-ARG CUDA_SHORT_VERSION
-RUN conda env create --name cudf --file /cudf/conda/environments/cudf_dev_cuda${CUDA_SHORT_VERSION}.yml
+# Install CMake
+RUN cd /tmp \
+ && curl -fsSLO --compressed "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION.tar.gz" -o /tmp/cmake-$CMAKE_VERSION.tar.gz \
+ && tar -xvzf /tmp/cmake-$CMAKE_VERSION.tar.gz && cd /tmp/cmake-$CMAKE_VERSION \
+ && /tmp/cmake-$CMAKE_VERSION/bootstrap \
+    --system-curl \
+    --parallel=${PARALLEL_LEVEL} \
+ && make install -j${PARALLEL_LEVEL} \
+ && cd /tmp && rm -rf /tmp/cmake-$CMAKE_VERSION*
 
-# libcudf build/install
-ARG CC
-ARG CXX
-ENV CC=/usr/bin/gcc-${CC}
-ENV CXX=/usr/bin/g++-${CXX}
-RUN source activate cudf && \
-    mkdir -p /cudf/cpp/build && \
-    cd /cudf/cpp/build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} && \
-    make -j"$(nproc)" install
-
-# Default to cudf conda environment
-RUN echo "source activate cudf" > /.bash-init.sh
-ENTRYPOINT /bin/bash --init-file /.bash-init.sh

--- a/udf-examples/README.md
+++ b/udf-examples/README.md
@@ -18,6 +18,5 @@ can be used to include the native UDF examples in the build, i.e.: specify
 The `Dockerfile` in this directory can be used to setup a Docker image that
 provides a libcudf build environment. This repository will either need to be
 cloned or mounted into a container using that Docker image.
-There are a number of build arguments in the `Dockerfile` to control the
-Linux version, GCC version, CUDA version, and other settings. See the top of
-the `Dockerfile` for details.
+The `Dockerfile` contains build arguments to control the Linux version,
+CUDA version, and other settings. See the top of the `Dockerfile` for details.

--- a/udf-examples/pom.xml
+++ b/udf-examples/pom.xml
@@ -36,9 +36,8 @@
     <udf.native.build.path>${project.build.directory}/cpp-build</udf.native.build.path>
     <CMAKE_CXX_FLAGS/>
     <GPU_ARCHS>ALL</GPU_ARCHS>
-    <CUDA_STATIC_RUNTIME>ON</CUDA_STATIC_RUNTIME>
     <PER_THREAD_DEFAULT_STREAM>ON</PER_THREAD_DEFAULT_STREAM>
-    <CUDF_CMAKE_BUILD_DIR>/cudf/cpp/build</CUDF_CMAKE_BUILD_DIR>
+    <CPP_PARALLEL_LEVEL>10</CPP_PARALLEL_LEVEL>
   </properties>
 
   <dependencies>
@@ -116,14 +115,14 @@
                       <arg value="${basedir}/src/main/cpp"/>
                       <arg value="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"/>
                       <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
-                      <arg value="-DCUDA_STATIC_RUNTIME=${CUDA_STATIC_RUNTIME}"/>
                       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>
-                      <arg value="-DCUDF_CMAKE_BUILD_DIR=${CUDF_CMAKE_BUILD_DIR}"/>
                     </exec>
-                    <exec dir="${udf.native.build.path}"
-                          failonerror="true"
-                          executable="make">
-                      <arg value="-j"/>
+                    <exec failonerror="true"
+                          executable="cmake">
+                      <arg value="--build"/>
+                      <arg value="${udf.native.build.path}"/>
+                      <arg value="-j${CPP_PARALLEL_LEVEL}"/>
+                      <arg value="-v"/>
                     </exec>
                   </tasks>
                 </configuration>

--- a/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/CMakeLists.txt
@@ -13,9 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+# Use GPU_ARCHS if it is defined
+if(DEFINED GPU_ARCHS)
+  if (GPU_ARCHS STREQUAL "ALL")
+    set(CUDF_BUILD_FOR_ALL_ARCHS TRUE)
+  else()
+    set(CMAKE_CUDA_ARCHITECTURES ${GPU_ARCHS})
+  endif()
+endif()
 
 project(UDFEXAMPLESJNI VERSION 0.6.0 LANGUAGES C CXX CUDA)
+
+option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
+option(BUILD_UDF_BENCHMARKS "Build the benchmarks" OFF)
+
+#################################################################################################
+# - CPM -----------------------------------------------------------------------------------------
+
+set(CPM_DOWNLOAD_VERSION 0.27.2)
+set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+    message(STATUS "Downloading CPM.cmake")
+    file(DOWNLOAD https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})
 
 ###################################################################################################
 # - build type ------------------------------------------------------------------------------------
@@ -23,21 +49,11 @@ project(UDFEXAMPLESJNI VERSION 0.6.0 LANGUAGES C CXX CUDA)
 # Set a default build type if none was specified
 set(DEFAULT_BUILD_TYPE "Release")
 
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' since none specified.")
-  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE
-      STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
-
 ###################################################################################################
 # - compiler options ------------------------------------------------------------------------------
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_C_COMPILER $ENV{CC})
 set(CMAKE_CXX_COMPILER $ENV{CXX})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -45,11 +61,13 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 if(CMAKE_CUDA_COMPILER_VERSION)
-  # Compute the version from CMAKE_CUDA_COMPILER_VERSION
+  # Compute the version. from  CMAKE_CUDA_COMPILER_VERSION
   string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1" CUDA_VERSION_MAJOR ${CMAKE_CUDA_COMPILER_VERSION})
   string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\2" CUDA_VERSION_MINOR ${CMAKE_CUDA_COMPILER_VERSION})
   set(CUDA_VERSION "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}" CACHE STRING "Version of CUDA as computed from nvcc.")
@@ -63,109 +81,28 @@ message(STATUS "CUDA_VERSION: ${CUDA_VERSION}")
 # Always set this convenience variable
 set(CUDA_VERSION_STRING "${CUDA_VERSION}")
 
-set(GPU_ARCHS "ALL" CACHE STRING
-  "List of GPU architectures (semicolon-separated) to be compiled for. Pass 'ALL' if you want to compile for all supported GPU architectures.")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relaxed-constexpr")
 
-if("${GPU_ARCHS}" STREQUAL "ALL")
+####################################################################################################
+# - cudf -------------------------------------------------------------------------------------------
 
-  # Check for embedded vs workstation architectures
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    # This is being built for Linux4Tegra or SBSA ARM64
-    set(GPU_ARCHS "62")
-    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
-      set(GPU_ARCHS "${GPU_ARCHS};72")
-    endif()
-    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
-      set(GPU_ARCHS "${GPU_ARCHS};75;80")
-    endif()
+# Ensure CUDA runtime is dynamic despite statically linking Arrow in libcudf
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
-  else()
-    # This is being built for an x86 or x86_64 architecture
-    set(GPU_ARCHS "60")
-    if((CUDA_VERSION_MAJOR EQUAL 9) OR (CUDA_VERSION_MAJOR GREATER 9))
-      set(GPU_ARCHS "${GPU_ARCHS};70")
-    endif()
-    if((CUDA_VERSION_MAJOR EQUAL 10) OR (CUDA_VERSION_MAJOR GREATER 10))
-      set(GPU_ARCHS "${GPU_ARCHS};75")
-    endif()
-    if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
-      set(GPU_ARCHS "${GPU_ARCHS};80")
-    endif()
-
-  endif()
-
-endif()
-message("GPU_ARCHS = ${GPU_ARCHS}")
-
-foreach(arch ${GPU_ARCHS})
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_${arch},code=sm_${arch}")
-endforeach()
-
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr")
-
-# set warnings as errors
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Werror cross-execution-space-call -Xcompiler -Wall,-Werror,-Wno-error=deprecated-declarations")
-
-# Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
-option(CMAKE_CUDA_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler)" OFF)
-if (CMAKE_CUDA_LINEINFO)
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lineinfo")
-endif(CMAKE_CUDA_LINEINFO)
-
-# Debug options
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-    message(STATUS "Building with debugging flags")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -G -Xcompiler -rdynamic")
-endif(CMAKE_BUILD_TYPE MATCHES Debug)
-
-option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" ON)
-
-if(CUDA_STATIC_RUNTIME)
-    message(STATUS "Enabling static linking of cudart")
-    set(CUDART_LIBRARY "cudart_static")
-else()
-    message(STATUS "Enabling dynamic linking of cudart")
-    set(CUDART_LIBRARY "cudart")
-endif(CUDA_STATIC_RUNTIME)
-
-###################################################################################################
-# - CUDF ------------------------------------------------------------------------------------------
-
-find_path(CUDF_INCLUDE "cudf"
-    HINTS "$ENV{CUDF_ROOT}"
-          "$ENV{CONDA_PREFIX}/include")
-
-find_library(CUDF_BASE_LIBRARY "cudf_base"
-    HINTS "$ENV{CUDF_ROOT}"
-          "$ENV{CUDF_ROOT}/lib"
-          "$ENV{CONDA_PREFIX}/lib")
-
-###################################################################################################
-# - RMM -------------------------------------------------------------------------------------------
-
-find_path(RMM_INCLUDE "rmm"
-          HINTS "$ENV{RMM_ROOT}/include"
-                "$ENV{CONDA_PREFIX}/include")
-
-###################################################################################################
-# - Thrust/CUB/libcudacxx ------------------------------------------------------------------------------------
-
-# path to libcudf cmake build directory
-if(NOT DEFINED CUDF_CMAKE_BUILD_DIR)
-  set(CUDF_CMAKE_BUILD_DIR "/cudf/cpp/build")
-endif(NOT DEFINED CUDF_CMAKE_BUILD_DIR)
-
-find_path(THRUST_INCLUDE "thrust"
-    HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
-          "${CUDF_CMAKE_BUILD_DIR}/_deps/thrust-src")
-
-find_path(CUB_INCLUDE "cub"
-    HINTS "$ENV{CUDF_ROOT}/_deps/thrust-src"
-          "${CUDF_CMAKE_BUILD_DIR}/_deps/thrust-src")
-
-find_path(LIBCUDACXX_INCLUDE "cuda"
-    HINTS "$ENV{CUDF_ROOT}/_deps/libcudacxx-src/include"
-          "${CUDF_CMAKE_BUILD_DIR}/_deps/libcudacxx-src/include")
+CPMAddPackage(NAME  cudf
+        VERSION         "0.19.0"
+        GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
+        GIT_TAG         branch-0.19
+        GIT_SHALLOW     TRUE
+        SOURCE_SUBDIR   cpp
+        OPTIONS         "BUILD_TESTS OFF"
+                        "BUILD_BENCHMARKS OFF"
+                        "CUDF_USE_ARROW_STATIC ON"
+                        "JITIFY_USE_CACHE ON"
+                        "CUDA_STATIC_RUNTIME OFF"
+                        "DISABLE_DEPRECATION_WARNING ON"
+                        "AUTO_DETECT_CUDA_ARCHITECTURES OFF"
+    )
 
 ###################################################################################################
 # - find JNI -------------------------------------------------------------------------------------
@@ -176,18 +113,6 @@ if(JNI_FOUND)
 else()
     message(FATAL_ERROR "JDK with JNI not found, please check your settings.")
 endif(JNI_FOUND)
-
-###################################################################################################
-# - include paths ---------------------------------------------------------------------------------
-
-include_directories("${THRUST_INCLUDE}"
-                    "${CUB_INCLUDE}"
-                    "${LIBCUDACXX_INCLUDE}"
-                    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
-                    "${CMAKE_SOURCE_DIR}/src"
-                    "${CUDF_INCLUDE}"
-                    "${RMM_INCLUDE}"
-                    "${JNI_INCLUDE_DIRS}")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
@@ -215,13 +140,15 @@ SET_TARGET_PROPERTIES(udfexamplesjni PROPERTIES BUILD_RPATH "\$ORIGIN")
 option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
 if(PER_THREAD_DEFAULT_STREAM)
     message(STATUS "Using per-thread default stream")
-    add_compile_definitions(CUDA_API_PER_THREAD_DEFAULT_STREAM)
+    target_compile_definitions(udfexamplesjni PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
 endif(PER_THREAD_DEFAULT_STREAM)
+
+target_include_directories(udfexamplesjni PRIVATE ${JNI_INCLUDE_DIRS})
 
 ###################################################################################################
 # - rmm logging level -----------------------------------------------------------------------------
 
-set(RMM_LOGGING_LEVEL "INFO" CACHE STRING "Choose the logging level.")
+set(RMM_LOGGING_LEVEL "OFF" CACHE STRING "Choose the logging level.")
 # Set the possible values of build type for cmake-gui
 set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS
         "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
@@ -233,4 +160,4 @@ target_compile_definitions(udfexamplesjni
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(udfexamplesjni ${CUDF_BASE_LIBRARY} ${CUDART_LIBRARY} cuda)
+target_link_libraries(udfexamplesjni cudf::cudf)


### PR DESCRIPTION
This simplifies the native UDF build by using CPM to pull in libcudf rather than manually building it in a Docker image.  This work was heavily influenced by the RAPIDS example project using libcudf via CPM at https://github.com/rapidsai/rapids-examples/tree/main/strings_udf.