### PR TITLE
Activate databricks 8.2 runtime jar being included in nightly and use property instead of profile

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -21,7 +21,7 @@ set -ex
 
 ## export 'M2DIR' so that shims can get the correct cudf/spark dependency info
 export M2DIR="$WORKSPACE/.m2"
-mvn -U -B -Pinclude-databricks301,spark301tests,snapshot-shims clean deploy $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR \
+mvn -U -B -Dinclude-databricks -Pspark301tests,snapshot-shims clean deploy $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR \
     -Dpytest.TEST_TAGS='' -Dpytest.TEST_TYPE="nightly" -Dcuda.version=$CUDA_CLASSIFIER
 # Run unit tests against other spark versions
 mvn -U -B -Pspark302tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -56,24 +56,10 @@
         </profile>
         <profile>
             <!-- use a separate profile to just pull databricks from maven repository without building it -->
-            <id>include-databricks</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark301-databricks_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark310-databricks_${scala.binary.version}</artifactId>
-                    <version>${project.version}</version>
-                    <scope>compile</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>include-databricks-301</id>
+            <id>include-databricks301</id>
+            <activation>
+                <property><name>include-databricks</name></property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>
@@ -84,7 +70,11 @@
             </dependencies>
         </profile>
         <profile>
-            <id>include-databricks-310</id>
+            <!-- use a separate profile to just pull databricks from maven repository without building it -->
+            <id>include-databricks310</id>
+            <activation>
+                <property><name>include-databricks</name></property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>


### PR DESCRIPTION
All the builds are setup and jars for the new databricks 8.2 runtime are pushed, so now activate including both databricks runtimes in the nightly jar. Also change include-databricks to be a property so we don't duplicate code.

I also had a type in the include-databricks-301.. the final dash shouldn't have been there.

This should be last PR for enabling all the CI for the databricks 8.2 runtime.

fixes https://github.com/NVIDIA/spark-rapids/issues/2390

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
