### PR TITLE
Refine GpuHashAggregateExec.setupReference

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -629,7 +629,7 @@ class GpuHashAggregateIterator(
     // boundInputReferences is used to pick out of the input batch the appropriate columns
     // for aggregation.
     //
-    // - PartialMerge with Partial mode: we use the inputProjections or distinct update expressions
+    // - PartialMerge with Partial mode: we use the inputProjections
     //   for Partial and non distinct merge expressions for PartialMerge.
     // - Final or PartialMerge-only mode: we pick the columns in the order as handed to us.
     // - Partial or Complete mode: we use the inputProjections or distinct update expressions.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -632,7 +632,7 @@ class GpuHashAggregateIterator(
     // - PartialMerge with Partial mode: we use the inputProjections
     //   for Partial and non distinct merge expressions for PartialMerge.
     // - Final or PartialMerge-only mode: we pick the columns in the order as handed to us.
-    // - Partial or Complete mode: we use the inputProjections or distinct update expressions.
+    // - Partial or Complete mode: we use the inputProjections
     val boundInputReferences =
     if (modeInfo.hasPartialMergeMode && modeInfo.hasPartialMode) {
       // The 3rd stage of AggWithOneDistinct, which combines (partial) reduce-side


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Current PR refined `GpuHashAggregateExec.setupReference` to support `TypedImperativeAggregate`, which is required by #2916 .  The primary work of current PR is reorganizing the code of `boundInputReferences`.

Originally, we workaround `PartialMerge` modes when we construct `boundInputReferences`.  To be specific, the code piece dealing with aggregations which contain both `PartialMerge` and  `Partial` mode is not generic enough. It regards `GpuPivotFirst`  and `GpuAverage` as exceptional cases:
```scala
      case Partial =>
        // Partial with distinct case
        val updateExpressionsCudfAggsDistinct =
          updateExpressionsDistinct.filter(_.isInstanceOf[CudfAggregate])
              .map(_.asInstanceOf[CudfAggregate].ref)
        if (inputProjectionsDistinct.exists(p => !p.isInstanceOf[NamedExpression])) {
          // Case of distinct average we need to evaluate the "GpuCast and GpuIsNotNull" columns.
          // Refer to how input projections are setup for GpuAverage.
          // In the case where we have expressions to evaluate, pick the unique attributes
          // references from them as you only have one column for it before you start evaluating.
          distinctExpressions = inputProjectionsDistinct
          distinctAttributes = inputProjectionsDistinct.flatMap(ref =>
            ref.references.toSeq).distinct
        } else {
          distinctAttributes = updateAttributesDistinct
          distinctExpressions = updateExpressionsCudfAggsDistinct
        }
```

With the new implementation, we avoid all kinds of workaround.  Instead, we fit all kinds of aggregation modes into three categories by the stage of AggregateExec in aggregation stack:
1. The first stage of aggregation stack, in terms of aggregation modes, it may contain aggregate expressions with `Partial` or `Complete` mode. It may also contain no aggregate expressions. For the first aggregation stage, the input projections are necessary, because it consume the outputs of non-Aggregate plans.
2. The final-like stages, including three conditions: 
    * the final (last) stage of aggregation stack
    * the (partial) merge stage merely for `nonDistinctAggAttributes` (the second stage of aggregation stack with one distinct)

   For final-like stages, we just pass through all output attributes of child plan.
3. The third stage of aggregation stack with one distinct,  in terms of aggregation modes, it contains both `Partial` mode (for distinctAgg) and `PartialMerge` mode (for nonDistinctAgg). For this stage, we need to switch the position of distinctAttributes and nonDistinctAttributes to match the output schema of the previous stage:
   *  the schema of the 2nd stage's outputs: _groupingAttributes ++ distinctAttributes ++ nonDistinctAggBufferAttributes_
   *  the schema of the 3rd stage's aggregate expressions: _nonDistinctMergeAggExpressions ++ distinctPartialAggExpressions_





