### PR TITLE
Add cosine similarity native UDF example

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -313,7 +313,10 @@ class FloatGen(DataGen):
 
     def _fixup_nans(self, v):
         if self._no_nans and (math.isnan(v) or v == math.inf or v == -math.inf):
-            v = None
+            if self.nullable:
+                v = None
+            else:
+                v = 0.0
         return v
 
     def start(self, rand):
@@ -372,7 +375,10 @@ class DoubleGen(DataGen):
 
     def _fixup_nans(self, v):
         if self._no_nans and (math.isnan(v) or v == math.inf or v == -math.inf):
-            v = None
+            if self.nullable:
+                v = None
+            else:
+                v = 0.0
         return v
 
     def start(self, rand):

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -313,10 +313,7 @@ class FloatGen(DataGen):
 
     def _fixup_nans(self, v):
         if self._no_nans and (math.isnan(v) or v == math.inf or v == -math.inf):
-            if self.nullable:
-                v = None
-            else:
-                v = 0.0
+            v = None if self.nullable else 0.0
         return v
 
     def start(self, rand):
@@ -375,10 +372,7 @@ class DoubleGen(DataGen):
 
     def _fixup_nans(self, v):
         if self._no_nans and (math.isnan(v) or v == math.inf or v == -math.inf):
-            if self.nullable:
-                v = None
-            else:
-                v = 0.0
+            v = None if self.nullable else 0.0
         return v
 
     def start(self, rand):

--- a/integration_tests/src/main/python/rapids_udf_test.py
+++ b/integration_tests/src/main/python/rapids_udf_test.py
@@ -62,6 +62,7 @@ def test_hive_generic_udf():
 @rapids_udf_example_native
 def test_hive_simple_udf_native(enable_rapids_udf_example_native):
     with_spark_session(skip_if_no_hive)
+    data_gens = [["s", StringGen('.{0,30}')]]
     def evalfn(spark):
         load_hive_udf_or_skip_test(spark, "wordcount", "com.nvidia.spark.rapids.udf.hive.StringWordCount")
         return gen_df(spark, data_gens)
@@ -87,4 +88,25 @@ def test_java_url_encode():
     def evalfn(spark):
         load_java_udf_or_skip_test(spark, 'urlencode', 'com.nvidia.spark.rapids.udf.java.URLEncode')
         return unary_op_df(spark, StringGen('.{0,30}')).selectExpr("urlencode(a)")
+    assert_gpu_and_cpu_are_equal_collect(evalfn)
+
+@rapids_udf_example_native
+def test_java_cosine_similarity_reasonable_range(enable_rapids_udf_example_native):
+    def evalfn(spark):
+        class RangeFloatGen(FloatGen):
+            def start(self, rand):
+                def gen_float(): return rand.uniform(-1000.0, 1000.0)
+                self._start(rand, gen_float)
+        load_java_udf_or_skip_test(spark, "cosine_similarity", "com.nvidia.spark.rapids.udf.java.CosineSimilarity")
+        arraygen = ArrayGen(RangeFloatGen(nullable=False), min_length=8, max_length=8)
+        df = binary_op_df(spark, arraygen, length=16)
+        return df.selectExpr("cosine_similarity(a, b)")
+    assert_gpu_and_cpu_are_equal_collect(evalfn)
+
+@rapids_udf_example_native
+def test_java_cosine_similarity_with_nans(enable_rapids_udf_example_native):
+    def evalfn(spark):
+        load_java_udf_or_skip_test(spark, "cosine_similarity", "com.nvidia.spark.rapids.udf.java.CosineSimilarity")
+        arraygen = ArrayGen(FloatGen(nullable=False), min_length=8, max_length=8)
+        return binary_op_df(spark, arraygen).selectExpr("cosine_similarity(a, b)")
     assert_gpu_and_cpu_are_equal_collect(evalfn)

