### PR TITLE
Update UDF native example libcudf dependency to 0.20

### DIFF
--- a/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/CMakeLists.txt
@@ -90,9 +90,9 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
 CPMAddPackage(NAME  cudf
-        VERSION         "0.19.0"
+        VERSION         "0.20.0"
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
-        GIT_TAG         branch-0.19
+        GIT_TAG         branch-0.20
         GIT_SHALLOW     TRUE
         SOURCE_SUBDIR   cpp
         OPTIONS         "BUILD_TESTS OFF"


### PR DESCRIPTION
#2226 originally targeted branch-0.5 which is based on cudf 0.19, but when it was retargeted to branch-0.6 the cudf dependency wasn't updated to 0.20.  This doesn't break the build given the simple libcudf interfaces the UDF native examples require, as they haven't changed between libcudf 0.19 and 0.20.  However it's best to be consistent with the libcudf dependency.