### PR TITLE
Unify legacy and 3.1.x struct cast implementations

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -624,12 +624,7 @@ def test_struct_groupby_count(key_data_gen):
     assert_gpu_and_cpu_are_equal_collect(group_by_count)
 
 
-@pytest.mark.parametrize('cast_struct_tostring', [
-    pytest.param('LEGACY', marks=pytest.mark.xfail(
-        reason='https://github.com/NVIDIA/spark-rapids/issues/2315')),
-    pytest.param('SPARK311+', marks=pytest.mark.xfail(condition=is_before_spark_311(),
-        reason='https://github.com/NVIDIA/spark-rapids/issues/2315')),
-    ])
+@pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
 @pytest.mark.parametrize('key_data_gen', [
     StructGen([
         ('a', IntegerGen(min_val=0, max_val=9)),
@@ -669,12 +664,7 @@ def test_struct_count_distinct(key_data_gen):
     assert_gpu_and_cpu_are_equal_collect(_count_distinct_by_struct)
 
 
-@pytest.mark.parametrize('cast_struct_tostring', [
-    pytest.param('LEGACY', marks=pytest.mark.xfail(
-        reason='https://github.com/NVIDIA/spark-rapids/issues/2315')),
-    pytest.param('SPARK311+', marks=pytest.mark.xfail(condition=is_before_spark_311(),
-        reason='https://github.com/NVIDIA/spark-rapids/issues/2315')),
-])
+@pytest.mark.parametrize('cast_struct_tostring', ['LEGACY', 'SPARK311+'])
 @pytest.mark.parametrize('key_data_gen', [
     StructGen([
         ('a', StructGen([

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -529,8 +529,7 @@ case class GpuCast(
       spaceColumn: ColumnVector,
       leftColumn: ColumnVector,
       rightColumn: ColumnVector) = {
-      val columns = ArrayBuffer.empty[ColumnVector]
-      try {
+      withResource(ArrayBuffer.empty[ColumnVector]) { columns =>
         // legacy: [firstCol
         //   3.1+: {firstCol
         columns += leftColumn.incRefCount()
@@ -555,8 +554,6 @@ case class GpuCast(
         withResource(ColumnVector.stringConcatenate(emptyScalar, nullScalar, columns.toArray))(
           _.mergeAndSetValidity(BinaryOp.BITWISE_AND, input) // original whole row is null
         )
-      } finally {
-        columns.safeClose()
       }
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -271,7 +271,7 @@ case class GpuCast(
       case (TimestampType, StringType) =>
         castTimestampToString(input)
       case (StructType(fields), StringType) =>
-        castStructToString(input, legacyCastToString, fields)
+        castStructToString(input, fields)
 
       // ansi cast from larger-than-integer integral types, to integer
       case (LongType, IntegerType) if ansiMode =>
@@ -510,126 +510,71 @@ case class GpuCast(
     }
   }
 
-  private def legacyStructToString(input: ColumnView,
-    inputSchema: Array[StructField]): ColumnVector = {
-    var separatorColumn: ColumnVector = null
-    var spaceColumn: ColumnVector = null
-    val columns: ArrayBuffer[ColumnVector] = new ArrayBuffer[ColumnVector]()
-    // coreColumns tracks the casted child columns
-    val coreColumns: ArrayBuffer[ColumnVector] = new ArrayBuffer[ColumnVector]()
-
-    try {
-      withResource(GpuScalar.from(",", StringType)) { separatorScalar =>
-        separatorColumn = ColumnVector.fromScalar(separatorScalar, input.getRowCount.toInt)
-      }
-      withResource(GpuScalar.from(" ", StringType)) { separatorScalar =>
-        spaceColumn = ColumnVector.fromScalar(separatorScalar, input.getRowCount.toInt)
-      }
-      withResource(GpuScalar.from("[", StringType)) { bracketScalar =>
-        columns += ColumnVector.fromScalar(bracketScalar, input.getRowCount.toInt)
-      }
-
-      withResource(input.getChildColumnView(0)) { childView =>
-        columns += doColumnar(childView, inputSchema(0).dataType)
-        coreColumns += columns.last
-      }
-      for(childIndex <- 1 until input.getNumChildren()) {
-        withResource(input.getChildColumnView(childIndex)) { childView =>
-          columns += separatorColumn
-          // Copies the whitespace column's validity with the current column's validity.
-          // Mimics the Spark null behavior of consecutive commas with no space between them
-          columns += spaceColumn.mergeAndSetValidity(BinaryOp.BITWISE_AND, childView)
-          columns += doColumnar(childView, inputSchema(childIndex).dataType)
-          coreColumns += columns.last
-        }
-      }
-      withResource(GpuScalar.from("]", StringType)) { bracketScalar =>
-        columns += ColumnVector.fromScalar(bracketScalar, input.getRowCount.toInt)
-      }
-
-      // Merge casted child columns
-      withResource(GpuScalar.from("", StringType)) { emptyStrScalar =>
-        withResource(ColumnVector.stringConcatenate(emptyStrScalar, emptyStrScalar,
-          columns.toArray[ColumnView])) { fullResult =>
-          // Merge the validity of all child columns, fully null rows are null in the result
-          withResource(fullResult.mergeAndSetValidity(BinaryOp.BITWISE_OR,
-            coreColumns: _*)) { nulledResult =>
-            // Reflect the struct column's validity vector in the result
-            nulledResult.mergeAndSetValidity(BinaryOp.BITWISE_AND, input, nulledResult)
-          }
-        }
-      }
-    } finally {
-      if (separatorColumn != null) {
-        columns.foreach(col =>
-          if(col.getNativeView() != separatorColumn.getNativeView()) {
-            col.close()
-          })
-        separatorColumn.close()
-      }
-      if (spaceColumn != null) {
-        spaceColumn.close()
-      }
-    }
-  }
-
-  private def modernStructToString(input: ColumnView,
-    inputSchema: Array[StructField]): ColumnVector = {
-    var separatorColumn: ColumnVector = null
-    var spaceColumn: ColumnVector = null
-    val columns: ArrayBuffer[ColumnVector] = new ArrayBuffer[ColumnVector]()
-
-    try {
-      withResource(GpuScalar.from(", ", StringType)) { separatorScalar =>
-        separatorColumn = ColumnVector.fromScalar(separatorScalar, input.getRowCount.toInt)
-      }
-      withResource(GpuScalar.from("{", StringType)) { bracketScalar =>
-        columns += ColumnVector.fromScalar(bracketScalar, input.getRowCount.toInt)
-      }
-
-      withResource(input.getChildColumnView(0)) { childView =>
-        columns += doColumnar(childView, inputSchema(0).dataType)
-      }
-      for(childIndex <- 1 until input.getNumChildren()) {
-        withResource(input.getChildColumnView(childIndex)) { childView =>
-          columns += separatorColumn
-          columns += doColumnar(childView, inputSchema(childIndex).dataType)
-        }
-      }
-      withResource(GpuScalar.from("}", StringType)) { bracketScalar =>
-        columns += ColumnVector.fromScalar(bracketScalar, input.getRowCount.toInt)
-      }
-
-      // Merge casted child columns
-      withResource(GpuScalar.from("", StringType)) { emptyStrScalar =>
-        withResource(GpuScalar.from("null", StringType)) { nullStringScalar =>
-          withResource(ColumnVector.stringConcatenate(emptyStrScalar, nullStringScalar,
-            columns.toArray[ColumnView])) { fullResult =>
-            // Reflect the struct column's validity vector in the result
-            fullResult.mergeAndSetValidity(BinaryOp.BITWISE_AND, input)
-          }
-        }
-      }
-    } finally {
-      if (separatorColumn != null) {
-        columns.foreach(col =>
-          if(col.getNativeView() != separatorColumn.getNativeView()) {
-            col.close()
-          })
-        separatorColumn.close()
-      }
-      if (spaceColumn != null) {
-        spaceColumn.close()
-      }
-    }
-  }
-
   private def castStructToString(input: ColumnView,
-    legacyCastToString: Boolean, inputSchema: Array[StructField]): ColumnVector = {
-    if (legacyCastToString) {
-      legacyStructToString(input, inputSchema)
-    } else {
-      modernStructToString(input,inputSchema)
+    inputSchema: Array[StructField]): ColumnVector = {
+
+    val (leftStr, rightStr) = if (legacyCastToString) ("[", "]") else ("{", "}")
+    val emptyStr = ""
+    val nullStr = if (legacyCastToString) "" else "null"
+    val separatorStr = if (legacyCastToString) "," else ", "
+    val spaceStr = " "
+    val numRows = input.getRowCount.toInt
+    val numInputColumns = input.getNumChildren()
+
+    def doCastStructToString(
+      emptyScalar: Scalar,
+      nullScalar: Scalar,
+      sepColumn: ColumnVector,
+      spaceColumn: ColumnVector,
+      leftColumn: ColumnVector,
+      rightColumn: ColumnVector) = {
+      val columns = ArrayBuffer.empty[ColumnVector]
+      try {
+        // legacy: [firstCol
+        //   3.1+: {firstCol
+        columns += leftColumn.incRefCount()
+        withResource(input.getChildColumnView(0)) { firstColumnView =>
+          columns += doColumnar(firstColumnView, inputSchema.head.dataType)
+        }
+        for (nonFirstIndex <- 1 until numInputColumns) {
+          withResource(input.getChildColumnView(nonFirstIndex)) { nonFirstColumnView =>
+            // legacy: ","
+            //   3.1+: ", "
+            columns += sepColumn.incRefCount()
+            val nonFirstColumn = doColumnar(nonFirstColumnView, inputSchema(nonFirstIndex).dataType)
+            if (legacyCastToString) {
+              // " " if non-null
+              columns += spaceColumn.mergeAndSetValidity(BinaryOp.BITWISE_AND, nonFirstColumnView)
+            }
+            columns += nonFirstColumn
+          }
+        }
+
+        columns += rightColumn.incRefCount()
+        withResource(
+          ColumnVector.stringConcatenate(emptyScalar, nullScalar, columns.toArray)
+        ) { res =>
+          // null rows
+          res.mergeAndSetValidity(BinaryOp.BITWISE_AND, input)
+        }
+      } finally {
+        columns.foreach(_.close())
+      }
+    }
+
+    withResource(Array(
+      Scalar.fromString(emptyStr),
+      Scalar.fromString(nullStr),
+      Scalar.fromString(separatorStr),
+      Scalar.fromString(spaceStr),
+      Scalar.fromString(leftStr),
+      Scalar.fromString(rightStr)
+    )) { case Array(emptyScalar, nullScalar, columnScalars@_*) =>
+      withResource(columnScalars.map(s => ColumnVector.fromScalar(s, numRows)))(columns => {
+        val Seq(sepColumn, spaceColumn, leftColumn, rightColumn) = columns
+        doCastStructToString(emptyScalar, nullScalar,
+          sepColumn, spaceColumn, leftColumn, rightColumn)
+      })
     }
   }
 


### PR DESCRIPTION
Refactors struct cast to string such that there no need for a dedicated method handling the legacy mode cast. Fixes #2309 and #2315
    
Signed-off-by: Gera Shegalov <gera@apache.org>
