### PR TITLE
Fix noop filter check to handle nulls

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -423,7 +423,7 @@ class AdaptiveQueryExecSuite
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key, "true")
-      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "500")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "400")
       .set(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key, "50")
       // disable DemoteBroadcastHashJoin rule from removing BHJ due to empty partitions
       .set(SQLConf.NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN.key, "0")


### PR DESCRIPTION
This fixes #2364

The reason this was not found until the nightly tests was because of partitioning of the data to all of the available tasks. If you run the tests with 6 tasks I was able to reproduce the issue locally.

I am willing to write a unit test for this if we really want one.