### PR TITLE
Include memory access costs in cost models (cost-based optimizer)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1134,33 +1134,33 @@ object RapidsConf {
       .doubleConf
       .createWithDefault(0.0)
 
-  val OPTIMIZER_CPU_READ_COST = conf(
+  val OPTIMIZER_CPU_READ_SPEED = conf(
     "spark.rapids.sql.optimizer.cpuReadSpeed")
       .internal()
-      .doc("Cost of reading data from CPU memory")
+      .doc("Speed of reading data from CPU memory in GB/s")
       .doubleConf
-      .createWithDefault(0.0)
+      .createWithDefault(30.0)
 
-  val OPTIMIZER_CPU_WRITE_COST = conf(
+  val OPTIMIZER_CPU_WRITE_SPEED = conf(
     "spark.rapids.sql.optimizer.cpuWriteSpeed")
     .internal()
-    .doc("Cost of writing data to CPU memory")
+    .doc("Speed of writing data to CPU memory in GB/s")
     .doubleConf
-    .createWithDefault(0.0)
+    .createWithDefault(30.0)
 
-  val OPTIMIZER_GPU_READ_COST = conf(
+  val OPTIMIZER_GPU_READ_SPEED = conf(
     "spark.rapids.sql.optimizer.gpuReadSpeed")
     .internal()
-    .doc("Cost of reading data from GPU memory")
+    .doc("Speed of reading data from GPU memory in GB/s")
     .doubleConf
-    .createWithDefault(0.0)
+    .createWithDefault(320.0)
 
-  val OPTIMIZER_GPU_WRITE_COST = conf(
+  val OPTIMIZER_GPU_WRITE_SPEED = conf(
     "spark.rapids.sql.optimizer.gpuWriteSpeed")
     .internal()
-    .doc("Cost of writing data to GPU memory")
+    .doc("Speed of writing data to GPU memory in GB/s")
     .doubleConf
-    .createWithDefault(0.0)
+    .createWithDefault(320.0)
 
   val USE_ARROW_OPT = conf("spark.rapids.arrowCopyOptimizationEnabled")
     .doc("Option to turn off using the optimized Arrow copy code when reading from " +
@@ -1540,13 +1540,13 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val defaultGpuExpressionCost: Double = get(OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST)
 
-  lazy val cpuReadMemoryCost: Double = get(OPTIMIZER_CPU_READ_COST)
+  lazy val cpuReadMemorySpeed: Double = get(OPTIMIZER_CPU_READ_SPEED)
 
-  lazy val cpuWriteMemoryCost: Double = get(OPTIMIZER_CPU_WRITE_COST)
+  lazy val cpuWriteMemorySpeed: Double = get(OPTIMIZER_CPU_WRITE_SPEED)
 
-  lazy val gpuReadMemoryCost: Double = get(OPTIMIZER_GPU_READ_COST)
+  lazy val gpuReadMemorySpeed: Double = get(OPTIMIZER_GPU_READ_SPEED)
 
-  lazy val gpuWriteMemoryCost: Double = get(OPTIMIZER_GPU_WRITE_COST)
+  lazy val gpuWriteMemorySpeed: Double = get(OPTIMIZER_GPU_WRITE_SPEED)
 
   lazy val getAlluxioPathsToReplace: Option[Seq[String]] = get(ALLUXIO_PATHS_REPLACE)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1103,12 +1103,6 @@ object RapidsConf {
     .longConf
     .createWithDefault(1000000)
 
-  val OPTIMIZER_DEFAULT_GPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.defaultExecGpuCost")
-      .internal()
-      .doc("Default per-row GPU cost of running an operator on the GPU")
-      .doubleConf
-      .createWithDefault(0.8)
-
   val OPTIMIZER_CLASS_NAME = conf("spark.rapids.sql.optimizer.className")
     .internal()
     .doc("Optimizer implementation class name. The class must implement the " +
@@ -1116,25 +1110,57 @@ object RapidsConf {
     .stringConf
     .createWithDefault("com.nvidia.spark.rapids.CostBasedOptimizer")
 
-  val OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.defaultExprGpuCost")
-      .internal()
-      .doc("Default relative GPU cost of running an expression on the GPU")
-      .doubleConf
-      .createWithDefault(0.01)
+  val OPTIMIZER_DEFAULT_CPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.cpu.exec.default")
+    .internal()
+    .doc("Default per-row CPU cost of executing an operator")
+    .doubleConf
+    .createWithDefault(0.0)
 
-  val OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST = conf(
-    "spark.rapids.sql.optimizer.defaultTransitionToCpuCost")
-      .internal()
-      .doc("Default per-row cost of transitioning from GPU to CPU")
-      .doubleConf
-      .createWithDefault(0.1)
+  val OPTIMIZER_DEFAULT_CPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.cpu.expr.default")
+    .internal()
+    .doc("Default per-row CPU cost of evaluating an expression")
+    .doubleConf
+    .createWithDefault(0.0)
 
-  val OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST = conf(
-    "spark.rapids.sql.optimizer.defaultTransitionToGpuCost")
+  val OPTIMIZER_DEFAULT_GPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.gpu.exec.default")
       .internal()
-      .doc("Default per-row cost of transitioning from CPU to GPU")
+      .doc("Default per-row GPU cost of executing an operator")
       .doubleConf
-      .createWithDefault(0.1)
+      .createWithDefault(0.0)
+
+  val OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.gpu.expr.default")
+      .internal()
+      .doc("Default per-row GPU cost of evaluating an expression")
+      .doubleConf
+      .createWithDefault(0.0)
+
+  val OPTIMIZER_CPU_READ_COST = conf(
+    "spark.rapids.sql.optimizer.cpuReadSpeed")
+      .internal()
+      .doc("Cost of reading data from CPU memory")
+      .doubleConf
+      .createWithDefault(0.0)
+
+  val OPTIMIZER_CPU_WRITE_COST = conf(
+    "spark.rapids.sql.optimizer.cpuWriteSpeed")
+    .internal()
+    .doc("Cost of writing data to CPU memory")
+    .doubleConf
+    .createWithDefault(0.0)
+
+  val OPTIMIZER_GPU_READ_COST = conf(
+    "spark.rapids.sql.optimizer.gpuReadSpeed")
+    .internal()
+    .doc("Cost of reading data from GPU memory")
+    .doubleConf
+    .createWithDefault(0.0)
+
+  val OPTIMIZER_GPU_WRITE_COST = conf(
+    "spark.rapids.sql.optimizer.gpuWriteSpeed")
+    .internal()
+    .doc("Cost of writing data to GPU memory")
+    .doubleConf
+    .createWithDefault(0.0)
 
   val USE_ARROW_OPT = conf("spark.rapids.arrowCopyOptimizationEnabled")
     .doc("Option to turn off using the optimized Arrow copy code when reading from " +
@@ -1506,13 +1532,21 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val defaultRowCount: Long = get(OPTIMIZER_DEFAULT_ROW_COUNT)
 
-  lazy val defaultOperatorCost: Double = get(OPTIMIZER_DEFAULT_GPU_OPERATOR_COST)
+  lazy val defaultCpuOperatorCost: Double = get(OPTIMIZER_DEFAULT_CPU_OPERATOR_COST)
 
-  lazy val defaultExpressionCost: Double = get(OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST)
+  lazy val defaultCpuExpressionCost: Double = get(OPTIMIZER_DEFAULT_CPU_EXPRESSION_COST)
 
-  lazy val defaultTransitionToCpuCost: Double = get(OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST)
+  lazy val defaultGpuOperatorCost: Double = get(OPTIMIZER_DEFAULT_GPU_OPERATOR_COST)
 
-  lazy val defaultTransitionToGpuCost: Double = get(OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST)
+  lazy val defaultGpuExpressionCost: Double = get(OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST)
+
+  lazy val cpuReadMemoryCost: Double = get(OPTIMIZER_CPU_READ_COST)
+
+  lazy val cpuWriteMemoryCost: Double = get(OPTIMIZER_CPU_WRITE_COST)
+
+  lazy val gpuReadMemoryCost: Double = get(OPTIMIZER_GPU_READ_COST)
+
+  lazy val gpuWriteMemoryCost: Double = get(OPTIMIZER_GPU_WRITE_COST)
 
   lazy val getAlluxioPathsToReplace: Option[Seq[String]] = get(ALLUXIO_PATHS_REPLACE)
 
@@ -1534,7 +1568,7 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
    */
   def getGpuExpressionCost(operatorName: String): Option[Double] = {
     val key = s"spark.rapids.sql.optimizer.gpu.expr.$operatorName"
-    conf.get(key).map(toDouble(_, key))
+    getOptionalCost(key)
   }
 
   /**
@@ -1542,7 +1576,7 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
    */
   def getGpuOperatorCost(operatorName: String): Option[Double] = {
     val key = s"spark.rapids.sql.optimizer.gpu.exec.$operatorName"
-    conf.get(key).map(toDouble(_, key))
+    getOptionalCost(key)
   }
 
   /**
@@ -1550,7 +1584,7 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
    */
   def getCpuExpressionCost(operatorName: String): Option[Double] = {
     val key = s"spark.rapids.sql.optimizer.cpu.expr.$operatorName"
-    conf.get(key).map(toDouble(_, key))
+    getOptionalCost(key)
   }
 
   /**
@@ -1558,6 +1592,10 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
    */
   def getCpuOperatorCost(operatorName: String): Option[Double] = {
     val key = s"spark.rapids.sql.optimizer.cpu.exec.$operatorName"
+    getOptionalCost(key)
+  }
+
+  private def getOptionalCost(key: String) = {
     conf.get(key).map(toDouble(_, key))
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -65,8 +65,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(TRANSITION_TO_CPU_COST, "0.3")
-        .set(TRANSITION_TO_GPU_COST, "0.3")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
@@ -270,8 +268,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Avoid move to GPU for trivial projection, AQE on") {
     logError("Avoid move to GPU for trivial projection, AQE on")
     val conf = new SparkConf()
-        .set(TRANSITION_TO_CPU_COST, "0.1")
-        .set(TRANSITION_TO_GPU_COST, "0.1")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -375,8 +371,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Avoid move to GPU for shuffle, AQE off") {
     logError("Avoid move to GPU for shuffle, AQE off")
     val conf = new SparkConf()
-        .set(TRANSITION_TO_CPU_COST, "0.1")
-        .set(TRANSITION_TO_GPU_COST, "0.1")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -32,6 +32,12 @@ import org.apache.spark.sql.types.DataTypes
 
 class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndAfter with Logging {
 
+  // these tests currently rely on setting expensive transitions to force desired outcomes
+  // and were written before we had the concept of memory access costs, so for now we use these
+  // config keys to set an explicit cost for these transitions
+  private val TRANSITION_TO_GPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuRowToColumnarExec"
+  private val TRANSITION_TO_CPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuColumnarToRowExec"
+
   before {
     GpuOverrides.removeAllListeners()
   }
@@ -48,8 +54,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.3")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.3")
+        .set(TRANSITION_TO_CPU_COST, "0.3")
+        .set(TRANSITION_TO_GPU_COST, "0.3")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
@@ -105,8 +111,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.15")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.15")
+        .set(TRANSITION_TO_CPU_COST, "0.15")
+        .set(TRANSITION_TO_GPU_COST, "0.15")
+        .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
+        .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
+        .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
+        .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
@@ -162,8 +172,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.3")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.3")
+        .set(TRANSITION_TO_CPU_COST, "0.3")
+        .set(TRANSITION_TO_GPU_COST, "0.3")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -206,8 +216,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0.15")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0.15")
+        .set(TRANSITION_TO_CPU_COST, "0.15")
+        .set(TRANSITION_TO_GPU_COST, "0.15")
+        .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
+        .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
+        .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
+        .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
         .set(RapidsConf.EXPLAIN.key, "ALL")
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -245,6 +259,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
   test("Avoid move to GPU for trivial projection, AQE on") {
     logError("Avoid move to GPU for trivial projection, AQE on")
     val conf = new SparkConf()
+        .set(TRANSITION_TO_CPU_COST, "0.1")
+        .set(TRANSITION_TO_GPU_COST, "0.1")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -278,6 +294,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
   test("Avoid move to GPU for trivial projection, AQE off") {
     logError("Avoid move to GPU for trivial projection, AQE off")
     val conf = new SparkConf()
+        .set(TRANSITION_TO_CPU_COST, "0.1")
+        .set(TRANSITION_TO_GPU_COST, "0.1")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -346,6 +364,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
   test("Avoid move to GPU for shuffle, AQE off") {
     logError("Avoid move to GPU for shuffle, AQE off")
     val conf = new SparkConf()
+        .set(TRANSITION_TO_CPU_COST, "0.1")
+        .set(TRANSITION_TO_GPU_COST, "0.1")
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -378,9 +398,9 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite with BeforeAndA
         .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
         .set(RapidsConf.OPTIMIZER_EXPLAIN.key, "ALL")
         .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_CPU_COST.key, "0")
-        .set(RapidsConf.OPTIMIZER_DEFAULT_TRANSITION_TO_GPU_COST.key, "0")
-        .set("spark.rapids.sql.optimizer.exec.CustomShuffleReaderExec", "99999999")
+        .set(TRANSITION_TO_CPU_COST, "0")
+        .set(TRANSITION_TO_GPU_COST, "0")
+        .set("spark.rapids.sql.optimizer.gpu.exec.GpuCustomShuffleReaderExec", "99999999")
         .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
           "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
               "RoundRobinPartitioning")


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR starts to introduce the mechansim for including memory access costs in the cost model. The default settings are 320 GB/s for GPU and 30 GB/s for CPU.

This also contains a fix for a bug that was highlighted during testing where CBO could move a BroadcastExchange back to CPU but leave the BHJ on GPU, resulting in an invalid plan.