### PR TITLE
Update doc to note that single quoted json strings are not ok

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -454,5 +454,5 @@ on constant folding and parts of the query will not be accelerated if
 ## JSON string handling
 The 0.5 release introduces the `get_json_object` operator.  The JSON specification only allows
 double quotes around strings, whereas Spark allows single quotes.  The `get_json_object` operation
-on the GPU will return `None` in Pyspark or `Null` in Scala when trying to match a string surrounded
+on the GPU will return `None` in PySpark or `Null` in Scala when trying to match a string surrounded
 by single quotes. 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -455,4 +455,4 @@ on constant folding and parts of the query will not be accelerated if
 The 0.5 release introduces the `get_json_object` operation.  The JSON specification only allows
 double quotes around strings, whereas Spark allows single quotes.  The `get_json_object` operation
 on the GPU will return `None` in PySpark or `Null` in Scala when trying to match a string surrounded
-by single quotes.
+by single quotes.  The behavior will be updated in a future release to more closely match Spark. 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -452,7 +452,7 @@ on constant folding and parts of the query will not be accelerated if
 `org.apache.spark.sql.catalyst.optimizer.ConstantFolding` is excluded as a rule.
 
 ## JSON string handling
-The 0.5 release introduces the `get_json_object` operator.  The JSON specification only allows
+The 0.5 release introduces the `get_json_object` operation.  The JSON specification only allows
 double quotes around strings, whereas Spark allows single quotes.  The `get_json_object` operation
 on the GPU will return `None` in PySpark or `Null` in Scala when trying to match a string surrounded
-by single quotes. 
+by single quotes.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -453,6 +453,7 @@ on constant folding and parts of the query will not be accelerated if
 
 ## JSON string handling
 The 0.5 release introduces the `get_json_object` operation.  The JSON specification only allows
-double quotes around strings, whereas Spark allows single quotes.  The `get_json_object` operation
-on the GPU will return `None` in PySpark or `Null` in Scala when trying to match a string surrounded
-by single quotes.  The behavior will be updated in a future release to more closely match Spark. 
+double quotes around strings in JSON data, whereas Spark allows single quotes around strings in JSON
+data.  The RAPIDS Spark `get_json_object` operation on the GPU will return `None` in PySpark or
+`Null` in Scala when trying to match a string surrounded by single quotes.  This behavior will be
+updated in a future release to more closely match Spark.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -450,3 +450,9 @@ ConstantFolding is an operator optimization rule in Catalyst that replaces expre
 be statically evaluated with their equivalent literal values. The RAPIDS Accelerator relies
 on constant folding and parts of the query will not be accelerated if 
 `org.apache.spark.sql.catalyst.optimizer.ConstantFolding` is excluded as a rule.
+
+## JSON string handling
+The 0.5 release introduces the `get_json_object` operator.  The JSON specification only allows
+double quotes around strings, whereas Spark allows single quotes.  The `get_json_object` operation
+on the GPU will return `None` in Pyspark or `Null` in Scala when trying to match a string surrounded
+by single quotes. 


### PR DESCRIPTION
Update doc to note that `get_json_object` on the GPU only supports double quoted strings in JSON per the http://json.org/ spec.  Spark appears to support single quoted strings in JSON per https://github.com/apache/spark/blob/4e8701a77dff729c4e8e0ad39c16e2717c2c32fe/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala#L108 .  Single quote support will be addressed in a future release.  