### PR TITLE
Switch to single-level structs in hash aggregate tests and work around value-dedupe bug 

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -605,6 +605,7 @@ def test_subquery_in_agg(adaptive, expr):
         conf = {"spark.sql.adaptive.enabled" : adaptive})
 
 
+# TODO support multi-level structs https://github.com/NVIDIA/spark-rapids/issues/2438
 def assert_single_level_struct(df):
     first_level_dt = df.schema['a'].dataType
     second_level_dt = first_level_dt['aa'].dataType


### PR DESCRIPTION
Closes #2428. Due to a subtle difference between the single-column
gen_df and two_col_df copy-and-pasting of the StructGen between tests
introduced testing of double-nestedd structs in single-column tests
using gen_df. 

Workaround https://github.com/apache/spark/pull/31778
    
Signed-off-by: Gera Shegalov <gera@apache.org>