### PR TITLE
Allow partial materialization of broadcast nested loop join and cartesian exec

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -315,8 +315,8 @@ Name | Description | Default Value | Notes
 <a name="sql.exec.BroadcastExchangeExec"></a>spark.rapids.sql.exec.BroadcastExchangeExec|The backend for broadcast exchange of data|true|None|
 <a name="sql.exec.ShuffleExchangeExec"></a>spark.rapids.sql.exec.ShuffleExchangeExec|The backend for most data being exchanged between processes|true|None|
 <a name="sql.exec.BroadcastHashJoinExec"></a>spark.rapids.sql.exec.BroadcastHashJoinExec|Implementation of join using broadcast data|true|None|
-<a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
-<a name="sql.exec.CartesianProductExec"></a>spark.rapids.sql.exec.CartesianProductExec|Implementation of join using brute force|false|This is disabled by default because large joins can cause out of memory errors|
+<a name="sql.exec.BroadcastNestedLoopJoinExec"></a>spark.rapids.sql.exec.BroadcastNestedLoopJoinExec|Implementation of join using brute force|true|None|
+<a name="sql.exec.CartesianProductExec"></a>spark.rapids.sql.exec.CartesianProductExec|Implementation of join using brute force|true|None|
 <a name="sql.exec.ShuffledHashJoinExec"></a>spark.rapids.sql.exec.ShuffledHashJoinExec|Implementation of join using hashed shuffled data|true|None|
 <a name="sql.exec.SortMergeJoinExec"></a>spark.rapids.sql.exec.SortMergeJoinExec|Sort merge join, replacing with shuffled hash join|true|None|
 <a name="sql.exec.AggregateInPandasExec"></a>spark.rapids.sql.exec.AggregateInPandasExec|The backend for Grouped Aggregation Pandas UDF, it runs on CPU itself now but supports scheduling GPU resources for the Python process when enabled|false|This is disabled by default because Performance is not ideal now|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -615,7 +615,7 @@ Accelerator supports are described below.
 <tr>
 <td>BroadcastNestedLoopJoinExec</td>
 <td>Implementation of join using brute force</td>
-<td>This is disabled by default because large joins can cause out of memory errors</td>
+<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -638,7 +638,7 @@ Accelerator supports are described below.
 <tr>
 <td>CartesianProductExec</td>
 <td>Implementation of join using brute force</td>
-<td>This is disabled by default because large joins can cause out of memory errors</td>
+<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>

--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -107,8 +107,7 @@ def test_cache_broadcast_hash_join(data_gen, join_type, enableVectorizedConf):
 
 shuffled_conf = {"spark.sql.autoBroadcastJoinThreshold": "160",
                  "spark.sql.join.preferSortMergeJoin": "false",
-                 "spark.sql.shuffle.partitions": "2",
-                 "spark.rapids.sql.exec.BroadcastNestedLoopJoinExec": "true"}
+                 "spark.sql.shuffle.partitions": "2"}
 
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('enableVectorizedConf', enableVectorizedConf, ids=idfn)
@@ -130,8 +129,6 @@ def test_cache_shuffled_hash_join(data_gen, join_type, enableVectorizedConf):
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @ignore_order
 def test_cache_broadcast_nested_loop_join(data_gen, join_type, enableVectorizedConf):
