### PR TITLE
Fix package name

### DIFF
--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/TestUtils.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/TestUtils.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.tool.qualification
+package com.nvidia.spark.rapids.tool
 
 import java.io.File
 
-object QualificationTestUtils {
+object TestUtils {
 
   def getTestResourceFile(file: String): File = {
     new File(getClass.getClassLoader.getResource(file).getFile)

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool
 
 import java.io.File
 
-object TestUtils {
+object ToolTestUtils {
 
   def getTestResourceFile(file: String): File = {
     new File(getClass.getClassLoader.getResource(file).getFile)

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids.tool.qualification
 
 import java.io.File
 
-import com.nvidia.spark.rapids.tool.TestUtils
+import com.nvidia.spark.rapids.tool.ToolTestUtils
 import org.scalatest.FunSuite
 
 import org.apache.spark.internal.Logging
@@ -34,8 +34,8 @@ class QualificationSuite extends FunSuite with Logging {
       .getOrCreate()
   }
 
-  private val expRoot = TestUtils.getTestResourceFile("QualificationExpectations")
-  private val logDir = TestUtils.getTestResourcePath("spark-events-qualification")
+  private val expRoot = ToolTestUtils.getTestResourceFile("QualificationExpectations")
+  private val logDir = ToolTestUtils.getTestResourcePath("spark-events-qualification")
 
   private def runQualificationTest(eventLogs: Array[String], expectFileName: String) = {
     Seq(true, false).foreach { hasExecCpu =>

--- a/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/rapids-4-spark-tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.tool.qualification
 
 import java.io.File
 
+import com.nvidia.spark.rapids.tool.TestUtils
 import org.scalatest.FunSuite
 
 import org.apache.spark.internal.Logging
@@ -33,8 +34,8 @@ class QualificationSuite extends FunSuite with Logging {
       .getOrCreate()
   }
 
-  private val expRoot = QualificationTestUtils.getTestResourceFile("QualificationExpectations")
-  private val logDir = QualificationTestUtils.getTestResourcePath("spark-events-qualification")
+  private val expRoot = TestUtils.getTestResourceFile("QualificationExpectations")
+  private val logDir = TestUtils.getTestResourcePath("spark-events-qualification")
 
   private def runQualificationTest(eventLogs: Array[String], expectFileName: String) = {
     Seq(true, false).foreach { hasExecCpu =>


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Package name and directory name were very different for `QualificationTestUtils` and the directory name contained a typo (`orga` instead of `org`). I moved the class to the `com.nvidia.spark.rapids.tool` package and renamed it to `ToolTestUtils` since not specific to qualification.