### PR TITLE
Fixes bad string contains in run_pyspark_from_build

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -151,7 +151,7 @@ else
       export PYSP_TEST_spark_master="local-cluster[$NUM_LOCAL_EXECS,$CORES_PER_EXEC,$MB_PER_EXEC]"
     else
       # If a master is not specified, use "local[*, $SPARK_TASK_MAXFAILURES]"
-      if [ -z "${PYSP_TEST_spark_master}" ] && [ "$SPARK_SUBMIT_FLAGS" != *"--master"* ]; then
+      if [ -z "${PYSP_TEST_spark_master}" ] && [[ "$SPARK_SUBMIT_FLAGS" != *"--master"* ]]; then
         export PYSP_TEST_spark_master="local[*,$SPARK_TASK_MAXFAILURES]"
       fi
     fi


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/spark-rapids/issues/2907

Double square brackets are required here for the string match operation, otherwise bash is going to exactly try to match `*` instead of expanding that to be a wildcard.