### PR TITLE
Change aggregation of executor CPU and run time for Qualification tool to speed up query

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -83,10 +83,10 @@ It can also print out any potential problems it finds in a separate column, whic
 currently only includes some UDFs. The tool won't catch all UDFs, and some of the UDFs can be handled with additional steps. 
 Please refer to [supported_ops.md](../docs/supported_ops.md) for more details on UDF.
 
-There is also an optional column `Executor CPU Time Percent`
-that can be reported that is not included in the score. This is an estimate at how much time the tasks spent doing
-processing on the CPU vs waiting on IO. This is not always a good indicator because sometimes you may be doing IO that
-is encrypted and the CPU has to do work to decrypt it, so the environment you are running on needs to be taken into account.
+The output also contains a `Executor CPU Time Percent` column that is not included in the score. This is an estimate
+at how much time the tasks spent doing processing on the CPU vs waiting on IO. This is not always a good indicator
+because sometimes you may be doing IO that is encrypted and the CPU has to do work to decrypt it, so the environment
+you are running on needs to be taken into account.
 
 Sample output in csv:
 ```
@@ -135,10 +135,7 @@ rapids-4-spark-tools_2.12-<version>.jar \
 
 For usage see below:
 
-  -i, --include-exec-cpu-percent   Include the executor CPU time percent. It
-                                   will take longer with this option and you may
-                                   want to limit the number of applications
-                                   processed at once.
+  -i, --no-exec-cpu-percent        Do not include the executor CPU time percent.
   -f, --filter-criteria  <arg>     Filter newest or oldest N event logs for processing.
                                    Supported formats are:
                                    To process 10 recent event logs: --filter-criteria "10-newest"
@@ -175,11 +172,8 @@ The output location can be changed using the `--output-directory` option. Defaul
 
 The output format can be changed using the `--output-format` option. Default is csv. The other option is text.
   
-The `--include-exec-cpu-percent` option can be used to include executor CPU time percent which is based on the aggregated task metrics:
+The `--no-exec-cpu-percent` option can be used to include executor CPU time percent which is based on the aggregated task metrics:
 `sum(executorCPUTime)/sum(executorRunTime)`. It can show us roughly how much time is spent on CPU.
-Note: This option needs lot of memory for large amount of event logs as input and will take longer to process.
-We suggest you use around 30GB of driver memory if using this option and to only process around 50 apps at a time.
-Note you could run it multiple times over 50 each and output to csv and combined afterwards.
 
 Run `--help` for more information.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -135,7 +135,7 @@ rapids-4-spark-tools_2.12-<version>.jar \
 
 For usage see below:
 
-  -i, --no-exec-cpu-percent        Do not include the executor CPU time percent.
+      --no-exec-cpu-percent        Do not include the executor CPU time percent.
   -f, --filter-criteria  <arg>     Filter newest or oldest N event logs for processing.
                                    Supported formats are:
                                    To process 10 recent event logs: --filter-criteria "10-newest"
@@ -172,9 +172,6 @@ The output location can be changed using the `--output-directory` option. Defaul
 
 The output format can be changed using the `--output-format` option. Default is csv. The other option is text.
   
-The `--no-exec-cpu-percent` option can be used to include executor CPU time percent which is based on the aggregated task metrics:
-`sum(executorCPUTime)/sum(executorRunTime)`. It can show us roughly how much time is spent on CPU.
-
 Run `--help` for more information.
 
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -112,7 +112,10 @@ in the local filesystem, HDFS, S3 or mixed.
 
 ### Use from spark-shell
 1. Include `rapids-4-spark-tools_2.12-<version>.jar` in the '--jars' option to spark-shell or spark-submit
-2. After starting spark-shell:
+2. Starting spark-shell:
+```bash
+$SPARK_HOME/bin/spark-shell --driver-memory 5g --jars ~/rapids-4-spark-tools_2.12-<version>.jar
+```
 
 For multiple event logs:
 ```bash
