### PR TITLE
Add spillable batch caching and sort fallback to hash aggregation

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * target size. It assumes that the input batches will already be close to that size and does
  * not try to split them too much further.
  */
-class GpuKeyBatchingIterator private (
+class GpuKeyBatchingIterator(
     iter: Iterator[ColumnarBatch],
     sorter: GpuSorter,
     types: Array[DataType],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -16,7 +16,9 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.mutable.ArrayBuffer
+import java.util
+
+import scala.collection.mutable
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{NvtxColor, Scalar}
@@ -24,15 +26,18 @@ import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSeq, AttributeSet, Expression, If, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, Attribute, AttributeReference, AttributeSeq, AttributeSet, Expression, If, NamedExpression, NullsFirst}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, HashPartitioning, Partitioning, UnspecifiedDistribution}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.{ExplainUtils, SortExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.rapids.{CudfAggregate, GpuAggregateExpression}
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{ArrayType, LongType, MapType, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
@@ -65,6 +70,640 @@ object AggregateUtils {
           case First(If(_, _, _), _) if validateAggregate(func.references) => true
           case _ => false
         }
+      }
+    }
+  }
+}
+
+/** Utility class to hold all of the metrics related to hash aggregation */
+case class GpuHashAggregateMetrics(
+    numOutputRows: GpuMetric,
+    numOutputBatches: GpuMetric,
+    totalTime: GpuMetric,
+    computeAggTime: GpuMetric,
+    concatTime: GpuMetric,
+    sortTime: GpuMetric,
+    spillCallback: RapidsBuffer.SpillCallback)
+
+/** Utility class to convey information on the aggregation modes being used */
+case class AggregateModeInfo(
+    uniqueModes: Seq[AggregateMode],
+    hasPartialMode: Boolean,
+    hasFinalMode: Boolean,
+    hasCompleteMode: Boolean)
+
+class GpuHashAggregateIterator(
+    cbIter: Iterator[ColumnarBatch],
+    groupingExpressions: Seq[Expression],
+    aggregateExpressions: Seq[GpuAggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    resultExpressions: Seq[NamedExpression],
+    childOutput: Seq[Attribute],
+    modeInfo: AggregateModeInfo,
+    metrics: GpuHashAggregateMetrics,
+    targetBatchSize: Long)
+    extends Iterator[ColumnarBatch] with Arm with AutoCloseable with Logging {
+  // Partial mode:
+  //  1. boundInputReferences: picks column from raw input
+  //  2. boundUpdateAgg: performs the partial half of the aggregates (GpuCount => CudfCount)
+  //  3. boundMergeAgg: (if needed) perform a merge of partial aggregates (CudfCount => CudfSum)
+  //  4. boundResultReferences: is a pass-through of the merged aggregate
+  //
+  // Final mode:
+  //  1. boundInputReferences: is a pass-through of the merged aggregate
+  //  2. boundMergeAgg: perform merges of incoming, and subsequent batches if required.
+  //  3. boundFinalProjections: on merged batches, finalize aggregates
+  //     (GpuAverage => CudfSum/CudfCount)
+  //  4. boundResultReferences: project the result expressions Spark expects in the output.
+  private case class BoundExpressionsModeAggregates(
+      boundInputReferences: Seq[GpuExpression],
+      boundFinalProjections: Option[scala.Seq[GpuExpression]],
+      boundResultReferences: scala.Seq[Expression],
+      aggModeCudfAggregates: scala.Seq[(AggregateMode, scala.Seq[CudfAggregate])])
+
+  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+
+  private[this] val isReductionOnly = groupingExpressions.isEmpty
+  private[this] val boundExpressions = setupReferences(childOutput)
+  private[this] val aggregatedBatches = new util.ArrayDeque[LazySpillableColumnarBatch]
+  private[this] var outOfCoreIter: Option[GpuOutOfCoreSortIterator] = None
+
+  /** Iterator for fetching aggregated batches if a sort-based fallback has occurred */
+  private[this] var sortFallbackIter: Option[Iterator[ColumnarBatch]] = None
+
+  /** Whether a batch is pending for a reduction-only aggregation */
+  private[this] var hasReductionOnlyBatch: Boolean = isReductionOnly
+
+  override def hasNext: Boolean = {
+    // FIXME: totalTime accounting if it stays
+    sortFallbackIter.map(_.hasNext).getOrElse {
+      // reductions produce a result even if the input is empty
+      hasReductionOnlyBatch || !aggregatedBatches.isEmpty || cbIter.hasNext
+    }
+  }
+
+  override def next(): ColumnarBatch = {
+    val batch = sortFallbackIter.map(_.next()).getOrElse {
+      // aggregate and merge all pending inputs
+      if (cbIter.hasNext) {
+        aggregateInputBatches()
+        mergeAggregatedBatches()
+      }
+
+      if (aggregatedBatches.size() > 1) {
+        // Unable to merge to a single output, so must fall back to a sort-based approach.
+        sortFallbackIter = Some(buildSortFallbackIterator())
+        sortFallbackIter.get.next()
+      } else if (aggregatedBatches.isEmpty) {
+        if (hasReductionOnlyBatch) {
+          hasReductionOnlyBatch = false
+          generateEmptyReductionBatch()
+        } else {
+          throw new NoSuchElementException("batches exhausted")
+        }
+      } else {
+        // this will be the last batch
+        hasReductionOnlyBatch = false
+        aggregatedBatches.pop().getBatch
+      }
+    }
+
+    finalProjectBatch(batch)
+  }
+
+  override def close(): Unit = {
+    aggregatedBatches.forEach(_.safeClose())
+    aggregatedBatches.clear()
+    outOfCoreIter.foreach(_.close())
+    outOfCoreIter = None
+    sortFallbackIter = None
+    hasReductionOnlyBatch = false
+  }
+
+  /** Aggregate all input batches and place the results in the aggregatedBatches queue. */
+  private def aggregateInputBatches(): Unit = {
+    while (cbIter.hasNext) {
+      val (childCvs, isLastInputBatch) = withResource(cbIter.next()) { inputBatch =>
+        val isLast = GpuColumnVector.isTaggedAsFinalBatch(inputBatch)
+        (processIncomingBatch(inputBatch), isLast)
+      }
+      withResource(childCvs) { _ =>
+        withResource(computeAggregate(childCvs, merge = false)) { aggregatedBatch =>
+          val batch = LazySpillableColumnarBatch(aggregatedBatch, metrics.spillCallback,
+            "aggbatch")
+          // Avoid making batch spillable for the common case of the last and only batch
+          if (!(isLastInputBatch && aggregatedBatches.isEmpty)) {
+            batch.allowSpilling()
+          }
+          aggregatedBatches.add(batch)
+        }
+      }
+    }
+  }
+
+  /**
+   * Attempt to merge adjacent batches in the aggregatedBatches queue until either there is only
+   * one batch or merging adjacent batches would exceed the target batch size.
+   */
+  private def mergeAggregatedBatches(): Unit = {
+    while (aggregatedBatches.size() > 1) {
+      val concatTime = metrics.concatTime
+      withResource(new NvtxWithMetrics("agg merge pass", NvtxColor.BLUE, concatTime)) { _ =>
+        // continue merging as long as some batches are able to be combined
+        if (!mergePass()) {
+          if (aggregatedBatches.size() > 1 && isReductionOnly) {
+            // We were unable to merge the aggregated batches within the target batch size limit,
+            // which means normally we would fallback to a sort-based approach. However for
+            // reduction-only aggregation there are no keys to use for a sort. The only way this
+            // can work is if all batches are merged. This will exceed the target batch size limit,
+            // but at this point it is either risk an OOM/cudf error and potentially work or
+            // not work at all.
+            logWarning(s"Unable to merge reduction-only aggregated batches within " +
+                s"target batch limit of ${targetBatchSize}, attempting to merge remaining " +
+                s"${aggregatedBatches.size()} batches beyond limit")
+            withResource(mutable.ArrayBuffer[LazySpillableColumnarBatch]()) { batchesToConcat =>
+              aggregatedBatches.forEach(b => batchesToConcat += b)
+              aggregatedBatches.clear()
+              val batch = concatenateAndMerge(batchesToConcat)
+              // batch does not need to be marked spillable since it is the last and only batch
+              // and will be immediately retrieved on the next() call.
+              aggregatedBatches.add(batch)
+            }
+          }
+          return
+        }
+      }
+    }
+  }
+
+  /**
+   * Perform a single pass over the aggregated batches attempting to merge adjacent batches.
+   * @return true if at least one merge operation occurred
+   */
+  private def mergePass(): Boolean = {
+    val batchesToConcat: mutable.ArrayBuffer[LazySpillableColumnarBatch] = mutable.ArrayBuffer.empty
+    var wasBatchMerged = false
+    var concatSize: Long = 0L
+    var batchesLeftInPass = aggregatedBatches.size()
+
+    while (batchesLeftInPass > 0) {
+      closeOnExcept(batchesToConcat) { _ =>
+        var isConcatSearchFinished = false
+        // Although tempting to allow the pass to "wrap around" and pick up batches previously
+        // merged in this pass, it's avoided to prevent changing the order of aggregated batches.
+        while (batchesLeftInPass > 0 && !isConcatSearchFinished) {
+          val candidate = aggregatedBatches.getFirst
+          val potentialSize = concatSize + candidate.deviceMemorySize
+          isConcatSearchFinished = concatSize > 0 && potentialSize > targetBatchSize
+          if (!isConcatSearchFinished) {
+            batchesLeftInPass -= 1
+            batchesToConcat += aggregatedBatches.removeFirst()
+            concatSize = potentialSize
+          }
+        }
+      }
+
+      val mergedBatch = if (batchesToConcat.length > 1) {
+        wasBatchMerged = true
+        val batch = concatenateAndMerge(batchesToConcat)
+        batch.allowSpilling()
+        batch
+      } else {
+        // Unable to find a neighboring buffer to produce a valid merge in this pass,
+        // so simply put this buffer back on the queue for other passes.
+        batchesToConcat.remove(0)
+      }
+
+      aggregatedBatches.addLast(mergedBatch)
+      batchesToConcat.clear()
+      concatSize = 0
+    }
+
+    wasBatchMerged
+  }
+
+  /**
+   * Concatenate batches together and perform a merge aggregation on the result. The input batches
+   * will be closed as part of this operation.
+   * @param batches batches to concatenate and merge aggregate
+   * @return lazy spillable batch which has NOT been marked spillable
+   */
+  private def concatenateAndMerge(
+      batches: mutable.ArrayBuffer[LazySpillableColumnarBatch]): LazySpillableColumnarBatch = {
+    withResource(batches) { _ =>
+      val concatVectors = concatenateBatches(batches)
+      withResource(computeAggregate(concatVectors, merge = true)) { mergedBatch =>
+        LazySpillableColumnarBatch(mergedBatch, metrics.spillCallback, "agg merged batch")
+      }
+    }
+  }
+
+  /** Build an iterator that uses a sort-based approach to merge aggregated batches together. */
+  private def buildSortFallbackIterator(): Iterator[ColumnarBatch] = {
+    logInfo("Falling back to sort-based aggregation with ${aggregatedBatches.size()} batches")
+    val aggregatedBatchIter = new Iterator[ColumnarBatch] {
+      override def hasNext: Boolean = !aggregatedBatches.isEmpty
+
+      override def next(): ColumnarBatch = {
+        withResource(aggregatedBatches.removeFirst()) { lazyBatch =>
+          GpuColumnVector.incRefCounts(lazyBatch.getBatch)
+        }
+      }
+    }
+
+    if (isReductionOnly) {
+      // TODO: Should reduction-only aggregation ignore the target batch size and try to merge
+      //       batches up to the cudf limit instead?  In other words, risk a potential but not
+      //       guaranteed OOM while trying to make it work instead of assuming it cannot work.
+      throw new IllegalStateException("Unable to fallback to sort-based aggregation " +
+          "without grouping keys")
+    }
+
+    val shims = ShimLoader.getSparkShims
+    val ordering = groupingExpressions.map(shims.sortOrder(_, Ascending, NullsFirst))
+    val groupingAttributes = groupingExpressions.map(_.asInstanceOf[NamedExpression].toAttribute)
+    val aggBufferAttributes = groupingAttributes ++
+        aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
+    val sorter = new GpuSorter(ordering, aggBufferAttributes)
+    val aggregates = boundExpressions.aggModeCudfAggregates.flatMap(_._2)
+    val aggBatchTypes = groupingExpressions.map(_.dataType) ++ aggregates.map(_.dataType)
+
+    // Use the out of core sort iterator to sort the batches by grouping key
+    outOfCoreIter = Some(GpuOutOfCoreSortIterator(
+      aggregatedBatchIter,
+      sorter,
+      LazilyGeneratedOrdering.forSchema(TrampolineUtil.fromAttributes(groupingAttributes)),
+      targetBatchSize,
+      totalTime = NoopMetric,
+      sortTime = metrics.sortTime,
+      outputBatches = NoopMetric,
+      outputRows = NoopMetric,
+      peakDevMemory = NoopMetric,
+      spillCallback = metrics.spillCallback))
+
+    // The out of core sort iterator does not guarantee that a batch contains all of the values
+    // for a particular key, so add a key batching iterator to enforce this. That allows each batch
+    // to be merge-aggregated safely since all values associated with a particular key are
+    // guaranteed to be in the same batch.
+    val keyBatchingIter = new GpuKeyBatchingIterator(
+      outOfCoreIter.get,
+      sorter,
+      aggBatchTypes.toArray,
+      targetBatchSize,
+      numInputRows = NoopMetric,
+      numInputBatches = NoopMetric,
+      numOutputRows = NoopMetric,
+      numOutputBatches = NoopMetric,
+      collectTime = NoopMetric,
+      concatTime = metrics.concatTime,
+      totalTime = NoopMetric,
+      peakDevMemory = NoopMetric,
+      spillCallback = metrics.spillCallback)
+
+    // Finally wrap the key batching iterator with a merge aggregation on the output batches.
+    new Iterator[ColumnarBatch] {
+      override def hasNext: Boolean = keyBatchingIter.hasNext
+
+      override def next(): ColumnarBatch = {
+        // batches coming out of the sort need to be merged
+        withResource(keyBatchingIter.next()) { unmergedBatch =>
+          computeAggregate(GpuColumnVector.extractColumns(unmergedBatch), merge = true)
+        }
+      }
+    }
+  }
+
+  /**
+   * Generates the result of a reduction-only aggregation on empty input by emitting the
+   * initial value of each aggregator.
+   */
+  private def generateEmptyReductionBatch(): ColumnarBatch = {
+    val aggregateFunctions = aggregateExpressions.map(_.aggregateFunction)
+    val defaultValues =
+      aggregateFunctions.flatMap(_.initialValues)
+    val vecs = defaultValues.safeMap { ref =>
+      withResource(GpuScalar.from(ref.asInstanceOf[GpuLiteral].value, ref.dataType)) {
+        scalar => GpuColumnVector.from(scalar, 1, ref.dataType)
+      }
+    }
+    new ColumnarBatch(vecs.toArray, 1)
+  }
+
+  /**
+   * Project a merged aggregated batch result to the layout that Spark expects
+   * i.e.: select avg(foo) from bar group by baz will produce:
+   *  Partial mode: 3 columns => [bar, sum(foo) as sum_foo, count(foo) as count_foo]
+   *  Final mode:   2 columns => [bar, sum(sum_foo) / sum(count_foo)]
+   */
+  private def finalProjectBatch(batch: ColumnarBatch): ColumnarBatch = {
+    val finalBatch = if (boundExpressions.boundFinalProjections.isDefined) {
+      withResource(batch) { _ =>
+        val finalCvs = boundExpressions.boundFinalProjections.get.map { ref =>
+            // aggregatedCb is made up of ColumnVectors
+            // and the final projections from the aggregates won't change that,
+            // so we can assume they will be vectors after we eval
+            ref.columnarEval(batch).asInstanceOf[GpuColumnVector]
+          }
+        new ColumnarBatch(finalCvs.toArray, finalCvs.head.getRowCount.toInt)
+      }
+    } else {
+      batch
+    }
+
+    // Perform the last project to get the correct shape that Spark expects. Note this may
+    // add things like literals that were not part of the aggregate into the batch.
+    val resultCvs = withResource(finalBatch) { _ =>
+      boundExpressions.boundResultReferences.safeMap { ref =>
+        // Result references can be virtually anything, we need to coerce
+        // them to be vectors since this is going into a ColumnarBatch
+        GpuExpressionsUtils.columnarEvalToColumn(ref, finalBatch)
+      }
+    }
+    closeOnExcept(resultCvs) { _ =>
+      val rowCount = if (resultCvs.isEmpty) 0 else resultCvs.head.getRowCount.toInt
+      metrics.numOutputRows += resultCvs.head.getBase.getRowCount
+      metrics.numOutputBatches += 1
+      new ColumnarBatch(resultCvs.toArray, rowCount)
+    }
+  }
+
+  /** Perform the initial projection on the input batch and extract the result columns */
+  private def processIncomingBatch(batch: ColumnarBatch): Seq[GpuColumnVector] = {
+    boundExpressions.boundInputReferences.safeMap { ref =>
+      val childCv = GpuExpressionsUtils.columnarEvalToColumn(ref, batch)
+      if (childCv.dataType == ref.dataType) {
+        childCv
+      } else {
+        withResource(childCv) { childCv =>
+          val rapidsType = GpuColumnVector.getNonNestedRapidsType(ref.dataType)
+          GpuColumnVector.from(childCv.getBase.castTo(rapidsType), ref.dataType)
+        }
+      }
+    }
+  }
+
+  /**
+   * Concatenates batches by concatenating the corresponding column vectors within the batches.
+   * @note the input batches are not closed as part of this operation
+   * @param batchesToConcat batches to concatenate
+   * @return concatenated vectors that together represent the concatenated batch result
+   */
+  private def concatenateBatches(
+      batchesToConcat: mutable.ArrayBuffer[LazySpillableColumnarBatch]): Seq[GpuColumnVector] = {
+    val concatTime = metrics.concatTime
+    withResource(new NvtxWithMetrics("concatenateBatches", NvtxColor.BLUE, concatTime)) { _ =>
+      val numCols = batchesToConcat.head.numCols
+      (0 until numCols).safeMap { i =>
+        val columnType = batchesToConcat.head.getBatch.column(i).dataType()
+        val columnsToConcat = batchesToConcat.map {
+          _.getBatch.column(i).asInstanceOf[GpuColumnVector].getBase
+        }
+        GpuColumnVector.from(cudf.ColumnVector.concatenate(columnsToConcat: _*), columnType)
+      }
+    }
+  }
+
+  /**
+   * getCudfAggregates returns a sequence of `cudf.Aggregate`, given the current mode
+   * `AggregateMode`, and a sequence of all expressions for this [[GpuHashAggregateExec]]
+   * node, we get all the expressions as that's important for us to be able to resolve the current
+   * ordinal for this cudf aggregate.
+   *
+   * Examples:
+   * fn = sum, min, max will always be Seq(fn)
+   * avg will be Seq(sum, count) for Partial mode, but Seq(sum, sum) for other modes
+   * count will be Seq(count) for Partial mode, but Seq(sum) for other modes
+   *
+   * @return Seq of `cudf.Aggregate`, with one or more aggregates that correspond to each
+   *         expression in allExpressions
+   */
+  private def setupReferences(childAttr: AttributeSeq): BoundExpressionsModeAggregates = {
+    val groupingAttributes = groupingExpressions.map(_.asInstanceOf[NamedExpression].toAttribute)
+    val aggBufferAttributes = groupingAttributes ++
+        aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
+
+    //
+    // update expressions are those performed on the raw input data
+    // e.g. for count it's count, and for average it's sum and count.
+    //
+    val updateExpressionsSeq =
+    aggregateExpressions.map(
+      _.aggregateFunction.updateExpressions)
+    //
+    // merge expressions are used while merging multiple batches, or while on final mode
+    // e.g. for count it's sum, and for average it's sum and sum.
+    //
+    val mergeExpressionsSeq =
+    aggregateExpressions.map(
+      _.aggregateFunction.mergeExpressions)
+
+    val aggModeCudfAggregates = aggregateExpressions.zipWithIndex.map { case (expr, modeIndex) =>
+      val cudfAggregates = if (expr.mode == Partial || expr.mode == Complete) {
+        GpuBindReferences.bindGpuReferences(updateExpressionsSeq(modeIndex), aggBufferAttributes)
+            .asInstanceOf[Seq[CudfAggregate]]
+      } else {
+        GpuBindReferences.bindGpuReferences(mergeExpressionsSeq(modeIndex), aggBufferAttributes)
+            .asInstanceOf[Seq[CudfAggregate]]
+      }
+      (expr.mode, cudfAggregates)
+    }
+
+    //
+    // expressions to pick input to the aggregate, and finalize the output to the result projection.
+    //
+    // Pick update distinct attributes or input projections for Partial
+    val (distinctAggExpressions, nonDistinctAggExpressions) = aggregateExpressions.partition(
+      _.isDistinct)
+    val updateExpressionsDistinct =
+      distinctAggExpressions.flatMap(
+        _.aggregateFunction.updateExpressions)
+    val updateAttributesDistinct =
+      distinctAggExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
+    val inputProjectionsDistinct =
+      distinctAggExpressions.flatMap(_.aggregateFunction.inputProjection)
+
+    // Pick merge non-distinct for PartialMerge
+    val mergeExpressionsNonDistinct =
+      nonDistinctAggExpressions
+          .flatMap(_.aggregateFunction.mergeExpressions)
+          .map(_.asInstanceOf[CudfAggregate].ref)
+    val mergeAttributesNonDistinct =
+      nonDistinctAggExpressions.flatMap(
+        _.aggregateFunction.aggBufferAttributes)
+
+    // Partial with no distinct or when modes are empty
+    val inputProjections: Seq[Expression] = groupingExpressions ++ aggregateExpressions
+        .flatMap(_.aggregateFunction.inputProjection)
+
+    var distinctAttributes = Seq[Attribute]()
+    var distinctExpressions = Seq[Expression]()
+    var nonDistinctAttributes = Seq[Attribute]()
+    var nonDistinctExpressions = Seq[Expression]()
+    modeInfo.uniqueModes.foreach {
+      case PartialMerge =>
+        nonDistinctAttributes = mergeAttributesNonDistinct
+        nonDistinctExpressions = mergeExpressionsNonDistinct
+      case Partial =>
+        // Partial with distinct case
+        val updateExpressionsCudfAggsDistinct =
+          updateExpressionsDistinct.filter(_.isInstanceOf[CudfAggregate])
+              .map(_.asInstanceOf[CudfAggregate].ref)
+        if (inputProjectionsDistinct.exists(p => !p.isInstanceOf[NamedExpression])) {
+          // Case of distinct average we need to evaluate the "GpuCast and GpuIsNotNull" columns.
+          // Refer to how input projections are setup for GpuAverage.
+          // In the case where we have expressions to evaluate, pick the unique attributes
+          // references from them as you only have one column for it before you start evaluating.
+          distinctExpressions = inputProjectionsDistinct
+          distinctAttributes = inputProjectionsDistinct.flatMap(ref =>
+            ref.references.toSeq).distinct
+        } else {
+          distinctAttributes = updateAttributesDistinct
+          distinctExpressions = updateExpressionsCudfAggsDistinct
+        }
+      case _ =>
+    }
+    val inputBindExpressions = groupingExpressions ++ nonDistinctExpressions ++ distinctExpressions
+    val resultingBindAttributes = groupingAttributes ++ distinctAttributes ++ nonDistinctAttributes
+
+    val finalProjections = groupingExpressions ++
+        aggregateExpressions.map(_.aggregateFunction.evaluateExpression)
+
+    // boundInputReferences is used to pick out of the input batch the appropriate columns
+    // for aggregation
+    // - Partial Merge mode: we use the inputBindExpressions which can be only
+    //   non distinct merge expressions.
+    // - Partial or Complete mode: we use the inputProjections or distinct update expressions.
+    // - Partial, PartialMerge mode: we use the inputProjections or distinct update expressions
+    //   for Partial and non distinct merge expressions for PartialMerge.
+    // - Final mode: we pick the columns in the order as handed to us.
+    val boundInputReferences = if (modeInfo.uniqueModes.contains(PartialMerge)) {
+      GpuBindReferences.bindGpuReferences(inputBindExpressions, resultingBindAttributes)
+    } else if (modeInfo.hasFinalMode) {
+      GpuBindReferences.bindGpuReferences(childAttr.attrs.asInstanceOf[Seq[Expression]], childAttr)
+    } else {
+      GpuBindReferences.bindGpuReferences(inputProjections, childAttr)
+    }
+
+    val boundFinalProjections = if (modeInfo.hasFinalMode || modeInfo.hasCompleteMode) {
+      Some(GpuBindReferences.bindGpuReferences(finalProjections, aggBufferAttributes))
+    } else {
+      None
+    }
+
+    // allAttributes can be different things, depending on aggregation mode:
+    // - Partial mode: grouping key + cudf aggregates (e.g. no avg, intead sum::count
+    // - Final mode: grouping key + spark aggregates (e.g. avg)
+    val finalAttributes = groupingAttributes ++ aggregateAttributes
+
+    // boundResultReferences is used to project the aggregated input batch(es) for the result.
+    // - Partial mode: it's a pass through. We take whatever was aggregated and let it come
+    //   out of the node as is.
+    // - Final or Complete mode: we use resultExpressions to pick out the correct columns that
+    //   finalReferences has pre-processed for us
+    val boundResultReferences = if (modeInfo.hasPartialMode) {
+      GpuBindReferences.bindGpuReferences(
+        resultExpressions,
+        resultExpressions.map(_.toAttribute))
+    } else if (modeInfo.hasFinalMode || modeInfo.hasCompleteMode) {
+      GpuBindReferences.bindGpuReferences(
+        resultExpressions,
+        finalAttributes)
+    } else {
+      GpuBindReferences.bindGpuReferences(
+        resultExpressions,
+        groupingAttributes)
+    }
+    BoundExpressionsModeAggregates(boundInputReferences, boundFinalProjections,
+      boundResultReferences, aggModeCudfAggregates)
+  }
+
+  /**
+   * Compute the aggregations on the projected input columns.
+   * @param toAggregateCvs column vectors representing the input batch to aggregate
+   * @param merge true indicates a merge aggregation should be performed
+   * @return aggregated batch
+   */
+  private def computeAggregate(
+      toAggregateCvs: Seq[GpuColumnVector],
+      merge: Boolean): ColumnarBatch  = {
+    val aggModeCudfAggregates = boundExpressions.aggModeCudfAggregates
+    val computeAggTime = metrics.computeAggTime
+    withResource(new NvtxWithMetrics("computeAggregate", NvtxColor.CYAN, computeAggTime)) { _ =>
+      if (groupingExpressions.nonEmpty) {
+        // Perform group by aggregation
+        // Create a cudf Table, which we use as the base of aggregations.
+        // At this point we are getting the cudf aggregate's merge or update version
+        //
+        // For example: GpuAverage has an update version of: (CudfSum, CudfCount)
+        // and CudfCount has an update version of AggregateOp.COUNT and a
+        // merge version of AggregateOp.COUNT.
+        val aggregates = aggModeCudfAggregates.flatMap(_._2)
+        val cudfAggregates = aggModeCudfAggregates.flatMap { case (mode, aggregates) =>
+          if ((mode == Partial || mode == Complete) && !merge) {
+            aggregates.map(a => a.updateAggregate.onColumn(a.getOrdinal(a.ref)))
+          } else {
+            aggregates.map(a => a.mergeAggregate.onColumn(a.getOrdinal(a.ref)))
+          }
+        }
+        val result = withResource(new cudf.Table(toAggregateCvs.map(_.getBase): _*)) { tbl =>
+          tbl.groupBy(groupingExpressions.indices: _*).aggregate(cudfAggregates: _*)
+        }
+        withResource(result) { result =>
+          // Turn aggregation into a ColumnarBatch for the result evaluation
+          // Note that the resulting ColumnarBatch has the following shape:
+          //
+          //   [key1, key2, ..., keyN, cudfAgg1, cudfAgg2, ..., cudfAggN]
+          //
+          // where cudfAgg_i can be multiple columns foreach Spark aggregate
+          // (i.e. partial_gpuavg => cudf sum and cudf count)
+          //
+          // The type of the columns returned by aggregate depends on cudf. A count of a long column
+          // may return a 32bit column, which is bad if you are trying to concatenate batches
+          // later. Cast here to the type that the aggregate expects (e.g. Long in case of count)
+          val dataTypes = groupingExpressions.map(_.dataType) ++ aggregates.map(_.dataType)
+
+          val resCols = new mutable.ArrayBuffer[ColumnVector](result.getNumberOfColumns)
+          for (i <- 0 until result.getNumberOfColumns) {
+            val rapidsType = GpuColumnVector.getNonNestedRapidsType(dataTypes(i))
+            // cast will be cheap if type matches, only does refCount++ in that case
+            closeOnExcept(result.getColumn(i).castTo(rapidsType)) { castedCol =>
+              resCols += GpuColumnVector.from(castedCol, dataTypes(i))
+            }
+          }
+          new ColumnarBatch(resCols.toArray, result.getRowCount.toInt)
+        }
+      } else {
+        // Reduction aggregate
+        // we ask the appropriate merge or update CudfAggregates, what their
+        // reduction merge or update aggregates functions are
+        val cvs = mutable.ArrayBuffer[GpuColumnVector]()
+        aggModeCudfAggregates.foreach { case (mode, aggs) =>
+          aggs.foreach { agg =>
+            val aggFn = if ((mode == Partial || mode == Complete) && !merge) {
+              agg.updateReductionAggregate
+            } else {
+              agg.mergeReductionAggregate
+            }
+            withResource(aggFn(toAggregateCvs(agg.getOrdinal(agg.ref)).getBase)) { res =>
+              val rapidsType = GpuColumnVector.getNonNestedRapidsType(agg.dataType)
+              withResource(cudf.ColumnVector.fromScalar(res, 1)) { cv =>
+                cvs += GpuColumnVector.from(cv.castTo(rapidsType), agg.dataType)
+              }
+            }
+          }
+        }
+        // If cvs is empty, we add a single row with zero value. The value in the row is
+        // meaningless as it doesn't matter what we put in it. The projection will add a zero
+        // column to the result set in case of a parameter-less count.
+        // This is to fix a bug in the plugin where a paramater-less count wasn't returning the
+        // desired result compared to Spark-CPU.
+        // For more details go to https://github.com/NVIDIA/spark-rapids/issues/1737
+        if (cvs.isEmpty) {
+          withResource(Scalar.fromLong(0L)) { ZERO =>
+            cvs += GpuColumnVector.from(cudf.ColumnVector.fromScalar(ZERO, 1), LongType)
+          }
+        }
+        new ColumnarBatch(cvs.toArray, cvs.head.getBase.getRowCount.toInt)
       }
     }
   }
@@ -166,13 +805,18 @@ abstract class GpuBaseAggregateMeta[INPUT <: SparkPlan](
   }
 
   override def convertToGpu(): GpuExec = {
+    // Joins currently require up to 4X the configured target size in memory, so aggregates can use
+    // up to 2X that size (one input batch and one output batch). Keep the target batch size under
+    // the 2GB limit to avoid exploding the cudf row count limit of a column.
+    val targetBatchSize = Math.min(conf.gpuTargetBatchSizeBytes * 2, Int.MaxValue)
     GpuHashAggregateExec(
       requiredChildDistributionExpressions.map(_.map(_.convertToGpu())),
       groupingExpressions.map(_.convertToGpu()),
       aggregateExpressions.map(_.convertToGpu()).asInstanceOf[Seq[GpuAggregateExpression]],
       aggregateAttributes.map(_.convertToGpu()).asInstanceOf[Seq[Attribute]],
       resultExpressions.map(_.convertToGpu()).asInstanceOf[Seq[NamedExpression]],
-      childPlans.head.convertIfNeeded())
+      childPlans.head.convertIfNeeded(),
+      targetBatchSize)
   }
 }
 
