### PR TITLE
Change Databricks zone [skip ci]

### DIFF
--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -33,7 +33,7 @@ class ClusterUtils(object):
         templ['spark_version'] = runtime
         if (cloud_provider == 'aws'):
             templ['aws_attributes'] = {
-                        "zone_id": "us-west-2a",
+                        "zone_id": "us-west-2c",
                         "first_on_demand": 1,
                         "availability": "SPOT_WITH_FALLBACK",
                         "spot_bid_price_percent": 100,


### PR DESCRIPTION
Change Databricks zone to `us-west-2c`, as these are not sufficient g4dn.2xlarge capacity in the Zone us-west-2a.

If we set the zone_id to `us-west-2a`,  it reports below error during creating DB clusters, saying not g4dn.2xlarge resource available.

This should be DB service provider issue, guess it reduced or removed the 2xlarge instances in .`us-west-2a`

Don't know how to check how many GPU instances in every zone, but found only zone `us-west-2c` has sufficient `2xlarge` instance.

`We currently do not have sufficient g4dn.2xlarge capacity in the Availability Zone you requested (us-west-2a). Our system will be working on provisioning additional capacity. You can currently get g4dn.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-west-2b, us-west-2c`

Signed-off-by: Tim Liu <timl@nvidia.com>