### PR TITLE
Provide optional pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repos:
+  - repo: local
+    hooks:
+      - id: auto-copyrighter
+        name: Update copyright year
+        entry: scripts/auto-copyrighter.sh
+        language: script
+        pass_filenames: true
+        verbose: true
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,15 @@ Please visit the [testing doc](tests/README.md) for details about how to run tes
 We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to
 automate some aspects of the development process. As a convenience you can enable automatic 
 copyright year updates by following the installation instructions on the
-[pre-commit homepage](https://pre-commit.com/), and setting the environment variable:
+[pre-commit homepage](https://pre-commit.com/), e.g.: 
+
+```bash
+conda install -c conda-forge pre-commit
+pre-commit install --allow-missing-config
+```
+
+and setting the environment variable:
+
 ```bash
 export SPARK_RAPIDS_AUTO_COPYRIGHTER=ON
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,10 +155,14 @@ Please visit the [testing doc](tests/README.md) for details about how to run tes
 We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to
 automate some aspects of the development process. As a convenience you can enable automatic 
 copyright year updates by following the installation instructions on the
-[pre-commit homepage](https://pre-commit.com/), e.g.: 
+[pre-commit homepage](https://pre-commit.com/).
+
+To this end, first install `pre-commit` itself using the method most suitable for your development
+environment. Then you will need to run `pre-commit install` to enable it in your local git
+repository. Using `--allow-missing-config` will make it easy to work with older branches
+that do not have `.pre-commit-config.yaml`.
 
 ```bash
-conda install -c conda-forge pre-commit
 pre-commit install --allow-missing-config
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,5 +150,15 @@ By making a contribution to this project, I certify that:
 ### Testing Your Code
 Please visit the [testing doc](tests/README.md) for details about how to run tests
 
+
+### Pre-commit hooks
+We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to automate some aspects of the development process. As a convenience you can enable automatic copyright year updates by following the installation instructions on the pre-commit homepage, and setting the envrionment variable:
+
+```bash
+export SPARK_RAPIDS_AUTO_COPYRIGHTER=ON
+```
+
+The default value of `SPARK_RAPIDS_AUTO_COPYRIGHTER` is OFF
+
 ## Attribution
-Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md  
+Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,13 +152,14 @@ Please visit the [testing doc](tests/README.md) for details about how to run tes
 
 
 ### Pre-commit hooks
-We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to automate some aspects of the development process. As a convenience you can enable automatic copyright year updates by following the installation instructions on the pre-commit homepage, and setting the envrionment variable:
-
+We provide a basic config `.pre-commit-config.yaml` for [pre-commit](https://pre-commit.com/) to
+automate some aspects of the development process. As a convenience you can enable automatic 
+copyright year updates by following the installation instructions on the
+[pre-commit homepage](https://pre-commit.com/), and setting the environment variable:
 ```bash
 export SPARK_RAPIDS_AUTO_COPYRIGHTER=ON
 ```
-
-The default value of `SPARK_RAPIDS_AUTO_COPYRIGHTER` is OFF
+The default value of `SPARK_RAPIDS_AUTO_COPYRIGHTER` is `OFF`.
 
 ## Attribution
 Portions adopted from https://github.com/rapidsai/cudf/blob/main/CONTRIBUTING.md, https://github.com/NVIDIA/nvidia-docker/blob/main/CONTRIBUTING.md, and https://github.com/NVIDIA/DALI/blob/main/CONTRIBUTING.md

--- a/scripts/auto-copyrighter.sh
+++ b/scripts/auto-copyrighter.sh
@@ -29,7 +29,6 @@ correspondingly"
     ON)
         ;;
 
-
     *)
         echo "Invalid value of SPARK_RAPIDS_AUTO_COPYRIGHTER=$SPARK_RAPIDS_AUTO_COPYRIGHTER.
         Only ON or OFF are allowed"

--- a/scripts/auto-copyrighter.sh
+++ b/scripts/auto-copyrighter.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+SPARK_RAPIDS_AUTO_COPYRIGHTER=${SPARK_RAPIDS_AUTO_COPYRIGHTER:-OFF}
+
+case "$SPARK_RAPIDS_AUTO_COPYRIGHTER" in
+
+    OFF)
+        echo "Copyright updater is DISABLED. Automatic Copyright Updater can be enabled/disabled by setting \
+SPARK_RAPIDS_AUTO_COPYRIGHTER=ON or SPARK_RAPIDS_AUTO_COPYRIGHTER=OFF, \
+correspondingly"
+        exit 0
+        ;;
+
+    ON)
+        ;;
+
+
+    *)
+        echo "Invalid value of SPARK_RAPIDS_AUTO_COPYRIGHTER=$SPARK_RAPIDS_AUTO_COPYRIGHTER.
+        Only ON or OFF are allowed"
+        exit 1
+        ;;
+esac
+
+set -x
+echo "$@" | xargs -L1 sed -i -E \
+    "s/Copyright *\(c\) *([0-9,-]+)*-([0-9]{4}), *NVIDIA *CORPORATION/Copyright (c) \\1-`date +%Y`, NVIDIA CORPORATION/; /`date +%Y`/! s/Copyright *\(c\) ([0-9]{4}), *NVIDIA *CORPORATION/Copyright (c) \\1-`date +%Y`, NVIDIA CORPORATION/"


### PR DESCRIPTION
Allows to update copyrights automatically by setting the environment
variable `SPARK_RAPIDS_AUTO_COPYRIGHTER=ON`

Fixes #2167 

Signed-off-by: Gera Shegalov <gera@apache.org>