### PR TITLE
Split window exec into multiple stages if needed

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -296,6 +296,7 @@ def test_window_running_no_part(b_gen, batch_size):
         'select ' +
         ', '.join(query_parts) +
         ' from window_agg_table ',
+        validate_execs_in_gpu_plan = ['GpuRunningWindowExec'],
         conf = conf)
 
 # This is for aggregations that work with a running window optimization. They don't need to be batched
@@ -319,6 +320,7 @@ def test_window_running(b_gen, c_gen, batch_size):
         'select ' +
         ', '.join(query_parts) +
         ' from window_agg_table ',
+        validate_execs_in_gpu_plan = ['GpuRunningWindowExec'],
         conf = conf)
 
 @ignore_order
@@ -527,6 +529,8 @@ def test_window_aggs_for_rows_collect_list():
 
 # SortExec does not support array type, so sort the result locally.
 @ignore_order(local=True)
+# This test is more directed at Databricks and their running window optimization instead of ours
+# this is why we do not validate that we inserted in a GpuRunningWindowExec, yet.
 def test_running_window_function_exec_for_all_aggs():
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, _gen_data_for_collect_list),
@@ -553,7 +557,6 @@ def test_running_window_function_exec_for_all_aggs():
             (partition by a order by b,c_int rows between UNBOUNDED PRECEDING AND CURRENT ROW) as collect_struct
         from window_collect_table
         ''')
-
 
 # Generates some repeated values to test the deduplication of GpuCollectSet.
 # And GpuCollectSet does not yet support struct type.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -834,6 +834,10 @@ case class GpuSpecialFrameBoundary(boundary : SpecialFrameBoundary)
   }
 }
 
+// This is here for now just to tag an expression as being a GpuWindowFunction and match
+// Spark. This may expand in the future if other types of window functions show up.
+trait GpuWindowFunction extends GpuUnevaluable
+
 /**
  * GPU Counterpart of `AggregateWindowFunction`.
  * On the CPU this would extend `DeclarativeAggregate` and use the provided methods
@@ -842,7 +846,7 @@ case class GpuSpecialFrameBoundary(boundary : SpecialFrameBoundary)
  * expressions.
  */
 trait GpuAggregateWindowFunction[T <: Aggregation with RollingAggregation[T]]
-    extends GpuUnevaluable {
+    extends GpuWindowFunction {
   /**
    * Using child references, define the shape of the vectors sent to the window operations
    */


### PR DESCRIPTION
This fixes #2688 

It does not go all the way and change window functions so that they are combined into fewer calls.  I plan on doing that in a follow on PR because this was large enough already. I tested this on databricks.

One of the big advantages to this is that on databricks we now can now optimized for GpuRunningWindowExec even if there are complicated operations.