### PR TITLE
Fixing the merge of 21.06 to 21.08 for comment changes in Profiling tool

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -88,3 +88,13 @@ TESTS_DOC_JARS="-Dsources=${TESTS_FPATH}-sources.jar -Djavadoc=${TESTS_FPATH}-ja
 $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             $TESTS_DOC_JARS \
             -Dfile=$TESTS_FPATH.jar -DpomFile=${TESTS_PL}/pom.xml
+
+###### Deploy profiling tool jar(s) ######
+TOOL_PL=${TOOL_PL:-"rapids-4-spark-tools"}
+TOOL_ART_ID=`mvn help:evaluate -q -pl $TOOL_PL -Dexpression=project.artifactId -DforceStdout`
+TOOL_ART_VER=`mvn help:evaluate -q -pl $TOOL_PL -Dexpression=project.version -DforceStdout`
+TOOL_FPATH="$TOOL_PL/target/$TOOL_ART_ID-$TOOL_ART_VER"
+TOOL_DOC_JARS="-Dsources=${TOOL_FPATH}-sources.jar -Djavadoc=${TOOL_FPATH}-javadoc.jar"
+$DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
+            $TOOL_DOC_JARS \
+            -Dfile=$TOOL_FPATH.jar -DpomFile=${TOOL_PL}/pom.xml

--- a/rapids-4-spark-tools/README.md
+++ b/rapids-4-spark-tools/README.md
@@ -11,7 +11,7 @@ Works with both cpu and gpu generated event logs.
 
 ## How to compile and use with Spark
 1. `mvn clean package`
-2. Include rapids-4-spark-tools-<version>.jar in the '--jars' option to spark-shell or spark-submit
+2. Include rapids-4-spark-tools_2.12-<version>.jar in the '--jars' option to spark-shell or spark-submit
 3. After starting spark-shell:
 For a single event log analysis:
 ```
@@ -26,29 +26,29 @@ com.nvidia.spark.rapids.tool.profiling.ProfileMain.main(Array("/path/to/eventlog
 ## How to compile and use from command-line
 1. `mvn clean package`
 2. `cd $SPARK_HOME (Download Apache Spark if required)`
-3. `./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar /path/to/eventlog1`
+3. `./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar /path/to/eventlog1`
 
 ## Options
 ```
-$ ./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar --help
+$ ./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar --help
 
 Spark event log profiling tool
 
 Example:
 
 # Input 1 or more event logs from local path:
-./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar /path/to/eventlog1 /path/to/eventlog2
+./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar /path/to/eventlog1 /path/to/eventlog2
 
 # If event log is from S3:
 export AWS_ACCESS_KEY_ID=xxx
 export AWS_SECRET_ACCESS_KEY=xxx
-./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar s3a://<BUCKET>/eventlog1 /path/to/eventlog2
+./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar s3a://<BUCKET>/eventlog1 /path/to/eventlog2
 
 # If event log is from hdfs:
-./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar hdfs://<BUCKET>/eventlog1 /path/to/eventlog2
+./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar hdfs://<BUCKET>/eventlog1 /path/to/eventlog2
 
 # Change output directory to /tmp. It outputs as "rapids_4_spark_tools_output.log" in the local directory if the output directory is not specified.
-./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar -o /tmp /path/to/eventlog1
+./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain  <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar -o /tmp /path/to/eventlog1
 
 For usage see below:
   -o, --output-directory  <arg>   Output directory. Default is current directory

--- a/rapids-4-spark-tools/pom.xml
+++ b/rapids-4-spark-tools/pom.xml
@@ -25,7 +25,7 @@
         <version>21.08.0-SNAPSHOT</version>
     </parent>
     <groupId>com.nvidia</groupId>
-    <artifactId>rapids-4-spark-tools</artifactId>
+    <artifactId>rapids-4-spark-tools_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark tools</name>
     <description>RAPIDS Accelerator for Apache Spark tools</description>
     <version>21.08.0-SNAPSHOT</version>
@@ -151,6 +151,10 @@
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
 	    </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/rapids-4-spark-tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -26,19 +26,19 @@ Example:
 
 # Input 1 or more event logs from local path:
 ./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain
-<Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar
+<Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar
  /path/to/eventlog1 /path/to/eventlog2
 
 # If any event log is from S3:
 export AWS_ACCESS_KEY_ID=xxx
 export AWS_SECRET_ACCESS_KEY=xxx
 ./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain
-<Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar
+<Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar
 s3a://<BUCKET>/eventlog1 /path/to/eventlog2
 
 # Change output directory to /tmp
 ./bin/spark-submit --class com.nvidia.spark.rapids.tool.profiling.ProfileMain
- <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools-<version>.jar
+ <Spark-Rapids-Repo>/rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-<version>.jar
  -o /tmp /path/to/eventlog1
 
 For usage see below:

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/QualificationInfoUtils.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/QualificationInfoUtils.scala
@@ -137,10 +137,10 @@ object QualificationInfoUtils extends Logging {
   /*
    * Example command:
    * $SPARK_HOME/bin/spark-submit --master local[1] --driver-memory 30g \
-   * --jars ./rapids-4-spark-tools/target/rapids-4-spark-tools-21.08.0-SNAPSHOT-tests.jar,\
-   *  ./rapids-4-spark-tools/target/rapids-4-spark-tools-21.08.0-SNAPSHOT.jar \
+   * --jars ./rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-21.08.0-SNAPSHOT-tests.jar,\
+   *  ./rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-21.08.0-SNAPSHOT.jar \
    * --class com.nvidia.spark.rapids.tool.profiling.QualificationInfoUtils \
-   * ./rapids-4-spark-tools/target/rapids-4-spark-tools-21.08.0-SNAPSHOT-tests.jar udffunc \
+   * ./rapids-4-spark-tools/target/rapids-4-spark-tools_2.12-21.08.0-SNAPSHOT-tests.jar udffunc \
    * /tmp/testeventlogDir 100001
    */
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
Fixing the merge of 21.06 to 21.08 for comment changes.  Conflict was in QualificationInfoUtils.scala 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
