### PR TITLE
Remove download section for unreleased 0.4.2

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -63,43 +63,6 @@ Performance improvements for this release include:
 * Allow spilled buffers to be unspilled
 
 
-## Release v0.4.2
-
-This is a patch release based on version 0.4.1 with the following change:
-* Depend on cuDF 0.18.2
-
-The release is supported on Apache Spark 3.0.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS and
-Google Cloud Platform Dataproc 2.0.
-
-The list of all supported operations is provided [here](supported_ops.md).
-
-For a detailed list of changes, please refer to the
-[CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
-
-Hardware Requirements: 
-
-	GPU Architecture: NVIDIA Pascal™ or better (Tested on V100, T4 and A100 GPU)
-	
-Software Requirements:
-
-	OS: Ubuntu 16.04, Ubuntu 18.04 or CentOS 7
-	
-	CUDA & Nvidia Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
-	
-	Apache Spark 3.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS Runtime, or GCP Dataproc 2.0 
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
-	Python 3.6+, Scala 2.12, Java 8 
-
-### Download v0.4.2
-* Download [RAPIDS Spark Package](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/0.4.2/rapids-4-spark_2.12-0.4.2.jar)
-* Download RAPIDS cuDF 0.18.2 for your system: 
-  * [cuDF 11.0 Package](https://repo1.maven.org/maven2/ai/rapids/cudf/0.18.2/cudf-0.18.2-cuda11.jar)
-  * [cuDF 10.2 Package](https://repo1.maven.org/maven2/ai/rapids/cudf/0.18.2/cudf-0.18.2-cuda10-2.jar)
-  * [cuDF 10.1 Package](https://repo1.maven.org/maven2/ai/rapids/cudf/0.18.2/cudf-0.18.2-cuda10-1.jar)
-
-
 ## Release v0.4.1
 ### Download v0.4.1
 * Download [RAPIDS Accelerator For Apache Spark v0.4.1](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/0.4.1/rapids-4-spark_2.12-0.4.1.jar)


### PR DESCRIPTION
RAPIDS Accelerator v0.4.2 was never released but the download section is referencing it with dangling hyperlinks.  This removes the download docs for the non-existent release.