### PR TITLE
Add code for generating dot file visualizations

### DIFF
--- a/rapids-4-spark-tools/pom.xml
+++ b/rapids-4-spark-tools/pom.xml
@@ -132,7 +132,7 @@
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.apache.spark.sql.rapids.tool.profiling.ProfileMain</mainClass>
+                                    <mainClass>com.nvidia.spark.rapids.tool.profiling.ProfileMain</mainClass>
                                 </transformer>
                             </transformers>
                             <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -46,7 +46,6 @@ object GenerateDot {
    * @param plan First query plan and metrics
    * @param comparisonPlan Optional second query plan and metrics
    * @param filename Filename to write dot graph to
-   * @param includeCodegen Include WholeStageCodegen and InputAdapter nodes, if true
    */
   def generateDotGraph(
       plan: QueryPlanWithMetrics,

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -34,11 +34,11 @@ object GenerateDot {
    * @param includeCodegen Include WholeStageCodegen and InputAdapter nodes, if true
    */
   def generateDotGraph(
-                        plan: QueryPlanWithMetrics,
-                        comparisonPlan: Option[QueryPlanWithMetrics],
-                        dir: File,
-                        filename: String,
-                        includeCodegen: Boolean): Unit = {
+      plan: QueryPlanWithMetrics,
+      comparisonPlan: Option[QueryPlanWithMetrics],
+      dir: File,
+      filename: String,
+      includeCodegen: Boolean): Unit = {
 
     var nextId = 1
 
@@ -82,10 +82,10 @@ object GenerateDot {
 
     /** Recursively graph the operator nodes in the spark plan */
     def writeGraph(
-                    w: FileWriter,
-                    node: QueryPlanWithMetrics,
-                    comparisonNode: QueryPlanWithMetrics,
-                    id: Int = 0): Unit = {
+        w: FileWriter,
+        node: QueryPlanWithMetrics,
+        comparisonNode: QueryPlanWithMetrics,
+        id: Int = 0): Unit = {
 
       val nodeNormalized = normalize(node.plan)
       val comparisonNodeNormalized = normalize(comparisonNode.plan)

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -167,7 +167,6 @@ object GenerateDot {
 
     // write the dot graph to a file
     val file = new File(dir, filename)
-    println(s"Writing ${file.getAbsolutePath}")
     val w = new FileWriter(file)
     try {
       w.write("digraph G {\n")

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.{File, FileWriter}

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -1,0 +1,193 @@
+package com.nvidia.spark.rapids.tool.profiling
+
+import java.io.{File, FileWriter}
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.execution.SparkPlanInfo
+import org.apache.spark.sql.execution.metric.SQLMetricInfo
+
+/**
+ * Generate a DOT graph for one query plan, or showing differences between two query plans.
+ *
+ * Diff mode is intended for comparing query plans that are expected to have the same
+ * structure, such as two different runs of the same query but with different tuning options.
+ *
+ * When running in diff mode, any differences in SQL metrics are shown. Also, if the plan
+ * starts to deviate then the graph will show where the plans deviate and will not recurse
+ * further.
+ *
+ * Graphviz and other tools can be used to generate images from DOT files.
+ *
+ * See https://graphviz.org/pdf/dotguide.pdf for a description of DOT files.
+ */
+object GenerateDot {
+  private val GPU_COLOR = "#76b900" // NVIDIA Green
+  private val CPU_COLOR = "#0071c5"
+  private val TRANSITION_COLOR = "red"
+
+  /**
+   * Generate a query plan visualization in dot format.
+   *
+   * @param plan First query plan and metrics
+   * @param comparisonPlan Optional second query plan and metrics
+   * @param filename Filename to write dot graph to
+   * @param includeCodegen Include WholeStageCodegen and InputAdapter nodes, if true
+   */
+  def generateDotGraph(
+                        plan: QueryPlanWithMetrics,
+                        comparisonPlan: Option[QueryPlanWithMetrics],
+                        dir: File,
+                        filename: String,
+                        includeCodegen: Boolean): Unit = {
+
+    var nextId = 1
+
+    def isGpuPlan(plan: SparkPlanInfo): Boolean = {
+      plan.nodeName match {
+        case name if name contains "QueryStage" =>
+          plan.children.isEmpty || isGpuPlan(plan.children.head)
+        case name if name == "ReusedExchange" =>
+          plan.children.isEmpty || isGpuPlan(plan.children.head)
+        case name =>
+          name.startsWith("Gpu")
+      }
+    }
+
+    /**
+     * Optionally remove code-gen nodes.
+     */
+    def normalize(plan: SparkPlanInfo): SparkPlanInfo = {
+      if (!includeCodegen
+        && (plan.nodeName.startsWith("WholeStageCodegen")
+        || plan.nodeName.startsWith("InputAdapter"))) {
+        plan.children.head
+      } else {
+        plan
+      }
+    }
+
+    def formatMetric(m: SQLMetricInfo, value: Long): String = {
+      val formatter = java.text.NumberFormat.getIntegerInstance
+      m.metricType match {
+        case "timing" =>
+          val ms = value
+          s"${formatter.format(ms)} ms"
+        case "nsTiming" =>
+          val ms = TimeUnit.NANOSECONDS.toMillis(value)
+          s"${formatter.format(ms)} ms"
+        case _ =>
+          s"${formatter.format(value)}"
+      }
+    }
+
+    /** Recursively graph the operator nodes in the spark plan */
+    def writeGraph(
+                    w: FileWriter,
+                    node: QueryPlanWithMetrics,
+                    comparisonNode: QueryPlanWithMetrics,
+                    id: Int = 0): Unit = {
+
+      val nodeNormalized = normalize(node.plan)
+      val comparisonNodeNormalized = normalize(comparisonNode.plan)
+      if (nodeNormalized.nodeName == comparisonNodeNormalized.nodeName &&
+        nodeNormalized.children.length == comparisonNodeNormalized.children.length) {
+
+        val metricNames = (nodeNormalized.metrics.map(_.name) ++
+          comparisonNodeNormalized.metrics.map(_.name)).distinct.sorted
+
+        val metrics = metricNames.flatMap(name => {
+          val l = nodeNormalized.metrics.find(_.name == name)
+          val r = comparisonNodeNormalized.metrics.find(_.name == name)
+          if (l.isDefined && r.isDefined) {
+            val metric1 = l.get
+            val metric2 = r.get
+            (node.metrics.get(metric1.accumulatorId),
+              comparisonNode.metrics.get(metric1.accumulatorId)) match {
+              case (Some(value1), Some(value2)) =>
+                if (value1 == value2) {
+                  Some(s"$name: ${formatMetric(metric1, value1)}")
+                } else {
+                  metric1.metricType match {
+                    case "nsTiming" | "timing" =>
+                      val n1 = value1
+                      val n2 = value2
+                      val pct = (n2 - n1) * 100.0 / n1
+                      val pctStr = if (pct < 0) {
+                        f"$pct%.1f"
+                      } else {
+                        f"+$pct%.1f"
+                      }
+                      Some(s"$name: ${formatMetric(metric1, value1)} / " +
+                        s"${formatMetric(metric2, value2)} ($pctStr %)")
+                    case _ =>
+                      Some(s"$name: ${formatMetric(metric1, value1)} / " +
+                        s"${formatMetric(metric2, value2)}")
+                  }
+                }
+              case _ => None
+            }
+          } else {
+            None
+          }
+        }).mkString("\n")
+
+        val color = if (isGpuPlan(nodeNormalized)) { GPU_COLOR } else { CPU_COLOR }
+
+        val label = if (nodeNormalized.nodeName.contains("QueryStage")) {
+          nodeNormalized.simpleString
+        } else {
+          nodeNormalized.nodeName
+        }
+
+        val nodeText =
+          s"""node$id [shape=box,color="$color",style="filled",
+             |label = "$label\n
+             |$metrics"];
+             |""".stripMargin
+
+        w.write(nodeText)
+        nodeNormalized.children.indices.foreach(i => {
+          val childId = nextId
+          nextId += 1
+          writeGraph(
+            w,
+            QueryPlanWithMetrics(nodeNormalized.children(i), node.metrics),
+            QueryPlanWithMetrics(comparisonNodeNormalized.children(i), comparisonNode.metrics),
+            childId);
+
+          val style = (isGpuPlan(nodeNormalized), isGpuPlan(nodeNormalized.children(i))) match {
+            case (true, true) => s"""color="$GPU_COLOR""""
+            case (false, false) => s"""color="$CPU_COLOR""""
+            case _ =>
+              // show emphasis on transitions between CPU and GPU
+              s"color=$TRANSITION_COLOR, style=bold"
+          }
+          w.write(s"node$childId -> node$id [$style];\n")
+        })
+      } else {
+        // plans have diverged - cannot recurse further
+        w.write(
+          s"""node$id [shape=box, color=red,
+             |label = "plans diverge here:
+             |${nodeNormalized.nodeName} vs ${comparisonNodeNormalized.nodeName}"];\n""".stripMargin)
+      }
+    }
+
+    // write the dot graph to a file
+    val file = new File(dir, filename)
+    println(s"Writing ${file.getAbsolutePath}")
+    val w = new FileWriter(file)
+    w.write("digraph G {\n")
+    writeGraph(w, plan, comparisonPlan.getOrElse(plan), 0)
+    w.write("}\n")
+    w.close()
+  }
+}
+
+/**
+ * Query plan with metrics.
+ *
+ * @param plan Query plan.
+ * @param metrics Map of accumulatorId to metric.
+ */
+case class QueryPlanWithMetrics(plan: SparkPlanInfo, metrics: Map[Long, Long])

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -59,5 +59,9 @@ For usage see below:
   val numOutputRows: ScallopOption[Int] =
     opt[Int](required = false,
       descr = "Number of output rows for each Application. Default is 1000")
+  val generateDot: ScallopOption[Boolean] =
+    opt[Boolean](required = false,
+      descr = "Generate query visualizations in DOT format. Default is false")
+
   verify()
 }

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -17,32 +17,41 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.FileWriter
-
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.tool.profiling._
 
 /**
  * A profiling tool to parse Spark Event Log
- * This is the Main function.
  */
 object ProfileMain extends Logging {
+  /**
+   * Entry point from spark-submit running this as the driver.
+   */
   def main(args: Array[String]) {
+    val sparkSession = ProfileUtils.createSparkSession
+    val exitCode = mainInternal(sparkSession, new ProfileArgs(args))
+    if (exitCode != 0) {
+      System.exit(exitCode)
+    }
+  }
+
+  /**
+   * Entry point for tests
+   */
+  def mainInternal(sparkSession: SparkSession, appArgs: ProfileArgs): Int = {
 
     // This tool's output log file name
     val logFileName = "rapids_4_spark_tools_output.log"
 
     // Parsing args
-    val appArgs = new ProfileArgs(args)
     val eventlogPaths = appArgs.eventlog()
     val outputDirectory = appArgs.outputDirectory().stripSuffix("/")
 
     // Create the FileWriter and sparkSession used for ALL Applications.
     val fileWriter = new FileWriter(s"$outputDirectory/$logFileName")
-    val sparkSession = ProfileUtils.createSparkSession
     logInfo(s"Output directory:  $outputDirectory")
 
     // Convert the input path string to Path(s)
@@ -68,9 +77,9 @@ object ProfileMain extends Logging {
       //Exit if there are no applications to process.
       if (apps.isEmpty) {
         logInfo("No application to process. Exiting")
-        System.exit(0)
+        return 0
       }
-      processApps(apps)
+      processApps(apps, generateDot = false)
       // Show the application Id <-> appIndex mapping.
       for (app <- apps) {
         logApplicationInfo(app)
@@ -84,7 +93,7 @@ object ProfileMain extends Logging {
         val app = new ApplicationInfo(appArgs, sparkSession, fileWriter, path, index)
         apps += app
         logApplicationInfo(app)
-        processApps(apps)
+        processApps(apps, appArgs.generateDot())
         app.dropAllTempViews()
         index += 1
       }
@@ -100,7 +109,7 @@ object ProfileMain extends Logging {
      * evaluated at once and the output is one row per application. Else each eventlog is parsed one
      * at a time.
      */
-    def processApps(apps: ArrayBuffer[ApplicationInfo]): Unit = {
+    def processApps(apps: ArrayBuffer[ApplicationInfo], generateDot: Boolean): Unit = {
       if (appArgs.compare()) { // Compare Applications
         logInfo(s"### A. Compare Information Collected ###")
         val compare = new CompareApplications(apps)
@@ -113,6 +122,9 @@ object ProfileMain extends Logging {
         collect.printAppInfo()
         collect.printExecutorInfo()
         collect.printRapidsProperties()
+        if (generateDot) {
+          collect.generateDot()
+        }
       }
 
       logInfo(s"### B. Analysis ###")
@@ -133,5 +145,7 @@ object ProfileMain extends Logging {
       logInfo(s"==============  ${app.appId} (index=${app.index})  ==============")
       logInfo("========================================================================")
     }
+
+    0
   }
 }

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -17,8 +17,10 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.FileWriter
-import scala.collection.mutable.ArrayBuffer
+
 import org.apache.hadoop.fs.Path
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.tool.profiling._

--- a/rapids-4-spark-tools/src/test/resources/log4j.properties
+++ b/rapids-4-spark-tools/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-4-spark-tools/src/test/resources/log4j.properties
+++ b/rapids-4-spark-tools/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2019, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/surefire-reports/scala-test-detailed-output.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+#Just warnings for the console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n

--- a/rapids-4-spark-tools/src/test/resources/log4j.properties
+++ b/rapids-4-spark-tools/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -1,0 +1,83 @@
+package com.nvidia.spark.rapids.tool.profiling
+
+import java.io.{File, FilenameFilter}
+
+import com.google.common.io.Files
+import org.scalatest.FunSuite
+import scala.io.Source
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+
+class GenerateDotSuite extends FunSuite with Logging {
+
+  test("Generate DOT") {
+    val eventLogDir = Files.createTempDir()
+    eventLogDir.deleteOnExit()
+
+    val spark = SparkSession
+      .builder()
+      .master("local[*]")
+      .appName("Rapids Spark Profiling Tool Unit Tests")
+      .config("spark.eventLog.enabled", "true")
+      .config("spark.eventLog.dir", eventLogDir.getAbsolutePath)
+      .getOrCreate()
+
+    // generate some events
+    import spark.implicits._
+    val t1 = Seq((1, 2), (3, 4)).toDF("a", "b")
+    t1.createOrReplaceTempView("t1")
+    val df = spark.sql("SELECT a, MAX(b) FROM t1 GROUP BY a ORDER BY a")
+    df.collect()
+
+    // close the event log
+    spark.close()
+
+    val files = eventLogDir.listFiles(new FilenameFilter {
+      override def accept(file: File, s: String): Boolean = !s.startsWith(".")
+    })
+    assert(files.length === 1)
+
+    // create new session for tool to use
+    val spark2 = SparkSession
+      .builder()
+      .master("local[*]")
+      .appName("Rapids Spark Profiling Tool Unit Tests")
+      .getOrCreate()
+
+    val dotFileDir = Files.createTempDir()
+    dotFileDir.deleteOnExit()
+
+    val appArgs = new ProfileArgs(Array(
+      "--output-directory",
+      dotFileDir.getAbsolutePath,
+      "--generate-dot",
+      files.head.getAbsolutePath
+    ))
+    ProfileMain.mainInternal(spark2, appArgs)
+
+    // assert that a file was generated
+    val dotDirs = listFilesEnding(dotFileDir, "-1")
+    assert(dotDirs.length === 1)
+    val dotFiles = listFilesEnding(dotDirs.head, ".dot")
+    assert(dotFiles.length === 1)
+
+    // assert that the generated file looks something like what we expect
+    val source = Source.fromFile(dotFiles.head)
+    try {
+      val lines = source.getLines().toArray
+      assert(lines.head === "digraph G {")
+      assert(lines.last === "}")
+      assert(lines.count(_.contains("HashAggregate")) === 2)
+    } finally {
+      source.close()
+    }
+  }
+
+  private def listFilesEnding(dir: File, pattern: String): Array[File] = {
+    dir.listFiles(new FilenameFilter {
+      override def accept(file: File, s: String): Boolean = s.endsWith(pattern)
+    })
+  }
+
+}

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.{File, FilenameFilter}

--- a/rapids-4-spark-tools/src/test/scala/org/apache/spark/sql/TrampolineUtil.scala
+++ b/rapids-4-spark-tools/src/test/scala/org/apache/spark/sql/TrampolineUtil.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+object TrampolineUtil {
+  /** Shuts down and cleans up any existing Spark session */
+  def cleanupAnyExistingSession(): Unit = SparkSession.cleanupAnyExistingSession()
+}


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR adds the code for generating query plan visualizations.

This is the code that was originally part of the integration test module and integrated into the benchmarks. There is also a copy of this code in our internal benchmarks repo, and the plan now is to move it back into the open-source repo as part of the profiling and qualification tooling.