### PR TITLE
Add support for timeParserPolicy=LEGACY

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -353,7 +353,12 @@ the specified format string will fall into one of three categories:
 - Supported on GPU but may produce different results to Spark
 - Unsupported on GPU
 
-The formats which are supported on GPU and 100% compatible with Spark are :
+The formats which are supported on GPU vary depending on the setting for `timeParserPolicy`.
+
+### CORRECTED and EXCEPTION timeParserPolicy
+
+With timeParserPolicy set to `CORRECTED` or `EXCEPTION` (the default), the following formats are supported
+on the GPU without requiring any additional settings.
 
 - `dd/MM/yyyy`
 - `yyyy/MM`
@@ -366,10 +371,11 @@ The formats which are supported on GPU and 100% compatible with Spark are :
 - `dd-MM`
 - `dd/MM`
 
-Examples of supported formats that may produce different results are:
+Valid Spark date/time formats that do not appear in the list above may also be supported but have not been 
+extensively tested and may produce different results compared to the CPU. Known issues include:
 
-- Trailing characters (including whitespace) may return a non-null value on GPU and Spark will 
-  return null 
+- Valid dates and timestamps followed by trailing characters (including whitespace) may be parsed to non-null 
+  values on GPU where Spark would treat the data as invalid and return null
 
 To attempt to use other formats on the GPU, set
 [`spark.rapids.sql.incompatibleDateFormats.enabled`](configs.md#sql.incompatibleDateFormats.enabled)
@@ -390,6 +396,26 @@ Formats that contain any of the following words are unsupported and will fall ba
 "D", "DD", "DDD", "s", "m", "H", "h", "M", "MMM", "MMMM", "MMMMM", "L", "LLL", "LLLL", "LLLLL",
 "d", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSSSSS", "SSSSSSS", "SSSSSSSS"
 ```
+
+### LEGACY timeParserPolicy
+
+With timeParserPolicy set to `LEGACY` and
+[`spark.rapids.sql.incompatibleDateFormats.enabled`](configs.md#sql.incompatibleDateFormats.enabled)
+set to `true`, and `spark.sql.ansi.enabled` set to `false`, the following formats are supported but not 
+guaranteed to produce the same results as the CPU:
+
+- `dd-MM-yyyy`
+- `dd/MM/yyyy`
+- `yyyy/MM/dd`
+- `yyyy-MM-dd`
+- `yyyy/MM/dd HH:mm:ss`
+- `yyyy-MM-dd HH:mm:ss`
+
+LEGACY timeParserPolicy support has the following limitations when running on the GPU:
+
+- Only 4 digit years are supported
+- The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calender 
+  that Spark uses in legacy mode
 
 ## Formatting dates and timestamps as strings
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -477,54 +477,54 @@ object GpuToTimestamp extends Arm {
   // tests for.
   val LEGACY_COMPATIBLE_FORMATS = Seq(
     LegacyParseFormat("yyyy-MM-dd", '-', isTimestamp = false,
-      "\\A\\d{4}-\\d{2}-\\d{2}(\\D|\\s|\\Z)"),
+      raw"\A\d{4}-\d{2}-\d{2}(\D|\s|\Z)"),
     LegacyParseFormat("yyyy/MM/dd", '/', isTimestamp = false,
-      "\\A\\d{4}/\\d{2}/\\d{2}(\\D|\\s|\\Z)"),
+      raw"\A\d{4}/\d{2}/\d{2}(\D|\s|\Z)"),
     LegacyParseFormat("dd-MM-yyyy", '-', isTimestamp = false,
-      "\\A\\d{2}-\\d{2}-\\d{4}(\\D|\\s|\\Z)"),
+      raw"\A\d{2}-\d{2}-\d{4}(\D|\s|\Z)"),
     LegacyParseFormat("dd/MM/yyyy", '/', isTimestamp = false,
-      "\\A\\d{2}/\\d{2}/\\d{4}(\\D|\\s|\\Z)"),
+      raw"\A\d{2}/\d{2}/\d{4}(\D|\s|\Z)"),
     LegacyParseFormat("yyyy-MM-dd HH:mm:ss", '-', isTimestamp = true,
-      "\\A\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}(\\D|\\s|\\Z)"),
+      raw"\A\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\D|\s|\Z)"),
     LegacyParseFormat("yyyy/MM/dd HH:mm:ss", '/', isTimestamp = true,
-      "\\A\\d{4}/\\d{2}/\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}(\\D|\\s|\\Z)")
+      raw"\A\d{4}/\d{2}/\d{2}[ T]\d{2}:\d{2}:\d{2}(\D|\s|\Z)")
   )
 
   /** remove whitespace before month and day */
   val REMOVE_WHITESPACE_FROM_MONTH_DAY: RegexReplace =
-    RegexReplace("(\\A\\d+)-([ \\t]*)(\\d+)-([ \\t]*)(\\d+)", "\\1-\\3-\\5")
+    RegexReplace(raw"(\A\d+)-([ \t]*)(\d+)-([ \t]*)(\d+)", raw"\1-\3-\5")
 
   /** Regex rule to replace "yyyy-m-" with "yyyy-mm-" */
   val FIX_SINGLE_DIGIT_MONTH: RegexReplace =
-    RegexReplace("(\\A\\d+)-(\\d{1}-)", "\\1-0\\2")
+    RegexReplace(raw"(\A\d+)-(\d{1}-)", raw"\1-0\2")
 
   /** Regex rule to replace "yyyy-mm-d" with "yyyy-mm-dd" */
   val FIX_SINGLE_DIGIT_DAY_1: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2})-(\\d{1}[\\D\\s]+)", "\\1-0\\2")
+    RegexReplace(raw"(\A\d+-\d{2})-(\d{1}[\D\s]+)", raw"\1-0\2")
 
   /** Regex rule to replace "yyyy-mm-d" with "yyyy-mm-dd" */
   val FIX_SINGLE_DIGIT_DAY_2: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2})-(\\d{1})\\Z", "\\1-0\\2")
+    RegexReplace(raw"(\A\d+-\d{2})-(\d{1})\Z", raw"\1-0\2")
 
   /** Regex rule to replace "yyyy-mm-dd h-" with "yyyy-mm-dd hh-" */
   val FIX_SINGLE_DIGIT_HOUR_1: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2}-\\d{2}) (\\d{1}:)", "\\1 0\\2")
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2}) (\d{1}:)", raw"\1 0\2")
 
   /** Regex rule to replace "yyyy-mm-ddTh-" with "yyyy-mm-ddThh-" */
   val FIX_SINGLE_DIGIT_HOUR_2: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2}-\\d{2})T(\\d{1}:)", "\\1T0\\2")
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2})T(\d{1}:)", raw"\1T0\2")
 
   /** Regex rule to replace "yyyy-mm-dd[ T]hh-m-" with "yyyy-mm-dd[ T]hh-mm-" */
   val FIX_SINGLE_DIGIT_MINUTE: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2}-\\d{2}[ T]\\d{2}):(\\d{1}:)", "\\1:0\\2")
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}):(\d{1}:)", raw"\1:0\2")
 
   /** Regex rule to replace "yyyy-mm-dd[ T]hh-mm-s" with "yyyy-mm-dd[ T]hh-mm-ss" */
   val FIX_SINGLE_DIGIT_SECOND_1: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}):(\\d{1}\\D+)", "\\1:0\\2")
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1}\D+)", raw"\1:0\2")
 
   /** Regex rule to replace "yyyy-mm-dd[ T]hh-mm-s" with "yyyy-mm-dd[ T]hh-mm-ss" */
   val FIX_SINGLE_DIGIT_SECOND_2: RegexReplace =
-    RegexReplace("(\\A\\d+-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}):(\\d{1})\\Z", "\\1:0\\2")
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1})\Z", raw"\1:0\2")
 
   /** Convert dates to standard format */
   val FIX_DATES = Seq(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -502,13 +502,9 @@ object GpuToTimestamp extends Arm {
   val FIX_SINGLE_DIGIT_DAY: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2})-(\d{1})([\D\s]|\Z)", raw"\1-0\2\3")
 
-  /** Regex rule to replace "yyyy-mm-dd h:" with "yyyy-mm-dd hh:" */
-  val FIX_SINGLE_DIGIT_HOUR_1: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2}-\d{2}) (\d{1}:)", raw"\1 0\2")
-
-  /** Regex rule to replace "yyyy-mm-ddTh:" with "yyyy-mm-ddThh:" */
-  val FIX_SINGLE_DIGIT_HOUR_2: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2}-\d{2})T(\d{1}:)", raw"\1T0\2")
+  /** Regex rule to replace "yyyy-mm-dd[ T]h:" with "yyyy-mm-dd hh:" */
+  val FIX_SINGLE_DIGIT_HOUR: RegexReplace =
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2})[ T](\d{1}:)", raw"\1 0\2")
 
   /** Regex rule to replace "yyyy-mm-dd[ T]hh:m:" with "yyyy-mm-dd[ T]hh:mm:" */
   val FIX_SINGLE_DIGIT_MINUTE: RegexReplace =
@@ -526,8 +522,7 @@ object GpuToTimestamp extends Arm {
 
   /** Convert timestamps to standard format */
   val FIX_TIMESTAMPS = Seq(
-    FIX_SINGLE_DIGIT_HOUR_1,
-    FIX_SINGLE_DIGIT_HOUR_2,
+    FIX_SINGLE_DIGIT_HOUR,
     FIX_SINGLE_DIGIT_MINUTE,
     FIX_SINGLE_DIGIT_SECOND
   )

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -499,30 +499,26 @@ object GpuToTimestamp extends Arm {
     RegexReplace(raw"(\A\d+)-(\d{1}-)", raw"\1-0\2")
 
   /** Regex rule to replace "yyyy-mm-d" with "yyyy-mm-dd" */
-  val FIX_SINGLE_DIGIT_DAY_1: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2})-(\d{1}[\D\s]+)", raw"\1-0\2")
+  val FIX_SINGLE_DIGIT_DAY: RegexReplace =
+    RegexReplace(raw"(\A\d+-\d{2})-(\d{1})([\D\s]|\Z)", raw"\1-0\2\3")
 
-  /** Regex rule to replace "yyyy-mm-d" with "yyyy-mm-dd" */
-  val FIX_SINGLE_DIGIT_DAY_2: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2})-(\d{1})\Z", raw"\1-0\2")
-
-  /** Regex rule to replace "yyyy-mm-dd h-" with "yyyy-mm-dd hh-" */
+  /** Regex rule to replace "yyyy-mm-dd h:" with "yyyy-mm-dd hh:" */
   val FIX_SINGLE_DIGIT_HOUR_1: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2}-\d{2}) (\d{1}:)", raw"\1 0\2")
 
-  /** Regex rule to replace "yyyy-mm-ddTh-" with "yyyy-mm-ddThh-" */
+  /** Regex rule to replace "yyyy-mm-ddTh:" with "yyyy-mm-ddThh:" */
   val FIX_SINGLE_DIGIT_HOUR_2: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2}-\d{2})T(\d{1}:)", raw"\1T0\2")
 
-  /** Regex rule to replace "yyyy-mm-dd[ T]hh-m-" with "yyyy-mm-dd[ T]hh-mm-" */
+  /** Regex rule to replace "yyyy-mm-dd[ T]hh:m:" with "yyyy-mm-dd[ T]hh:mm:" */
   val FIX_SINGLE_DIGIT_MINUTE: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}):(\d{1}:)", raw"\1:0\2")
 
-  /** Regex rule to replace "yyyy-mm-dd[ T]hh-mm-s" with "yyyy-mm-dd[ T]hh-mm-ss" */
+  /** Regex rule to replace "yyyy-mm-dd[ T]hh:mm:s" with "yyyy-mm-dd[ T]hh:mm:ss" */
   val FIX_SINGLE_DIGIT_SECOND_1: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1}\D+)", raw"\1:0\2")
 
-  /** Regex rule to replace "yyyy-mm-dd[ T]hh-mm-s" with "yyyy-mm-dd[ T]hh-mm-ss" */
+  /** Regex rule to replace "yyyy-mm-dd[ T]hh:mm:s" with "yyyy-mm-dd[ T]hh:mm:ss" */
   val FIX_SINGLE_DIGIT_SECOND_2: RegexReplace =
     RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1})\Z", raw"\1:0\2")
 
@@ -530,8 +526,7 @@ object GpuToTimestamp extends Arm {
   val FIX_DATES = Seq(
     REMOVE_WHITESPACE_FROM_MONTH_DAY,
     FIX_SINGLE_DIGIT_MONTH,
-    FIX_SINGLE_DIGIT_DAY_1,
-    FIX_SINGLE_DIGIT_DAY_2)
+    FIX_SINGLE_DIGIT_DAY)
 
   /** Convert timestamps to standard format */
   val FIX_TIMESTAMPS = Seq(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -515,12 +515,8 @@ object GpuToTimestamp extends Arm {
     RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}):(\d{1}:)", raw"\1:0\2")
 
   /** Regex rule to replace "yyyy-mm-dd[ T]hh:mm:s" with "yyyy-mm-dd[ T]hh:mm:ss" */
-  val FIX_SINGLE_DIGIT_SECOND_1: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1}\D+)", raw"\1:0\2")
-
-  /** Regex rule to replace "yyyy-mm-dd[ T]hh:mm:s" with "yyyy-mm-dd[ T]hh:mm:ss" */
-  val FIX_SINGLE_DIGIT_SECOND_2: RegexReplace =
-    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1})\Z", raw"\1:0\2")
+  val FIX_SINGLE_DIGIT_SECOND: RegexReplace =
+    RegexReplace(raw"(\A\d+-\d{2}-\d{2}[ T]\d{2}:\d{2}):(\d{1})([\D\s]|\Z)", raw"\1:0\2\3")
 
   /** Convert dates to standard format */
   val FIX_DATES = Seq(
@@ -533,8 +529,7 @@ object GpuToTimestamp extends Arm {
     FIX_SINGLE_DIGIT_HOUR_1,
     FIX_SINGLE_DIGIT_HOUR_2,
     FIX_SINGLE_DIGIT_MINUTE,
-    FIX_SINGLE_DIGIT_SECOND_1,
-    FIX_SINGLE_DIGIT_SECOND_2
+    FIX_SINGLE_DIGIT_SECOND
   )
 
   def daysScalarSeconds(name: String): Scalar = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{ColumnView, DType, HostColumnVector, HostColumnVectorCore}
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals}
+
+/**
+ * Convenience methods for testing cuDF calls directly. This code is largely copied
+ * from the cuDF Java test suite.
+ */
+object CudfTestHelper {
+
+  /**
+   * Checks and asserts that passed in columns match
+   *
+   * @param expect The expected result column
+   * @param cv     The input column
+   */
+  def assertColumnsAreEqual(expect: ColumnView, cv: ColumnView): Unit = {
+    assertColumnsAreEqual(expect, cv, colName = "unnamed")
+  }
+
+  /**
+   * Checks and asserts that passed in columns match
+   *
+   * @param expected The expected result column
+   * @param cv       The input column
+   * @param colName  The name of the column
+   */
+  def assertColumnsAreEqual(expected: ColumnView, cv: ColumnView, colName: String): Unit = {
+    assertPartialColumnsAreEqual(expected, 0, expected.getRowCount, cv, colName,
+      enableNullCheck = true)
+  }
+
+  /**
+   * Checks and asserts that passed in host columns match
+   *
+   * @param expected The expected result host column
+   * @param cv       The input host column
+   * @param colName  The name of the host column
+   */
+  def assertColumnsAreEqual(expected: HostColumnVector,
+                            cv: HostColumnVector, colName: String): Unit = {
+    assertPartialColumnsAreEqual(expected, 0,
+      expected.getRowCount, cv, colName, enableNullCheck = true)
+  }
+
+  def assertPartialColumnsAreEqual(
+                                    expected: ColumnView,
+                                    rowOffset: Long,
+                                    length: Long,
+                                    cv: ColumnView,
+                                    colName: String,
+                                    enableNullCheck: Boolean): Unit = {
+    try {
+      val hostExpected = expected.copyToHost
+      val hostcv = cv.copyToHost
+      try assertPartialColumnsAreEqual(hostExpected, rowOffset, length,
+        hostcv, colName, enableNullCheck)
+      finally {
+        if (hostExpected != null) hostExpected.close()
+        if (hostcv != null) hostcv.close()
+      }
+    }
+  }
+
+  def assertPartialColumnsAreEqual(
+      expected: HostColumnVectorCore,
+      rowOffset: Long, length: Long,
+      cv: HostColumnVectorCore,
+      colName: String, enableNullCheck: Boolean): Unit = {
+    assertEquals(expected.getType, cv.getType, "Type For Column " + colName)
+    assertEquals(length, cv.getRowCount, "Row Count For Column " + colName)
+    assertEquals(expected.getNumChildren, cv.getNumChildren, "Child Count for Column " + colName)
+    if (enableNullCheck) assertEquals(expected.getNullCount,
+      cv.getNullCount, "Null Count For Column " + colName)
+    else {
+      // TODO add in a proper check when null counts are
+      //  supported by serializing a partitioned column
+    }
+
+    import ai.rapids.cudf.DType.DTypeEnum._
+
+    val `type`: DType = expected.getType
+    for (expectedRow <- rowOffset until (rowOffset + length)) {
+      val tableRow: Long = expectedRow - rowOffset
+      assertEquals(expected.isNull(expectedRow), cv.isNull(tableRow),
+        "NULL for Column " + colName + " Row " + tableRow)
+      if (!expected.isNull(expectedRow)) `type`.getTypeId match {
+        case BOOL8 | INT8 | UINT8 =>
+          assertEquals(expected.getByte(expectedRow), cv.getByte(tableRow),
+            "Column " + colName + " Row " + tableRow)
+
+        case INT16 | UINT16 =>
+          assertEquals(expected.getShort(expectedRow), cv.getShort(tableRow),
+            "Column " + colName + " Row " + tableRow)
+
+        case INT32 | UINT32 | TIMESTAMP_DAYS | DURATION_DAYS | DECIMAL32 =>
+          assertEquals(expected.getInt(expectedRow), cv.getInt(tableRow),
+            "Column " + colName + " Row " + tableRow)
+
+        case INT64 | UINT64 |
+             DURATION_MICROSECONDS | DURATION_MILLISECONDS | DURATION_NANOSECONDS |
+             DURATION_SECONDS | TIMESTAMP_MICROSECONDS | TIMESTAMP_MILLISECONDS |
+             TIMESTAMP_NANOSECONDS | TIMESTAMP_SECONDS | DECIMAL64 =>
+          assertEquals(expected.getLong(expectedRow), cv.getLong(tableRow),
+            "Column " + colName + " Row " + tableRow)
+
+        case STRING =>
+          assertArrayEquals(expected.getUTF8(expectedRow), cv.getUTF8(tableRow),
+            "Column " + colName + " Row " + tableRow)
+
+        case _ =>
+          throw new IllegalArgumentException(`type` + " is not supported yet")
+      }
+    }
+  }
+
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -245,22 +245,22 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   test("Regex: Fix single digit month") {
     testRegex(FIX_SINGLE_DIGIT_MONTH,
-      Seq("1-2-3", "1111-2-3", null),
-      Seq("1-02-3", "1111-02-3", null))
+      Seq("1-2-3", "1111-2-3", "2000-7-7\n9\t8568:\n", null),
+      Seq("1-02-3", "1111-02-3", "2000-07-7\n9\t8568:\n", null))
   }
 
   test("Regex: Fix single digit day followed by non digit char") {
     // single digit day followed by non digit
     testRegex(FIX_SINGLE_DIGIT_DAY_1,
-      Seq("1111-02-3 ", "1111-02-3:", null),
-      Seq("1111-02-03 ", "1111-02-03:", null))
+      Seq("1111-02-3 ", "1111-02-3:", "2000-03-192", "2000-07-7\n9\t8568:\n", null),
+      Seq("1111-02-03 ", "1111-02-03:", "2000-03-192", "2000-07-07\n9\t8568:\n", null))
   }
 
   test("Regex: Fix single digit day at end of string") {
     // single digit day at end of string
     testRegex(FIX_SINGLE_DIGIT_DAY_2,
-      Seq("1-02-3", "1111-02-3", "1111-02-03", null),
-      Seq("1-02-03", "1111-02-03", "1111-02-03", null))
+      Seq("1-02-3", "1111-02-3", "1111-02-03", "2000-03-192", null),
+      Seq("1-02-03", "1111-02-03", "1111-02-03", "2000-03-192", null))
   }
 
   test("Regex: Fix single digit hour 1") {
@@ -483,7 +483,12 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     "1999/12/31",
     "2001- 1-1",
     "2001-1- 1",
-    "2001- 1- 1") ++ singleDigits ++ singleDigits.map(_.replace('-', '/'))
+    "2001- 1- 1",
+    "2000-3-192",
+    // interesting test cases from fuzzing that original triggered differences between CPU and GPU
+    "2000-1- 099\n305\n 7-390--.0:-",
+    "2000-7-7\n9\t8568:\n",
+    "2000-\t5-2.7.44584.9935") ++ singleDigits ++ singleDigits.map(_.replace('-', '/'))
 
   private val dateValues = Seq(
     Date.valueOf("2020-07-24"),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions.{col, to_date, to_timestamp, unix_timestamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY, FIX_SINGLE_DIGIT_HOUR_1, FIX_SINGLE_DIGIT_HOUR_2, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND_1, FIX_SINGLE_DIGIT_SECOND_2, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
+import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY, FIX_SINGLE_DIGIT_HOUR_1, FIX_SINGLE_DIGIT_HOUR_2, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
 import org.apache.spark.sql.rapids.RegexReplace
 
 class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
@@ -264,36 +264,36 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
   }
 
   test("Regex: Fix single digit hour 1") {
-    // single digit day at end of string
+    // single digit hour with space separating date and time
     testRegex(FIX_SINGLE_DIGIT_HOUR_1,
       Seq("2001-12-31 1:2:3", "2001-12-31 1:22:33", null),
       Seq("2001-12-31 01:2:3", "2001-12-31 01:22:33", null))
   }
 
   test("Regex: Fix single digit hour 2") {
-    // single digit day at end of string
+    // single digit hour with 'T' separating date and time
     testRegex(FIX_SINGLE_DIGIT_HOUR_2,
       Seq("2001-12-31T1:2:3", "2001-12-31T1:22:33", null),
       Seq("2001-12-31T01:2:3", "2001-12-31T01:22:33", null))
   }
 
   test("Regex: Fix single digit minute") {
-    // single digit day at end of string
+    // single digit minute at end of string
     testRegex(FIX_SINGLE_DIGIT_MINUTE,
       Seq("2001-12-31 01:2:3", "2001-12-31 01:22:33", null),
       Seq("2001-12-31 01:02:3", "2001-12-31 01:22:33", null))
   }
 
-  test("Regex: Fix single digit second 1") {
-    // single digit day at end of string
-    testRegex(FIX_SINGLE_DIGIT_SECOND_1,
-      Seq("2001-12-31 01:02:3:", "2001-12-31 01:22:33:", null),
-      Seq("2001-12-31 01:02:03:", "2001-12-31 01:22:33:", null))
+  test("Regex: Fix single digit second followed by non digit") {
+    // single digit second followed by non digit
+    testRegex(FIX_SINGLE_DIGIT_SECOND,
+      Seq("2001-12-31 01:02:3:", "2001-12-31 01:22:33:", "2001-12-31 01:02:3 ", null),
+      Seq("2001-12-31 01:02:03:", "2001-12-31 01:22:33:", "2001-12-31 01:02:03 ", null))
   }
 
-  test("Regex: Fix single digit second 2") {
+  test("Regex: Fix single digit second at end of string") {
     // single digit day at end of string
-    testRegex(FIX_SINGLE_DIGIT_SECOND_2,
+    testRegex(FIX_SINGLE_DIGIT_SECOND,
       Seq("2001-12-31 01:02:3", "2001-12-31 01:22:33", null),
       Seq("2001-12-31 01:02:03", "2001-12-31 01:22:33", null))
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions.{col, to_date, to_timestamp, unix_timestamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY, FIX_SINGLE_DIGIT_HOUR_1, FIX_SINGLE_DIGIT_HOUR_2, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
+import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY, FIX_SINGLE_DIGIT_HOUR, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
 import org.apache.spark.sql.rapids.RegexReplace
 
 class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
@@ -265,16 +265,17 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   test("Regex: Fix single digit hour 1") {
     // single digit hour with space separating date and time
-    testRegex(FIX_SINGLE_DIGIT_HOUR_1,
+    testRegex(FIX_SINGLE_DIGIT_HOUR,
       Seq("2001-12-31 1:2:3", "2001-12-31 1:22:33", null),
       Seq("2001-12-31 01:2:3", "2001-12-31 01:22:33", null))
   }
 
   test("Regex: Fix single digit hour 2") {
     // single digit hour with 'T' separating date and time
-    testRegex(FIX_SINGLE_DIGIT_HOUR_2,
+    // note that the T gets replaced with whitespace in this case
+    testRegex(FIX_SINGLE_DIGIT_HOUR,
       Seq("2001-12-31T1:2:3", "2001-12-31T1:22:33", null),
-      Seq("2001-12-31T01:2:3", "2001-12-31T01:22:33", null))
+      Seq("2001-12-31 01:2:3", "2001-12-31 01:22:33", null))
   }
 
   test("Regex: Fix single digit minute") {
@@ -338,7 +339,7 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
       ("1999-2-3:", "1999-02-03:"),
       ("1999-2-3", "1999-02-03"),
       ("1999-2-3 1:2:3.4", "1999-02-03 01:02:03.4"),
-      ("1999-2-3T1:2:3.4", "1999-02-03T01:02:03.4")
+      ("1999-2-3T1:2:3.4", "1999-02-03 01:02:03.4")
     )
     val values = testPairs.map(_._1)
     val expected = testPairs.map(_._2)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions.{col, to_date, to_timestamp, unix_timestamp}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY_1, FIX_SINGLE_DIGIT_DAY_2, FIX_SINGLE_DIGIT_HOUR_1, FIX_SINGLE_DIGIT_HOUR_2, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND_1, FIX_SINGLE_DIGIT_SECOND_2, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
+import org.apache.spark.sql.rapids.GpuToTimestamp.{FIX_DATES, FIX_SINGLE_DIGIT_DAY, FIX_SINGLE_DIGIT_HOUR_1, FIX_SINGLE_DIGIT_HOUR_2, FIX_SINGLE_DIGIT_MINUTE, FIX_SINGLE_DIGIT_MONTH, FIX_SINGLE_DIGIT_SECOND_1, FIX_SINGLE_DIGIT_SECOND_2, FIX_TIMESTAMPS, REMOVE_WHITESPACE_FROM_MONTH_DAY}
 import org.apache.spark.sql.rapids.RegexReplace
 
 class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
@@ -251,14 +251,14 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   test("Regex: Fix single digit day followed by non digit char") {
     // single digit day followed by non digit
-    testRegex(FIX_SINGLE_DIGIT_DAY_1,
+    testRegex(FIX_SINGLE_DIGIT_DAY,
       Seq("1111-02-3 ", "1111-02-3:", "2000-03-192", "2000-07-7\n9\t8568:\n", null),
       Seq("1111-02-03 ", "1111-02-03:", "2000-03-192", "2000-07-07\n9\t8568:\n", null))
   }
 
   test("Regex: Fix single digit day at end of string") {
     // single digit day at end of string
-    testRegex(FIX_SINGLE_DIGIT_DAY_2,
+    testRegex(FIX_SINGLE_DIGIT_DAY,
       Seq("1-02-3", "1111-02-3", "1111-02-03", "2000-03-192", null),
       Seq("1-02-03", "1111-02-03", "1111-02-03", "2000-03-192", null))
   }


### PR DESCRIPTION
Closes #2860

This PR adds support for parsing strings to date/timestamp when `spark.sql.legacy.timeParserPolicy=LEGACY` for the following formats:

- `dd-MM-yyyy`
- `dd/MM/yyyy`
- `yyyy/MM/dd`
- `yyyy-MM-dd`
- `yyyy/MM/dd HH:mm:ss`
- `yyyy-MM-dd HH:mm:ss`

We are not 100% compatible with Spark on CPU in all cases so this support is only enabled when `spark.rapids.sql.incompatibleDateFormats.enabled` is also set to true. We have the following limitations when running on the GPU:

- Only 4-digit years are supported
- The proleptic Gregorian calendar is used instead of the hybrid Julian+Gregorian calendar that Spark uses in legacy mode, so we produce different results for dates prior to the Gregorian calendar starting.