### PR TITLE
Fix for UCP Listener created spark.port.maxRetries times

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -180,16 +180,19 @@ class UCX(executor: BlockManagerId, rapidsConf: RapidsConf) extends AutoCloseabl
           // TODO: remove this once ucx1.11 with random port selection would be released
           1024 + Random.nextInt(65535 - 1024)
         }
-        for (i <- 0 until maxRetries) {
-          val sockAddress = new InetSocketAddress(executor.host, startPort + i)
+        var attempt = 0
+        while (listener.isEmpty && attempt < maxRetries) {
+          val sockAddress = new InetSocketAddress(executor.host, startPort + attempt)
           try {
             ucpListenerParams.setSockAddr(sockAddress)
             listener = Option(worker.newListener(ucpListenerParams))
           } catch {
-            case ex: UcxException =>
-              logDebug(s"Failed to bind UcpListener on $sockAddress")
+            case _: UcxException =>
+              logDebug(s"Failed to bind UcpListener on $sockAddress. " +
+                s"Attempt ${attempt + 1} out of $maxRetries.")
               listener = None
           }
+          attempt += 1
         }
         if (listener.isEmpty) {
           throw new BindException(s"Couldn't start UcpListener " +

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -183,16 +183,16 @@ class UCX(executor: BlockManagerId, rapidsConf: RapidsConf) extends AutoCloseabl
         var attempt = 0
         while (listener.isEmpty && attempt < maxRetries) {
           val sockAddress = new InetSocketAddress(executor.host, startPort + attempt)
+          attempt += 1
           try {
             ucpListenerParams.setSockAddr(sockAddress)
             listener = Option(worker.newListener(ucpListenerParams))
           } catch {
             case _: UcxException =>
               logDebug(s"Failed to bind UcpListener on $sockAddress. " +
-                s"Attempt ${attempt + 1} out of $maxRetries.")
+                s"Attempt $attempt out of $maxRetries.")
               listener = None
           }
-          attempt += 1
         }
         if (listener.isEmpty) {
           throw new BindException(s"Couldn't start UcpListener " +


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/2474

This bug shows when the UCP listener connection method is enabled (this is an internal config, and is disabled by default). It was just connecting up to all the retry attempts, instead of exiting once the listener could bind.