### PR TITLE
Add filter node in the query plan for conditional joins

### DIFF
--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
@@ -71,13 +71,16 @@ class GpuBroadcastHashJoinMeta(
       case BuildRight => right
     }
     verifyBuildSideWasReplaced(buildSide)
-    GpuBroadcastHashJoinExec(
+    val joinExec = GpuBroadcastHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left, right)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 }
 
@@ -97,8 +100,7 @@ case class GpuBroadcastHashJoinExec(
     TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
     JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
     STREAM_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_STREAM_TIME),
-    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
+    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME)) ++ spillMetrics
 
   override def requiredChildDistribution: Seq[Distribution] = {
     val mode = HashedRelationBroadcastMode(buildKeys)
@@ -136,7 +138,6 @@ case class GpuBroadcastHashJoinExec(
     val totalTime = gpuLongMetric(TOTAL_TIME)
     val streamTime = gpuLongMetric(STREAM_TIME)
     val joinTime = gpuLongMetric(JOIN_TIME)
-    val filterTime = gpuLongMetric(FILTER_TIME)
     val joinOutputRows = gpuLongMetric(JOIN_OUTPUT_ROWS)
 
     val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
@@ -152,7 +153,7 @@ case class GpuBroadcastHashJoinExec(
       GpuColumnVector.extractBases(builtBatch).foreach(_.noWarnLeakExpected())
       doJoin(builtBatch, it, targetSize, spillCallback,
         numOutputRows, joinOutputRows, numOutputBatches, streamTime, joinTime,
-        filterTime, totalTime)
+        totalTime)
     }
   }
 }

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
@@ -57,16 +57,19 @@ class GpuShuffledHashJoinMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    val Seq(left, right) = childPlans.map(_.convertIfNeeded)
-    GpuShuffledHashJoinExec(
+    val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val joinExec = GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left,
       right,
       isSkewJoin = false)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 }
 

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
@@ -77,15 +77,18 @@ class GpuSortMergeJoinMeta(
       throw new IllegalStateException(s"Cannot build either side for ${join.joinType} join")
     }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
