### PR TITLE
Support aggregation on NullType in RunningWindowExec

### DIFF
--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -105,7 +105,7 @@ class Spark301dbShims extends Spark301Shims {
         "Databricks-specific window function exec, for \"running\" windows, " +
             "i.e. (UNBOUNDED PRECEDING TO CURRENT ROW)",
         ExecChecks(
-          TypeSig.commonCudfTypes + TypeSig.DECIMAL +
+          TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.Null +
               TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL) +
               TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.STRUCT
                   + TypeSig.ARRAY),

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -108,7 +108,7 @@ class Spark311dbShims extends Spark311Shims {
         "Databricks-specific window function exec, for \"running\" windows, " +
             "i.e. (UNBOUNDED PRECEDING TO CURRENT ROW)",
         ExecChecks(
-            TypeSig.commonCudfTypes + TypeSig.DECIMAL +
+            TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.NULL +
                 TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL) +
                 TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.STRUCT
                     + TypeSig.ARRAY),


### PR DESCRIPTION
Fixes #2715.

#2596 extended `WindowExec`'s meta to allow for aggregations on `NullType` input. E.g.
```sql
SELECT MIN(null) OVER (PARTITION BY foo ORDER BY bar ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)...
```
`test_window_running()` and `test_window_running_no_part()` integration tests were added to exercise this path.

 #2596 did not include a change to enable `NullType` aggregations in the Databricks Shims, causing the `test_window_running*()` tests to fail. 

This commit should resolve the failure.

Signed-off-by: Mithun RK <mythrocks@gmail.com>

