### PR TITLE
Support for Decimals with negative scale for Parquet Cached Batch Serializer

### DIFF
--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -28,7 +28,7 @@ conf = [{"spark.sql.inMemoryColumnarStorage.enableVectorizedReader": "true",
 decimal_gens = [decimal_gen_default, decimal_gen_neg_scale, decimal_gen_scale_precision,
                 DecimalGen(precision=7, scale=-2),
                 decimal_gen_same_scale_precision, decimal_gen_64bit]
-decimal_struct_gen= StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(decimal_gens)])
+decimal_struct_gen= StructGen([['child0', sub_gen] for ind, sub_gen in enumerate(decimal_gens)])
 
 @pytest.mark.parametrize('conf', conf, ids=idfn)
 @allow_non_gpu('CollectLimitExec')
@@ -142,7 +142,8 @@ def test_cache_expand_exec(data_gen, conf):
 
     assert_gpu_and_cpu_are_equal_collect(op_df, conf = conf)
 
-@pytest.mark.parametrize('data_gen', [ decimal_struct_gen], ids=idfn)
+@pytest.mark.parametrize('data_gen', [all_basic_struct_gen, StructGen([['child0', StructGen([['child1', byte_gen]])]]),
+                                      parquet_decimal_struct_gen] + all_gen, ids=idfn)
 @pytest.mark.parametrize('conf', conf, ids=idfn)
 @allow_non_gpu('CollectLimitExec')
 def test_cache_partial_load(data_gen, conf):
@@ -152,17 +153,6 @@ def test_cache_partial_load(data_gen, conf):
         return partial_return_cache
     assert_gpu_and_cpu_are_equal_collect(partial_return(f.col("a")), conf)
     assert_gpu_and_cpu_are_equal_collect(partial_return(f.col("b")), conf)
-
-@pytest.mark.parametrize('data_gen', [StructGen([['child0', StructGen([['child0', byte_gen],['child1', byte_gen]])],['child1', IntegerGen()]])], ids=idfn)
-@pytest.mark.parametrize('conf', conf, ids=idfn)
-@allow_non_gpu('CollectLimitExec')
-def test_cache_partial_load_struct(data_gen, conf):
-    def partial_return(col):
-        def partial_return_cache(spark):
-            return two_col_df(spark, data_gen, string_gen).select(f.col("a"), f.col("b")).cache().limit(50).select(col)
-        return partial_return_cache
-    assert_gpu_and_cpu_are_equal_collect(partial_return(f.col("a.child0.child0")), conf)
-#    assert_gpu_and_cpu_are_equal_collect(partial_return(f.col("b")), conf)
 
 @allow_non_gpu('CollectLimitExec')
 def test_cache_diff_req_order(spark_tmp_path):

--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -273,11 +273,11 @@ def test_cache_additional_types(enable_vectorized, with_x_session, select_expr):
     cached_result = with_x_session(with_cache(True),
                                    conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
                                          'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED',
-                                         'spark.sql.inMemoryColumnarStorage.enableVectorizedReader': enableVectorized})
+                                         'spark.sql.inMemoryColumnarStorage.enableVectorizedReader': enable_vectorized})
     reg_result = with_x_session(with_cache(False),
                                 conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'CORRECTED',
                                       'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED',
-                                      'spark.sql.inMemoryColumnarStorage.enableVectorizedReader': enableVectorized})
+                                      'spark.sql.inMemoryColumnarStorage.enableVectorizedReader': enable_vectorized})
 
     # NOTE: we aren't comparing cpu and gpu results, we are comparing the cached and non-cached results.
     assert_equal(reg_result, cached_result)

--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -209,10 +209,7 @@ def test_cache_cpu_gpu_mixed(data_gen, conf):
         df = binary_op_df(spark, data_gen)
         df.cache().count()
         enabled = spark.conf.get("spark.rapids.sql.enabled")
-        if (enabled == "true"):
-            spark.conf.set("spark.rapids.sql.enabled", "false")
-        else:
-            spark.conf.set("spark.rapids.sql.enabled", "true")
+        spark.conf.set("spark.rapids.sql.enabled", not enabled)
 
         return df.selectExpr("a", "b")
 

--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -214,23 +214,21 @@ def test_cache_columnar(spark_tmp_path, data_gen, enable_vectorized, ts_write):
 
     assert_gpu_and_cpu_are_equal_collect(read_parquet_cached(data_path_gpu), conf)
 
-
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen, StructGen([['child0', StructGen([['child1', byte_gen]])]]),
                                       decimal_struct_gen]+ all_gen, ids=idfn)
 @pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
 def test_cache_cpu_gpu_mixed(data_gen, enable_vectorized_conf):
     def func(spark):
