### PR TITLE
Optimize AQE with Spark 3.2+ to avoid redundant transitions [databricks]

### DIFF
--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
@@ -707,4 +707,15 @@ abstract class Spark30XdbShims extends Spark30XdbShimsBase with Logging {
   }
 
   override def getLegacyStatisticalAggregate(): Boolean = true
+
+  override def supportsColumnarAdaptivePlans: Boolean = false
+
+  override def columnarAdaptivePlan(a: AdaptiveSparkPlanExec, goal: CoalesceSizeGoal): SparkPlan = {
+    // When the input is an adaptive plan we do not get to see the GPU version until
+    // the plan is executed and sometimes the plan will have a GpuColumnarToRowExec as the
+    // final operator and we can bypass this to keep the data columnar by inserting
+    // the [[AvoidAdaptiveTransitionToRow]] operator here
+    AvoidAdaptiveTransitionToRow(GpuRowToColumnarExec(a, goal))
+  }
+
 }

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/AvoidAdaptiveTransitionToRow.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/AvoidAdaptiveTransitionToRow.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims.v2
+
+import java.lang.reflect.Method
+
+import com.nvidia.spark.rapids.{GpuColumnarToRowExec, GpuExec, GpuRowToColumnarExec}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * This operator will attempt to optimize the case when we are writing the results of
+ * an adaptive query to disk so that we remove the redundant transitions from columnar
+ * to row within AdaptiveSparkPlanExec followed by a row to columnar transition.
+ *
+ * Specifically, this is the plan we see in this case:
+ *
+ * {{{
+ * GpuRowToColumnar(AdaptiveSparkPlanExec(GpuColumnarToRow(child))
+ * }}}
+ *
+ * We perform this optimization at runtime rather than during planning, because when the adaptive
+ * plan is being planned and executed, we don't know whether it is being called from an operation
+ * that wants rows (such as CollectTailExec) or from an operation that wants columns (such as
+ * GpuDataWritingCommandExec).
+ *
+ * Spark does not provide a mechanism for executing an adaptive plan and retrieving columnar
+ * results and the internal methods that we need to call are private, so we use reflection to
+ * call them.
+ *
+ * @param child The plan to execute
+ */
+case class AvoidAdaptiveTransitionToRow(child: SparkPlan) extends ShimUnaryExecNode with GpuExec {
+
+  override def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+
+  override def output: Seq[Attribute] = child.output
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child match {
+    case GpuRowToColumnarExec(a: AdaptiveSparkPlanExec, _, _) =>
+      val getFinalPhysicalPlan = getPrivateMethod("getFinalPhysicalPlan")
+      val plan = getFinalPhysicalPlan.invoke(a)
+      val rdd = plan match {
+        case t: GpuColumnarToRowExec =>
+          t.child.executeColumnar()
+        case _ =>
+          child.executeColumnar()
+      }
+
+      // final UI update
+      val finalPlanUpdate = getPrivateMethod("finalPlanUpdate")
+      finalPlanUpdate.invoke(a)
+
+      rdd
+
+    case _ =>
+      child.executeColumnar()
+  }
+
+  private def getPrivateMethod(name: String): Method = {
+    val m = classOf[AdaptiveSparkPlanExec].getDeclaredMethod(name)
+    m.setAccessible(true)
+    m
+  }
+}

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -519,4 +519,14 @@ abstract class Spark31XShims extends Spark301util320Shims with Logging {
     SQLConf.get.legacyStatisticalAggregate
 
   override def hasCastFloatTimestampUpcast: Boolean = false
+
+  override def supportsColumnarAdaptivePlans: Boolean = false
+
+  override def columnarAdaptivePlan(a: AdaptiveSparkPlanExec, goal: CoalesceSizeGoal): SparkPlan = {
+    // When the input is an adaptive plan we do not get to see the GPU version until
+    // the plan is executed and sometimes the plan will have a GpuColumnarToRowExec as the
+    // final operator and we can bypass this to keep the data columnar by inserting
+    // the [[AvoidAdaptiveTransitionToRow]] operator here
+    AvoidAdaptiveTransitionToRow(GpuRowToColumnarExec(a, goal))
+  }
 }

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
@@ -849,4 +849,15 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
 
   override def getLegacyStatisticalAggregate(): Boolean =
     SQLConf.get.legacyStatisticalAggregate
+
+  override def supportsColumnarAdaptivePlans: Boolean = false
+
+  override def columnarAdaptivePlan(a: AdaptiveSparkPlanExec, goal: CoalesceSizeGoal): SparkPlan = {
+    // When the input is an adaptive plan we do not get to see the GPU version until
+    // the plan is executed and sometimes the plan will have a GpuColumnarToRowExec as the
+    // final operator and we can bypass this to keep the data columnar by inserting
+    // the [[AvoidAdaptiveTransitionToRow]] operator here
+    AvoidAdaptiveTransitionToRow(GpuRowToColumnarExec(a, goal))
+  }
+
 }

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -1086,4 +1086,11 @@ trait Spark32XShims extends SparkShims  with Logging {
   override def getAdaptiveInputPlan(adaptivePlan: AdaptiveSparkPlanExec): SparkPlan = {
     adaptivePlan.initialPlan
   }
+
+  override def columnarAdaptivePlan(a: AdaptiveSparkPlanExec,
+      goal: CoalesceSizeGoal): SparkPlan = {
+    a.copy(supportsColumnar = true)
+  }
+
+  override def supportsColumnarAdaptivePlans: Boolean = true
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -16,14 +16,8 @@
 
 package com.nvidia.spark.rapids
 
-import java.lang.reflect.Method
-
 import scala.annotation.tailrec
 
-import com.nvidia.spark.rapids.shims.v2.ShimUnaryExecNode
-
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, SortOrder}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
@@ -34,8 +28,7 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExecBase
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, Exchange, ReusedExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
 import org.apache.spark.sql.rapids.{GpuDataSourceScanExec, GpuFileSourceScanExec, GpuInputFileBlockLength, GpuInputFileBlockStart, GpuInputFileName, GpuShuffleEnv}
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExec, GpuBroadcastToCpuExec, GpuCustomShuffleReaderExec, GpuHashJoin, GpuShuffleExchangeExecBase}
-import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExec, GpuBroadcastExchangeExecBase, GpuBroadcastToCpuExec, GpuCustomShuffleReaderExec, GpuHashJoin, GpuShuffleExchangeExecBase}
 
 /**
  * Rules that run after the row to columnar and columnar to row transitions have been inserted.
@@ -82,48 +75,64 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
   def optimizeAdaptiveTransitions(
       plan: SparkPlan,
       parent: Option[SparkPlan]): SparkPlan = plan match {
+
+    case GpuBringBackToHost(child) if parent.isEmpty =>
+      // This is hacky but we need to remove the GpuBringBackToHost from the final
+      // query stage, if there is one. It gets inserted by
+      // GpuTransitionOverrides.insertColumnarFromGpu around columnar adaptive
+      // plans when we are writing to columnar formats on the GPU. It would be nice to avoid
+      // inserting it in the first place but we just don't have enough context
+      // at the time GpuTransitionOverrides is applying rules.
+      child
+
     // HostColumnarToGpu(RowToColumnarExec(..)) => GpuRowToColumnarExec(..)
     case HostColumnarToGpu(r2c: RowToColumnarExec, goal) =>
       val child = optimizeAdaptiveTransitions(r2c.child, Some(r2c))
-      val preProcessing = child.getTagValue(GpuOverrides.preRowToColProjection)
-          .getOrElse(Seq.empty)
-      val transition = GpuRowToColumnarExec(child, goal, preProcessing)
-      r2c.child match {
-        case _: AdaptiveSparkPlanExec =>
-          // When the input is an adaptive plan we do not get to see the GPU version until
-          // the plan is executed and sometimes the plan will have a GpuColumnarToRowExec as the
-          // final operator and we can bypass this to keep the data columnar by inserting
-          // the [[AvoidAdaptiveTransitionToRow]] operator here
-          AvoidAdaptiveTransitionToRow(transition)
+      child match {
+        case a: AdaptiveSparkPlanExec =>
+          // we hit this case when we have an adaptive plan wrapped in a write
+          // to columnar file format on the GPU
+          val columnarAdaptivePlan = ShimLoader.getSparkShims.columnarAdaptivePlan(a, goal)
+          optimizeAdaptiveTransitions(columnarAdaptivePlan, None)
         case _ =>
-          transition
+          val preProcessing = child.getTagValue(GpuOverrides.preRowToColProjection)
+            .getOrElse(Seq.empty)
+          GpuRowToColumnarExec(child, goal, preProcessing)
       }
 
-    case ColumnarToRowExec(GpuBringBackToHost(
-        GpuShuffleCoalesceExec(e: GpuShuffleExchangeExecBase, _))) if parent.isEmpty =>
-      // We typically want the final operator in the plan (the operator that has no parent) to be
-      // wrapped in `ColumnarToRowExec(GpuBringBackToHost(ShuffleCoalesceExec(_)))` operators to
-      // bring the data back onto the host and be translated to rows so that it can be returned
-      // from the Spark API. However, in the case of AQE, each exchange operator is treated as an
-      // individual query with no parent and we need to remove these operators in this case
-      // because we need to return an operator that implements `BroadcastExchangeLike` or
-      // `ShuffleExchangeLike`. The coalesce step gets added back into the plan later on, in a
-      // future query stage that reads the output from this query stage. This is handled in the
-      // case clauses below.
-      e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
+      // adaptive plan final query stage with columnar output
+      case r2c @ RowToColumnarExec(child) if parent.isEmpty =>
+        val optimizedChild = optimizeAdaptiveTransitions(child, Some(r2c))
+        val preProcessing = optimizedChild.getTagValue(GpuOverrides.preRowToColProjection)
+          .getOrElse(Seq.empty)
+        GpuRowToColumnarExec(optimizedChild, TargetSize(rapidsConf.gpuTargetBatchSizeBytes),
+          preProcessing)
 
-    case ColumnarToRowExec(GpuBringBackToHost(
-        GpuCoalesceBatches(e: GpuShuffleExchangeExecBase, _))) if parent.isEmpty =>
-      // We typically want the final operator in the plan (the operator that has no parent) to be
-      // wrapped in `ColumnarToRowExec(GpuBringBackToHost(GpuCoalesceBatches(_)))` operators to
-      // bring the data back onto the host and be translated to rows so that it can be returned
-      // from the Spark API. However, in the case of AQE, each exchange operator is treated as an
-      // individual query with no parent and we need to remove these operators in this case
-      // because we need to return an operator that implements `BroadcastExchangeLike` or
-      // `ShuffleExchangeLike`. The coalesce step gets added back into the plan later on, in a
-      // future query stage that reads the output from this query stage. This is handled in the
-      // case clauses below.
-      e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
+      case ColumnarToRowExec(bb: GpuBringBackToHost) =>
+        // We typically want the final operator in the plan (the operator that has no parent) to be
+        // wrapped in `ColumnarToRowExec(GpuBringBackToHost(_))` operators to
+        // bring the data back onto the host and be translated to rows so that it can be returned
+        // from the Spark API. However, in the case of AQE, each exchange operator is treated as an
+        // individual query with no parent and we need to remove these operators in this case
+        // because we need to return an operator that implements `BroadcastExchangeLike` or
+        // `ShuffleExchangeLike`.
+        bb.child match {
+          case GpuShuffleCoalesceExec(e: GpuShuffleExchangeExecBase, _) if parent.isEmpty =>
+            // The coalesce step gets added back into the plan later on, in a
+            // future query stage that reads the output from this query stage. This
+            // is handled in the case clauses below.
+            e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
+          case GpuCoalesceBatches(e: GpuShuffleExchangeExecBase, _) if parent.isEmpty =>
+            // The coalesce step gets added back into the plan later on, in a
+            // future query stage that reads the output from this query stage. This
+            // is handled in the case clauses below.
+            e.withNewChildren(e.children.map(c => optimizeAdaptiveTransitions(c, Some(e))))
+          case _ => optimizeAdaptiveTransitions(bb.child, Some(bb)) match {
+            case e: GpuBroadcastExchangeExecBase => e
+            case e: GpuShuffleExchangeExecBase => e
+            case other => getColumnarToRowExec(other)
+          }
+        }
 
     case s: ShuffleQueryStageExec =>
       // When reading a materialized shuffle query stage in AQE mode, we need to insert an
@@ -169,13 +178,6 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       }
     case ColumnarToRowExec(e: ShuffleQueryStageExec) =>
       getColumnarToRowExec(optimizeAdaptiveTransitions(e, Some(plan)))
-
-    case ColumnarToRowExec(bb: GpuBringBackToHost) =>
-      optimizeAdaptiveTransitions(bb.child, Some(bb)) match {
-        case e: GpuBroadcastExchangeExec => e
-        case e: GpuShuffleExchangeExecBase => e
-        case other => getColumnarToRowExec(other)
-      }
 
     // inserts postColumnarToRowTransition into newly-created GpuColumnarToRowExec
     case p if p.getTagValue(GpuOverrides.postColToRowProjection).nonEmpty =>
@@ -612,62 +614,5 @@ object GpuTransitionOverrides {
     case _: InputFileBlockStart => true
     case _: InputFileBlockLength => true
     case e => e.children.exists(checkHasInputFileExpressions)
-  }
-}
-
-/**
- * This operator will attempt to optimize the case when we are writing the results of
- * an adaptive query to disk so that we remove the redundant transitions from columnar
- * to row within AdaptiveSparkPlanExec followed by a row to columnar transition.
- *
- * Specifically, this is the plan we see in this case:
- *
- * {{{
- * GpuRowToColumnar(AdaptiveSparkPlanExec(GpuColumnarToRow(child))
- * }}}
- *
- * We perform this optimization at runtime rather than during planning, because when the adaptive
- * plan is being planned and executed, we don't know whether it is being called from an operation
- * that wants rows (such as CollectTailExec) or from an operation that wants columns (such as
- * GpuDataWritingCommandExec).
- *
- * Spark does not provide a mechanism for executing an adaptive plan and retrieving columnar
- * results and the internal methods that we need to call are private, so we use reflection to
- * call them.
- *
- * @param child The plan to execute
- */
-case class AvoidAdaptiveTransitionToRow(child: SparkPlan) extends ShimUnaryExecNode with GpuExec {
-
-  override def doExecute(): RDD[InternalRow] =
-    throw new IllegalStateException(s"Row-based execution should not occur for $this")
-
-  override def output: Seq[Attribute] = child.output
-
-  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child match {
-    case GpuRowToColumnarExec(a: AdaptiveSparkPlanExec, _, _) =>
-      val getFinalPhysicalPlan = getPrivateMethod("getFinalPhysicalPlan")
-      val plan = getFinalPhysicalPlan.invoke(a)
-      val rdd = plan match {
-        case t: GpuColumnarToRowExec =>
-          t.child.executeColumnar()
-        case _ =>
-          child.executeColumnar()
-      }
-
-      // final UI update
-      val finalPlanUpdate = getPrivateMethod("finalPlanUpdate")
-      finalPlanUpdate.invoke(a)
-
-      rdd
-
-    case _ =>
-      child.executeColumnar()
-  }
-
-  private def getPrivateMethod(name: String): Method = {
-    val m = classOf[AdaptiveSparkPlanExec].getDeclaredMethod(name)
-    m.setAccessible(true)
-    m
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -298,4 +298,13 @@ trait SparkShims {
   def timestampFormatInRead(csvOpts: CSVOptions): Option[String]
 
   def neverReplaceShowCurrentNamespaceCommand: ExecRule[_ <: SparkPlan]
+
+  /**
+   * Determine if the Spark version allows the supportsColumnar flag to be overridden
+   * in AdaptiveSparkPlanExec. This feature was introduced in Spark 3.2 as part of
+   * SPARK-35881.
+   */
+  def supportsColumnarAdaptivePlans: Boolean
+
+  def columnarAdaptivePlan(a: AdaptiveSparkPlanExec, goal: CoalesceSizeGoal): SparkPlan
 }


### PR DESCRIPTION
Spark PR https://github.com/apache/spark/pull/33624 added the capability to create adaptive plans with `supportsColumnar=true`.

This PR leverages this new capability to avoid redundant columnar-to-row / row-to-columnar transitions when possible.

Here is an example plan. Note that the only transition is at the root.

```
GpuColumnarToRow false
+- Execute GpuInsertIntoHadoopFsRelationCommand file:/tmp/AdaptiveQueryExecSuite$/AvoidTransitionOutput.parquet, false, com.nvidia.spark.rapids.GpuParquetFileFormat@1b632442, [path=/tmp/AdaptiveQueryExecSuite$/AvoidTransitionOutput.parquet], Overwrite, [a]
   +- AdaptiveSparkPlan isFinalPlan=true supportsColumnar=true
      +- == Final Plan ==
         GpuFileGpuScan parquet [a#7] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/AdaptiveQueryExecSuite$/AvoidTransitionInput.parquet], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<a:int>
      +- == Initial Plan ==
         FileScan parquet [a#7] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/tmp/AdaptiveQueryExecSuite$/AvoidTransitionInput.parquet], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<a:int>
```



