### PR TITLE
Automatically set spark.task.maxFailures and local[*, maxFailures]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -122,7 +122,7 @@ else
     # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
     # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
     # for Spark 3.1.1+
-    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|awk '/version\ [0-9.]+$/{print $NF}'`
+    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|grep -v Scala|awk '/version\ [0-9.]+/{print $NF}'`
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
     echo "Detected Spark version $VERSION_STRING"
 

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -122,13 +122,11 @@ else
     # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
     # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
     # for Spark 3.1.1+
-    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|grep version\ |grep -v Scala|awk '{print $5}'`
+    VERSION_STRING=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | head -1 | cut -d'=' -f2`
     echo "Detected Spark version is $VERSION_STRING"
     IS_BEFORE_SPARK_311=`python -c "print(1 if '$VERSION_STRING' < '3.1.1' else 0)"`
     SPARK_TASK_MAXFAILURES=1
-    if (( $IS_BEFORE_SPARK_311 )); then
-      SPARK_TASK_MAXFAILURES=4
-    fi
+    [[ "$VERSION_STRING" < "3.1.1" ]] && SPARK_TASK_MAXFAILURES=4
 
     export PYSP_TEST_spark_driver_extraClassPath="${ALL_JARS// /:}"
     export PYSP_TEST_spark_executor_extraClassPath="${ALL_JARS// /:}"

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -122,7 +122,7 @@ else
     # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
     # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
     # for Spark 3.1.1+
-    VERSION_STRING=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | grep ^version= | cut -d'=' -f2`
+    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|awk '/version\ [0-9.]+$/{print $NF}'`
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
     echo "Detected Spark version $VERSION_STRING"
 

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -117,6 +117,11 @@ else
     NUM_LOCAL_EXECS=${NUM_LOCAL_EXECS:-0}
     MB_PER_EXEC=${MB_PER_EXEC:-1024}
     CORES_PER_EXEC=${CORES_PER_EXEC:-1}
+    # Spark 3.1.1 includes https://github.com/apache/spark/pull/31540
+    # which helps with spurious task failures in the tests. If you are running
+    # older versions of Spark, and experience #31540, please set this environment
+    # variable higher (Spark has 4 by default).
+    SPARK_TASK_MAXFAILURES=${SPARK_TASK_MAXFAILURES:-1}
 
     if ((NUM_LOCAL_EXECS > 0)); then
       export PYSP_TEST_spark_master="local-cluster[$NUM_LOCAL_EXECS,$CORES_PER_EXEC,$MB_PER_EXEC]"
@@ -129,9 +134,9 @@ else
     export PYSP_TEST_spark_ui_showConsoleProgress='false'
     export PYSP_TEST_spark_sql_session_timeZone='UTC'
     export PYSP_TEST_spark_sql_shuffle_partitions='12'
-    # prevent cluster shape to change - and fail quicker rather than retry
-    export PYSP_TEST_spark_task_maxFailures='1'
+    # prevent cluster shape to change
     export PYSP_TEST_spark_dynamicAllocation_enabled='false'
