### PR TITLE
Remove commented/redundant window-function tests.

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -86,18 +86,6 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
                 "row_num", "count_all")
     }
 
-  /* There is no easy way to make dateLong not nullable with how these test are written
-  Very similar functionality is covered by the python integration tests.  When
-  https://github.com/NVIDIA/spark-rapids/issues/1039 is fixed then we can enable these tests again
-  testSparkResultsAreEqual("[Window] [ROWS/RANGE] [default] ", windowTestDfOrcNonNullable,
-      execsAllowedNonGpu=Seq("DeserializeToObjectExec", "CreateExternalRow",
-        "Invoke", "StaticInvoke"), skipCanonicalizationCheck = skipRangeCanon) {
-    val rowsWindow = Window.partitionBy("uid")
-        .orderBy("dateLong")
-    windowAggregationTester(rowsWindow)
-  }
-  */
-
   testSparkResultsAreEqual("[Window] [ROWS] [-2, 3] ", windowTestDfOrc) {
     val rowsWindow = Window.partitionBy("uid")
                            .orderBy("uid", "dateLong", "dollars")
@@ -277,36 +265,6 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
     testAllWindowAggregations(windowClause)
   }
 
-  /* There is no easy way to make dateLong not nullable with how these test are written
-  Very similar functionality is covered by the python integration tests.  When
-  https://github.com/NVIDIA/spark-rapids/issues/1039 is fixed then we can enable these tests again
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [-2 DAYS, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC
-        | RANGE BETWEEN INTERVAL 2 DAYS PRECEDING AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [-2 DAYS, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC
-        | RANGE BETWEEN INTERVAL 2 DAYS PRECEDING AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-  */
-
   testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [CURRENT ROW, 3 DAYS] ", windowTestDfOrc,
     skipCanonicalizationCheck = skipRangeCanon) {
 
@@ -425,139 +383,6 @@ class WindowFunctionSuite extends SparkQueryCompareTestSuite {
 
     testAllWindowAggregations(windowClause)
   }
-
-
-  /* There is no easy way to make dateLong not nullable with how these test are written
-  Very similar functionality is covered by the python integration tests.  When
-  https://github.com/NVIDIA/spark-rapids/issues/1039 is fixed then we can enable these tests again
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [CURRENT ROW, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC
-        | RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [CURRENT ROW, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC
-        | RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [UNBOUNDED PRECEDING, 3 DAYS] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND INTERVAL 3 DAYS FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [UNBOUNDED PRECEDING, 3 DAYS] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND INTERVAL 3 DAYS FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [UNBOUNDED PRECEDING, CURRENT ROW] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [UNBOUNDED PRECEDING, CURRENT ROW] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [UNBOUNDED PRECEDING, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [UNBOUNDED PRECEDING, UNBOUNDED FOLLOWING] ",
-      windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC
-        | RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [ ASC] [Unspecified bounds] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) ASC)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-
-  testSparkResultsAreEqual("[Window] [RANGE] [DESC] [Unspecified bounds] ", windowTestDfOrc,
-    skipCanonicalizationCheck = skipRangeCanon) {
-
-    val windowClause =
-      """
-        | (PARTITION BY uid
-        | ORDER BY CAST(dateLong AS TIMESTAMP) DESC)
-        |""".stripMargin
-
-    testAllWindowAggregations(windowClause)
-  }
-  */
 
   IGNORE_ORDER_testSparkResultsAreEqual("[Window] [MIXED WINDOW SPECS] ",
       windowTestDfOrc, skipCanonicalizationCheck = skipRangeCanon) {


### PR DESCRIPTION
This commit removes commented tests from WindowFunctionSuite.
The null-`ORDER BY` column cases are already tested as part of
`window_function_test.py`.

Signed-off-by: Mithun RK <mythrocks@gmail.com>