### PR TITLE
fix GDS spill bug when copying from the batch write buffer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -259,9 +259,9 @@ class RapidsGdsStore(
           case dmOriginal: DeviceMemoryBuffer =>
             val dm = dmOriginal.slice(dstOffset, length)
             if (isPending) {
-              copyToBuffer(dm, fileOffset + srcOffset, size, stream)
+              copyToBuffer(dm, fileOffset + srcOffset, length, stream)
               stream.sync()
-              logDebug(s"Created device buffer $size from batch write buffer")
+              logDebug(s"Created device buffer $length from batch write buffer")
             } else {
               // TODO: switch to async API when it's released, using the passed in CUDA stream.
               stream.sync()


### PR DESCRIPTION
When a spilled buffer is pending and still in GPU memory, sometimes we want to copy part of it to the UCX bounce buffer. We shouldn't copy the whole length of the buffer, and should only copy the specified length.

Signed-off-by: Rong Ou <rong.ou@gmail.com>

