### PR TITLE
Update pre-merge to use reserved_pool [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -25,8 +25,6 @@
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 
-def pluginPremerge
-
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
 def CUDA_NAME = 'cuda11.0' // hardcode cuda version for docker build part
@@ -34,7 +32,6 @@ def PREMERGE_DOCKERFILE = 'jenkins/Dockerfile-blossom.ubuntu'
 def IMAGE_PREMERGE // temp image for premerge test
 def PREMERGE_TAG
 def skipped = false
-def gpuType
 
 pipeline {
     agent {
@@ -140,11 +137,6 @@ pipeline {
                             // if no pre-merge dockerfile change, use nightly image
                             IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu18-$CUDA_NAME-blossom-dev"
                         }
-
-                        // get available GPU resources from reserved pool
-                        def gpuTypes = common.getAvailableResources("${params.GPU_POOL}")
-                        gpuType = gpuTypes.get(0)
-                        pluginPremerge = pod.getGPUYAML("${IMAGE_PREMERGE}", gpuType, '8', '32Gi') // cpu: 8, memory: 32Gi
                     }
                 }
             }
@@ -162,13 +154,13 @@ pipeline {
             options {
                 // We have to use params to pass the resource label in options block,
                 // this is a limitation of declarative pipeline. And we need to lock resource before agent start
-                lock(label: "${params.GPU_POOL}", quantity: 1)
+                lock(label: "${params.GPU_POOL}", quantity: 1, variable: 'GPU_RESOURCE')
             }
             agent {
                 kubernetes {
                     label "premerge-test-${BUILD_TAG}"
                     cloud 'sc-ipp-blossom-prod'
-                    yaml "$pluginPremerge"
+                    yaml pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.GPU_RESOURCE}", '8', '32Gi') // cpu: 8, memory: 32Gi
                     workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
                     customWorkspace "${CUSTOM_WORKSPACE}"
                 }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -34,6 +34,7 @@ def PREMERGE_DOCKERFILE = 'jenkins/Dockerfile-blossom.ubuntu'
 def IMAGE_PREMERGE // temp image for premerge test
 def PREMERGE_TAG
 def skipped = false
+def gpuType
 
 pipeline {
     agent {
@@ -48,7 +49,7 @@ pipeline {
         buildDiscarder(logRotator(numToKeepStr: '50'))
         skipDefaultCheckout true
         // TODO: improve resource management
-        timeout(time: 9, unit: 'HOURS') // long enough to make sure we won't timeout GPU scheduling w/ too many concurrent builds
+        timeout(time: 12, unit: 'HOURS') // long enough to make sure we won't timeout GPU scheduling w/ too many concurrent builds
     }
 
     environment {
@@ -140,8 +141,10 @@ pipeline {
                             IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu18-$CUDA_NAME-blossom-dev"
                         }
 
-
-                        pluginPremerge = pod.getGPUYAML("${IMAGE_PREMERGE}", "${env.PRE_MERGE_GPU_TYPE}", '8', '32Gi') // cpu: 8, memory: 32Gi
+                        // get available GPU resources from reserved pool
+                        def gpuTypes = common.getAvailableResources("${params.GPU_POOL}")
+                        gpuType = gpuTypes.get(0)
+                        pluginPremerge = pod.getGPUYAML("${IMAGE_PREMERGE}", gpuType, '8', '32Gi') // cpu: 8, memory: 32Gi
                     }
                 }
             }
@@ -151,11 +154,16 @@ pipeline {
         stage('Premerge Test') {
             when {
                 beforeAgent true
+                beforeOptions true
                 expression {
                     !skipped
                 }
             }
-
+            options {
+                // We have to use params to pass the resource label in options block,
+                // this is a limitation of declarative pipeline. And we need to lock resource before agent start
+                lock(label: "${params.GPU_POOL}", quantity: 1)
+            }
             agent {
                 kubernetes {
                     label "premerge-test-${BUILD_TAG}"
@@ -170,7 +178,7 @@ pipeline {
                 script {
                     container('gpu') {
                         // TODO: improve resource management
-                        timeout(time: 3, unit: 'HOURS') { // step only timeout for test run
+                        timeout(time: 4, unit: 'HOURS') { // step only timeout for test run
                             sh "$PREMERGE_SCRIPT"
                             step([$class                : 'JacocoPublisher',
                                   execPattern           : '**/target/jacoco.exec',


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

use the jenkins lockable resources plugin to achieve a reserved resource pool. 
so pre-merge can try use any available GPUs in pool. 

All nightly pipelines have already applied the change to lock the GPU resource they are using

Tested in forked repo.