### PR TITLE
Update cmake to build udf native [skip ci]

### DIFF
--- a/udf-examples/Dockerfile
+++ b/udf-examples/Dockerfile
@@ -58,7 +58,7 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
 # Set JDK8 as the default Java
 && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
-ARG CMAKE_VERSION=3.19.0
+ARG CMAKE_VERSION=3.20.5
 
 # Install CMake
 RUN cd /tmp \

--- a/udf-examples/pom.xml
+++ b/udf-examples/pom.xml
@@ -38,6 +38,7 @@
     <GPU_ARCHS>ALL</GPU_ARCHS>
     <PER_THREAD_DEFAULT_STREAM>ON</PER_THREAD_DEFAULT_STREAM>
     <CPP_PARALLEL_LEVEL>10</CPP_PARALLEL_LEVEL>
+    <CUDF_ENABLE_ARROW_S3>OFF</CUDF_ENABLE_ARROW_S3>
   </properties>
 
   <dependencies>
@@ -117,6 +118,7 @@
                       <arg value="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"/>
                       <arg value="-DGPU_ARCHS=${GPU_ARCHS}"/>
                       <arg value="-DPER_THREAD_DEFAULT_STREAM=${PER_THREAD_DEFAULT_STREAM}"/>
+                      <arg value="-DCUDF_ENABLE_ARROW_S3=${CUDF_ENABLE_ARROW_S3}"/>
                     </exec>
                     <exec failonerror="true"
                           executable="cmake">


### PR DESCRIPTION
Install cmake '3.20.5' andd add the var 'CUDF_ENABLE_ARROW_S3=OFF' to build cuDF 21.08 native source

Signed-off-by: Tim Liu <timl@nvidia.com>

