### PR TITLE
Remove scaladoc on an internal method to avoid warning during build

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -724,14 +724,10 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
    * @return
    */
   private def convertDecimal64ToDecimal32Wrapper(cv: ColumnVector, precision: Int): ColumnVector = {
-    /**
-     * This method returns a ColumnView that should be copied out to a ColumnVector before closing
-     * the `toClose` views otherwise it will close the returned view and it's children as well.
-     *
-     * @param cv          ColumnView to be checked if it has Decimal32 values stored as Decimal64
-     * @param precision   precision list of all the Decimal columns in this ColumnVector
-     * @param toClose     The ColumnViews to be closed after this method is done. This will also
-     *                    contain the returned view
+    /*
+      'convertDecimal64ToDecimal32' method returns a ColumnView that should be copied out to a
+      ColumnVector  before closing the `toClose` views otherwise it will close the returned view
+      and it's children as well.
      */
     def convertDecimal64ToDecimal32(
        cv: ColumnView,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -725,9 +725,9 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
    */
   private def convertDecimal64ToDecimal32Wrapper(cv: ColumnVector, precision: Int): ColumnVector = {
     /*
-      'convertDecimal64ToDecimal32' method returns a ColumnView that should be copied out to a
-      ColumnVector  before closing the `toClose` views otherwise it will close the returned view
-      and it's children as well.
+     * 'convertDecimal64ToDecimal32' method returns a ColumnView that should be copied out to a
+     * ColumnVector  before closing the `toClose` views otherwise it will close the returned view
+     * and it's children as well.
      */
     def convertDecimal64ToDecimal32(
        cv: ColumnView,


### PR DESCRIPTION
Internal method to a private method doesn't need scaladocs. I have kept the comment as a multi-line comment. 
I couldn't take this function up one level because we created the wrapper just so no one can misuse this function accidentally. 

fixes #2495 


Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
