### PR TITLE
Update the documentation for behavior of reading early dates in LEGACY mode

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -238,9 +238,8 @@ issues between them. Dates and timestamps are where the known issues exist.  For
 `spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `CORRECTED`
 [timestamps](https://github.com/NVIDIA/spark-rapids/issues/132) before the transition between the
 Julian and Gregorian calendars are wrong, but dates are fine. When
-`spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `LEGACY`, however both dates and
-timestamps are read incorrectly before the Gregorian calendar transition as described
-[here](https://github.com/NVIDIA/spark-rapids/issues/133).
+`spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `LEGACY`, the read may fail before
+transition between the Julian and Gregorian calendars. Eg, Date <= 1582-10-04.
 
 When writing `spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is currently ignored as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/144).

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -238,8 +238,8 @@ issues between them. Dates and timestamps are where the known issues exist.  For
 `spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `CORRECTED`
 [timestamps](https://github.com/NVIDIA/spark-rapids/issues/132) before the transition between the
 Julian and Gregorian calendars are wrong, but dates are fine. When
-`spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `LEGACY`, the read may fail before
-transition between the Julian and Gregorian calendars. Eg, Date <= 1582-10-04.
+`spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is set to `LEGACY`, the read may fail for
+values occurring before the transition between the Julian and Gregorian calendars, i.e.: date <= 1582-10-04.
 
 When writing `spark.sql.legacy.parquet.datetimeRebaseModeInWrite` is currently ignored as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/144).


### PR DESCRIPTION
Update the behavior for reading a LEGACY dates

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

A small change on the documentation to show the behavior for reading a LEGACY date/timestamp.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
