### PR TITLE
fix a bug of function typeConversionAllowed()

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -594,13 +594,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     if (colType instanceof MapType) {
       MapType mType = (MapType) colType;
       // list of struct of key/value
-      if (!(dt.equals(DType.LIST))) {
+      if (!(dt.equals(DType.STRUCT))) {
         return false;
       }
-      try (ColumnView structCv = cv.getChildColumnView(0)) {
-        if (!(structCv.getType().equals(DType.STRUCT))) {
-          return false;
-        }
+      try (ColumnView structCv = cv) {
         if (structCv.getNumChildren() != 2) {
           return false;
         }


### PR DESCRIPTION
close #2374
This pr fix a bug of function `typeConversionAllowed(ColumnView cv, DataType colType)` when converts a cudf internal vector to a Spark compatible vector , and it needs check cudf columnvector data type and spark vector data type if it' convertible.
Now, the problem is that when colType is `MapType`,  `cv` type check is wrong, because `cv` data type should be `StructType` instead of `ListType`.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
