### PR TITLE
Fix regression in cost-based optimizer when calculating cost for Window operations

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -262,8 +262,7 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
-    if (MemoryCostHelper.isWindowExpr(expr)) {
-      // Window expressions are Unevaluable and accessing dataType causes an exception
+    if (MemoryCostHelper.isExcludedFromCost(expr)) {
       return 0
     }
 
@@ -312,8 +311,7 @@ class GpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
-    if (MemoryCostHelper.isWindowExpr(expr)) {
-      // Window expressions are Unevaluable and accessing dataType causes an exception
+    if (MemoryCostHelper.isExcludedFromCost(expr)) {
       return 0
     }
 
@@ -360,9 +358,11 @@ object MemoryCostHelper {
     (dataSize / GIGABYTE) / memorySpeed
   }
 
-  def isWindowExpr[INPUT <: Expression](expr: BaseExprMeta[INPUT]) = {
+  def isExcludedFromCost[INPUT <: Expression](expr: BaseExprMeta[INPUT]) = {
     expr.wrapped match {
-      case _: WindowSpecDefinition | _: WindowFrame => true
+      case _: WindowSpecDefinition | _: WindowFrame =>
+        // Window expressions are Unevaluable and accessing dataType causes an exception
+        true
       case _ => false
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, GetStructField}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, GetStructField, WindowFrame, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftAnti, LeftSemi}
 import org.apache.spark.sql.execution.{GlobalLimitExec, LocalLimitExec, SparkPlan, TakeOrderedAndProjectExec, UnionExec}
 import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec}
@@ -262,6 +262,10 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
+    if (MemoryCostHelper.isWindowExpr(expr)) {
+      // Window expressions are Unevaluable and accessing dataType causes an exception
+      return 0
+    }
 
     val memoryReadCost = expr.wrapped match {
       case _: Alias =>
@@ -308,6 +312,10 @@ class GpuCostModel(conf: RapidsConf) extends CostModel {
   }
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
+    if (MemoryCostHelper.isWindowExpr(expr)) {
+      // Window expressions are Unevaluable and accessing dataType causes an exception
+      return 0
+    }
 
     var memoryReadCost = 0d
     var memoryWriteCost = 0d
@@ -350,6 +358,13 @@ object MemoryCostHelper {
    */
   def calculateCost(dataSize: Long, memorySpeed: Double): Double = {
     (dataSize / GIGABYTE) / memorySpeed
+  }
+
+  def isWindowExpr[INPUT <: Expression](expr: BaseExprMeta[INPUT]) = {
+    expr.wrapped match {
+      case _: WindowSpecDefinition | _: WindowFrame => true
+      case _ => false
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -263,7 +263,7 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
     if (MemoryCostHelper.isExcludedFromCost(expr)) {
-      return 0
+      return 0d
     }
 
     val memoryReadCost = expr.wrapped match {
@@ -312,7 +312,7 @@ class GpuCostModel(conf: RapidsConf) extends CostModel {
 
   private def exprCost[INPUT <: Expression](expr: BaseExprMeta[INPUT], rowCount: Double): Double = {
     if (MemoryCostHelper.isExcludedFromCost(expr)) {
-      return 0
+      return 0d
     }
 
     var memoryReadCost = 0d


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/2489