### PR TITLE
Make spark303 shim version w/o snapshot and add shim layer for spark304

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -288,6 +288,7 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.0.1 EMR  | com.nvidia.spark.rapids.spark301emr.RapidsShuffleManager |
     | 3.0.2      | com.nvidia.spark.rapids.spark302.RapidsShuffleManager    |
     | 3.0.3      | com.nvidia.spark.rapids.spark303.RapidsShuffleManager    |
+    | 3.0.4      | com.nvidia.spark.rapids.spark304.RapidsShuffleManager    |
     | 3.1.1      | com.nvidia.spark.rapids.spark311.RapidsShuffleManager    |
     | 3.1.2      | com.nvidia.spark.rapids.spark312.RapidsShuffleManager    |
     | 3.1.3      | com.nvidia.spark.rapids.spark313.RapidsShuffleManager    |

--- a/docs/dev/adaptive-query.md
+++ b/docs/dev/adaptive-query.md
@@ -96,4 +96,4 @@ version of the Exchange node as the key for this cache but this can result in
 errors if there are both CPU and GPU query stages that are created from
 Exchange nodes that have equivalent canonical plan. This issue was resolved in
 [SPARK-35093](https://issues.apache.org/jira/browse/SPARK-35093) and the fix is
-available in Spark versions 3.0.3, 3.1.2, and 3.2.0.
+available in Spark versions 3.0.3+, 3.1.2+, and 3.2.0+.

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -175,7 +175,7 @@ pipeline {
                             step([$class                : 'JacocoPublisher',
                                   execPattern           : '**/target/jacoco.exec',
                                   classPattern          : 'target/jacoco_classes/',
-                                  sourcePattern         : 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,sql-plugin/src/main/java/,sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,shims/spark312/src/main/scala/,shims/spark313/src/main/scala/',
+                                  sourcePattern         : 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,sql-plugin/src/main/java/,sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,shims/spark304/src/main/scala/,shims/spark312/src/main/scala/,shims/spark313/src/main/scala/',
                                   sourceInclusionPattern: '**/*.java,**/*.scala'
                             ])
                         }

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -26,6 +26,7 @@ mvn -U -B -Dinclude-databricks -Pspark301tests,snapshot-shims clean deploy $MVN_
 # Run unit tests against other spark versions
 mvn -U -B -Pspark302tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark303tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
+mvn -U -B -Pspark304tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark311tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark312tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER
 mvn -U -B -Pspark313tests,snapshot-shims test $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -53,10 +53,9 @@ mvn -U -B $MVN_URM_MIRROR '-P!snapshot-shims,pre-merge' clean verify -Dpytest.TE
     -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=4 -Dcuda.version=$CUDA_CLASSIFIER
 # Run the unit tests for other Spark versions but dont run full python integration tests
 # NOT ALL TESTS NEEDED FOR PREMERGE
-#env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark301tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
-env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark302tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
+# Test latest stable and snapshot shims for a spark minor versions. All others shims test should be covered in nightly pipelines
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark303tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
-env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark311tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
+env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark304tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark312tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 env -u SPARK_HOME mvn -U -B $MVN_URM_MIRROR -Pspark313tests,snapshot-shims test -Dpytest.TEST_TAGS='' -Dcuda.version=$CUDA_CLASSIFIER
 # Disabled until Spark 3.2 source incompatibility fixed, see https://github.com/NVIDIA/spark-rapids/issues/2052

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
             </properties>
         </profile>
         <profile>
+            <id>spark304tests</id>
+            <properties>
+                <spark.test.version>${spark304.version}</spark.test.version>
+            </properties>
+        </profile>
+        <profile>
             <id>spark311tests</id>
             <properties>
                 <spark.test.version>${spark311.version}</spark.test.version>
@@ -255,7 +261,8 @@
         <spark301db.version>3.0.1-databricks</spark301db.version>
         <spark301emr.version>3.0.1-amzn</spark301emr.version>
         <spark302.version>3.0.2</spark302.version>
-        <spark303.version>3.0.3-SNAPSHOT</spark303.version>
+        <spark303.version>3.0.3</spark303.version>
+        <spark304.version>3.0.4-SNAPSHOT</spark304.version>
         <spark311db.version>3.1.1-databricks</spark311db.version>
         <spark311.version>3.1.1</spark311.version>
         <spark311cdh.version>3.1.1.3.1.7270.0-253</spark311cdh.version>

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -103,7 +103,7 @@
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-shims-spark303_${scala.binary.version}</artifactId>
+                    <artifactId>rapids-4-spark-shims-spark304_${scala.binary.version}</artifactId>
                     <version>${project.version}</version>
                     <scope>compile</scope>
                 </dependency>
@@ -133,6 +133,12 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-shims-spark302_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark303_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -56,7 +56,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>spark303</module>
+                <module>spark304</module>
                 <module>spark313</module>
             </modules>
         </profile>
@@ -66,6 +66,7 @@
         <module>spark301emr</module>
         <module>spark301</module>
         <module>spark302</module>
+        <module>spark303</module>
         <module>spark311</module>
         <module>spark312</module>
         <module>aggregator</module>

--- a/shims/spark304/pom.xml
+++ b/shims/spark304/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2021, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nvidia</groupId>
+        <artifactId>rapids-4-spark-shims_2.12</artifactId>
+        <version>21.08.0-SNAPSHOT</version>
+	<relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>rapids-4-spark-shims-spark304_2.12</artifactId>
+    <name>RAPIDS Accelerator for Apache Spark SQL Plugin Spark 3.0.4 Shim</name>
+    <description>The RAPIDS SQL plugin for Apache Spark 3.0.4 Shim</description>
+    <version>21.08.0-SNAPSHOT</version>
+
+    <!-- Set 'spark.version' for the shims layer -->
+    <!-- Create a separate file 'SPARK_VER.properties' in the jar to save cudf & spark version info -->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dependency</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/extra-resources"/>
+                                <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark304.version}-info.properties">
+                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${cudf.version}"/>
+                                    <arg value="${cuda.version}"/>
+                                    <arg value="${spark304.version}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <resources>
+          <resource>
+            <!-- Include the properties file to provide the build information. -->
+            <directory>${project.build.directory}/extra-resources</directory>
+          </resource>
+          <resource>
+            <directory>src/main/resources</directory>
+          </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark301_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark302_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-shims-spark303_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark304.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/shims/spark304/src/main/resources/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider
+++ b/shims/spark304/src/main/resources/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider
@@ -1,0 +1,1 @@
+com.nvidia.spark.rapids.shims.spark304.SparkShimServiceProvider

