### PR TITLE
Fix bug when collecting directly from a GPU shuffle query stage with AQE on

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -158,9 +158,11 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       p.withNewChildren(p.children.map(c => optimizeAdaptiveTransitions(c, Some(p))))
   }
 
-  private def isGpuShuffleLike(execNode: SparkPlan): Boolean =
-    execNode.isInstanceOf[GpuShuffleExchangeExecBase] ||
-      execNode.isInstanceOf[GpuCustomShuffleReaderExec]
+  private def isGpuShuffleLike(execNode: SparkPlan): Boolean = execNode match {
+    case _: GpuShuffleExchangeExecBase | _: GpuCustomShuffleReaderExec => true
+    case qs: ShuffleQueryStageExec => isGpuShuffleLike(qs.plan)
+    case _ => false
+  }
 
   /**
    * This optimizes the plan to remove [[GpuCoalesceBatches]] nodes that are unnecessary


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes #2901 

We have an optimization that removes `GpuCoalesceBatchesExec` from  `GpuColumnarToRowExec(GpuCoalesceBatchesExec(child))` if the child is not a GPU shuffle or shuffle reader. However, the code that determined if the child was a GPU shuffle did not handle the case where the child was a `ShuffleQueryStageExec` which can happen if the final query stage is a shuffle and we are directly collecting from that stage. In this case, the optimization was incorrectly removing the `GpuCoalesceBatchesExec`.

## Plan before this fix

```
== Physical Plan ==
AdaptiveSparkPlan (13)
+- == Final Plan ==
   GpuColumnarToRow (12)
   +- ShuffleQueryStage (11)
```

## Plan after this fix

```
AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   GpuColumnarToRow false
   +- GpuCoalesceBatches targetsize(2147483647)
      +- ShuffleQueryStage 1
```

## Testing

This PR is a draft because we need unit and/or integration tests for this case so that we don't have regressions. 

