### PR TITLE
Fix shutdown bugs in the RAPIDS Shuffle Manager

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -192,7 +192,7 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
         }
       }
 
-      worker.synchronized {
+      synchronized {
         logDebug("Exiting UCX progress thread.")
         Seq(endpointManager, worker, context).safeClose()
         worker = null
@@ -636,7 +636,7 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
     if (rapidsConf.shuffleUcxUseWakeup) {
       withResource(new NvtxRange("UCX Signal", NvtxColor.RED)) { _ =>
         // take up the worker object lock to protect against another `.close`
-        worker.synchronized {
+        synchronized {
           if (worker != null) {
             worker.signal()
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -260,6 +260,10 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
 
   private lazy val localBlockManagerId = blockManager.blockManagerId
 
+  // Used to prevent stopping multiple times RAPIDS Shuffle Manager internals.
+  // see the `stop` method
+  private var stopped: Boolean = false
+
   // Code that expects the shuffle catalog to be initialized gets it this way,
   // with error checking in case we are in a bad state.
   private def getCatalogOrThrow: ShuffleBufferCatalog =
@@ -404,9 +408,12 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
 
   override def shuffleBlockResolver: ShuffleBlockResolver = resolver
 
-  override def stop(): Unit = {
+  override def stop(): Unit = synchronized {
     wrapped.stop()
-    server.foreach(_.close())
-    transport.foreach(_.close())
+    if (!stopped) {
+      stopped = true
+      server.foreach(_.close())
+      transport.foreach(_.close())
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

While debugging another issue, I noticed these were causing NPEs in the logs.

- the `stop()` function in the shuffle manager can be called multiple times, so I am protecting against calling `.close()` multiple times in things like the bounce buffers
- the worker and context can be null at various times during shut down, protecting against that too and fixing the order of shutdown in UCX.scala so it doesn't happen.