### PR TITLE
Make GenerateDot test more robust

### DIFF
--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -79,19 +79,23 @@ class GenerateDotSuite extends FunSuite with BeforeAndAfterAll with Logging {
     // assert that a file was generated
     val dotDirs = listFilesMatching(dotFileDir, _.startsWith("local"))
     assert(dotDirs.length === 2)
-    val dotFiles = listFilesMatching(dotDirs.last, _.endsWith(".dot"))
-    assert(dotFiles.length === 1)
 
-    // assert that the generated file looks something like what we expect
-    val source = Source.fromFile(dotFiles.head)
-    try {
-      val lines = source.getLines().toArray
-      assert(lines.head === "digraph G {")
-      assert(lines.last === "}")
-      assert(lines.count(_.contains("HashAggregate")) === 2)
-    } finally {
-      source.close()
+    // assert that the generated files looks something like what we expect
+    var hashAggCount = 0
+    for (dir <- dotDirs) {
+      val dotFiles = listFilesMatching(dir, _.endsWith(".dot"))
+      assert(dotFiles.length === 1)
+      val source = Source.fromFile(dotFiles.head)
+      try {
+        val lines = source.getLines().toArray
+        assert(lines.head === "digraph G {")
+        assert(lines.last === "}")
+        hashAggCount += lines.count(_.contains("HashAggregate"))
+      } finally {
+        source.close()
+      }
     }
+    assert(hashAggCount === 2)
   }
 
   private def listFilesMatching(dir: File, matcher: String => Boolean): Array[File] = {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

The new `Generate DOT` test is failing intermittently:

```
GenerateDotSuite:
- Generate DOT *** FAILED ***
  0 did not equal 2 (GenerateDotSuite.scala:91)
```

The test generates two DOT diagrams and when listing directories an assumption was made about the order of the directories returned from `File.listFiles`. The test now looks at both generated files and asserts on the count of aggregate queries.