### PR TITLE
Fix local mode starting RAPIDS shuffle heartbeats

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
@@ -164,7 +164,11 @@ class RapidsShuffleHeartbeatEndpoint(pluginContext: PluginContext, conf: RapidsC
   }
 
   GpuShuffleEnv.mgr.foreach { mgr =>
-    executorService.submit(new InitializeShuffleManager(pluginContext, mgr))
+    if (mgr.isDriver) {
+      logDebug("Local mode detected. Skipping shuffle heartbeat registration.")
+    } else {
+      executorService.submit(new InitializeShuffleManager(pluginContext, mgr))
+    }
   }
 
   override def close(): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -197,7 +197,7 @@ class RapidsCachingWriter[K, V](
  *       `ShuffleManager` and `SortShuffleManager` classes. When configuring
  *       Apache Spark to use the RAPIDS shuffle manager,
  */
-abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, isDriver: Boolean)
+abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
     extends ShuffleManager with RapidsShuffleHeartbeatHandler with Logging {
 
   def getServerId: BlockManagerId = server.fold(blockManager.blockManagerId)(_.getId)


### PR DESCRIPTION
Fixes: #2725 

The issue is with local mode, where a single "executor" is created within the driver with as many cores as provided in the `local[*]` pattern. This is not a setup that should use UCX, therefore the heartbeats do not apply. The fix is to skip the registration of such an executor that resides in the driver.