### PR TITLE
Add spark312 and spark320 versions of cache serializer

### DIFF
--- a/docs/additional-functionality/cache-serializer.md
+++ b/docs/additional-functionality/cache-serializer.md
@@ -33,8 +33,18 @@ nav_order: 2
   ParquetCachedBatchSerializer does by decomposing intervals to struct containing the
   months, days and microseconds and NullType to Int column containing nulls.
 
-  To use this serializer please run Spark
+  Please make sure to use the right package corresponding to the spark version you are using. To use
+  this serializer with Spark 3.1.1 please run Spark with the following conf.
   ```
   spark-shell --conf spark.sql.cache.serializer=com.nvidia.spark.rapids.shims.spark311.ParquetCachedBatchSerializer"
   ```
+  Please see the below table for all the names of the serializers corresponding to the Spark
+  versions
+
+  | Spark version | Serializer name |
+  | ------ | -----|
+  | 3.1.1 | com.nvidia.spark.rapids.shims.spark311.ParquetCachedBatchSerializer |
+  | 3.1.2 | com.nvidia.spark.rapids.shims.spark312.ParquetCachedBatchSerializer |
+  | 3.2.0 | com.nvidia.spark.rapids.shims.spark320.ParquetCachedBatchSerializer |
+
   To use the default serializer don't set the `spark.sql.cache.serializer` conf

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/ParquetCachedBatchSerializer.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/ParquetCachedBatchSerializer.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark312
+
+import com.nvidia.spark.rapids.shims
+
+class ParquetCachedBatchSerializer extends shims.spark311.ParquetCachedBatchSerializer {
+}

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/ParquetCachedBatchSerializer.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/ParquetCachedBatchSerializer.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark320
+
+import com.nvidia.spark.rapids.shims
+
+class ParquetCachedBatchSerializer extends shims.spark311.ParquetCachedBatchSerializer {
+}


### PR DESCRIPTION
After #2204 the nightly tests are failing with this error:
```
16:52:03  E                   : java.lang.ClassNotFoundException: com.nvidia.spark.rapids.shims.spark312.ParquetCachedBatchSerializer
16:52:03  E                   	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
16:52:03  E                   	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
16:52:03  E                   	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
16:52:03  E                   	at java.lang.Class.forName0(Native Method)
16:52:03  E                   	at java.lang.Class.forName(Class.java:348)
16:52:03  E                   	at org.apache.spark.util.Utils$.classForName(Utils.scala:207)
16:52:03  E                   	at org.apache.spark.sql.execution.columnar.InMemoryRelation$.getSerializer(InMemoryRelation.scala:273)
16:52:03  E                   	at org.apache.spark.sql.execution.columnar.InMemoryRelation$.apply(InMemoryRelation.scala:301)
16:52:03  E                   	at org.apache.spark.sql.execution.CacheManager.$anonfun$cacheQuery$2(CacheManager.scala:102)
16:52:03  E                   	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
16:52:03  E                   	at org.apache.spark.sql.execution.CacheManager.cacheQuery(CacheManager.scala:97)
16:52:03  E                   	at org.apache.spark.sql.Dataset.persist(Dataset.scala:3165)
16:52:03  E                   	at org.apache.spark.sql.Dataset.cache(Dataset.scala:3175)
16:52:03  E                   	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
16:52:03  E                   	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
16:52:03  E                   	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
16:52:03  E                   	at java.lang.reflect.Method.invoke(Method.java:498)
16:52:03  E                   	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
16:52:03  E                   	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
16:52:03  E                   	at py4j.Gateway.invoke(Gateway.java:282)
16:52:03  E                   	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
16:52:03  E                   	at py4j.commands.CallCommand.execute(CallCommand.java:79)
16:52:03  E                   	at py4j.GatewayConnection.run(GatewayConnection.java:238)
16:52:03  E                   	at java.lang.Thread.run(Thread.java:748)
```

The scripts are asking for a shim-specific cache serializer but there's currently only the spark311 version.  This adds spark312 and spark320 versions of the cache batch serializer which are trivial derivations of the spark311 version.