--- a/integration_tests/src/main/python/rapids_udf_test.py
+++ b/integration_tests/src/main/python/rapids_udf_test.py
@@ -95,11 +95,10 @@ def test_java_cosine_similarity_reasonable_range(enable_rapids_udf_example_nativ
     def evalfn(spark):
         class RangeFloatGen(FloatGen):
             def start(self, rand):
-                def gen_float(): return rand.uniform(-1000.0, 1000.0)
-                self._start(rand, gen_float)
+                self._start(rand, lambda: rand.uniform(-1000.0, 1000.0))
         load_java_udf_or_skip_test(spark, "cosine_similarity", "com.nvidia.spark.rapids.udf.java.CosineSimilarity")
-        arraygen = ArrayGen(RangeFloatGen(nullable=False), min_length=8, max_length=8)
-        df = binary_op_df(spark, arraygen, length=16)
+        arraygen = ArrayGen(RangeFloatGen(nullable=False, no_nans=True, special_cases=[]), min_length=8, max_length=8)
+        df = binary_op_df(spark, arraygen)
         return df.selectExpr("cosine_similarity(a, b)")
     assert_gpu_and_cpu_are_equal_collect(evalfn)
 

--- a/udf-examples/pom.xml
+++ b/udf-examples/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <udf.native.build.path>${project.build.directory}/cpp-build</udf.native.build.path>
+    <BUILD_UDF_BENCHMARKS>OFF</BUILD_UDF_BENCHMARKS>
     <CMAKE_CXX_FLAGS/>
     <GPU_ARCHS>ALL</GPU_ARCHS>
     <PER_THREAD_DEFAULT_STREAM>ON</PER_THREAD_DEFAULT_STREAM>
@@ -113,6 +114,7 @@
                           failonerror="true"
                           executable="cmake">
                       <arg value="${basedir}/src/main/cpp"/>
+                      <arg value="-DBUILD_UDF_BENCHMARKS=${BUILD_UDF_BENCHMARKS}"/>
                       <arg value="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"/>
                       <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
                       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>

--- a/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/CMakeLists.txt
@@ -105,6 +105,21 @@ CPMAddPackage(NAME  cudf
     )
 
 ###################################################################################################
+# - benchmarks ------------------------------------------------------------------------------------
+
+if(BUILD_UDF_BENCHMARKS)
+    # Find or install GoogleBench
+    CPMFindPackage(NAME benchmark
+        VERSION         1.5.2
+        GIT_REPOSITORY  https://github.com/google/benchmark.git
+        GIT_TAG         v1.5.2
+        GIT_SHALLOW     TRUE
+        OPTIONS         "BENCHMARK_ENABLE_TESTING OFF"
+                        "BENCHMARK_ENABLE_INSTALL OFF")
+    add_subdirectory(benchmarks)
+endif()
+
+###################################################################################################
 # - find JNI -------------------------------------------------------------------------------------
 
 find_package(JNI REQUIRED)
@@ -126,7 +141,9 @@ link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}"
 # - library targets -------------------------------------------------------------------------------
 
 set(SOURCE_FILES
+    "src/CosineSimilarityJni.cpp"
     "src/StringWordCountJni.cpp"
+    "src/cosine_similarity.cu"
     "src/string_word_count.cu")
 
 add_library(udfexamplesjni SHARED ${SOURCE_FILES})

