### PR TITLE
fix GpuCreateNamedStruct not serializable issue

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -89,6 +89,18 @@ object GpuExpressionsUtils extends Arm {
    */
   def columnarEvalToColumn(expr: Expression, batch: ColumnarBatch): GpuColumnVector =
     resolveColumnVector(expr.columnarEval(batch), batch.numRows, expr.dataType)
+
+  /**
+   * Extract the GpuLiteral
+   * @param exp the input expression to be extracted
+   * @return an optional GpuLiteral
+   */
+  @scala.annotation.tailrec
+  def extractGpuLit(exp: Expression): Option[GpuLiteral] = exp match {
+    case gl: GpuLiteral => Some(gl)
+    case ga: GpuAlias => extractGpuLit(ga.child)
+    case _ => None
+  }
 }
 
 /**

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{ColumnVector, DType}
-import com.nvidia.spark.rapids.{GpuAlias, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuLiteral}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -94,10 +94,11 @@ case class GpuCreateNamedStruct(children: Seq[Expression]) extends GpuExpression
   // And on the other hand, the calling for columnarEval(null) in the driver side is
   // dangerous for GpuExpressions, we'll have to pull it apart manually.
   private lazy val names = nameExprs.map {
-    case gl: GpuLiteral => gl.value
-    case GpuAlias(gl: GpuLiteral, _) => gl.value
     case ge: GpuExpression =>
-      throw new IllegalStateException(s"Unexpected GPU expression $ge")
+      GpuExpressionsUtils.extractGpuLit(ge) match {
+        case Some(gpuLiteral) => gpuLiteral.value
+        case None => throw new IllegalStateException(s"Unexpected GPU expression $ge")
+      }
     case e => e.eval(EmptyRow)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{ColumnVector, DType}
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuScalar}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
@@ -88,7 +88,13 @@ case class GpuCreateNamedStruct(children: Seq[Expression]) extends GpuExpression
   }.toList.unzip
 
   private lazy val names = nameExprs.map {
-    case g: GpuExpression => g.columnarEval(null)
+    case g: GpuExpression =>
+      val ret = g.columnarEval(null)
+      if (ret.isInstanceOf[GpuScalar]) {
+        ret.asInstanceOf[GpuScalar].getValue
+      } else {
+        ret
+      }
     case e => e.eval(EmptyRow)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -95,10 +95,8 @@ case class GpuCreateNamedStruct(children: Seq[Expression]) extends GpuExpression
   // dangerous for GpuExpressions, we'll have to pull it apart manually.
   private lazy val names = nameExprs.map {
     case ge: GpuExpression =>
-      GpuExpressionsUtils.extractGpuLit(ge) match {
-        case Some(gpuLiteral) => gpuLiteral.value
-        case None => throw new IllegalStateException(s"Unexpected GPU expression $ge")
-      }
+      GpuExpressionsUtils.extractGpuLit(ge).map(_.value)
+        .getOrElse(throw new IllegalStateException(s"Unexpected GPU expression $ge"))
     case e => e.eval(EmptyRow)
   }
 


### PR DESCRIPTION
The return from columnarEval of GpuLiteral has been changed to GpuScalar which
will be as the type of names(a private field in GpuCreateNamedStruct). And the
names will be serialized before spark scheduling, but the GpuScalar is not serializable,
it will cause "org.apache.spark.SparkException: Task not serializable".

On the other hand, the calling `columnarEval(null)` in the driver side is really dangerous,
This PR also pull it apart manually

Signed-off-by: Bobby Wang <wbo4958@gmail.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/2427
Closes  https://github.com/NVIDIA/spark-rapids/issues/2443
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
