### PR TITLE
Profiling tool generate dot file fails on unescaped html characters

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -344,9 +344,9 @@ object SparkPlanGraph {
     // pre-calculate size post substitutions
     val formatBytes = queryLabelFormat.length() - sqlPlanPlaceHolder.length()
     val escapedPlan = StringEscapeUtils.escapeHtml4(physicalPlan)
-    val planStrLength = formatBytes + escapedPlan.length()
     val numLinebreaks = physicalPlan.count(_ == '\n')
     val lineBreakBytes = numLinebreaks * htmlLineBreak.length()
+    val planStrLength = formatBytes + lineBreakBytes + escapedPlan.length()
     val planStr = if (planStrLength >= maxLength) {
       println("truncating")
       // this might be overestimate depending on how much we truncate that would have

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -343,14 +343,21 @@ object SparkPlanGraph {
 
     // pre-calculate size post substitutions
     val formatBytes = queryLabelFormat.length() - sqlPlanPlaceHolder.length()
+    val escapedPlan = StringEscapeUtils.escapeHtml4(physicalPlan)
+    val planStrLength = formatBytes + escapedPlan.length()
     val numLinebreaks = physicalPlan.count(_ == '\n')
     val lineBreakBytes = numLinebreaks * htmlLineBreak.length()
-    val maxPlanLength = maxLength - formatBytes - lineBreakBytes
-
-    queryLabelFormat.format(
-      physicalPlan.take(maxPlanLength)
-        .replaceAll("\n", htmlLineBreak)
-    )
+    val planStr = if (planStrLength >= 16384) {
+      println("truncating")
+      // this might be overestimate depending on how much we truncate that would have
+      // been escaped, but it will be safe on size
+      val htmlEscapeLength = escapedPlan.length() - physicalPlan.length()
+      val truncatePlanBy = maxLength - formatBytes - lineBreakBytes - htmlEscapeLength
+      StringEscapeUtils.escapeHtml4(physicalPlan.take(truncatePlanBy))
+    } else {
+      escapedPlan
+    }
+    queryLabelFormat.format(planStr.replaceAll("\n", htmlLineBreak))
   }
 }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -347,7 +347,7 @@ object SparkPlanGraph {
     val planStrLength = formatBytes + escapedPlan.length()
     val numLinebreaks = physicalPlan.count(_ == '\n')
     val lineBreakBytes = numLinebreaks * htmlLineBreak.length()
-    val planStr = if (planStrLength >= 16384) {
+    val planStr = if (planStrLength >= maxLength) {
       println("truncating")
       // this might be overestimate depending on how much we truncate that would have
       // been escaped, but it will be safe on size

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDot.scala
@@ -348,7 +348,6 @@ object SparkPlanGraph {
     val lineBreakBytes = numLinebreaks * htmlLineBreak.length()
     val planStrLength = formatBytes + lineBreakBytes + escapedPlan.length()
     val planStr = if (planStrLength >= maxLength) {
-      println("truncating")
       // this might be overestimate depending on how much we truncate that would have
       // been escaped, but it will be safe on size
       val htmlEscapeLength = escapedPlan.length() - physicalPlan.length()

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/GenerateDotSuite.scala
@@ -101,22 +101,26 @@ class GenerateDotSuite extends FunSuite with BeforeAndAfterAll with Logging {
     random.setSeed(seed);
     info("Seeding test with: " + seed)
     val numTests = 100
-
     val lineLengthRange = 50 until 200
-
-
     val planLengthSeq = mutable.ArrayBuffer.empty[Int]
     val labelLengthSeq = mutable.ArrayBuffer.empty[Int]
 
     // some imperfect randomness for edge cases
-    for (_ <- 1 to numTests) {
+    for (iter <- 1 to numTests) {
       val lineLength = lineLengthRange.start +
         random.nextInt(lineLengthRange.length) -
         SparkPlanGraph.htmlLineBreak.length()
 
       val sign = if (random.nextBoolean()) 1 else -1
       val planLength = 16 * 1024 + sign * lineLength * (1 + random.nextInt(5));
-      val planStr = (0 to planLength / lineLength).map(_ => "a" * lineLength).mkString("\n")
+      val initPlanStr = (0 to planLength / lineLength).map(_ => "a" * lineLength).mkString("\n")
+
+      // throw some html characters in there to make sure escaped
+      val planStr = if (iter == 2) {
+        """ReadSchema: struct<_c1:string,_c2:string><br align="left"/>""" + initPlanStr
+      } else {
+        initPlanStr
+      }
 
       planLengthSeq += planStr.length()
 


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/3066

If the html in the label generated has less than or greater than signs like 
`ReadSchema: struct<_c1:string,_c2:string><br align="left"/>
`

The dot graph generation will fail.  Here we escape any html characters in the physical plan. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
