### PR TITLE
Not compile RapidsUDF when udf compiler is enabled

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -72,7 +72,7 @@ object GpuScalaUDF {
    * if it does. The lambda wrapper that Spark applies to Java UDFs will be inspected if necessary
    * to locate the user's UDF instance.
    */
-  private def getRapidsUDFInstance(function: AnyRef): Option[RapidsUDF] = {
+  def getRapidsUDFInstance(function: AnyRef): Option[RapidsUDF] = {
     function match {
       case f: RapidsUDF => Some(f)
       case f =>

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
@@ -51,13 +51,8 @@ case class LogicalPlanRules() extends Rule[LogicalPlan] with Logging {
     val conf = new RapidsConf(plan.conf)
     // iterating over NamedExpression
     exp match {
-      case f: ScalaUDF => // found a ScalaUDF
-        // If it implements the RapidsUDF interface, no need to compile it.
-        if (!getRapidsUDFInstance(f.function).isEmpty) {
-          exp
-        } else {
-          GpuScalaUDFLogical(f).compile(conf.isTestEnabled)
-        }
+      case f: ScalaUDF if getRapidsUDFInstance(f.function).isEmpty =>
+        GpuScalaUDFLogical(f).compile(conf.isTestEnabled)
       case _ =>
         if (exp == null) {
           exp

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, ScalaUDF}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.rapids.GpuScalaUDF.getRapidsUDFInstance
 
 class Plugin extends Function1[SparkSessionExtensions, Unit] with Logging {
   override def apply(extensions: SparkSessionExtensions): Unit = {
@@ -52,7 +53,7 @@ case class LogicalPlanRules() extends Rule[LogicalPlan] with Logging {
     exp match {
       case f: ScalaUDF => // found a ScalaUDF
         // If it implements the RapidsUDF interface, no need to compile it.
-        if (f.function.isInstanceOf[RapidsUDF]) {
+        if (!getRapidsUDFInstance(f.function).isEmpty) {
           exp
         } else {
           GpuScalaUDFLogical(f).compile(conf.isTestEnabled)

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.udf
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.RapidsUDF
 import com.nvidia.spark.rapids.RapidsConf
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, ScalaUDF}

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.udf
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.RapidsUDF
 import com.nvidia.spark.rapids.RapidsConf
 
 import org.apache.spark.internal.Logging
@@ -51,6 +50,9 @@ case class LogicalPlanRules() extends Rule[LogicalPlan] with Logging {
     val conf = new RapidsConf(plan.conf)
     // iterating over NamedExpression
     exp match {
+      // Check if this UDF implements RapidsUDF interface. If so, the UDF has already provided a
+      // columnar execution that could run on GPU, then no need to translate it to Catalyst
+      // expressions. If not, compile it.
       case f: ScalaUDF if getRapidsUDFInstance(f.function).isEmpty =>
         GpuScalaUDFLogical(f).compile(conf.isTestEnabled)
       case _ =>

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/Plugin.scala
@@ -17,8 +17,8 @@
 package com.nvidia.spark.udf
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.RapidsUDF
 import com.nvidia.spark.rapids.RapidsConf
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression, ScalaUDF}
@@ -50,7 +50,12 @@ case class LogicalPlanRules() extends Rule[LogicalPlan] with Logging {
     // iterating over NamedExpression
     exp match {
       case f: ScalaUDF => // found a ScalaUDF
-        GpuScalaUDFLogical(f).compile(conf.isTestEnabled)
+        // If it implements the RapidsUDF interface, no need to compile it.
+        if (f.function.isInstanceOf[RapidsUDF]) {
+          exp
+        } else {
+          GpuScalaUDFLogical(f).compile(conf.isTestEnabled)
+        }
       case _ =>
         if (exp == null) {
           exp


### PR DESCRIPTION
To close: https://github.com/NVIDIA/spark-rapids/issues/1712.
Originally, when UDF Compiler is enabled, it will always try to compile the bytecodes for any instance of a ScalaUDF. 
This PR detects if a ScalaUDF implements the RapidsUDF interface. If yes, don't compile its bytecode because user has already provided a columnar evaluation method for the function.

Signed-off-by: Allen Xu <wjxiz1992@gmail.com>