--- a/udf-examples/src/main/cpp/benchmarks/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/benchmarks/CMakeLists.txt
@@ -1,0 +1,36 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Use an OBJECT library so we only compile these helper source files only once
+add_library(udf_benchmark_common OBJECT
+    synchronization/synchronization.cpp)
+
+target_link_libraries(udf_benchmark_common PUBLIC benchmark::benchmark cudf)
+
+target_include_directories(udf_benchmark_common
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+           "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_SOURCE_DIR}>"
+           "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_SOURCE_DIR}>/src")
+
+function(ConfigureBench CMAKE_BENCH_NAME)
+    add_executable(${CMAKE_BENCH_NAME} ${ARGN})
+    set_target_properties(${CMAKE_BENCH_NAME}
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<BUILD_INTERFACE:${UDFEXAMPLESJNI_BINARY_DIR}/gbenchmarks>")
+    target_link_libraries(${CMAKE_BENCH_NAME}
+        PRIVATE udf_benchmark_common udfexamplesjni benchmark::benchmark_main)
+endfunction()
+
+ConfigureBench(COSINE_SIMILARITY_BENCH cosine_similarity/cosine_similarity_benchmark.cpp)

--- a/udf-examples/src/main/cpp/benchmarks/cosine_similarity/cosine_similarity_benchmark.cpp
+++ b/udf-examples/src/main/cpp/benchmarks/cosine_similarity/cosine_similarity_benchmark.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmarks/fixture/benchmark_fixture.hpp"
+#include "benchmarks/synchronization/synchronization.hpp"
+#include "cosine_similarity.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+
+static void cosine_similarity_bench_args(benchmark::internal::Benchmark* b)
+{
+  int const min_rows   = 1 << 12;
+  int const max_rows   = 1 << 24;
+  int const row_mult   = 8;
+  int const min_rowlen = 1 << 0;
+  int const max_rowlen = 1 << 12;
+  int const len_mult   = 8;
+  for (int row_count = min_rows; row_count <= max_rows; row_count *= row_mult) {
+    for (int rowlen = min_rowlen; rowlen <= max_rowlen; rowlen *= len_mult) {
+      // avoid generating combinations that exceed the cudf column limit
+      size_t total_chars = static_cast<size_t>(row_count) * rowlen;
+      if (total_chars < std::numeric_limits<cudf::size_type>::max()) {
+        b->Args({row_count, rowlen});
+      }
+    }
+  }
+}
+
+static void BM_cosine_similarity(benchmark::State& state)
+{
+  cudf::size_type const n_rows{static_cast<cudf::size_type>(state.range(0))};
+  cudf::size_type const list_len{static_cast<cudf::size_type>(state.range(1))};
+
+  auto val_start = cudf::make_fixed_width_scalar(1.0f);
+  auto val_step = cudf::make_fixed_width_scalar(-1.0f);
+  auto child_rows = n_rows * list_len;
+  auto col1_child = cudf::sequence(child_rows, *val_start);
+  auto col2_child = cudf::sequence(child_rows, *val_start, *val_step);
+  auto offset_start = cudf::make_fixed_width_scalar(static_cast<int32_t>(0));
+  auto offset_step = cudf::make_fixed_width_scalar(list_len);
+  auto offsets = cudf::sequence(n_rows + 1, *offset_start, *offset_step);
+
+  auto col1 = cudf::make_lists_column(
+      n_rows,
+      std::make_unique<cudf::column>(*offsets),
+      std::move(col1_child),
+      0,
+      cudf::create_null_mask(n_rows, cudf::mask_state::ALL_VALID));
+  auto lcol1 = cudf::lists_column_view(*col1);
+  auto col2 = cudf::make_lists_column(
+      n_rows,
+      std::move(offsets),
+      std::move(col2_child),
+      0,
+      cudf::create_null_mask(n_rows, cudf::mask_state::ALL_VALID));
+  auto lcol2 = cudf::lists_column_view(*col2);
+
+  for (auto _ : state) {
+    cuda_event_timer raii(state, true, rmm::cuda_stream_default);
+    auto output = cosine_similarity(lcol1, lcol2);
+  }
+
+  state.SetBytesProcessed(state.iterations() * child_rows * sizeof(float));
+}
+
+class CosineSimilarity : public native_udf::benchmark {
+};
+
+BENCHMARK_DEFINE_F(CosineSimilarity, cosine_similarity)
+(::benchmark::State& state) { BM_cosine_similarity(state); }
+
+BENCHMARK_REGISTER_F(CosineSimilarity, cosine_similarity)
+  ->Apply(cosine_similarity_bench_args)
+  ->Unit(benchmark::kMillisecond)
+  ->UseManualTime();

--- a/udf-examples/src/main/cpp/benchmarks/fixture/benchmark_fixture.hpp
+++ b/udf-examples/src/main/cpp/benchmarks/fixture/benchmark_fixture.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+
+namespace native_udf {
+
+namespace {
+// memory resource factory helpers
+inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
+
+inline auto make_pool()
+{
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+}
+}  // namespace
+
+/**
+ * @brief Google Benchmark fixture for native UDF benchmarks
+ *
+ * Native UDF benchmarks should use a fixture derived from this fixture class to
+ * ensure that the RAPIDS Memory Manager pool mode is used in benchmarks, which
+ * eliminates memory allocation / deallocation performance overhead from the
+ * benchmark.
+ *
+ * The SetUp and TearDown methods of this fixture initialize RMM into pool mode
+ * and finalize it, respectively. These methods are called automatically by
+ * Google Benchmark
+ *
+ * Example:
+ *
+ * template <class T>
+ * class my_benchmark : public native_udf::benchmark {
+ * public:
+ *   using TypeParam = T;
+ * };
+ *
+ * Then:
+ *
+ * BENCHMARK_TEMPLATE_DEFINE_F(my_benchmark, my_test_name, int)
+ *   (::benchmark::State& state) {
+ *     for (auto _ : state) {
+ *       // benchmark stuff
+ *     }
+ * }
+ *
+ * BENCHMARK_REGISTER_F(my_benchmark, my_test_name)->Range(128, 512);
+ */
+class benchmark : public ::benchmark::Fixture {
+ public:
+  virtual void SetUp(const ::benchmark::State& state)
+  {
+    mr = make_pool();
+    rmm::mr::set_current_device_resource(mr.get());  // set default resource to pool
+  }
+
+  virtual void TearDown(const ::benchmark::State& state)
+  {
+    // reset default resource to the initial resource
+    rmm::mr::set_current_device_resource(nullptr);
+    mr.reset();
+  }
+
+  // eliminate partial override warnings (see benchmark/benchmark.h)
+  virtual void SetUp(::benchmark::State& st) { SetUp(const_cast<const ::benchmark::State&>(st)); }
+  virtual void TearDown(::benchmark::State& st)
+  {
+    TearDown(const_cast<const ::benchmark::State&>(st));
+  }
+
+  std::shared_ptr<rmm::mr::device_memory_resource> mr;
+};
+
+}  // namespace native_udf

--- a/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synchronization.hpp"
+
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+
+cuda_event_timer::cuda_event_timer(benchmark::State& state,
+                                   bool flush_l2_cache,
+                                   rmm::cuda_stream_view stream)
+  : stream(stream), p_state(&state)
+{
+  // flush all of L2$
+  if (flush_l2_cache) {
+    int current_device = 0;
+    CUDA_TRY(cudaGetDevice(&current_device));
+
+    int l2_cache_bytes = 0;
+    CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
+
+    if (l2_cache_bytes > 0) {
+      const int memset_value = 0;
+      rmm::device_buffer l2_cache_buffer(l2_cache_bytes, stream);
+      CUDA_TRY(
+        cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream.value()));
+    }
+  }
+
+  CUDA_TRY(cudaEventCreate(&start));
+  CUDA_TRY(cudaEventCreate(&stop));
+  CUDA_TRY(cudaEventRecord(start, stream.value()));
+}
+
+cuda_event_timer::~cuda_event_timer()
+{
+  CUDA_TRY(cudaEventRecord(stop, stream.value()));
+  CUDA_TRY(cudaEventSynchronize(stop));
+
+  float milliseconds = 0.0f;
+  CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
+  p_state->SetIterationTime(milliseconds / (1000.0f));
+  CUDA_TRY(cudaEventDestroy(start));
+  CUDA_TRY(cudaEventDestroy(stop));
+}

