### PR TITLE
Assert that CPU and GPU row fields match when present

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -30,6 +30,7 @@ def _assert_equal(cpu, gpu, float_check, path):
     if (t is Row):
         assert len(cpu) == len(gpu), "CPU and GPU row have different lengths at {} CPU: {} GPU: {}".format(path, len(cpu), len(gpu))
         if hasattr(cpu, "__fields__") and hasattr(gpu, "__fields__"):
+            assert cpu.__fields__ == gpu.__fields__, "CPU and GPU row have different fields at {} CPU: {} GPU: {}".format(path, cpu.__fields__, gpu.__fields__)
             for field in cpu.__fields__:
                 _assert_equal(cpu[field], gpu[field], float_check, path + [field])
         else:


### PR DESCRIPTION
While investigating #2965, I noticed that the assert code was checking if both the CPU and GPU had fields but was not verifying that the two had the _same fields_.  This adds a sanity check that the CPU and GPU fields match before trying to lookup values by the field names.