@@ -222,11 +866,8 @@ class GpuSortAggregateMeta(
 }
 
 /**
- * GpuHashAggregateExec - is the GPU version of HashAggregateExec, with some major differences:
- * - it doesn't support spilling to disk
- * - it doesn't support strings in the grouping key
- * - it doesn't support count(col1, col2, ..., colN)
- * - it doesn't support distinct
+ * The GPU version of HashAggregateExec
+ *
  * @param requiredChildDistributionExpressions this is unchanged by the GPU. It is used in
  *                                             EnsureRequirements to be able to add shuffle nodes
  * @param groupingExpressions The expressions that, when applied to the input batch, return the
@@ -236,6 +877,7 @@ class GpuSortAggregateMeta(
  * @param resultExpressions the expected output expression of this hash aggregate (which this
  *                          node should project)
  * @param child incoming plan (where we get input columns from)
+ * @param targetBatchSize maximum device memory size of a batch to produce during processing
  */
 case class GpuHashAggregateExec(
     requiredChildDistributionExpressions: Option[Seq[Expression]],
@@ -243,7 +885,23 @@ case class GpuHashAggregateExec(
     aggregateExpressions: Seq[GpuAggregateExpression],
     aggregateAttributes: Seq[Attribute],
     resultExpressions: Seq[NamedExpression],
-    child: SparkPlan) extends UnaryExecNode with GpuExec with Arm {
+    child: SparkPlan,
+    targetBatchSize: Long) extends UnaryExecNode with GpuExec with Arm {
+  private lazy val uniqueModes: Seq[AggregateMode] = aggregateExpressions.map(_.mode).distinct
+  private lazy val partialMode = uniqueModes.contains(Partial) || uniqueModes.contains(PartialMerge)
+  private lazy val finalMode = uniqueModes.contains(Final)
+  private lazy val completeMode = uniqueModes.contains(Complete)
+
+  protected override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL
+  protected override val outputBatchesLevel: MetricsLevel = MODERATE_LEVEL
+  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
+    AGG_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_AGG_TIME),
+    CONCAT_TIME-> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_CONCAT_TIME),
+    SORT_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_SORT_TIME)
+  ) ++ spillMetrics
+
+  override def childrenCoalesceGoal: Seq[CoalesceGoal] = Seq(TargetSize(targetBatchSize))
 
   override def verboseStringWithOperatorId(): String = {
     s"""
@@ -256,545 +914,43 @@ case class GpuHashAggregateExec(
        |""".stripMargin
   }
 
