### PR TITLE
Update audit script to clone branch-3.2 instead of master

### DIFF
--- a/scripts/audit-spark-3.2.sh
+++ b/scripts/audit-spark-3.2.sh
@@ -18,18 +18,18 @@
 # This script generates the commits that went in Apache Spark for audit.
 # Audit is required to evaluate if the code needs to be updated based
 # on new commits merged in Apache Spark. This currently audits changes for
-# Spark-3.2 (master branch).
+# Spark branch-3.2
 # Arguments:
 #   lastcommit - File which contains the latest commit hash when this script ran last.
 #   basebranch - branch in Apache Spark for which commits needs to be audited.
-#                Currently it's master as Spark-3.2 branch is not cut yet.
+#                Currently it's Apache Spark's branch-3.2.
 #   tag        - tag until which the commits are audited 
 
 
 set -ex
 ABSOLUTE_PATH=$(cd $(dirname $0) && pwd)
 lastcommit=""
-basebranch="master"
+basebranch="branch-3.2"
 tag="v3.1.1-rc3"
 REF=${REF:-"main"}
 REF=main


### PR DESCRIPTION
This is a small PR. Recently Apache Spark cut branch-3.2 from master. Since we want to audit commits for branch-3.2, updating the basebranch to branch-3.2 from master. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
