### PR TITLE
Fix childExprs list for GpuWindowExpression, for Spark 3.1.x.

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/OffsetWindowFunctionMeta.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/OffsetWindowFunctionMeta.scala
@@ -64,7 +64,7 @@ abstract class OffsetWindowFunctionMeta[INPUT <: OffsetWindowFunction] (
     GpuOverrides.wrapExpr(adjustedOffset, conf, Some(this))
   lazy val default: BaseExprMeta[_] = GpuOverrides.wrapExpr(expr.default, conf, Some(this))
 
-  override val childExprs: Seq[BaseExprMeta[_]] = Seq.empty
+  override val childExprs: Seq[BaseExprMeta[_]] = Seq(input, offset, default)
 
   override def tagExprForGpu(): Unit = {
     expr match {


### PR DESCRIPTION
Fixes #2939.

When the type-checking for expressions in `RapidsMeta` was changed in #2888 (i.e. commit 1a093229),
`OffsetWindowFunctionMeta` was modified to include `input`, `offset`, and `default` expressions among
its `childExprs`.
Unfortunately, the commit neglected to replicate that change in `Spark311Shims` `OffsetWindowFunctionMeta`.

The error manifests as a failure to do type-checks for `LEAD()`/`LAG()` window functions, with the message:
`java.lang.AssertionError: assertion failed: Lead expected at least 3 but found 0`.

This commit should remedy the situation, and allow `LEAD()`/`LAG()` to function correctly.
