### PR TITLE
WIP: batch read small buffers spilled through GDS

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -262,13 +262,13 @@ abstract class RapidsBufferStore(
       override val meta: TableMeta,
       initialSpillPriority: Long,
       override val spillCallback: RapidsBuffer.SpillCallback,
-      catalog: RapidsBufferCatalog = RapidsBufferCatalog.singleton,
-      deviceStorage: RapidsDeviceMemoryStore = RapidsBufferCatalog.getDeviceStorage)
-      extends RapidsBuffer with Arm {
-    private val MAX_UNSPILL_ATTEMPTS = 100
+      catalog: RapidsBufferCatalog = RapidsBufferCatalog.singleton) extends RapidsBuffer with Arm {
+    protected val MAX_UNSPILL_ATTEMPTS = 100
     private[this] var isValid = true
     protected[this] var refcount = 0
     private[this] var spillPriority: Long = initialSpillPriority
+    protected[this] val deviceStorage: RapidsDeviceMemoryStore =
+      RapidsBufferCatalog.getDeviceStorage
 
     /** Release the underlying resources for this buffer. */
     protected def releaseResources(): Unit

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -401,7 +401,7 @@ object RapidsConf {
         "cause more memory consumption because of padding.")
     .internal()
     .bytesConf(ByteUnit.BYTE)
-    .createWithDefault(ByteUnit.KiB.toBytes(64))
+    .createWithDefault(ByteUnit.MiB.toBytes(8))
 
   val POOLED_MEM = conf("spark.rapids.memory.gpu.pooling.enabled")
     .doc("Should RMM act as a pooling allocator for GPU memory, or should it just pass " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -57,7 +57,7 @@ class RapidsDiskStore(
       }
       logDebug(s"Spilled to $path $fileOffset:${incoming.size}")
       new this.RapidsDiskBuffer(id, fileOffset, incoming.size, incoming.meta,
-        incoming.getSpillPriority, incoming.spillCallback, deviceStorage)
+        incoming.getSpillPriority, incoming.spillCallback)
     }
   }
 
@@ -89,10 +89,8 @@ class RapidsDiskStore(
       size: Long,
       meta: TableMeta,
       spillPriority: Long,
-      spillCallback: RapidsBuffer.SpillCallback,
-      deviceStorage: RapidsDeviceMemoryStore)
-      extends RapidsBufferBase(
-        id, size, meta, spillPriority, spillCallback, deviceStorage = deviceStorage) {
+      spillCallback: RapidsBuffer.SpillCallback)
+      extends RapidsBufferBase(id, size, meta, spillPriority, spillCallback) {
     private[this] var hostBuffer: Option[HostMemoryBuffer] = None
 
     override val storageTier: StorageTier = StorageTier.DISK

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -253,7 +253,7 @@ class RapidsGdsStore(
         } else if (RapidsBufferCatalog.shouldUnspill) {
           withResource(DeviceMemoryBuffer.allocate(batchWriteBufferSize)) { buffer =>
             CuFile.readFileToDeviceMemory(buffer.getAddress, buffer.getLength, path, 0)
-            logDebug(s"Created device buffer for $path 0:$size via GDS")
+            logDebug(s"Created device buffer for $path 0:$batchWriteBufferSize via GDS")
             spilledBuffers.get(path).foreach { id =>
               if (id != this.id) {
                 withResource(catalog.acquireBuffer(id)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import com.nvidia.spark.rapids.StorageTier.{DEVICE, StorageTier}
+import com.nvidia.spark.rapids.StorageTier.{DEVICE, GDS, StorageTier}
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.sql.rapids.{RapidsDiskBlockManager, TempSpillBufferId}
@@ -170,7 +170,7 @@ class RapidsGdsStore(
     private[this] var currentOffset = 0L
     private[this] val batchReadExecutor = Executors.newSingleThreadExecutor(
       GpuDeviceManager.wrapThreadFactory(new ThreadFactoryBuilder()
-          .setNameFormat(s"shuffle-server-copy-thread-%d")
+          .setNameFormat(s"gds-spill-batch-read-thread-%d")
           .setDaemon(true)
           .build))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -91,6 +91,7 @@ class RapidsHostMemoryStore(
           hostBuffer.close()
           throw e
       }
+      logDebug(s"Spilled to host memory size=${other.size}")
       new RapidsHostMemoryBuffer(
         other.id,
         other.size,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -99,8 +99,7 @@ class RapidsHostMemoryStore(
         other.getSpillPriority,
         hostBuffer,
         isPinned,
-        other.spillCallback,
-        deviceStorage)
+        other.spillCallback)
     }
   }
 
@@ -118,10 +117,8 @@ class RapidsHostMemoryStore(
       spillPriority: Long,
       buffer: HostMemoryBuffer,
       isInternalPoolAllocated: Boolean,
-      spillCallback: RapidsBuffer.SpillCallback,
-      deviceStorage: RapidsDeviceMemoryStore)
-      extends RapidsBufferBase(
-        id, size, meta, spillPriority, spillCallback, deviceStorage = deviceStorage) {
+      spillCallback: RapidsBuffer.SpillCallback)
+      extends RapidsBufferBase(id, size, meta, spillPriority, spillCallback) {
     override val storageTier: StorageTier = StorageTier.HOST
 
     override def getMemoryBuffer: MemoryBuffer = {


### PR DESCRIPTION
It's relatively inefficient to read and write small spill buffers one by one through GDS. #2295 batches small buffers when writing, this PR is the counter part for reading. When unspill is enabled and a spilled buffer is requested, the whole batched buffer file (default to 8MB) is read back, and each buffer is then unspilled in a background thread.

The caveat is the batched buffers from the same file may not be needed at the same time, so some of them may be spilled and read back repeatedly. An improvement would be to batch buffers with similar a life cycle together, but it's hard to do this with Spark.