### PR TITLE
Ignore group order in test_struct_groupby_count

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -617,6 +617,7 @@ def test_subquery_in_agg(adaptive, expr):
             ('ab', IntegerGen(min_val=5, max_val=9)),
         ]))], nullable=False),
 ], ids=idfn)
+@ignore_order(local=True)
 def test_struct_groupby_count(key_data_gen):
     def group_by_count(spark):
         df = two_col_df(spark, key_data_gen, IntegerGen())


### PR DESCRIPTION
Contributes to #2406.

Signed-off-by: Gera Shegalov <gera@apache.org>