-    GpuShuffledHashJoinExec(
+    val joinExec = GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left,
       right,
       join.isSkewJoin)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 
   /**

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
@@ -71,13 +71,16 @@ class GpuBroadcastHashJoinMeta(
       case BuildRight => right
     }
     verifyBuildSideWasReplaced(buildSide)
-    GpuBroadcastHashJoinExec(
+    val joinExec = GpuBroadcastHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left, right)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 }
 
@@ -97,8 +100,7 @@ case class GpuBroadcastHashJoinExec(
     TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
     JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
     STREAM_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_STREAM_TIME),
-    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
+    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME)) ++ spillMetrics
 
   override def requiredChildDistribution: Seq[Distribution] = {
     val mode = HashedRelationBroadcastMode(buildKeys)
@@ -136,7 +138,6 @@ case class GpuBroadcastHashJoinExec(
     val totalTime = gpuLongMetric(TOTAL_TIME)
     val streamTime = gpuLongMetric(STREAM_TIME)
     val joinTime = gpuLongMetric(JOIN_TIME)
-    val filterTime = gpuLongMetric(FILTER_TIME)
     val joinOutputRows = gpuLongMetric(JOIN_OUTPUT_ROWS)
 
     val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
@@ -152,7 +153,7 @@ case class GpuBroadcastHashJoinExec(
       GpuColumnVector.extractBases(builtBatch).foreach(_.noWarnLeakExpected())
       doJoin(builtBatch, it, targetSize, spillCallback,
         numOutputRows, joinOutputRows, numOutputBatches, streamTime, joinTime,
-        filterTime, totalTime)
+        totalTime)
     }
   }
 }

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
@@ -58,16 +58,19 @@ class GpuShuffledHashJoinMeta(
   }
 
   override def convertToGpu(): GpuExec = {
-    val Seq(left, right) = childPlans.map(_.convertIfNeeded)
-    GpuShuffledHashJoinExec(
+    val Seq(left, right) = childPlans.map(_.convertIfNeeded())
+    val joinExec = GpuShuffledHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left,
       right,
       isSkewJoin = false)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 }
 

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
@@ -71,13 +71,16 @@ class GpuBroadcastHashJoinMeta(
       case BuildRight => right
     }
     verifyBuildSideWasReplaced(buildSide)
-    GpuBroadcastHashJoinExec(
+    val joinExec = GpuBroadcastHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
       join.joinType,
       GpuJoinUtils.getGpuBuildSide(join.buildSide),
-      condition.map(_.convertToGpu()),
+      None,
       left, right)
+    // The GPU does not yet support conditional joins, so conditions are implemented
+    // as a filter after the join when possible.
+    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
   }
 }
 
@@ -97,8 +100,7 @@ case class GpuBroadcastHashJoinExec(
     TOTAL_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_TOTAL_TIME),
     JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
     STREAM_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_STREAM_TIME),
-    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
+    JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME)) ++ spillMetrics
 
   override def requiredChildDistribution: Seq[Distribution] = {
     val mode = HashedRelationBroadcastMode(buildKeys)
@@ -136,7 +138,6 @@ case class GpuBroadcastHashJoinExec(
     val totalTime = gpuLongMetric(TOTAL_TIME)
     val streamTime = gpuLongMetric(STREAM_TIME)
     val joinTime = gpuLongMetric(JOIN_TIME)
-    val filterTime = gpuLongMetric(FILTER_TIME)
     val joinOutputRows = gpuLongMetric(JOIN_OUTPUT_ROWS)
 
     val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
@@ -152,7 +153,7 @@ case class GpuBroadcastHashJoinExec(
       GpuColumnVector.extractBases(builtBatch).foreach(_.noWarnLeakExpected())
       doJoin(builtBatch, it, targetSize, spillCallback,
         numOutputRows, joinOutputRows, numOutputBatches, streamTime, joinTime,
-        filterTime, totalTime)
+        totalTime)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinBase.scala
@@ -41,8 +41,7 @@ abstract class GpuShuffledHashJoinBase(
     BUILD_TIME -> createNanoTimingMetric(ESSENTIAL_LEVEL, DESCRIPTION_BUILD_TIME),
     STREAM_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_STREAM_TIME),
     JOIN_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_TIME),
-    JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS),
-    FILTER_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_FILTER_TIME)) ++ spillMetrics
+    JOIN_OUTPUT_ROWS -> createMetric(MODERATE_LEVEL, DESCRIPTION_JOIN_OUTPUT_ROWS)) ++ spillMetrics
 
   override def requiredChildDistribution: Seq[Distribution] =
     HashClusteredDistribution(leftKeys) :: HashClusteredDistribution(rightKeys) :: Nil
@@ -66,7 +65,6 @@ abstract class GpuShuffledHashJoinBase(
     val buildTime = gpuLongMetric(BUILD_TIME)
     val streamTime = gpuLongMetric(STREAM_TIME)
     val joinTime = gpuLongMetric(JOIN_TIME)
-    val filterTime = gpuLongMetric(FILTER_TIME)
     val joinOutputRows = gpuLongMetric(JOIN_OUTPUT_ROWS)
     val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
     val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
@@ -86,7 +84,7 @@ abstract class GpuShuffledHashJoinBase(
 
           doJoin(builtBatch, streamIter, targetSize, spillCallback,
             numOutputRows, joinOutputRows, numOutputBatches,
-            streamTime, joinTime, filterTime, totalTime)
+            streamTime, joinTime, totalTime)
         }
       }
     }


### PR DESCRIPTION
This refactors the implementation of conditional inner joins.  The post-join filter is now an explicit node in the query plan rather than an implementation detail of the join node.  This has the advantage of adding visibility into how many rows were manifested from the join and subsequently filtered.

Despite joins no longer using the conditional expression after this PR, I left the condition parameter in place for now.  When AST conditional join support is added to the plugin, we can use this condition parameter to convey an expression that should be translated to an AST and processed directly as part of the join rather than as a post-filter.