### PR TITLE
Update docs to move RAPIDS Shuffle out of beta [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -5,12 +5,6 @@ parent: Additional Functionality
 nav_order: 5
 ---
 # RAPIDS Shuffle Manager
----
-**NOTE**
-
-The _RAPIDS Shuffle Manager_ is a beta feature!
-
----
 
 The RAPIDS Shuffle Manager is an implementation of the `ShuffleManager` interface in Apache Spark
 that allows custom mechanisms to exchange shuffle data. It has two components: a spillable cache, 

--- a/docs/download.md
+++ b/docs/download.md
@@ -72,6 +72,7 @@ New functionality for this release includes:
 * Support for the `concat_ws` operator
 
 Performance improvements for this release include: 
+* Moving RAPIDS Shuffle out of beta
 * Updates to UCX error handling
 * GPU Direct storage for spilling
 


### PR DESCRIPTION
Update docs to remove beta designation from RAPIDS Shuffle (replaces PR #2653 )