### PR TITLE
Qualification tool - add in estimating the App end time when the event log missing application end event

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -73,6 +73,8 @@ Currently it does this by looking at the amount of time spent doing SQL Datafram
 operations vs the entire application time: `(sum(SQL Dataframe Duration) / (application-duration))`.
 The more time spent doing SQL Dataframe operations the higher the score is
 and the more likely the plugin will be able to help accelerate that application.
+Note that the application time is from application start to application end so if you are using an interactive
+shell where there is nothing running from a while, this time will include that which might skew the score.
 
 Each application(event log) could have multiple SQL queries. If a SQL's plan has Dataset API inside such as keyword
  `$Lambda` or `.apply`, that SQL query is categorized as a DataSet SQL query, otherwise it is a Dataframe SQL query.
@@ -88,23 +90,27 @@ at how much time the tasks spent doing processing on the CPU vs waiting on IO. T
 because sometimes you may be doing IO that is encrypted and the CPU has to do work to decrypt it, so the environment
 you are running on needs to be taken into account.
 
+The last column `App Duration Estimated` is used to indicate if we had to estimate the application duration. If we
+had to estimate it, it means the event log was missing the application finished event so we will use the last job
+or sql execution time we find as the end time used to calculate the duration.
+
 Note that SQL queries that contain failed jobs are not included.
 
 Sample output in csv:
 ```
-App Name,App ID,Rank,Potential Problems,SQL Dataframe Duration,App Duration,Executor CPU Time Percent
-Spark shell,app-20210507105707-0001,78.03,"",810923,1039276,32.03
-Spark shell,app-20210507103057-0000,75.87,"",316622,417307,64.07
+App Name,App ID,Score,Potential Problems,SQL Dataframe Duration,App Duration,Executor CPU Time Percent,App Duration Estimated
+Spark shell,app-20210507105707-0001,78.03,"",810923,1039276,32.03,false
+Spark shell,app-20210507103057-0000,75.87,"",316622,417307,64.07,false
 ```
 
 Sample output in text:
 ```
-+-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+
-|App Name   |App ID                 |Rank |Potential Problems|SQL Dataframe Duration|App Duration|Executor CPU Time Percent|
-+-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+
-|Spark shell|app-20210507105707-0001|78.03|                  |810923                |1039276     |32.03                    |
-|Spark shell|app-20210507103057-0000|75.87|                  |316622                |417307      |64.07                    |
-+-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+
++-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+----------------------+
+|App Name   |App ID                 |Score|Potential Problems|SQL Dataframe Duration|App Duration|Executor CPU Time Percent|App Duration Estimated|
++-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+----------------------+
+|Spark shell|app-20210507105707-0001|78.03|                  |810923                |1039276     |32.03                    |false                 |
+|Spark shell|app-20210507103057-0000|75.87|                  |316622                |417307      |64.07                    |false                 |
++-----------+-----------------------+-----+------------------+----------------------+------------+-------------------------+----------------------+
 ```
 
 ### How to use this tool

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -38,7 +38,8 @@ case class PropertiesCase(
 case class ApplicationCase(
   appName: String, appId: Option[String], startTime: Long,
   sparkUser: String, endTime: Option[Long], duration: Option[Long],
-  durationStr: String, sparkVersion: String, gpuMode: Boolean)
+  durationStr: String, sparkVersion: String, gpuMode: Boolean,
+  endDurationEstimated: Boolean)
 
 case class ExecutorCase(
   executorID: String, host: String, totalCores: Int, resourceProfileId: Int)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -206,7 +206,8 @@ class EventsProcessor(forQualification: Boolean = false) extends Logging {
       None,
       "",
       "",
-      gpuMode = false
+      gpuMode = false,
+      endDurationEstimated = false
     )
     app.appStart += thisAppStart
     app.appId = event.appId.getOrElse("")

--- a/tools/src/test/resources/QualificationExpectations/nds_q86_fail_test_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/nds_q86_fail_test_expectation.csv
@@ -1,2 +1,2 @@
-appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio
-TPC-DS Like Bench q86,app-20210319163812-1778,0.02,"",4,26171,"-"
+appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio,appEndDurationEstimated
+TPC-DS Like Bench q86,app-20210319163812-1778,0.02,"",4,26171,"-",false

--- a/tools/src/test/resources/QualificationExpectations/nds_q86_test_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/nds_q86_test_expectation.csv
@@ -1,2 +1,2 @@
-appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio
-TPC-DS Like Bench q86,app-20210319163812-1778,36.56,"",9569,26171,35.34
+appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio,appEndDurationEstimated
+TPC-DS Like Bench q86,app-20210319163812-1778,36.56,"",9569,26171,35.34,false

