### PR TITLE
Fix cast string to bool

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -61,9 +61,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
   private val NUMERIC_CHARS = "inf \t\r\n0123456789.+-eE"
   private val DATE_CHARS = " \t\r\n0123456789:-/TZ"
 
-  ignore("Cast from string to boolean using random inputs") {
-    // Test ignored due to known issues
-    // https://github.com/NVIDIA/spark-rapids/issues/2902
+  test("Cast from string to boolean using random inputs") {
     testCastStringTo(DataTypes.BooleanType,
       generateRandomStrings(Some(BOOL_CHARS), maxStringLen = 1))
     testCastStringTo(DataTypes.BooleanType,
@@ -71,9 +69,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
     testCastStringTo(DataTypes.BooleanType, generateRandomStrings(Some(BOOL_CHARS)))
   }
 
-  ignore("Cast from string to boolean using hand-picked values") {
-    // Test ignored due to known issues
-    // https://github.com/NVIDIA/spark-rapids/issues/2902
+  test("Cast from string to boolean using hand-picked values") {
     testCastStringTo(DataTypes.BooleanType, Seq("\n\nN", "False", "FALSE", "false", "FaLsE",
       "f", "F", "True", "TRUE", "true", "tRuE", "t", "T", "Y", "y", "10", "01", "0", "1"))
   }


### PR DESCRIPTION
Builds on https://github.com/NVIDIA/spark-rapids/pull/2898 and closes https://github.com/NVIDIA/spark-rapids/issues/2902

In CAST string to bool, we were not removing whitespace and were performing a case-sensitive comparison so we did not recognize `TRUE` as a boolean value.

The bug fix is in this commit: https://github.com/NVIDIA/spark-rapids/pull/2903/commits/3488fb4b90e892aadb65e1a50ff46c33fdfc0f35
