### PR TITLE
Tweak scaladoc to callout the GDS+unspill case in copyBuffer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -124,7 +124,8 @@ abstract class RapidsBufferStore(
    * This does not need to update the catalog, the caller is responsible for that.
    * @param buffer data from another store
    * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. It will be closed
-   *                     by this method
+   *                     by this method unless `memoryBuffer` is already on the device, which is
+   *                     the case when GDS is enabled and we are unspilling.
    * @param stream CUDA stream to use for copy or null
    * @return new buffer that was created
    */
@@ -202,7 +203,8 @@ abstract class RapidsBufferStore(
    * @note DO NOT close the buffer unless adding a reference!
    * @param buffer data from another store
    * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. It will be closed
-   *                     by this method
+   *                     by this method unless `memoryBuffer` is already on the device, which is
+   *                     the case when GDS is enabled and we are unspilling.
    * @param stream CUDA stream to use or null
    * @return new buffer tracking the data in this store
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -123,9 +123,9 @@ abstract class RapidsBufferStore(
    * (i.e.: this method will not take ownership of the incoming buffer object).
    * This does not need to update the catalog, the caller is responsible for that.
    * @param buffer data from another store
-   * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. It will be closed
-   *                     by this method unless `memoryBuffer` is already on the device, which is
-   *                     the case when GDS is enabled and we are unspilling.
+   * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. The ownership
+   *                     for `memoryBuffer` is transferred to this store. The store may close
+   *                     `memoryBuffer` if necessary.
    * @param stream CUDA stream to use for copy or null
    * @return new buffer that was created
    */
@@ -202,9 +202,9 @@ abstract class RapidsBufferStore(
    * adding a reference to the existing buffer and later closing it when the transfer completes.
    * @note DO NOT close the buffer unless adding a reference!
    * @param buffer data from another store
-   * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. It will be closed
-   *                     by this method unless `memoryBuffer` is already on the device, which is
-   *                     the case when GDS is enabled and we are unspilling.
+   * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. The ownership
+   *                     for `memoryBuffer` is transferred to this store. The store may close
+   *                     `memoryBuffer` if necessary.
    * @param stream CUDA stream to use or null
    * @return new buffer tracking the data in this store
    */


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Small doc-only change for the `copyBuffer` > `createBuffer` path when we are unspilling a buffer that was materialized from GDS. @rongou let me know if I misunderstood the code. I thought there was a leak https://github.com/NVIDIA/spark-rapids/issues/3038, but there wasn't one. That said, while reading through the code though to tweak the comment for the GDS+unspill case.