### PR TITLE
fix 301db-shim typecheck typo

### DIFF
--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -105,7 +105,7 @@ class Spark301dbShims extends Spark301Shims {
         "Databricks-specific window function exec, for \"running\" windows, " +
             "i.e. (UNBOUNDED PRECEDING TO CURRENT ROW)",
         ExecChecks(
-          TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.Null +
+          TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.NULL +
               TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL) +
               TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL + TypeSig.STRUCT
                   + TypeSig.ARRAY),


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

to fix a typo in [#2722](https://github.com/NVIDIA/spark-rapids/pull/2722/files#diff-28709416a6d3bbc3b8485a6052b3a35d0af288e3a58d12544107174e086fcab4R108)

```
shims/spark301db/Spark301dbShims.scala:108: value Null is not a member of object com.nvidia.spark.rapids.TypeSig
```