### PR TITLE
Propagate child output ordering in GpuCoalesceBatches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -554,7 +554,7 @@ case class GpuCoalesceBatches(child: SparkPlan, goal: CoalesceGoal)
     case batchingGoal: BatchedByKey =>
       batchingGoal.order
     case _ =>
-      super.outputOrdering
+      child.outputOrdering
   }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {


### PR DESCRIPTION
Fixes #3002.

`GpuCoalesceBatches` was failing to propagate the child output ordering.  This can force the plan to re-sort the data on a subset of the keys that the plan had already sorted on, and without forcing a stable sort can cause inadvertent reordering of data.