### PR TITLE
Update CBO to use fixed cost model and to respect estimated row counts

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -257,8 +257,12 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT]): Double = {
+
+    val childExprCost = expr.childExprs
+      .map(e => exprCost(e.asInstanceOf[BaseExprMeta[Expression]])).sum
+
     // always check for user overrides first
-    expr.conf.getExpressionCost(expr.getClass.getSimpleName).getOrElse {
+    childExprCost + expr.conf.getExpressionCost(expr.getClass.getSimpleName).getOrElse {
       expr match {
         case _ =>
           // many of our BaseExprMeta implementations are anonymous classes so we look directly at
@@ -301,8 +305,12 @@ class GpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT]): Double = {
+
+    val childExprCost = expr.childExprs
+      .map(e => exprCost(e.asInstanceOf[BaseExprMeta[Expression]])).sum
+
     // always check for user overrides first
-    expr.conf.getExpressionCost(expr.getClass.getSimpleName).getOrElse {
+    childExprCost + expr.conf.getExpressionCost(expr.getClass.getSimpleName).getOrElse {
       expr match {
         case cast: CastExprMeta[_] =>
           // different CAST operations have different costs, so we allow these to be configured

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -151,7 +151,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
                 && childGpuTotal > childCpuCost) {
               // force this child plan back onto CPU
               optimizations.append(ReplaceSection(
-                child, totalCpuCost, totalGpuCost /*childCpuCost, childGpuTotal*/))
+                child, totalCpuCost, totalGpuCost))
               child.recursiveCostPreventsRunningOnGpu()
             }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, GetStructField}
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftAnti, LeftSemi}
 import org.apache.spark.sql.execution.{GlobalLimitExec, LocalLimitExec, ProjectExec, SparkPlan, TakeOrderedAndProjectExec, UnionExec}
 import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec}
