### PR TITLE
Improve UCX assertion to show the failed assertion

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -88,7 +88,8 @@ object GpuShuffleEnv extends Logging {
     managerOpt: Option[RapidsShuffleInternalManagerBase] = None): Unit = {
     if (managerOpt.isDefined) {
       val manager = managerOpt.get
-      assert(manager.getClass.getCanonicalName == GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS)
+      assert(manager.getClass.getCanonicalName == GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS,
+        s"${manager.getClass.getCanonicalName} != ${GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS}")
       logInfo("RapidsShuffleManager is initialized")
     }
     mgr = managerOpt

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -89,7 +89,7 @@ object GpuShuffleEnv extends Logging {
     if (managerOpt.isDefined) {
       val manager = managerOpt.get
       assert(manager.getClass.getCanonicalName == GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS,
-        s"${manager.getClass.getCanonicalName} != ${GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS}")
+        s"${manager.getClass.getCanonicalName} == ${GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS}")
       logInfo("RapidsShuffleManager is initialized")
     }
     mgr = managerOpt

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -88,8 +88,12 @@ object GpuShuffleEnv extends Logging {
     managerOpt: Option[RapidsShuffleInternalManagerBase] = None): Unit = {
     if (managerOpt.isDefined) {
       val manager = managerOpt.get
-      assert(manager.getClass.getCanonicalName == GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS,
-        s"${manager.getClass.getCanonicalName} == ${GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS}")
+      if (manager.getClass.getCanonicalName != GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS) {
+        throw new IllegalStateException(s"RapidsShuffleManager class mismatch (" +
+          s"${manager.getClass.getCanonicalName} != ${GpuShuffleEnv.RAPIDS_SHUFFLE_CLASS}). " +
+          s"Check that configuration setting spark.shuffle.manager is correct for the Spark " +
+          s"version being used.")
+      }
       logInfo("RapidsShuffleManager is initialized")
     }
     mgr = managerOpt


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

I had an error in my setup and got an `assertion failed` with no additional context. This PR simply shows what the failed assertion was, saving a bit of time in debugging.

## Before:

```
Caused by: java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:208)
	at org.apache.spark.sql.rapids.GpuShuffleEnv$.setRapidsShuffleManager(GpuShuffleEnv.scala:91)
```
## After:

```
Caused by: java.lang.AssertionError: assertion failed: com.nvidia.spark.rapids.spark301.RapidsShuffleManager == com.nvidia.spark.rapids.spark311.RapidsShuffleManager
	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.spark.sql.rapids.GpuShuffleEnv$.setRapidsShuffleManager(GpuShuffleEnv.scala:92)
```