### PR TITLE
Remove the null replacement in `computePredicate`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -25,21 +25,13 @@ import org.apache.spark.sql.types.{BooleanType, DataType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 abstract class GpuConditionalExpression extends ComplexTypeMergingExpression with GpuExpression {
-  private def computePredicate(
-      batch: ColumnarBatch,
-      predicateExpr: Expression): GpuColumnVector = {
-    predicateExpr.columnarEval(batch) match {
-      case gcv: GpuColumnVector => gcv
-      case _ => throw new IllegalStateException("Predicate result is not a column")
-    }
-  }
 
   protected def computeIfElse(
       batch: ColumnarBatch,
       predicateExpr: Expression,
       trueExpr: Expression,
       falseValues: GpuColumnVector): GpuColumnVector = {
-    withResource(computePredicate(batch, predicateExpr)) { predicate =>
+    withResource(GpuExpressionsUtils.columnarEvalToColumn(predicateExpr, batch)) { predicate =>
       val trueResult: Any = trueExpr.columnarEval(batch)
       try {
         val result = trueResult match {
@@ -63,7 +55,7 @@ abstract class GpuConditionalExpression extends ComplexTypeMergingExpression wit
       predicateExpr: Expression,
       trueExpr: Expression,
       falseValue: Scalar): GpuColumnVector = {
-    withResource(computePredicate(batch, predicateExpr)) { predicate =>
+    withResource(GpuExpressionsUtils.columnarEvalToColumn(predicateExpr, batch)) { predicate =>
       val trueResult: Any = trueExpr.columnarEval(batch)
       try {
         val result = trueResult match {


### PR DESCRIPTION
This small PR is to remove the  null replacement in [GpuConditionalExpression.computePredicate](https://github.com/NVIDIA/spark-rapids/blob/branch-21.06/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala#L38).

Since the issue https://github.com/rapidsai/cudf/issues/3856 mentioned in its comment has been fixed already by the PR https://github.com/rapidsai/cudf/pull/3911.

closes https://github.com/NVIDIA/spark-rapids/issues/2468

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
