### PR TITLE
Handle UCX connection timeouts from heartbeats more gracefully

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -737,8 +737,10 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
       peerMgmtPort: Int) = {
     logInfo(s"Connecting to $peerMgmtHost:$peerMgmtPort")
     withResource(new NvtxRange(s"UCX Connect to $peerMgmtHost:$peerMgmtPort", NvtxColor.RED)) { _ =>
-      withResource(new Socket(peerMgmtHost, peerMgmtPort)) { socket =>
+      withResource(new Socket()) { socket =>
         socket.setTcpNoDelay(true)
+        socket.connect(new InetSocketAddress(peerMgmtHost, peerMgmtPort),
+          rapidsConf.shuffleUcxMgmtConnTimeout)
         val os = socket.getOutputStream
         val is = socket.getInputStream
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -999,6 +999,13 @@ object RapidsConf {
     .stringConf
     .createWithDefault(null)
 
+  val SHUFFLE_UCX_MGMT_CONNECTION_TIMEOUT =
+    conf("spark.rapids.shuffle.ucx.managementConnectionTimeout")
+    .doc("The timeout for client connections to a remote peer")
+    .internal()
+    .integerConf
+    .createWithDefault(0)
+
   val SHUFFLE_UCX_BOUNCE_BUFFERS_SIZE = conf("spark.rapids.shuffle.ucx.bounceBuffers.size")
     .doc("The size of bounce buffer to use in bytes. Note that this size will be the same " +
       "for device and host memory")
@@ -1535,6 +1542,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shuffleUcxListenerStartPort: Int = get(SHUFFLE_UCX_LISTENER_START_PORT)
 
   lazy val shuffleUcxMgmtHost: String = get(SHUFFLE_UCX_MGMT_SERVER_HOST)
+
+  lazy val shuffleUcxMgmtConnTimeout: Int = get(SHUFFLE_UCX_MGMT_CONNECTION_TIMEOUT)
 
   lazy val shuffleUcxBounceBuffersSize: Long = get(SHUFFLE_UCX_BOUNCE_BUFFERS_SIZE)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -203,7 +203,23 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
   def getServerId: BlockManagerId = server.fold(blockManager.blockManagerId)(_.getId)
 
   override def addPeer(peer: BlockManagerId): Unit = {
-    transport.foreach(_.connect(peer))
+    transport.foreach { t =>
+      try {
+        t.connect(peer)
+      } catch {
+        case ex: Exception =>
+          // We ignore the exception after logging in this instance because
+          // we may have a peer that doesn't exist anymore by the time `addPeer` is invoked
+          // due to a heartbeat response from the driver, or the peer may have a temporary network
+          // issue.
+          //
+          // This is safe because `addPeer` is only invoked due to a heartbeat that is used to
+          // opportunistically hide cost of initializing transport connections. The transport
+          // will re-try if it must fetch from this executor at a later time, in that case
+          // a connection failure causes the tasks to fail.
+          logError(s"Unable to connect to peer $peer, ignoring!", ex)
+      }
+    }
   }
 
   private val rapidsConf = new RapidsConf(conf)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -217,7 +217,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boole
           // opportunistically hide cost of initializing transport connections. The transport
           // will re-try if it must fetch from this executor at a later time, in that case
           // a connection failure causes the tasks to fail.
-          logError(s"Unable to connect to peer $peer, ignoring!", ex)
+          logWarning(s"Unable to connect to peer $peer, ignoring!", ex)
       }
     }
   }


### PR DESCRIPTION
This patch adds an internal config for the UCX management port connection from the client side. The config defaults to `0`, which was what we were doing before.

If there is a timeout for a connection initiated due to a heartbeat (not due to the act of needing a client to fetch blocks at shuffle time), we log and ignore the exception. There will be a more invasive change in 21.08 to remove such stale executors, but I thought not to add in 21.06 to not add too much risk.

The change also improves the error message to include the `BlockManagerId`. Instead of just:
```
 21/05/27 23:07:11 ERROR RapidsShuffleHeartbeatEndpoint: Error initializing shuffle
 java.net.ConnectException: Connection timed out (Connection timed out)
```