### PR TITLE
WIP: Leverage SPARK-35881 to remove use of reflection when avoiding redundant transitions in AQE

### DIFF
--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/AvoidAdaptiveTransitionToRow.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/AvoidAdaptiveTransitionToRow.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims.spark301
+
+import java.lang.reflect.Method
+
+import com.nvidia.spark.rapids.{GpuColumnarToRowExec, GpuExec, GpuRowToColumnarExec}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * This operator will attempt to optimize the case when we are writing the results of
+ * an adaptive query to disk so that we remove the redundant transitions from columnar
+ * to row within AdaptiveSparkPlanExec followed by a row to columnar transition.
+ *
+ * Specifically, this is the plan we see in this case:
+ *
+ * {{{
+ * GpuRowToColumnar(AdaptiveSparkPlanExec(GpuColumnarToRow(child))
+ * }}}
+ *
+ * We perform this optimization at runtime rather than during planning, because when the adaptive
+ * plan is being planned and executed, we don't know whether it is being called from an operation
+ * that wants rows (such as CollectTailExec) or from an operation that wants columns (such as
+ * GpuDataWritingCommandExec).
+ *
+ * Spark does not provide a mechanism for executing an adaptive plan and retrieving columnar
+ * results and the internal methods that we need to call are private, so we use reflection to
+ * call them.
+ *
+ * @param child The plan to execute
+ */
+case class AvoidAdaptiveTransitionToRow(child: SparkPlan) extends UnaryExecNode with GpuExec {
+
+  override def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+
+  override def output: Seq[Attribute] = child.output
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child match {
+    case GpuRowToColumnarExec(a: AdaptiveSparkPlanExec, _) =>
+      val getFinalPhysicalPlan = getPrivateMethod("getFinalPhysicalPlan")
+      val plan = getFinalPhysicalPlan.invoke(a)
+      val rdd = plan match {
+        case t: GpuColumnarToRowExec =>
+          t.child.executeColumnar()
+        case _ =>
+          child.executeColumnar()
+      }
+
+      // final UI update
+      val finalPlanUpdate = getPrivateMethod("finalPlanUpdate")
+      finalPlanUpdate.invoke(a)
+
+      rdd
+
+    case _ =>
+      child.executeColumnar()
+  }
+
+  private def getPrivateMethod(name: String): Method = {
+    val m = classOf[AdaptiveSparkPlanExec].getDeclaredMethod(name)
+    m.setAccessible(true)
+    m
+  }
+}

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
@@ -638,6 +638,12 @@ abstract class SparkBaseShims extends SparkShims {
     extensions.injectQueryStagePrepRule(_ => GpuQueryStagePrepOverrides())
   }
 
+  override def adaptivePlanToRow(plan: AdaptiveSparkPlanExec): SparkPlan = {
+    // no action require here since we have a GpuColumnarToRowExec inside
+    // the adaptive plan
+    plan
+  }
+
   override def createGpuRowToColumnarTransition(
       optimizedChild: SparkPlan,
       r2c: RowToColumnarExec,

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
@@ -41,6 +41,9 @@ class Spark313Shims extends Spark312Shims {
     extensions.injectFinalStagePrepRule(_ => GpuFinalStagePrepOverrides())
   }
 
+  override def adaptivePlanToRow(plan: AdaptiveSparkPlanExec): SparkPlan =
+    GpuColumnarToRowExec(plan)
+
   override def createGpuRowToColumnarTransition(
       optimizedChild: SparkPlan,
       r2c: RowToColumnarExec,

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
@@ -20,6 +20,10 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.spark312.Spark312Shims
 import com.nvidia.spark.rapids.spark313.RapidsShuffleManager
 
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.execution.{RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+
 class Spark313Shims extends Spark312Shims {
 
   override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION
@@ -27,4 +31,33 @@ class Spark313Shims extends Spark312Shims {
   override def getRapidsShuffleManagerClass: String = {
     classOf[RapidsShuffleManager].getCanonicalName
   }
+
+  override def injectRules(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectColumnar(_ => ColumnarOverrideRules())
+    extensions.injectQueryStagePrepRule(_ => GpuQueryStagePrepOverrides())
+    // injectFinalStagePrepRule is proposed to be added in Spark version 3.2.0 and
+    // possibly back-ported to 3.0.4 and 3.1.3. We use this to make the final query
+    // stage columnar in adaptive queries, where possible
+    extensions.injectFinalStagePrepRule(_ => GpuFinalStagePrepOverrides())
+  }
+
+  override def createGpuRowToColumnarTransition(
+      optimizedChild: SparkPlan,
+      r2c: RowToColumnarExec,
+      goal: CoalesceSizeGoal): SparkPlan = {
+    // with earlier Spark releases, we would need to insert an
+    // AvoidAdaptiveTransitions operator here but this is no longer required
+    // once SPARK-35881 is implemented
+    optimizedChild match {
+      case GpuColumnarToRowExec(child, _) =>
+        // avoid a redundant GpuRowToColumnarExec(GpuColumnarToRowExec((_))
+        GpuRowToColumnarExec(child, goal)
+      case _ =>
+        GpuRowToColumnarExec(optimizedChild, goal)
+    }
+  }
+
+  override def isAdaptiveFinalPlanColumnar(plan: AdaptiveSparkPlanExec): Boolean =
+    plan.finalPlanSupportsColumnar()
+
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.{CudfUnsafeRow, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.rapids.execution.GpuColumnToRowMapPartitionsRDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -292,13 +293,18 @@ abstract class GpuColumnarToRowExecParent(child: SparkPlan, val exportColumnarRd
 
     val f = makeIteratorFunc(child.output, numOutputRows, numInputBatches, opTime, collectTime)
 
-    val cdata = child.executeColumnar()
-    if (exportColumnarRdd) {
-      // If we are exporting columnar rdd we need an easy way for the code that walks the
-      // RDDs to know where the columnar to row transition is happening.
-      GpuColumnToRowMapPartitionsRDD.mapPartitions(cdata, f)
-    } else {
-      cdata.mapPartitions(f)
+    child match {
+      case a: AdaptiveSparkPlanExec if !ShimLoader.getSparkShims.isAdaptiveFinalPlanColumnar(a) =>
+        a.execute()
+      case _ =>
+        val cdata = child.executeColumnar()
+        if (exportColumnarRdd) {
+          // If we are exporting columnar rdd we need an easy way for the code that walks the
+          // RDDs to know where the columnar to row transition is happening.
+          GpuColumnToRowMapPartitionsRDD.mapPartitions(cdata, f)
+        } else {
+          cdata.mapPartitions(f)
+        }
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -145,7 +145,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
     // will see GpuRowToColumnar(GpuColumnarToRow(adaptivePlan)) and the
     // redundant transition will be optimized out
     case p: AdaptiveSparkPlanExec =>
-      GpuColumnarToRowExec(p)
+      ShimLoader.getSparkShims.adaptivePlanToRow(p)
 
     case p =>
       p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -16,10 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import java.lang.reflect.Method
-
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, SortOrder}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -31,7 +27,6 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, Exchange,
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
 import org.apache.spark.sql.rapids.{GpuDataSourceScanExec, GpuFileSourceScanExec, GpuInputFileBlockLength, GpuInputFileBlockStart, GpuInputFileName, GpuShuffleEnv}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastToCpuExec, GpuCustomShuffleReaderExec, GpuHashJoin, GpuShuffleExchangeExecBase}
-import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * Rules that run after the row to columnar and columnar to row transitions have been inserted.
@@ -67,18 +62,8 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       parent: Option[SparkPlan]): SparkPlan = plan match {
     // HostColumnarToGpu(RowToColumnarExec(..)) => GpuRowToColumnarExec(..)
     case HostColumnarToGpu(r2c: RowToColumnarExec, goal) =>
-      val transition = GpuRowToColumnarExec(
-        optimizeAdaptiveTransitions(r2c.child, Some(r2c)), goal)
-      r2c.child match {
-        case _: AdaptiveSparkPlanExec =>
-          // When the input is an adaptive plan we do not get to see the GPU version until
-          // the plan is executed and sometimes the plan will have a GpuColumnarToRowExec as the
-          // final operator and we can bypass this to keep the data columnar by inserting
-          // the [[AvoidAdaptiveTransitionToRow]] operator here
-          AvoidAdaptiveTransitionToRow(transition)
-        case _ =>
-          transition
-      }
+      val optimizedChild = optimizeAdaptiveTransitions(r2c.child, Some(r2c))
+      ShimLoader.getSparkShims.createGpuRowToColumnarTransition(optimizedChild, r2c, goal)
 
     case ColumnarToRowExec(GpuBringBackToHost(
         GpuShuffleCoalesceExec(e: GpuShuffleExchangeExecBase, _))) if parent.isEmpty =>
@@ -153,6 +138,14 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
         case e: GpuShuffleExchangeExecBase => e
         case other => getColumnarToRowExec(other)
       }
+
+    // AdaptiveSparkPlanExec reports supportsColumnar=false even though the final
+    // query stage could be columnar so we wrap in GpuColumnarToRowExec to
+    // keep it row-based during planning. If a consumer needs columnar data then we
+    // will see GpuRowToColumnar(GpuColumnarToRow(adaptivePlan)) and the
+    // redundant transition will be optimized out
+    case p: AdaptiveSparkPlanExec =>
+      GpuColumnarToRowExec(p)
 
     case p =>
       p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))
@@ -533,59 +526,4 @@ object GpuTransitionOverrides {
   }
 }
 
-/**
- * This operator will attempt to optimize the case when we are writing the results of
- * an adaptive query to disk so that we remove the redundant transitions from columnar
- * to row within AdaptiveSparkPlanExec followed by a row to columnar transition.
- *
- * Specifically, this is the plan we see in this case:
- *
- * {{{
- * GpuRowToColumnar(AdaptiveSparkPlanExec(GpuColumnarToRow(child))
- * }}}
- *
- * We perform this optimization at runtime rather than during planning, because when the adaptive
- * plan is being planned and executed, we don't know whether it is being called from an operation
- * that wants rows (such as CollectTailExec) or from an operation that wants columns (such as
- * GpuDataWritingCommandExec).
- *
- * Spark does not provide a mechanism for executing an adaptive plan and retrieving columnar
- * results and the internal methods that we need to call are private, so we use reflection to
- * call them.
- *
- * @param child The plan to execute
- */
-case class AvoidAdaptiveTransitionToRow(child: SparkPlan) extends UnaryExecNode with GpuExec {
 
-  override def doExecute(): RDD[InternalRow] =
-    throw new IllegalStateException(s"Row-based execution should not occur for $this")
-
-  override def output: Seq[Attribute] = child.output
-
-  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child match {
-    case GpuRowToColumnarExec(a: AdaptiveSparkPlanExec, _) =>
-      val getFinalPhysicalPlan = getPrivateMethod("getFinalPhysicalPlan")
-      val plan = getFinalPhysicalPlan.invoke(a)
-      val rdd = plan match {
-        case t: GpuColumnarToRowExec =>
-          t.child.executeColumnar()
-        case _ =>
-          child.executeColumnar()
-      }
-
-      // final UI update
-      val finalPlanUpdate = getPrivateMethod("finalPlanUpdate")
-      finalPlanUpdate.invoke(a)
-
-      rdd
-
-    case _ =>
-      child.executeColumnar()
-  }
-
-  private def getPrivateMethod(name: String): Method = {
-    val m = classOf[AdaptiveSparkPlanExec].getDeclaredMethod(name)
-    m.setAccessible(true)
-    m
-  }
-}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -64,8 +64,7 @@ class SQLExecPlugin extends (SparkSessionExtensions => Unit) with Logging {
     val cudfVersion = cudfProps.getProperty("version", "UNKNOWN")
     logWarning(s"RAPIDS Accelerator $pluginVersion using cudf $cudfVersion." +
       s" To disable GPU support set `${RapidsConf.SQL_ENABLED}` to false")
-    extensions.injectColumnar(_ => ColumnarOverrideRules())
-    extensions.injectQueryStagePrepRule(_ => GpuQueryStagePrepOverrides())
+    ShimLoader.getSparkShims.injectRules(extensions)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -31,13 +31,11 @@ import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, ExprId, NullOrdering, SortDirection, SortOrder}
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.connector.read.Scan
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.{RowToColumnarExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{FileIndex, FilePartition, HadoopFsRelation, PartitionDirectory, PartitionedFile}
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
@@ -224,4 +222,13 @@ trait SparkShims {
   def hasAliasQuoteFix: Boolean
 
   def hasCastFloatTimestampUpcast: Boolean
+
+  def injectRules(extensions: SparkSessionExtensions)
+
+  def createGpuRowToColumnarTransition(
+    child: SparkPlan,
+    r2c: RowToColumnarExec,
+    goal: CoalesceSizeGoal): SparkPlan
+
+  def isAdaptiveFinalPlanColumnar(plan: AdaptiveSparkPlanExec): Boolean
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -225,6 +225,8 @@ trait SparkShims {
 
   def injectRules(extensions: SparkSessionExtensions)
 
+  def adaptivePlanToRow(p: AdaptiveSparkPlanExec): SparkPlan
+
   def createGpuRowToColumnarTransition(
     child: SparkPlan,
     r2c: RowToColumnarExec,


### PR DESCRIPTION
This PR demonstrates how we can simplify handling of transitions around the final query stage of adaptive queries once [SPARK-35881](https://github.com/apache/spark/pull/33140) is merged and remove the need to use reflection to access private Spark methods. 

This PR currently only implements the improvement with the fix backported to Spark 3.1.3-SNAPSHOT and we would need to make similar changes to other shims.

## Problem

Prior to this PR, the final query stage of an adaptive query is always row-based. We insert a transition inside the query stage to ensure this. If the adaptive plan is nested in a columnar write then we insert another transition to convert back to columnar, so we now have:

```
InsertIntoHadoopFsRelationExec
  GpuRowToColumnarExec
    AdaptiveSparkPlanExec
      GpuColumnarToRowExec    
```

These transitions are redundant so we insert another operator to avoid the transition at runtime.

```
InsertIntoHadoopFsRelationExec
  AvoidAdaptiveTransitionToRowExec
    GpuRowToColumnarExec
      AdaptiveSparkPlanExec
        GpuColumnarToRowExec  
```

The `AvoidAdaptiveTransitionToRowExec` operator uses reflection to access private methods within `AdaptiveSparkPlanExec`. This is necessary because adaptive plans do not support columnar execution prior to SPARK-35881.

## New Approach

With SPARK-35881 supporting columnar execution of adaptive plans, we can now put the transition outside of the adaptive plan:

```
GpuColumnarToRowExec 
  AdaptiveSparkPlanExec
```

When nested in a columnar write, we now see this interim plan:

```
InsertIntoHadoopFsRelationExec
  GpuRowToColumnarExec
    GpuColumnarToRowExec 
      AdaptiveSparkPlanExec
```

The redundant transitions are now easily optimized out in `GpuTransitionOverrides`, leaving us with:

```
InsertIntoHadoopFsRelationExec
  GpuRowToColumnarExec
    AdaptiveSparkPlanExec
```

We need to still have the `GpuRowToColumnarExec` in the plan because `AdaptiveSparkPlanExec.supportsColumnar` is always false (see SPARK-35881 for more details) but this operator is essential a no-op if it is wrapping an adaptive plan where the final stage is columnar.
