### PR TITLE
Add in application timeline to profiling tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -231,6 +231,7 @@ The profiling tool generates information which can be used for debugging and pro
 - SQL Plan Metrics
 - Optionally : SQL Plan for each SQL query
 - Optionally : Generates DOT graphs for each SQL query
+- Optionally : Generates timeline graph for application
 
 For example, GPU run vs CPU run performance comparison or different runs with different parameters.
 
@@ -326,6 +327,33 @@ dot -Tpdf ./app-20210507103057-0000-query-0/0.dot > app-20210507103057-0000.pdf
 ```
 The pdf file has the SQL plan graph with metrics.
 
+- Generate timeline for application (--generate-timeline option):
+
+The output of this is an [svg](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) file
+named `${APPLICATION_ID}-timeline.svg`.  Most web browsers can display this file.  It is a
+timeline view similar Apache Spark's 
+[event timeline](https://spark.apache.org/docs/latest/web-ui.html). 
+
+This displays several data sections.
+
+1) **Tasks** This shows all tasks in the application divided by executor.  Please note that this
+   tries to pack the tasks in the graph. It does not represent actual scheduling on CPU cores.
+   The tasks are labeled with the time it took for them to run, but there is no breakdown about
+   different aspects of each task, like there is in Spark's timeline.
+2) **STAGES** This shows the stages times reported by Spark. It starts with when the stage was 
+   scheduled and ends when Spark considered the stage done.
+3) **STAGE RANGES** This shows the time from the start of the first task to the end of the last
+   task. Often a stage is scheduled, but there are not enough resources in the cluster to run it.
+   This helps to show. How long it takes for a task to start running after it is scheduled, and in
+   many cases how long it took to run all of the tasks in the stage. This is not always true because
+   Spark can intermix tasks from different stages.
+4) **JOBS** This shows the time range reported by Spark from when a job was scheduled to when it
+   completed.
+5) **SQL** This shows the time range reported by Spark from when a SQL statement was scheduled to
+   when it completed.
+
+Tasks and stages all are color coordinated to help know what tasks are associated with a given
+stage. Jobs and SQL are not color coordinated.
 
 #### B. Analysis
 - Job + Stage level aggregated task metrics

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -380,6 +380,12 @@ object GenerateTimeline {
                 fileWriter)
           }
           currentExecsStartY += execHostHeight
+
+          // Add a line to show different executors from each other
+          fileWriter.write(
+            s"""<line x1="$timingsStartX" y1="$currentExecsStartY"
+               |  x2="$timingsEndX" y2="$currentExecsStartY" style="stroke:black;stroke-width:1"/>
+               |""".stripMargin)
       }
 
       scaleWithLines(timingsStartX,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -108,7 +108,7 @@ object GenerateTimeline {
       scheduleCallback: (A, Int) => Unit,
       errorOnMissingSlot: Boolean,
       slotsFreeUntil: mutable.Buffer[Long]): Unit = {
-    toSchedule.toSeq.sortWith{
+    toSchedule.toSeq.sortWith {
       case (a, b) => a.startTime < b.startTime
     }.foreach { timing =>
       val startTime = timing.startTime
@@ -288,8 +288,8 @@ object GenerateTimeline {
     // Do the high level layout of what the output page should look like
     // TITLE
     // EXEC(s)      | TASK TIMING
-    // STAGES       | STAGE TIMING
-    // STAGE RANGES | STAGE RANGE TIMING
+    // STAGES       | STAGE TIMING (Scheduled Stage to completed Stage)
+    // STAGE RANGES | STAGE RANGE TIMING (Start of first task to end of the last task in stage)
     // JOBS         | JOB TIMING
     // SQLS         | SQL TIMING
     val titleStartX = PADDING
@@ -445,7 +445,7 @@ object GenerateTimeline {
       doLayout(jobInfo, numJobsSlots) {
         case (ji, slot) =>
           timingBox(s"JOB ${ji.jobId} ${ji.duration} ms",
-            "green", // TODO select unique colors???
+            "green",
             ji,
             slot,
             timingsStartX,
@@ -466,7 +466,7 @@ object GenerateTimeline {
       doLayout(sqlInfo, numSqlsSlots) {
         case (sql, slot) =>
           timingBox(s"SQL ${sql.sqlId} ${sql.duration} ms",
-            "blue", // TODO select unique colors???
+            "blue",
             sql,
             slot,
             timingsStartX,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimeline.scala
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool.profiling
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import com.nvidia.spark.rapids.tool.ToolTextFileWriter
+
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+
+abstract class TimelineTiming(
+    val startTime: Long,
+    val endTime: Long)
+
+class TimelineTaskInfo(val stageId: Int, val taskId: Long,
+    startTime: Long, endTime: Long, val duration: Long)
+    extends TimelineTiming(startTime, endTime)
+
+class TimelineStageInfo(val stageId: Int,
+    startTime: Long,
+    endTime:Long,
+    val duration: Long) extends TimelineTiming(startTime, endTime)
+
+class TimelineJobInfo(val jobId: Int,
+    startTime: Long,
+    endTime: Long,
+    val duration: Long) extends TimelineTiming(startTime, endTime)
+
+class TimelineSqlInfo(val sqlId: Long,
+    startTime: Long,
+    endTime: Long,
+    val duration: Long) extends TimelineTiming(startTime, endTime)
+
+/**
+ * Generates an SVG graph that is used to show cluster timeline.
+ */
+object GenerateTimeline {
+  private val TASK_HEIGHT = 20
+  private val TITLE_BOX_WIDTH = 200
+  private val PADDING = 5
+  private val FONT_SIZE = 14
+  private val TITLE_HEIGHT = FONT_SIZE + (PADDING * 2)
+  private val FOOTER_HEIGHT = FONT_SIZE + (PADDING * 2)
+  private val MS_PER_PIXEL = 5.0
+
+  // Generated using https://mokole.com/palette.html
+  private val COLORS = Array(
+    "#696969",
+    "#dcdcdc",
+    "#556b2f",
+    "#8b4513",
+    "#483d8b",
+    "#008000",
+    "#3cb371",
+    "#008b8b",
+    "#000080",
+    "#800080",
+    "#b03060",
+    "#ff4500",
+    "#ffa500",
+    // Going to be used by lines/etc "#00ff00",
+    "#8a2be2",
+    "#00ff7f",
+    "#dc143c",
+    "#00ffff",
+    "#00bfff",
+    "#f4a460",
+    "#0000ff",
+    "#f08080",
+    "#adff2f",
+    "#da70d6",
+    "#ff00ff",
+    "#1e90ff",
+    "#eee8aa",
+    "#ffff54",
+    "#ff1493",
+    "#7b68ee")
+
+  def calcLayoutSlotsNeeded[A <: TimelineTiming](toSchedule: Iterable[A]): Int = {
+    val slotsFreeUntil = ArrayBuffer[Long]()
+    computeLayout(toSchedule, (_: A, _: Int) => (), false, slotsFreeUntil)
+    slotsFreeUntil.length
+  }
+
+  def doLayout[A <: TimelineTiming](
+      toSchedule: Iterable[A],
+      numSlots: Int)(scheduleCallback: (A, Int) => Unit): Unit = {
+    val slotsFreeUntil = new Array[Long](numSlots).toBuffer
+    computeLayout(toSchedule, scheduleCallback, true, slotsFreeUntil)
+  }
+
+  def computeLayout[A <: TimelineTiming](
+      toSchedule: Iterable[A],
+      scheduleCallback: (A, Int) => Unit,
+      errorOnMissingSlot: Boolean,
+      slotsFreeUntil: mutable.Buffer[Long]): Unit = {
+    toSchedule.foreach { timing =>
+      val startTime = timing.startTime
+      val slot = slotsFreeUntil.indices
+          // There is some slop in how Spark reports this. Not sure why...
+          .find(i => (startTime + 1) >= slotsFreeUntil(i))
+          .getOrElse {
+            if (errorOnMissingSlot) {
+              throw new IllegalStateException("Not enough slots to schedule")
+            } else {
+              // Add a slot
+              slotsFreeUntil.append(0L)
+              slotsFreeUntil.length - 1
+            }
+          }
+      slotsFreeUntil(slot) = timing.endTime
+      scheduleCallback(timing, slot)
+    }
+  }
+
+  private def textBoxVirtCentered(
+      text: String,
+      x: Number,
+      y: Long,
+      fileWriter: ToolTextFileWriter): Unit =
+    fileWriter.write(
+      s"""<text x="$x" y="$y" dominant-baseline="middle"
+         | font-family="Courier,monospace" font-size="$FONT_SIZE">$text</text>
+         |""".stripMargin)
+
+  private def sectionBox(
+      text: String,
+      yStart: Long,
+      numElements: Int,
+      fileWriter: ToolTextFileWriter): Unit = {
+    val boxHeight = numElements * TASK_HEIGHT
+    val boxMiddleY = boxHeight/2 + yStart
+    // Draw a box for the Host
+    fileWriter.write(
+      s"""<rect x="$PADDING" y="$yStart" width="$TITLE_BOX_WIDTH" height="$boxHeight"
+         | style="fill:white;fill-opacity:0.0;stroke:black;stroke-width:2"/>
+         |""".stripMargin)
+    textBoxVirtCentered(text, PADDING * 2, boxMiddleY, fileWriter)
+  }
+
+  private def timingBox[A <: TimelineTiming](
+      text: String,
+      color: String,
+      timing: A,
+      slot: Int,
+      xStart: Long,
+      yStart: Long,
+      minStart: Long,
+      fileWriter: ToolTextFileWriter): Unit = {
+    val startTime = timing.startTime
+    val endTime = timing.endTime
+    val x = xStart + (startTime - minStart)/MS_PER_PIXEL
+    val y = (slot * TASK_HEIGHT) + yStart
+    val width = (endTime - startTime)/MS_PER_PIXEL
+    fileWriter.write(
+      s"""<rect x="$x" y="$y" width="$width" height="$TASK_HEIGHT"
+         | style="fill:$color;fill-opacity:1.0;stroke:#00ff00;stroke-width:1"/>
+         |""".stripMargin)
+    textBoxVirtCentered(text, x, y + TASK_HEIGHT/2, fileWriter)
+  }
+
+  private def scaleWithLines(x: Long,
+      y: Long,
+      minStart: Long,
+      maxFinish: Long,
+      height: Long,
+      fileWriter: ToolTextFileWriter): Unit = {
+    val timeRange = maxFinish - minStart
+    val xEnd = x + timeRange/MS_PER_PIXEL
+    val yEnd = y + height
+    fileWriter.write(
+      s"""<line x1="$x" y1="$yEnd" x2="$xEnd" y2="$yEnd" style="stroke:black;stroke-width:1"/>
+         |<line x1="$x" y1="$y" x2="$xEnd" y2="$y" style="stroke:black;stroke-width:1"/>
+         |""".stripMargin)
+    (0L until timeRange).by(100L).foreach { timeForTick =>
+      val xTick = timeForTick/MS_PER_PIXEL + x
+      fileWriter.write(
+        s"""<line x1="$xTick" y1="$y" x2="$xTick" y2="$yEnd"
+           | style="stroke:black;stroke-width:1;opacity:0.5"/>
+           |""".stripMargin)
+      if (timeForTick % 1000 == 0) {
+        fileWriter.write(
+          s"""<line x1="$xTick" y1="$yEnd"
+             | x2="$xTick" y2="${yEnd + PADDING}"
+             | style="stroke:black;stroke-width:1"/>
+             |<text x="$xTick" y="${yEnd + PADDING + FONT_SIZE}"
+             |font-family="Courier,monospace" font-size="$FONT_SIZE">$timeForTick ms</text>
+             |""".stripMargin)
+      }
+    }
+  }
+
+  private def calcTimingHeights(slots: Int): Int = slots * TASK_HEIGHT
+
+  def generateFor(app: ApplicationInfo, outputDirectory: String): Unit = {
+    // Gather the data
+    val execHostToTaskList = new mutable.TreeMap[String, ArrayBuffer[TimelineTaskInfo]]()
+    val stageIdToColor = mutable.HashMap[Int, String]()
+    var colorIndex = 0
+    var minStartTime = Long.MaxValue
+    var maxEndTime = 0L
+    app.runQuery(
+      s"""
+         | select
+         | host,
+         | executorId,
+         | stageId,
+         | taskId,
+         | launchTime,
+         | finishTime,
+         | duration
+         | from taskDF_${app.index} order by executorId, launchTime
+         | """.stripMargin).collect().foreach { row =>
+      val host = row.getString(0)
+      val execId = row.getString(1)
+      val stageId = row.getInt(2)
+      val taskId = row.getLong(3)
+      val launchTime = row.getLong(4)
+      val finishTime = row.getLong(5)
+      val duration = row.getLong(6)
+      val taskInfo = new TimelineTaskInfo(stageId, taskId, launchTime, finishTime, duration)
+      val execHost = s"$execId/$host"
+      execHostToTaskList.getOrElseUpdate(execHost, ArrayBuffer.empty) += taskInfo
+      minStartTime = Math.min(launchTime, minStartTime)
+      maxEndTime = Math.max(finishTime, maxEndTime)
+      stageIdToColor.getOrElseUpdate(stageId, {
+        val color = COLORS(colorIndex % COLORS.length)
+        colorIndex += 1
+        color
+      })
+    }
+
+    val stageRangeInfo = execHostToTaskList.values.flatMap { taskList =>
+      taskList
+    }.groupBy { taskInfo =>
+      taskInfo.stageId
+    }.map {
+      case (stageId, iter) =>
+        val start = iter.map(_.startTime).min
+        val end = iter.map(_.endTime).max
+        new TimelineStageInfo(stageId, start, end, end-start)
+    }
+
+    val stageInfo = app.runQuery(
+      s"""
+         |select
+         |stageId,
+         |submissionTime,
+         |completionTime,
+         |duration
+         |from stageDF_${app.index} order by submissionTime
+         |""".stripMargin).collect().map { row =>
+      val stageId = row.getInt(0)
+      val submissionTime = row.getLong(1)
+      val completionTime = row.getLong(2)
+      val duration = row.getLong(3)
+      minStartTime = Math.min(minStartTime, submissionTime)
+      maxEndTime = Math.max(maxEndTime, completionTime)
+      new TimelineStageInfo(stageId, submissionTime, completionTime, duration)
+    }
+
+    val execHostToSlots = execHostToTaskList.map {
+      case (execHost, taskList) =>
+        (execHost, calcLayoutSlotsNeeded(taskList))
+    }.toMap
+
+    val jobInfo = app.runQuery(
+      s"""
+         |select
+         |jobID,
+         |startTime,
+         |endTime,
+         |duration
+         |from jobDF_${app.index} order by startTime
+         |""".stripMargin).collect().map { row =>
+      val jobId = row.getInt(0)
+      val startTime = row.getLong(1)
+      val endTime = row.getLong(2)
+      val duration = row.getLong(3)
+      minStartTime = Math.min(minStartTime, startTime)
+      maxEndTime = Math.max(maxEndTime, endTime)
+      new TimelineJobInfo(jobId, startTime, endTime, duration)
+    }
+
+    val sqlInfo = app.runQuery(
+      s"""
+         |select
+         |sqlID,
+         |startTime,
+         |endTime,
+         |duration
+         |from sqlDF_${app.index} order by startTime
+         |""".stripMargin).collect().map { row =>
+      val sqlId = row.getLong(0)
+      val startTime = row.getLong(1)
+      val endTime = row.getLong(2)
+      val duration = row.getLong(3)
+      minStartTime = Math.min(minStartTime, startTime)
+      maxEndTime = Math.max(maxEndTime, endTime)
+      new TimelineSqlInfo(sqlId, startTime, endTime, duration)
+    }
+
+    // Add 1 second for padding at the end...
+    maxEndTime += 1000
+
+    // Do the high level layout of what the output page should look like
+    // TITLE
+    // EXEC(s)      | TASK TIMING
+    // STAGES       | STAGE TIMING
+    // STAGE RANGES | STAGE RANGE TIMING
+    // JOBS         | JOB TIMING
+    // SQLS         | SQL TIMING
+    val titleStartX = PADDING
+    val titleStartY = 0
+    val titleEndY = titleStartY + TITLE_HEIGHT
+
+    // All of the timings start at the same place
+    val titleBoxStartX = PADDING
+    val titleBoxWidth = TITLE_BOX_WIDTH
+    val timingsStartX = titleBoxStartX + titleBoxWidth
+    val timingsWidth = (maxEndTime - minStartTime)/MS_PER_PIXEL
+    val timingsEndX = timingsStartX + timingsWidth
+
+    // EXEC(s)
+    val execsStartY = titleEndY
+    val numExecTaskSlotsTotal = execHostToSlots.values.sum
+    val execsHeight = calcTimingHeights(numExecTaskSlotsTotal)
+    val execsWithFooterHeight = execsHeight + FOOTER_HEIGHT
+    val execsEndY = execsStartY + execsWithFooterHeight
+
+    // STAGES
+    val stagesStartY = execsEndY
+    val numStageSlots = calcLayoutSlotsNeeded(stageInfo)
+    val stagesHeight = calcTimingHeights(numStageSlots)
+    val stagesWithFooterHeight = stagesHeight + FOOTER_HEIGHT
+    val stagesEndY = stagesStartY + stagesWithFooterHeight
+
+    // STAGE RANGES
+    val stageRangesStartY = stagesEndY
+    val numStageRangeSlots = calcLayoutSlotsNeeded(stageRangeInfo)
+    val stageRangesHeight = calcTimingHeights(numStageRangeSlots)
+    val stageRangesWithFooterHeight = stageRangesHeight + FOOTER_HEIGHT
+    val stageRangesEndY = stageRangesStartY + stageRangesWithFooterHeight
+
+    // JOBS
+    val jobsStartY = stageRangesEndY
+    val numJobsSlots = calcLayoutSlotsNeeded(jobInfo)
+    val jobsHeight = calcTimingHeights(numJobsSlots)
+    val jobsWithFooterHeight = jobsHeight + FOOTER_HEIGHT
+    val jobsEndY = jobsStartY + jobsWithFooterHeight
+
+    // SQLS
+    val sqlsStartY = jobsEndY
+    val numSqlsSlots = calcLayoutSlotsNeeded(sqlInfo)
+    val sqlsHeight = calcTimingHeights(numSqlsSlots)
+    val sqlsWithFooterHeight = sqlsHeight + FOOTER_HEIGHT
+    val sqlsEndY = sqlsStartY + sqlsWithFooterHeight
+
+    // TOTAL IMAGE
+    val imageHeight = sqlsEndY + PADDING
+    val imageWidth = timingsEndX
+
+    val fileWriter = new ToolTextFileWriter(outputDirectory,
+      s"${app.appId}-timeline.svg")
+    try {
+      fileWriter.write(
+        s"""<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+           |<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+           | "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+           |<!-- Generated by Rapids Accelerator For Apache Spark Profiling Tool -->
+           |<svg width="$imageWidth" height="$imageHeight"
+           | xmlns="http://www.w3.org/2000/svg">
+           | <title>${app.appId} Timeline</title>
+           |""".stripMargin)
+      // TITLE
+      textBoxVirtCentered(s"${app.appId} Timeline",
+        titleStartX,
+        titleStartY + TITLE_HEIGHT/2,
+        fileWriter)
+
+      // EXEC(s)
+      var currentExecsStartY = execsStartY
+      execHostToTaskList.foreach {
+        case (execHost, taskList) =>
+          val numElements = execHostToSlots(execHost)
+          val execHostHeight = calcTimingHeights(numElements)
+
+          sectionBox(execHost, currentExecsStartY, numElements, fileWriter)
+          doLayout(taskList, numElements) {
+            case (taskInfo, slot) =>
+              timingBox(s"${taskInfo.duration} ms",
+                stageIdToColor(taskInfo.stageId),
+                taskInfo,
+                slot,
+                timingsStartX,
+                currentExecsStartY,
+                minStartTime,
+                fileWriter)
+          }
+          currentExecsStartY += execHostHeight
+      }
+
+      scaleWithLines(timingsStartX,
+        execsStartY,
+        minStartTime,
+        maxEndTime,
+        execsHeight,
+        fileWriter)
+
+      // STAGES
+      sectionBox("STAGES", stagesStartY, numStageSlots, fileWriter)
+
+      doLayout(stageInfo, numStageSlots) {
+        case (si, slot) =>
+          timingBox(s"STAGE ${si.stageId} ${si.duration} ms",
+            stageIdToColor(si.stageId),
+            si,
+            slot,
+            timingsStartX,
+            stagesStartY,
+            minStartTime,
+            fileWriter)
+      }
+
+      scaleWithLines(timingsStartX,
+        stagesStartY,
+        minStartTime,
+        maxEndTime,
+        stagesHeight,
+        fileWriter)
+
+      // STAGE RANGES
+      sectionBox("STAGE RANGES", stageRangesStartY, numStageRangeSlots, fileWriter)
+
+      doLayout(stageRangeInfo, numStageRangeSlots) {
+        case (si, slot) =>
+          timingBox(s"STAGE RANGE ${si.stageId} ${si.duration} ms",
+            stageIdToColor(si.stageId),
+            si,
+            slot,
+            timingsStartX,
+            stageRangesStartY,
+            minStartTime,
+            fileWriter)
+      }
+
+      scaleWithLines(timingsStartX,
+        stageRangesStartY,
+        minStartTime,
+        maxEndTime,
+        stageRangesHeight,
+        fileWriter)
+
+      // JOBS
+      sectionBox("JOBS", jobsStartY, numJobsSlots, fileWriter)
+
+      doLayout(jobInfo, numJobsSlots) {
+        case (ji, slot) =>
+          timingBox(s"JOB ${ji.jobId} ${ji.duration} ms",
+            "green", // TODO select unique colors???
+            ji,
+            slot,
+            timingsStartX,
+            jobsStartY,
+            minStartTime,
+            fileWriter)
+      }
+      scaleWithLines(timingsStartX,
+        jobsStartY,
+        minStartTime,
+        maxEndTime,
+        jobsHeight,
+        fileWriter)
+
+      // SQLS
+      sectionBox("SQL", sqlsStartY, numSqlsSlots, fileWriter)
+
+      doLayout(sqlInfo, numSqlsSlots) {
+        case (sql, slot) =>
+          timingBox(s"SQL ${sql.sqlId} ${sql.duration} ms",
+            "blue", // TODO select unique colors???
+            sql,
+            slot,
+            timingsStartX,
+            sqlsStartY,
+            minStartTime,
+            fileWriter)
+      }
+      scaleWithLines(timingsStartX,
+        sqlsStartY,
+        minStartTime,
+        maxEndTime,
+        sqlsHeight,
+        fileWriter)
+
+      fileWriter.write(s"""</svg>""")
+    } finally {
+      fileWriter.close()
+    }
+  }
+}

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -76,6 +76,9 @@ For usage see below:
   val printPlans: ScallopOption[Boolean] =
     opt[Boolean](required = false,
       descr = "Print the SQL plans to a file starting with 'planDescriptions-'. Default is false")
+  val generateTimeline: ScallopOption[Boolean] =
+    opt[Boolean](required = false,
+      descr = "Write an SVG graph out for the full application timeline.")
 
   verify()
 }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileMain.scala
@@ -174,6 +174,15 @@ object ProfileMain extends Logging {
       healthCheck.listRemovedBlockManager()
       healthCheck.listRemovedExecutors()
       healthCheck.listPossibleUnsupportedSQLPlan()
+
+      if (appArgs.generateTimeline()) {
+        if (appArgs.compare()) {
+          logWarning("Timeline graph does not compare apps")
+        }
+        apps.foreach { app =>
+          GenerateTimeline.generateFor(app, outputDirectory)
+        }
+      }
     }
 
     def logApplicationInfo(app: ApplicationInfo) = {

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -126,6 +126,93 @@ class ApplicationInfo(
   val stageCompletionTime: HashMap[Int, Option[Long]] = HashMap.empty[Int, Option[Long]]
   val stageFailureReason: HashMap[Int, Option[String]] = HashMap.empty[Int, Option[String]]
 
+  // A cleaned up version of stageSubmitted
+  lazy val enhancedStage: ArrayBuffer[StageCase] = {
+    val ret: ArrayBuffer[StageCase] = ArrayBuffer[StageCase]()
+    for (res <- stageSubmitted) {
+      val thisEndTime = stageCompletionTime.getOrElse(res.stageId, None)
+      val thisFailureReason = stageFailureReason.getOrElse(res.stageId, None)
+
+      val durationResult =
+        ProfileUtils.optionLongMinusOptionLong(thisEndTime, res.submissionTime)
+      val durationString = durationResult match {
+        case Some(i) => UIUtils.formatDuration(i)
+        case None => ""
+      }
+
+      // only for qualification set the runtime and cputime
+      // could expand later for profiling
+      val stageAndAttempt = s"${res.stageId}:${res.attemptId}"
+      val stageTaskExecSum = stageTaskQualificationEnd.get(stageAndAttempt)
+      val runTime = stageTaskExecSum.map(_.executorRunTime).getOrElse(0L)
+      val cpuTime = stageTaskExecSum.map(_.executorCPUTime).getOrElse(0L)
+
+      val stageNew = res.copy(completionTime = thisEndTime,
+        failureReason = thisFailureReason,
+        duration = durationResult,
+        durationStr = durationString,
+        executorRunTimeSum = runTime,
+        executorCPUTimeSum = cpuTime)
+      ret += stageNew
+    }
+    ret
+  }
+
+  lazy val enhancedJob: ArrayBuffer[JobCase] = {
+    val ret = ArrayBuffer[JobCase]()
+    for (res <- jobStart) {
+      val thisEndTime = jobEndTime.get(res.jobID)
+      val durationResult = ProfileUtils.OptionLongMinusLong(thisEndTime, res.startTime)
+      val durationString = durationResult match {
+        case Some(i) => UIUtils.formatDuration(i)
+        case None => ""
+      }
+
+      val jobNew = res.copy(endTime = thisEndTime,
+        duration = durationResult,
+        durationStr = durationString,
+        jobResult = jobEndResult.get(res.jobID),
+        failedReason = jobFailedReason.get(res.jobID)
+      )
+      ret += jobNew
+    }
+    ret
+  }
+
+  lazy val enhancedSql: ArrayBuffer[SQLExecutionCase] = {
+    val ret: ArrayBuffer[SQLExecutionCase] = ArrayBuffer[SQLExecutionCase]()
+    for (res <- sqlStart) {
+      val thisEndTime = sqlEndTime.get(res.sqlID)
+      val durationResult = ProfileUtils.OptionLongMinusLong(thisEndTime, res.startTime)
+      val durationString = durationResult match {
+        case Some(i) => UIUtils.formatDuration(i)
+        case None => ""
+      }
+      val (containsDataset, sqlQDuration) = if (datasetSQL.exists(_.sqlID == res.sqlID)) {
+        (true, Some(0L))
+      } else {
+        (false, durationResult)
+      }
+      val potProbs = problematicSQL.filter { p =>
+        p.sqlID == res.sqlID && p.reason.nonEmpty
+      }.map(_.reason).mkString(",")
+      val finalPotProbs = if (potProbs.isEmpty) {
+        null
+      } else {
+        potProbs
+      }
+      val sqlExecutionNew = res.copy(endTime = thisEndTime,
+        duration = durationResult,
+        durationStr = durationString,
+        sqlQualDuration = sqlQDuration,
+        hasDataset = containsDataset,
+        problematic = finalPotProbs
+      )
+      ret += sqlExecutionNew
+    }
+    ret
+  }
+
   // From SparkListenerTaskStart & SparkListenerTaskEnd
   // taskStart was not used so comment out for now
   // var taskStart: ArrayBuffer[SparkListenerTaskStart] = ArrayBuffer[SparkListenerTaskStart]()
@@ -355,93 +442,19 @@ class ApplicationInfo(
 
     // For sqlDF
     if (sqlStart.nonEmpty) {
-      val sqlStartNew: ArrayBuffer[SQLExecutionCase] = ArrayBuffer[SQLExecutionCase]()
-      for (res <- sqlStart) {
-        val thisEndTime = sqlEndTime.get(res.sqlID)
-        val durationResult = ProfileUtils.OptionLongMinusLong(thisEndTime, res.startTime)
-        val durationString = durationResult match {
-          case Some(i) => UIUtils.formatDuration(i)
-          case None => ""
-        }
-        val (containsDataset, sqlQDuration) = if (datasetSQL.exists(_.sqlID == res.sqlID)) {
-          (true, Some(0L))
-        } else {
-          (false, durationResult)
-        }
-        val potProbs = problematicSQL.filter { p =>
-          p.sqlID == res.sqlID && p.reason.nonEmpty
-        }.map(_.reason).mkString(",")
-        val finalPotProbs = if (potProbs.isEmpty) {
-          null
-        } else {
-          potProbs
-        }
-        val sqlExecutionNew = res.copy(endTime = thisEndTime,
-          duration = durationResult,
-          durationStr = durationString,
-          sqlQualDuration = sqlQDuration,
-          hasDataset = containsDataset,
-          problematic = finalPotProbs
-        )
-        sqlStartNew += sqlExecutionNew
-      }
-      allDataFrames += (s"sqlDF_$index" -> sqlStartNew.toDF)
+      allDataFrames += (s"sqlDF_$index" -> enhancedSql.toDF)
     } else {
       logInfo("No SQL Execution Found. Skipping generating SQL Execution DataFrame.")
     }
 
     // For jobDF
     if (jobStart.nonEmpty) {
-      val jobStartNew: ArrayBuffer[JobCase] = ArrayBuffer[JobCase]()
-      for (res <- jobStart) {
-        val thisEndTime = jobEndTime.get(res.jobID)
-        val durationResult = ProfileUtils.OptionLongMinusLong(thisEndTime, res.startTime)
-        val durationString = durationResult match {
-          case Some(i) => UIUtils.formatDuration(i)
-          case None => ""
-        }
-
-        val jobNew = res.copy(endTime = thisEndTime,
-          duration = durationResult,
-          durationStr = durationString,
-          jobResult = jobEndResult.get(res.jobID),
-          failedReason = jobFailedReason.get(res.jobID)
-        )
-        jobStartNew += jobNew
-      }
-      allDataFrames += (s"jobDF_$index" -> jobStartNew.toDF)
+      allDataFrames += (s"jobDF_$index" -> enhancedJob.toDF)
     }
 
     // For stageDF
     if (stageSubmitted.nonEmpty) {
-      val stageSubmittedNew: ArrayBuffer[StageCase] = ArrayBuffer[StageCase]()
-      for (res <- stageSubmitted) {
-        val thisEndTime = stageCompletionTime.getOrElse(res.stageId, None)
-        val thisFailureReason = stageFailureReason.getOrElse(res.stageId, None)
-
-        val durationResult =
-          ProfileUtils.optionLongMinusOptionLong(thisEndTime, res.submissionTime)
-        val durationString = durationResult match {
-          case Some(i) => UIUtils.formatDuration(i)
-          case None => ""
-        }
-
-        // only for qualification set the runtime and cputime
-        // could expand later for profiling
-        val stageAndAttempt = s"${res.stageId}:${res.attemptId}"
-        val stageTaskExecSum = stageTaskQualificationEnd.get(stageAndAttempt)
-        val runTime = stageTaskExecSum.map(_.executorRunTime).getOrElse(0L)
-        val cpuTime = stageTaskExecSum.map(_.executorCPUTime).getOrElse(0L)
-
-        val stageNew = res.copy(completionTime = thisEndTime,
-          failureReason = thisFailureReason,
-          duration = durationResult,
-          durationStr = durationString,
-          executorRunTimeSum = runTime,
-          executorCPUTimeSum = cpuTime)
-        stageSubmittedNew += stageNew
-      }
-      allDataFrames += (s"stageDF_$index" -> stageSubmittedNew.toDF)
+      allDataFrames += (s"stageDF_$index" -> enhancedStage.toDF)
     }
 
     // For taskDF

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateTimelineSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool.profiling
+
+import java.io.File
+
+import scala.io.Source
+
+import com.nvidia.spark.rapids.tool.ToolTestUtils
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{SparkSession, TrampolineUtil}
+
+class GenerateTimelineSuite extends FunSuite with BeforeAndAfterAll with Logging {
+
+  override def beforeAll(): Unit = {
+    TrampolineUtil.cleanupAnyExistingSession()
+  }
+
+  test("Generate Timeline") {
+    TrampolineUtil.withTempDir { eventLogDir =>
+      val eventLog = ToolTestUtils.generateEventLog(eventLogDir, "timeline") { spark =>
+        import spark.implicits._
+        val t1 = Seq((1, 2), (3, 4)).toDF("a", "b")
+        t1.createOrReplaceTempView("t1")
+        spark.sql("SELECT a, MAX(b) FROM t1 GROUP BY a ORDER BY a")
+      }
+
+      // create new session for tool to use
+      val spark2 = SparkSession
+        .builder()
+        .master("local[*]")
+        .appName("Rapids Spark Profiling Tool Unit Tests")
+        .getOrCreate()
+
+      TrampolineUtil.withTempDir { dotFileDir =>
+        val appArgs = new ProfileArgs(Array(
+          "--output-directory",
+          dotFileDir.getAbsolutePath,
+          "--generate-timeline",
+          eventLog))
+        ProfileMain.mainInternal(spark2, appArgs)
+
+        val tempSubDir = new File(dotFileDir, ProfileMain.SUBDIR)
+
+        // assert that a file was generated
+        val outputDirs = ToolTestUtils.listFilesMatching(tempSubDir, _.startsWith("local"))
+        assert(outputDirs.length === 1)
+
+        // assert that the generated files looks something like what we expect
+        var stageZeroCount = 0
+        var stageRangeZeroCount = 0
+        var jobZeroCount = 0
+        // We cannot really simply test the SQL count because that counter does not get reset
+        // with each test
+        for (file <- outputDirs) {
+          assert(file.getAbsolutePath.endsWith(".svg"))
+          val source = Source.fromFile(file)
+          try {
+            val lines = source.getLines().toArray
+            stageZeroCount += lines.count(_.contains("STAGE 0"))
+            stageRangeZeroCount += lines.count(_.contains("STAGE RANGE 0"))
+            jobZeroCount += lines.count(_.contains("JOB 0"))
+          } finally {
+            source.close()
+          }
+        }
+        //
+        assert(stageZeroCount === 1)
+        assert(stageRangeZeroCount === 1)
+        assert(jobZeroCount === 1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds in application timeline generation the the profiling tool. It is helpful in understanding what was running and where to know if a stage was long because it was preempted by another stage or if there was skew, etc. This really helped me see the high startup overhead, even if it is not reflected in benchmark numbers because the benchmarks start on the SQL query, not when setting up the data.

I used this to help debug some data/time skew issues.

![example](https://user-images.githubusercontent.com/3441321/122795691-3106a580-d283-11eb-8f4a-d6a3c1867490.png)
