### PR TITLE
Make test event log compression codec configurable

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -227,6 +227,13 @@ SPARK_HISTORY_OPTS="-Dspark.history.fs.logDirectory=integration_tests/target/run
   ${SPARK_HOME}/bin/spark-class org.apache.spark.deploy.history.HistoryServer
 ```
 
+By default, integration tests write event logs using [Zstandard](https://facebook.github.io/zstd/)
+(`zstd`) compression codec. It can be changed by setting the environment variable `PYSP_TEST_spark_eventLog_compression_codec` to one of
+the SHS supported values for the config key
+[`spark.eventLog.compression.codec`](https://spark.apache.org/docs/3.1.1/configuration.html#spark-ui)
+
+With `zstd` it's easy to view / decompress event logs using the CLI `zstd -d [--stdout] <file>`
+
 ### Enabling cudf_udf Tests
 
 The cudf_udf tests in this framework are testing Pandas UDF(user-defined function) with cuDF. They are disabled by default not only because of the complicated environment setup, but also because GPU resources scheduling for Pandas UDF is an experimental feature now, the performance may not always be better.

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -233,6 +233,7 @@ the SHS supported values for the config key
 [`spark.eventLog.compression.codec`](https://spark.apache.org/docs/3.1.1/configuration.html#spark-ui)
 
 With `zstd` it's easy to view / decompress event logs using the CLI `zstd -d [--stdout] <file>`
+even without the SHS webUI.
 
 ### Enabling cudf_udf Tests
 

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -75,6 +75,7 @@ def _handle_event_log_dir(sb, wid):
                                 spark_conf.get("spark.master", 'local'))
     event_log_config = os.environ.get('PYSP_TEST_spark_eventLog_enabled',
                                       spark_conf.get('spark.eventLog.enabled', str(False).lower()))
+    event_log_codec = os.environ.get('PYSP_TEST_spark_eventLog_compression_codec', 'zstd')
 
     if not master_url.startswith('local') or event_log_config != str(False).lower():
         print("SPARK_EVENTLOG_ENABLED is ignored for non-local Spark master and when "
@@ -90,7 +91,8 @@ def _handle_event_log_dir(sb, wid):
     sb\
         .config('spark.eventLog.dir', "file://{}".format(os.path.abspath(d))) \
         .config('spark.eventLog.compress', True) \
-        .config('spark.eventLog.enabled', True)
+        .config('spark.eventLog.enabled', True) \
+        .config('spark.eventLog.compression.codec', event_log_codec)
 
 
 _spark = _spark__init()


### PR DESCRIPTION
- Switch to `zstd` for event log compression
- Make compression codec configurable

Signed-off-by: Gera Shegalov <gera@apache.org>