### PR TITLE
Update doc to reflect nanosleep problem with 460.32.03

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -100,10 +100,10 @@ The list of all supported operations is provided [here](supported_ops.md).
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md). 
 
-**_Note:_** Using Nvidia driver release 450.80.02 or 450.102.04 in combination with the CUDA 10.1 or
-10.2 toolkit may result in long read times when reading a file that is snappy compressed.  In those
-cases we recommend either running with the CUDA 11.0 toolkit or using a newer driver.  This issue is
-resolved in the 0.5.0 and higher releases. 
+**_Note:_** Using Nvidia driver release 450.80.02, 450.102.04 or 460.32.03 in combination with the
+CUDA 10.1 or 10.2 toolkit may result in long read times when reading a file that is snappy
+compressed.  In those cases we recommend either running with the CUDA 11.0 toolkit or using a newer
+driver.  This issue is resolved in the 0.5.0 and higher releases.
 
 ## Release v0.4.0
 ### Download v0.4.0
@@ -154,10 +154,10 @@ The list of all supported operations is provided [here](supported_ops.md).
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md). 
 
-**_Note:_** Using Nvidia driver release 450.80.02 or 450.102.04 in combination with the CUDA 10.1 or
-10.2 toolkit may result in long read times when reading a file that is snappy compressed.  In those
-cases we recommend either running with the CUDA 11.0 toolkit or using a newer driver.  This issue is
-resolved in the 0.5.0 and higher releases. 
+**_Note:_** Using Nvidia driver release 450.80.02, 450.102.04 or 460.32.03 in combination with the
+CUDA 10.1 or 10.2 toolkit may result in long read times when reading a file that is snappy
+compressed.  In those cases we recommend either running with the CUDA 11.0 toolkit or using a newer
+driver.  This issue is resolved in the 0.5.0 and higher releases.
 
 ## Release v0.3.0
 ### Download v0.3.0
@@ -205,10 +205,10 @@ The list of all supported operations is provided [here](supported_ops.md).
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md). 
 
-**_Note:_** Using Nvidia driver release 450.80.02 or 450.102.04 in combination with the CUDA 10.1 or
-10.2 toolkit may result in long read times when reading a file that is snappy compressed.  In those
-cases we recommend either running with the CUDA 11.0 toolkit or using a newer driver.  This issue is
-resolved in the 0.5.0 and higher releases. 
+**_Note:_** Using Nvidia driver release 450.80.02, 450.102.04 or 460.32.03 in combination with the
+CUDA 10.1 or 10.2 toolkit may result in long read times when reading a file that is snappy
+compressed.  In those cases we recommend either running with the CUDA 11.0 toolkit or using a newer
+driver.  This issue is resolved in the 0.5.0 and higher releases.
 
 ## Release v0.2.0
 ### Download v0.2.0
@@ -259,10 +259,10 @@ The list of all supported operations is provided
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md). 
 
-**_Note:_** Using Nvidia driver release 450.80.02 or 450.102.04 in combination with the CUDA 10.1 or
-10.2 toolkit may result in long read times when reading a file that is snappy compressed.  In those
-cases we recommend either running with the CUDA 11.0 toolkit or using a newer driver.  This issue is
-resolved in the 0.5.0 and higher releases. 
+**_Note:_** Using Nvidia driver release 450.80.02, 450.102.04 or 460.32.03 in combination with the
+CUDA 10.1 or 10.2 toolkit may result in long read times when reading a file that is snappy
+compressed.  In those cases we recommend either running with the CUDA 11.0 toolkit or using a newer
+driver.  This issue is resolved in the 0.5.0 and higher releases.
 
 ## Release v0.1.0
 ### Download v0.1.0


### PR DESCRIPTION
This PR addressed the comment in https://github.com/NVIDIA/spark-rapids/pull/2289#discussion_r623104735 to note that an R460 driver also has the nanosleep issue.  