### PR TITLE
Refactor to avoid code duplication between GpuBroadcastToCpu and GpuBroadcastExchange

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -365,6 +365,11 @@ abstract class GpuBroadcastExchangeExecBase(
   }
 
   protected def checkRowLimit(numRows: Int) = {
+    // Spark restricts the size of broadcast relations to be less than 512000000 rows and we
+    // enforce the same limit
+    // scalastyle:off line.size.limit
+    // https://github.com/apache/spark/blob/v3.1.1/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala#L586
+    // scalastyle:on line.size.limit
     if (numRows >= 512000000) {
       throw new SparkException(
         s"Cannot broadcast the table with 512 million or more rows: $numRows rows")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -302,10 +302,7 @@ abstract class GpuBroadcastExchangeExecBase(
             }
 
             val numRows = batch.numRows
-            if (numRows >= 512000000) {
-              throw new SparkException(
-                s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
-            }
+            checkRowLimit(numRows)
             numOutputBatches += 1
             numOutputRows += numRows
 
@@ -339,12 +336,7 @@ abstract class GpuBroadcastExchangeExecBase(
             // SparkFatalException, which is a subclass of Exception. ThreadUtils.awaitResult
             // will catch this exception and re-throw the wrapped fatal throwable.
             case oe: OutOfMemoryError =>
-              val ex = new Exception(
-                new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
-                    "worker nodes. As a workaround, you can either disable broadcast by setting " +
-                    s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
-                    s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
-                    .initCause(oe.getCause))
+              val ex = createOutOfMemoryException(oe)
               promise.failure(ex)
               throw ex
             case e if !NonFatal(e) =>
@@ -361,6 +353,22 @@ abstract class GpuBroadcastExchangeExecBase(
       }
     }
     GpuBroadcastExchangeExec.executionContext.submit[Broadcast[Any]](task)
+  }
+
+  protected def createOutOfMemoryException(oe: OutOfMemoryError) = {
+    new Exception(
+      new OutOfMemoryError("Not enough memory to build and broadcast the table to all " +
+        "worker nodes. As a workaround, you can either disable broadcast by setting " +
+        s"${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1 or increase the spark " +
+        s"driver memory by setting ${SparkLauncher.DRIVER_MEMORY} to a higher value.")
+        .initCause(oe.getCause))
+  }
+
+  protected def checkRowLimit(numRows: Int) = {
+    if (numRows >= 512000000) {
+      throw new SparkException(
+        s"Cannot broadcast the table with 512 million or more rows: $numRows rows")
+    }
   }
 
   override protected def doPrepare(): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -252,7 +252,7 @@ abstract class GpuBroadcastExchangeExecBase(
   override def outputBatching: CoalesceGoal = RequireSingleBatch
 
   @transient
-  private lazy val promise = Promise[Broadcast[Any]]()
+  protected lazy val promise = Promise[Broadcast[Any]]()
 
   /**
    * For registering callbacks on `relationFuture`.
@@ -262,7 +262,7 @@ abstract class GpuBroadcastExchangeExecBase(
   lazy val completionFuture: concurrent.Future[Broadcast[Any]] = promise.future
 
   @transient
-  private val timeout: Long = SQLConf.get.broadcastTimeout
+  protected val timeout: Long = SQLConf.get.broadcastTimeout
 
   val _runId: UUID = UUID.randomUUID()
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToCpuExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToCpuExec.scala
@@ -28,14 +28,12 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 
 import org.apache.spark.SparkException
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec.MAX_BROADCAST_TABLE_BYTES
 import org.apache.spark.sql.execution.metric.SQLMetrics
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.KnownSizeEstimation
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToCpuExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToCpuExec.scala
@@ -15,26 +15,24 @@
  */
 package org.apache.spark.sql.rapids.execution
 
-import java.util.{Optional, UUID}
-import java.util.concurrent.{Callable, Future, TimeoutException, TimeUnit}
+import java.util.Optional
+import java.util.concurrent.{Callable, Future}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 import ai.rapids.cudf.{HostColumnVector, NvtxColor}
-import com.nvidia.spark.rapids.{GpuExec, GpuMetric, MetricRange, NvtxWithMetrics, RapidsHostColumnVector}
+import com.nvidia.spark.rapids.{GpuMetric, MetricRange, NvtxWithMetrics, RapidsHostColumnVector}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 
 import org.apache.spark.SparkException
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.launcher.SparkLauncher
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection, UnsafeRow}
-import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
-import org.apache.spark.sql.execution.{SparkPlan, SQLExecution, UnaryExecNode}
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
+import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec.MAX_BROADCAST_TABLE_BYTES
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.internal.SQLConf
@@ -49,46 +47,13 @@ import org.apache.spark.util.KnownSizeEstimation
  * @param mode Broadcast mode
  * @param child Input to broadcast
  */
-case class GpuBroadcastToCpuExec(mode: BroadcastMode, child: SparkPlan)
-    extends UnaryExecNode with GpuExec {
+case class GpuBroadcastToCpuExec(override val mode: BroadcastMode, child: SparkPlan)
+    extends GpuBroadcastExchangeExecBase(mode, child) {
 
   import GpuMetric._
-  // We need to do this so the assertions don't fail
-  override def supportsColumnar = false
-
-  override def output: Seq[Attribute] = child.output
-
-  override def outputPartitioning: Partitioning = child.outputPartitioning
-
-  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
-
-  // Override the original metrics to remove NUM_OUTPUT_BATCHES, which makes no sense.
-  override lazy val allMetrics: Map[String, GpuMetric] = Map(
-    "dataSize" -> createSizeMetric(ESSENTIAL_LEVEL, "data size"),
-    NUM_OUTPUT_ROWS -> createMetric(outputRowsLevel, DESCRIPTION_NUM_OUTPUT_ROWS),
-    BUILD_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_BUILD_TIME),
-    "broadcastTime" -> createNanoTimingMetric(ESSENTIAL_LEVEL, "time to broadcast"),
-    COLLECT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_COLLECT_TIME),
-    TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
-    NUM_INPUT_BATCHES -> createMetric(DEBUG_LEVEL, DESCRIPTION_NUM_INPUT_BATCHES))
 
   @transient
-  private lazy val promise = Promise[Broadcast[Any]]()
-
-  @transient
-  private val timeout: Long = SQLConf.get.broadcastTimeout
-
-  /**
-   * For registering callbacks on `relationFuture`.
-   * Note that calling this field will not start the execution of broadcast job.
-   */
-  @transient
-  lazy val completionFuture: concurrent.Future[Broadcast[Any]] = promise.future
-
-  val _runId: UUID = UUID.randomUUID()
-
-  @transient
-  lazy val relationFuture: Future[Broadcast[Any]] = {
+  override lazy val relationFuture: Future[Broadcast[Any]] = {
     // relationFuture is used in "doExecute". Therefore we can get the execution id correctly here.
     val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
@@ -216,24 +181,4 @@ case class GpuBroadcastToCpuExec(mode: BroadcastMode, child: SparkPlan)
     GpuBroadcastExchangeExec.executionContext.submit[Broadcast[Any]](task)
   }
 
-  override protected[sql] def doExecuteBroadcast[T](): Broadcast[T] = {
-    try {
-      relationFuture.get(timeout, TimeUnit.SECONDS).asInstanceOf[Broadcast[T]]
-    } catch {
-      case ex: TimeoutException =>
-        logError(s"Could not execute broadcast in $timeout secs.", ex)
-        if (!relationFuture.isDone) {
-          sparkContext.cancelJobGroup(_runId.toString)
-          relationFuture.cancel(true)
-        }
-        throw new SparkException(s"Could not execute broadcast in $timeout secs. " +
-          s"You can increase the timeout for broadcasts via ${SQLConf.BROADCAST_TIMEOUT.key} or " +
-          s"disable broadcast join by setting ${SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key} to -1",
-          ex)
-    }
-  }
-
-  override protected def doExecute(): RDD[InternalRow] = {
-    throw new UnsupportedOperationException(s"$nodeName does not implement doExecute")
-  }
 }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/2219

I manually tested the changes with NDS q14a to confirm that the query ran without error and included `GpuBroadcastToCpu` operatrors in the query plan.
