### PR TITLE
Fix the failing test `test_window` on Databricks

### DIFF
--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from conftest import is_at_least_precommit_run, is_databricks_runtime
+from conftest import is_at_least_precommit_run
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
 try:
@@ -275,8 +275,6 @@ def test_sql_group(enable_cudf_udf):
 
 # ======= Test Window In Pandas =======
 @cudf_udf
-@pytest.mark.xfail(condition=is_databricks_runtime(),
-    reason='https://github.com/NVIDIA/spark-rapids/issues/2372')
 def test_window(enable_cudf_udf):
     @pandas_udf("int")
     def _sum_cpu_func(v: pd.Series) -> int:

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
@@ -54,7 +54,7 @@ case class GpuWindowInPandasExec(
     }
   }
 
-  private val outReferences = {
+  private lazy val outReferences = {
     val allExpressions = windowFramesWithExpressions.map(_._2).flatten
     val references = allExpressions.zipWithIndex.map { case (e, i) =>
       // Results of window expressions will be on the right side of child's output

--- a/shims/spark310db/src/main/scala/org/apache/spark/sql/rapids/execution/python/shims/spark310db/GpuWindowInPandasExec.scala
+++ b/shims/spark310db/src/main/scala/org/apache/spark/sql/rapids/execution/python/shims/spark310db/GpuWindowInPandasExec.scala
@@ -64,7 +64,7 @@ case class GpuWindowInPandasExec(
     }
   }
 
-  private val outReferences = {
+  private lazy val outReferences = {
     val allExpressions = windowFramesWithExpressions.map(_._2).flatten
     val references = allExpressions.zipWithIndex.map { case (e, i) =>
       // Results of window expressions will be on the right side of child's output


### PR DESCRIPTION
This small PR is to fix the failing test `test_window` on Databricks by making the `outReference` be lazy.

Because on Databricks, it will get some invalid expressions (e.g.  `none#0L`, `none@1L`.) in the `projectList` if binding the references on the driver side. 

closes https://github.com/NVIDIA/spark-rapids/issues/2372

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
