### PR TITLE
Fix NPE when spilling with debug logging enabled

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -147,12 +147,20 @@ object MetaUtils extends Arm {
   }
 
   /**
-   * This is a hack to create a table meta that passed muster, but is not really going to be used
+   * Constructs a table metadata buffer from a device buffer without describing any schema
+   * for the buffer.
    */
-  lazy val ignoreTableMeta: TableMeta = {
+  def getTableMetaNoTable(buffer: DeviceMemoryBuffer): TableMeta = {
     val fbb = new FlatBufferBuilder(1024)
+    val bufferSize = buffer.getLength
+    BufferMeta.startBufferMeta(fbb)
+    BufferMeta.addId(fbb, 0)
+    BufferMeta.addSize(fbb, bufferSize)
+    BufferMeta.addUncompressedSize(fbb, bufferSize)
+    val bufferMetaOffset = BufferMeta.endBufferMeta(fbb)
     TableMeta.startTableMeta(fbb)
     TableMeta.addRowCount(fbb, 0)
+    TableMeta.addBufferMeta(fbb, bufferMetaOffset)
     fbb.finish(TableMeta.endTableMeta(fbb))
     // copy the message to trim the backing array to only what is needed
     TableMeta.getRootAsTableMeta(ByteBuffer.wrap(fbb.sizedByteArray()))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -273,7 +273,8 @@ object SpillableBuffer extends Arm {
       priority: Long,
       spillCallback: RapidsBuffer.SpillCallback): SpillableBuffer = {
     val id = TempSpillBufferId()
-    RapidsBufferCatalog.addBuffer(id, buffer, MetaUtils.ignoreTableMeta, priority, spillCallback)
+    val meta = MetaUtils.getTableMetaNoTable(buffer)
+    RapidsBufferCatalog.addBuffer(id, buffer, meta, priority, spillCallback)
     new SpillableBuffer(id)
   }
 }


### PR DESCRIPTION
This ensures that a valid `BufferMeta` is created for `SpillableBuffer`'s table metadata.  This will avoid an NPE when code tries to examine the size of a buffer via its metadata or whether the data is compressed.