### PR TITLE
Disable dynamicAllocation and set maxFailures to 1 in integration tests

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -129,7 +129,9 @@ else
     export PYSP_TEST_spark_ui_showConsoleProgress='false'
     export PYSP_TEST_spark_sql_session_timeZone='UTC'
     export PYSP_TEST_spark_sql_shuffle_partitions='12'
+    # prevent cluster shape to change - and fail quicker rather than retry
     export PYSP_TEST_spark_task_maxFailures='1'
+    export PYSP_TEST_spark_dynamicAllocation_enabled='false'
     if ((${#TEST_PARALLEL_OPTS[@]} > 0));
     then
         export PYSP_TEST_spark_rapids_memory_gpu_allocFraction=$MEMORY_FRACTION

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -129,6 +129,7 @@ else
     export PYSP_TEST_spark_ui_showConsoleProgress='false'
     export PYSP_TEST_spark_sql_session_timeZone='UTC'
     export PYSP_TEST_spark_sql_shuffle_partitions='12'
+    export PYSP_TEST_spark_task_maxFailures='1'
     if ((${#TEST_PARALLEL_OPTS[@]} > 0));
     then
         export PYSP_TEST_spark_rapids_memory_gpu_allocFraction=$MEMORY_FRACTION

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -66,6 +66,8 @@ BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
     --executor-memory 12G \
     --total-executor-cores 6 \
     --conf spark.sql.shuffle.partitions=12 \
+    --conf spark.task.maxFailures=1 \
+    --conf spark.dynamicAllocation.enabled=false \
     --conf spark.driver.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
     --conf spark.executor.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
     --conf spark.driver.extraJavaOptions=-Duser.timezone=UTC \


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes: #2698

This should make tests fail quicker instead of sometimes succeeding on a re-attempt. We have test failure that is triggered when the shape of the cluster changes, to gain a new executor or when an executor is getting removed between cpu and gpu sessions (https://github.com/NVIDIA/spark-rapids/issues/2477).