### PR TITLE
Handle mmap exception more gracefully in RapidsShuffleServer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -16,12 +16,15 @@
 
 package com.nvidia.spark.rapids.shuffle
 
+import java.io.IOException
+
 import ai.rapids.cudf.{Cuda, MemoryBuffer}
 import com.nvidia.spark.rapids.{Arm, RapidsBuffer, ShuffleMetadata, StorageTier}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, BufferTransferRequest}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.RapidsShuffleSendPrepareException
 
 /**
  * A helper case class to maintain the server side state in response to a transfer
@@ -54,7 +57,7 @@ class BufferSendState(
     sendBounceBuffers: SendBounceBuffers,
     requestHandler: RapidsShuffleRequestHandler,
     serverStream: Cuda.Stream = Cuda.DEFAULT_STREAM)
-    extends Iterator[MemoryBuffer] with AutoCloseable with Logging with Arm {
+    extends AutoCloseable with Logging with Arm {
 
   class SendBlock(val bufferId: Int, tableSize: Long) extends BlockWithSize {
     override def size: Long = tableSize
@@ -114,7 +117,7 @@ class BufferSendState(
     transaction
   }
 
-  def hasNext: Boolean = synchronized { hasMoreBlocks }
+  def hasMoreSends: Boolean = synchronized { hasMoreBlocks }
 
   private[this] def freeBounceBuffers(): Unit = {
     sendBounceBuffers.close()
@@ -148,7 +151,7 @@ class BufferSendState(
     }
   }
 
-  def next(): MemoryBuffer = synchronized {
+  def tryGetBufferToSend(): MemoryBuffer = synchronized {
     require(acquiredBuffs.isEmpty,
       "Called next without calling `releaseAcquiredToCatalog` first")
 
@@ -185,11 +188,32 @@ class BufferSendState(
           hostBounceBuffer.buffer
         }
 
-        acquiredBuffs.foreach { case RangeBuffer(blockRange, rapidsBuffer) =>
-          require(blockRange.rangeSize() <= bounceBuffToUse.getLength - buffOffset)
-          rapidsBuffer.copyToMemoryBuffer(blockRange.rangeStart, bounceBuffToUse, buffOffset,
-            blockRange.rangeSize(), serverStream)
-          buffOffset += blockRange.rangeSize()
+        // `copyToMemoryBuffer` can throw if the `RapidsBuffer` is in the DISK tier and
+        // the file fails to mmap. We catch the `IOException` and attempt a retry
+        // in the server.
+        var needsCleanup = false
+        try {
+          acquiredBuffs.foreach { case RangeBuffer(blockRange, rapidsBuffer) =>
+            needsCleanup = true
+            require(blockRange.rangeSize() <= bounceBuffToUse.getLength - buffOffset)
+            rapidsBuffer.copyToMemoryBuffer(blockRange.rangeStart, bounceBuffToUse, buffOffset,
+              blockRange.rangeSize(), serverStream)
+            buffOffset += blockRange.rangeSize()
+          }
+          needsCleanup = false
+        } catch {
+          case ioe: IOException =>
+            val ex = new RapidsShuffleSendPrepareException(
+              s"Error while copying to bounce buffer for executor ${peerExecutorId} and " +
+                  s"header ${TransportUtils.toHex(peerBufferReceiveHeader)}")
+            ex.addSuppressed(ioe)
+            throw ex
+        } finally {
+          if (needsCleanup) {
+            // we likely failed in `copyToMemoryBuffer`
+            // unacquire buffs (removing ref count)
+            releaseAcquiredToCatalog()
+          }
         }
 
         val buffSlice = bounceBuffToUse.slice(0, buffOffset)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -331,7 +331,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
           // For each `BufferSendState` we ask for a bounce buffer fill up
           // so the server is servicing N (`bufferSendStates`) requests
           try {
-            val buffersToSend = bufferSendState.tryGetBufferToSend()
+            val buffersToSend = bufferSendState.getBufferToSend()
             bssBuffers.append((bufferSendState, buffersToSend))
           } catch {
             case ex: RapidsShuffleSendPrepareException =>

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
@@ -36,5 +36,7 @@ class RapidsShuffleTimeoutException(message: String) extends Exception(message)
  * Internal exception thrown by `BufferSendState` in case where it detects
  * an `IOException` when copying buffers into a bounce buffer that it is preparing.
  * @param message - string describing the issue
+ * @param cause - causing exception, or null
  */
