### PR TITLE
Added nested structs to UnionExec

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -422,7 +422,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS* (unionByName will not optionally impute nulls for missing struct fields  when the column is a struct and there are non-overlapping fields; missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT)</em></td>
+<td><em>PS* (unionByName will not optionally impute nulls for missing struct fields  when the column is a struct and there are non-overlapping fields; missing nested BINARY, CALENDAR, ARRAY, MAP, UDT)</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -21,16 +21,35 @@ from marks import ignore_order, allow_non_gpu
 import pyspark.sql.functions as f
 
 nested_scalar_mark=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/1459")
+# 4 level nested struct
+# each level has a different number of children to avoid a bug in spark < 3.1
+nested_struct = StructGen([
+    ['child0', StructGen([
+        ['child0', StructGen([
+            ['child0', StructGen([
+                ['child0', StructGen([
+                    ['child0', DecimalGen(7, 2)],
+                    ['child1', BooleanGen()],
+                    ['child2', BooleanGen()],
+                    ['child3', BooleanGen()]
+                ])],
+                ['child1', BooleanGen()],
+                ['child2', BooleanGen()]
+            ])],
+            ['child1', BooleanGen()]
+        ])],
+        ['child1', BooleanGen()]
+    ])]])
 @pytest.mark.parametrize('data_gen', [pytest.param((StructGen([['child0', DecimalGen(7, 2)]]),
                                                     StructGen([['child1', IntegerGen()]])), marks=nested_scalar_mark),
-                                      # left_struct(child0 = 4 level nested, child1 = Int)
-                                      # right_struct(child0 = 4 level nested, child1 = missing)
+                                      # left_struct(child0 = 4 level nested struct, child1 = Int)
+                                      # right_struct(child0 = 4 level nested struct, child1 = missing)
                                       (StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
                                                              StructGen([['child0', DecimalGen(7, 2)]])]])]])]])], ['child1', IntegerGen()]], nullable=False),
                                        StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
                                                             StructGen([['child0', DecimalGen(7, 2)]])]])]])]])]], nullable=False)),
-                                      # left_struct(child0 = 4 level nested, child1=missing)
-                                      # right_struct(child0 = missing, child1 = Int)
+                                      # left_struct(child0 = 4 level nested struct, child1=missing)
+                                      # right_struct(child0 = missing struct, child1 = Int)
                                       (StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
                                                              StructGen([['child0', DecimalGen(7, 2)]])]])]])]])]], nullable=False),
                                        StructGen([['child1', IntegerGen()]], nullable=False)),
@@ -46,9 +65,7 @@ def test_union_struct_missing_children(data_gen):
             spark, right_gen), True))
 
 @pytest.mark.parametrize('data_gen', all_gen + [all_basic_struct_gen, StructGen([['child0', DecimalGen(7, 2)]]),
-                                                # 4 level nested struct
-                                                StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
-                                                                                 StructGen([['child0', DecimalGen(7, 2)]])]])]])]])], ['child1', IntegerGen()]])], ids=idfn)
+                                                nested_struct], ids=idfn)
 # This tests union of two DFs of two cols each. The types of the left col and right col is the same
 def test_union(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -56,6 +73,7 @@ def test_union(data_gen):
 
 @pytest.mark.parametrize('data_gen', all_gen + [pytest.param(all_basic_struct_gen, marks=nested_scalar_mark),
                                                 pytest.param(StructGen([[ 'child0', DecimalGen(7, 2)]]), marks=nested_scalar_mark),
+                                                nested_struct,
                                                 StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
                                                                       StructGen([['child0', DecimalGen(7, 2)]])]])]])]])], ['child1', IntegerGen()]])], ids=idfn)
 @pytest.mark.skipif(is_before_spark_311(), reason="This is supported only in Spark 3.1.1+")
@@ -66,7 +84,8 @@ def test_union_by_missing_col_name(data_gen):
         lambda spark : binary_op_df(spark, data_gen).withColumnRenamed("a", "x")
                                 .unionByName(binary_op_df(spark, data_gen).withColumnRenamed("a", "y"), True))
 
-@pytest.mark.parametrize('data_gen', all_gen + [all_basic_struct_gen, StructGen([['child0', DecimalGen(7, 2)]])], ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen + [all_basic_struct_gen, StructGen([['child0', DecimalGen(7, 2)]]),
+                                                nested_struct], ids=idfn)
 def test_union_by_name(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).unionByName(binary_op_df(spark, data_gen)))

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -27,16 +27,13 @@ nested_struct = StructGen([
     ['child0', StructGen([
         ['child0', StructGen([
             ['child0', StructGen([
-                ['child0', StructGen([
-                    ['child0', DecimalGen(7, 2)],
-                    ['child1', BooleanGen()],
-                    ['child2', BooleanGen()],
-                    ['child3', BooleanGen()]
-                ])],
+                ['child0', DecimalGen(7, 2)],
                 ['child1', BooleanGen()],
-                ['child2', BooleanGen()]
+                ['child2', BooleanGen()],
+                ['child3', BooleanGen()]
             ])],
-            ['child1', BooleanGen()]
+            ['child1', BooleanGen()],
+            ['child2', BooleanGen()]
         ])],
         ['child1', BooleanGen()]
     ])]])

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2916,7 +2916,8 @@ object GpuOverrides {
     exec[UnionExec](
       "The backend for the union operator",
       ExecChecks(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL +
-        TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL)
+        TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL
+            + TypeSig.STRUCT)
         .withPsNote(TypeEnum.STRUCT,
           "unionByName will not optionally impute nulls for missing struct fields  " +
           "when the column is a struct and there are non-overlapping fields"), TypeSig.all),


### PR DESCRIPTION
This PR adds nested structs to UnionExec

#### This was tested by
Adding a 4-level nested StructGen to existing tests

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
