### PR TITLE
Update documentation for unsupported edge cases when casting from string to timestamp

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -541,7 +541,12 @@ Casting from string to timestamp currently has the following limitations.
 
 - <a name="Footnote1"></a>[1] The timestamp portion must be complete in terms of hours, minutes, seconds, and
  milliseconds, with 2 digits each for hours, minutes, and seconds, and 6 digits for milliseconds. 
- Only timezone 'Z' (UTC) is supported. Casting unsupported formats will result in null values. 
+ Only timezone 'Z' (UTC) is supported. Casting unsupported formats will result in null values.
+
+Spark is very lenient when casting from string to timestamp because all date and time components
+are optional, meaning that input values such as `T`, `T2`, `:`, `::`, `1:`, `:1`, and `::1`
+are considered valid timestamps. The GPU will treat these values as invalid and cast them to null
+values.
 
 ### Constant Folding
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Related to #2889

I started down the path of trying to support all the edge cases, and also looked at having a regex to detect the edge cases and throw an error, but even that seems to be a fair bit of work, so perhaps we are better off just documenting this.