### PR TITLE
[auto-merge] branch-21.08 to branch-21.10 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-21.06
+    - branch-21.08
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-21.06 # force to fetch from latest upstream instead of PR ref
+          ref: branch-21.08 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-21.06
-          BASE: branch-21.08
+          HEAD: branch-21.08
+          BASE: branch-21.10
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-21.08` to create a PR keeping `branch-21.10` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.