### PR TITLE
Fix cast to date bug

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -166,12 +166,10 @@ object GpuCast extends Arm {
    */
   def sanitizeStringToDate(input: ColumnVector): ColumnVector = {
     val rules = Seq(
-      /// replace yyyy-m with yyyy-mm
-      RegexReplace("(\\A\\d{4})-(\\d{1})\\Z", "\\1-0\\2"),
-      /// replace yyyy-m- with yyyy-mm-
-      RegexReplace("(\\A\\d{4})-(\\d{1}-)", "\\1-0\\2"),
-      /// replace yyyy-mm-d with yyyy-mm-dd
-      RegexReplace("(\\A\\d{4}-\\d{2})-(\\d{1})([ T]|\\Z)", "\\1-0\\2\\3")
+      // replace yyyy-m with yyyy-mm
+      RegexReplace(raw"(\A\d{4})-(\d{1})(-|\Z)", raw"\1-0\2\3"),
+      // replace yyyy-mm-d with yyyy-mm-dd
+      RegexReplace(raw"(\A\d{4}-\d{2})-(\d{1})([ T]|\Z)", raw"\1-0\2\3")
     )
     rules.foldLeft(input.incRefCount())((cv, rule) => withResource(cv) { _ =>
       cv.stringReplaceWithBackrefs(rule.search, rule.replace)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -22,6 +22,7 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.util.TimeZone
 
+import ai.rapids.cudf.ColumnVector
 import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkConf
@@ -692,6 +693,30 @@ class CastOpSuite extends GpuExpressionTestSuite {
       testCastToDecimal(DataTypes.StringType, scale = scale,
         customDataGenerator = Some(exponentsAsStrings),
         ansiEnabled = true)
+    }
+  }
+
+  test("CAST string to date - sanitize step") {
+    val testPairs = Seq(
+      ("2001-1", "2001-01"),
+      ("2001-01-1", "2001-01-01"),
+      ("2001-1-1", "2001-01-01"),
+      ("2001-01-1", "2001-01-01"),
+      ("2001-01-1 ", "2001-01-01 "),
+      ("2001-1-1 ", "2001-01-01 "),
+      ("2001-1-1 ZZZ", "2001-01-01 ZZZ"),
+      ("2001-1-1TZZZ", "2001-01-01TZZZ"),
+      ("3330-7 39 49: 1", "3330-7 39 49: 1"),
+      ("today", "today")
+    )
+    val inputs = testPairs.map(_._1)
+    val expected = testPairs.map(_._2)
+    withResource(ColumnVector.fromStrings(inputs: _*)) { v =>
+      withResource(ColumnVector.fromStrings(expected: _*)) { expected =>
+        withResource(GpuCast.sanitizeStringToDate(v)) { actual =>
+          CudfTestHelper.assertColumnsAreEqual(expected, actual)
+        }
+      }
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -1007,6 +1007,7 @@ object CastOpSuite {
       Seq(
         "200", // year too few digits
         "20000", // year too many digits
+        "3330-7 39 49: 1",
         "1999\rGARBAGE",
         "1999-1\rGARBAGE",
         "1999-12\rGARBAGE",


### PR DESCRIPTION
This PR builds on #2875 and closes #2868 

Commit # 4 adds the test and commit # 5 adds the fix.

There was a bug in the regex that sanitizes input for CAST string to date where it was removing trailing characters in some cases, converting invalid inputs into valid inputs.