### PR TITLE
Tag last batch when coalescing

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -369,8 +369,10 @@ abstract class AbstractGpuCoalesceIterator(
         }
       }
 
+      val isLastBatch = !(hasOnDeck || iter.hasNext)
+
       // enforce single batch limit when appropriate
-      if (goal == RequireSingleBatch && (hasOnDeck || iter.hasNext)) {
+      if (goal == RequireSingleBatch && !isLastBatch) {
         throw new IllegalStateException("A single batch is required for this operation." +
             " Please try increasing your partition count.")
       }
@@ -378,7 +380,11 @@ abstract class AbstractGpuCoalesceIterator(
       numOutputRows += numRows
       numOutputBatches += 1
       withResource(new NvtxWithMetrics(s"$opName concat", NvtxColor.CYAN, concatTime)) { _ =>
-        concatAllAndPutOnGPU()
+        val batch = concatAllAndPutOnGPU()
+        if (isLastBatch) {
+          GpuColumnVector.tagAsFinalBatch(batch)
+        }
+        batch
       }
     } finally {
       cleanupConcatIsDone()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -50,15 +50,46 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
 
       // assert final results are correct
       assert(batches.hasNext)
-      val batch = batches.next()
-      assert(batch.numCols() == 5)
-      assert(batch.numRows() == 14)
-      assert(!batches.hasNext)
-      batch.close()
+      withResource(batches.next()) { batch =>
+        assert(batch.numCols() == 5)
+        assert(batch.numRows() == 14)
+        assert(GpuColumnVector.isTaggedAsFinalBatch(batch))
+        assert(!batches.hasNext)
+      }
 
       // assert metrics are correct
       assert(gpuCoalesceBatches.metrics(GpuMetric.NUM_OUTPUT_ROWS).value == 14)
       assert(gpuCoalesceBatches.metrics(GpuMetric.NUM_OUTPUT_BATCHES).value == 1)
+    })
+  }
+
+  test("test multiple output batches") {
+    withGpuSparkSession(spark => {
+      val testData = mixedDf(spark, numSlices = 1)
+      val gpuRowToColumnarExec = GpuRowToColumnarExec(testData.queryExecution.sparkPlan,
+        TargetSize(1))
+      val gpuCoalesceBatches = GpuCoalesceBatches(gpuRowToColumnarExec, TargetSize(50))
+      val rdd = gpuCoalesceBatches.doExecuteColumnar()
+      val part = rdd.partitions.head
+      val context = new MockTaskContext(taskAttemptId = 1, partitionId = 0)
+      val batches = rdd.compute(part, context)
+
+      var totalRows = 0
+      var totalBatches = 0
+      while(batches.hasNext) {
+        totalBatches += 1
+        withResource(batches.next()) { batch =>
+          assertResult(5)(batch.numCols())
+          assertResult(!batches.hasNext)(GpuColumnVector.isTaggedAsFinalBatch(batch))
+          totalRows += batch.numRows()
+        }
+      }
+      assert(totalBatches > 1)
+      assertResult(14)(totalRows)
+
+      // assert metrics are correct
+      assertResult(14)(gpuCoalesceBatches.metrics(GpuMetric.NUM_OUTPUT_ROWS).value)
+      assertResult(totalBatches)(gpuCoalesceBatches.metrics(GpuMetric.NUM_OUTPUT_BATCHES).value)
     })
   }
 
@@ -459,6 +490,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     while (coalesceIter.hasNext) {
       withResource(coalesceIter.next()) { batch =>
         assertResult(2)(batch.numCols)
+        assertResult(!coalesceIter.hasNext)(GpuColumnVector.isTaggedAsFinalBatch(batch))
         val Array(longCol, decCol) = GpuColumnVector.extractBases(batch)
         withResource(longCol.copyToHost) { longHcv =>
           withResource(decCol.copyToHost) { decHcv =>
@@ -541,6 +573,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     while (coalesceIter.hasNext) {
       withResource(coalesceIter.next()) { batch =>
         assertResult(2)(batch.numCols)
+        assertResult(!coalesceIter.hasNext)(GpuColumnVector.isTaggedAsFinalBatch(batch))
         val Array(longCol, decCol) = GpuColumnVector.extractBases(batch)
         withResource(longCol.copyToHost) { longHcv =>
           withResource(decCol.copyToHost) { decHcv =>


### PR DESCRIPTION
Updates the coalesce iterator to tag the last batch being emitted.  This allows code using the iterator to detect the last batch from the iterator without relying on `hasNext` which often has the unfortunate side-effect of manifesting another batch in memory.