### PR TITLE
Add file size check to pre-merge CI

### DIFF
--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -40,6 +40,6 @@ RUN python3.8 -m easy_install pip
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 RUN ln -s /usr/bin/python3.8 /usr/bin/python
-RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist
+RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit
 
 RUN apt install -y inetutils-ping expect

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -21,9 +21,9 @@ nvidia-smi
 
 . jenkins/version-def.sh
 
-# get BASE commit from merged PR, e.g. "Merge HEAD into BASE"
-BASE_REF=$(git --no-pager log --oneline -1 | awk '{ print $NF }');
-# file size check for pull request, the size of committed file should be less than 1.5MiB
+# get merge BASE from merged pull request. Log message e.g. "Merge HEAD into BASE"
+BASE_REF=$(git --no-pager log --oneline -1 | awk '{ print $NF }')
+# file size check for pull request. The size of a committed file should be less than 1.5MiB
 pre-commit run check-added-large-files --from-ref $BASE_REF --to-ref HEAD
 
 ARTF_ROOT="$WORKSPACE/.download"

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -21,6 +21,11 @@ nvidia-smi
 
 . jenkins/version-def.sh
 
+# get BASE commit from merged PR, e.g. "Merge HEAD into BASE"
+BASE_REF=$(git --no-pager log --oneline -1 | awk '{ print $NF }');
+# file size check for pull request, the size of committed file should be less than 1.5MiB
+pre-commit run check-added-large-files --from-ref $BASE_REF --to-ref HEAD
+
 ARTF_ROOT="$WORKSPACE/.download"
 MVN_GET_CMD="mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B \
     $MVN_URM_MIRROR -DremoteRepositories=$URM_URL \


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/2674 using https://github.com/NVIDIA/spark-rapids/pull/2699

We could add `--all-files` after the existing large testing files get moved our or compressed.

```
[2021-06-15T02:56:04.451Z] + BASE_REF=e0ad5882ee04d90acc8e9754a0ea2d07b924f58d
[2021-06-15T02:56:04.451Z] + pre-commit run check-added-large-files --from-ref e0ad5882ee04d90acc8e9754a0ea2d07b924f58d --to-ref HEAD
[2021-06-15T02:56:08.648Z] [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.git.
[2021-06-15T02:56:08.907Z] [INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.git.
[2021-06-15T02:56:08.907Z] [INFO] Once installed this environment will be reused.
[2021-06-15T02:56:08.907Z] [INFO] This may take a few minutes...
[2021-06-15T02:56:13.091Z] Check for file over 1.5MiB...............................................Passed
```