-        df = binary_op_df(spark, data_gen)
+        df = unary_op_df(spark, data_gen)
         df.cache().count()
         enabled = spark.conf.get("spark.rapids.sql.enabled")
         spark.conf.set("spark.rapids.sql.enabled", not enabled)
 
-        return df.selectExpr("a", "b")
+        return df.selectExpr("a")
 
     conf = enable_vectorized_conf.copy()
     conf.update(allow_negative_scale_of_decimal_conf)
     assert_gpu_and_cpu_are_equal_collect(func, conf)
-
 
 @pytest.mark.parametrize('enable_vectorized', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize('with_x_session', [with_gpu_session, with_cpu_session])

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -199,7 +199,7 @@ def test_ts_read_fails_datetime_legacy(gen, spark_tmp_path, ts_write, ts_rebase,
             lambda spark : readParquetCatchException(spark, data_path),
             conf=all_confs)
 
-@pytest.mark.parametrize('parquet_gens', [[byte_gen, short_gen], decimal_gens,
+@pytest.mark.parametrize('parquet_gens', [[byte_gen, short_gen, DecimalGen(precision=7, scale=3)], decimal_gens,
                                           [ArrayGen(DecimalGen(7,2), max_length=10)],
                                           [StructGen([['child0', DecimalGen(7, 2)]])]], ids=idfn)
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -199,7 +199,7 @@ def test_ts_read_fails_datetime_legacy(gen, spark_tmp_path, ts_write, ts_rebase,
             lambda spark : readParquetCatchException(spark, data_path),
             conf=all_confs)
 
-@pytest.mark.parametrize('parquet_gens', [decimal_gens,
+@pytest.mark.parametrize('parquet_gens', [[byte_gen, short_gen], decimal_gens,
                                           [ArrayGen(DecimalGen(7,2), max_length=10)],
                                           [StructGen([['child0', DecimalGen(7, 2)]])]], ids=idfn)
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -833,7 +833,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
                           } else {
                             newRow.setInterval(index, interval)
                           }
-                        case d:DecimalType =>
+                        case d: DecimalType =>
                           if (row.isNullAt(index)) {
                             newRow.setDecimal(index, null, d.precision)
                           } else {

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 import ai.rapids.cudf._
 import ai.rapids.cudf.ParquetWriterOptions.StatisticsFrequency
-import com.nvidia.spark.rapids.{GpuColumnVector, _}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import java.util

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -379,7 +379,7 @@ class ParquetCachedBatchSerializer extends CachedBatchSerializer with Arm {
     val columns = for (i <- 0 until oldGpuCB.numCols()) yield {
       val gpuVector = oldGpuCB.column(i).asInstanceOf[GpuColumnVector]
       var dataType = schema(i).dataType
-      val v = ColumnUtil.convertTypeAtoTypeB(gpuVector.getBase,
+      val v = ColumnUtil.ifTrueThenDeepConvertTypeAtoTypeB(gpuVector.getBase,
         // we are checking for scale > 0 because cudf and spark refer to scales as opposites
         // e.g. scale = -3 in Spark is scale = 3 in cudf
         cv => cv.getType().isDecimalType() && cv.getType().getScale > 0,

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/ParquetCachedBatchSerializer.scala
@@ -47,7 +47,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{vectorized, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, ExprId, GenericInternalRow, SpecializedGetters, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, GenericInternalRow, SpecializedGetters, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, GenericArrayData, MapData}
 import org.apache.spark.sql.columnar.{CachedBatch, CachedBatchSerializer}

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -348,19 +348,12 @@ class Spark311Shims extends Spark301Shims {
         }),
       GpuOverrides.exec[InMemoryTableScanExec](
         "Implementation of InMemoryTableScanExec to use GPU accelerated Caching",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.STRUCT).nested()
-          .withPsNote(TypeEnum.DECIMAL,
-            "Negative scales aren't supported at the moment even with " +
-              "spark.sql.legacy.allowNegativeScaleOfDecimal set to true. This is because Parquet " +
-              "doesn't support negative scale for decimal values"),
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.STRUCT).nested(),
           TypeSig.all),
         (scan, conf, p, r) => new SparkPlanMeta[InMemoryTableScanExec](scan, conf, p, r) {
           override def tagPlanForGpu(): Unit = {
             if (!scan.relation.cacheBuilder.serializer.isInstanceOf[ParquetCachedBatchSerializer]) {
               willNotWorkOnGpu("ParquetCachedBatchSerializer is not being used")
-            }
-            if (SQLConf.get.allowNegativeScaleOfDecimalEnabled) {
-              willNotWorkOnGpu("Parquet doesn't support negative scales for Decimal values")
             }
           }
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
@@ -56,7 +56,7 @@ object ColumnCastUtil extends Arm {
         predicate: (DataType, ColumnView) => Boolean,
         toClose: ArrayBuffer[ColumnView]): ColumnView = {
       dataType match {
-        case a:ArrayType =>
+        case a: ArrayType =>
           val child = cv.getChildColumnView(0)
           toClose += child
           val newChild = convertTypeAToTypeB(child, a.elementType, predicate, toClose)
@@ -67,7 +67,7 @@ object ColumnCastUtil extends Arm {
             toClose += newView
             newView
           }
-        case s:StructType =>
+        case s: StructType =>
           val newColumns = ArrayBuilder.make[ColumnView]()
           newColumns.sizeHint(cv.getNumChildren)
           val newColIndices = ArrayBuilder.make[Int]()

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
@@ -18,11 +18,17 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder}
 
-import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
+import ai.rapids.cudf.{ColumnVector, ColumnView}
 
-import org.apache.spark.sql.types.{ArrayType, DataType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
 
-object ColumnUtil extends Arm {
+/**
+ * This class casts a column to another column if the predicate passed resolves to true.
+ * This method should be able to handle nested or non-nested types
+ *
+ * At this time this is strictly a place for casting methods
+ */
+object ColumnCastUtil extends Arm {
 
   /**
    * This method deep casts the input ColumnView to a new column if the predicate passed to this

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnUtil.scala
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnUtil.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import scala.collection.mutable.{ArrayBuffer, ArrayBuilder}
+
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
+
+object ColumnUtil extends Arm {
+
+  /**
+   * This method deep casts the input ColumnView to a new column if the predicate passed to this
+   * method resolves to true.
+   * Note: This method will also cast children of nested types to the given type if predicate
+   * succeeds
+   * @param cv              The column view that could potentially have a type to replace
+   * @param predicate       Condition on which to cast the column or child column view
+   * @param convert         Method used to convert the column view to a new column view
+   * @return
+   */
+  def convertTypeAtoTypeB(cv: ColumnVector,
+      predicate: ColumnView => Boolean, convert: ColumnView => ColumnView): ColumnVector = {
+    /*
+     * 'convertTypeAtoTypeB' method returns a ColumnView that should be copied out to a
+     * ColumnVector  before closing the `toClose` views otherwise it will close the returned view
+     * and it's children as well.
+     */
+    def convertTypeAToTypeB(
+        cv: ColumnView,
+        predicate: ColumnView => Boolean,
+        toClose: ArrayBuffer[ColumnView]): ColumnView = {
+      val dt = cv.getType
+      if (!dt.isNestedType) {
+        if (predicate(cv)) {
+          val col = convert(cv)
+          toClose += col
+          col
+        } else {
+          cv
+        }
+      } else if (dt == DType.LIST) {
+        val child = cv.getChildColumnView(0)
+        toClose += child
+        val newChild = convertTypeAToTypeB(child, predicate, toClose)
+        if (child == newChild) {
+          cv
+        } else {
+          val newView = cv.replaceListChild(newChild)
+          toClose += newView
+          newView
+        }
+      } else if (dt == DType.STRUCT) {
+        val newColumns = ArrayBuilder.make[ColumnView]()
+        newColumns.sizeHint(cv.getNumChildren)
+        val newColIndices = ArrayBuilder.make[Int]()
+        newColIndices.sizeHint(cv.getNumChildren)
+        (0 until cv.getNumChildren).foreach { i =>
+          val child = cv.getChildColumnView(i)
+          toClose += child
+          val newChild = convertTypeAToTypeB(child, predicate, toClose)
+          if (newChild != child) {
+            newColumns += newChild
+            newColIndices += i
+          }
+        }
+        val cols = newColumns.result()
+        if (cols.nonEmpty) {
+          // create a new struct column with the new ones
+          val newView = cv.replaceChildrenWithViews(newColIndices.result(), cols)
+          toClose += newView
+          newView
+        } else {
+          cv
+        }
+      } else {
+        throw new IllegalArgumentException(s"Unsupported data type ${dt.getTypeId}")
+      }
+    }
+
+    withResource(new ArrayBuffer[ColumnView]) { toClose =>
+      val tmp = convertTypeAToTypeB(cv, predicate, toClose)
+      if (tmp != cv) {
+        tmp.copyToColumnVector()
+      } else {
+        tmp.asInstanceOf[ColumnVector].incRefCount()
+      }
+    }
+  }
+
+}

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnUtil.scala
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnUtil.scala
@@ -32,7 +32,7 @@ object ColumnUtil extends Arm {
    * @param convert         Method used to convert the column view to a new column view
    * @return
    */
-  def convertTypeAtoTypeB(cv: ColumnVector,
+  def ifTrueThenDeepConvertTypeAtoTypeB(cv: ColumnVector,
       predicate: ColumnView => Boolean, convert: ColumnView => ColumnView): ColumnVector = {
     /*
      * 'convertTypeAtoTypeB' method returns a ColumnView that should be copied out to a

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DecimalUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DecimalUtil.scala
@@ -22,6 +22,10 @@ import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object DecimalUtil {
 
+  def createCudfDecimal(dt: DecimalType): DType = {
+    createCudfDecimal(dt.precision, dt.scale)
+  }
+
   def createCudfDecimal(precision: Int, scale: Int): DType = {
     if (precision <= Decimal.MAX_INT_DIGITS) {
       DType.create(DType.DTypeEnum.DECIMAL32, -scale)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -660,7 +660,8 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
               val origCol = table.getColumn(readAt)
               val col: ColumnVector = if (typeCastingNeeded) {
                 ColumnCastUtil.ifTrueThenDeepConvertTypeAtoTypeB(origCol, readField.dataType,
-                  (dt, cv) => !GpuColumnVector.getNonNestedRapidsType(dt).equals(cv.getType()),
+                  (dt, cv) => cv.getType.isDecimalType &&
+                      !GpuColumnVector.getNonNestedRapidsType(dt).equals(cv.getType()),
                   (dt, cv) =>
                     cv.castTo(DecimalUtil.createCudfDecimal(dt.asInstanceOf[DecimalType])))
               } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -690,21 +690,6 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
     }
   }
 
-  protected def dumpParquetData(
-      hmb: HostMemoryBuffer,
-      dataLength: Long,
-      splits: Array[PartitionedFile],
-      debugDumpPrefix: String): Unit = {
-    val (out, path) = FileUtils.createTempFile(conf, debugDumpPrefix, ".parquet")
-    try {
-      logInfo(s"Writing Parquet split data for $splits to $path")
-      val in = new HostMemoryInputStream(hmb, dataLength)
-      IOUtils.copy(in, out)
-    } finally {
-      out.close()
-    }
-  }
-
   protected def readPartFile(
       blocks: Seq[BlockMetaData],
       clippedSchema: MessageType,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -661,7 +661,7 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
               val origCol = table.getColumn(readAt)
               val col = if (typeCastingNeeded && precisionList.nonEmpty) {
                 val prec = precisionList.dequeue()
-                ColumnUtil.convertTypeAtoTypeB(origCol,
+                ColumnUtil.ifTrueThenDeepConvertTypeAtoTypeB(origCol,
                   cv => cv.getType.getTypeId == DTypeEnum.DECIMAL64
                       && prec <= DType.DECIMAL32_MAX_PRECISION,
                   cv => cv.castTo(DecimalUtil.createCudfDecimal(prec, -cv.getType.getScale())))

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -149,7 +149,7 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
         Array(StructField("empty", ByteType, false),
           StructField("empty", ByteType, false),
           StructField("empty", ByteType, false)))
-      ser.compressColumnarBatchWithParquet(cb, dummySchema)
+      ser.compressColumnarBatchWithParquet(cb, dummySchema, dummySchema)
       theTableMock.close()
     }
   }
@@ -170,7 +170,7 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
     }
     val ser = new ParquetCachedBatchSerializer
 
-    val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema,
+    val producer = new ser.CachedBatchIteratorProducer[ColumnarBatch](cbIter, schema, schema,
       withCpuSparkSession(spark => spark.sparkContext.broadcast(new SQLConf().getAllConfs)))
     val mockParquetOutputFileFormat = mock(classOf[ParquetOutputFileFormat])
     var totalSize = 0L

--- a/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
+++ b/tests-spark310+/src/test/scala/com/nvidia/spark/rapids/Spark310ParquetWriterSuite.scala
@@ -20,19 +20,16 @@ import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, DType, Table, TableWriter}
 import com.nvidia.spark.rapids.shims.spark311.{ParquetCachedBatchSerializer, ParquetOutputFileFormat}
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
-import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.SerializableConfiguration
 
 
 /**
@@ -148,7 +145,10 @@ class Spark310ParquetWriterSuite extends SparkQueryCompareTestSuite {
       val cb = new ColumnarBatch(gpuCols, ROWS)
       whenSplitCalled(cb)
       val ser = new ParquetCachedBatchSerializer
-      val dummySchema = new StructType(Array(new StructField("empty", BooleanType, false)))
+      val dummySchema = new StructType(
+        Array(StructField("empty", ByteType, false),
+          StructField("empty", ByteType, false),
+          StructField("empty", ByteType, false)))
       ser.compressColumnarBatchWithParquet(cb, dummySchema)
       theTableMock.close()
     }


### PR DESCRIPTION
PCBS stores cache in parquet format which is good because it compresses it but the drawback is that we have to handle data that parquet doesn't one example is Decimals with negative scale, which is supported as a Legacy feature in Spark.

This PR deals with storing the unscaled long value associated with Decimals so we can support negative scale. This PR also lays the foundation for possible improvement in performance which is a part of #1143 

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
