### PR TITLE
Avoid listener race collecting wrong plan in assert_gpu_fallback_collect

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -29,7 +29,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer}
-import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.{DataFrame, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -320,6 +320,11 @@ object ExecutionPlanCaptureCallback {
     val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(Some(gpuPlan))
     assert(executedPlan.find(didFallBack(_, fallbackCpuClass)).isDefined,
         s"Could not find $fallbackCpuClass in the GPU plan\n$executedPlan")
+  }
+
+  def assertDidFallBack(df: DataFrame, fallbackCpuClass: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    assertDidFallBack(executedPlan, fallbackCpuClass)
   }
 
   private def didFallBack(exp: Expression, fallbackCpuClass: String): Boolean = {


### PR DESCRIPTION
Fixes #2407.

This fixes a race condition in `assert_gpu_fallback_collect` where the event listener callback could accidentally capture the plan from a previous query.  Instead of relying on the racy event callback approach, the executed plan is examined on the original dataframe after the collect has been performed.