### PR TITLE
Change test_single_sort_in_part to print source data frame on failure

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -380,6 +380,15 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True):
     """
     _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first)
 
+def assert_gpu_and_cpu_are_equal_collect_debug(df_fun, result_fun, conf={}, debug=False, is_cpu_first=True):
+    def do_it_all(spark):
+        df = df_fun(spark)
+        if debug:
+            data_gen.debug_df(df)
+        return result_fun(df)
+
+    assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first)
+
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}, is_cpu_first=True):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -380,15 +380,6 @@ def assert_gpu_and_cpu_are_equal_collect(func, conf={}, is_cpu_first=True):
     """
     _assert_gpu_and_cpu_are_equal(func, 'COLLECT', conf=conf, is_cpu_first=is_cpu_first)
 
-def assert_gpu_and_cpu_are_equal_collect_debug(df_fun, result_fun, conf={}, debug=False, is_cpu_first=True):
-    def do_it_all(spark):
-        df = df_fun(spark)
-        if debug:
-            data_gen.debug_df(df)
-        return result_fun(df)
-
-    assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first)
-
 def assert_gpu_and_cpu_are_equal_iterator(func, conf={}, is_cpu_first=True):
     """
     Assert when running func on both the CPU and the GPU that the results are equal.

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -107,11 +107,9 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 def test_single_sort_in_part(data_gen, order):
     # This outputs the source data frame each time to debug intermittent test
     # failures as documented here: https://github.com/NVIDIA/spark-rapids/issues/2477
-    def doit(spark):
-        df = unary_op_df(spark, data_gen)
-        debug_df(df)
-        return df.sortWithinPartitions(order)
-    assert_gpu_and_cpu_are_equal_collect(doit, conf = allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : debug_df(unary_op_df(spark, data_gen)).sortWithinPartitions(order),
+        conf = allow_negative_scale_of_decimal_conf)
 
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen], ids=idfn)
 @pytest.mark.parametrize('order', [

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_collect_debug
+from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
@@ -105,12 +105,11 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
-    assert_gpu_and_cpu_are_equal_collect_debug(
-        lambda spark: unary_op_df(spark, data_gen),
-        lambda df: df.sortWithinPartitions(order),
-        conf = allow_negative_scale_of_decimal_conf,
-        debug = True)
-
+    def doit(spark):
+        df = unary_op_df(spark, data_gen)
+        debug_df(df)
+        return df.sortWithinPartitions(order)
+    assert_gpu_and_cpu_are_equal_collect(doit, conf = allow_negative_scale_of_decimal_conf)
 
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen], ids=idfn)
 @pytest.mark.parametrize('order', [

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -105,6 +105,8 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
+    # This outputs the source data frame each time to debug intermittent test
+    # failures as documented here: https://github.com/NVIDIA/spark-rapids/issues/2477
     def doit(spark):
         df = unary_op_df(spark, data_gen)
         debug_df(df)

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_collect_debug
 from data_gen import *
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
@@ -105,9 +105,11 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
-    assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).sortWithinPartitions(order),
-            conf = allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect_debug(
+        lambda spark: unary_op_df(spark, data_gen),
+        lambda df: df.sortWithinPartitions(order),
+        conf = allow_negative_scale_of_decimal_conf,
+        debug = True)
 
 
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen], ids=idfn)


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Relates #2477. This is an attempt to capture the source data frame when `test_single_sort_in_part` fails. The output prints to stdout, so the pytest framework outputs it after the fact, like so:

```
----------------------------- Captured stdout call -----------------------------
### CPU RUN ###
COLLECTED
[Row(a=-341142443), Row(a=48424546), Row(a=-100515324), Row(a=1752831507), Row(a=-936999309), Row(a=1727289611), Row(a=987119867), Row(a=790204970),...
```

The output happens for both CPU and GPU sessions which is overkill and I can work to make that a single output if we are inclined.

I also made this an explicit single call, but was going down the route of making it for every test function without api changes. I figure for now it's probably best just to capture the output of this flaky test, we can discuss when/how to capture and output the dataframe for every test here or in a follow on.