-  case class BoundExpressionsModeAggregates(boundInputReferences: Seq[GpuExpression] ,
-    boundFinalProjections: Option[scala.Seq[GpuExpression]],
-    boundResultReferences: scala.Seq[Expression] ,
-    aggModeCudfAggregates: scala.Seq[(AggregateMode, scala.Seq[CudfAggregate])])
-  // This handles GPU hash aggregation without spilling.
-  //
-  // The CPU version of this is (assume no fallback to sort-based aggregation)
-  //  Re: TungstenAggregationIterator.scala, and AggregationIterator.scala
-  //
-  // 1) Obtaining an input row and finding a buffer (by hash of the grouping key) where
-  //    to aggregate on.
-  // 2) Once it has a buffer, it calls processRow on it with the incoming row.
-  // 3) This will in turn update the buffer, for each row received, agg function by agg function
-  // 4) In the happy case, we never spill, and an iterator (from the HashMap) is produced s.t.
-  //    downstream nodes can access the aggregated and projected results.
-  // 5) Spill case (not handled in gpu case)
-  //    a) we create an external sorter [[UnsafeKVExternalSorter]] from the hash map (spilling)
-  //       this leaves room for more aggregations to happen. The external sorter first sorts, and
-  //       then stores the results to disk, and last it clears the in-memory hash map.
-  //    b) we merge external sorters as we spill the map further.
-  //    c) after the hash agg is done with its incoming rows, it will switch to sort-based
-  //       aggregation, because it detected a spill
-  //    d) sort based aggregation is then the mode forward, and not covered in this.
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {
-    val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
-    val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
-    val totalTime = gpuLongMetric(TOTAL_TIME)
-    val computeAggTime = gpuLongMetric(AGG_TIME)
-    val concatTime = gpuLongMetric(CONCAT_TIME)
-    val rdd = child.executeColumnar()
+    val aggMetrics = GpuHashAggregateMetrics(
+      numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS),
+      numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES),
+      totalTime = gpuLongMetric(TOTAL_TIME),
+      computeAggTime = gpuLongMetric(AGG_TIME),
+      concatTime = gpuLongMetric(CONCAT_TIME),
+      sortTime = gpuLongMetric(SORT_TIME),
+      makeSpillCallback(allMetrics))
 
     // cache in a local variable to avoid serializing the full child plan
     val childOutput = child.output
