### PR TITLE
Add shuffle doc section on the periodicGC configuration

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -321,3 +321,20 @@ the [defaults](../configs.md) work in your case.
 This setting controls the amount of host memory (RAM) that can be utilized to spill GPU blocks when
 the GPU is out of memory, before going to disk. Please verify the [defaults](../configs.md).
 - `spark.rapids.memory.host.spillStorageSize`
+
+##### Shuffle Garbage Collection
+Shuffle buffers cached in the spillable store, whether they are in the GPU, host, or disk, will not
+be removed even after all actions for your query complete. This is a design decision in Spark, where 
+shuffle temporary stores are cleaned when there is a garbage collection on the driver, and the 
+references to the RDDs supporting your query are not reachable. 
+
+One of the issues with this is with large JVM footprints in the driver. The driver may not run a GC at
+all between different parts of your application, causing output for shuffle to accumulate (output that
+will not be reused), and eventually causing OOM or even filled disk. This is true from Spark even without
+the RAPIDS Shuffle Manager, but in our case it's likely GPU memory that is being occupied, and performance
+degrades given the churn due to spill to host memory or disk. As of this stage, there isn't a good solution 
+for this, other than to cause GC to happen. 
+
+Spark has a configuration `spark.cleaner.periodicGC.interval` (defaults to 30 minutes), that 
+can be used to periodically cause garbage collection. If you are experiencing OOM situations, or 
+performance degradation with several Spark actions, consider tuning this setting in your jobs.

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -333,7 +333,7 @@ all between different parts of your application, causing output for shuffle to a
 will not be reused), and eventually causing OOM or even filled disk. This is true for Spark even without
 the RAPIDS Shuffle Manager, but in our case it's likely GPU memory that is being occupied, and performance
 degrades given the churn due to spill to host memory or disk. As of this stage, there isn't a good solution 
-for this, other than to cause GC to happen. 
+for this, other than to trigger a GC cycle on the driver.
 
 Spark has a configuration `spark.cleaner.periodicGC.interval` (defaults to 30 minutes), that 
 can be used to periodically cause garbage collection. If you are experiencing OOM situations, or 

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -330,7 +330,7 @@ references to the RDDs supporting your query are not reachable.
 
 One of the issues with this is with large JVM footprints in the driver. The driver may not run a GC at
 all between different parts of your application, causing output for shuffle to accumulate (output that
-will not be reused), and eventually causing OOM or even filled disk. This is true from Spark even without
+will not be reused), and eventually causing OOM or even filled disk. This is true for Spark even without
 the RAPIDS Shuffle Manager, but in our case it's likely GPU memory that is being occupied, and performance
 degrades given the churn due to spill to host memory or disk. As of this stage, there isn't a good solution 
 for this, other than to cause GC to happen. 


### PR DESCRIPTION
This is a documantion-only PR for a reference to the `spark.cleaner.periodicGC.interval` config in Spark (re: shuffle buffers in the catalog accumulating over time).