### PR TITLE
Restore hash partitioning of arrays

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -584,7 +584,7 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS* (Round-robin partitioning is not supported if spark.sql.execution.sortBeforeRepartition is true and hash partitioning for array of arrays, maps, strings, or structs is not supported; missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
+<td><em>PS* (Round-robin partitioning is not supported if spark.sql.execution.sortBeforeRepartition is true; missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
 <td><em>PS* (Round-robin partitioning is not supported if spark.sql.execution.sortBeforeRepartition is true; missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
 <td><em>PS* (Round-robin partitioning is not supported for nested structs if spark.sql.execution.sortBeforeRepartition is true; missing nested BINARY, CALENDAR, MAP, UDT)</em></td>
 <td><b>NS</b></td>

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -99,10 +99,6 @@ def test_sortmerge_join(data_gen, join_type, batch_size):
     conf.update(_sortmerge_join_conf)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
-# Cudf had some issues with hash partitioning of some arrays
-# https://github.com/NVIDIA/spark-rapids/issues/2330 should fix that, and then the allow_non_gpu
-# can be removed
-@allow_non_gpu('ShuffleExchangeExec', 'HashPartitioning')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross', 'FullOuter'], ids=idfn)
@@ -149,10 +145,6 @@ def test_sortmerge_join_struct(data_gen, join_type, batch_size):
 # unless we can give it some help. Parameters are setup to try to make
 # this happen, if test fails something might have changed related to that.
 @validate_execs_in_gpu_plan('GpuShuffledHashJoinExec')
-# Cudf had some issues with hash partitioning of some arrays
-# https://github.com/NVIDIA/spark-rapids/issues/2330 should fix that, and then the allow_non_gpu
-# can be removed
-@allow_non_gpu('ShuffleExchangeExec', 'HashPartitioning')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'Right', 'Inner', 'LeftSemi', 'LeftAnti', 'Cross', 'FullOuter'], ids=idfn)
@@ -175,12 +167,6 @@ def test_broadcast_join_right_table(data_gen, join_type):
         return left.join(broadcast(right), left.a == right.r_a, join_type)
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
 
-# Cudf had some issues with hash partitioning of some arrays. Yes a broadcast join
-# should not be doing hash partitioning, but in some cases (FullOuter and Right) it cannot do the
-# broadcast so it falls back to a SortMergeJoin
-# https://github.com/NVIDIA/spark-rapids/issues/2330 should fix that, and then the allow_non_gpu
-# can be removed
-@allow_non_gpu('ShuffleExchangeExec', 'HashPartitioning')
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2838,8 +2838,7 @@ object GpuOverrides {
           .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
               s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
           .withPsNote(TypeEnum.ARRAY, "Round-robin partitioning is not supported if " +
-              s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true and hash partitioning for array " +
-              "of arrays, maps, strings, or structs is not supported")
+              s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
           .withPsNote(TypeEnum.MAP, "Round-robin partitioning is not supported if " +
               s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true"),
         TypeSig.all),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -27,13 +27,13 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute}
-import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RoundRobinPartitioning}
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, RoundRobinPartitioning}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.{Exchange, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.metric._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuShuffleDependency, GpuShuffleEnv}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructType}
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.MutablePair
 
@@ -63,19 +63,6 @@ class GpuShuffleMeta(
               willNotWorkOnGpu(s"round-robin partitioning cannot sort $dataType to run " +
                   s"this on the GPU set ${SQLConf.SORT_BEFORE_REPARTITION.key} to false")
             }
-      case _: HashPartitioning =>
-        val hasArraysOfNested = TrampolineUtil.dataTypeExistsRecursively(shuffle.schema,
-          {
-            case ArrayType(et, _) => et match {
-              case _: ArrayType | _: MapType | _: StringType | _: StructType => true
-              case _ => false
-            }
-            case _ => false
-          })
-        if (hasArraysOfNested) {
-          willNotWorkOnGpu("hash partitioning does not support array of arrays, " +
-              "maps, strings, or structs")
-        }
       case _ =>
     }
   }


### PR DESCRIPTION
Fixes #2330 

Now that https://github.com/rapidsai/cudf/issues/8098 has been fixed, this restores support for hash partitioning for arrays that was removed in #2319.