+    export PYSP_TEST_spark_task_maxFailures="${SPARK_TASK_MAXFAILURES}"
     if ((${#TEST_PARALLEL_OPTS[@]} > 0));
     then
         export PYSP_TEST_spark_rapids_memory_gpu_allocFraction=$MEMORY_FRACTION

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -118,13 +118,16 @@ else
     MB_PER_EXEC=${MB_PER_EXEC:-1024}
     CORES_PER_EXEC=${CORES_PER_EXEC:-1}
     # Spark 3.1.1 includes https://github.com/apache/spark/pull/31540
-    # which helps with spurious task failures in the tests. If you are running
-    # older versions of Spark, and experience #31540, please set this environment
-    # variable higher (Spark has 4 by default).
-    SPARK_TASK_MAXFAILURES=${SPARK_TASK_MAXFAILURES:-1}
-
-    if ((NUM_LOCAL_EXECS > 0)); then
-      export PYSP_TEST_spark_master="local-cluster[$NUM_LOCAL_EXECS,$CORES_PER_EXEC,$MB_PER_EXEC]"
+    # which helps with spurious task failures as observed in our tests. If you are running
+    # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
+    # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
+    # for Spark 3.1.1+
+    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|grep version\ |grep -v Scala|awk '{print $5}'`
+    echo "Detected Spark version is $VERSION_STRING"
+    IS_BEFORE_SPARK_311=`python -c "print(1 if '$VERSION_STRING' < '3.1.1' else 0)"`
+    SPARK_TASK_MAXFAILURES=1
+    if (( $IS_BEFORE_SPARK_311 )); then
+      SPARK_TASK_MAXFAILURES=4
     fi
 
     export PYSP_TEST_spark_driver_extraClassPath="${ALL_JARS// /:}"
@@ -136,7 +139,24 @@ else
     export PYSP_TEST_spark_sql_shuffle_partitions='12'
     # prevent cluster shape to change
     export PYSP_TEST_spark_dynamicAllocation_enabled='false'
-    export PYSP_TEST_spark_task_maxFailures="${SPARK_TASK_MAXFAILURES}"
+
+    # Set spark.task.maxFailures for most schedulers.
+    #
+    # Local (non-cluster) mode is the exception and does not work with `spark.task.maxFailures`.
+    # It requires two arguments to the master specification "local[N, K]" where
+    # N is the number of threads, and K is the maxFailures (otherwise this is hardcoded to 1,
+    # see https://issues.apache.org/jira/browse/SPARK-2083).
+    export PYSP_TEST_spark_task_maxFailures="$SPARK_TASK_MAXFAILURES"
+
+    if ((NUM_LOCAL_EXECS > 0)); then
+      export PYSP_TEST_spark_master="local-cluster[$NUM_LOCAL_EXECS,$CORES_PER_EXEC,$MB_PER_EXEC]"
+    else
+      # If a master is not specified, use "local[*, $SPARK_TASK_MAXFAILURES]"
+      if [ -z "${PYSP_TEST_spark_master}" ] && [ "$SPARK_SUBMIT_FLAGS" != *"--master"* ]; then
+        export PYSP_TEST_spark_master="local[*,$SPARK_TASK_MAXFAILURES]"
+      fi
+    fi
+
     if ((${#TEST_PARALLEL_OPTS[@]} > 0));
     then
         export PYSP_TEST_spark_rapids_memory_gpu_allocFraction=$MEMORY_FRACTION

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -122,16 +122,9 @@ else
     # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
     # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
     # for Spark 3.1.1+
-    set +e
-    VERSION_PROPERTY=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | grep ^version=`
-    if [[ $? -eq "0" ]]; then
-      VERSION_STRING=`echo "$VERSION_PROPERTY" | cut -d'=' -f2`
-      echo "Detected Spark version is $VERSION_STRING"
-    else
-      echo "Unable to detect the Spark version from the distribution in $SPARK_HOME"
-      exit 1
-    fi
-    set -e
+    VERSION_STRING=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | grep ^version= | cut -d'=' -f2`
+    [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
+    echo "Detected Spark version $VERSION_STRING"
 
     SPARK_TASK_MAXFAILURES=1
     [[ "$VERSION_STRING" < "3.1.1" ]] && SPARK_TASK_MAXFAILURES=4

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -122,8 +122,17 @@ else
     # Spark versions before 3.1.1, this sets the spark.max.taskFailures to 4 to allow for
     # more lineant configuration, else it will set them to 1 as spurious task failures are not expected
     # for Spark 3.1.1+
-    VERSION_STRING=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | head -1 | cut -d'=' -f2`
-    echo "Detected Spark version is $VERSION_STRING"
+    set +e
+    VERSION_PROPERTY=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | grep ^version=`
+    if [[ $? -eq "0" ]]; then
+      VERSION_STRING=`echo "$VERSION_PROPERTY" | cut -d'=' -f2`
+      echo "Detected Spark version is $VERSION_STRING"
+    else
+      echo "Unable to detect the Spark version from the distribution in $SPARK_HOME"
+      exit 1
+    fi
+    set -e
+
     SPARK_TASK_MAXFAILURES=1
     [[ "$VERSION_STRING" < "3.1.1" ]] && SPARK_TASK_MAXFAILURES=4
 

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -124,7 +124,6 @@ else
     # for Spark 3.1.1+
     VERSION_STRING=`unzip -q -c $SPARK_HOME/jars/spark-core_*.jar spark-version-info.properties | head -1 | cut -d'=' -f2`
     echo "Detected Spark version is $VERSION_STRING"
-    IS_BEFORE_SPARK_311=`python -c "print(1 if '$VERSION_STRING' < '3.1.1' else 0)"`
     SPARK_TASK_MAXFAILURES=1
     [[ "$VERSION_STRING" < "3.1.1" ]] && SPARK_TASK_MAXFAILURES=4
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -66,7 +66,6 @@ BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
     --executor-memory 12G \
     --total-executor-cores 6 \
     --conf spark.sql.shuffle.partitions=12 \
-    --conf spark.task.maxFailures=1 \
     --conf spark.dynamicAllocation.enabled=false \
     --conf spark.driver.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
     --conf spark.executor.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -60,12 +60,18 @@ export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
 
+IS_SPARK_311_OR_LATER=0
+[[ "$(printf '%s\n' "3.1.1" "$SPARK_VER" | sort -V | head -n1)" = "3.1.1" ]] && IS_SPARK_311_OR_LATER=1
+
+SPARK_TASK_MAXFAILURES=1
+[[ "$IS_SPARK_311_OR_LATER" -eq "0" ]] && SPARK_TASK_MAXFAILURES=4
 
 BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
     --master spark://$HOSTNAME:7077 \
     --executor-memory 12G \
     --total-executor-cores 6 \
     --conf spark.sql.shuffle.partitions=12 \
+    --conf spark.task.maxFailures=$SPARK_TASK_MAXFAILURES \
     --conf spark.dynamicAllocation.enabled=false \
     --conf spark.driver.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
     --conf spark.executor.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
@@ -96,7 +102,7 @@ TEST_TYPE="nightly"
 spark-submit $BASE_SPARK_SUBMIT_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/" --test_type=$TEST_TYPE
 spark-submit $BASE_SPARK_SUBMIT_ARGS $CUDF_UDF_TEST_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -m "cudf_udf" -v -rfExXs --cudf_udf --test_type=$TEST_TYPE
 #only run cache tests with our serializer in nightly test for Spark version >= 3.1.1
-if [ "$(printf '%s\n' "3.1.1" "$SPARK_VER" | sort -V | head -n1)" = "3.1.1" ]; then
+if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
   SHIM_PACKAGE=$(echo ${SPARK_VER} | sed 's/\.//g' | sed 's/-SNAPSHOT//')
   spark-submit ${BASE_SPARK_SUBMIT_ARGS} --conf spark.sql.cache.serializer=com.nvidia.spark.rapids.shims.spark${SHIM_PACKAGE}.ParquetCachedBatchSerializer --jars $RAPIDS_TEST_JAR \
   ./runtests.py -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/" -k cache_test.py -x


### PR DESCRIPTION
…task failures

Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes #2772 

This should alleviate issues with older Spark's by making `spark.task.maxFailures` automatically to 1 for Spark 3.1.1+ and to 4 for prior versions of Spark.

If the user sets `spark.master` or specifies `--master` in the `$SPARK_SUBMIT_FLAGS`, it is assumed they know what they are doing, and so the local mode workaround for https://issues.apache.org/jira/browse/SPARK-2083 is not followed. That said, it still sets `spark.task.maxFailures`.