### PR TITLE
fix orc readers leak issue for ORC PERFILE type

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -846,20 +846,18 @@ private case class GpuOrcFileFilterHandler(
       OrcProto.Stream.Kind.ROW_INDEX)
 
     def getOrcPartitionReaderContext: OrcPartitionReaderContext = {
-      closeOnExcept(orcReader) { _ =>
-        val updatedReadSchema = checkSchemaCompatibility(orcReader.getSchema, readerOpts.getSchema,
-          readerOpts.getIsSchemaEvolutionCaseAware)
-        val evolution = new SchemaEvolution(orcReader.getSchema, readerOpts.getSchema, readerOpts)
-        val (sargApp, sargColumns) = getSearchApplier(evolution,
-          orcFileReaderOpts.getUseUTCTimestamp)
-        val splitStripes = orcReader.getStripes.asScala.filter(s =>
-          s.getOffset >= partFile.start && s.getOffset < partFile.start + partFile.length)
-        val stripes = buildOutputStripes(splitStripes, evolution,
-          sargApp, sargColumns, OrcConf.IGNORE_NON_UTF8_BLOOM_FILTERS.getBoolean(conf),
-          orcReader.getWriterVersion)
-        OrcPartitionReaderContext(updatedReadSchema, evolution, dataReader, orcReader,
-          stripes.iterator.buffered, requestedMapping)
-      }
+      val updatedReadSchema = checkSchemaCompatibility(orcReader.getSchema, readerOpts.getSchema,
+        readerOpts.getIsSchemaEvolutionCaseAware)
+      val evolution = new SchemaEvolution(orcReader.getSchema, readerOpts.getSchema, readerOpts)
+      val (sargApp, sargColumns) = getSearchApplier(evolution,
+        orcFileReaderOpts.getUseUTCTimestamp)
+      val splitStripes = orcReader.getStripes.asScala.filter(s =>
+        s.getOffset >= partFile.start && s.getOffset < partFile.start + partFile.length)
+      val stripes = buildOutputStripes(splitStripes, evolution,
+        sargApp, sargColumns, OrcConf.IGNORE_NON_UTF8_BLOOM_FILTERS.getBoolean(conf),
+        orcReader.getWriterVersion)
+      OrcPartitionReaderContext(updatedReadSchema, evolution, dataReader, orcReader,
+        stripes.iterator.buffered, requestedMapping)
     }
 
     /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -370,7 +370,7 @@ private case class OrcPartitionReaderContext(
     requestedMapping: Option[Array[Int]]) {
   private var isClosed = false
 
-  def cleanUp = {
+  def cleanUp() = {
     if (!isClosed) {
       Seq(orcReader, dataReader).safeClose()
       isClosed =  true
@@ -600,7 +600,7 @@ trait OrcPartitionReaderBase extends Logging with Arm with ScanWithMetrics {
 
   def cleanUpOrc(ctx: OrcPartitionReaderContext) = {
     if (ctx != null) {
-      ctx.cleanUp
+      ctx.cleanUp()
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -641,12 +641,16 @@ class GpuOrcPartitionReader(
       }
       isFirstBatch = false
     }
-    batch.isDefined
+    val ret = batch.isDefined
+    // After finishing reading, we should clean up ctx just in case leaking orc readers
+    if (!ret) {
+      cleanUpOrc(ctx)
+    }
+    ret
   }
 
   override def close(): Unit = {
     super.close()
-    cleanUpOrc(ctx)
   }
 
   private def readBatch(): Option[ColumnarBatch] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -935,18 +935,6 @@ class MultiFileParquetPartitionReader(
     }
     (buffer, finalSize)
   }
-
-  private def reallocHostBufferAndCopy(
-      in: HostMemoryInputStream,
-      newSizeEstimate: Long): HostMemoryBuffer = {
-    // realloc memory and copy
-    closeOnExcept(HostMemoryBuffer.allocate(newSizeEstimate)) { newhmb =>
-      withResource(new HostMemoryOutputStream(newhmb)) { out =>
-        IOUtils.copy(in, out)
-      }
-      newhmb
-    }
-  }
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.PartitionedFile
@@ -28,13 +27,16 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  */
 class PartitionReaderIterator(reader: PartitionReader[ColumnarBatch])
     extends Iterator[ColumnarBatch] with AutoCloseable {
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
 
   var hasNextResult: Option[Boolean] = None
 
   override def hasNext: Boolean = {
     if (hasNextResult.isEmpty) {
       hasNextResult = Some(reader.next())
+    }
+    hasNextResult match {
+      case Some(false) => reader.close()
+      case _ =>
     }
     hasNextResult.get
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.PartitionedFile
@@ -27,16 +28,13 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  */
 class PartitionReaderIterator(reader: PartitionReader[ColumnarBatch])
     extends Iterator[ColumnarBatch] with AutoCloseable {
+  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
 
   var hasNextResult: Option[Boolean] = None
 
   override def hasNext: Boolean = {
     if (hasNextResult.isEmpty) {
       hasNextResult = Some(reader.next())
-    }
-    hasNextResult match {
-      case Some(false) => reader.close()
-      case _ =>
     }
     hasNextResult.get
   }


### PR DESCRIPTION
Signed-off-by: Bobby Wang <wbo4958@gmail.com>

This issue is to fix #2850

The **close** function of GpuOrcPartitionReader is not called when GpuOrcPartitionReader has finished reading which results in orc readers not be closed, like leaking. 

Eventually, the **close** function of GpuOrcPartitionReader will be called on Spark task completion, but it's too late. The orc readers occupy the connection pool and result in another one that applies connection timeout for the S3 case.

For example, If the max connection of s3a is set to 256 and we have 257 ORC files to read, let's assume we only have 1 task. then the first 256 ORC files can be read without any problem, but for the last orc file, it will timeout to apply connection from s3 pool since the 256 connections have been unavailable.

So the fix is releasing the orc readers after GpuOrcPartitionReader has finished the reading.

I did the testes for 600 Orc files and 1000 Orc files for PERFILE reader. And no task failed.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
