### PR TITLE
Remove temporary logging and adjust test column names

### DIFF
--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -81,7 +81,7 @@ def test_repartition_df(data_gen, num_parts, length):
                 'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
 
 @allow_non_gpu('ShuffleExchangeExec', 'RoundRobinPartitioning')
-@pytest.mark.parametrize('data_gen', [[('a', ArrayGen(string_gen))],
+@pytest.mark.parametrize('data_gen', [[('ag', ArrayGen(string_gen))],
     [('a', StructGen([
       ('a_1', StructGen([
         ('a_1_1', int_gen),
@@ -96,7 +96,7 @@ def test_round_robin_sort_fallback(data_gen):
     from pyspark.sql.functions import lit
     assert_gpu_fallback_collect(
             # Add a computed column to avoid shuffle being optimized back to a CPU shuffle like in test_repartition_df
-            lambda spark : gen_df(spark, data_gen).withColumn('x', lit(1)).repartition(13),
+            lambda spark : gen_df(spark, data_gen).withColumn('extra', lit(1)).repartition(13),
             'ShuffleExchangeExec')
 
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExec.scala
@@ -57,17 +57,12 @@ class GpuShuffleMeta(
     shuffle.outputPartitioning match {
       case _: RoundRobinPartitioning if shuffle.sqlContext.conf.sortBeforeRepartition =>
         val orderableTypes = GpuOverrides.pluginSupportedOrderableSig
-        System.err.println(s"Checking round-robin sort for ${shuffle.output.map(_.dataType)}")
         shuffle.output.map(_.dataType)
             .filterNot(orderableTypes.isSupportedByPlugin(_, conf.decimalTypeEnabled))
             .foreach { dataType =>
-              System.err.println(s"Disallowing $dataType for round-robin partitioning")
               willNotWorkOnGpu(s"round-robin partitioning cannot sort $dataType to run " +
                   s"this on the GPU set ${SQLConf.SORT_BEFORE_REPARTITION.key} to false")
             }
-      case _: RoundRobinPartitioning =>
-        System.err.println(s"Allowing ${shuffle.output.map(_.dataType)} for round-robin " +
-            s"sort-before=${shuffle.sqlContext.conf.sortBeforeRepartition}")
       case _ =>
     }
   }


### PR DESCRIPTION
Fixes #2494.

This removes the debug logging added in #2490.  It also adjusts the column names in `test_round_robin_sort_fallback` to disambiguate the schema from a very similar query being built in `test_repartition_df`.  As seen in the Dataproc test failures, the test that executes just before the one that fails ends up having the same schema, so it's not easy to tell if the test accidentally captured the plan from the previous query.  From the Dataproc test log before this change:
```
06:46:47  integration_tests/src/main/python/repart_test.py::test_repartition_df[4096-2345-[('a', Array(String))]][IGNORE_ORDER({'local': True})] [32mPASSED[0m[33m [ 81%][0m
06:46:47  integration_tests/src/main/python/repart_test.py::test_round_robin_sort_fallback[[('a', Array(String))]][IGNORE_ORDER({'local': True}), ALLOW_NON_GPU(ShuffleExchangeExec,RoundRobinPartitioning)] [31mFAILED[0m[31m [ 81%][0m
```