### PR TITLE
Avoid struct aliasing in test_round_robin_sort_fallback

### DIFF
--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -132,7 +132,8 @@ def test_repartition_df(data_gen, num_parts, length):
         ('a_1_2', float_gen),
         ('a_1_3', double_gen)
       ])),
-      ('b_1', long_gen)
+      ('b_1', long_gen),
+      ('c_1', int_gen)
     ]))],
     [('a', simple_string_to_string_map_gen)]], ids=idfn)
 @ignore_order(local=True) # To avoid extra data shuffle by 'sort on Spark' for this repartition test.


### PR DESCRIPTION
This fixes #2965 by adding yet another struct field to avoid aliasing with the top-level schema which is also a struct-with-long.