+    val groupingExprs = groupingExpressions
+    val aggregateExprs = aggregateExpressions
+    val aggregateAttrs = aggregateAttributes
+    val resultExprs = resultExpressions
+    val modeInfo = AggregateModeInfo(
+      uniqueModes,
+      hasPartialMode = partialMode,
+      hasFinalMode = finalMode,
+      hasCompleteMode = completeMode)
 
-    rdd.mapPartitions { cbIter => {
-      var batch: ColumnarBatch = null // incoming batch
-      //
-      // aggregated[Input]Cb
-      // This is the equivalent of the aggregation buffer for the cpu case with the grouping key.
-      // Its columns are: [key1, key2, ..., keyN, cudfAgg1, cudfAgg2, ..., cudfAggN]
-      //
-      // For aggregate expressions that are multiple cudf aggregates (like average),
-      // aggregated[Input]Cb can have one or more cudf aggregate columns. This isn't different than
-      // the cpu version, other than in the cpu version everything is a catalyst expression.
-      var aggregatedInputCb: ColumnarBatch = null // aggregated raw incoming batch
-      var aggregatedCb: ColumnarBatch = null // aggregated concatenated batches
+    val rdd = child.executeColumnar()
 
-      var finalCb: ColumnarBatch = null // batch after the final projection for each aggregator
-      var resultCb: ColumnarBatch = null // after the result projection given in resultExpressions
-      var success = false
-
-      var childCvs: Seq[GpuColumnVector] = null
-      var concatCvs: Seq[GpuColumnVector] = null
-      var resultCvs: Seq[GpuColumnVector] = null
-
-      //
-      // For aggregate exec there are four stages of operation:
-      //   1) extract columns from input
-      //   2) aggregation (update/merge)
-      //   3) finalize aggregations (avg = sum/count)
-      //   4) result projection (resolve any expressions in the output)
-      //
-      // In the CPU hash aggregate, Spark is using a buffer to aggregate the results.
-      // This buffer has room for each aggregate it is computing (based on type).
-      // Note that some AggregateExpressions are more than one slot in this buffer
-      // (avg is a sum and a count slot).
-      //
-      // In the GPU, we don't have an aggregation buffer in Spark code (this happens behind the
-      // scenes in cudf), but we still need to be able to pick out columns out of the input CB (for
-      // aggregation)
-      // and the aggregated CB (for the result projection).
-      //
-      // Partial mode:
-      //  1. boundInputReferences: picks column from raw input
-      //  2. boundUpdateAgg: performs the partial half of the aggregates (GpuCount => CudfCount)
-      //  3. boundMergeAgg: (if needed) perform a merge of partial aggregates (CudfCount => CudfSum)
-      //  4. boundResultReferences: is a pass-through of the merged aggregate
-      //
-      // Final mode:
-      //  1. boundInputReferences: is a pass-through of the merged aggregate
-      //  2. boundMergeAgg: perform merges of incoming, and subsequent batches if required.
-      //  3. boundFinalProjections: on merged batches, finalize aggregates
-      //     (GpuAverage => CudfSum/CudfCount)
-      //  4. boundResultReferences: project the result expressions Spark expects in the output.
-      val boundExpression = setupReferences(childOutput, groupingExpressions, aggregateExpressions)
-      try {
-        while (cbIter.hasNext) {
-          // 1) Consume the raw incoming batch, evaluating nested expressions
-          // (e.g. avg(col1 + col2)), obtaining ColumnVectors that can be aggregated
-          batch = cbIter.next()
-          if (batch.numRows() == 0) {
-            batch.close()
-            batch = null
-          } else {
-            withResource(new NvtxWithMetrics("Hash Aggregate Batch", NvtxColor.YELLOW,
-              totalTime)) { _ =>
-              childCvs = processIncomingBatch(batch, boundExpression.boundInputReferences)
-
-              // done with the batch, clean it as soon as possible
-              batch.close()
-              batch = null
-
-              // 2) When a partition gets multiple batches, we need to do two things:
-              //     a) if this is the first batch, run aggregation and store the aggregated result
-              //     b) if this is a subsequent batch, we need to merge the previously aggregated
-              //        results with the incoming batch
-              //     c) also update total time and aggTime metrics
-              aggregatedInputCb = computeAggregate(childCvs, groupingExpressions,
-                boundExpression.aggModeCudfAggregates, merge = false, computeAggTime)
-
-              childCvs.safeClose()
-              childCvs = null
-
-              if (aggregatedCb == null) {
-                // this is the first batch, regardless of mode.
-                aggregatedCb = aggregatedInputCb
-                aggregatedInputCb = null
-              } else {
-                // this is a subsequent batch, and we must:
-                // 1) concatenate aggregatedInputCb with the prior result (aggregatedCb)
-                // 2) perform a merge aggregate on the concatenated columns
-                //
-                // In the future, we could plugin in spilling here, where if the concatenated
-                // batch sizes would go over a threshold, we'd spill the aggregatedCb,
-                // and perform aggregation on the new batch (which would need to be merged, with the
-                // spilled aggregates)
-                // Please note that in order for first/last to work properly we have to maintain
-                // the order of the input batches.
-                concatCvs = concatenateBatches(aggregatedCb, aggregatedInputCb, concatTime)
-                aggregatedCb.close()
-                aggregatedCb = null
-                aggregatedInputCb.close()
-                aggregatedInputCb = null
-
-                // 3) Compute aggregate. In subsequent iterations we'll use this result
-                //    to concatenate against incoming batches (step 2)
-                aggregatedCb = computeAggregate(concatCvs, groupingExpressions,
-                  boundExpression.aggModeCudfAggregates, merge = true, computeAggTime)
-                concatCvs.safeClose()
-                concatCvs = null
-              }
-            }
-          }
-        }
-
-        // if - the input iterator was empty &&
-        //      we weren't grouping (reduction op)
-        // We need to return a single row, that contains the initial values of each
-        // aggregator.
-        // Note: for grouped aggregates, we will eventually return an empty iterator.
-        withResource(new NvtxWithMetrics("Final column eval", NvtxColor.YELLOW,
-          totalTime)) { _ =>
-          if (aggregatedCb == null && groupingExpressions.isEmpty) {
-            val aggregateFunctions = aggregateExpressions.map(_.aggregateFunction)
-            val defaultValues =
-              aggregateFunctions.flatMap(_.initialValues)
-            val vecs = defaultValues.safeMap { ref =>
-              withResource(GpuScalar.from(ref.asInstanceOf[GpuLiteral].value, ref.dataType)) {
-                scalar => GpuColumnVector.from(scalar, 1, ref.dataType)
-              }
-            }
-            aggregatedCb = new ColumnarBatch(vecs.toArray, 1)
-          }
-
-          // 4) Finally, project the result to the expected layout that Spark expects
-          //    i.e.: select avg(foo) from bar group by baz will produce:
-          //       Partial mode: 3 columns => [bar, sum(foo) as sum_foo, count(foo) as count_foo]
-          //       Final mode:   2 columns => [bar, sum(sum_foo) / sum(count_foo)]
-          finalCb = if (boundExpression.boundFinalProjections.isDefined) {
-            if (aggregatedCb != null) {
-              val finalCvs =
-                boundExpression.boundFinalProjections.get.map { ref =>
-                  // aggregatedCb is made up of ColumnVectors
-                  // and the final projections from the aggregates won't change that,
-                  // so we can assume they will be vectors after we eval
-                  ref.columnarEval(aggregatedCb).asInstanceOf[GpuColumnVector]
-                }
-              aggregatedCb.close()
-              aggregatedCb = null
-              new ColumnarBatch(finalCvs.toArray, finalCvs.head.getRowCount.toInt)
-            } else {
-              null // this was a grouped aggregate, with an empty input
-            }
-          } else {
-            aggregatedCb
-          }
-
-          aggregatedCb = null
-
-          if (finalCb != null) {
-            // Perform the last project to get the correct shape that Spark expects. Note this will
-            // add things like literals, that were not part of the aggregate into the batch.
-            resultCvs = boundExpression.boundResultReferences.map { ref =>
-              // Result references can be virtually anything, we need to coerce
-              // them to be vectors since this is going into a ColumnarBatch
-              GpuExpressionsUtils.columnarEvalToColumn(ref, finalCb)
-            }
-            finalCb.close()
-            finalCb = null
-            resultCb = if (resultCvs.isEmpty) {
-              new ColumnarBatch(Seq().toArray, 0)
-            } else {
-              numOutputRows += resultCvs.head.getBase.getRowCount
-              new ColumnarBatch(resultCvs.toArray, resultCvs.head.getBase.getRowCount.toInt)
-            }
-            numOutputBatches += 1
-            success = true
-            new Iterator[ColumnarBatch] {
-              TaskContext.get().addTaskCompletionListener[Unit] { _ =>
-                if (resultCb != null) {
-                  resultCb.close()
-                  resultCb = null
-                }
-              }
-
-              override def hasNext: Boolean = resultCb != null
-
-              override def next(): ColumnarBatch = {
-                val out = resultCb
-                resultCb = null
-                out
-              }
-            }
-          } else {
-            // we had a grouped aggregate, without input
-            Iterator.empty
-          }
-        }
-      } finally {
-        if (!success) {
-          if (resultCvs != null) {
-            resultCvs.safeClose()
-          }
-        }
-        childCvs.safeClose()
-        concatCvs.safeClose()
-        Seq(batch, aggregatedInputCb, aggregatedCb, finalCb)
-          .safeClose()
-      }
-    }}
-  }
-
-  private def processIncomingBatch(batch: ColumnarBatch,
-      boundInputReferences: Seq[Expression]): Seq[GpuColumnVector] = {
-    boundInputReferences.safeMap { ref =>
-      val childCv = GpuExpressionsUtils.columnarEvalToColumn(ref, batch)
-      if (childCv.dataType == ref.dataType) {
-        childCv
-      } else {
-        withResource(childCv) { childCv =>
-          val rapidsType = GpuColumnVector.getNonNestedRapidsType(ref.dataType)
-          GpuColumnVector.from(childCv.getBase.castTo(rapidsType), ref.dataType)
-        }
-      }
+    rdd.mapPartitions { cbIter =>
+      new GpuHashAggregateIterator(
+        cbIter,
+        groupingExprs,
+        aggregateExprs,
+        aggregateAttrs,
+        resultExprs,
+        childOutput,
+        modeInfo,
+        aggMetrics,
+        targetBatchSize)
     }
   }
-
-  /**
-   * concatenateBatches - given two ColumnarBatch instances, return a sequence of GpuColumnVector
-   * that is the concatenated columns of the two input batches.
-   * @param aggregatedInputCb this is an incoming batch
-   * @param aggregatedCb this is a batch that was kept for concatenation
-   * @return Seq[GpuColumnVector] with concatenated vectors
-   */
-  private def concatenateBatches(aggregatedInputCb: ColumnarBatch,
-      aggregatedCb: ColumnarBatch,
-      concatTime: GpuMetric): Seq[GpuColumnVector] = {
-    withResource(new NvtxWithMetrics("concatenateBatches", NvtxColor.BLUE, concatTime)) { _ =>
-      // get tuples of columns to concatenate
-
-      val zipped = (0 until aggregatedCb.numCols()).map { i =>
-        (aggregatedInputCb.column(i), aggregatedCb.column(i))
-      }
-
-      zipped.map {
-        case (col1, col2) =>
-          GpuColumnVector.from(
-            cudf.ColumnVector.concatenate(
-              col1.asInstanceOf[GpuColumnVector].getBase,
-              col2.asInstanceOf[GpuColumnVector].getBase), col1.dataType())
-      }
-    }
-  }
-
-  private lazy val allModes: Seq[AggregateMode] = aggregateExpressions.map(_.mode)
-  private lazy val uniqueModes: Seq[AggregateMode] = allModes.distinct
-  private lazy val partialMode = uniqueModes.contains(Partial) || uniqueModes.contains(PartialMerge)
-  private lazy val finalMode = uniqueModes.contains(Final)
-  private lazy val completeMode = uniqueModes.contains(Complete)
-
-  /**
-   * getCudfAggregates returns a sequence of `cudf.Aggregate`, given the current mode
-   * `AggregateMode`, and a sequence of all expressions for this [[GpuHashAggregateExec]]
-   * node, we get all the expressions as that's important for us to be able to resolve the current
-   * ordinal for this cudf aggregate.
-   *
-   * Examples:
-   * fn = sum, min, max will always be Seq(fn)
-   * avg will be Seq(sum, count) for Partial mode, but Seq(sum, sum) for other modes
-   * count will be Seq(count) for Partial mode, but Seq(sum) for other modes
-   *
-   * @return Seq of `cudf.Aggregate`, with one or more aggregates that correspond to each
-   *         expression in allExpressions
-   */
-  def setupReferences(childAttr: AttributeSeq,
-      groupingExpressions: Seq[Expression],
-      aggregateExpressions: Seq[GpuAggregateExpression]): BoundExpressionsModeAggregates = {
-
-    val groupingAttributes = groupingExpressions.map(_.asInstanceOf[NamedExpression].toAttribute)
-    val aggBufferAttributes = groupingAttributes ++
-      aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
-
-    //
-    // update expressions are those performed on the raw input data
-    // e.g. for count it's count, and for average it's sum and count.
-    //
-    val updateExpressionsSeq =
-      aggregateExpressions.map(
-        _.aggregateFunction.updateExpressions)
-    //
-    // merge expressions are used while merging multiple batches, or while on final mode
-    // e.g. for count it's sum, and for average it's sum and sum.
-    //
-    val mergeExpressionsSeq =
-      aggregateExpressions.map(
-        _.aggregateFunction.mergeExpressions)
-
-    val aggModeCudfAggregates = aggregateExpressions.zipWithIndex.map { case (expr, modeIndex) =>
-      val cudfAggregates = if (expr.mode == Partial || expr.mode == Complete) {
-        GpuBindReferences.bindGpuReferences(updateExpressionsSeq(modeIndex), aggBufferAttributes)
-          .asInstanceOf[Seq[CudfAggregate]]
-      } else {
-        GpuBindReferences.bindGpuReferences(mergeExpressionsSeq(modeIndex), aggBufferAttributes)
-          .asInstanceOf[Seq[CudfAggregate]]
-      }
-      (expr.mode, cudfAggregates)
-    }
-
-    //
-    // expressions to pick input to the aggregate, and finalize the output to the result projection.
-    //
-    // Pick update distinct attributes or input projections for Partial
-    val (distinctAggExpressions, nonDistinctAggExpressions) = aggregateExpressions.partition(
-      _.isDistinct)
-    val updateExpressionsDistinct =
-      distinctAggExpressions.flatMap(
-        _.aggregateFunction.updateExpressions)
-    val updateAttributesDistinct =
-      distinctAggExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
-    val inputProjectionsDistinct =
-      distinctAggExpressions.flatMap(_.aggregateFunction.inputProjection)
-
-    // Pick merge non-distinct for PartialMerge
-    val mergeExpressionsNonDistinct =
-      nonDistinctAggExpressions
-        .flatMap(_.aggregateFunction.mergeExpressions)
-        .map(_.asInstanceOf[CudfAggregate].ref)
-    val mergeAttributesNonDistinct =
-      nonDistinctAggExpressions.flatMap(
-        _.aggregateFunction.aggBufferAttributes)
-
-    // Partial with no distinct or when modes are empty
-    val inputProjections: Seq[Expression] = groupingExpressions ++ aggregateExpressions
-      .flatMap(_.aggregateFunction.inputProjection)
-
-    var distinctAttributes = Seq[Attribute]()
-    var distinctExpressions = Seq[Expression]()
-    var nonDistinctAttributes = Seq[Attribute]()
-    var nonDistinctExpressions = Seq[Expression]()
-    uniqueModes.foreach {
-      case PartialMerge =>
-        nonDistinctAttributes = mergeAttributesNonDistinct
-        nonDistinctExpressions = mergeExpressionsNonDistinct
-      case Partial =>
-        // Partial with distinct case
-        val updateExpressionsCudfAggsDistinct =
-          updateExpressionsDistinct.filter(_.isInstanceOf[CudfAggregate])
-            .map(_.asInstanceOf[CudfAggregate].ref)
-        if (inputProjectionsDistinct.exists(p => !p.isInstanceOf[NamedExpression])) {
-          // Case of distinct average we need to evaluate the "GpuCast and GpuIsNotNull" columns.
-          // Refer to how input projections are setup for GpuAverage.
-          // In the case where we have expressions to evaluate, pick the unique attributes
-          // references from them as you only have one column for it before you start evaluating.
-          distinctExpressions = inputProjectionsDistinct
-          distinctAttributes = inputProjectionsDistinct.flatMap(ref =>
-            ref.references.toSeq).distinct
-        } else {
-          distinctAttributes = updateAttributesDistinct
-          distinctExpressions = updateExpressionsCudfAggsDistinct
-        }
-      case _ =>
-    }
-    val inputBindExpressions = groupingExpressions ++ nonDistinctExpressions ++ distinctExpressions
-    val resultingBindAttributes = groupingAttributes ++ distinctAttributes ++ nonDistinctAttributes
-
-    val finalProjections = groupingExpressions ++
-      aggregateExpressions.map(_.aggregateFunction.evaluateExpression)
-
-    // boundInputReferences is used to pick out of the input batch the appropriate columns
-    // for aggregation
-    // - Partial Merge mode: we use the inputBindExpressions which can be only
-    //   non distinct merge expressions.
-    // - Partial or Complete mode: we use the inputProjections or distinct update expressions.
-    // - Partial, PartialMerge mode: we use the inputProjections or distinct update expressions
-    //   for Partial and non distinct merge expressions for PartialMerge.
-    // - Final mode: we pick the columns in the order as handed to us.
-    val boundInputReferences = if (uniqueModes.contains(PartialMerge)) {
-      GpuBindReferences.bindGpuReferences(inputBindExpressions, resultingBindAttributes)
-    } else if (finalMode) {
-      GpuBindReferences.bindGpuReferences(childAttr.attrs.asInstanceOf[Seq[Expression]], childAttr)
-    } else {
-      GpuBindReferences.bindGpuReferences(inputProjections, childAttr)
-    }
-
-    val boundFinalProjections = if (finalMode || completeMode) {
-      Some(GpuBindReferences.bindGpuReferences(finalProjections, aggBufferAttributes))
-    } else {
-      None
-    }
-
-    // allAttributes can be different things, depending on aggregation mode:
-    // - Partial mode: grouping key + cudf aggregates (e.g. no avg, intead sum::count
-    // - Final mode: grouping key + spark aggregates (e.g. avg)
-    val finalAttributes = groupingAttributes ++ aggregateAttributes
-
-    // boundResultReferences is used to project the aggregated input batch(es) for the result.
-    // - Partial mode: it's a pass through. We take whatever was aggregated and let it come
-    //   out of the node as is.
-    // - Final or Complete mode: we use resultExpressions to pick out the correct columns that
-    //   finalReferences has pre-processed for us
-    val boundResultReferences = if (partialMode) {
-      GpuBindReferences.bindGpuReferences(
-        resultExpressions,
-        resultExpressions.map(_.toAttribute))
-    } else if (finalMode || completeMode) {
-      GpuBindReferences.bindGpuReferences(
-        resultExpressions,
-        finalAttributes)
-    } else {
-      GpuBindReferences.bindGpuReferences(
-        resultExpressions,
-        groupingAttributes)
-    }
-    BoundExpressionsModeAggregates(boundInputReferences, boundFinalProjections,
-      boundResultReferences, aggModeCudfAggregates)
-  }
-
-  def computeAggregate(toAggregateCvs: Seq[GpuColumnVector],
-                       groupingExpressions: Seq[Expression],
-                       aggModeCudfAggregates : Seq[(AggregateMode, Seq[CudfAggregate])],
-                       merge : Boolean,
-                       computeAggTime: GpuMetric): ColumnarBatch  = {
-    withResource(new NvtxWithMetrics("computeAggregate", NvtxColor.CYAN, computeAggTime)) { _ =>
-      if (groupingExpressions.nonEmpty) {
-        // Perform group by aggregation
-        // Create a cudf Table, which we use as the base of aggregations.
-        // At this point we are getting the cudf aggregate's merge or update version
-        //
-        // For example: GpuAverage has an update version of: (CudfSum, CudfCount)
-        // and CudfCount has an update version of AggregateOp.COUNT and a
-        // merge version of AggregateOp.COUNT.
-        val aggregates = aggModeCudfAggregates.flatMap(_._2)
-        val cudfAggregates = aggModeCudfAggregates.flatMap { case (mode, aggregates) =>
-          if ((mode == Partial || mode == Complete) && !merge) {
-            aggregates.map(a => a.updateAggregate.onColumn(a.getOrdinal(a.ref)))
-          } else {
-            aggregates.map(a => a.mergeAggregate.onColumn(a.getOrdinal(a.ref)))
-          }
-        }
-        val result = withResource(new cudf.Table(toAggregateCvs.map(_.getBase): _*)) { tbl =>
-          tbl.groupBy(groupingExpressions.indices: _*).aggregate(cudfAggregates: _*)
-        }
-        withResource(result) { result =>
-          // Turn aggregation into a ColumnarBatch for the result evaluation
-          // Note that the resulting ColumnarBatch has the following shape:
-          //
-          //   [key1, key2, ..., keyN, cudfAgg1, cudfAgg2, ..., cudfAggN]
-          //
-          // where cudfAgg_i can be multiple columns foreach Spark aggregate
-          // (i.e. partial_gpuavg => cudf sum and cudf count)
-          //
-          // The type of the columns returned by aggregate depends on cudf. A count of a long column
-          // may return a 32bit column, which is bad if you are trying to concatenate batches
-          // later. Cast here to the type that the aggregate expects (e.g. Long in case of count)
-          val dataTypes = groupingExpressions.map(_.dataType) ++ aggregates.map(_.dataType)
-
-          val resCols = new ArrayBuffer[ColumnVector](result.getNumberOfColumns)
-          for (i <- 0 until result.getNumberOfColumns) {
-            val rapidsType = GpuColumnVector.getNonNestedRapidsType(dataTypes(i))
-            // cast will be cheap if type matches, only does refCount++ in that case
-            closeOnExcept(result.getColumn(i).castTo(rapidsType)) { castedCol =>
-              resCols += GpuColumnVector.from(castedCol, dataTypes(i))
-            }
-          }
-          new ColumnarBatch(resCols.toArray, result.getRowCount.toInt)
-        }
-      } else {
-        // Reduction aggregate
-        // we ask the appropriate merge or update CudfAggregates, what their
-        // reduction merge or update aggregates functions are
-        val cvs = ArrayBuffer[GpuColumnVector]()
-        aggModeCudfAggregates.foreach { case (mode, aggs) =>
-          aggs.foreach { agg =>
-            val aggFn = if ((mode == Partial || mode == Complete) && !merge) {
-              agg.updateReductionAggregate
-            } else {
-              agg.mergeReductionAggregate
-            }
-            withResource(aggFn(toAggregateCvs(agg.getOrdinal(agg.ref)).getBase)) { res =>
-              val rapidsType = GpuColumnVector.getNonNestedRapidsType(agg.dataType)
-              withResource(cudf.ColumnVector.fromScalar(res, 1)) { cv =>
-                cvs += GpuColumnVector.from(cv.castTo(rapidsType), agg.dataType)
-              }
-            }
-          }
-        }
-        // If cvs is empty, we add a single row with zero value. The value in the row is
-        // meaningless as it doesn't matter what we put in it. The projection will add a zero
-        // column to the result set in case of a parameter-less count.
-        // This is to fix a bug in the plugin where a paramater-less count wasn't returning the
-        // desired result compared to Spark-CPU.
-        // For more details go to https://github.com/NVIDIA/spark-rapids/issues/1737
-        if (cvs.isEmpty) {
-          withResource(Scalar.fromLong(0L)) { ZERO =>
-            cvs += GpuColumnVector.from(cudf.ColumnVector.fromScalar(ZERO, 1), LongType)
-          }
-        }
-        new ColumnarBatch(cvs.toArray, cvs.head.getBase.getRowCount.toInt)
-      }
-    }
-  }
-
-  protected override val outputRowsLevel: MetricsLevel = ESSENTIAL_LEVEL
-  protected override val outputBatchesLevel: MetricsLevel = MODERATE_LEVEL
-  override lazy val additionalMetrics = Map(
-    TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
-    AGG_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_AGG_TIME),
-    CONCAT_TIME-> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_CONCAT_TIME)
-  )
 
   protected def outputExpressions: Seq[NamedExpression] = resultExpressions
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -136,12 +136,14 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
 
       gpuPlan match {
         case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _)) =>
