### PR TITLE
Set numSlices and use parallelize to build dataframe for partition-se…

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -617,7 +617,7 @@ def skip_if_not_utc():
     if (not is_tz_utc()):
         skip_unless_precommit_tests('The java system time zone is not set to UTC')
 
-def gen_df(spark, data_gen, length=2048, seed=0, numSlices=None):
+def gen_df(spark, data_gen, length=2048, seed=0, num_slices=None):
     """Generate a spark dataframe from the given data generators."""
     if isinstance(data_gen, list):
         src = StructGen(data_gen, nullable=False)
@@ -636,7 +636,7 @@ def gen_df(spark, data_gen, length=2048, seed=0, numSlices=None):
     # We use `numSlices` to create an RDD with the specific number of partitions,
     # which is then turned into a dataframe. If not specified, it is `None` (default spark value)
     return spark.createDataFrame(
-        SparkContext.getOrCreate().parallelize(data, numSlices=numSlices),
+        SparkContext.getOrCreate().parallelize(data, numSlices=num_slices),
         src.data_type)
 
 def _mark_as_lit(data, data_type = None):
@@ -718,20 +718,20 @@ def idfn(val):
     """Provide an API to provide display names for data type generators."""
     return str(val)
 
-def three_col_df(spark, a_gen, b_gen, c_gen, length=2048, seed=0, numSlices=None):
+def three_col_df(spark, a_gen, b_gen, c_gen, length=2048, seed=0, num_slices=None):
     gen = StructGen([('a', a_gen),('b', b_gen),('c', c_gen)], nullable=False)
-    return gen_df(spark, gen, length=length, seed=seed, numSlices=numSlices)
+    return gen_df(spark, gen, length=length, seed=seed, num_slices=num_slices)
 
-def two_col_df(spark, a_gen, b_gen, length=2048, seed=0, numSlices=None):
+def two_col_df(spark, a_gen, b_gen, length=2048, seed=0, num_slices=None):
     gen = StructGen([('a', a_gen),('b', b_gen)], nullable=False)
-    return gen_df(spark, gen, length=length, seed=seed, numSlices=numSlices)
+    return gen_df(spark, gen, length=length, seed=seed, num_slices=num_slices)
 
-def binary_op_df(spark, gen, length=2048, seed=0, numSlices=None):
-    return two_col_df(spark, gen, gen, length=length, seed=seed, numSlices=numSlices)
+def binary_op_df(spark, gen, length=2048, seed=0, num_slices=None):
+    return two_col_df(spark, gen, gen, length=length, seed=seed, num_slices=num_slices)
 
-def unary_op_df(spark, gen, length=2048, seed=0, numSlices=None):
+def unary_op_df(spark, gen, length=2048, seed=0, num_slices=None):
     return gen_df(spark, StructGen([('a', gen)], nullable=False),
-        length=length, seed=seed, numSlices=numSlices)
+        length=length, seed=seed, num_slices=num_slices)
 
 def to_cast_string(spark_type):
     if isinstance(spark_type, ByteType):

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -16,6 +16,7 @@ import copy
 from datetime import date, datetime, timedelta, timezone
 from decimal import *
 import math
+from pyspark.context import SparkContext
 from pyspark.sql import Row
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
@@ -616,7 +617,7 @@ def skip_if_not_utc():
     if (not is_tz_utc()):
         skip_unless_precommit_tests('The java system time zone is not set to UTC')
 
-def gen_df(spark, data_gen, length=2048, seed=0):
+def gen_df(spark, data_gen, length=2048, seed=0, numSlices=None):
     """Generate a spark dataframe from the given data generators."""
     if isinstance(data_gen, list):
         src = StructGen(data_gen, nullable=False)
@@ -632,7 +633,11 @@ def gen_df(spark, data_gen, length=2048, seed=0):
     rand = random.Random(seed)
     src.start(rand)
     data = [src.gen() for index in range(0, length)]
-    return spark.createDataFrame(data, src.data_type)
+    # We use `numSlices` to create an RDD with the specific number of partitions,
+    # which is then turned into a dataframe. If not specified, it is `None` (default spark value)
+    return spark.createDataFrame(
+        SparkContext.getOrCreate().parallelize(data, numSlices=numSlices),
+        src.data_type)
 
 def _mark_as_lit(data, data_type = None):
     # Sadly you cannot create a literal from just an array in pyspark
