### PR TITLE
Update spark 312 shim, and Add spark 313-SNAPSHOT shim

### DIFF
--- a/docs/additional-functionality/cache-serializer.md
+++ b/docs/additional-functionality/cache-serializer.md
@@ -47,6 +47,7 @@ nav_order: 2
   | ------ | -----|
   | 3.1.1 | com.nvidia.spark.rapids.shims.spark311.ParquetCachedBatchSerializer |
   | 3.1.2 | com.nvidia.spark.rapids.shims.spark312.ParquetCachedBatchSerializer |
+  | 3.1.3 | com.nvidia.spark.rapids.shims.spark313.ParquetCachedBatchSerializer |
   | 3.2.0 | com.nvidia.spark.rapids.shims.spark320.ParquetCachedBatchSerializer | 
   
 ##          Supported Types                       

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -286,6 +286,7 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.0.3      | com.nvidia.spark.rapids.spark303.RapidsShuffleManager    |
     | 3.1.1      | com.nvidia.spark.rapids.spark311.RapidsShuffleManager    |
     | 3.1.2      | com.nvidia.spark.rapids.spark312.RapidsShuffleManager    |
+    | 3.1.3      | com.nvidia.spark.rapids.spark313.RapidsShuffleManager    |
     | 3.2.0      | com.nvidia.spark.rapids.spark320.RapidsShuffleManager    |
 
 2. Recommended settings for UCX 1.10.1+

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -172,7 +172,7 @@ pipeline {
                         step([$class                : 'JacocoPublisher',
                               execPattern           : '**/target/jacoco.exec',
                               classPattern          : 'target/jacoco_classes/',
-                              sourcePattern         : 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,sql-plugin/src/main/java/,sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,shims/spark312/src/main/scala/',
+                              sourcePattern         : 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,sql-plugin/src/main/java/,sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,shims/spark312/src/main/scala/,shims/spark313/src/main/scala/',
                               sourceInclusionPattern: '**/*.java,**/*.scala'
                         ])
                     }

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -28,6 +28,7 @@ mvn -U -B -Pspark302tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local
 mvn -U -B -Pspark303tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark311tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark312tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
+mvn -U -B -Pspark313tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 # Disabled until Spark 3.2 source incompatibility fixed, see https://github.com/NVIDIA/spark-rapids/issues/2052
 #mvn -U -B -Pspark320tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -46,6 +46,7 @@ env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark302tests,snapshot-shims test 
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark303tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark311tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark312tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
+env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark313tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 # Disabled until Spark 3.2 source incompatibility fixed, see https://github.com/NVIDIA/spark-rapids/issues/2052
 #env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark320tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,15 @@
             </modules>
         </profile>
         <profile>
+            <id>spark313tests</id>
+            <properties>
+                <spark.test.version>${spark313.version}</spark.test.version>
+            </properties>
+            <modules>
+                <module>tests-spark310+</module>
+            </modules>
+        </profile>
+        <profile>
             <id>spark320tests</id>
             <properties>
                 <spark.test.version>${spark320.version}</spark.test.version>
@@ -240,7 +249,8 @@
         <spark303.version>3.0.3-SNAPSHOT</spark303.version>
         <spark311db.version>3.1.1-databricks</spark311db.version>
         <spark311.version>3.1.1</spark311.version>
-        <spark312.version>3.1.2-SNAPSHOT</spark312.version>
+        <spark312.version>3.1.2</spark312.version>
+        <spark313.version>3.1.3-SNAPSHOT</spark313.version>
         <spark320.version>3.2.0-SNAPSHOT</spark320.version>
         <mockito.version>3.6.0</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -109,7 +109,7 @@
                 </dependency>
                 <dependency>
                     <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark312_${scala.binary.version}</artifactId>
+                    <artifactId>rapids-4-spark-shims-spark313_${scala.binary.version}</artifactId>
                     <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
@@ -139,6 +139,12 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark311_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark312_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -57,7 +57,7 @@
             </activation>
             <modules>
                 <module>spark303</module>
-                <module>spark312</module>
+                <module>spark313</module>
             </modules>
         </profile>
     </profiles>
@@ -67,6 +67,7 @@
         <module>spark301</module>
         <module>spark302</module>
         <module>spark311</module>
+        <module>spark312</module>
         <module>aggregator</module>
     </modules>
     <dependencies>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -57,6 +57,7 @@
             </activation>
             <modules>
                 <module>spark303</module>
+                <module>spark312</module>
                 <module>spark313</module>
             </modules>
         </profile>
@@ -67,7 +68,6 @@
         <module>spark301</module>
         <module>spark302</module>
         <module>spark311</module>
-        <module>spark312</module>
         <module>aggregator</module>
     </modules>
     <dependencies>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -57,7 +57,6 @@
             </activation>
             <modules>
                 <module>spark303</module>
-                <module>spark312</module>
                 <module>spark313</module>
             </modules>
         </profile>
@@ -68,6 +67,7 @@
         <module>spark301</module>
         <module>spark302</module>
         <module>spark311</module>
+        <module>spark312</module>
         <module>aggregator</module>
     </modules>
     <dependencies>

