### PR TITLE
Fix cdh shim version in 21.08 [skip ci]

### DIFF
--- a/shims/spark311cdh/pom.xml
+++ b/shims/spark311cdh/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-shims_2.12</artifactId>
-        <version>21.06.0-SNAPSHOT</version>
+        <version>21.08.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>rapids-4-spark-shims-spark311cdh_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark SQL Plugin Spark 3.1.1 Cloudera Shim</name>
     <description>The RAPIDS SQL plugin for Apache Spark 3.1.1 Cloudera Shim</description>
-    <version>21.06.0-SNAPSHOT</version>
+    <version>21.08.0-SNAPSHOT</version>
 
     <!-- Set 'spark.version' for the shims layer -->
     <!-- Create a separate file 'SPARK_VER.properties' in the jar to save cudf & spark version info -->


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

https://github.com/NVIDIA/spark-rapids/pull/2423 merged after branch-21.08 was ready, and got auto-merged into branch-21.08 w/ 21.06-version.
Simple fix to unblock blossom-ci (https://github.com/NVIDIA/spark-rapids/runs/2725861137?check_suite_focus=true)