--- a/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/Spark304Shims.scala
+++ b/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/Spark304Shims.scala
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark303
+package com.nvidia.spark.rapids.shims.spark304
 
-import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+import com.nvidia.spark.rapids.ShimVersion
+import com.nvidia.spark.rapids.shims.spark303.Spark303Shims
+import com.nvidia.spark.rapids.spark303.RapidsShuffleManager
 
-object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 0, 3)
-  val VERSIONNAMES = Seq(s"$VERSION")
-}
-class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
+class Spark304Shims extends Spark303Shims {
 
-  def matchesVersion(version: String): Boolean = {
-    SparkShimServiceProvider.VERSIONNAMES.contains(version)
-  }
+  override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
 
-  def buildShim: SparkShims = {
-    new Spark303Shims()
+  override def getRapidsShuffleManagerClass: String = {
+    classOf[RapidsShuffleManager].getCanonicalName
   }
 }

--- a/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/SparkShimServiceProvider.scala
+++ b/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/SparkShimServiceProvider.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark303
+package com.nvidia.spark.rapids.shims.spark304
 
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 0, 3)
-  val VERSIONNAMES = Seq(s"$VERSION")
+  val VERSION = SparkShimVersion(3, 0, 4)
+  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
 }
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
 
@@ -29,6 +29,6 @@ class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceP
   }
 
   def buildShim: SparkShims = {
-    new Spark303Shims()
+    new Spark304Shims()
   }
 }

--- a/shims/spark304/src/main/scala/com/nvidia/spark/rapids/spark304/RapidsShuffleManager.scala
+++ b/shims/spark304/src/main/scala/com/nvidia/spark/rapids/spark304/RapidsShuffleManager.scala
@@ -14,21 +14,13 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark303
+package com.nvidia.spark.rapids.spark304
 
-import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.rapids.shims.spark301.RapidsShuffleInternalManager
 
-object SparkShimServiceProvider {
-  val VERSION = SparkShimVersion(3, 0, 3)
-  val VERSIONNAMES = Seq(s"$VERSION")
-}
-class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
-
-  def matchesVersion(version: String): Boolean = {
-    SparkShimServiceProvider.VERSIONNAMES.contains(version)
-  }
-
-  def buildShim: SparkShims = {
-    new Spark303Shims()
-  }
+/** A shuffle manager optimized for the RAPIDS Plugin for Apache Spark. */
+sealed class RapidsShuffleManager(
+    conf: SparkConf,
+    isDriver: Boolean) extends RapidsShuffleInternalManager(conf, isDriver) {
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ profiles:
    - `-Pspark301tests` (spark 3.0.1)
    - `-Pspark302tests` (spark 3.0.2)
    - `-Pspark303tests` (spark 3.0.3)
+   - `-Pspark304tests` (spark 3.0.4)
    - `-Pspark311tests` (spark 3.1.1)
    - `-Pspark312tests` (spark 3.1.2)
    - `-Pspark313tests` (spark 3.1.3)


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #2782 

1. remove snapshot version from spark 3.0.3 shim
2. add shim layer of spark 3.0.4-SNAPSHOT
3. reduce shim layers tests in pre-merge change, related to https://github.com/NVIDIA/spark-rapids/issues/2731

Please help review, I will trigger pre-merge check after spark 3.0.3 get officially released