--- a/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/udf-examples/src/main/cpp/benchmarks/synchronization/synchronization.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file synchronization.hpp
+ * @brief This is the header file for `cuda_event_timer`.
+ */
+
+/**
+ * @brief  This class serves as a wrapper for using `cudaEvent_t` as the user
+ * defined timer within the framework of google benchmark
+ * (https://github.com/google/benchmark).
+ *
+ * It is built on top of the idea of Resource acquisition is initialization
+ * (RAII). In the following we show a minimal example of how to use this class.
+
+    #include <benchmark/benchmark.h>
+
+    static void sample_cuda_benchmark(benchmark::State& state) {
+
+      for (auto _ : state){
+
+        rmm::cuda_stream_view stream{}; // default stream, could be another stream
+
+        // Create (Construct) an object of this class. You HAVE to pass in the
+        // benchmark::State object you are using. It measures the time from its
+        // creation to its destruction that is spent on the specified CUDA stream.
+        // It also clears the L2 cache by cudaMemset'ing a device buffer that is of
+        // the size of the L2 cache (if flush_l2_cache is set to true and there is
+        // an L2 cache on the current device).
+        cuda_event_timer raii(state, true, stream); // flush_l2_cache = true
+
+        // Now perform the operations that is to be benchmarked
+        sample_kernel<<<1, 256, 0, stream.value()>>>(); // Possibly launching a CUDA kernel
+
+      }
+    }
+
+    // Register the function as a benchmark. You will need to set the `UseManualTime()`
+    // flag in order to use the timer embedded in this class.
+    BENCHMARK(sample_cuda_benchmark)->UseManualTime();
+
+
+ */
+
+#ifndef UDF_BENCH_SYNCHRONIZATION_H
+#define UDF_BENCH_SYNCHRONIZATION_H
+
+// Google Benchmark library
+#include <benchmark/benchmark.h>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <driver_types.h>
+
+class cuda_event_timer {
+ public:
+  /**
+   * @brief This c'tor clears the L2$ by cudaMemset'ing a buffer of L2$ size
+   * and starts the timer.
+   *
+   * @param[in,out] state  This is the benchmark::State whose timer we are going
+   * to update.
+   * @param[in] flush_l2_cache_ whether or not to flush the L2 cache before
+   *                            every iteration.
+   * @param[in] stream_ The CUDA stream we are measuring time on.
+   */
+  cuda_event_timer(benchmark::State& state,
+                   bool flush_l2_cache,
+                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+  // The user must provide a benchmark::State object to set
+  // the timer so we disable the default c'tor.
+  cuda_event_timer() = delete;
+
+  // The d'tor stops the timer and performs a synchronization.
+  // Time of the benchmark::State object provided to the c'tor
+  // will be set to the value given by `cudaEventElapsedTime`.
+  ~cuda_event_timer();
+
+ private:
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  rmm::cuda_stream_view stream;
+  benchmark::State* p_state;
+};
+
+#endif

--- a/udf-examples/src/main/cpp/src/CosineSimilarityJni.cpp
+++ b/udf-examples/src/main/cpp/src/CosineSimilarityJni.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+#include <memory>
+#include <jni.h>
+
+#include "cosine_similarity.hpp"
+
+namespace {
+
+constexpr char const* RUNTIME_ERROR_CLASS = "java/lang/RuntimeException";
+constexpr char const* ILLEGAL_ARG_CLASS   = "java/lang/IllegalArgumentException";
+
+/**
+ * @brief Throw a Java exception
+ *
+ * @param env The Java environment
+ * @param class_name The fully qualified Java class name of the exception
+ * @param msg The message string to associate with the exception
+ */
+void throw_java_exception(JNIEnv* env, char const* class_name, char const* msg) {
+  jclass ex_class = env->FindClass(class_name);
+  if (ex_class != NULL) {
+    env->ThrowNew(ex_class, msg);
+  }
+}
+
+}  // anonymous namespace
+
+extern "C" {
+
+/**
+ * @brief The native implementation of CosineSimilarity.cosineSimilarity which
+ * computes the cosine similarity between two LIST(FLOAT32) columns as a FLOAT32
+ * columnar result.
+ *
+ * @param env The Java environment
+ * @param j_view1 The address of the cudf column view of the first LIST column
+ * @param j_view2 The address of the cudf column view of the second LIST column
+ * @return The address of the cudf column containing the FLOAT32 results
+ */
+JNIEXPORT jlong JNICALL
+Java_com_nvidia_spark_rapids_udf_java_CosineSimilarity_cosineSimilarity(JNIEnv* env, jclass,
+                                                                        jlong j_view1,
+                                                                        jlong j_view2) {
+  // Use a try block to translate C++ exceptions into Java exceptions to avoid
+  // crashing the JVM if a C++ exception occurs.
+  try {
+    // turn the addresses into column_view pointers
+    auto v1 = reinterpret_cast<cudf::column_view const*>(j_view1);
+    auto v2 = reinterpret_cast<cudf::column_view const*>(j_view2);
+    if (v1->type().id() != v2->type().id() || v1->type().id() != cudf::type_id::LIST) {
+      throw_java_exception(env, ILLEGAL_ARG_CLASS, "inputs not list columns");
+      return 0;
+    }
+
+    // run the GPU kernel to compute the cosine similarity
+    auto lv1 = cudf::lists_column_view(*v1);
+    auto lv2 = cudf::lists_column_view(*v2);
+    std::unique_ptr<cudf::column> result = cosine_similarity(lv1, lv2);
+
+    // take ownership of the column and return the column address to Java
+    return reinterpret_cast<jlong>(result.release());
+  } catch (std::bad_alloc const& e) {
+    auto msg = std::string("Unable to allocate native memory: ") +
+        (e.what() == nullptr ? "" : e.what());
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg.c_str());
+  } catch (std::invalid_argument const& e) {
+    throw_java_exception(env, ILLEGAL_ARG_CLASS, e.what() == nullptr ? "" : e.what());
+  } catch (std::exception const& e) {
+    auto msg = e.what() == nullptr ? "" : e.what();
+    throw_java_exception(env, RUNTIME_ERROR_CLASS, msg);
+  }
+  return 0;
+}
+
+}

