### PR TITLE
Restore aggregation sorted data hint

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -500,10 +500,7 @@ class GpuHashAggregateIterator(
       override def next(): ColumnarBatch = {
         // batches coming out of the sort need to be merged
         withResource(keyBatchingIter.next()) { batch =>
-          // TODO: Normally we would want to hint to cudf that the data is already sorted on the
-          // grouping keys here, but this doesn't always produce the expected result due to a bug.
-          // See https://github.com/rapidsai/cudf/issues/8717 for details.
-          computeAggregate(GpuColumnVector.extractColumns(batch), merge = true, isSorted = false)
+          computeAggregate(GpuColumnVector.extractColumns(batch), merge = true, isSorted = true)
         }
       }
     }


### PR DESCRIPTION
After https://github.com/rapidsai/cudf/pull/8731,  the sorted data hint to libcudf when merging aggregated batches coming from the out-of-core sorter can be restored.