### PR TITLE
Fix order of operations when using mkString in typeConversionInfo

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -311,14 +311,14 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
         (cannotRunOnGpuBecauseOfSparkPlan || shouldThisBeRemoved) => "could " + replaceMessage
     case Some(v) if v.isEmpty => "will " + replaceMessage
     case Some(v) =>
-      noReplacementPossibleMessage(v mkString "; ")
+      noReplacementPossibleMessage(v.mkString("; "))
   }
 
   private def willBeRemovedInfo: String = shouldBeRemovedReasons match {
     case None => ""
     case Some(v) if v.isEmpty => ""
     case Some(v) =>
-      val reasons = v mkString "; "
+      val reasons = v.mkString("; ")
       s" but is going to be removed because $reasons"
   }
 
@@ -327,7 +327,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     case Some(v) if v.isEmpty => ""
     case Some(v) =>
       "The data type of following expressions will be converted in GPU runtime: " +
-          (v mkString "; ")
+          (v.mkString("; "))
   }
 
   /**
@@ -811,7 +811,8 @@ class DataTypeMeta(
   def reasonForConversion: String = {
     val reasonMsg = (if (typeConverted) reason else None)
         .map(r => s", because $r").getOrElse("")
-    s"Converted ${wrapped.get} to ${dataType.get}" + reasonMsg
+    s"Converted ${wrapped.getOrElse("N/A")} to " +
+      s"${dataType.getOrElse("N/A")}" + reasonMsg
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -327,7 +327,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     case Some(v) if v.isEmpty => ""
     case Some(v) =>
       "The data type of following expressions will be converted in GPU runtime: " +
-          (v.mkString("; "))
+          v.mkString("; ")
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -244,7 +244,7 @@ final class TypeSig private(
         meta.willNotWorkOnGpu(s"$name only supports $dt if it is a literal value")
       }
       if (typeMeta.typeConverted) {
-        meta.addConvertedDataType(expr.getClass.getSimpleName, typeMeta)
+        meta.addConvertedDataType(expr, typeMeta)
       }
     }
   }
@@ -569,7 +569,7 @@ case class ContextChecks(
               s"produces an unsupported type $dt")
         }
         if (meta.typeMeta.typeConverted) {
-          meta.addConvertedDataType(expr.prettyName, meta.typeMeta)
+          meta.addConvertedDataType(expr, meta.typeMeta)
         }
       case None =>
         if (!meta.ignoreUnsetDataTypes) {


### PR DESCRIPTION
Prior to this, the explain was broken when doing type conversions (this was found while reviewing: https://github.com/NVIDIA/spark-rapids/pull/2971). 

```
      *Exec <ObjectHashAggregateExec> will run on GPU
 ; T; h; e;  ; d; a; t; a;  ; t; y; p; e;  ; o; f;  ; f; o; l; l; o; w; i; n; g;  ; e; x; p; r; e; s; s; i; o; n; s;  ; w; i; l; l;  ; b; e;  ; c; o; n; v; e; r; t; e; d;  ; i; n;  ; G; P; U;  ; r; u; n; t; i; m; e; :; 
; S; e; t; (; C; o; n; v; e; r; t; e; d;  ; D; a; t; a; T; y; p; e;  ; o; f;  ; b; u; f;  ; f; r; o; m;  ; B; i; n; a; r; y; T; y; p; e;  ; t; o;  ; A; r; r; a; y; T; y; p; e; (; I; n; t; e; g; e; r; T; y; p; e; ,; f; a; l; s; e; ); ,;  ; b; e; c; a; u; s; e;  ; C; o; n; v; e; r; t; e; d;  ; B; i; n; a; r; y; T; y; p; e;  ; t; o;  ; A; r; r; a; y; T; y; p; e; (; I; n; t; e; g; e; r; T; y; p; e; ,; f; a; l; s; e; ); ,;  ; b; e; c; a; u; s; e;  ; )
```

This tweaks the explain so it's in one line, and does some minor fixes. The original function duplicated the message, but I think the code I have here is safe since the `typeMeta` passed looks to be at the same expression level, and contains the same data as caller. It would be good to get confirmation I understood this correctly.
```
           *Exec <ObjectHashAggregateExec> will run on GPU. The data type of following expressions will be converted in GPU runtime: buf#10: Converted BinaryType to ArrayType(IntegerType,false)
```
