### PR TITLE
Tweak RAPIDS Shuffle Manager configs for 21.08

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -303,10 +303,9 @@ In this section, we are using a docker container built using the sample dockerfi
     --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
     --conf spark.shuffle.service.enabled=false \
     --conf spark.dynamicAllocation.enabled=false \
+    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
     --conf spark.executorEnv.UCX_ERROR_SIGNALS= \
-    --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
-    --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
-    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
+    --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n
     ```
 
     Recommended configuration:
@@ -316,13 +315,13 @@ In this section, we are using a docker container built using the sample dockerfi
     --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
     --conf spark.shuffle.service.enabled=false \
     --conf spark.dynamicAllocation.enabled=false \
-    --conf spark.executorEnv.UCX_TLS=cuda_copy,cuda_ipc,rc,tcp \
+    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
     --conf spark.executorEnv.UCX_ERROR_SIGNALS= \
-    --conf spark.executorEnv.UCX_RNDV_SCHEME=put_zcopy \
-    --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1 \
     --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
     --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
-    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
+    --conf spark.executorEnv.UCX_TLS=cuda_copy,cuda_ipc,rc,tcp \
+    --conf spark.executorEnv.UCX_RNDV_SCHEME=put_zcopy \
+    --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1
     ```
 
 Please note `LD_LIBRARY_PATH` should optionally be set if the UCX library is installed in a

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -300,7 +300,7 @@ In this section, we are using a docker container built using the sample dockerfi
 
     ```shell
     ...
-    --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
+    --conf spark.shuffle.manager=com.nvidia.spark.rapids.[shim package].RapidsShuffleManager \
     --conf spark.shuffle.service.enabled=false \
     --conf spark.dynamicAllocation.enabled=false \
     --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
@@ -312,7 +312,7 @@ In this section, we are using a docker container built using the sample dockerfi
 
     ```shell
     ...
-    --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
+    --conf spark.shuffle.manager=com.nvidia.spark.rapids.[shim package].RapidsShuffleManager \
     --conf spark.shuffle.service.enabled=false \
     --conf spark.dynamicAllocation.enabled=false \
     --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR} \
@@ -323,6 +323,9 @@ In this section, we are using a docker container built using the sample dockerfi
     --conf spark.executorEnv.UCX_RNDV_SCHEME=put_zcopy \
     --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1
     ```
+
+Please replace `[shim package]` with the appropriate value. For example, the full class name for
+Apache Spark 3.1.3 is: `com.nvidia.spark.rapids.spark313.RapidsShuffleManager`.
 
 Please note `LD_LIBRARY_PATH` should optionally be set if the UCX library is installed in a
 non-standard location.

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -294,19 +294,36 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.1.2      | com.nvidia.spark.rapids.spark312.RapidsShuffleManager    |
     | 3.1.3      | com.nvidia.spark.rapids.spark313.RapidsShuffleManager    |
 
-2. Recommended settings for UCX 1.10.1+
-```shell
-...
---conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
---conf spark.shuffle.service.enabled=false \
---conf spark.executorEnv.UCX_TLS=cuda_copy,cuda_ipc,rc,tcp \
---conf spark.executorEnv.UCX_ERROR_SIGNALS= \
---conf spark.executorEnv.UCX_RNDV_SCHEME=put_zcopy \
---conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1 \
---conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
---conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
---conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
-```
+2. Settings for UCX 1.10.1+:
+
+    Minimum configuration:
+
+    ```shell
+    ...
+    --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
+    --conf spark.shuffle.service.enabled=false \
+    --conf spark.dynamicAllocation.enabled=false \
+    --conf spark.executorEnv.UCX_ERROR_SIGNALS= \
+    --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
+    --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
+    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
+    ```
+
+    Recommended configuration:
+
+    ```shell
+    ...
+    --conf spark.shuffle.manager=com.nvidia.spark.rapids.spark301.RapidsShuffleManager \
+    --conf spark.shuffle.service.enabled=false \
+    --conf spark.dynamicAllocation.enabled=false \
+    --conf spark.executorEnv.UCX_TLS=cuda_copy,cuda_ipc,rc,tcp \
+    --conf spark.executorEnv.UCX_ERROR_SIGNALS= \
+    --conf spark.executorEnv.UCX_RNDV_SCHEME=put_zcopy \
+    --conf spark.executorEnv.UCX_MAX_RNDV_RAILS=1 \
+    --conf spark.executorEnv.UCX_MEMTYPE_CACHE=n \
+    --conf spark.executorEnv.UCX_IB_RX_QUEUE_LEN=1024 \
+    --conf spark.executor.extraClassPath=${SPARK_CUDF_JAR}:${SPARK_RAPIDS_PLUGIN_JAR}
+    ```
 
 Please note `LD_LIBRARY_PATH` should optionally be set if the UCX library is installed in a
 non-standard location.

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -290,9 +290,9 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.0.3      | com.nvidia.spark.rapids.spark303.RapidsShuffleManager    |
     | 3.0.4      | com.nvidia.spark.rapids.spark304.RapidsShuffleManager    |
     | 3.1.1      | com.nvidia.spark.rapids.spark311.RapidsShuffleManager    |
+    | 3.1.1 CDH  | com.nvidia.spark.rapids.spark311cdh.RapidsShuffleManager |
     | 3.1.2      | com.nvidia.spark.rapids.spark312.RapidsShuffleManager    |
     | 3.1.3      | com.nvidia.spark.rapids.spark313.RapidsShuffleManager    |
-    | 3.2.0      | com.nvidia.spark.rapids.spark320.RapidsShuffleManager    |
 
 2. Recommended settings for UCX 1.10.1+
 ```shell


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

- The RAPIDS Shuffle Manager class for the CDH shim was missing, so this adds it.  I also removed the Spark 3.2.0 manager since support for this version of Spark is currently being worked on and is not available for 21.08.

- I also changed the configs to specify that `dynamicAllocation` be disabled, as some cluster managers enable it by default, especially with ESS.

-  Now the doc has minimum and recommended settings to make the distinction clear.