### PR TITLE
support creating list ColumnVector for Literal(ArrayType(NullType))

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -54,6 +54,7 @@ def test_make_array(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
+                'array(null)',
                 'array(a, b)',
                 'array(b, a, null, {}, {})'.format(s1, s2)))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -176,8 +176,8 @@ object GpuScalar extends Arm with Logging {
         val colType = resolveElementType(elementType)
         val rows = seq.map(convertElementTo(_, elementType))
         ColumnVector.fromStructs(colType, rows.asInstanceOf[Seq[HostColumnVector.StructData]]: _*)
-      case NullType => // Byte is used for NullType
-        ColumnVector.fromBoxedBytes(seq.asInstanceOf[Seq[JByte]]: _*)
+      case NullType =>
+        GpuColumnVector.columnVectorFromNull(seq.size, NullType)
       case u =>
         throw new IllegalArgumentException(s"Unsupported element type ($u) to create a" +
           s" ColumnVector.")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -176,6 +176,8 @@ object GpuScalar extends Arm with Logging {
         val colType = resolveElementType(elementType)
         val rows = seq.map(convertElementTo(_, elementType))
         ColumnVector.fromStructs(colType, rows.asInstanceOf[Seq[HostColumnVector.StructData]]: _*)
+      case NullType => // Byte is used for NullType
+        ColumnVector.fromBoxedBytes(seq.asInstanceOf[Seq[JByte]]: _*)
       case u =>
         throw new IllegalArgumentException(s"Unsupported element type ($u) to create a" +
           s" ColumnVector.")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
@@ -61,6 +61,7 @@ class ProjectExprSuite extends SparkQueryCompareTestSuite {
             Array(StructField("id", IntegerType), StructField("name", StringType)))))),
         new Column(Literal.create(List(BigDecimal(123L, 2), BigDecimal(-1444L, 2)),
           ArrayType(DecimalType(10, 2)))))
+        .selectExpr("array(null)", "array(array(null))", "array()")
   }
 
   testSparkResultsAreEqual("project time", frameFromParquet("timestamp-date-test.parquet"),


### PR DESCRIPTION
This PR is bringing back the feature to support creating list ColumnVector for
ArrayType(NullType). 

The previous implementation was a workaround to generate GpuCreateArray
from LiteralExprMeta for ArrayType(NullType) and then create the corresponding
list ColumnVector in GpuCreateArray. 

This PR just implement the logic based on the feature GpuLiteral for array
instead of GpuCreateArray.

Signed-off-by: Bobby Wang <wbo4958@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
