### PR TITLE
Fix distributed cache to read requested schema 

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -831,7 +831,8 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
           this.totalRowCount += block.getRowCount
         }
 
-        // initialize missingColumns
+        // initialize missingColumns to cover the case where requested column isn't present in the
+        // cache, which should never happen but just in case it does
         val columns = reqParquetSchema.getColumns
         val paths = reqParquetSchema.getPaths
         val fileSchema = parquetFileReader.getFooter.getFileMetaData.getSchema

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.execution.datasources.parquet.rapids.shims.spark311.
 import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, WritableColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
-import org.apache.spark.sql.types.{StructType, _}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -849,13 +849,12 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
               throw new UnsupportedOperationException("Schema evolution not supported.")
             }
             missingColumns(i) = false
-          }
-          else {
+          } else {
             if (columns.get(i).getMaxDefinitionLevel == 0) {
               // Column is missing in data but the required data is non-nullable.
               // This file is invalid.
-              throw new IOException("Required column is missing in data file. Col: "
-                + colPath.toList)
+              throw new IOException(s"Required column is missing in data file. Col: " +
+                s"${colPath.toList}")
             }
             missingColumns(i) = true
           }

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -853,8 +853,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
             if (columns.get(i).getMaxDefinitionLevel == 0) {
               // Column is missing in data but the required data is non-nullable.
               // This file is invalid.
-              throw new IOException(s"Required column is missing in data file. Col: " +
-                s"${colPath.toList}")
+              throw new IOException(s"Required column is missing in data file: ${colPath.toList}")
             }
             missingColumns(i) = true
           }

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -697,8 +697,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
           }
           parquetFileReader.close()
           val iter = unsafeRows.iterator
-          val unsafeProjection =
-            GenerateUnsafeProjection.generate(requestedSchema, cacheSchema)
+          val unsafeProjection = GenerateUnsafeProjection.generate(requestedSchema, cacheSchema)
           if (hasUnsupportedType) {
             new UnsupportedDataHandlerIterator() {
               val wrappedIter: Iterator[InternalRow] = iter

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -171,8 +171,6 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
     val ser = new ParquetCachedBatchSerializer
 
     val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
-      withCpuSparkSession(spark =>
-        spark.sparkContext.broadcast(new SerializableConfiguration(new Configuration(true)))),
       withCpuSparkSession(spark => spark.sparkContext.broadcast(new SQLConf().getAllConfs)))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -26,11 +26,13 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
 
 
 /**
@@ -167,8 +169,10 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
       }
     }
     val ser = new ParquetCachedBatchSerializer
+
     val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
-      new Configuration(true), new SQLConf)
+      SparkContext.getOrCreate().broadcast(new SerializableConfiguration(new Configuration(true))),
+      SparkContext.getOrCreate().broadcast(new SQLConf().getAllConfs))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L
     val mockRecordWriter = new RecordWriter[Void, InternalRow] {

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -171,8 +171,9 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
     val ser = new ParquetCachedBatchSerializer
 
     val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
-      SparkContext.getOrCreate().broadcast(new SerializableConfiguration(new Configuration(true))),
-      SparkContext.getOrCreate().broadcast(new SQLConf().getAllConfs))
+      withCpuSparkSession(spark =>
+        spark.sparkContext.broadcast(new SerializableConfiguration(new Configuration(true)))),
+      withCpuSparkSession(spark => spark.sparkContext.broadcast(new SQLConf().getAllConfs)))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L
     val mockRecordWriter = new RecordWriter[Void, InternalRow] {


### PR DESCRIPTION
This PR fixes a bug which caused a failure when reading the cache if the column order was different from the stored cache. There is a point where we read the schema directly from the stored cache and use it to initialize the `VectorizedColumnReader`s but the `WritableColumnVectors` are still initialized using the originalRequestSchema which caused a failure because of a mismatch between the type of `WriteableColumnVector` and `VectorizedColumnReader`. 

A defensive piece of code is also added that protects against a case where the requested schema has a column that doesn't exist in the cache. 

Another change that this PR makes is that the Hadoop Conf will not be broadcasted, instead it will be created on the executor side to save the driver from broadcasting all the properties inside the object. 

Unit test was added to test

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
