### PR TITLE
Upload build failure log to Github for external contributors access

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -191,6 +191,12 @@ pipeline {
                 if (currentBuild.currentResult == "SUCCESS") {
                     githubHelper.updateCommitStatus("$BUILD_URL", "Success", GitHubCommitState.SUCCESS)
                 } else {
+                    // upload log only in case of build failure
+                    def guardWords = ["gitlab.*?\\.com", "urm.*?\\.com"]
+                    def logPattern = "### BEGIN OF TEST LOG ###.*### END OF TEST LOG ###"
+
+                    githubHelper.uploadPartialLogs(this, env.JOB_NAME, env.BUILD_NUMBER, null, guardWords, logPattern)
+
                     githubHelper.updateCommitStatus("$BUILD_URL", "Fail", GitHubCommitState.FAILURE)
                 }
 

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -19,6 +19,13 @@ set -ex
 
 nvidia-smi
 
+function on_exit {
+    echo '### END OF TEST LOG ###'
+}
+trap on_exit EXIT
+
+echo '### BEGIN OF TEST LOG ###'
+
 . jenkins/version-def.sh
 
 ARTF_ROOT="$WORKSPACE/.download"


### PR DESCRIPTION
~Please do not merge this PR as it still need more testings.~

The log will be uploaded as one of artifacts on github and can be reached via link of blossom-ci Details in case of build failed