### PR TITLE
Add a threadpool to Qualification tool to process logs in parallel

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -43,7 +43,7 @@ class QualOutputWriter(outputDir: String, numRows: Int) {
   private def getTextSpacing(sums: Seq[QualificationSummaryInfo]): (Int, Int)= {
     val sizePadLongs = problemDurStr.size
     val sizes = sums.map(_.appId.size)
-    val appIdMaxSize = if (sizes.size > 0) sizes.max else 0
+    val appIdMaxSize = if (sizes.size > 0) sizes.max else appIdStr.size
     (appIdMaxSize, sizePadLongs)
   }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -49,15 +49,13 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
   }
 
   def qualifyApps(allPaths: Seq[EventLogInfo]): Seq[QualificationSummaryInfo] = {
-    try {
-      allPaths.foreach(path => threadPool.submit(new QualifyThread(path)))
-    } catch {
-      case e: Exception =>
-        logError("Exception processing event logs", e)
-        threadPool.shutdown()
-        if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
-          threadPool.shutdownNow()
-        }
+    allPaths.foreach { path =>
+      try {
+        threadPool.submit(new QualifyThread(path))
+      } catch {
+        case e: Exception =>
+          logError(s"Unexpected exception submitting log ${path.eventLog.toString}, skipping!", e)
+      }
     }
     // wait for the threads to finish processing the files
     threadPool.shutdown()

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -78,6 +78,7 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
       numRows: Int,
       hadoopConf: Configuration): Unit = {
     try {
+      val startTime = System.currentTimeMillis()
       val app = QualAppInfo.createApp(path, numRows, hadoopConf)
       if (!app.isDefined) {
         logWarning(s"No Application found that contain SQL for ${path.eventLog.toString}!")
@@ -86,6 +87,8 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
         val qualSumInfo = app.get.aggregateStats()
         if (qualSumInfo.isDefined) {
           allApps.add(qualSumInfo.get)
+          val endTime = System.currentTimeMillis()
+          logInfo(s"Took ${endTime - startTime}ms to process ${path.eventLog.toString}")
         } else {
           logWarning(s"No aggregated stats for event log at: ${path.eventLog.toString}")
         }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -56,7 +56,7 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   val timeout: ScallopOption[Long] =
     opt[Long](required = false,
       descr = "Maximum time in seconds to wait for the event logs to be processed. " +
-        "Default is 10 hours (36000 seconds) and must be greater than 3 seconds. If it " +
+        "Default is 24 hours (86400 seconds) and must be greater than 3 seconds. If it " +
         "times out, it will report what it was able to process up until the timeout.")
 
   validate(filterCriteria) {

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -49,10 +49,24 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   val numOutputRows: ScallopOption[Int] =
     opt[Int](required = false,
       descr = "Number of output rows. Default is 1000.")
+  val numThreads: ScallopOption[Int] =
+    opt[Int](required = false,
+      descr = "Number of thread to use for parallel processing. The default is the " +
+        "number of cores on host divided by 4.")
+  val timeout: ScallopOption[Long] =
+    opt[Long](required = false,
+      descr = "Maximum time in seconds to wait for the event logs to be processed. " +
+        "Default is 10 hours (36000 seconds) and must be greater than 3 seconds. If it " +
+        "times out, it will report what it was able to process up until the timeout.")
 
   validate(filterCriteria) {
     case crit if (crit.endsWith("-newest") || crit.endsWith("-oldest")) => Right(Unit)
     case _ => Left("Error, the filter criteria must end with either -newest or -oldest")
+  }
+
+  validate(timeout) {
+    case timeout if (timeout > 3) => Right(Unit)
+    case _ => Left("Error, timeout must be greater than 3 seconds.")
   }
 
   verify()

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -48,6 +48,10 @@ object QualificationMain extends Logging {
     val outputDirectory = appArgs.outputDirectory().stripSuffix("/")
     val numOutputRows = appArgs.numOutputRows.getOrElse(1000)
 
+    val nThreads = appArgs.numThreads.getOrElse(
+      Math.ceil(Runtime.getRuntime.availableProcessors() / 4f).toInt)
+    val timeout = appArgs.timeout.toOption
+
     val hadoopConf = new Configuration()
     val eventLogInfos = EventLogPathProcessor.processAllPaths(filterN.toOption,
       matchEventLogs.toOption, eventlogPaths, hadoopConf)
@@ -56,9 +60,8 @@ object QualificationMain extends Logging {
       return (0, Seq[QualificationSummaryInfo]())
     }
 
-    val res = Qualification.qualifyApps(eventLogInfos, numOutputRows,
-      outputDirectory, hadoopConf)
+    val qual = new Qualification(outputDirectory, numOutputRows, hadoopConf, timeout, nThreads)
+    val res = qual.qualifyApps(eventLogInfos)
     (0, res)
   }
-
 }

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -95,7 +95,7 @@ abstract class AppBase(
     } else {
       logError(s"Error getting reader for ${eventlog.getName}")
     }
-    logInfo("Total number of events parsed: " + totalNumEvents)
+    logInfo(s"Total number of events parsed: $totalNumEvents for ${eventlog.toString}")
   }
 
   protected def isDataSetPlan(desc: String): Boolean = {

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
@@ -74,7 +74,7 @@ class QualAppInfo(
           if (lastSQLEndTime.isEmpty && lastJobEndTime.isEmpty) {
             None
           } else {
-            logWarning("Application End Time is unknown, estimating based on" +
+            logWarning(s"Application End Time is unknown for $appId, estimating based on" +
               " job and sql end times!")
             // estimate the app end with job or sql end times
             val sqlEndTime = if (this.lastSQLEndTime.isEmpty) 0L else this.lastSQLEndTime.get
@@ -197,7 +197,7 @@ object QualAppInfo extends Logging {
       hadoopConf: Configuration): Option[QualAppInfo] = {
     val app = try {
         val app = new QualAppInfo(numRows, path, hadoopConf)
-        logInfo(s"==============  ${app.appId} ============== ")
+        logInfo(s"${path.eventLog.toString} has App: ${app.appId}")
         Some(app)
       } catch {
         case json: com.fasterxml.jackson.core.JsonParseException =>

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import com.nvidia.spark.rapids.tool.EventLogInfo
 import com.nvidia.spark.rapids.tool.profiling._
 import org.apache.hadoop.conf.Configuration
-+import org.apache.hadoop.security.AccessControlException
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.SparkListenerEvent
@@ -206,10 +205,6 @@ object QualAppInfo extends Logging {
           None
         case il: IllegalArgumentException =>
           logWarning(s"Error parsing file: ${path.eventLog.toString}", il)
-          None
-        case e: AccessControlException =>
-          // We don't have read permissions on the log file
-          logWarning(s"Unable to read log ${path.eventLog.toString}", e)
           None
         case e: Exception =>
           // catch all exceptions and skip that file


### PR DESCRIPTION
Add a threadpool and parameters to configure timeout and number of threads (defaults to cores on host/4).
Updated some log messages so it shows path or something useful since now the log messages don't come out in sequential order.

Fixed a bug with printing out the text file when there aren't any apps in QualOutputWriter.

Times to process 105 log files went from about 6.5 minutes to 45 seconds, interestingly enough, processing 210 log files only takes a bit longer at like 50 seconds, it looks like a few of the log files are skewed and take much longer than others.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
