### PR TITLE
Fix hash aggregate tests leaking configs into other tests

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -271,7 +271,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "avg literals dbl_max",
       longsFromCSVDf,
       maxFloatDiff = 0.0001,
-      conf = floatAggConf.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
+      conf = floatAggConf.clone.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
     frame => frame.agg(avg(lit(1.4718094e+19)),avg(lit(1.4718094e+19)))
   }
 
@@ -316,7 +316,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "avg literals strings dbl",
       longsFromCSVDf,
       maxFloatDiff = 0.0001,
-      conf = floatAggConf.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
+      conf = floatAggConf.clone.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
     frame => frame.agg(avg(lit("1.4718094e+19")),avg(lit("1.4718094e+19")))
   }
 
@@ -361,7 +361,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
   IGNORE_ORDER_testSparkResultsAreEqual(
       "group by string include nulls in count aggregate small batches",
       nullableStringsIntsDf,
-      conf = floatAggConf.set(RapidsConf.GPU_BATCH_SIZE_BYTES.key, "10")) {
+      conf = floatAggConf.clone.set(RapidsConf.GPU_BATCH_SIZE_BYTES.key, "10")) {
     frame => frame.groupBy("strings").agg(
       max("ints"),
       min("ints"),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, DataTypes}
 
 class HashAggregatesSuite extends SparkQueryCompareTestSuite {
-  private val floatAggConf: SparkConf = enableCsvConf()
+  private def floatAggConf: SparkConf = enableCsvConf()
       .set(RapidsConf.ENABLE_FLOAT_AGG.key, "true")
       .set(RapidsConf.HAS_NANS.key, "false")
 
@@ -271,7 +271,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "avg literals dbl_max",
       longsFromCSVDf,
       maxFloatDiff = 0.0001,
-      conf = floatAggConf.clone.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
+      conf = floatAggConf.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
     frame => frame.agg(avg(lit(1.4718094e+19)),avg(lit(1.4718094e+19)))
   }
 
@@ -316,7 +316,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       "avg literals strings dbl",
       longsFromCSVDf,
       maxFloatDiff = 0.0001,
-      conf = floatAggConf.clone.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
+      conf = floatAggConf.set(RapidsConf.INCOMPATIBLE_OPS.key, "true")) {
     frame => frame.agg(avg(lit("1.4718094e+19")),avg(lit("1.4718094e+19")))
   }
 
@@ -361,7 +361,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
   IGNORE_ORDER_testSparkResultsAreEqual(
       "group by string include nulls in count aggregate small batches",
       nullableStringsIntsDf,
-      conf = floatAggConf.clone.set(RapidsConf.GPU_BATCH_SIZE_BYTES.key, "10")) {
+      conf = floatAggConf.set(RapidsConf.GPU_BATCH_SIZE_BYTES.key, "10")) {
     frame => frame.groupBy("strings").agg(
       max("ints"),
       min("ints"),


### PR DESCRIPTION
While working on changes to hash aggregate, I noticed that some test-specific configs were leaking into other tests because a reused `SparkConf` instance was being modified directly with test-specific settings.  This fixes the tests to make a copy of the configs before updating it with specific settings.