### PR TITLE
Simplify launching integration tests a pseudo-distributed mode

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -60,6 +60,33 @@ The python tests run with pytest and the script honors pytest parameters. Some h
 - `-r fExXs` Show extra test summary info as specified by chars: (f)ailed, (E)rror, (x)failed, (X)passed, (s)kipped
 - For other options and more details please visit [pytest-usage](https://docs.pytest.org/en/stable/usage.html) or type `pytest --help`
 
+### Spark execution mode
+
+Spark Applications (pytest in this case) can be run against different cluster backends
+specified by the configuration `spark.master`. It can be provided by various means such
+as via `--master` argument of `spark-submit`.
+
+By default, the [local mode](
+https://github.com/apache/spark/blob/1a042cc414c0c720535798b9a1197fe8885d6f6e/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala#L214
+) is used to run the Driver and Executors in the same JVM. Albeit convenient, this mode sometimes
+masks problems occurring in fully distributed production deployments. These are often bugs related
+to object serialization and hash code implementation.
+
+Thus, Apache Spark provides another lightweight way to test applications in the pseudo-distributed
+[local-cluster[numWorkers,coresPerWorker,memoryPerWorker]](
+https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L3025
+) mode where executors are run in separate JVMs on your local machine.
+
+The following environment variables control the behavior in the `run_pyspark_from_build.sh` script
+
+- `NUM_LOCAL_EXECS` if set to a positive integer value activates the `local-cluster` mode
+  and sets the number of workers to `NUM_LOCAL_EXECS`
+- `CORES_PER_EXEC` determines the number of cores per executor if `local-cluster` is activated
+- `MB_PER_EXEC` determines the amount of memory per executor in megabyte if `local-cluster`
+  is activated
+
+### Pytest execution mode
+
 By default the tests try to use the python packages `pytest-xdist` and `findspark` to oversubscribe
 your GPU and run the tests in Spark local mode. This can speed up these tests significantly as all
 of the tests that run by default process relatively small amounts of data. Be careful because if

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -67,14 +67,14 @@ specified by the configuration `spark.master`. It can be provided by various mea
 as via `--master` argument of `spark-submit`.
 
 By default, the [local mode](
-https://github.com/apache/spark/blob/1a042cc414c0c720535798b9a1197fe8885d6f6e/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala#L214
+https://github.com/apache/spark/blob/v3.1.1/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala#L214
 ) is used to run the Driver and Executors in the same JVM. Albeit convenient, this mode sometimes
 masks problems occurring in fully distributed production deployments. These are often bugs related
 to object serialization and hash code implementation.
 
 Thus, Apache Spark provides another lightweight way to test applications in the pseudo-distributed
 [local-cluster[numWorkers,coresPerWorker,memoryPerWorker]](
-https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L3025
+https://github.com/apache/spark/blob/v3.1.1/core/src/main/scala/org/apache/spark/SparkContext.scala#L2993
 ) mode where executors are run in separate JVMs on your local machine.
 
 The following environment variables control the behavior in the `run_pyspark_from_build.sh` script

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -115,6 +115,7 @@ else
           "$@")
 
     export PYSP_TEST_spark_driver_extraClassPath="${ALL_JARS// /:}"
+    export PYSP_TEST_spark_executor_extraClassPath="${ALL_JARS// /:}"
     export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=UTC $COVERAGE_SUBMIT_FLAGS"
     export PYSP_TEST_spark_executor_extraJavaOptions='-ea -Duser.timezone=UTC'
     export PYSP_TEST_spark_ui_showConsoleProgress='false'

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -114,6 +114,14 @@ else
           $RUN_TEST_PARAMS
           "$@")
 
+    NUM_LOCAL_EXECS=${NUM_LOCAL_EXECS:-0}
+    MB_PER_EXEC=${MB_PER_EXEC:-1024}
+    CORES_PER_EXEC=${CORES_PER_EXEC:-1}
+
+    if ((NUM_LOCAL_EXECS > 0)); then
+      export PYSP_TEST_spark_master="local-cluster[$NUM_LOCAL_EXECS,$CORES_PER_EXEC,$MB_PER_EXEC]"
+    fi
+
     export PYSP_TEST_spark_driver_extraClassPath="${ALL_JARS// /:}"
     export PYSP_TEST_spark_executor_extraClassPath="${ALL_JARS// /:}"
     export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=UTC $COVERAGE_SUBMIT_FLAGS"


### PR DESCRIPTION
1. Pre-set executor classpath
2. Easier than full spec of PYSP_TEST_spark_master for local-cluster

Example
```bash
TEST_PARALLEL=4 NUM_LOCAL_EXECS=2 SPARK_HOME=~/dist/spark-3.0.1-bin-hadoop3.2 \
./integration_tests/run_pyspark_from_build.sh -k test_struct_groupby_count
```

Signed-off-by: Gera Shegalov <gera@apache.org>