-          assert(plan.children.head.isInstanceOf[GpuHashAggregateExec])
+          assert(plan.children.head.isInstanceOf[GpuCoalesceBatches])
+          assert(plan.children.head.children.head.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 
         case GpuColumnarToRowExec(plan, _) => // Codegen disabled
-          assert(plan.children.head.isInstanceOf[GpuHashAggregateExec])
+          assert(plan.children.head.isInstanceOf[GpuCoalesceBatches])
+          assert(plan.children.head.children.head.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 


### PR DESCRIPTION
This adds out-of-core support for hash aggregation by making all batches that are held while iterating spillable along with a sort-based fallback for groupby aggregations.

The aggregation strategy has changed as part of this PR.  Besides the sort-based fallback, the approach to aggregations before falling back is also different. The overall goal is to maximize the input size and minimize the number of aggregation calls.
- Input batches are coalesced to 2X the target size (or 2GB cudf limit, whichever is smaller) to target an approximate 4X overall non-spillable footprint (input batch + output batch). This matches the 4X target size footprint for joins.
- Instead of aggregating and immediately merging with a single held batch, aggregated batches are made spillable and collected in a queue.  Only after all input batches have been aggregated do we attempt to merge-aggregate them.
- If we are unable to merge the aggregated batches into a single batch due to the target batch limits then a sort-based fallback is used where an out-of-core sorter sorts the batches based on grouping keys.  The resulting batches are sliced at a key boundary so the batches can be independently merge-aggregated without needing to hold the entire output at once.
