### PR TITLE
ParquetCachedBatchSerializer broadcast AllConfs instead of SQLConf to fix distributed mode

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -697,8 +697,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
           }
           parquetFileReader.close()
           val iter = unsafeRows.iterator
-          val unsafeProjection =
-            GenerateUnsafeProjection.generate(requestedSchema, cacheSchema)
+          val unsafeProjection = GenerateUnsafeProjection.generate(requestedSchema, cacheSchema)
           if (hasUnsupportedType) {
             new UnsupportedDataHandlerIterator() {
               val wrappedIter: Iterator[InternalRow] = iter

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -26,11 +26,13 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
 
 
 /**
@@ -167,8 +169,10 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
       }
     }
     val ser = new ParquetCachedBatchSerializer
+
     val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
-      new Configuration(true), new SQLConf)
+      SparkContext.getOrCreate().broadcast(new SerializableConfiguration(new Configuration(true))),
+      SparkContext.getOrCreate().broadcast(new SQLConf().getAllConfs))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L
     val mockRecordWriter = new RecordWriter[Void, InternalRow] {

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -171,8 +171,9 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
     val ser = new ParquetCachedBatchSerializer
 
     val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
-      SparkContext.getOrCreate().broadcast(new SerializableConfiguration(new Configuration(true))),
-      SparkContext.getOrCreate().broadcast(new SQLConf().getAllConfs))
+      withCpuSparkSession(spark =>
+        spark.sparkContext.broadcast(new SerializableConfiguration(new Configuration(true)))),
+      withCpuSparkSession(spark => spark.sparkContext.broadcast(new SQLConf().getAllConfs)))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L
     val mockRecordWriter = new RecordWriter[Void, InternalRow] {


### PR DESCRIPTION
In a distributed cluster, SQLConf is broadcasted as an uninitialized object. This PR broadcasts the conf as a Map and then creates the SQLConf needed in each executor node. 

fixes #2203 

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