--- a/udf-examples/src/main/cpp/src/cosine_similarity.cu
+++ b/udf-examples/src/main/cpp/src/cosine_similarity.cu
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cosine_similarity.hpp"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/lists/list_device_view.cuh>
+#include <cudf/lists/lists_column_device_view.cuh>
+#include <cudf/lists/lists_column_view.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/table/table_view.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/logical.h>
+#include <thrust/transform.h>
+
+#include <cmath>
+
+namespace {
+
+/**
+ * @brief Functor for computing the cosine similarity between two list of float columns
+ */
+struct cosine_similarity_functor {
+  float const* const v1;
+  float const* const v2;
+  int32_t const* const v1_offsets;
+  int32_t const* const v2_offsets;
+
+  // This kernel executes thread-per-row which should be fine for relatively short lists
+  // but may need to be revisited for performance if operating on long lists.
+  __device__ float operator()(cudf::size_type row_idx) {
+    auto const v1_start_idx = v1_offsets[row_idx];
+    auto const v1_num_elems = v1_offsets[row_idx + 1] - v1_start_idx;
+    auto const v2_start_idx = v2_offsets[row_idx];
+    auto const v2_num_elems = v2_offsets[row_idx + 1] - v2_start_idx;
+    auto const num_elems = std::min(v1_num_elems, v2_num_elems);
+    double mag1 = 0;
+    double mag2 = 0;
+    double dot_product = 0;
+    for (auto i = 0; i < num_elems; i++) {
+      float const f1 = v1[v1_start_idx + i];
+      mag1 += f1 * f1;
+      float const f2 = v2[v2_start_idx + i];
+      mag2 += f2 * f2;
+      dot_product += f1 * f2;
+    }
+    mag1 = std::sqrt(mag1);
+    mag2 = std::sqrt(mag2);
+    return static_cast<float>(dot_product / (mag1 * mag2));
+  }
+};
+
+} // anonymous namespace
+
+/**
+ * @brief Compute the cosine similarity between two LIST of FLOAT32 columns
+ *
+ * The input vectors must have matching shapes, i.e.: same row count and same number of
+ * list elements per row. A null list row is supported, but null float entries within a
+ * list are not supported.
+ *
+ * @param lv1 The first LIST of FLOAT32 column view
+ * @param lv2 The second LIST of FLOAT32 column view
+ * @return A FLOAT32 column containing the cosine similarity corresponding to each input row
+ */
+std::unique_ptr<cudf::column> cosine_similarity(cudf::lists_column_view const& lv1,
+                                                cudf::lists_column_view const& lv2) {
+  // sanity-check the input types
+  if (lv1.child().type().id() != lv2.child().type().id() ||
+      lv1.child().type().id() != cudf::type_id::FLOAT32) {
+    throw std::invalid_argument("inputs are not lists of floats");
+  }
+
+  // sanity check the input shape
+  auto const row_count = lv1.size();
+  if (row_count != lv2.size()) {
+    throw std::invalid_argument("input row counts do not match");
+  }
+  if (row_count == 0) {
+    return cudf::make_empty_column(cudf::data_type{cudf::type_id::FLOAT32});
+  }
+  if (lv1.child().null_count() != 0 || lv2.child().null_count() != 0) {
+    throw std::invalid_argument("null floats are not supported");
+  }
+
+  auto const stream = rmm::cuda_stream_default;
+  auto d_view1_ptr = cudf::column_device_view::create(lv1.parent());
+  auto d_lists1 = cudf::detail::lists_column_device_view(*d_view1_ptr);
+  auto d_view2_ptr = cudf::column_device_view::create(lv2.parent());
+  auto d_lists2 = cudf::detail::lists_column_device_view(*d_view2_ptr);
+  bool const are_offsets_equal =
+    thrust::all_of(rmm::exec_policy(stream),
+                   thrust::make_counting_iterator<cudf::size_type>(0),
+                   thrust::make_counting_iterator<cudf::size_type>(row_count),
+                   [d_lists1, d_lists2] __device__(cudf::size_type idx) {
+                     auto ldv1 = cudf::list_device_view(d_lists1, idx);
+                     auto ldv2 = cudf::list_device_view(d_lists2, idx);
+                     return ldv1.is_null() || ldv2.is_null() || ldv1.size() == ldv2.size();
+                   });
+  if (not are_offsets_equal) {
+    throw std::invalid_argument("input list lengths do not match for every row");
+  }
+
+  // allocate the vector of float results
+  rmm::device_uvector<float> float_results(row_count, stream);
+
+  // compute the cosine similarity
+  auto const lv1_data = lv1.child().data<float>();
+  auto const lv2_data = lv2.child().data<float>();
+  auto const lv1_offsets = lv1.offsets().data<int32_t>();
+  auto const lv2_offsets = lv2.offsets().data<int32_t>();
+  thrust::transform(rmm::exec_policy(stream),
+                    thrust::make_counting_iterator<cudf::size_type>(0),
+                    thrust::make_counting_iterator<cudf::size_type>(row_count),
+                    float_results.data(),
+                    cosine_similarity_functor({lv1_data, lv2_data, lv1_offsets, lv2_offsets}));
+
+  // the validity of the output is the bitwise-and of the two input validity masks
+  rmm::device_buffer null_mask = cudf::bitmask_and(cudf::table_view({lv1.parent(), lv2.parent()}));
+
+  return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::FLOAT32},
+                                        row_count,
+                                        float_results.release(),
+                                        std::move(null_mask));
+}

