### PR TITLE
Tweak repart_test struct for SPARK-35108

### DIFF
--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -82,7 +82,14 @@ def test_repartition_df(data_gen, num_parts, length):
 
 @allow_non_gpu('ShuffleExchangeExec', 'RoundRobinPartitioning')
 @pytest.mark.parametrize('data_gen', [[('a', ArrayGen(string_gen))],
-    [('a', StructGen([('a_1', StructGen([('a_1_1', int_gen)]))]))],
+    [('a', StructGen([
+      ('a_1', StructGen([
+        ('a_1_1', int_gen),
+        ('a_1_2', float_gen),
+        ('a_1_3', double_gen)
+      ])),
+      ('b_1', long_gen)
+    ]))],
     [('a', simple_string_to_string_map_gen)]], ids=idfn)
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 def test_round_robin_sort_fallback(data_gen):
@@ -91,7 +98,6 @@ def test_round_robin_sort_fallback(data_gen):
             # Add a computed column to avoid shuffle being optimized back to a CPU shuffle like in test_repartition_df
             lambda spark : gen_df(spark, data_gen).withColumn('x', lit(1)).repartition(13),
             'ShuffleExchangeExec')
-
 
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
 @pytest.mark.parametrize('num_parts', [1, 2, 10, 17, 19, 32], ids=idfn)


### PR DESCRIPTION
We've seen failures in CI that look to be related to https://issues.apache.org/jira/browse/SPARK-35108. This PR is a way to make a test pass `test_round_robin_sort_fallback` by making sure the struct we are generated doesn't have the same shape at each level.

Once the new version of SPARK comes out with the fix for SPARK-35108, we should revisit and add the original case back.

```
14:42:06  self = Row(a_1=None), item = 'a_1_1'
14:42:06  
14:42:06      def __getitem__(self, item):
14:42:06          if isinstance(item, (int, slice)):
14:42:06              return super(Row, self).__getitem__(item)
14:42:06          try:
14:42:06              # it will be slow when it has many fields,
14:42:06              # but this will not be used in normal cases
14:42:06  >           idx = self.__fields__.index(item)
14:42:06  [1m[31mE           ValueError: 'a_1_1' is not in list[0m
14:42:06  
14:42:06  [1m[31m/var/lib/jenkins/spark/spark-3.0.2-bin-hadoop3.2/python/lib/pyspark.zip/pyspark/sql/types.py[0m:1582: ValueError
14:42:06  
14:42:06  [33mDuring handling of the above exception, another exception occurred:[0m
14:42:06  data_gen = [('a', Struct(('a_1', Struct(('a_1_1', Integer)))))]
14:42:06  
14:42:06      @allow_non_gpu('ShuffleExchangeExec', 'RoundRobinPartitioning')
14:42:06      @pytest.mark.parametrize('data_gen', [[('a', ArrayGen(string_gen))],
14:42:06          [('a', StructGen([('a_1', StructGen([('a_1_1', int_gen)]))]))],
14:42:06          [('a', simple_string_to_string_map_gen)]], ids=idfn)
14:42:06      @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.
14:42:06      def test_round_robin_sort_fallback(data_gen):
14:42:06          from pyspark.sql.functions import lit
14:42:06  >       assert_gpu_fallback_collect(
14:42:06                  # Add a computed column to avoid shuffle being optimized back to a CPU shuffle like in test_repartition_df
14:42:06                  lambda spark : gen_df(spark, data_gen).withColumn('x', lit(1)).repartition(13),
14:42:06                  'ShuffleExchangeExec')
```