### PR TITLE
Profiling tool - fix reporting contains dataset when sql time 0

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -57,6 +57,7 @@ case class SQLExecutionCase(
     duration: Option[Long],
     durationStr: String,
     sqlQualDuration: Option[Long],
+    hasDataset: Boolean,
     problematic: String = "")
 
 case class SQLPlanMetricsCase(

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -347,10 +347,10 @@ class ApplicationInfo(
           case Some(i) => UIUtils.formatDuration(i)
           case None => ""
         }
-        val sqlQDuration = if (datasetSQL.exists(_.sqlID == res.sqlID)) {
-          Some(0L)
+        val (containsDataset, sqlQDuration) = if (datasetSQL.exists(_.sqlID == res.sqlID)) {
+          (true, Some(0L))
         } else {
-          durationResult
+          (false, durationResult)
         }
         val potProbs = problematicSQL.filter { p =>
           p.sqlID == res.sqlID && p.reason.nonEmpty
@@ -364,6 +364,7 @@ class ApplicationInfo(
           duration = durationResult,
           durationStr = durationString,
           sqlQualDuration = sqlQDuration,
+          hasDataset = containsDataset,
           problematic = finalPotProbs
         )
         sqlStartNew += sqlExecutionNew
@@ -851,7 +852,7 @@ class ApplicationInfo(
        |'$appId' as `App ID`,
        |sq.sqlID,
        |sq.duration as `SQL Duration`,
-       |case when sq.sqlQualDuration > 0 then false else true end as `Contains Dataset Op`,
+       |sq.hasDataset as `Contains Dataset Op`,
        |app.duration as `App Duration`,
        |problematic as `Potential Problems`,
        |round(executorCPUTime/executorRunTime*100,2) as `Executor CPU Time Percent`

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -343,6 +343,7 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
       None,
       "",
       None,
+      false,
       ""
     )
     app.sqlStart += sqlExecution

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
@@ -149,4 +149,22 @@ class AnalysisSuite extends FunSuite {
     val actualDf = analysis.shuffleSkewCheckSingleApp(apps.head)
     assert(actualDf.count() == 0)
   }
+
+  test("test contains dataset false") {
+    val qualLogDir = ToolTestUtils.getTestResourcePath("spark-events-qualification")
+    val logs = Array(s"$qualLogDir/nds_q86_test")
+
+    val apps = ToolTestUtils.processProfileApps(logs, sparkSession)
+    val analysis = new Analysis(apps, None)
+    val sqlAggMetricsDF = analysis.sqlMetricsAggregation()
+    sqlAggMetricsDF.createOrReplaceTempView("sqlAggMetricsDF")
+    val actualDf = analysis.sqlMetricsAggregationDurationAndCpuTime()
+
+    val rows = actualDf.collect()
+    assert(rows.length === 25)
+    def fieldIndex(name: String) = actualDf.schema.fieldIndex(name)
+    rows.foreach { row =>
+      assert(row.getBoolean(fieldIndex("Contains Dataset Op")) == false)
+    }
+  }
 }


### PR DESCRIPTION
There was a bug on profiling side with reporting contains dataset when the sql time was 0.  Simply add another field to the table to explicitly set it.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
