### PR TITLE
Check validity of any() or all() results that could be null

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -134,6 +134,19 @@ def test_int96_write_conf(spark_tmp_path, data_gen):
                  'spark.rapids.sql.format.parquet.writer.int96.enabled': 'false'})
     with_gpu_session(lambda spark: unary_op_df(spark, data_gen).coalesce(1).write.parquet(data_path), conf=confs)
 
+def test_all_null_int96(spark_tmp_path):
+    class AllNullTimestampGen(TimestampGen):
+        def start(self, rand):
+            self._start(rand, lambda : None)
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    confs = writer_confs.copy()
+    confs.update({'spark.sql.parquet.outputTimestampType': 'INT96'})
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        lambda spark, path : unary_op_df(spark, AllNullTimestampGen()).coalesce(1).write.parquet(path),
+        lambda spark, path : spark.read.parquet(path),
+        data_path,
+        conf=confs)
+
 parquet_write_compress_options = ['none', 'uncompressed', 'snappy']
 @pytest.mark.parametrize('compress', parquet_write_compress_options)
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/RebaseHelper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/RebaseHelper.scala
@@ -33,7 +33,7 @@ object RebaseHelper extends Arm {
       withResource(Scalar.timestampDaysFromInt(startDay)) { minGood =>
         withResource(column.lessThan(minGood)) { hasBad =>
           withResource(hasBad.any()) { a =>
-            a.getBoolean
+            a.isValid && a.getBoolean
           }
         }
       }
@@ -45,7 +45,7 @@ object RebaseHelper extends Arm {
         Scalar.timestampFromLong(DType.TIMESTAMP_MICROSECONDS, startTs)) { minGood =>
         withResource(column.lessThan(minGood)) { hasBad =>
           withResource(hasBad.any()) { a =>
-            a.getBoolean
+            a.isValid && a.getBoolean
           }
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -303,7 +303,7 @@ class GpuParquetWriter(
                       withResource(int64.lessOrEqualTo(lower)) { b =>
                         withResource(a.or(b)) { aOrB =>
                           withResource(aOrB.any()) { any =>
-                            if (any.getBoolean()) {
+                            if (any.isValid && any.getBoolean) {
                               // its the writer's responsibility to close the batch
                               batch.close()
                               throw new IllegalArgumentException("INT96 column contains one " +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -165,7 +165,7 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
         if (failOnError) {
           withResource(lhs.getBase.getMapKeyExistence(rhs.getBase)){ keyExistenceColumn =>
             withResource(keyExistenceColumn.all()) { exist =>
-              if (exist.getBoolean) {
+              if (!exist.isValid || exist.getBoolean) {
                 lhs.getBase.getMapValue(rhs.getBase)
               } else {
                 throw new NoSuchElementException(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -187,7 +187,7 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
     if (failOnError){
       withResource(lhs.getBase.getMapKeyExistence(rhs.getBase)) { keyExistenceColumn =>
         withResource(keyExistenceColumn.all) { exist =>
-          if (!exist.getBoolean) {
+          if (exist.isValid && !exist.getBoolean) {
             throw new NoSuchElementException(
               s"Key: ${rhs.getValue.asInstanceOf[UTF8String].toString} " +
                 s"does not exist in any one of the rows in the map column")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -638,6 +638,15 @@ class CastOpSuite extends GpuExpressionTestSuite {
     }
   }
 
+  test("ansi cast null ints to decimal") {
+    testCastToDecimal(DataTypes.IntegerType, -5,
+      customDataGenerator = Some((spark: SparkSession) => {
+        import spark.implicits._
+        Seq[Integer](null, null, null).toDF("col")
+      }),
+      ansiEnabled = true)
+  }
+
   test("cast long to decimal") {
     List(-18, -10, -3, 0, 1, 5, 15).foreach { scale =>
       testCastToDecimal(DataTypes.LongType, scale,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.RebaseHelper
+import org.scalatest.FunSuite
+
+class RebaseHelperSuite extends FunSuite with Arm {
+  test("all null timestamp days column rebase check") {
+    withResource(ColumnVector.timestampDaysFromBoxedInts(null, null, null)) { c =>
+      assertResult(false)(RebaseHelper.isDateTimeRebaseNeededWrite(c))
+      assertResult(false)(RebaseHelper.isDateTimeRebaseNeededRead(c))
+    }
+  }
+
+  test("all null timestamp microseconds column rebase check") {
+    withResource(ColumnVector.timestampMicroSecondsFromBoxedLongs(null, null, null)) { c =>
+      assertResult(false)(RebaseHelper.isDateTimeRebaseNeededWrite(c))
+      assertResult(false)(RebaseHelper.isDateTimeRebaseNeededRead(c))
+    }
+  }
+}


### PR DESCRIPTION
While reviewing the legacy timestamp casting changes, I noticed that `any()` and `all()` can return a null scalar result, but there are places in the plugin code where it blindly assumes the value cannot be null.  This updates those locations to check for validity of the scalar before checking the value, as it's undefined behavior to access a null scalar value.