@@ -44,7 +44,10 @@ trait Optimizer {
 }
 
 /**
- * Experimental cost-based optimizer.
+ * Experimental cost-based optimizer that aims to avoid moving sections of the plan to the GPU when
+ * it would be better to keep that part of the plan on the CPU. For example, we don't want to move
+ * data to the GPU just for a trivial projection and then have to move data back to the CPU on the
+ * next step.
  */
 class CostBasedOptimizer extends Optimizer with Logging {
 
@@ -57,9 +60,10 @@ class CostBasedOptimizer extends Optimizer with Logging {
    * @return A list of optimizations that were applied
    */
   def optimize(conf: RapidsConf, plan: SparkPlanMeta[SparkPlan]): Seq[Optimization] = {
-    val costModel = new DefaultCostModel(conf)
+    val cpuCostModel = new CpuCostModel(conf)
+    val gpuCostModel = new GpuCostModel(conf)
     val optimizations = new ListBuffer[Optimization]()
-    recursivelyOptimize(conf, costModel, plan, optimizations, finalOperator = true)
+    recursivelyOptimize(conf, cpuCostModel, gpuCostModel, plan, optimizations, finalOperator = true)
     optimizations
   }
 
@@ -77,7 +81,8 @@ class CostBasedOptimizer extends Optimizer with Logging {
    */
   private def recursivelyOptimize(
       conf: RapidsConf,
-      costModel: CostModel,
+      cpuCostModel: CostModel,
+      gpuCostModel: CostModel,
       plan: SparkPlanMeta[SparkPlan],
       optimizations: ListBuffer[Optimization],
       finalOperator: Boolean): (Double, Double) = {
@@ -86,7 +91,8 @@ class CostBasedOptimizer extends Optimizer with Logging {
     val childCosts = plan.childPlans
         .map(child => recursivelyOptimize(
           conf,
-          costModel,
+          cpuCostModel,
+          gpuCostModel,
           child,
           optimizations,
           finalOperator = false))
@@ -94,7 +100,8 @@ class CostBasedOptimizer extends Optimizer with Logging {
     val (childCpuCosts, childGpuCosts) = childCosts.unzip
 
     // get the CPU and GPU cost of this operator (excluding cost of children)
-    val (operatorCpuCost, operatorGpuCost) = costModel.applyCost(plan)
+    val operatorCpuCost = cpuCostModel.getCost(plan)
+    val operatorGpuCost = gpuCostModel.getCost(plan)
 
     // calculate total (this operator + children)
     val totalCpuCost = operatorCpuCost + childCpuCosts.sum
@@ -117,7 +124,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
         // at least one child is transitioning from CPU to GPU so we calculate the
         // transition costs
         val transitionCost = plan.childPlans.filter(!_.canThisBeReplaced)
-            .map(costModel.transitionToGpuCost).sum
+            .map(transitionToGpuCost(conf, _)).sum
 
         // if the GPU cost including transition is more than the CPU cost then avoid this
         // transition and reset the GPU cost
@@ -138,13 +145,13 @@ class CostBasedOptimizer extends Optimizer with Logging {
         plan.childPlans.zip(childCosts).foreach {
           case (child, childCosts) =>
             val (childCpuCost, childGpuCost) = childCosts
-            val transitionCost = costModel.transitionToCpuCost(child)
+            val transitionCost = transitionToCpuCost(conf, child)
             val childGpuTotal = childGpuCost + transitionCost
             if (child.canThisBeReplaced && !consumesQueryStage(child)
                 && childGpuTotal > childCpuCost) {
               // force this child plan back onto CPU
               optimizations.append(ReplaceSection(
-                child.asInstanceOf[SparkPlanMeta[SparkPlan]], totalCpuCost, totalGpuCost))
+                child, totalCpuCost, totalGpuCost /*childCpuCost, childGpuTotal*/))
               child.recursiveCostPreventsRunningOnGpu()
             }
         }
@@ -152,7 +159,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
         // recalculate the transition costs because child plans may have changed
         val transitionCost = plan.childPlans
             .filter(_.canThisBeReplaced)
-            .map(costModel.transitionToCpuCost).sum
+            .map(transitionToCpuCost(conf, _)).sum
         totalGpuCost += transitionCost
       }
     }
@@ -160,7 +167,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
     // special behavior if this is the final operator in the plan because we always have the
     // cost of going back to CPU at the end
     if (finalOperator && plan.canThisBeReplaced) {
-      totalGpuCost += costModel.transitionToCpuCost(plan)
+      totalGpuCost += transitionToCpuCost(conf, plan)
     }
 
     if (totalGpuCost > totalCpuCost) {
@@ -182,6 +189,20 @@ class CostBasedOptimizer extends Optimizer with Logging {
     }
 
     (totalCpuCost, totalGpuCost)
+  }
+
+  private def transitionToGpuCost(conf: RapidsConf, plan: SparkPlanMeta[_]): Double = {
+    // this is a placeholder for now - we would want to try and calculate the transition cost
+    // based on the data types and size (if known)
+    val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble).getOrElse(conf.defaultRowCount.toDouble)
+    conf.defaultTransitionToGpuCost * rowCount
+  }
+
+  private def transitionToCpuCost(conf: RapidsConf, plan: SparkPlanMeta[_]): Double = {
+    // this is a placeholder for now - we would want to try and calculate the transition cost
+    // based on the data types and size (if known)
+    val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble).getOrElse(conf.defaultRowCount.toDouble)
+    conf.defaultTransitionToCpuCost * rowCount
   }
 
   /**
@@ -211,49 +232,38 @@ trait CostModel {
    * @param plan Operator
    * @return (cpuCost, gpuCost)
    */
-  def applyCost(plan: SparkPlanMeta[_]): (Double, Double)
+  def getCost(plan: SparkPlanMeta[_]): Double
 
-  /**
-   * Determine the cost of transitioning data from CPU to GPU for a specific operator
-   * @param plan Operator
-   * @return Cost
-   */
-  def transitionToGpuCost(plan: SparkPlanMeta[_]): Double
-
-  /**
-   * Determine the cost of transitioning data from GPU to CPU for a specific operator
-   */
-  def transitionToCpuCost(plan: SparkPlanMeta[_]): Double
 }
 
