### PR TITLE
Add a pre-commit hook to reject large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
     rev: v4.0.1
     hooks:
       - id: check-added-large-files
-        name: Reject files over 50M
-        args: ['--maxkb=51200', '--enforce-all']
+        name: Check for file over 1.5MiB
+        args: ['--maxkb=1500', '--enforce-all']
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,8 @@ repos:
         language: script
         pass_filenames: true
         verbose: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,6 @@ repos:
     rev: v4.0.1
     hooks:
       - id: check-added-large-files
+        name: Reject files over 50M
         args: ['--maxkb=51200', '--enforce-all']
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,5 @@ repos:
     rev: v4.0.1
     hooks:
       - id: check-added-large-files
+        args: ['--maxkb=51200', '--enforce-all']
 


### PR DESCRIPTION
Prevents large files as in #2644. 

Contributes to #2420, #2674
    
Signed-off-by: Gera Shegalov <gera@apache.org>