@@ -121,7 +124,7 @@ com.nvidia.spark.rapids.tool.qualification.QualificationMain.main(Array("/path/t
 
 ### Use from spark-submit
 ```bash
-$SPARK_HOME/bin/spark-submit --class com.nvidia.spark.rapids.tool.qualification.QualificationMain \
+$SPARK_HOME/bin/spark-submit --driver-memory 5g --class com.nvidia.spark.rapids.tool.qualification.QualificationMain \
 rapids-4-spark-tools_2.12-<version>.jar \
 /path/to/eventlog1 /path/to/eventlog2 /directory/with/eventlogs
 ```

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
@@ -118,6 +118,18 @@ class Analysis(apps: ArrayBuffer[ApplicationInfo], fileWriter: Option[FileWriter
     }
   }
 
+  def sqlMetricsAggregationQual(): DataFrame = {
+    val query = apps
+      .filter(p => p.allDataFrames.contains(s"sqlDF_${p.index}"))
+      .map( app => "(" + app.sqlMetricsAggregationSQLQual + ")")
+      .mkString(" union ")
+    if (query.nonEmpty) {
+      apps.head.runQuery(query)
+    } else {
+      apps.head.sparkSession.emptyDataFrame
+    }
+  }
+
   // custom query execution. Normally for debugging use.
   def customQueryExecution(app: ApplicationInfo): Unit = {
     fileWriter.foreach(_.write("Custom query execution:"))

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -114,8 +114,8 @@ case class StageCase(
     duration: Option[Long],
     durationStr: String,
     gpuMode: Boolean,
-    executorRunTime: Long,
-    executorCPUTime: Long)
+    executorRunTimeSum: Long,
+    executorCPUTimeSum: Long)
 
 class StageTaskQualificationSummary(
     val stageId: Int,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -114,6 +114,12 @@ case class StageCase(
     duration: Option[Long],
     durationStr: String, gpuMode: Boolean)
 
+class TaskQualificationSummary(
+    stageId: Int,
+    stageAttemptId: Int,
+    var executorRunTime: Long,
+    var executorCPUTime: Long)
+
 // Note: sr = Shuffle Read; sw = Shuffle Write
 // Totally 39 columns
 case class TaskCase(

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -112,11 +112,14 @@ case class StageCase(
     completionTime: Option[Long],
     failureReason: Option[String],
     duration: Option[Long],
-    durationStr: String, gpuMode: Boolean)
+    durationStr: String,
+    gpuMode: Boolean,
+    executorRunTime: Long,
+    executorCPUTime: Long)
 
-class TaskQualificationSummary(
-    stageId: Int,
-    stageAttemptId: Int,
+class StageTaskQualificationSummary(
+    val stageId: Int,
+    val stageAttemptId: Int,
     var executorRunTime: Long,
     var executorCPUTime: Long)
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -59,7 +59,7 @@ object Qualification extends Logging {
     if (apps.isEmpty) return None
     val analysis = new Analysis(apps, None)
     if (includeCpuPercent) {
-      val sqlAggMetricsDF = analysis.sqlMetricsAggregation()
+      val sqlAggMetricsDF = analysis.sqlMetricsAggregationQual()
       sqlAggMetricsDF.cache().createOrReplaceTempView("sqlAggMetricsDF")
       // materialize table to cache
       sqlAggMetricsDF.count()

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -73,11 +73,10 @@ For usage see below:
   val numOutputRows: ScallopOption[Int] =
     opt[Int](required = false,
       descr = "Number of output rows for each Application. Default is 1000.")
-  val includeExecCpuPercent: ScallopOption[Boolean] =
+  val noExecCpuPercent: ScallopOption[Boolean] =
     opt[Boolean](
       required = false,
       default = Some(false),
-      descr = "Include the executor CPU time percent. It will take longer with this option" +
-        " and you may want to limit the number of applications processed at once.")
+      descr = "Do not include the executor CPU time percent.")
   verify()
 }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -53,7 +53,7 @@ object QualificationMain extends Logging {
     // Get the event logs required to process
     lazy val allPaths = ToolUtils.processAllPaths(filterN, matchEventLogs, eventlogPaths)
 
-    val includeCpuPercent = appArgs.includeExecCpuPercent.getOrElse(false)
+    val includeCpuPercent = !(appArgs.noExecCpuPercent.getOrElse(false))
     val numOutputRows = appArgs.numOutputRows.getOrElse(1000)
     val dfOpt = Qualification.qualifyApps(allPaths,
       numOutputRows, sparkSession, includeCpuPercent, dropTempViews)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -126,8 +126,9 @@ class ApplicationInfo(
   val stageFailureReason: HashMap[Int, Option[String]] = HashMap.empty[Int, Option[String]]
 
   // From SparkListenerTaskStart & SparkListenerTaskEnd
-  // taskEnd contains task level metrics - only used for profiling
+  // taskStart was not used so comment out for now
   // var taskStart: ArrayBuffer[SparkListenerTaskStart] = ArrayBuffer[SparkListenerTaskStart]()
+  // taskEnd contains task level metrics - only used for profiling
   var taskEnd: ArrayBuffer[TaskCase] = ArrayBuffer[TaskCase]()
 
   // this is used to aggregate metrics for qualification to speed up processing and

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -691,7 +691,6 @@ class ApplicationInfo(
        |sq.sqlID, sq.description,
        |sum(executorCPUTimeSum) as executorCPUTime,
        |sum(executorRunTimeSum) as executorRunTime,
-       |round(sum(executorCPUTimeSum)/sum(executorRunTimeSum)*100,2) executorCPURatio
        |from stageDF_$index s,
        |jobDF_$index j, sqlDF_$index sq
        |where array_contains(j.stageIds, s.stageId)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.rapids.tool.profiling
 
 import java.io.FileWriter
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import com.nvidia.spark.rapids.tool.profiling._
 import org.apache.hadoop.conf.Configuration
@@ -682,7 +683,7 @@ class ApplicationInfo(
        |sq.sqlID, sq.description,
        |sum(executorCPUTimeSum) as executorCPUTime,
        |sum(executorRunTimeSum) as executorRunTime,
-       |round(sum(executorCPUTime)/sum(executorRunTime)*100,2) executorCPURatio
+       |round(sum(executorCPUTimeSum)/sum(executorRunTimeSum)*100,2) executorCPURatio
        |from stageDF_$index s,
        |jobDF_$index j, sqlDF_$index sq
        |where array_contains(j.stageIds, s.stageId)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -408,8 +408,8 @@ class ApplicationInfo(
         // could expand later for profiling
         val stageAndAttempt = s"${res.stageId}:${res.attemptId}"
         val stageTaskExecSum = stageTaskQualificationEnd.get(stageAndAttempt)
-        val runTime = stageTaskExecSum.map(_.executorRunTime).getOrElse(0)
-        val cpuTime = stageTaskExecSum.map(_.executorCPUTime).getOrElse(0)
+        val runTime = stageTaskExecSum.map(_.executorRunTime).getOrElse(0L)
+        val cpuTime = stageTaskExecSum.map(_.executorCPUTime).getOrElse(0L)
 
         val stageNew = res.copy(completionTime = thisEndTime,
           failureReason = thisFailureReason,
@@ -680,14 +680,12 @@ class ApplicationInfo(
   def sqlMetricsAggregationSQLQual: String = {
     s"""select $index as appIndex, '$appId' as appID,
        |sq.sqlID, sq.description,
-       |count(*) as numTasks, max(sq.duration) as Duration,
        |sum(executorCPUTime) as executorCPUTime,
        |sum(executorRunTime) as executorRunTime,
        |round(sum(executorCPUTime)/sum(executorRunTime)*100,2) executorCPURatio
-       |$generateAggSQLString
        |from stageDF_$index s,
        |jobDF_$index j, sqlDF_$index sq
-       |and array_contains(j.stageIds, s.stageId)
+       |where array_contains(j.stageIds, s.stageId)
        |and sq.sqlID=j.sqlID
        |group by sq.sqlID,sq.description
        |""".stripMargin

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -415,8 +415,8 @@ class ApplicationInfo(
           failureReason = thisFailureReason,
           duration = durationResult,
           durationStr = durationString,
-          executorRunTime = runTime,
-          executorCPUTime = cpuTime)
+          executorRunTimeSum = runTime,
+          executorCPUTimeSum = cpuTime)
         stageSubmittedNew += stageNew
       }
       allDataFrames += (s"stageDF_$index" -> stageSubmittedNew.toDF)
@@ -680,8 +680,8 @@ class ApplicationInfo(
   def sqlMetricsAggregationSQLQual: String = {
     s"""select $index as appIndex, '$appId' as appID,
        |sq.sqlID, sq.description,
-       |sum(executorCPUTime) as executorCPUTime,
-       |sum(executorRunTime) as executorRunTime,
+       |sum(executorCPUTimeSum) as executorCPUTime,
+       |sum(executorRunTimeSum) as executorRunTime,
        |round(sum(executorCPUTime)/sum(executorRunTime)*100,2) executorCPURatio
        |from stageDF_$index s,
        |jobDF_$index j, sqlDF_$index sq

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -684,7 +684,8 @@ class ApplicationInfo(
        |""".stripMargin
   }
 
-  // Function to generate a query for SQL level Task Metrics aggregation
+  // Function to generate a query for getting the executor CPU time and run time
+  // specifically for how we aggregate for qualification
   def sqlMetricsAggregationSQLQual: String = {
     s"""select $index as appIndex, '$appId' as appID,
        |sq.sqlID, sq.description,

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -690,7 +690,7 @@ class ApplicationInfo(
     s"""select $index as appIndex, '$appId' as appID,
        |sq.sqlID, sq.description,
        |sum(executorCPUTimeSum) as executorCPUTime,
-       |sum(executorRunTimeSum) as executorRunTime,
+       |sum(executorRunTimeSum) as executorRunTime
        |from stageDF_$index s,
        |jobDF_$index j, sqlDF_$index sq
        |where array_contains(j.stageIds, s.stageId)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -262,8 +262,8 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
       val taskSum = app.stageTaskQualificationEnd.getOrElseUpdate(stageAndAttempt, {
         new StageTaskQualificationSummary(event.stageId,
           event.stageAttemptId,
-          event.taskMetrics.executorRunTime,
-          NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime))
+          0,
+          0)
       })
       taskSum.executorRunTime += event.taskMetrics.executorRunTime
       taskSum.executorCPUTime += NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -259,8 +259,8 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
 
     if (forQualification) {
       val stageAndAttempt = s"${event.stageId}:${event.stageAttemptId}"
-      val taskSum = app.taskQualificationEnd.getOrElseUpdate(stageAndAttempt, {
-        new TaskQualificationSummary(event.stageId,
+      val taskSum = app.stageTaskQualificationEnd.getOrElseUpdate(stageAndAttempt, {
+        new StageTaskQualificationSummary(event.stageId,
           event.stageAttemptId,
           event.taskMetrics.executorRunTime,
           NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime))

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.rapids.tool.profiling
 
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
 import scala.collection.JavaConverters._
 
 import com.nvidia.spark.rapids.tool.profiling._
@@ -26,9 +28,9 @@ import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui.{SparkListenerDriverAccumUpdates, SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLAdaptiveSQLMetricUpdates, SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
 
 /**
- * This object is to process all events and do validation in the end.
+ * This class is to process all events and do validation in the end.
  */
-object EventsProcessor extends Logging {
+class EventsProcessor(forQualification: Boolean = false) extends Logging {
 
   def processAnyEvent(app: ApplicationInfo, event: SparkListenerEvent): Unit = {
     event match {
@@ -246,7 +248,8 @@ object EventsProcessor extends Logging {
       app: ApplicationInfo,
       event: SparkListenerTaskStart): Unit = {
     logDebug("Processing event: " + event.getClass)
-    app.taskStart += event
+    // currently not used
+    // app.taskStart += event
   }
 
   def doSparkListenerTaskEnd(
@@ -254,67 +257,80 @@ object EventsProcessor extends Logging {
       event: SparkListenerTaskEnd): Unit = {
     logDebug("Processing event: " + event.getClass)
 
-    // Parse task accumulables
-    for (res <- event.taskInfo.accumulables) {
-      try {
-        val value = res.value.getOrElse("").toString.toLong
-        val thisMetric = TaskStageAccumCase(
-          event.stageId, event.stageAttemptId, Some(event.taskInfo.taskId),
-          res.id, res.name, Some(value), res.internal)
-        app.taskStageAccum += thisMetric
-      } catch {
-        case e: ClassCastException =>
-          logWarning("ClassCastException when parsing accumulables for task "
+    if (forQualification) {
+      val stageAndAttempt = s"${event.stageId}:${event.stageAttemptId}"
+      val taskSum = app.taskQualificationEnd.getOrElseUpdate(stageAndAttempt, {
+        new TaskQualificationSummary(event.stageId,
+          event.stageAttemptId,
+          event.taskMetrics.executorRunTime,
+          NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime))
+      })
+      taskSum.executorRunTime += event.taskMetrics.executorRunTime
+      taskSum.executorCPUTime += NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime)
+    } else {
+
+      // Parse task accumulables
+      for (res <- event.taskInfo.accumulables) {
+        try {
+          val value = res.value.getOrElse("").toString.toLong
+          val thisMetric = TaskStageAccumCase(
+            event.stageId, event.stageAttemptId, Some(event.taskInfo.taskId),
+            res.id, res.name, Some(value), res.internal)
+          app.taskStageAccum += thisMetric
+        } catch {
+          case e: ClassCastException =>
+            logWarning("ClassCastException when parsing accumulables for task "
               + "stageID=" + event.stageId + ",taskId=" + event.taskInfo.taskId
               + ": ")
-          logWarning(e.toString)
-          logWarning("The problematic accumulable is: name="
+            logWarning(e.toString)
+            logWarning("The problematic accumulable is: name="
               + res.name + ",value=" + res.value)
+        }
       }
-    }
 
-    val thisTask = TaskCase(
-      event.stageId,
-      event.stageAttemptId,
-      event.taskType,
-      event.reason.toString,
-      event.taskInfo.taskId,
-      event.taskInfo.attemptNumber,
-      event.taskInfo.launchTime,
-      event.taskInfo.finishTime,
-      event.taskInfo.duration,
-      event.taskInfo.successful,
-      event.taskInfo.executorId,
-      event.taskInfo.host,
-      event.taskInfo.taskLocality.toString,
-      event.taskInfo.speculative,
-      event.taskInfo.gettingResultTime,
-      event.taskMetrics.executorDeserializeTime,
-      event.taskMetrics.executorDeserializeCpuTime / 1000000,
-      event.taskMetrics.executorRunTime,
-      event.taskMetrics.executorCpuTime / 1000000,
-      event.taskMetrics.peakExecutionMemory,
-      event.taskMetrics.resultSize,
-      event.taskMetrics.jvmGCTime,
-      event.taskMetrics.resultSerializationTime,
-      event.taskMetrics.memoryBytesSpilled,
-      event.taskMetrics.diskBytesSpilled,
-      event.taskMetrics.shuffleReadMetrics.remoteBlocksFetched,
-      event.taskMetrics.shuffleReadMetrics.localBlocksFetched,
-      event.taskMetrics.shuffleReadMetrics.fetchWaitTime,
-      event.taskMetrics.shuffleReadMetrics.remoteBytesRead,
-      event.taskMetrics.shuffleReadMetrics.remoteBytesReadToDisk,
-      event.taskMetrics.shuffleReadMetrics.localBytesRead,
-      event.taskMetrics.shuffleReadMetrics.totalBytesRead,
-      event.taskMetrics.shuffleWriteMetrics.bytesWritten,
-      event.taskMetrics.shuffleWriteMetrics.writeTime / 1000000,
-      event.taskMetrics.shuffleWriteMetrics.recordsWritten,
-      event.taskMetrics.inputMetrics.bytesRead,
-      event.taskMetrics.inputMetrics.recordsRead,
-      event.taskMetrics.outputMetrics.bytesWritten,
-      event.taskMetrics.outputMetrics.recordsWritten
-    )
-    app.taskEnd += thisTask
+      val thisTask = TaskCase(
+        event.stageId,
+        event.stageAttemptId,
+        event.taskType,
+        event.reason.toString,
+        event.taskInfo.taskId,
+        event.taskInfo.attemptNumber,
+        event.taskInfo.launchTime,
+        event.taskInfo.finishTime,
+        event.taskInfo.duration,
+        event.taskInfo.successful,
+        event.taskInfo.executorId,
+        event.taskInfo.host,
+        event.taskInfo.taskLocality.toString,
+        event.taskInfo.speculative,
+        event.taskInfo.gettingResultTime,
+        event.taskMetrics.executorDeserializeTime,
+        NANOSECONDS.toMillis(event.taskMetrics.executorDeserializeCpuTime),
+        event.taskMetrics.executorRunTime,
+        NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime),
+        event.taskMetrics.peakExecutionMemory,
+        event.taskMetrics.resultSize,
+        event.taskMetrics.jvmGCTime,
+        event.taskMetrics.resultSerializationTime,
+        event.taskMetrics.memoryBytesSpilled,
+        event.taskMetrics.diskBytesSpilled,
+        event.taskMetrics.shuffleReadMetrics.remoteBlocksFetched,
+        event.taskMetrics.shuffleReadMetrics.localBlocksFetched,
+        event.taskMetrics.shuffleReadMetrics.fetchWaitTime,
+        event.taskMetrics.shuffleReadMetrics.remoteBytesRead,
+        event.taskMetrics.shuffleReadMetrics.remoteBytesReadToDisk,
+        event.taskMetrics.shuffleReadMetrics.localBytesRead,
+        event.taskMetrics.shuffleReadMetrics.totalBytesRead,
+        event.taskMetrics.shuffleWriteMetrics.bytesWritten,
+        NANOSECONDS.toMillis(event.taskMetrics.shuffleWriteMetrics.writeTime),
+        event.taskMetrics.shuffleWriteMetrics.recordsWritten,
+        event.taskMetrics.inputMetrics.bytesRead,
+        event.taskMetrics.inputMetrics.recordsRead,
+        event.taskMetrics.outputMetrics.bytesWritten,
+        event.taskMetrics.outputMetrics.recordsWritten
+      )
+      app.taskEnd += thisTask
+    }
   }
 
   def doSparkListenerSQLExecutionStart(

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -260,10 +260,7 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
     if (forQualification) {
       val stageAndAttempt = s"${event.stageId}:${event.stageAttemptId}"
       val taskSum = app.stageTaskQualificationEnd.getOrElseUpdate(stageAndAttempt, {
-        new StageTaskQualificationSummary(event.stageId,
-          event.stageAttemptId,
-          0,
-          0)
+        new StageTaskQualificationSummary(event.stageId, event.stageAttemptId, 0, 0)
       })
       taskSum.executorRunTime += event.taskMetrics.executorRunTime
       taskSum.executorCPUTime += NANOSECONDS.toMillis(event.taskMetrics.executorCpuTime)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -434,7 +434,9 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
       None,
       None,
       "",
-      ProfileUtils.isGPUMode(event.properties.asScala) || app.gpuMode
+      ProfileUtils.isGPUMode(event.properties.asScala) || app.gpuMode,
+      0,
+      0
     )
     app.stageSubmitted += thisStage
   }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids.tool.qualification
 
 import java.io.File
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import com.nvidia.spark.rapids.tool.ToolTestUtils
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
@@ -146,21 +147,13 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
         assert(collect.getString(fieldIndex("description")).startsWith("collect"))
 
         // parse results from listener
-        val numTasks = listener.completedStages.map(_.stageInfo.numTasks).sum
         val executorCpuTime = listener.executorCpuTime
         val executorRunTime = listener.completedStages
           .map(_.stageInfo.taskMetrics.executorRunTime).sum
-        val shuffleBytesRead = listener.completedStages
-          .map(_.stageInfo.taskMetrics.shuffleReadMetrics.localBytesRead).sum
-        val shuffleBytesWritten = listener.completedStages
-          .map(_.stageInfo.taskMetrics.shuffleWriteMetrics.bytesWritten).sum
 
         // compare metrics from event log with metrics from listener
-        assert(collect.getLong(fieldIndex("numTasks")) === numTasks)
         assert(collect.getLong(fieldIndex("executorCPUTime")) === executorCpuTime)
         assert(collect.getLong(fieldIndex("executorRunTime")) === executorRunTime)
-        assert(collect.getLong(fieldIndex("sr_localBytesRead_sum")) === shuffleBytesRead)
-        assert(collect.getLong(fieldIndex("sw_bytesWritten_sum")) === shuffleBytesWritten)
       }
     }
   }
@@ -171,7 +164,7 @@ class ToolTestListener extends SparkListener {
   var executorCpuTime = 0L
 
   override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
-    executorCpuTime += taskEnd.taskMetrics.executorCpuTime / 1000000
+    executorCpuTime += NANOSECONDS.toMillis(taskEnd.taskMetrics.executorCpuTime)
   }
 
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -51,8 +51,8 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
           "--output-directory",
           outpath.getAbsolutePath())
         val allArgs = hasExecCpu match  {
-          case true => outputArgs ++ Array("--include-exec-cpu-percent")
-          case false => outputArgs
+          case true => outputArgs
+          case false => outputArgs ++ Array("--no-exec-cpu-percent")
         }
         val appArgs = new QualificationArgs(allArgs ++ eventLogs)
 
@@ -127,7 +127,6 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
           .getOrCreate()
 
         val appArgs = new QualificationArgs(Array(
-          "--include-exec-cpu-percent",
           "--output-directory",
           outpath.getAbsolutePath,
           eventLog))


### PR DESCRIPTION
Running the qualification tool over all nds results and having it include the executor cpu time percent was taking about 45 minutes and required 30G driver memory.  To address this I changed the way we aggregate those metrics just for the qualification side so that we don't need to keep all tasks and create the individual tasks table.  Now it just aggregates them up per stage on the fly and we can simply look it up per stage and aggregate them based on that.  That improved the run time to be about 15 minutes and I used 5G memory (I might be able to use less, this is what I set it at).

since the performance is better I turned it on by default and changed config to allow removing it if you don't want it for some reason.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
