### PR TITLE
Update shuffle documentation for branch-21.06 and UCX 1.10.1

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -64,8 +64,7 @@ The minimum UCX requirement for the RAPIDS Shuffle Manager is
 2. Fetch and install the UCX package for your OS and CUDA version 
    [UCX 1.10.1](https://github.com/openucx/ucx/releases/tag/v1.10.1).
    
-   UCX versions 1.10.1 requires the user to install `libnuma1`. RDMA packages have extra 
-   requirements that should be satisfied by MLNX_OFED.
+   RDMA packages have extra requirements that should be satisfied by MLNX_OFED.
   
    ---
    **NOTE:**
@@ -112,9 +111,9 @@ ARG CUDA_VER=11.0
 FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
 
 RUN apt update
-RUN apt-get install -y wget libnuma1
+RUN apt-get install -y wget 
 RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
-RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
+RUN apt install -y /tmp/*.deb && rm -rf /tmp/*.deb
 ```
 
 ##### With RDMA:
@@ -140,9 +139,9 @@ FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
 COPY --from=rdma_core /*.deb /tmp/
 
 RUN apt update
-RUN apt-get install -y cuda-compat-11-0 wget udev dh-make libnuma1 libudev-dev libnl-3-dev libnl-route-3-dev python3-dev cython3
+RUN apt-get install -y cuda-compat-11-0 wget udev dh-make libudev-dev libnl-3-dev libnl-route-3-dev python3-dev cython3
 RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
-RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
+RUN apt install -y /tmp/*.deb && rm -rf /tmp/*.deb
 ```
    
 ### Validating UCX Environment

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -101,53 +101,49 @@ system if you have RDMA capable hardware.
 Within the Docker container we need to install UCX and its requirements. These are Dockerfile
 examples for Ubuntu 18.04:
 
-1. Without RDMA:   
+##### Without RDMA:   
+The following is an example of a Docker container with UCX 1.10.1 and cuda-11.0 support, built
+for a setup without RDMA capable hardware:
 
-   <a name="ucx-minimal-no-rdma-dockerfile"></a> 
-   The following is an example of a Docker container with UCX 1.10.1 and cuda-11.0 support, built
-   for a setup without RDMA capable hardware:
-   
-   ```
-   ARG CUDA_VER=11.0
-   
-   # Now start the main container
-   FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
-   
-   RUN apt update
-   RUN apt-get install -y wget libnuma1
-   RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
-   RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
-   ```
+```
+ARG CUDA_VER=11.0
 
-2. With RDMA:
+# Now start the main container
+FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
 
-   <a name="ucx-minimal-rdma-dockerfile"></a>
-   The following is an example of a Docker container that shows how to install `rdma-core` and 
-   UCX 1.10.1 with `cuda-11.0` support. You can use this as a base layer for containers that your 
-   executors will use.
-   
-   ```
-   ARG CUDA_VER=11.0
-   
-   # Throw away image to build rdma_core
-   FROM ubuntu:18.04 as rdma_core
-   
-   RUN apt update
-   RUN apt-get install -y dh-make git build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc
-   
-   RUN git clone --depth 1 --branch v33.0 https://github.com/linux-rdma/rdma-core
-   RUN cd rdma-core && debian/rules binary
-   
-   # Now start the main container
-   FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
-   
-   COPY --from=rdma_core /*.deb /tmp/
-   
-   RUN apt update
-   RUN apt-get install -y cuda-compat-11-0 wget udev dh-make libnuma1 libudev-dev libnl-3-dev libnl-route-3-dev python3-dev cython3
-   RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
-   RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
-   ```
+RUN apt update
+RUN apt-get install -y wget libnuma1
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
+RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
+```
+
+##### With RDMA:
+The following is an example of a Docker container that shows how to install `rdma-core` and 
+UCX 1.10.1 with `cuda-11.0` support. You can use this as a base layer for containers that your 
+executors will use.
+
+```
+ARG CUDA_VER=11.0
+
+# Throw away image to build rdma_core
+FROM ubuntu:18.04 as rdma_core
+
+RUN apt update
+RUN apt-get install -y dh-make git build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc
+
+RUN git clone --depth 1 --branch v33.0 https://github.com/linux-rdma/rdma-core
+RUN cd rdma-core && debian/rules binary
+
+# Now start the main container
+FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu18.04
+
+COPY --from=rdma_core /*.deb /tmp/
+
+RUN apt update
+RUN apt-get install -y cuda-compat-11-0 wget udev dh-make libnuma1 libudev-dev libnl-3-dev libnl-route-3-dev python3-dev cython3
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
+RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
+```
    
 ### Validating UCX Environment
 

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -39,7 +39,10 @@ in these scenarios:
 
 In order to enable the RAPIDS Shuffle Manager, UCX user-space libraries and its dependencies must 
 be installed on the host and inside Docker containers (if not baremetal). A host has additional 
-requirements, like the MLNX_OFED driver and `nv_peer_mem` kernel module.
+requirements, like the MLNX_OFED driver and `nv_peer_mem` kernel module. 
+
+The minimum UCX requirement for the RAPIDS Shuffle Manager is 
+[UCX 1.10.1](https://github.com/openucx/ucx/releases/tag/v1.10.1)
 
 #### Baremetal
 
@@ -138,7 +141,7 @@ examples for Ubuntu 18.04:
    
    RUN apt update
    RUN apt-get install -y cuda-compat-11-0 wget udev dh-make libnuma1 libudev-dev libnl-3-dev libnl-route-3-dev python3-dev cython3
-   RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.9.0/ucx-v1.9.0-ubuntu18.04-mofed5.0-1.0.0.0-cuda11.0.deb
+   RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v1.10.1/ucx-v1.10.1-ubuntu18.04-mofed5.x-cuda11.0.deb
    RUN dpkg -i /tmp/*.deb && rm -rf /tmp/*.deb
    ```
    

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -64,6 +64,13 @@ requirements, like the MLNX_OFED driver and `nv_peer_mem` kernel module.
    UCX versions 1.10.1 requires the user to install `libnuma1`. RDMA packages have extra 
    requirements that should be satisfied by MLNX_OFED.
    
+   Please note that the RAPIDS Shuffle Manager is built against 
+   [JUCX 1.11.0](https://search.maven.org/artifact/org.openucx/jucx/1.11.0/jar). This is the JNI
+   component of UCX, and was published ahead of the native library UCX 1.11.0. JUCX 1.11.0 is 
+   actually compatible with UCX starting version 1.10.0. Please disregard the 
+   startup [warning](https://github.com/openucx/ucx/issues/6694) compatibility warning in this case, 
+   as the JUCX usage within the RAPIDS Shuffle Manager is compatible with UCX 1.10.x.
+   
 #### Docker containers
 
 Running with UCX in containers imposes certain requirements. In a multi-GPU system, all GPUs that 

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -66,13 +66,17 @@ The minimum UCX requirement for the RAPIDS Shuffle Manager is
    
    UCX versions 1.10.1 requires the user to install `libnuma1`. RDMA packages have extra 
    requirements that should be satisfied by MLNX_OFED.
+  
+   ---
+   **NOTE:**
    
    Please note that the RAPIDS Shuffle Manager is built against 
    [JUCX 1.11.0](https://search.maven.org/artifact/org.openucx/jucx/1.11.0/jar). This is the JNI
-   component of UCX, and was published ahead of the native library UCX 1.11.0. JUCX 1.11.0 is 
-   actually compatible with UCX starting version 1.10.0. Please disregard the 
-   startup [warning](https://github.com/openucx/ucx/issues/6694) compatibility warning in this case, 
+   component of UCX and was published ahead of the native library (UCX 1.11.0). Please disregard the 
+   startup [compatibility warning](https://github.com/openucx/ucx/issues/6694), 
    as the JUCX usage within the RAPIDS Shuffle Manager is compatible with UCX 1.10.x.
+   
+   ---
    
 #### Docker containers
 


### PR DESCRIPTION
This updates the documentation for the RAPIDS Shuffle Manager for the change to JUCX 1.11.0, and UCX 1.10.1+.

Closes https://github.com/NVIDIA/spark-rapids/issues/2286.