### PR TITLE
change rapids-4-spark-tools directory to tools in deploy script [skip ci]

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -90,7 +90,7 @@ $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             -Dfile=$TESTS_FPATH.jar -DpomFile=${TESTS_PL}/pom.xml
 
 ###### Deploy profiling tool jar(s) ######
-TOOL_PL=${TOOL_PL:-"rapids-4-spark-tools"}
+TOOL_PL=${TOOL_PL:-"tools"}
 TOOL_ART_ID=`mvn help:evaluate -q -pl $TOOL_PL -Dexpression=project.artifactId -DforceStdout`
 TOOL_ART_VER=`mvn help:evaluate -q -pl $TOOL_PL -Dexpression=project.version -DforceStdout`
 TOOL_FPATH="$TOOL_PL/target/$TOOL_ART_ID-$TOOL_ART_VER"


### PR DESCRIPTION
This is the follow on rename of 'rapids-4-spark-tools' directory to 'tools', to align with https://github.com/NVIDIA/spark-rapids/pull/2598

Signed-off-by: Tim Liu <timl@nvidia.com>