-class DefaultCostModel(conf: RapidsConf) extends CostModel {
+class CpuCostModel(conf: RapidsConf) extends CostModel {
 
-  def transitionToGpuCost(plan: SparkPlanMeta[_]) = {
-    // this is a placeholder for now - we would want to try and calculate the transition cost
-    // based on the data types and size (if known)
-    conf.defaultTransitionToGpuCost
+  def getCost(plan: SparkPlanMeta[_]): Double = {
+    val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble)
+      .getOrElse(conf.defaultRowCount.toDouble)
+    val costPerRow = plan.conf.getOperatorCost(plan.wrapped.getClass.getSimpleName).getOrElse {
+      plan.wrapped match {
+        case _: ProjectExec =>
+          plan.childExprs.length * 0.01
+        case _ => 1.0
+      }
+    }
+    rowCount * costPerRow
   }
+}
 
-  def transitionToCpuCost(plan: SparkPlanMeta[_]) = {
-    // this is a placeholder for now - we would want to try and calculate the transition cost
-    // based on the data types and size (if known)
-    conf.defaultTransitionToCpuCost
-  }
+class GpuCostModel(conf: RapidsConf) extends CostModel {
 
-  override def applyCost(plan: SparkPlanMeta[_]): (Double, Double) = {
-
-    // for now we have a constant cost for CPU operations and we make the GPU cost relative
-    // to this but later we may want to calculate actual CPU costs
-    val cpuCost = 1.0
-
-    // always check for user overrides first
-    val gpuCost = plan.conf.getOperatorCost(plan.wrapped.getClass.getSimpleName).getOrElse {
+  def getCost(plan: SparkPlanMeta[_]): Double = {
+    val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble)
+      .getOrElse(conf.defaultRowCount.toDouble)
+    val perRowCost = plan.conf.getOperatorCost(plan.wrapped.getClass.getSimpleName).getOrElse {
       plan.wrapped match {
         case _: ProjectExec =>
           // the cost of a projection is the average cost of its expressions
           plan.childExprs
-              .map(expr => exprCost(expr.asInstanceOf[BaseExprMeta[Expression]]))
-              .sum / plan.childExprs.length
+            .map(expr => exprCost(expr.asInstanceOf[BaseExprMeta[Expression]]))
+            .sum
 
         case _: ShuffleExchangeExec =>
           // setting the GPU cost of ShuffleExchangeExec to 1.0 avoids moving from CPU to GPU for
@@ -264,11 +274,7 @@ class DefaultCostModel(conf: RapidsConf) extends CostModel {
         case _ => conf.defaultOperatorCost
       }
     }
-
-    plan.cpuCost = cpuCost
-    plan.gpuCost = gpuCost
-
-    (cpuCost, gpuCost)
+    rowCount * perRowCost
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT]): Double = {
@@ -279,20 +285,22 @@ class DefaultCostModel(conf: RapidsConf) extends CostModel {
           // different CAST operations have different costs, so we allow these to be configured
           // based on the data types involved
           expr.conf.getExpressionCost(s"Cast${cast.fromType}To${cast.toType}")
-              .getOrElse(conf.defaultExpressionCost)
+            .getOrElse(conf.defaultExpressionCost)
         case _ =>
           // many of our BaseExprMeta implementations are anonymous classes so we look directly at
           // the wrapped expressions in some cases
           expr.wrapped match {
-            case _: AttributeReference => 1.0 // no benefit on GPU
-            case Alias(_: AttributeReference, _) => 1.0 // no benefit on GPU
+            case _: AttributeReference => 0.01 // no benefit on GPU
+            case Alias(_: AttributeReference, _) => 0.01 // no benefit on GPU
+            case _: GetStructField => 0.01 // no benefit on GPU
+            case Alias(_: GetStructField, _) => 0.01 // no benefit on GPU
             case _ => conf.defaultExpressionCost
           }
       }
     }
   }
-
 }
+
 
 /**
  * Estimate the number of rows that an operator will output. Note that these row counts are

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1055,9 +1055,16 @@ object RapidsConf {
       .stringConf
       .createWithDefault("NONE")
 
+  val OPTIMIZER_DEFAULT_ROW_COUNT = conf("spark.rapids.sql.optimizer.defaultRowCount")
+    .internal()
+    .doc("The cost-based optimizer uses estimated row counts to calculate costs and sometimes " +
+      "there is no row count available so we need a default assumption to use in this case")
+    .longConf
+    .createWithDefault(1000000)
+
   val OPTIMIZER_DEFAULT_GPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.defaultExecGpuCost")
       .internal()
-      .doc("Default relative GPU cost of running an operator on the GPU")
+      .doc("Default per-row GPU cost of running an operator on the GPU")
       .doubleConf
       .createWithDefault(0.8)
 
@@ -1072,19 +1079,19 @@ object RapidsConf {
       .internal()
       .doc("Default relative GPU cost of running an expression on the GPU")
       .doubleConf
-      .createWithDefault(0.8)
+      .createWithDefault(0.01)
 
   val OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST = conf(
     "spark.rapids.sql.optimizer.defaultTransitionToCpuCost")
       .internal()
-      .doc("Default cost of transitioning from GPU to CPU")
+      .doc("Default per-row cost of transitioning from GPU to CPU")
       .doubleConf
       .createWithDefault(0.1)
 
   val OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST = conf(
     "spark.rapids.sql.optimizer.defaultTransitionToGpuCost")
       .internal()
-      .doc("Default cost of transitioning from CPU to GPU")
+      .doc("Default per-row cost of transitioning from CPU to GPU")
       .doubleConf
       .createWithDefault(0.1)
 
@@ -1453,6 +1460,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val optimizerExplain: String = get(OPTIMIZER_EXPLAIN)
 
   lazy val optimizerClassName: String = get(OPTIMIZER_CLASS_NAME)
+
+  lazy val defaultRowCount: Long = get(OPTIMIZER_DEFAULT_ROW_COUNT)
 
   lazy val defaultOperatorCost: Double = get(OPTIMIZER_DEFAULT_GPU_OPERATOR_COST)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1481,17 +1481,32 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   /**
    * Get the GPU cost of an expression, for use in the cost-based optimizer.
    */
-  def getExpressionCost(operatorName: String): Option[Double] = {
-    val key = s"spark.rapids.sql.optimizer.expr.$operatorName"
+  def getGpuExpressionCost(operatorName: String): Option[Double] = {
+    val key = s"spark.rapids.sql.optimizer.gpu.expr.$operatorName"
     conf.get(key).map(toDouble(_, key))
   }
 
   /**
    * Get the GPU cost of an operator, for use in the cost-based optimizer.
    */
-  def getOperatorCost(operatorName: String): Option[Double] = {
-    val key = s"spark.rapids.sql.optimizer.exec.$operatorName"
+  def getGpuOperatorCost(operatorName: String): Option[Double] = {
+    val key = s"spark.rapids.sql.optimizer.gpu.exec.$operatorName"
     conf.get(key).map(toDouble(_, key))
   }
 
+  /**
+   * Get the CPU cost of an expression, for use in the cost-based optimizer.
+   */
+  def getCpuExpressionCost(operatorName: String): Option[Double] = {
+    val key = s"spark.rapids.sql.optimizer.cpu.expr.$operatorName"
+    conf.get(key).map(toDouble(_, key))
+  }
+
+  /**
+   * Get the CPU cost of an operator, for use in the cost-based optimizer.
+   */
+  def getCpuOperatorCost(operatorName: String): Option[Double] = {
+    val key = s"spark.rapids.sql.optimizer.cpu.exec.$operatorName"
+    conf.get(key).map(toDouble(_, key))
+  }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -46,8 +46,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.15")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.15")
+        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.3")
+        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.3")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
@@ -76,7 +76,9 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
       df.collect()
 
       // check that the expected optimization was applied
-      val opt = optimizations.last.last.asInstanceOf[ReplaceSection[_]]
+      val replacedSections = getReplacedSections(optimizations)
+      val opt = replacedSections.last
+
       assert(opt.totalGpuCost > opt.totalCpuCost)
       assert(opt.plan.wrapped.isInstanceOf[SortExec])
 
@@ -156,8 +158,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.15")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.15")
+        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.3")
+        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.3")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -178,13 +180,16 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
       df.collect()
 
       // check that the expected optimization was applied
-      val opt = optimizations.last.last.asInstanceOf[ReplaceSection[_]]
+      val replacedSections = getReplacedSections(optimizations)
+      val opt = replacedSections.last
       assert(opt.totalGpuCost > opt.totalCpuCost)
       assert(opt.plan.wrapped.isInstanceOf[SortExec])
 
       //assert that the top-level sort stayed on the CPU
-      df.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
-          .executedPlan.asInstanceOf[WholeStageCodegenExec]
+      val finalPlan = df.queryExecution.executedPlan
+        .asInstanceOf[AdaptiveSparkPlanExec]
+        .executedPlan
+      finalPlan.asInstanceOf[WholeStageCodegenExec]
           .child.asInstanceOf[SortExec]
 
       df
@@ -219,7 +224,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
       df.collect()
 
       // check that the expected optimization was applied
-      val opt = optimizations.last.last.asInstanceOf[ReplaceSection[_]]
+      val replacedSections = getReplacedSections(optimizations)
+      val opt = replacedSections.last
       assert(opt.totalGpuCost > opt.totalCpuCost)
       assert(opt.plan.wrapped.isInstanceOf[SortExec])
 
@@ -509,4 +515,9 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
     df
   }
 
+  private def getReplacedSections(optimizations: ListBuffer[Seq[Optimization]]) = {
+    optimizations.flatten
+      .filter(_.isInstanceOf[ReplaceSection[_]])
+      .map(_.asInstanceOf[ReplaceSection[_]])
+  }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -42,6 +42,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
 
   test("Force section of plan back onto CPU, AQE on") {
     logError("Force section of plan back onto CPU, AQE on")
+    assumeSpark311orLater
+
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
@@ -155,6 +157,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
 
   test("Force last section of plan back onto CPU, AQE on") {
     logError("Force last section of plan back onto CPU, AQE on")
+    assumeSpark311orLater
+
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1826,6 +1826,9 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   def assumeSpark301orLater =
     assume(cmpSparkVersion(3, 0, 1) >= 0)
 
+  def assumeSpark311orLater =
+    assume(cmpSparkVersion(3, 1, 1) >= 0)
+
   def assumePriorToSpark320 =
     assume(cmpSparkVersion(3, 2, 0) < 0)
 


### PR DESCRIPTION
Changes in this PR:

- Switch from relative cost per operator to absolute cost that takes estimated row count into account
- CPU and GPU have separate cost models (both very simplistic still)
- Added cost for `GetStructField`