### PR TITLE
Avoid executing child plan twice in CoalesceExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -436,12 +436,13 @@ case class GpuCoalesceExec(numPartitions: Int, child: SparkPlan)
     s"${getClass.getCanonicalName} does not support row-based execution")
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    if (numPartitions == 1 && child.executeColumnar().getNumPartitions < 1) {
+    val rdd = child.executeColumnar()
+    if (numPartitions == 1 && rdd.getNumPartitions < 1) {
       // Make sure we don't output an RDD with 0 partitions, when claiming that we have a
       // `SinglePartition`.
       new GpuCoalesceExec.EmptyRDDWithPartitions(sparkContext, numPartitions)
     } else {
-      child.executeColumnar().coalesce(numPartitions, shuffle = false)
+      rdd.coalesce(numPartitions, shuffle = false)
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This is a small performance optimization to avoid executing a child plan twice in `GpuCoalesceExec` when `numPartitions == 1`.

The same issue exists in Spark: https://issues.apache.org/jira/browse/SPARK-35767