--- a/tools/src/test/resources/QualificationExpectations/qual_test_missing_sql_end_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/qual_test_missing_sql_end_expectation.csv
@@ -1,2 +1,2 @@
-appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio
-"-","local-1622561780883","-","","-","-","-"
+appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio,appEndDurationEstimated
+"-","local-1622561780883","-","","-","-","-","-"

--- a/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
@@ -1,5 +1,5 @@
-appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio
-Rapids Spark Profiling Tool Unit Tests,local-1622043423018,68.19,"",11128,16319,37.7
-Rapids Spark Profiling Tool Unit Tests,local-1621969619749,14.34,UDF,1560,10880,46.3
-Rapids Spark Profiling Tool Unit Tests,local-1621966649543,0.0,"",0,10650,26.65
-Rapids Spark Profiling Tool Unit Tests,local-1621955976602,0.0,"",0,10419,25.8
+appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio,appEndDurationEstimated
+Rapids Spark Profiling Tool Unit Tests,local-1622043423018,68.19,"",11128,16319,37.7,false
+Rapids Spark Profiling Tool Unit Tests,local-1621969619749,14.34,UDF,1560,10880,46.3,false
+Rapids Spark Profiling Tool Unit Tests,local-1621966649543,0.0,"",0,10650,26.65,false
+Rapids Spark Profiling Tool Unit Tests,local-1621955976602,0.0,"",0,10419,25.8,false

--- a/tools/src/test/resources/QualificationExpectations/truncated_1_end_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/truncated_1_end_expectation.csv
@@ -1,2 +1,2 @@
-appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio
-Rapids Spark Profiling Tool Unit Tests,local-1622043423018,"-","",0,"-",30.46
+appName,appID,dfRankTotal,potentialProblems,dfDurationFinal,appDuration,executorCPURatio,appEndDurationEstimated
+Rapids Spark Profiling Tool Unit Tests,local-1622043423018,0.0,"",0,4872,30.46,true

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/ToolTestUtils.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession, TrampolineUtil}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.types._
 
 object ToolTestUtils extends Logging {
 
@@ -81,9 +82,15 @@ object ToolTestUtils extends Logging {
     assert(diffCount == 0)
   }
 
-  def readExpectationCSV(sparkSession: SparkSession, path: String): DataFrame = {
+  def readExpectationCSV(sparkSession: SparkSession, path: String,
+      schema: Option[StructType] = None): DataFrame = {
     // make sure to change null value so empty strings don't show up as nulls
-    sparkSession.read.option("header", "true").option("nullValue", "-").csv(path)
+    if (schema.isDefined) {
+      sparkSession.read.option("header", "true").option("nullValue", "-")
+        .schema(schema.get).csv(path)
+    } else {
+      sparkSession.read.option("header", "true").option("nullValue", "-").csv(path)
+    }
   }
 
   def processProfileApps(logs: Array[String],

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ListBuffer
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted, SparkListenerTaskEnd}
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
+import org.apache.spark.sql.types._
 
 class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
@@ -60,8 +61,17 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
           QualificationMain.mainInternal(sparkSession, appArgs, writeOutput=false,
             dropTempViews=true)
         assert(exit == 0)
+        val schema = new StructType()
+          .add("appName",StringType,true)
+          .add("appID",StringType,true)
+          .add("dfRankTotal",DoubleType,true)
+          .add("potentialProblems",StringType,true)
+          .add("dfDurationFinal",LongType,true)
+          .add("appDuration",LongType,true)
+          .add("executorCPURatio",DoubleType,true)
+          .add("appEndDurationEstimated",BooleanType,true)
         val dfExpectOrig =
-          ToolTestUtils.readExpectationCSV(sparkSession, resultExpectation.getPath())
+          ToolTestUtils.readExpectationCSV(sparkSession, resultExpectation.getPath(), Some(schema))
         val dfExpect = if (hasExecCpu) dfExpectOrig else dfExpectOrig.drop("executorCPURatio")
         assert(dfQualOpt.isDefined)
         ToolTestUtils.compareDataFrames(dfQualOpt.get, dfExpect)


### PR DESCRIPTION
Many of the databricks event logs are missing the application end event so the application duration comes out as 0. To allow us to still score it, use the latest job end time or sql execution time instead and then add a column to indicate that we estimated the app duration in case user wants to know.

Note this does not change it for the profiling tool.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