--- a/udf-examples/src/main/cpp/src/cosine_similarity.hpp
+++ b/udf-examples/src/main/cpp/src/cosine_similarity.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/lists/lists_column_view.hpp>
+
+/**
+ * @brief Compute the cosine similarity between two LIST of FLOAT32 columns
+ *
+ * The input vectors must have matching shapes, i.e.: same row count and same number of
+ * list elements per row. A null list row is supported, but null float entries within a
+ * list are not supported.
+ *
+ * @param lv1 The first LIST of FLOAT32 column view
+ * @param lv2 The second LIST of FLOAT32 column view
+ * @return A FLOAT32 column containing the cosine similarity corresponding to each input row
+ */
+std::unique_ptr<cudf::column> cosine_similarity(cudf::lists_column_view const& lv1,
+                                                cudf::lists_column_view const& lv2);

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/StringWordCount.java
@@ -20,6 +20,7 @@ import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.NativeDepsLoader;
 import com.nvidia.spark.RapidsUDF;
+import com.nvidia.spark.rapids.udf.java.NativeUDFExamplesLoader;
 import org.apache.hadoop.hive.ql.exec.UDF;
 
 import java.io.IOException;
@@ -73,24 +74,9 @@ public class StringWordCount extends UDF implements RapidsUDF {
     // Load the native code if it has not been already loaded. This is done here
     // rather than in a static code block since the driver may not have the
     // required CUDA environment.
-    ensureNativeCodeLoaded();
+    NativeUDFExamplesLoader.ensureLoaded();
 
     return new ColumnVector(countWords(strs.getNativeView()));
-  }
-
-  private void ensureNativeCodeLoaded() {
-    if (!isNativeCodeLoaded) {
-      synchronized(StringWordCount.class) {
-        if (!isNativeCodeLoaded) {
-          try {
-            NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
-            isNativeCodeLoaded = true;
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      }
-    }
   }
 
   private static native long countWords(long stringsView);

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/CosineSimilarity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.ColumnVector;
+import com.nvidia.spark.RapidsUDF;
+import org.apache.spark.sql.api.java.UDF2;
+import scala.collection.mutable.WrappedArray;
+
+/**
+ * A Spark Java UDF that computes the cosine similarity between two float vectors.
+ * The input vectors must have matching shapes, i.e.: same number of elements.
+ * A null vector is supported, but null entries within the vector are not supported.
+ */
+public class CosineSimilarity
+    implements UDF2<WrappedArray<Float>, WrappedArray<Float>, Float>, RapidsUDF {
+
+  /** Row-by-row implementation that executes on the CPU */
+  @Override
+  public Float call(WrappedArray<Float> v1, WrappedArray<Float> v2) {
+    if (v1 == null || v2 == null) {
+      return null;
+    }
+    if (v1.length() != v2.length()) {
+      throw new IllegalArgumentException("Array lengths must match: " +
+          v1.length() + " != " + v2.length());
+    }
+
+    double dotProduct = 0;
+    for (int i = 0; i < v1.length(); i++) {
+      float f1 = v1.apply(i);
+      float f2 = v2.apply(i);
+      dotProduct += f1 * f2;
+    }
+    double magProduct = magnitude(v1) * magnitude(v2);
+    return (float) (dotProduct / magProduct);
+  }
+
+  private double magnitude(WrappedArray<Float> v) {
+    double sum = 0;
+    for (int i = 0; i < v.length(); i++) {
+      float x = v.apply(i);
+      sum += x * x;
+    }
+    return Math.sqrt(sum);
+  }
+
+  /** Columnar implementation that processes data on the GPU */
+  @Override
+  public ColumnVector evaluateColumnar(ColumnVector... args) {
+    if (args.length != 2) {
+      throw new IllegalArgumentException("Unexpected argument count: " + args.length);
+    }
+
+    // Load the native code if it has not been already loaded. This is done here
+    // rather than in a static code block since the driver may not have the
+    // required CUDA environment.
+    NativeUDFExamplesLoader.ensureLoaded();
+
+    return new ColumnVector(cosineSimilarity(args[0].getNativeView(), args[1].getNativeView()));
+  }
+
+  /** Native implementation that computes on the GPU */
+  private static native long cosineSimilarity(long vectorView1, long vectorView2);
+}

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.udf.java;
+
+import ai.rapids.cudf.NativeDepsLoader;
+
+import java.io.IOException;
+
+/** Loads the native dependencies for UDF examples with a native implementation */
+public class NativeUDFExamplesLoader {
+  private static volatile boolean isLoaded = false;
+
+  /** Loads native UDF code if necessary */
+  public static void ensureLoaded() {
+    if (!isLoaded) {
+      load();
+    }
+  }
+
+  private static synchronized void load() {
+    try {
+      NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
+      isLoaded = true;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/java/NativeUDFExamplesLoader.java
@@ -22,21 +22,17 @@ import java.io.IOException;
 
 /** Loads the native dependencies for UDF examples with a native implementation */
 public class NativeUDFExamplesLoader {
-  private static volatile boolean isLoaded = false;
+  private static boolean isLoaded;
 
   /** Loads native UDF code if necessary */
-  public static void ensureLoaded() {
+  public static synchronized void ensureLoaded() {
     if (!isLoaded) {
-      load();
-    }
-  }
-
-  private static synchronized void load() {
-    try {
-      NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
-      isLoaded = true;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      try {
+        NativeDepsLoader.loadNativeDeps(new String[]{"udfexamplesjni"});
+        isLoaded = true;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
Adding a Spark Java UDF that computes the cosine similarity between two float vectors.  The implementation is custom CUDA code and shows how a RAPIDS accelerator UDF can handle nested type inputs.

This also adds a native performance benchmark for cosine similarity along with the cmake framework for building benchmarks.  Benchmarks are not built by default but can be requested via `-DBUILD_UDF_BENCHMARKS=ON`.

As with other native UDFs, this does not build unless the `udf-native-examples` build profile is specified.