-class RapidsShuffleSendPrepareException(message: String) extends Exception(message)
+class RapidsShuffleSendPrepareException(message: String, cause: Throwable)
+    extends Exception(message, cause)

--- a/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/shuffle/RapidsShuffleExceptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,3 +31,10 @@ class RapidsShuffleFetchFailedException(
 }
 
 class RapidsShuffleTimeoutException(message: String) extends Exception(message)
+
+/**
+ * Internal exception thrown by `BufferSendState` in case where it detects
+ * an `IOException` when copying buffers into a bounce buffer that it is preparing.
+ * @param message - string describing the issue
+ */
+class RapidsShuffleSendPrepareException(message: String) extends Exception(message)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.shuffle
 
+import java.io.IOException
 import java.nio.ByteBuffer
 import java.util
 
@@ -107,12 +108,12 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
-          assert(bss.hasNext)
-          val mb = bss.next()
+          assert(bss.hasMoreSends)
+          val mb = bss.tryGetBufferToSend()
           val receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
           assertResult(10000)(mb.getLength)
-          assert(!bss.hasNext)
+          assert(!bss.hasMoreSends)
           bss.releaseAcquiredToCatalog()
           mockBuffers.foreach { b: RapidsBuffer =>
             // should have seen 2 closes, one for BufferSendState acquiring for metadata
@@ -138,16 +139,16 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
-          var buffs = bss.next()
+          var buffs = bss.tryGetBufferToSend()
           var receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
-          assert(bss.hasNext)
+          assert(bss.hasMoreSends)
           bss.releaseAcquiredToCatalog()
 
-          buffs = bss.next()
+          buffs = bss.tryGetBufferToSend()
           receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
-          assert(!bss.hasNext)
+          assert(!bss.hasMoreSends)
           bss.releaseAcquiredToCatalog()
 
           mockBuffers.foreach { b: RapidsBuffer =>
@@ -176,12 +177,12 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
           (0 until 246).foreach { _ =>
-            bss.next()
+            bss.tryGetBufferToSend()
             val receiveBlocks = receiveWindow.next()
             compareRanges(bounceBuffer, receiveBlocks)
             bss.releaseAcquiredToCatalog()
           }
-          assert(!bss.hasNext)
+          assert(!bss.hasMoreSends)
         }
         mockBuffers.foreach { b: RapidsBuffer =>
           verify(b, times(numCloses.get(b))).close()
@@ -251,6 +252,179 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         verify(mockRequestHandler, times(3))
           .acquireShuffleBuffer(ArgumentMatchers.eq(1))
         verify(rapidsBuffer, times(3)).close()
+      }
+    }
+  }
+
+  test("when we fail to prepare a send, throw if nothing can be handled") {
+    val mockSendBuffer = mock[SendBounceBuffers]
+    val mockDeviceBounceBuffer = mock[BounceBuffer]
+    withResource(DeviceMemoryBuffer.allocate(123)) { buff =>
+      when(mockDeviceBounceBuffer.buffer).thenReturn(buff)
+      when(mockSendBuffer.bounceBufferSize).thenReturn(buff.getLength)
+      when(mockSendBuffer.hostBounceBuffer).thenReturn(None)
+      when(mockSendBuffer.deviceBounceBuffer).thenReturn(mockDeviceBounceBuffer)
+
+      when(mockTransport.tryGetSendBounceBuffers(any(), any()))
+          .thenReturn(Seq(mockSendBuffer))
+
+      val tr = ShuffleMetadata.buildTransferRequest(0, Seq(1))
+      when(mockTransaction.getStatus)
+          .thenReturn(TransactionStatus.Success)
+      when(mockTransaction.releaseMessage()).thenReturn(
+        new MetadataTransportBuffer(new RefCountedDirectByteBuffer(tr)))
+
+      val mockServerConnection = mock[ServerConnection]
+      val mockRequestHandler = mock[RapidsShuffleRequestHandler]
+      val rapidsBuffer = mock[RapidsBuffer]
+
+      val bb = ByteBuffer.allocateDirect(123)
+      withResource(new RefCountedDirectByteBuffer(bb)) { _ =>
+        val tableMeta = MetaUtils.buildTableMeta(1, 456, bb, 100)
+        when(rapidsBuffer.meta).thenReturn(tableMeta)
+        when(rapidsBuffer.size).thenReturn(tableMeta.bufferMeta().size())
+        when(mockRequestHandler.acquireShuffleBuffer(ArgumentMatchers.eq(1)))
+            .thenReturn(rapidsBuffer)
+
+        val server = spy(new RapidsShuffleServer(
+          mockTransport,
+          mockServerConnection,
+          RapidsShuffleTestHelper.makeMockBlockManager("1", "foo"),
+          mockRequestHandler,
+          mockExecutor,
+          mockBssExecutor,
+          mockConf))
+
+        server.start()
+
+        when(rapidsBuffer.copyToMemoryBuffer(any(), any(), any(), any(), any()))
+            .thenAnswer(_ => {
+              throw new IOException("mmap failed in test")
+            })
+
+        val bss = new BufferSendState(mockTransaction, mockSendBuffer, mockRequestHandler, null)
+        // if nothing else can be handled, we throw
+        assertThrows[IllegalStateException] {
+          server.doHandleTransferRequest(Seq(bss))
+        }
+
+        // since nothing could be handled, we don't try again
+        verify(server, times(0)).addToContinueQueue(any())
+
+        // bounce buffers are freed
+        verify(mockSendBuffer, times(1)).close()
+
+        // acquire 2 times, 1 to make the ranges, and the 2 before the copy
+        // close 2 times corresponding to each open
+        verify(mockRequestHandler, times(2))
+            .acquireShuffleBuffer(ArgumentMatchers.eq(1))
+        verify(rapidsBuffer, times(2)).close()
+      }
+    }
+  }
+
+  test("when we fail to prepare a send, re-queue the request if anything can be handled") {
+    val mockSendBuffer = mock[SendBounceBuffers]
+    val mockDeviceBounceBuffer = mock[BounceBuffer]
+    withResource(DeviceMemoryBuffer.allocate(123)) { buff =>
+      when(mockDeviceBounceBuffer.buffer).thenReturn(buff)
+      when(mockSendBuffer.bounceBufferSize).thenReturn(buff.getLength)
+      when(mockSendBuffer.hostBounceBuffer).thenReturn(None)
+      when(mockSendBuffer.deviceBounceBuffer).thenReturn(mockDeviceBounceBuffer)
+
+      when(mockTransport.tryGetSendBounceBuffers(any(), any()))
+          .thenReturn(Seq(mockSendBuffer))
+
+      val tr = ShuffleMetadata.buildTransferRequest(0, Seq(1))
+      when(mockTransaction.getStatus)
+          .thenReturn(TransactionStatus.Success)
+      when(mockTransaction.releaseMessage()).thenReturn(
+        new MetadataTransportBuffer(new RefCountedDirectByteBuffer(tr)))
+
+      val tr2 = ShuffleMetadata.buildTransferRequest(0, Seq(2))
+      val mockTransaction2 = mock[Transaction]
+      when(mockTransaction2.getStatus)
+          .thenReturn(TransactionStatus.Success)
+      when(mockTransaction2.releaseMessage()).thenReturn(
+        new MetadataTransportBuffer(new RefCountedDirectByteBuffer(tr2)))
+
+      val mockServerConnection = mock[ServerConnection]
+      val ac = ArgumentCaptor.forClass(classOf[TransactionCallback])
+      when(mockServerConnection.send(
+        any(), any(), any(), any[MemoryBuffer](), ac.capture())).thenReturn(mockTransaction)
+
+      val mockRequestHandler = mock[RapidsShuffleRequestHandler]
+
+      def makeMockBuffer(tableId: Int, bb: ByteBuffer): RapidsBuffer = {
+        val rapidsBuffer = mock[RapidsBuffer]
+        val tableMeta = MetaUtils.buildTableMeta(tableId, 456, bb, 100)
+        when(rapidsBuffer.meta).thenReturn(tableMeta)
+        when(rapidsBuffer.size).thenReturn(tableMeta.bufferMeta().size())
+        when(mockRequestHandler.acquireShuffleBuffer(ArgumentMatchers.eq(tableId)))
+            .thenReturn(rapidsBuffer)
+        rapidsBuffer
+      }
+
+      val bb = ByteBuffer.allocateDirect(123)
+      val bb2 = ByteBuffer.allocateDirect(123)
+      withResource(new RefCountedDirectByteBuffer(bb)) { _ =>
+        withResource(new RefCountedDirectByteBuffer(bb2)) { _ =>
+          val rapidsBuffer = makeMockBuffer(1, bb)
+          val rapidsBuffer2 = makeMockBuffer(2, bb2)
+
+          // error with copy
+          when(rapidsBuffer.copyToMemoryBuffer(any(), any(), any(), any(), any()))
+              .thenAnswer(_ => {
+                throw new IOException("mmap failed in test")
+              })
+
+          // successful copy
+          doNothing()
+              .when(rapidsBuffer2)
+              .copyToMemoryBuffer(any(), any(), any(), any(), any())
+
+          val server = spy(new RapidsShuffleServer(
+            mockTransport,
+            mockServerConnection,
+            RapidsShuffleTestHelper.makeMockBlockManager("1", "foo"),
+            mockRequestHandler,
+            mockExecutor,
+            mockBssExecutor,
+            mockConf))
+
+          server.start()
+
+          val bssFailed = new BufferSendState(
+            mockTransaction, mockSendBuffer, mockRequestHandler, null)
+
+          val bssSuccess = spy(new BufferSendState(
+            mockTransaction2, mockSendBuffer, mockRequestHandler, null))
+
+          when(bssSuccess.hasMoreSends)
+              .thenReturn(true) // send 1 bounce buffer length
+              .thenReturn(false)
+
+          // if something else can be handled we don't throw, and re-queue
+          server.doHandleTransferRequest(Seq(bssFailed, bssSuccess))
+
+          val cb = ac.getValue.asInstanceOf[TransactionCallback]
+          cb(mockTransaction)
+
+          verify(server, times(1)).addToContinueQueue(any())
+
+          // the bounce buffer is freed 1 time for `bssSuccess`, but not for `bssFailed`
+          verify(mockSendBuffer, times(1)).close()
+
+          // acquire/close 4 times =>
+          // we had two requests for 1 buffer, and each request acquires 2 times and closes
+          // 2 times.
+          verify(mockRequestHandler, times(2))
+              .acquireShuffleBuffer(ArgumentMatchers.eq(1))
+          verify(mockRequestHandler, times(2))
+              .acquireShuffleBuffer(ArgumentMatchers.eq(2))
+          verify(rapidsBuffer, times(2)).close()
+          verify(rapidsBuffer2, times(2)).close()
+        }
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
@@ -109,7 +109,7 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
           assert(bss.hasMoreSends)
-          val mb = bss.tryGetBufferToSend()
+          val mb = bss.getBufferToSend()
           val receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
           assertResult(10000)(mb.getLength)
@@ -139,13 +139,13 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         val (handler, mockBuffers, numCloses) = setupMocks(deviceBuffers)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
-          var buffs = bss.tryGetBufferToSend()
+          var buffs = bss.getBufferToSend()
           var receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
           assert(bss.hasMoreSends)
           bss.releaseAcquiredToCatalog()
 
-          buffs = bss.tryGetBufferToSend()
+          buffs = bss.getBufferToSend()
           receiveBlocks = receiveWindow.next()
           compareRanges(bounceBuffer, receiveBlocks)
           assert(!bss.hasMoreSends)
@@ -177,7 +177,7 @@ class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
         val receiveWindow = new WindowedBlockIterator[MockBlockWithSize](receiveSide, 10000)
         withResource(new BufferSendState(mockTx, bounceBuffer, handler)) { bss =>
           (0 until 246).foreach { _ =>
-            bss.tryGetBufferToSend()
+            bss.getBufferToSend()
             val receiveBlocks = receiveWindow.next()
             compareRanges(bounceBuffer, receiveBlocks)
             bss.releaseAcquiredToCatalog()


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Improves handling of a potential `IOException` when attempting to `mmap` in a system without resources, with many small shuffle blocks, or with low settings for `vm.max_map_count`. This is an improvement related to https://github.com/NVIDIA/spark-rapids/issues/3040, but it is not the full solution.

The root of the problem is that the spilled blocks can be many, and that each block is likely to get `mmap`ed when read or transmitted. When we have many small blocks, the access pattern in `RapidsShuffleServer` can create issues as documented in https://github.com/NVIDIA/spark-rapids/issues/3040.

With this code, I can get q72 at 3TB to fail to `mmap` when there is a surge of requests, but reattempt the `mmap` successfully. Note that this doesn't prevent other parts of the system to fail when we are close to the OS limits. 