### PR TITLE
Qualification tool: fix performance regression

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -85,14 +85,13 @@ abstract class AppBase(
       logFiles.foreach { file =>
         Utils.tryWithResource(openEventLogInternal(file.getPath, fs)) { in =>
           val lines = Source.fromInputStream(in)(Codec.UTF8).getLines().toList
-          var isDone = false
           // Using find as foreach with conditional to exit early if we are done.
           // Do NOT use a while loop as it is much much slower.
           lines.find { line =>
-            try {
+            val isDone = try {
               totalNumEvents += 1
               val event = JsonProtocol.sparkEventFromJson(parse(line))
-              isDone = processEvent(event)
+              processEvent(event)
             }
             catch {
               case e: ClassNotFoundException =>
@@ -101,6 +100,7 @@ abstract class AppBase(
                 if (!e.getMessage.contains("SparkListenerResourceProfileAdded")) {
                   logWarning(s"ClassNotFoundException: ${e.getMessage}")
                 }
+                false
             }
             isDone
           }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/2972

It turns out this while loop is 4-5x slower. One particular event log took about 4.5 seconds to process before and when we switched to use while it took slower to 20 seconds.  

In this case we use find{} instead to loop through all elements until we hit an event that says we are done. The done is really only used for the app filtering logic when we want to stop processing the event log after the app start event.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
