### PR TITLE
Allow inner joins to fall back to the CPU if the gather map is too large

### DIFF
--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -77,7 +77,8 @@ class GpuBroadcastHashJoinMeta(
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
       condition.map(_.convertToGpu()),
-      left, right)
+      left, right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 }
 
@@ -86,9 +87,10 @@ case class GpuBroadcastHashJoinExec(
     rightKeys: Seq[Expression],
     joinType: JoinType,
     buildSide: GpuBuildSide,
-    override val condition: Option[Expression],
+    condition: Option[Expression],
     left: SparkPlan,
-    right: SparkPlan) extends BinaryExecNode with GpuHashJoin {
+    right: SparkPlan,
+    cpu: CpuJoinInfo) extends BinaryExecNode with GpuHashJoin {
   import GpuMetric._
 
   override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, SortMergeJoinExec}
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin}
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -85,6 +85,7 @@ class GpuSortMergeJoinMeta(
       condition.map(_.convertToGpu()),
       left,
       right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition),
       join.isSkewJoin)
   }
 

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -77,7 +77,8 @@ class GpuBroadcastHashJoinMeta(
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
       condition.map(_.convertToGpu()),
-      left, right)
+      left, right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 }
 
@@ -86,9 +87,10 @@ case class GpuBroadcastHashJoinExec(
     rightKeys: Seq[Expression],
     joinType: JoinType,
     buildSide: GpuBuildSide,
-    override val condition: Option[Expression],
+    condition: Option[Expression],
     left: SparkPlan,
-    right: SparkPlan) extends BinaryExecNode with GpuHashJoin {
+    right: SparkPlan,
+    cpu: CpuJoinInfo) extends BinaryExecNode with GpuHashJoin {
   import GpuMetric._
 
   override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
@@ -58,7 +58,7 @@ class GpuShuffledHashJoinMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val Seq(left, right) = childPlans.map(_.convertIfNeeded)
     GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuSortMergeJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuSortMergeJoinExec.scala
@@ -77,15 +77,16 @@ class GpuSortMergeJoinMeta(
     } else {
       throw new IllegalStateException(s"Cannot build either side for ${join.joinType} join")
     }
-    val Seq(leftChild, rightChild) = childPlans.map(_.convertIfNeeded())
+    val Seq(left, right) = childPlans.map(_.convertIfNeeded())
     GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(buildSide),
       condition.map(_.convertToGpu()),
-      leftChild,
-      rightChild)
+      left,
+      right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 
   /**

--- a/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -77,7 +77,8 @@ class GpuBroadcastHashJoinMeta(
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
       condition.map(_.convertToGpu()),
-      left, right)
+      left, right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 }
 
@@ -86,9 +87,10 @@ case class GpuBroadcastHashJoinExec(
     rightKeys: Seq[Expression],
     joinType: JoinType,
     buildSide: GpuBuildSide,
-    override val condition: Option[Expression],
+    condition: Option[Expression],
     left: SparkPlan,
-    right: SparkPlan) extends BinaryExecNode with GpuHashJoin {
+    right: SparkPlan,
+    cpu: CpuJoinInfo) extends BinaryExecNode with GpuHashJoin {
   import GpuMetric._
 
   override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL

--- a/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuShuffledHashJoinExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin}
 
 object GpuJoinUtils {
   def getGpuBuildSide(buildSide: BuildSide): GpuBuildSide = {
@@ -66,7 +66,8 @@ class GpuShuffledHashJoinMeta(
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
       condition.map(_.convertToGpu()),
       left,
-      right)
+      right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 }
 
@@ -77,10 +78,10 @@ case class GpuShuffledHashJoinExec(
     buildSide: GpuBuildSide,
     override val condition: Option[Expression],
     left: SparkPlan,
-    right: SparkPlan)
+    right: SparkPlan,
+    cpu: CpuJoinInfo)
   extends GpuShuffledHashJoinBase(
     leftKeys,
     rightKeys,
     buildSide,
-    condition,
     isSkewJoin = false)

--- a/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuSortMergeJoinExec.scala
+++ b/shims/spark310db/src/main/scala/com/nvidia/spark/rapids/shims/spark310db/GpuSortMergeJoinExec.scala
@@ -77,15 +77,16 @@ class GpuSortMergeJoinMeta(
     } else {
       throw new IllegalStateException(s"Cannot build either side for ${join.joinType} join")
     }
-    val Seq(leftChild, rightChild) = childPlans.map(_.convertIfNeeded())
+    val Seq(left, right) = childPlans.map(_.convertIfNeeded())
     GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(buildSide),
       condition.map(_.convertToGpu()),
-      leftChild,
-      rightChild)
+      left,
+      right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition))
   }
 
   /**

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{CpuJoinInfo, GpuHashJoin}
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -86,6 +86,7 @@ class GpuSortMergeJoinMeta(
       condition.map(_.convertToGpu()),
       left,
       right,
+      CpuJoinInfo(join.leftKeys, join.rightKeys, join.condition),
       join.isSkewJoin)
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -338,5 +338,13 @@ object GpuColumnarToRowExecParent {
   }
 }
 
+object ColumnarToRowIterator {
+  def simple(iter: Iterator[ColumnarBatch], schema: Seq[Attribute]): Iterator[InternalRow] = {
+    val f = GpuColumnarToRowExecParent.makeIteratorFunc(schema,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    f(iter)
+  }
+}
+
 case class GpuColumnarToRowExec(child: SparkPlan, override val exportColumnarRdd: Boolean = false)
    extends GpuColumnarToRowExecParent(child, exportColumnarRdd)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinBase.scala
@@ -29,7 +29,6 @@ abstract class GpuShuffledHashJoinBase(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
     buildSide: GpuBuildSide,
-    override val condition: Option[Expression],
     val isSkewJoin: Boolean) extends BinaryExecNode with GpuHashJoin {
   import GpuMetric._
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/joins/rapids/CpuSortMergeJoinFallback.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/joins/rapids/CpuSortMergeJoinFallback.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins.rapids
+
+import com.nvidia.spark.rapids.{ColumnarToRowIterator, GpuOutOfCoreSortIterator, RowToColumnarIterator}
+import com.nvidia.spark.rapids.RapidsBuffer.SpillCallback
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, JoinedRow, Predicate, Projection, RowOrdering, SortOrder, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.plans.{InnerLike, JoinType}
+import org.apache.spark.sql.execution.{ExternalAppendOnlyUnsafeRowArray, RowIterator}
+import org.apache.spark.sql.execution.joins.SortMergeJoinScanner
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class CpuSortMergeJoinFallback(
+    val joinType: JoinType,
+    val left: Iterator[ColumnarBatch],
+    val leftSchema: Seq[Attribute],
+    val unboundLeftGpuKeys: Seq[Expression],
+    val unboundLeftCpuKeys: Seq[Expression],
+    val right: Iterator[ColumnarBatch],
+    val rightSchema: Seq[Attribute],
+    val unboundRightGpuKeys: Seq[Expression],
+    val unboundRightCpuKeys: Seq[Expression],
+    val cpuCondition: Option[Expression],
+    val outputSchema: Seq[Attribute],
+    private val targetSize: Long,
+    private val spillThreshold: Int,
+    private val inMemoryThreshold: Int,
+    private val spillCallback: SpillCallback,
+    private val cleanupResources: () => Unit) extends Iterator[ColumnarBatch] {
+
+  private val leftGpuOrder = unboundLeftGpuKeys.map(SortOrder(_, Ascending))
+  private val sortedLeft = GpuOutOfCoreSortIterator.simple(left, leftGpuOrder, leftSchema,
+    targetSize, spillCallback)
+  // This is an ugly hack to avoid data not being spillable when we fall back
+  sortedLeft.firstPassReadBatches()
+  private val sortedRowLeft = ColumnarToRowIterator.simple(sortedLeft, leftSchema)
+
+  private val rightGpuOrder = unboundRightGpuKeys.map(SortOrder(_, Ascending))
+  private val sortedRight = GpuOutOfCoreSortIterator.simple(right, rightGpuOrder, rightSchema,
+    targetSize, spillCallback)
+  // This is an ugly hack to avoid data not being spillable when we fall back
+  sortedRight.firstPassReadBatches()
+  private val sortedRowRight = ColumnarToRowIterator.simple(sortedRight, rightSchema)
+
+  private def createLeftKeyGenerator(): Projection =
+    UnsafeProjection.create(unboundLeftCpuKeys, leftSchema)
+
+  private def createRightKeyGenerator(): Projection =
+    UnsafeProjection.create(unboundRightCpuKeys, rightSchema)
+
+  private val cpuJoined = {
+    // Most of this code is copied an pasted from SortMergeJoinExec.doExecute in Apache Spark
+    // This code should go away once we can do a better join with exploding joins on the GPU
+    val boundCondition: (InternalRow) => Boolean = {
+      cpuCondition.map { cond =>
+        Predicate.create(cond, leftSchema ++ rightSchema).eval _
+      }.getOrElse {
+        (r: InternalRow) => true
+      }
+    }
+
+    // An ordering that can be used to compare keys from both sides.
+    val keyOrdering = RowOrdering.createNaturalAscendingOrdering(unboundLeftCpuKeys.map(_.dataType))
+    val resultProj: InternalRow => InternalRow = UnsafeProjection.create(outputSchema, outputSchema)
+
+    joinType match {
+      case _: InnerLike =>
+        new RowIterator {
+          private[this] var currentLeftRow: InternalRow = _
+          private[this] var currentRightMatches: ExternalAppendOnlyUnsafeRowArray = _
+          private[this] var rightMatchesIterator: Iterator[UnsafeRow] = null
+          private[this] val smjScanner = new SortMergeJoinScanner(
+            createLeftKeyGenerator(),
+            createRightKeyGenerator(),
+            keyOrdering,
+            RowIterator.fromScala(sortedRowLeft),
+            RowIterator.fromScala(sortedRowRight),
+            inMemoryThreshold,
+            spillThreshold,
+            cleanupResources
+          )
+          private[this] val joinRow = new JoinedRow
+
+          if (smjScanner.findNextInnerJoinRows()) {
+            currentRightMatches = smjScanner.getBufferedMatches
+            currentLeftRow = smjScanner.getStreamedRow
+            rightMatchesIterator = currentRightMatches.generateIterator()
+          }
+
+          override def advanceNext(): Boolean = {
+            while (rightMatchesIterator != null) {
+              if (!rightMatchesIterator.hasNext) {
+                if (smjScanner.findNextInnerJoinRows()) {
+                  currentRightMatches = smjScanner.getBufferedMatches
+                  currentLeftRow = smjScanner.getStreamedRow
+                  rightMatchesIterator = currentRightMatches.generateIterator()
+                } else {
+                  currentRightMatches = null
+                  currentLeftRow = null
+                  rightMatchesIterator = null
+                  return false
+                }
+              }
+              joinRow(currentLeftRow, rightMatchesIterator.next())
+              if (boundCondition(joinRow)) {
+                return true
+              }
+            }
+            false
+          }
+
+          override def getRow: InternalRow = resultProj(joinRow)
+        }.toScala
+      case x =>
+        throw new IllegalArgumentException(
+          s"SortMergeJoin should not take $x as the JoinType")
+    }
+  }
+
+  private val finalResult = RowToColumnarIterator.simple(cpuJoined, outputSchema, targetSize)
+
+  override def hasNext: Boolean = finalResult.hasNext
+
+  override def next(): ColumnarBatch = finalResult.next()
+}
+
+object CpuSortMergeJoinFallback {
+  def fallbackFunc(
+      joinType: JoinType,
+      leftSchema: Seq[Attribute],
+      unboundLeftGpuKeys: Seq[Expression],
+      unboundLeftCpuKeys: Seq[Expression],
+      rightSchema: Seq[Attribute],
+      unboundRightGpuKeys: Seq[Expression],
+      unboundRightCpuKeys: Seq[Expression],
+      cpuCondition: Option[Expression],
+      outputSchema: Seq[Attribute],
+      targetSize: Long,
+      spillThreshold: Int,
+      inMemoryThreshold: Int,
+      spillCallback: SpillCallback,
+      cleanupResources: () => Unit):
+  (Iterator[ColumnarBatch], Iterator[ColumnarBatch]) => Iterator[ColumnarBatch] = {
+    def doIt(left: Iterator[ColumnarBatch],
+        right: Iterator[ColumnarBatch]): Iterator[ColumnarBatch] = {
+      new CpuSortMergeJoinFallback(joinType,
+        left, leftSchema, unboundLeftGpuKeys, unboundLeftCpuKeys,
+        right, rightSchema, unboundRightGpuKeys, unboundRightCpuKeys,
+        cpuCondition, outputSchema, targetSize, spillThreshold, inMemoryThreshold,
+        spillCallback, cleanupResources)
+    }
+    doIt
+  }
+}


### PR DESCRIPTION
This is a stop gap until #2408 can be implemented.  This is primarily to help get NDS query 72 to not crash because the join explodes.  This code runs and I have manually tested it on NDS Query 72 at scale factor 200, but I have not written any automated tests for it. Hopefully #2408 comes quickly and we can rip all of this out and put in better tests, but if people really want me to add in some kind of test for this I can, but it will likely involve putting in a special config for testing that will cause inner joins to throw an OutOfMemoryError to trigger the fallback.

The metrics are not perfect when this falls back to the CPU. Again if people want me to get the metrics to work well I can do it, but it will take a little time. The join output rows metric, however, is not something that I will be able to make work the same as on the GPU code and probably will go away once we have AST joins working once cudf supports it.

The performance of this is not great.  For NDS query 72 scale factor 200 on Spark 3.0.2 I was able to run it end to end on the CPU in 14 mins (12 cores). The same query on the GPU would crash before this, but after this it now takes between 38 mins and an hour depending on how you configure batch size, temperature of the GPU,.... The slower runs are due to spilling on larger batch sizes because I had all 12 cores enabled.  Another part of the reason for this is that this patch does not use code generation for the join.  Spark supports it for this use case, but we do not because of the added complexity involved. To put that in perspective I was able to run the rest of NDS at scale factor 200 on the GPU in under 35 mins.