### PR TITLE
skip test_window_aggs_for_rows_lead_lag_on_arrays

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -281,6 +281,12 @@ lead_lag_array_data_gens =\
 
 # lead and lag are supported for arrays, but the other window operations like min and max are not right now
 # once they are all supported the tests should be combined.
+@pytest.mark.skip(reason="If some rows of order-by columns (here is a,b,c) are equal, then it may fail because"
+                          "CPU and GPU can't guarantee the order for the same rows, while lead/lag is typically"
+                          "depending on row's order. The solution is we should add the d and d_default columns"
+                          "into the order-by to guarantee the order. But for now, sorting on array has not been"
+                          "supported yet, see https://github.com/NVIDIA/spark-rapids/issues/2470."
+                          "Once the issue is resolved, we should remove skip mark")
 @ignore_order(local=True)
 @pytest.mark.parametrize('d_gen', lead_lag_array_data_gens, ids=meta_idfn('agg:'))
 @pytest.mark.parametrize('c_gen', [long_gen], ids=meta_idfn('orderBy:'))


### PR DESCRIPTION
If some rows of order-by columns (it's `a,b,c` in the test) are equal,
then it may fail because CPU and GPU can't guarantee the order for the
same rows, while lead/lag is typically depending on row's order.

The solution is we should add the aggregation column `d` and the default column
`d_default` columns into the order-by to guarantee the order. But for now,
sorting on array has not been supported yet, see
https://github.com/NVIDIA/spark-rapids/issues/2470.

So this PR just skip the test

Signed-off-by: Bobby Wang <wbo4958@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
