### PR TITLE
Fix compiler warning

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals}
  * Convenience methods for testing cuDF calls directly. This code is largely copied
  * from the cuDF Java test suite.
  */
-object CudfTestHelper {
+object CudfTestHelper extends Arm {
 
   /**
    * Checks and asserts that passed in columns match
@@ -61,20 +61,16 @@ object CudfTestHelper {
   }
 
   def assertPartialColumnsAreEqual(
-                                    expected: ColumnView,
-                                    rowOffset: Long,
-                                    length: Long,
-                                    cv: ColumnView,
-                                    colName: String,
-                                    enableNullCheck: Boolean): Unit = {
-    try {
-      val hostExpected = expected.copyToHost
-      val hostcv = cv.copyToHost
-      try assertPartialColumnsAreEqual(hostExpected, rowOffset, length,
-        hostcv, colName, enableNullCheck)
-      finally {
-        if (hostExpected != null) hostExpected.close()
-        if (hostcv != null) hostcv.close()
+      expected: ColumnView,
+      rowOffset: Long,
+      length: Long,
+      cv: ColumnView,
+      colName: String,
+      enableNullCheck: Boolean): Unit = {
+    withResource(expected.copyToHost) { hostExpected =>
+      withResource(cv.copyToHost) { hostcv =>
+        assertPartialColumnsAreEqual(hostExpected, rowOffset, length,
+          hostcv, colName, enableNullCheck)
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Fixes a compiler warning and a formatting issue introduced in https://github.com/NVIDIA/spark-rapids/pull/2875 