@@ -713,19 +718,20 @@ def idfn(val):
     """Provide an API to provide display names for data type generators."""
     return str(val)
 
-def three_col_df(spark, a_gen, b_gen, c_gen, length=2048, seed=0):
+def three_col_df(spark, a_gen, b_gen, c_gen, length=2048, seed=0, numSlices=None):
     gen = StructGen([('a', a_gen),('b', b_gen),('c', c_gen)], nullable=False)
-    return gen_df(spark, gen, length=length, seed=seed)
+    return gen_df(spark, gen, length=length, seed=seed, numSlices=numSlices)
 
-def two_col_df(spark, a_gen, b_gen, length=2048, seed=0):
+def two_col_df(spark, a_gen, b_gen, length=2048, seed=0, numSlices=None):
     gen = StructGen([('a', a_gen),('b', b_gen)], nullable=False)
-    return gen_df(spark, gen, length=length, seed=seed)
+    return gen_df(spark, gen, length=length, seed=seed, numSlices=numSlices)
 
-def binary_op_df(spark, gen, length=2048, seed=0):
-    return two_col_df(spark, gen, gen, length=length, seed=seed)
+def binary_op_df(spark, gen, length=2048, seed=0, numSlices=None):
+    return two_col_df(spark, gen, gen, length=length, seed=seed, numSlices=numSlices)
 
-def unary_op_df(spark, gen, length=2048, seed=0):
-    return gen_df(spark, StructGen([('a', gen)], nullable=False), length=length, seed=seed)
+def unary_op_df(spark, gen, length=2048, seed=0, numSlices=None):
+    return gen_df(spark, StructGen([('a', gen)], nullable=False),
+        length=length, seed=seed, numSlices=numSlices)
 
 def to_cast_string(spark_type):
     if isinstance(spark_type, ByteType):

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -105,9 +105,9 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
-    # We set `numSlices` to handle https://github.com/NVIDIA/spark-rapids/issues/2477
+    # We set `num_slices` to handle https://github.com/NVIDIA/spark-rapids/issues/2477
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : debug_df(unary_op_df(spark, data_gen, numSlices=12)).sortWithinPartitions(order),
+        lambda spark : unary_op_df(spark, data_gen, num_slices=12).sortWithinPartitions(order),
         conf = allow_negative_scale_of_decimal_conf)
 
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen], ids=idfn)

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -105,12 +105,7 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 @pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
-    # This outputs the source data frame each time to debug intermittent test
-    # failures as documented here: https://github.com/NVIDIA/spark-rapids/issues/2477
-    # Update: we are setting the number of slices with `numSlices` as the error appears to be
-    #   because of a prior failure in an executor changing the number of total cores (and therefore
-    #   `defaultParallelism`). `numSlices` keeps the number of partitions static, rather than
-    #   the Spark default behaviour to use `defaultParallelism`.
+    # We set `numSlices` to handle https://github.com/NVIDIA/spark-rapids/issues/2477
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : debug_df(unary_op_df(spark, data_gen, numSlices=12)).sortWithinPartitions(order),
         conf = allow_negative_scale_of_decimal_conf)

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -107,8 +107,12 @@ def test_single_nested_orderby_with_limit(data_gen, order):
 def test_single_sort_in_part(data_gen, order):
     # This outputs the source data frame each time to debug intermittent test
     # failures as documented here: https://github.com/NVIDIA/spark-rapids/issues/2477
+    # Update: we are setting the number of slices with `numSlices` as the error appears to be
+    #   because of a prior failure in an executor changing the number of total cores (and therefore
+    #   `defaultParallelism`). `numSlices` keeps the number of partitions static, rather than
+    #   the Spark default behaviour to use `defaultParallelism`.
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : debug_df(unary_op_df(spark, data_gen)).sortWithinPartitions(order),
+        lambda spark : debug_df(unary_op_df(spark, data_gen, numSlices=12)).sortWithinPartitions(order),
         conf = allow_negative_scale_of_decimal_conf)
 
 @pytest.mark.parametrize('data_gen', [all_basic_struct_gen], ids=idfn)


### PR DESCRIPTION
…nsitive tests

Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Set `numSlices` and use the `parallelize` API, to create a dataframe that has a static number of partitions.

Re: #2477 