### PR TITLE
Improve CBO debug logging

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -60,10 +60,17 @@ class CostBasedOptimizer extends Optimizer with Logging {
    * @return A list of optimizations that were applied
    */
   def optimize(conf: RapidsConf, plan: SparkPlanMeta[SparkPlan]): Seq[Optimization] = {
+    println("CBO optimizing plan")
     val cpuCostModel = new CpuCostModel(conf)
     val gpuCostModel = new GpuCostModel(conf)
     val optimizations = new ListBuffer[Optimization]()
     recursivelyOptimize(conf, cpuCostModel, gpuCostModel, plan, optimizations, finalOperator = true)
+    if (optimizations.isEmpty) {
+      logTrace(s"CBO finished optimizing plan. No optimizations applied.")
+    } else {
+      logTrace(s"CBO finished optimizing plan. " +
+        s"${optimizations.length} optimizations applied:\n\t${optimizations.mkString("\n\t")}")
+    }
     optimizations
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CostBasedOptimizer.scala
@@ -60,7 +60,7 @@ class CostBasedOptimizer extends Optimizer with Logging {
    * @return A list of optimizations that were applied
    */
   def optimize(conf: RapidsConf, plan: SparkPlanMeta[SparkPlan]): Seq[Optimization] = {
-    println("CBO optimizing plan")
+    logTrace("CBO optimizing plan")
     val cpuCostModel = new CpuCostModel(conf)
     val gpuCostModel = new GpuCostModel(conf)
     val optimizations = new ListBuffer[Optimization]()


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

With AQE enabled, the optimizer will be called multiple times for a single query plan. This PR introduces BEGIN/END logging around each optimization pass to make it easier to understand the output.