### PR TITLE
Truncate long plan labels and refer to "print-plans"

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
@@ -29,9 +29,6 @@ class ToolTextFileWriter(finalOutputDir: String, logFileName: String) extends Lo
 
   private val textOutputPath = new Path(s"$finalOutputDir/$logFileName")
   private val fs = FileSystem.get(textOutputPath.toUri, new Configuration())
-
-  def outputFilePath = textOutputPath
-
   // this overwrites existing path
   private var outFile: Option[FSDataOutputStream] = Some(fs.create(textOutputPath))
   logInfo(s"Output directory: $finalOutputDir")

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/ToolTextFileWriter.scala
@@ -29,6 +29,9 @@ class ToolTextFileWriter(finalOutputDir: String, logFileName: String) extends Lo
 
   private val textOutputPath = new Path(s"$finalOutputDir/$logFileName")
   private val fs = FileSystem.get(textOutputPath.toUri, new Configuration())
+
+  def outputFilePath = textOutputPath
+
   // this overwrites existing path
   private var outFile: Option[FSDataOutputStream] = Some(fs.create(textOutputPath))
   logInfo(s"Output directory: $finalOutputDir")

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -16,7 +16,9 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import java.io.File
+import java.security.SecureRandom
 
+import scala.collection.mutable
 import scala.io.Source
 
 import com.nvidia.spark.rapids.tool.ToolTestUtils
@@ -67,21 +69,78 @@ class GenerateDotSuite extends FunSuite with BeforeAndAfterAll with Logging {
         for (file <- dotDirs) {
           assert(file.getAbsolutePath.endsWith(".dot"))
           val source = Source.fromFile(file)
-          try {
-            val lines = source.getLines().toArray
-            assert(lines.head === "digraph G {")
-            assert(lines.last === "}")
-            hashAggCount += lines.count(_.contains("HashAggregate"))
-            stageCount += lines.count(_.contains("STAGE "))
-          } finally {
-            source.close()
-          }
+          val dotFileStr = source.mkString
+          source.close()
+          assert(dotFileStr.startsWith("digraph G {"))
+          assert(dotFileStr.endsWith("}"))
+          val hashAggr = "HashAggregate"
+          val stageWord = "STAGE"
+          hashAggCount += dotFileStr.sliding(hashAggr.length).count(_ == hashAggr)
+          stageCount += dotFileStr.sliding(stageWord.length).count(_ == stageWord)
         }
-        // 2 node labels + 1 graph label
-        assert(hashAggCount === 3)
-        // Initial Aggregation, Final Aggregation, Sorting final output
-        assert(stageCount === 3)
+
+        assert(hashAggCount === 8, "Expected: 4 in node labels + 4 in graph label")
+        assert(stageCount === 4, "Expected: UNKNOWN Stage, Initial Aggregation, " +
+          "Final Aggregation, Sorting final output")
       }
     }
+  }
+
+  test("Empty physical plan") {
+    val planLabel = SparkPlanGraph.makeDotLabel(
+      appId = "local-12345-1",
+      sqlId = "120",
+      physicalPlan = "")
+
+    planLabelChecks(planLabel)
+  }
+
+  test("Long physical plan") {
+    val random = new SecureRandom()
+    val seed = System.currentTimeMillis();
+    random.setSeed(seed);
+    info("Seeding test with: " + seed)
+    val numTests = 100
+
+    val lineLengthRange = 50 until 200
+
+
+    val planLengthSeq = mutable.ArrayBuffer.empty[Int]
+    val labelLengthSeq = mutable.ArrayBuffer.empty[Int]
+
+    // some imperfect randomness for edge cases
+    for (_ <- 1 to numTests) {
+      val lineLength = lineLengthRange.start +
+        random.nextInt(lineLengthRange.length) -
+        SparkPlanGraph.htmlLineBreak.length()
+
+      val sign = if (random.nextBoolean()) 1 else -1
+      val planLength = 16 * 1024 + sign * lineLength * (1 + random.nextInt(5));
+      val planStr = (0 to planLength / lineLength).map(_ => "a" * lineLength).mkString("\n")
+
+      planLengthSeq += planStr.length()
+
+      val planLabel = SparkPlanGraph.makeDotLabel(
+        appId = "local-12345-1",
+        sqlId = "120",
+        physicalPlan = planStr)
+
+      labelLengthSeq += planLabel.length()
+
+      planLabelChecks(planLabel)
+      assert(planLabel.length() <= 16 * 1024)
+      assert(planLabel.contains("a" * lineLength))
+      assert(planLabel.contains(SparkPlanGraph.htmlLineBreak))
+    }
+
+    info(s"Plan length summary: min=${labelLengthSeq.min} max=${labelLengthSeq.max}")
+    info(s"Plan label summary: min=${planLengthSeq.min} max=${planLengthSeq.max}")
+  }
+
+  private def planLabelChecks(planLabel: String) {
+    assert(planLabel.startsWith("<<table "))
+    assert(planLabel.endsWith("</table>>"))
+    assert(planLabel.contains("local-12345-1"))
+    assert(planLabel.contains("Plan for SQL ID : 120"))
   }
 }


### PR DESCRIPTION
Properly treat graphviz compiled with the default 16K label max

Closes #2710.

Signed-off-by: Gera Shegalov <gera@apache.org>