### PR TITLE
Cost-based optimizer: Implement simple cost model that demonstrates benefits with NDS queries

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable.ListBuffer
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, GetStructField, WindowFrame, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftAnti, LeftSemi}
-import org.apache.spark.sql.execution.{GlobalLimitExec, LocalLimitExec, SparkPlan, TakeOrderedAndProjectExec, UnionExec}
-import org.apache.spark.sql.execution.adaptive.{CustomShuffleReaderExec, QueryStageExec}
+import org.apache.spark.sql.execution.{GlobalLimitExec, LocalLimitExec, ProjectExec, SparkPlan, TakeOrderedAndProjectExec, UnionExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, CustomShuffleReaderExec, QueryStageExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
@@ -67,7 +67,6 @@ class CostBasedOptimizer extends Optimizer with Logging {
     optimizations
   }
 
-
   /**
    * Walk the plan and determine CPU and GPU costs for each operator and then make decisions
    * about whether operators should run on CPU or GPU.
@@ -87,32 +86,38 @@ class CostBasedOptimizer extends Optimizer with Logging {
       optimizations: ListBuffer[Optimization],
       finalOperator: Boolean): (Double, Double) = {
 
-    // get the CPU and GPU cost of the child plan(s)
-    val childCosts = plan.childPlans
-        .map(child => recursivelyOptimize(
-          conf,
-          cpuCostModel,
-          gpuCostModel,
-          child,
-          optimizations,
-          finalOperator = false))
-
-    val (childCpuCosts, childGpuCosts) = childCosts.unzip
-
     // get the CPU and GPU cost of this operator (excluding cost of children)
     val operatorCpuCost = cpuCostModel.getCost(plan)
     val operatorGpuCost = gpuCostModel.getCost(plan)
 
+    showCosts(plan, "Operator costs", operatorCpuCost, operatorGpuCost)
+
+    // get the CPU and GPU cost of the child plan(s)
+    val childCosts = plan.childPlans
+      .map(child => recursivelyOptimize(
+        conf,
+        cpuCostModel,
+        gpuCostModel,
+        child,
+        optimizations,
+        finalOperator = false))
+
+    val (childCpuCosts, childGpuCosts) = childCosts.unzip
+
     // calculate total (this operator + children)
     val totalCpuCost = operatorCpuCost + childCpuCosts.sum
     var totalGpuCost = operatorGpuCost + childGpuCosts.sum
+
+    showCosts(plan, "Operator + child costs", totalCpuCost, totalGpuCost)
 
     plan.estimatedOutputRows = RowCountPlanVisitor.visit(plan)
 
     // determine how many transitions between CPU and GPU are taking place between
     // the child operators and this operator
     val numTransitions = plan.childPlans
-      .count(_.canThisBeReplaced != plan.canThisBeReplaced)
+      .count(canRunOnGpu(_) != canRunOnGpu(plan))
+
+    showCosts(plan, s"numTransitions=$numTransitions", totalCpuCost, totalGpuCost)
 
     if (numTransitions > 0) {
       // there are transitions between CPU and GPU so we need to calculate the transition costs
@@ -120,11 +125,12 @@ class CostBasedOptimizer extends Optimizer with Logging {
       // have been better off just staying on the CPU
 
       // is this operator on the GPU?
-      if (plan.canThisBeReplaced) {
+      if (canRunOnGpu(plan)) {
         // at least one child is transitioning from CPU to GPU so we calculate the
         // transition costs
-        val transitionCost = plan.childPlans.filter(!_.canThisBeReplaced)
-            .map(transitionToGpuCost(conf, _)).sum
+        val transitionCost = plan.childPlans
+          //.filterNot(canRunOnGpu)
+          .map(transitionToGpuCost(conf, _)).sum
 
         // if the GPU cost including transition is more than the CPU cost then avoid this
         // transition and reset the GPU cost
@@ -138,6 +144,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
           // add transition cost to total GPU cost
           totalGpuCost += transitionCost
         }
+        showCosts(plan, s"transitionFromCpuCost=$transitionCost", totalCpuCost, totalGpuCost)
       } else {
         // at least one child is transitioning from GPU to CPU so we evaulate each of this
         // child plans to see if it was worth running on GPU now that we have the cost of
@@ -147,7 +154,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
             val (childCpuCost, childGpuCost) = childCosts
             val transitionCost = transitionToCpuCost(conf, child)
             val childGpuTotal = childGpuCost + transitionCost
-            if (child.canThisBeReplaced && !isExchangeOp(child)
+            if (canRunOnGpu(child) && !isExchangeOp(child)
                 && childGpuTotal > childCpuCost) {
               // force this child plan back onto CPU
               optimizations.append(ReplaceSection(
@@ -158,37 +165,69 @@ class CostBasedOptimizer extends Optimizer with Logging {
 
         // recalculate the transition costs because child plans may have changed
         val transitionCost = plan.childPlans
-            .filter(_.canThisBeReplaced)
-            .map(transitionToCpuCost(conf, _)).sum
+          .filter(canRunOnGpu)
+          .map(transitionToCpuCost(conf, _)).sum
         totalGpuCost += transitionCost
+        showCosts(plan, s"transitionFromGpuCost=$transitionCost", totalCpuCost, totalGpuCost)
       }
     }
 
     // special behavior if this is the final operator in the plan because we always have the
     // cost of going back to CPU at the end
-    if (finalOperator && plan.canThisBeReplaced) {
-      totalGpuCost += transitionToCpuCost(conf, plan)
+    if (finalOperator && canRunOnGpu(plan)) {
+      val transitionCost = transitionToCpuCost(conf, plan)
+      totalGpuCost += transitionCost
+      showCosts(plan, s"final operator, transitionFromGpuCost=$transitionCost",
+        totalCpuCost, totalGpuCost)
     }
 
     if (totalGpuCost > totalCpuCost) {
       // we have reached a point where we have transitioned onto GPU for part of this
       // plan but with no benefit from doing so, so we want to undo this and go back to CPU
-      if (plan.canThisBeReplaced && !isExchangeOp(plan)) {
+      if (canRunOnGpu(plan) && !  isExchangeOp(plan)) {
         // this plan would have been on GPU so we move it and onto CPU and recurse down
         // until we reach a part of the plan that is already on CPU and then stop
         optimizations.append(ReplaceSection(plan, totalCpuCost, totalGpuCost))
         plan.recursiveCostPreventsRunningOnGpu()
         // reset the costs because this section of the plan was not moved to GPU
         totalGpuCost = totalCpuCost
+        showCosts(plan, s"ReplaceSection: ${plan}", totalCpuCost, totalGpuCost)
       }
     }
 
-    if (!plan.canThisBeReplaced || isExchangeOp(plan)) {
+    if (!canRunOnGpu(plan) || isExchangeOp(plan)) {
       // reset the costs because this section of the plan was not moved to GPU
       totalGpuCost = totalCpuCost
+      showCosts(plan, s"Reset costs (not on GPU)", totalCpuCost, totalGpuCost)
     }
 
+    showCosts(plan, "END", totalCpuCost, totalGpuCost)
     (totalCpuCost, totalGpuCost)
+  }
+
+  private def showCosts(
+      plan: SparkPlanMeta[_],
+      message: String,
+      cpuCost: Double,
+      gpuCost: Double): Unit = {
+    val sign = if (cpuCost == gpuCost) {
+      "=="
+    } else if (cpuCost < gpuCost) {
+      "<"
+    } else {
+      ">"
+    }
+    logTrace(s"CBO [${plan.wrapped.getClass.getSimpleName}] $message: " +
+      s"cpuCost=$cpuCost $sign gpuCost=$gpuCost)")
+  }
+
+  private def canRunOnGpu(plan: SparkPlanMeta[_]): Boolean = plan.wrapped match {
+    case _: AdaptiveSparkPlanExec =>
+      // this is hacky but AdaptiveSparkPlanExec is always tagged as "cannot replace" and
+      // there are no child plans to inspect, so we just assume that the plan is running
+      // on GPU
+      true
+    case _ => plan.canThisBeReplaced
   }
 
   private def transitionToGpuCost(conf: RapidsConf, plan: SparkPlanMeta[SparkPlan]): Double = {
@@ -219,10 +258,10 @@ class CostBasedOptimizer extends Optimizer with Logging {
     // next operator on GPU in these cases
     SQLConf.get.adaptiveExecutionEnabled && (plan.wrapped match {
         case _: CustomShuffleReaderExec
-             | _: ShuffledHashJoinExec
-             | _: BroadcastHashJoinExec
-             | _: BroadcastExchangeExec
-             | _: BroadcastNestedLoopJoinExec => true
+           | _: ShuffledHashJoinExec
+           | _: BroadcastHashJoinExec
+           | _: BroadcastExchangeExec
+           | _: BroadcastNestedLoopJoinExec => true
         case _ => false
       })
   }
@@ -250,9 +289,21 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
     val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble)
       .getOrElse(conf.defaultRowCount.toDouble)
 
-    val operatorCost = plan.conf
-      .getCpuOperatorCost(plan.wrapped.getClass.getSimpleName)
-      .getOrElse(conf.defaultCpuOperatorCost) * rowCount
+    val operatorCost = plan.wrapped match {
+      case _: ProjectExec =>
+        // this is not accurage because CPU projections do have a cost due to appending values
+        // to each row that is produced, but this needs to be a really small number because
+        // GpuProject cost is zero (in our cost model) and we don't want to encourage moving to
+        // the GPU just to do a trivial projection, so we pretend the overhead of a
+        // CPU projection (beyond evaluating the expressions) is also zero
+        0
+      case _: UnionExec =>
+        // union does not further process data produced by its children
+        0
+      case _ => plan.conf
+        .getCpuOperatorCost(plan.wrapped.getClass.getSimpleName)
+        .getOrElse(conf.defaultCpuOperatorCost) * rowCount
+    }
 
     val exprEvalCost = plan.childExprs
       .map(expr => exprCost(expr.asInstanceOf[BaseExprMeta[Expression]], rowCount))
@@ -299,9 +350,18 @@ class GpuCostModel(conf: RapidsConf) extends CostModel {
     val rowCount = RowCountPlanVisitor.visit(plan).map(_.toDouble)
       .getOrElse(conf.defaultRowCount.toDouble)
 
-    val operatorCost = plan.conf
-      .getGpuOperatorCost(plan.wrapped.getClass.getSimpleName)
-      .getOrElse(conf.defaultGpuOperatorCost) * rowCount
+    val operatorCost = plan.wrapped match {
+      case _: ProjectExec =>
+        // The cost of a GPU projection is mostly the cost of evaluating the expressions
+        // to produce the projected columns
+        0
+      case _: UnionExec =>
+        // union does not further process data produced by its children
+        0
+      case _ => plan.conf
+        .getGpuOperatorCost(plan.wrapped.getClass.getSimpleName)
+        .getOrElse(conf.defaultGpuOperatorCost) * rowCount
+    }
 
     val exprEvalCost = plan.childExprs
       .map(expr => exprCost(expr.asInstanceOf[BaseExprMeta[Expression]], rowCount))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -89,7 +89,6 @@ class CostBasedOptimizer extends Optimizer with Logging {
     // get the CPU and GPU cost of this operator (excluding cost of children)
     val operatorCpuCost = cpuCostModel.getCost(plan)
     val operatorGpuCost = gpuCostModel.getCost(plan)
-
     showCosts(plan, "Operator costs", operatorCpuCost, operatorGpuCost)
 
     // get the CPU and GPU cost of the child plan(s)
@@ -101,13 +100,11 @@ class CostBasedOptimizer extends Optimizer with Logging {
         child,
         optimizations,
         finalOperator = false))
-
     val (childCpuCosts, childGpuCosts) = childCosts.unzip
 
     // calculate total (this operator + children)
     val totalCpuCost = operatorCpuCost + childCpuCosts.sum
     var totalGpuCost = operatorGpuCost + childGpuCosts.sum
-
     showCosts(plan, "Operator + child costs", totalCpuCost, totalGpuCost)
 
     plan.estimatedOutputRows = RowCountPlanVisitor.visit(plan)
@@ -117,7 +114,6 @@ class CostBasedOptimizer extends Optimizer with Logging {
     val numTransitions = plan.childPlans
       .filterNot(isExchangeOp)
       .count(canRunOnGpu(_) != canRunOnGpu(plan))
-
     showCosts(plan, s"numTransitions=$numTransitions", totalCpuCost, totalGpuCost)
 
     if (numTransitions > 0) {
@@ -258,13 +254,13 @@ class CostBasedOptimizer extends Optimizer with Logging {
     // if the child query stage already executed on GPU then we need to keep the
     // next operator on GPU in these cases
     SQLConf.get.adaptiveExecutionEnabled && (plan.wrapped match {
-        case _: CustomShuffleReaderExec
-           | _: ShuffledHashJoinExec
-           | _: BroadcastHashJoinExec
-           | _: BroadcastExchangeExec
-           | _: BroadcastNestedLoopJoinExec => true
-        case _ => false
-      })
+      case _: CustomShuffleReaderExec
+         | _: ShuffledHashJoinExec
+         | _: BroadcastHashJoinExec
+         | _: BroadcastExchangeExec
+         | _: BroadcastNestedLoopJoinExec => true
+      case _ => false
+    })
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -147,7 +147,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
         }
         showCosts(plan, s"transitionFromCpuCost=$transitionCost", totalCpuCost, totalGpuCost)
       } else {
-        // at least one child is transitioning from GPU to CPU so we evaulate each of this
+        // at least one child is transitioning from GPU to CPU so we evaluate each of this
         // child plans to see if it was worth running on GPU now that we have the cost of
         // transitioning back to CPU
         plan.childPlans.zip(childCosts).foreach {
@@ -292,7 +292,7 @@ class CpuCostModel(conf: RapidsConf) extends CostModel {
 
     val operatorCost = plan.wrapped match {
       case _: ProjectExec =>
-        // this is not accurage because CPU projections do have a cost due to appending values
+        // this is not accurate because CPU projections do have a cost due to appending values
         // to each row that is produced, but this needs to be a really small number because
         // GpuProject cost is zero (in our cost model) and we don't want to encourage moving to
         // the GPU just to do a trivial projection, so we pretend the overhead of a

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -214,7 +214,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
     } else {
       ">"
     }
-    println(s"CBO [${plan.wrapped.getClass.getSimpleName}] $message: " +
+    logTrace(s"CBO [${plan.wrapped.getClass.getSimpleName}] $message: " +
       s"cpuCost=$cpuCost $sign gpuCost=$gpuCost)")
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1153,25 +1153,25 @@ object RapidsConf {
 
   val OPTIMIZER_DEFAULT_CPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.cpu.exec.default")
     .internal()
-    .doc("Default per-row CPU cost of executing an operator")
+    .doc("Default per-row CPU cost of executing an operator, in seconds")
     .doubleConf
-    .createWithDefault(0.0)
+    .createWithDefault(0.0002)
 
   val OPTIMIZER_DEFAULT_CPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.cpu.expr.default")
     .internal()
-    .doc("Default per-row CPU cost of evaluating an expression")
+    .doc("Default per-row CPU cost of evaluating an expression, in seconds")
     .doubleConf
     .createWithDefault(0.0)
 
   val OPTIMIZER_DEFAULT_GPU_OPERATOR_COST = conf("spark.rapids.sql.optimizer.gpu.exec.default")
       .internal()
-      .doc("Default per-row GPU cost of executing an operator")
+      .doc("Default per-row GPU cost of executing an operator, in seconds")
       .doubleConf
-      .createWithDefault(0.0)
+      .createWithDefault(0.0001)
 
   val OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.gpu.expr.default")
       .internal()
-      .doc("Default per-row GPU cost of evaluating an expression")
+      .doc("Default per-row GPU cost of evaluating an expression, in seconds")
       .doubleConf
       .createWithDefault(0.0)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1157,6 +1157,23 @@ object RapidsConf {
     .doubleConf
     .createWithDefault(0.0002)
 
+  val OPTIMIZER_CPU_PROJECT_EXEC_COST = conf("spark.rapids.sql.optimizer.cpu.exec.ProjectExec")
+    .internal()
+    .doc("Default per-row CPU cost of executing an projection, in seconds. this is not accurate " +
+      "because CPU projections do have a cost due to appending values to each row that is " +
+      "produced, but this needs to be a really small number because GpuProject cost is zero " +
+      "and we don't want to encourage moving to the GPU just to do a trivial projection, so we " +
+      "pretend the overhead of a CPU projection (beyond evaluating the expressions) is also zero")
+    .doubleConf
+    .createWithDefault(0.0)
+
+  val OPTIMIZER_CPU_UNION_EXEC_COST = conf("spark.rapids.sql.optimizer.cpu.exec.UnionExec")
+    .internal()
+    .doc("Default per-row CPU cost of executing a union, in seconds. Union does not further " +
+      "process data produced by its children")
+    .doubleConf
+    .createWithDefault(0.0)
+
   val OPTIMIZER_DEFAULT_CPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.cpu.expr.default")
     .internal()
     .doc("Default per-row CPU cost of evaluating an expression, in seconds")
@@ -1168,6 +1185,21 @@ object RapidsConf {
       .doc("Default per-row GPU cost of executing an operator, in seconds")
       .doubleConf
       .createWithDefault(0.0001)
+
+  val OPTIMIZER_GPU_PROJECT_EXEC_COST = conf("spark.rapids.sql.optimizer.gpu.exec.ProjectExec")
+    .internal()
+    .doc("Default per-row GPU cost of executing a projection, in seconds. The cost of a GPU " +
+      "projection is mostly the cost of evaluating the expressions to produce the projected " +
+      "columns")
+    .doubleConf
+    .createWithDefault(0.0)
+
+  val OPTIMIZER_GPU_UNION_EXEC_COST = conf("spark.rapids.sql.optimizer.gpu.exec.UnionExec")
+    .internal()
+    .doc("Default per-row GPU cost of executing a union, in seconds. Union does not further " +
+      "process data produced by its children")
+    .doubleConf
+    .createWithDefault(0.0)
 
   val OPTIMIZER_DEFAULT_GPU_EXPRESSION_COST = conf("spark.rapids.sql.optimizer.gpu.expr.default")
       .internal()
@@ -1210,6 +1242,13 @@ object RapidsConf {
     .internal()
     .booleanConf
     .createWithDefault(true)
+
+  val OPTIMIZER_COSTS = Seq(
+    OPTIMIZER_CPU_PROJECT_EXEC_COST,
+    OPTIMIZER_CPU_UNION_EXEC_COST,
+    OPTIMIZER_GPU_PROJECT_EXEC_COST,
+    OPTIMIZER_GPU_UNION_EXEC_COST,
+  ).map(entry => entry.key -> entry).toMap
 
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
@@ -1609,20 +1648,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val isRangeWindowLongEnabled: Boolean = get(ENABLE_RANGE_WINDOW_LONG)
 
-  private val optimizerDefaults = Map(
-    // this is not accurate because CPU projections do have a cost due to appending values
-    // to each row that is produced, but this needs to be a really small number because
-    // GpuProject cost is zero (in our cost model) and we don't want to encourage moving to
-    // the GPU just to do a trivial projection, so we pretend the overhead of a
-    // CPU projection (beyond evaluating the expressions) is also zero
-    "spark.rapids.sql.optimizer.cpu.exec.ProjectExec" -> "0",
-    // The cost of a GPU projection is mostly the cost of evaluating the expressions
-    // to produce the projected columns
-    "spark.rapids.sql.optimizer.gpu.exec.ProjectExec" -> "0",
-    // union does not further process data produced by its children
-    "spark.rapids.sql.optimizer.cpu.exec.UnionExec" -> "0",
-    "spark.rapids.sql.optimizer.gpu.exec.UnionExec" -> "0"
-  )
 
   def isOperatorEnabled(key: String, incompat: Boolean, isDisabledByDefault: Boolean): Boolean = {
     val default = !(isDisabledByDefault || incompat) || (incompat && isIncompatEnabled)
@@ -1662,7 +1687,14 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   }
 
   private def getOptionalCost(key: String) = {
-    // user-provided value takes precedence, then look in defaults map
-    conf.get(key).orElse(optimizerDefaults.get(key)).map(toDouble(_, key))
+    // this is a bit convoluted, but the flow is to see if we have a
+    // defined configuration setting (potentially with a default value)
+    // and if not, then we look for the key in the configuration values
+    // anyway so that we can provide costs for any operator or expression,
+    // even if there is no well-defined configuration yet
+    OPTIMIZER_COSTS.get(key)
+      .map(_.get(conf))
+      .orElse(conf.get(key)
+      .map(toDouble(_, key)))
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -42,6 +42,13 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   private val TRANSITION_TO_GPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuRowToColumnarExec"
   private val TRANSITION_TO_CPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuColumnarToRowExec"
 
+  private def DEFAULT_CONF = new SparkConf()
+    .set(RapidsConf.EXPLAIN.key, "ALL")
+    .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
+    .set(RapidsConf.OPTIMIZER_EXPLAIN.key, "ALL")
+    .set(RapidsConf.OPTIMIZER_DEFAULT_CPU_OPERATOR_COST.key, "0")
+    .set(RapidsConf.OPTIMIZER_DEFAULT_GPU_OPERATOR_COST.key, "0")
+
   before {
     GpuOverrides.removeAllListeners()
   }
@@ -61,16 +68,14 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     logError("Force section of plan back onto CPU, AQE on")
     assumeSpark311orLater
 
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec,SortMergeJoinExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec,SortMergeJoinExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -116,22 +121,20 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Force section of plan back onto CPU, AQE off") {
     logError("Force section of plan back onto CPU, AQE off")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
-        .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(TRANSITION_TO_CPU_COST, "0.15")
-        .set(TRANSITION_TO_GPU_COST, "0.15")
-        .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
-        .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
-        .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
-        .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec,SortMergeJoinExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+      .set(TRANSITION_TO_CPU_COST, "0.15")
+      .set(TRANSITION_TO_GPU_COST, "0.15")
+      .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
+      .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
+      .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
+      .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec,SortMergeJoinExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -178,16 +181,14 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     logError("Force last section of plan back onto CPU, AQE on")
     assumeSpark311orLater
 
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(TRANSITION_TO_CPU_COST, "0.3")
-        .set(TRANSITION_TO_GPU_COST, "0.3")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(TRANSITION_TO_CPU_COST, "0.3")
+      .set(TRANSITION_TO_GPU_COST, "0.3")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,RoundRobinPartitioning")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -222,20 +223,18 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Force last section of plan back onto CPU, AQE off") {
     logError("Force last section of plan back onto CPU, AQE off")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(TRANSITION_TO_CPU_COST, "0.15")
-        .set(TRANSITION_TO_GPU_COST, "0.15")
-        .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
-        .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
-        .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
-        .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+      .set(TRANSITION_TO_CPU_COST, "0.15")
+      .set(TRANSITION_TO_GPU_COST, "0.15")
+      .set("spark.rapids.sql.optimizer.cpu.exec.LocalTableScanExec", "1.0")
+      .set("spark.rapids.sql.optimizer.gpu.exec.LocalTableScanExec", "0.8")
+      .set("spark.rapids.sql.optimizer.cpu.exec.SortExec", "1.0")
+      .set("spark.rapids.sql.optimizer.gpu.exec.SortExec", "0.8")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,RoundRobinPartitioning")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -267,14 +266,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for trivial projection, AQE on") {
     logError("Avoid move to GPU for trivial projection, AQE on")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -300,16 +297,14 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for trivial projection, AQE off") {
     logError("Avoid move to GPU for trivial projection, AQE off")
-    val conf = new SparkConf()
-        .set(TRANSITION_TO_CPU_COST, "0.1")
-        .set(TRANSITION_TO_GPU_COST, "0.1")
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
-          "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(TRANSITION_TO_CPU_COST, "0.1")
+      .set(TRANSITION_TO_GPU_COST, "0.1")
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
+        "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
 
     var optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(
@@ -347,14 +342,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for shuffle, AQE on") {
     logError("Avoid move to GPU for shuffle, AQE on")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
 
     withGpuSparkSession(spark => {
       val df: DataFrame = createQuery(spark)
@@ -370,14 +363,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for shuffle, AQE off") {
     logError("Avoid move to GPU for shuffle, AQE off")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
-              "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
+      .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec," +
+            "Alias,Cast,LessThan,ShuffleExchangeExec,RoundRobinPartitioning")
 
     withGpuSparkSession(spark => {
       val df: DataFrame = createQuery(spark)
@@ -397,16 +388,13 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     // if we force a GPU CustomShuffleReaderExec back onto CPU due to cost then the query will
     // fail because the shuffle already happened on GPU and we end up with an invalid plan
 
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "1")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_EXPLAIN.key, "ALL")
-        .set(RapidsConf.EXPLAIN.key, "ALL")
-        .set("spark.rapids.sql.optimizer.gpu.exec.GpuCustomShuffleReaderExec", "99999999")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
-              "RoundRobinPartitioning,HashPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "1")
+      .set("spark.rapids.sql.optimizer.gpu.exec.GpuCustomShuffleReaderExec", "99999999")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
+            "RoundRobinPartitioning,HashPartitioning")
 
     withGpuSparkSession(spark => {
       val df1: DataFrame = createQuery(spark).alias("l")
@@ -422,13 +410,12 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Compute estimated row count nested joins no broadcast") {
     assumeSpark301orLater
     logError("Compute estimated row count nested joins no broadcast")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
-              "HashPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
+            "HashPartitioning")
 
     var plans: ListBuffer[SparkPlanMeta[SparkPlan]] =
       new ListBuffer[SparkPlanMeta[SparkPlan]]()
@@ -472,12 +459,11 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Compute estimated row count nested joins with broadcast") {
     assumeSpark301orLater
     logError("Compute estimated row count nested joins with broadcast")
-    val conf = new SparkConf()
-        .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-        .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
-        .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
-          "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
-              "RoundRobinPartitioning")
+    val conf = DEFAULT_CONF
+      .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+      .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
+        "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
+            "RoundRobinPartitioning")
 
     var plans: ListBuffer[SparkPlanMeta[SparkPlan]] =
       new ListBuffer[SparkPlanMeta[SparkPlan]]()
@@ -520,9 +506,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Window expression (unevaluable)") {
     logError("Window expression (unevaluable)")
 
-    val conf = new SparkConf()
+    val conf = DEFAULT_CONF
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
-      .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
         "ProjectExec,WindowExec,ShuffleExchangeExec,WindowSpecDefinition," +
           "SpecifiedWindowFrame,WindowExpression,Alias,Rank,HashPartitioning," +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -43,7 +43,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   private val TRANSITION_TO_GPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuRowToColumnarExec"
   private val TRANSITION_TO_CPU_COST = "spark.rapids.sql.optimizer.gpu.exec.GpuColumnarToRowExec"
 
-  private def DEFAULT_CONF = new SparkConf()
+  private def createDefaultConf() = new SparkConf()
     .set(RapidsConf.EXPLAIN.key, "ALL")
     .set(RapidsConf.OPTIMIZER_ENABLED.key, "true")
     .set(RapidsConf.OPTIMIZER_EXPLAIN.key, "ALL")
@@ -66,7 +66,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Avoid transition to GPU for trivial projection after CPU SMJ") {
     logError("Avoid transition to GPU for trivial projection after CPU SMJ")
 
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -117,7 +117,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     logError("Force section of plan back onto CPU, AQE on")
     assumeSpark311orLater
 
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
@@ -172,7 +172,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Force section of plan back onto CPU, AQE off") {
     logError("Force section of plan back onto CPU, AQE off")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
       .set(TRANSITION_TO_CPU_COST, "0.15")
@@ -232,7 +232,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     logError("Force last section of plan back onto CPU, AQE on")
     assumeSpark311orLater
 
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(TRANSITION_TO_CPU_COST, "0.3")
       .set(TRANSITION_TO_GPU_COST, "0.3")
@@ -274,7 +274,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Force last section of plan back onto CPU, AQE off") {
     logError("Force last section of plan back onto CPU, AQE off")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
       .set(TRANSITION_TO_CPU_COST, "0.15")
       .set(TRANSITION_TO_GPU_COST, "0.15")
@@ -317,7 +317,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for trivial projection, AQE on") {
     logError("Avoid move to GPU for trivial projection, AQE on")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -348,7 +348,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for trivial projection, AQE off") {
     logError("Avoid move to GPU for trivial projection, AQE off")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(TRANSITION_TO_CPU_COST, "0.1")
       .set(TRANSITION_TO_GPU_COST, "0.1")
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
@@ -393,7 +393,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for shuffle, AQE on") {
     logError("Avoid move to GPU for shuffle, AQE on")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -414,7 +414,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
 
   test("Avoid move to GPU for shuffle, AQE off") {
     logError("Avoid move to GPU for shuffle, AQE off")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "false")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_TIMESTAMP.key, "false")
       .set(RapidsConf.OPTIMIZER_DEFAULT_CPU_OPERATOR_COST.key, "0")
@@ -441,7 +441,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
     // if we force a GPU CustomShuffleReaderExec back onto CPU due to cost then the query will
     // fail because the shuffle already happened on GPU and we end up with an invalid plan
 
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "1")
       .set("spark.rapids.sql.optimizer.gpu.exec.GpuCustomShuffleReaderExec", "99999999")
@@ -463,7 +463,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Compute estimated row count nested joins no broadcast") {
     assumeSpark301orLater
     logError("Compute estimated row count nested joins no broadcast")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
@@ -512,7 +512,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Compute estimated row count nested joins with broadcast") {
     assumeSpark301orLater
     logError("Compute estimated row count nested joins with broadcast")
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
         "ProjectExec,SortMergeJoinExec,SortExec,Alias,Cast,LessThan,ShuffleExchangeExec," +
@@ -559,7 +559,7 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   test("Window expression (unevaluable)") {
     logError("Window expression (unevaluable)")
 
-    val conf = DEFAULT_CONF
+    val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
         "ProjectExec,WindowExec,ShuffleExchangeExec,WindowSpecDefinition," +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -73,7 +73,8 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
       .set(RapidsConf.ENABLE_REPLACE_SORTMERGEJOIN.key, "false")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
         "ProjectExec,BroadcastExchangeExec,BroadcastHashJoinExec,SortExec,SortMergeJoinExec," +
-          "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning,ShuffleExchangeExec")
+          "Alias,Cast,LessThan,ShuffleExchangeExec,RangePartitioning,HashPartitioning," +
+          "ShuffleExchangeExec")
 
     val optimizations: ListBuffer[Seq[Optimization]] = new ListBuffer[Seq[Optimization]]()
     GpuOverrides.addListener(


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/2718 and https://github.com/NVIDIA/spark-rapids/issues/2717

Changes in this PR:

- Implements a simple cost model by specifying default CPU and GPU operator costs, and implements special handling for ProjectExec and UnionExec
- Fixes a bug where writes would fall back to the CPU because the optimizer considered that AdaptiveSparkPlanExec was a CPU plan (#2718)
- Fixes a bug where joins were sometimes falling back to CPU (#2717)
- Added trace logging showing the costs calculated by the cost-based optimizer, and the actions it takes. This makes it possible to debug a query and see what the optimizer is doing.

Real-world benefits of this PR with NDS benchmarks:

- 20+ queries no longer fall back to CPU for writes
- q6: Avoids moving to the GPU for a trivial projection followed by a shuffle
- q11 & q74: Avoids moving to the GPU for a trivial projection following a CPU SortMergeJoin. The next operator moves to the GPU anyway, so this isn't of much benefit overall.
- q23a: Avoids moving to the GPU just for a union
- q58: Avoids moving to the GPU for a trivial projection between two CPU SortMergeJoins.

WIP because I can't test everything locally and need time on environments to do full runs at scale after code changes, to confirm no regressions. I also need to figure out how to write good tests for the current capabilites.