### PR TITLE
Show expected cudf type when type conversion check fails

### DIFF
--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -92,9 +92,45 @@ returned.
 ### Generating Columnar Output
 
 The `evaluateColumnar` method must return a `ColumnVector` of an appropriate
-cudf type to match the result type of the original UDF. For example, if the
-CPU UDF returns a `double` then `evaluateColumnar` must return a column of
-type `FLOAT64`.
+cudf type to match the result type of the original UDF. The following table
+shows the mapping of Spark types to equivalent cudf columnar types.
+
+Spark Type      | RAPIDS cudf Type
+--------------- | ----------------
+`BooleanType`   | `BOOL8`
+`ByteType`      | `INT8`
+`ShortType`     | `INT16`
+`IntegerType`   | `INT32`
+`LongType`      | `INT64`
+`FloatType`     | `FLOAT32`
+`DoubleType`    | `FLOAT64`
+`DecimalType`   | [See the decimal types section](#returning-decimal-types)
+`DateType`      | `TIMESTAMP_DAYS`
+`TimestampType` | `TIMESTAMP_MICROSECONDS`
+`StringType`    | `STRING`
+`NullType`      | `INT8`
+`ArrayType`     | `LIST` of the underlying element type
+`MapType`       | `LIST` of `STRUCT` of the key and value types
+`StructType`    | `STRUCT` of all the field types
+
+For example, if the CPU UDF returns the Spark type
+`ArrayType(MapType(StringType, StringType))` then `evaluateColumnar` must
+return a column of type `LIST(LIST(STRUCT(STRING,STRING)))`.
+
+#### Returning Decimal Types
+
+The RAPIDS cudf equivalent type for a Spark `DecimalType` depends on the precision
+of the decimal.
+
+`DecimalType` Precision           | RAPIDS cudf Type
+--------------------------------- | ----------------
+precision <= 9 digits             | `DECIMAL32`
+9 digits < precision <= 18 digits | `DECIMAL64`
+18 digits < precision             | Unsupported
+
+Note that RAPIDS cudf decimals use a negative scale relative to Spark `DecimalType`.
+For example, Spark `DecimalType(precision=11, scale=2)` would translate to RAPIDS cudf
+type `DECIMAL64(scale=-2)`.
 
 ## RAPIDS Accelerated UDF Examples
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -775,14 +775,8 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       sb.append("))");
     } else if (sparkType instanceof StructType) {
       StructType structType = (StructType) sparkType;
-      sb.append("STRUCT(");
-      for (int i = 0; i < structType.size(); i++) {
-        if (i != 0) {
-          sb.append(",");
-        }
-        sb.append(buildColumnTypeString(structType.apply(i).dataType()));
-      }
-      sb.append(")");
+      sb.append(structType.iterator().map(f -> buildColumnTypeString(f.dataType()))
+          .mkString("STRUCT(", ",", ")"));
     } else {
       throw new IllegalArgumentException("Unexpected data type: " + sparkType);
     }
@@ -798,8 +792,9 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    */
   public static GpuColumnVector fromChecked(ai.rapids.cudf.ColumnVector cudfCv, DataType type) {
     if (!typeConversionAllowed(cudfCv, type)) {
-      throw new IllegalArgumentException("Type conversion error for " + type + ": expected " +
-          buildColumnTypeString(type) + " found " + buildColumnTypeString(cudfCv));
+      throw new IllegalArgumentException("Type conversion error to " + type +
+          ": expected cudf type " + buildColumnTypeString(type) +
+          " found cudf type " + buildColumnTypeString(cudfCv));
     }
     return new GpuColumnVector(type, cudfCv);
   }


### PR DESCRIPTION
This extends the work in #2369 by also showing the expected cudf type, so it's clear how a Spark type is being translated to a RAPIDS cudf type.  This also updates the RAPIDS Accelerated UDF documentation to describe how Spark types are mapped to equivalent RAPIDS cudf types.