--- a/shims/spark313/pom.xml
+++ b/shims/spark313/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nvidia</groupId>
+        <artifactId>rapids-4-spark-shims_2.12</artifactId>
+        <version>21.06.0-SNAPSHOT</version>
+	<relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>rapids-4-spark-shims-spark313_2.12</artifactId>
+    <name>RAPIDS Accelerator for Apache Spark SQL Plugin Spark 3.1.3 Shim</name>
+    <description>The RAPIDS SQL plugin for Apache Spark 3.1.3 Shim</description>
+    <version>21.06.0-SNAPSHOT</version>
+
+    <!-- Set 'spark.version' for the shims layer -->
+    <!-- Create a separate file 'SPARK_VER.properties' in the jar to save cudf & spark version info -->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/extra-resources"/>
+                                <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark312.version}-info.properties">
+                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${cudf.version}"/>
+                                    <arg value="${cuda.version}"/>
+                                    <arg value="${spark312.version}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <resources>
+          <resource>
+            <!-- Include the properties file to provide the build information. -->
+            <directory>${project.build.directory}/extra-resources</directory>
+          </resource>
+          <resource>
+            <directory>src/main/resources</directory>
+          </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark311_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark313.version}</version>
+	    <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/shims/spark313/pom.xml
+++ b/shims/spark313/pom.xml
@@ -43,11 +43,11 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
-                                <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark312.version}-info.properties">
+                                <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark313.version}-info.properties">
                                     <arg value="${user.dir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
-                                    <arg value="${spark312.version}"/>
+                                    <arg value="${spark313.version}"/>
                                 </exec>
                             </target>
                         </configuration>
@@ -78,6 +78,11 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark311_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark312_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/shims/spark313/src/main/resources/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider
+++ b/shims/spark313/src/main/resources/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider
@@ -1,0 +1,1 @@
+com.nvidia.spark.rapids.shims.spark313.SparkShimServiceProvider

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/ParquetCachedBatchSerializer.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/ParquetCachedBatchSerializer.scala
@@ -16,20 +16,7 @@
 
 package com.nvidia.spark.rapids.shims.spark312
 
-import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+import com.nvidia.spark.rapids.shims
 
-object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 1, 2)
-  val VERSIONNAMES = Seq(s"$VERSION")
-}
-
-class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
-
-  def matchesVersion(version: String): Boolean = {
-    SparkShimServiceProvider.VERSIONNAMES.contains(version)
-  }
-
-  def buildShim: SparkShims = {
-    new Spark312Shims()
-  }
+class ParquetCachedBatchSerializer extends shims.spark312.ParquetCachedBatchSerializer {
 }

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/ParquetCachedBatchSerializer.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/ParquetCachedBatchSerializer.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark312
+package com.nvidia.spark.rapids.shims.spark313
 
 import com.nvidia.spark.rapids.shims
 

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
@@ -16,20 +16,15 @@
 
 package com.nvidia.spark.rapids.shims.spark312
 
-import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.shims.spark311.Spark311Shims
+import com.nvidia.spark.rapids.spark312.RapidsShuffleManager
 
-object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 1, 2)
-  val VERSIONNAMES = Seq(s"$VERSION")
-}
+class Spark313Shims extends Spark312Shims {
 
-class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
+  override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
 
-  def matchesVersion(version: String): Boolean = {
-    SparkShimServiceProvider.VERSIONNAMES.contains(version)
-  }
-
-  def buildShim: SparkShims = {
-    new Spark312Shims()
+  override def getRapidsShuffleManagerClass: String = {
+    classOf[RapidsShuffleManager].getCanonicalName
   }
 }

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark312
+package com.nvidia.spark.rapids.shims.spark313
 
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.shims.spark311.Spark311Shims
-import com.nvidia.spark.rapids.spark312.RapidsShuffleManager
+import com.nvidia.spark.rapids.shims.spark312.Spark312Shims
+import com.nvidia.spark.rapids.spark313.RapidsShuffleManager
 
 class Spark313Shims extends Spark312Shims {
 

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimServiceProvider.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimServiceProvider.scala
@@ -30,6 +30,6 @@ class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceP
   }
 
   def buildShim: SparkShims = {
-    new Spark312Shims()
+    new Spark313Shims()
   }
 }

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimServiceProvider.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimServiceProvider.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark312
+package com.nvidia.spark.rapids.shims.spark313
 
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 1, 2)
-  val VERSIONNAMES = Seq(s"$VERSION")
+  val VERSION = SparkShimVersion(3, 1, 3)
+  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/spark313/RapidsShuffleManager.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/spark313/RapidsShuffleManager.scala
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark312
+package com.nvidia.spark.rapids.spark313
 
-import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.rapids.shims.spark311.RapidsShuffleInternalManager
 
-object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 1, 2)
-  val VERSIONNAMES = Seq(s"$VERSION")
-}
-
-class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
-
-  def matchesVersion(version: String): Boolean = {
-    SparkShimServiceProvider.VERSIONNAMES.contains(version)
-  }
-
-  def buildShim: SparkShims = {
-    new Spark312Shims()
-  }
+/** A shuffle manager optimized for the RAPIDS Plugin for Apache Spark. */
+sealed class RapidsShuffleManager(
+    conf: SparkConf,
+    isDriver: Boolean) extends RapidsShuffleInternalManager(conf, isDriver) {
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,7 @@ profiles:
    - `-Pspark303tests` (spark 3.0.3)
    - `-Pspark311tests` (spark 3.1.1)
    - `-Pspark312tests` (spark 3.1.2)
+   - `-Pspark313tests` (spark 3.1.3)
 
 Please refer to the [tests project POM](pom.xml) to see the list of test profiles supported.
 Apache Spark specific configurations can be passed in by setting the `SPARK_CONF` environment


### PR DESCRIPTION
spark 3.1.2-SNAPSHOT has been replaced by 3.1.3-SNAPSHOT, in sonatype snapshot repo,

To bring our build back to work, update 3.1.2 shim dependencies and add spark 3.1.3 shim layer