### PR TITLE
Fix deprecated aggregation and GpuFlatMapGroupsInPandasExec scaladoc

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -663,7 +663,7 @@ case class GpuCollectList(child: Expression,
   // WINDOW FUNCTION
   override val windowInputProjection: Seq[Expression] = Seq(child)
   override def windowAggregation(inputs: Seq[(ColumnVector, Int)]): AggregationOnColumn =
-    Aggregation.collect().onColumn(inputs.head._2)
+    Aggregation.collectList().onColumn(inputs.head._2)
 
   // Declarative aggregate. But for now 'CollectList' does not support it.
   // The members as below should NOT be used yet, ensured by the

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
@@ -63,8 +63,7 @@ class GpuFlatMapGroupsInPandasExecMeta(
 }
 
 /**
- * Physical node of GPU version for
- * [[org.apache.spark.sql.catalyst.plans.logical.FlatMapGroupsInPandas]]
+ * GPU version of Spark's `FlatMapGroupsInPandasExec`
  *
  * Rows in each group are passed to the Python worker as an Arrow record batch.
  * The Python worker turns the record batch to a `pandas.DataFrame`, invoke the


### PR DESCRIPTION
This fixes the following warnings generated during the build:
```
[WARNING] [Warn] /spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala:666: method collect in class Aggregation is deprecated: see corresponding Javadoc for more information.
[...]
/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala:65: warning: Could not find any member to link for "org.apache.spark.sql.catalyst.plans.logical.FlatMapGroupsInPandas".
/**
^
```