-    enableVectorizedConf.update({'spark.rapids.sql.exec.BroadcastNestedLoopJoinExec':
-                                            'true'})
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         cached = left.crossJoin(right.hint("broadcast")).cache()

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -237,10 +237,25 @@ def test_cartesean_join(data_gen, batch_size):
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-def test_cartesean_join_special_case(data_gen, batch_size):
+def test_cartesean_join_special_case_count(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.crossJoin(right).selectExpr('COUNT(*)')
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
+# After 3.1.0 is the min spark version we can drop this
+@ignore_order(local=True)
+@pytest.mark.xfail(condition=is_databricks_runtime(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/334')
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
+@pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_cartesean_join_special_case_group_by(data_gen, batch_size):
+    def do_join(spark):
+        left, right = create_df(spark, data_gen, 50, 25)
+        return left.crossJoin(right).groupBy('a').count()
     conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
     conf.update(allow_negative_scale_of_decimal_conf)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
@@ -263,10 +278,25 @@ def test_broadcast_nested_loop_join(data_gen, batch_size):
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
-def test_broadcast_nested_loop_join_special_case(data_gen, batch_size):
+def test_broadcast_nested_loop_join_special_case_count(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right)).selectExpr('COUNT(*)')
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+# local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
+# After 3.1.0 is the min spark version we can drop this
+@ignore_order(local=True)
+@pytest.mark.xfail(condition=is_databricks_runtime(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/334')
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
+@pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_broadcast_nested_loop_join_special_case_group_by(data_gen, batch_size):
+    def do_join(spark):
+        left, right = create_df(spark, data_gen, 50, 25)
+        return left.crossJoin(broadcast(right)).groupBy('a').count()
     conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
     conf.update(allow_negative_scale_of_decimal_conf)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -71,14 +71,6 @@ _hash_join_conf = {'spark.sql.autoBroadcastJoinThreshold': '160',
                    'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
                   }
 
-_cartesean_join_conf = {'spark.rapids.sql.exec.CartesianProductExec': 'true',
-                        'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
-                       }
-
-_broadcastnestedloop_join_conf = {'spark.rapids.sql.exec.BroadcastNestedLoopJoinExec': 'true',
-                                  'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
-                                 }
-
 def create_df(spark, data_gen, left_length, right_length):
     left = binary_op_df(spark, data_gen, length=left_length)
     right = binary_op_df(spark, data_gen, length=right_length).withColumnRenamed("a", "r_a")\
@@ -229,11 +221,14 @@ def test_broadcast_join_right_table_with_job_group(data_gen, join_type):
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-def test_cartesean_join(data_gen):
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_cartesean_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(right)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_cartesean_join_conf)
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -241,38 +236,48 @@ def test_cartesean_join(data_gen):
 @pytest.mark.xfail(condition=is_databricks_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/334')
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-def test_cartesean_join_special_case(data_gen):
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_cartesean_join_special_case(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.crossJoin(right).selectExpr('COUNT(*)')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_cartesean_join_conf)
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-def test_broadcast_nested_loop_join(data_gen):
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_broadcast_nested_loop_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right))
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_broadcastnestedloop_join_conf)
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
-def test_broadcast_nested_loop_join_special_case(data_gen):
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_broadcast_nested_loop_join_special_case(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right)).selectExpr('COUNT(*)')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_broadcastnestedloop_join_conf)
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'Cross'], ids=idfn)
-def test_broadcast_nested_loop_join_with_conditionals(data_gen, join_type):
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
+def test_broadcast_nested_loop_join_with_conditionals(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         # This test is impacted by https://github.com/NVIDIA/spark-rapids/issues/294 
@@ -281,7 +286,9 @@ def test_broadcast_nested_loop_join_with_conditionals(data_gen, join_type):
         # that do not expose the error
         return left.join(broadcast(right),
                 (left.b >= right.r_b), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_broadcastnestedloop_join_conf)
+    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
+    conf.update(allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -17,10 +17,6 @@
 package com.nvidia.spark.rapids
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
-import org.apache.spark.sql.functions.{col, upper}
 
 class JoinsSuite extends SparkQueryCompareTestSuite {
 
@@ -41,8 +37,6 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
       .set("spark.sql.autoBroadcastJoinThreshold", "160")
       .set("spark.sql.join.preferSortMergeJoin", "false")
       .set("spark.sql.shuffle.partitions", "2") // hack to try and work around bug in cudf
-      .set("spark.rapids.sql.exec.BroadcastNestedLoopJoinExec", "true")
-      .set("spark.rapids.sql.exec.CartesianProductExec", "true")
 
   IGNORE_ORDER_testSparkResultsAreEqual2("Test hash join", longsDf, biggerLongsDf,
     conf = shuffledJoinConf) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2848,8 +2848,7 @@ object GpuOverrides {
     exec[BroadcastNestedLoopJoinExec](
       "Implementation of join using brute force",
       ExecChecks(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL, TypeSig.all),
-      (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r))
-        .disabledByDefault("large joins can cause out of memory errors"),
+      (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r)),
     exec[CartesianProductExec](
       "Implementation of join using brute force",
       ExecChecks(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL, TypeSig.all),
@@ -2867,8 +2866,7 @@ object GpuOverrides {
             condition.map(_.convertToGpu()),
             conf.gpuTargetBatchSizeBytes)
         }
-      })
-        .disabledByDefault("large joins can cause out of memory errors"),
+      }),
     exec[HashAggregateExec](
       "The backend for hash based aggregations",
       ExecChecks(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -481,6 +481,8 @@ class JoinGathererImpl(
     private val gatherMap: LazySpillableGatherMap,
     private val data: LazySpillableColumnarBatch) extends JoinGatherer {
 
+  assert(data.numCols > 0, "data with no columns should have been filtered out already")
+
   // How much of the gather map we have output so far
   private var gatheredUpTo: Long = 0
   private val totalRows: Long = gatherMap.getRowCount

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -16,10 +16,10 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{ColumnView, DeviceMemoryBuffer, DType, GatherMap, NvtxColor, NvtxRange, OrderByArg, Scalar, Table}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DeviceMemoryBuffer, DType, GatherMap, NvtxColor, NvtxRange, OrderByArg, Scalar, Table}
 import com.nvidia.spark.rapids.RapidsBuffer.SpillCallback
 
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataType, DateType, DecimalType, LongType, NullType, NumericType, StringType, StructType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataType, DateType, DecimalType, IntegerType, LongType, NullType, NumericType, StringType, StructType, TimestampType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -201,7 +201,6 @@ trait LazySpillableColumnarBatch extends LazySpillable {
    * Get the batch that this wraps and unspill it if needed.
    */
   def getBatch: ColumnarBatch
-
 }
 
 object LazySpillableColumnarBatch {
@@ -238,6 +237,8 @@ case class AllowSpillOnlyLazySpillableColumnarBatchImpl(wrapped: LazySpillableCo
     // Don't actually close it, we don't own it, just allow it to be spilled.
     wrapped.allowSpilling()
   }
+
+  override def toString: String = s"SPILL_ONLY $wrapped"
 }
 
 /**
@@ -285,25 +286,49 @@ class LazySpillableColumnarBatchImpl(
     spill.foreach(_.close())
     spill = None
   }
+
+  override def toString: String = s"SpillableBatch $name $numCols X $numRows"
+}
+
+trait LazySpillableGatherMap extends LazySpillable with Arm {
+  /**
+   * How many rows total are in this gather map
+   */
+  val getRowCount: Long
+
+  /**
+   * Get a column view that can be used to gather.
+   * @param startRow the row to start at.
+   * @param numRows the number of rows in the map.
+   */
+  def toColumnView(startRow: Long, numRows: Int): ColumnView
+}
+
+object LazySpillableGatherMap {
+  def apply(map: GatherMap, spillCallback: SpillCallback, name: String): LazySpillableGatherMap =
+    new LazySpillableGatherMapImpl(map, spillCallback, name)
+
+  def leftCross(leftCount: Int, rightCount: Int): LazySpillableGatherMap =
+    new LeftCrossGatherMap(leftCount, rightCount)
+
+  def rightCross(leftCount: Int, rightCount: Int): LazySpillableGatherMap =
+    new RightCrossGatherMap(leftCount, rightCount)
 }
 
 /**
  * Holds a gather map that is also lazy spillable.
  */
-class LazySpillableGatherMap(
+class LazySpillableGatherMapImpl(
     map: GatherMap,
     spillCallback: SpillCallback,
-    name: String) extends LazySpillable with Arm {
+    name: String) extends LazySpillableGatherMap {
 
-  val getRowCount: Long = map.getRowCount
+  override val getRowCount: Long = map.getRowCount
 
   private var cached: Option[DeviceMemoryBuffer] = Some(map.releaseBuffer())
   private var spill: Option[SpillableBuffer] = None
 
-  /**
-   * Get a ColumnView that can be used to do a cudf gather.
-   */
-  def toColumnView(startRow: Long, numRows: Int): ColumnView = {
+  override def toColumnView(startRow: Long, numRows: Int): ColumnView = {
     ColumnView.fromDeviceBuffer(getBuffer, startRow * 4L, DType.INT32, numRows)
   }
 
@@ -337,6 +362,59 @@ class LazySpillableGatherMap(
     spill.foreach(_.close())
     spill = None
   }
+}
+
+abstract class BaseCrossJoinGatherMap(leftCount: Int, rightCount: Int)
+    extends LazySpillableGatherMap {
+  override val getRowCount: Long = leftCount.toLong * rightCount.toLong
+
+  override def toColumnView(startRow: Long, numRows: Int): ColumnView = {
+    withResource(GpuScalar.from(startRow, LongType)) { startScalar =>
+      withResource(ai.rapids.cudf.ColumnVector.sequence(startScalar, numRows)) { rowNum =>
+        compute(rowNum)
+      }
+    }
+  }
+
+  /**
+   * Given a vector of INT64 row numbers compute the corresponding gather map (result should be
+   * INT32)
+   */
+  def compute(rowNum: ai.rapids.cudf.ColumnVector): ai.rapids.cudf.ColumnVector
+
+  override def allowSpilling(): Unit = {
+    // NOOP, we don't cache anything on the GPU
+  }
+
+  override def close(): Unit = {
+    // NOOP, we don't cache anything on the GPU
+  }
+}
+
+class LeftCrossGatherMap(leftCount: Int, rightCount: Int) extends
+    BaseCrossJoinGatherMap(leftCount, rightCount) {
+
+  override def compute(rowNum: ColumnVector): ColumnVector = {
+    withResource(GpuScalar.from(rightCount, IntegerType)) { rightCountScalar =>
+      rowNum.div(rightCountScalar, DType.INT32)
+    }
+  }
+
+  override def toString: String =
+    s"LEFT CROSS MAP $leftCount by $rightCount"
+}
+
+class RightCrossGatherMap(leftCount: Int, rightCount: Int) extends
+    BaseCrossJoinGatherMap(leftCount, rightCount) {
+
+  override def compute(rowNum: ColumnVector): ColumnVector = {
+    withResource(GpuScalar.from(rightCount, IntegerType)) { rightCountScalar =>
+      rowNum.mod(rightCountScalar, DType.INT32)
+    }
+  }
+
+  override def toString: String =
+    s"RIGHT CROSS MAP $leftCount by $rightCount"
 }
 
 object JoinGathererImpl {
@@ -411,6 +489,10 @@ class JoinGathererImpl(
     val fw = JoinGathererImpl.fixedWidthRowSizeBits(dts)
     val nullVal = JoinGathererImpl.nullRowSizeBits(dts)
     (fw, nullVal)
+  }
+
+  override def toString: String = {
+    s"GATHERER $gatheredUpTo/$totalRows $gatherMap $data"
   }
 
   override def realCheapPerRowSizeEstimate: Double = {
@@ -566,4 +648,6 @@ case class MultiJoinGather(left: JoinGatherer, right: JoinGatherer) extends Join
     left.close()
     right.close()
   }
+
+  override def toString: String = s"MULTI-GATHER $left and $right"
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -268,13 +268,12 @@ case class GpuCartesianProductExec(
         numOutputRows,
         numOutputBatches)
     } else {
-      val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
       val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
 
       new GpuCartesianRDD(sparkContext,
         boundCondition,
         spillCallback,
-        targetSize,
+        targetSizeBytes,
         joinTime,
         joinOutputRows,
         numOutputRows,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -20,8 +20,9 @@ import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.mutable
 
-import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange, Table}
-import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuExpression, GpuMetric, GpuSemaphore, MetricsLevel, RapidsBuffer, SpillableColumnarBatch, SpillPriorities}
+import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuMetric, GpuSemaphore, LazySpillableColumnarBatch, MetricsLevel, RapidsConf}
+import com.nvidia.spark.rapids.RapidsBuffer.SpillCallback
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.{Dependency, NarrowDependency, Partition, SparkContext, TaskContext}
@@ -31,8 +32,8 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.execution.{BinaryExecNode, ExplainUtils, SparkPlan}
 import org.apache.spark.sql.rapids.execution.GpuBroadcastNestedLoopJoinExecBase
 import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
-import org.apache.spark.util.{CompletionIterator, Utils}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.Utils
 
 @SerialVersionUID(100L)
 class GpuSerializableBatch(batch: ColumnarBatch)
@@ -110,8 +111,9 @@ class GpuCartesianPartition(
 
 class GpuCartesianRDD(
     sc: SparkContext,
-    boundCondition: Option[GpuExpression],
-    outputSchema: Array[DataType],
+    boundCondition: Option[Expression],
+    spillCallback: SpillCallback,
+    targetSize: Long,
     joinTime: GpuMetric,
     joinOutputRows: GpuMetric,
     numOutputRows: GpuMetric,
@@ -140,30 +142,28 @@ class GpuCartesianRDD(
     (rdd1.preferredLocations(currSplit.s1) ++ rdd2.preferredLocations(currSplit.s2)).distinct
   }
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[ColumnarBatch] = {
+  override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
     val currSplit = split.asInstanceOf[GpuCartesianPartition]
 
     // create a buffer to cache stream-side data in a spillable manner
-    val spillBatchBuffer = mutable.ArrayBuffer[SpillableColumnarBatch]()
+    val spillBatchBuffer = mutable.ArrayBuffer[LazySpillableColumnarBatch]()
     // sentinel variable to label whether stream-side data is cached or not
     var streamSideCached = false
-    // a pointer to track buildTableOnFlight
-    var buildTableOnFlight: Option[Table] = None
+
+    def close(): Unit = {
+      spillBatchBuffer.safeClose()
+      spillBatchBuffer.clear()
+    }
 
     // Add a taskCompletionListener to ensure the release of GPU memory. This listener will work
     // if the CompletionIterator does not fully iterate before the task completes, which may
     // happen if there exists specific plans like `LimitExec`.
-    context.addTaskCompletionListener[Unit]((_: TaskContext) => {
-      spillBatchBuffer.safeClose()
-      buildTableOnFlight.foreach(_.close())
-    })
+    context.addTaskCompletionListener[Unit](_ => close())
 
     rdd1.iterator(currSplit.s1, context).flatMap { lhs =>
-      val table = withResource(lhs) { lhs =>
-        GpuColumnVector.from(lhs.getBatch)
+      val batch = withResource(lhs.getBatch) { lhsBatch =>
+        LazySpillableColumnarBatch(lhsBatch, spillCallback, "cross_lhs")
       }
-      buildTableOnFlight = Some(table)
       // Introduce sentinel `streamSideCached` to record whether stream-side data is cached or
       // not, because predicate `spillBatchBuffer.isEmpty` will always be true if
       // `rdd2.iterator` is an empty iterator.
@@ -171,40 +171,22 @@ class GpuCartesianRDD(
         streamSideCached = true
         // lazily compute and cache stream-side data
         rdd2.iterator(currSplit.s2, context).map { serializableBatch =>
-          closeOnExcept(spillBatchBuffer) { buffer =>
-            val batch = SpillableColumnarBatch(serializableBatch.getBatch,
-              SpillPriorities.ACTIVE_ON_DECK_PRIORITY,
-              RapidsBuffer.defaultSpillCallback)
-            buffer += batch
-            batch.getColumnarBatch()
+          withResource(serializableBatch.getBatch) { batch =>
+            val lzyBatch = LazySpillableColumnarBatch(batch, spillCallback, "cross_rhs")
+            spillBatchBuffer += lzyBatch
+            // return a spill only version so we don't close it until the end
+            LazySpillableColumnarBatch.spillOnly(lzyBatch)
           }
         }
       } else {
-        // fetch stream-side data directly if they are cached
-        spillBatchBuffer.toIterator.map(_.getColumnarBatch())
+        // fetch cached stream-side data, and make it spill only so we don't close it until the end
+        spillBatchBuffer.toIterator.map(LazySpillableColumnarBatch.spillOnly)
       }
 
-      val ret = GpuBroadcastNestedLoopJoinExecBase.innerLikeJoin(
-        streamIterator,
-        table,
-        GpuBuildLeft,
-        boundCondition,
-        outputSchema,
-        joinTime,
-        joinOutputRows,
-        numOutputRows,
-        numOutputBatches,
-        filterTime,
-        totalTime)
-
-      CompletionIterator[ColumnarBatch, Iterator[ColumnarBatch]](ret, {
-        // clean up spill batch buffer
-        spillBatchBuffer.safeClose()
-        spillBatchBuffer.clear()
-        // clean up build table
-        table.close()
-        buildTableOnFlight = None
-      })
+      GpuBroadcastNestedLoopJoinExecBase.innerLikeJoin(
+        batch, streamIterator, targetSize, GpuBuildLeft, boundCondition,
+        numOutputRows, joinOutputRows, numOutputBatches,
+        joinTime, filterTime, totalTime)
     }
   }
 
@@ -221,52 +203,6 @@ class GpuCartesianRDD(
     super.clearDependencies()
     rdd1 = null
     rdd2 = null
-  }
-}
-
-object GpuNoColumnCrossJoin extends Arm {
-  def divideIntoBatches(
-      rowCounts: RDD[Long],
-      targetSizeBytes: Long,
-      numOutputRows: GpuMetric,
-      numOutputBatches: GpuMetric): RDD[ColumnarBatch] = {
-    // Hash aggregate explodes the rows out, so if we go too large
-    // it can blow up. The size of a Long is 8 bytes so we just go with
-    // that as our estimate, no nulls.
-    val maxRowCount = targetSizeBytes / 8
-
-    def divideIntoBatches(rows: Long): Iterable[ColumnarBatch] = {
-      val numBatches = (rows + maxRowCount - 1) / maxRowCount
-      (0L until numBatches).map(i => {
-        val ret = new ColumnarBatch(new Array[ColumnVector](0))
-        if ((i + 1) * maxRowCount > rows) {
-          ret.setNumRows((rows - (i * maxRowCount)).toInt)
-        } else {
-          ret.setNumRows(maxRowCount.toInt)
-        }
-        numOutputRows += ret.numRows()
-        numOutputBatches += 1
-        ret
-      })
-    }
-
-    rowCounts.flatMap(divideIntoBatches)
-  }
-
-  def divideIntoBatches(
-      table: Table,
-      numTimes: Long,
-      outputSchema: Array[DataType],
-      numOutputRows: GpuMetric,
-      numOutputBatches: GpuMetric): Iterator[ColumnarBatch] = {
-    // TODO if we hit a point where we need to we can divide the data up into batches
-    //  The current use case is likely to be small enough that we are OK without this.
-    assert(numTimes < Int.MaxValue)
-    withResource(table.repeat(numTimes.toInt)) { repeated =>
-      numOutputBatches += 1
-      numOutputRows += repeated.getRowCount
-      Iterator(GpuColumnVector.from(repeated, outputSchema))
-    }
   }
 }
 
@@ -293,7 +229,7 @@ case class GpuCartesianProductExec(
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
     JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
     JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME))
+    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
 
   protected override def doExecute(): RDD[InternalRow] =
     throw new IllegalStateException("This should only be called from columnar")
@@ -305,7 +241,6 @@ case class GpuCartesianProductExec(
     val joinOutputRows = gpuLongMetric(JOIN_OUTPUT_ROWS)
     val filterTime = gpuLongMetric(FILTER_TIME)
     val totalTime = gpuLongMetric(TOTAL_TIME)
-    val outputSchema = output.map(_.dataType).toArray
 
     val boundCondition = condition.map(GpuBindReferences.bindGpuReference(_, output))
 
@@ -327,15 +262,19 @@ case class GpuCartesianProductExec(
       // TODO here too it would probably be best to avoid doing any re-computation
       //  that happens with the built in cartesian, but writing another custom RDD
       //  just for this use case is not worth it without an explicit use case.
-      GpuNoColumnCrossJoin.divideIntoBatches(
+      GpuBroadcastNestedLoopJoinExecBase.divideIntoBatches(
         l.cartesian(r).map(p => p._1 * p._2),
         targetSizeBytes,
         numOutputRows,
         numOutputBatches)
     } else {
+      val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
+      val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
+
       new GpuCartesianRDD(sparkContext,
         boundCondition,
-        outputSchema,
+        spillCallback,
+        targetSize,
         joinTime,
         joinOutputRows,
         numOutputRows,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -21,7 +21,7 @@ import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 import scala.collection.mutable
 
 import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuMetric, GpuSemaphore, LazySpillableColumnarBatch, MetricsLevel, RapidsConf}
+import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuMetric, GpuSemaphore, LazySpillableColumnarBatch, MetricsLevel}
 import com.nvidia.spark.rapids.RapidsBuffer.SpillCallback
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -16,9 +16,8 @@
 
 package org.apache.spark.sql.rapids.execution
 
-import ai.rapids.cudf.{NvtxColor, Table}
+import ai.rapids.cudf.NvtxColor
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.GpuMetric.{NUM_OUTPUT_BATCHES, NUM_OUTPUT_ROWS, TOTAL_TIME}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.broadcast.Broadcast
@@ -31,10 +30,8 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.BroadcastNestedLoopJoinExec
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
-import org.apache.spark.sql.rapids.GpuNoColumnCrossJoin
 import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 class GpuBroadcastNestedLoopJoinMeta(
     join: BroadcastNestedLoopJoinExec,
@@ -91,46 +88,196 @@ class GpuBroadcastNestedLoopJoinMeta(
   }
 }
 
-object GpuBroadcastNestedLoopJoinExecBase extends Arm {
-  def innerLikeJoin(
-      streamedIter: Iterator[ColumnarBatch],
-      builtTable: Table,
-      buildSide: GpuBuildSide,
-      boundCondition: Option[GpuExpression],
-      outputSchema: Array[DataType],
-      joinTime: GpuMetric,
-      joinOutputRows: GpuMetric,
-      numOutputRows: GpuMetric,
-      numOutputBatches: GpuMetric,
-      filterTime: GpuMetric,
-      totalTime: GpuMetric): Iterator[ColumnarBatch] = {
-    streamedIter.map { cb =>
-      val startTime = System.nanoTime()
-      val streamTable = withResource(cb) { cb =>
-        GpuColumnVector.from(cb)
+/**
+ * An iterator that does a cross join against a stream of batches.
+ */
+class CrossJoinIterator(
+    builtBatch: LazySpillableColumnarBatch,
+    private val stream: Iterator[LazySpillableColumnarBatch],
+    val targetSize: Long,
+    val buildSide: GpuBuildSide,
+    private val joinTime: GpuMetric,
+    private val totalTime: GpuMetric) extends Iterator[ColumnarBatch] with Arm {
+
+  private var nextCb: Option[ColumnarBatch] = None
+  private var gathererStore: Option[JoinGatherer] = None
+
+  private var closed = false
+
+  def close(): Unit = {
+    if (!closed) {
+      nextCb.foreach(_.close())
+      nextCb = None
+      gathererStore.foreach(_.close())
+      gathererStore = None
+      // Close the build batch we are done with it.
+      builtBatch.close()
+      closed = true
+    }
+  }
+
+  TaskContext.get().addTaskCompletionListener[Unit](_ => close())
+
+  private def nextCbFromGatherer(): Option[ColumnarBatch] = {
+    withResource(new NvtxWithMetrics("cross join gather", NvtxColor.DARK_GREEN, joinTime)) { _ =>
+      val ret = gathererStore.map { gather =>
+        val nextRows = JoinGatherer.getRowsInNextBatch(gather, targetSize)
+        gather.gatherNext(nextRows)
       }
-      val joined =
-        withResource(new NvtxWithMetrics("join", NvtxColor.ORANGE, joinTime)) { _ =>
-          val joinedTable = withResource(streamTable) { tab =>
-            buildSide match {
-              case GpuBuildLeft => builtTable.crossJoin(tab)
-              case GpuBuildRight => tab.crossJoin(builtTable)
-            }
-          }
-          withResource(joinedTable) { jt =>
-            GpuColumnVector.from(jt, outputSchema)
-          }
-        }
-      joinOutputRows += joined.numRows()
-      val ret = if (boundCondition.isDefined) {
-        GpuFilter(joined, boundCondition.get, numOutputRows, numOutputBatches, filterTime)
+      if (gathererStore.exists(_.isDone)) {
+        gathererStore.foreach(_.close())
+        gathererStore = None
+      }
+
+      if (ret.isDefined) {
+        // We are about to return something. We got everything we need from it so now let it spill
+        // if there is more to be gathered later on.
+        gathererStore.foreach(_.allowSpilling())
+      }
+      ret
+    }
+  }
+
+  private def makeGatherer(streamBatch: LazySpillableColumnarBatch): Option[JoinGatherer] = {
+    // Don't close the built side because it will be used for each stream and closed
+    // when the iterator is done.
+    val (leftBatch, rightBatch) = buildSide match {
+      case GpuBuildLeft => (LazySpillableColumnarBatch.spillOnly(builtBatch), streamBatch)
+      case GpuBuildRight => (streamBatch, LazySpillableColumnarBatch.spillOnly(builtBatch))
+    }
+
+    val leftMap = LazySpillableGatherMap.leftCross(leftBatch.numRows, rightBatch.numRows)
+    val rightMap = LazySpillableGatherMap.rightCross(leftBatch.numRows, rightBatch.numRows)
+
+    val joinGatherer = JoinGatherer(leftMap, leftBatch, rightMap, rightBatch)
+    if (joinGatherer.isDone) {
+      joinGatherer.close()
+      None
+    } else {
+      Some(joinGatherer)
+    }
+  }
+
+  override def hasNext: Boolean = {
+    if (closed) {
+      return false
+    }
+    var mayContinue = true
+    while (nextCb.isEmpty && mayContinue) {
+      val startTime = System.nanoTime()
+      if (gathererStore.exists(!_.isDone)) {
+        nextCb = nextCbFromGatherer()
+      } else if (stream.hasNext) {
+        // Need to refill the gatherer
+        gathererStore.foreach(_.close())
+        gathererStore = None
+        gathererStore = makeGatherer(stream.next())
+        nextCb = nextCbFromGatherer()
       } else {
-        numOutputRows += joined.numRows()
-        numOutputBatches += 1
-        joined
+        mayContinue = false
       }
       totalTime += (System.nanoTime() - startTime)
-      ret
+    }
+    if (nextCb.isEmpty) {
+      // Nothing is left to return so close ASAP.
+      close()
+    }
+    nextCb.isDefined
+  }
+
+  override def next(): ColumnarBatch = {
+    if (!hasNext) {
+      throw new NoSuchElementException()
+    }
+    val ret = nextCb.get
+    nextCb = None
+    ret
+  }
+}
+
+object GpuBroadcastNestedLoopJoinExecBase extends Arm {
+  def innerLikeJoin(
+      builtBatch: LazySpillableColumnarBatch,
+      stream: Iterator[LazySpillableColumnarBatch],
+      targetSize: Long,
+      buildSide: GpuBuildSide,
+      boundCondition: Option[Expression],
+      numOutputRows: GpuMetric,
+      joinOutputRows: GpuMetric,
+      numOutputBatches: GpuMetric,
+      joinTime: GpuMetric,
+      filterTime: GpuMetric,
+      totalTime: GpuMetric): Iterator[ColumnarBatch] = {
+    val joinIterator =
+      new CrossJoinIterator(builtBatch, stream, targetSize, buildSide, joinTime, totalTime)
+    if (boundCondition.isDefined) {
+      val condition = boundCondition.get
+      joinIterator.flatMap { cb =>
+        joinOutputRows += cb.numRows()
+        withResource(
+          GpuFilter(cb, condition, numOutputRows, numOutputBatches, filterTime)) { filtered =>
+          if (filtered.numRows == 0) {
+            // Not sure if there is a better way to work around this
+            numOutputBatches.set(numOutputBatches.value - 1)
+            None
+          } else {
+            Some(GpuColumnVector.incRefCounts(filtered))
+          }
+        }
+      }
+    } else {
+      joinIterator.map { cb =>
+        joinOutputRows += cb.numRows()
+        numOutputRows += cb.numRows()
+        numOutputBatches += 1
+        cb
+      }
+    }
+  }
+
+  def divideIntoBatches(
+      rowCounts: RDD[Long],
+      targetSizeBytes: Long,
+      numOutputRows: GpuMetric,
+      numOutputBatches: GpuMetric): RDD[ColumnarBatch] = {
+    // Hash aggregate explodes the rows out, so if we go too large
+    // it can blow up. The size of a Long is 8 bytes so we just go with
+    // that as our estimate, no nulls.
+    val maxRowCount = targetSizeBytes / 8
+
+    def divideIntoBatches(rows: Long): Iterable[ColumnarBatch] = {
+      val numBatches = (rows + maxRowCount - 1) / maxRowCount
+      (0L until numBatches).map(i => {
+        val ret = new ColumnarBatch(new Array[ColumnVector](0))
+        if ((i + 1) * maxRowCount > rows) {
+          ret.setNumRows((rows - (i * maxRowCount)).toInt)
+        } else {
+          ret.setNumRows(maxRowCount.toInt)
+        }
+        numOutputRows += ret.numRows()
+        numOutputBatches += 1
+        ret
+      })
+    }
+
+    rowCounts.flatMap(divideIntoBatches)
+  }
+
+  def divideIntoBatches(
+      batch: ColumnarBatch,
+      numTimes: Long,
+      outputSchema: Array[DataType],
+      numOutputRows: GpuMetric,
+      numOutputBatches: GpuMetric): Iterator[ColumnarBatch] = {
+    // TODO if we hit a point where we need to we can divide the data up into batches
+    //  The current use case is likely to be small enough that we are OK without this.
+    assert(numTimes < Int.MaxValue)
+    withResource(GpuColumnVector.from(batch)) { table =>
+      withResource(table.repeat(numTimes.toInt)) { repeated =>
+        numOutputBatches += 1
+        numOutputRows += repeated.getRowCount
+        Iterator(GpuColumnVector.from(repeated, outputSchema))
+      }
     }
   }
 }
@@ -158,7 +305,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
     BUILD_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_BUILD_TIME),
     JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
     JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME))
+    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
 
   /** BuildRight means the right relation <=> the broadcast relation. */
   private val (streamed, broadcast) = getGpuBuildSide match {
@@ -201,19 +348,14 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
     }
   }
 
-  private[this] def makeBuiltTable(
+  private[this] def makeBuiltBatch(
       broadcastRelation: Broadcast[SerializeConcatHostBuffersDeserializeBatch],
       buildTime: GpuMetric,
-      buildDataSize: GpuMetric): Table = {
+      buildDataSize: GpuMetric): ColumnarBatch = {
     withResource(new NvtxWithMetrics("build join table", NvtxColor.GREEN, buildTime)) { _ =>
-      val ret = GpuColumnVector.from(broadcastRelation.value.batch)
-      // Don't warn for a leak, because we cannot control when we are done with this
-      (0 until ret.getNumberOfColumns).foreach(i => {
-        val column = ret.getColumn(i)
-        column.noWarnLeakExpected()
-        buildDataSize += column.getDeviceMemorySize
-      })
-      ret
+      val ret = broadcastRelation.value.batch
+      buildDataSize += GpuColumnVector.getTotalDeviceMemoryUsed(ret)
+      GpuColumnVector.incRefCounts(ret)
     }
   }
 
@@ -264,7 +406,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
       }
 
       val counts = streamed.executeColumnar().map(getRowCountAndClose)
-      GpuNoColumnCrossJoin.divideIntoBatches(
+      GpuBroadcastNestedLoopJoinExecBase.divideIntoBatches(
         counts.map(s => s * buildCount),
         targetSizeBytes,
         numOutputRows,
@@ -277,14 +419,12 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
       streamed.executeColumnar().mapPartitions { streamedIter =>
         streamedIter.flatMap { cb =>
           withResource(cb) { cb =>
-            withResource(GpuColumnVector.from(cb)) { table =>
-              GpuNoColumnCrossJoin.divideIntoBatches(
-                table,
-                buildCount,
-                outputSchema,
-                numOutputRows,
-                numOutputBatches)
-            }
+            GpuBroadcastNestedLoopJoinExecBase.divideIntoBatches(
+              cb,
+              buildCount,
+              outputSchema,
+              numOutputRows,
+              numOutputBatches)
           }
         }
       }
@@ -292,11 +432,12 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
       assert(boundCondition.isEmpty)
 
       // streamed is empty, not sure if this ever actually happens though
-      lazy val builtTable: Table = makeBuiltTable(broadcastRelation, buildTime, buildDataSize)
+      lazy val builtBatch: ColumnarBatch =
+        makeBuiltBatch(broadcastRelation, buildTime, buildDataSize)
       streamed.executeColumnar().flatMap { cb =>
         withResource(cb) { cb =>
-          GpuNoColumnCrossJoin.divideIntoBatches(
-            builtTable,
+          GpuBroadcastNestedLoopJoinExecBase.divideIntoBatches(
+            builtBatch,
             cb.numRows(),
             outputSchema,
             numOutputRows,
@@ -304,11 +445,21 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
         }
       }
     } else {
-      lazy val builtTable: Table = makeBuiltTable(broadcastRelation, buildTime, buildDataSize)
+      lazy val builtBatch: ColumnarBatch =
+        makeBuiltBatch(broadcastRelation, buildTime, buildDataSize)
+      val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
+      val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
       streamed.executeColumnar().mapPartitions { streamedIter =>
-        GpuBroadcastNestedLoopJoinExecBase.innerLikeJoin(streamedIter,
-          builtTable, getGpuBuildSide, boundCondition, outputSchema,
-          joinTime, joinOutputRows, numOutputRows, numOutputBatches, filterTime, totalTime)
+        val lazyStream = streamedIter.map { cb =>
+          withResource(cb) { cb =>
+            LazySpillableColumnarBatch(cb, spillCallback, "stream_batch")
+          }
+        }
+        GpuBroadcastNestedLoopJoinExecBase.innerLikeJoin(
+          LazySpillableColumnarBatch(builtBatch, spillCallback, "built_batch"),
+          lazyStream, targetSize, getGpuBuildSide, boundCondition,
+          numOutputRows, joinOutputRows, numOutputBatches,
+          joinTime, filterTime, totalTime)
       }
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -403,7 +403,6 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
     } else {
       lazy val builtBatch: ColumnarBatch =
         makeBuiltBatch(broadcastRelation, buildTime, buildDataSize)
-      val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
       val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
       streamed.executeColumnar().mapPartitions { streamedIter =>
         val lazyStream = streamedIter.map { cb =>
@@ -413,7 +412,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
         }
         GpuBroadcastNestedLoopJoinExecBase.innerLikeJoin(
           LazySpillableColumnarBatch(builtBatch, spillCallback, "built_batch"),
-          lazyStream, targetSize, getGpuBuildSide, boundCondition,
+          lazyStream, targetSizeBytes, getGpuBuildSide, boundCondition,
           numOutputRows, joinOutputRows, numOutputBatches,
           joinTime, filterTime, totalTime)
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/BroadcastNestedLoopJoinSuite.scala
@@ -25,7 +25,6 @@ class BroadcastNestedLoopJoinSuite extends SparkQueryCompareTestSuite {
 
   test("BroadcastNestedLoopJoinExec AQE off") {
     val conf = new SparkConf()
-      .set("spark.rapids.sql.exec.BroadcastNestedLoopJoinExec", "true")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
 
     withGpuSparkSession(spark => {


### PR DESCRIPTION
This is the second out of core join PR. This adds in support for doing out of core joins on cross joins (CarteaseanExec) and inner/cross joins for  broadcast nested loop joins.  Because these joins always explode in size we didn't have them enabled by default but with this work we can have them on by default now.  This has one big advantage over the other join implementations, in that I don't have to materialize the gather maps so even very very large joins we can output batches without having very large gather maps.