### PR TITLE
`CaseWhen` supports `ArrayType`

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -2964,7 +2964,7 @@ Accelerator support is described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS* (missing nested DECIMAL, BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT)</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -2985,7 +2985,7 @@ Accelerator support is described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS* (missing nested DECIMAL, BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT)</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -138,9 +138,11 @@ def test_ifnull(data_gen):
                 'ifnull({}, b)'.format(null_lit),
                 'ifnull(a, {})'.format(null_lit)))
 
-
+# Scalar of array type is not supported yet, so make it separate from the above one.
+# Supporting scalar of array type is tracked by
+#     https://github.com/NVIDIA/spark-rapids/issues/1902
 @pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
-def test_casewhen_array(data_gen):
+def test_case_when_array(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : three_col_df(spark,
             int_gen,

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -137,3 +137,12 @@ def test_ifnull(data_gen):
                 'ifnull({}, b)'.format(s1),
                 'ifnull({}, b)'.format(null_lit),
                 'ifnull(a, {})'.format(null_lit)))
+
+
+@pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
+def test_casewhen_array(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : three_col_df(spark,
+            int_gen,
+            data_gen,
+            data_gen).selectExpr('CASE WHEN a > 10 THEN b ELSE c END'))

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -138,8 +138,8 @@ def test_ifnull(data_gen):
                 'ifnull({}, b)'.format(null_lit),
                 'ifnull(a, {})'.format(null_lit)))
 
-# Scalar of array type is not supported yet, so make it separate from the above one.
-# Supporting scalar of array type is tracked by
+# GpuLiteral does not support array type yet, so make the test separate from the above one.
+# Supporting GpuLiteral of array type is tracked by
 #     https://github.com/NVIDIA/spark-rapids/issues/1902
 @pytest.mark.parametrize('data_gen', single_level_array_gens_no_decimal, ids=idfn)
 def test_case_when_array(data_gen):

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -751,7 +751,8 @@ case class ExprChecksImpl(contexts: Map[ExpressionContext, ContextChecks])
  * This is specific to CaseWhen, because it does not follow the typical parameter convention.
  */
 object CaseWhenCheck extends ExprChecks {
-  val check: TypeSig = TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL
+  val check: TypeSig = TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL +
+    TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.NULL)
   val sparkSig: TypeSig = TypeSig.all
 
   override def tag(meta: RapidsMeta[_, _, _]): Unit = {


### PR DESCRIPTION
This PR is to add `ArrayType ` support to the expression `CaseWhen`. Since the cudf has supported it by the PR https://github.com/rapidsai/cudf/pull/8135 .

Closed https://github.com/NVIDIA/spark-rapids/issues/1996

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
