### PR TITLE
Fix Alias to properly call the shim version

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -262,7 +262,7 @@ trait GpuExec extends SparkPlan with Arm {
         // normalize that for equality testing, by assigning expr id from 0 incrementally. The
         // alias name doesn't matter and should be erased.
         val normalizedChild = QueryPlan.normalizeExpressions(a.child, allAttributes)
-        Alias(normalizedChild, "")(ExprId(id), a.qualifier)
+        ShimLoader.getSparkShims.alias(normalizedChild, "")(ExprId(id), a.qualifier)
       case a: GpuAlias =>
         id += 1
         // As the root of the expression, Alias will always take an arbitrary exprId, we need to

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -498,6 +498,9 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       }
       if (conf.isTestEnabled) {
         assertIsOnTheGpu(updatedPlan, conf)
+        // Generate the canonicalized plan to ensure no incompatibilities.
+        // The plan itself is not currently checked.
+        updatedPlan.canonicalized
         validateExecsInGpuPlan(updatedPlan, conf)
       }
       updatedPlan


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/2359

Alias needs to be shimmed before spark 3.1.0 made changes to it. https://github.com/NVIDIA/spark-rapids/commit/cce1ec1ed401bcd7465f5bef9ab28ed38aa5a9a8

It appears that got lost and our tests never caught this.   

specifically call updatedPlan.canonicalized for testing cases which would have caught this error.  It doesn't test anything other then making sure it can generate the canonicalized plan.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
