### PR TITLE
Add optional projection via AST expression evaluation

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture
+from data_gen import *
+from marks import approximate_float
+import pyspark.sql.functions as f
+
+# Each descriptor contains a list of data generators and a corresponding boolean
+# indicating whether that data type is supported by the AST
+ast_integral_descrs = [
+    (byte_gen, False),  # AST implicitly upcasts to INT32, need AST cast to support
+    (short_gen, False), # AST implicitly upcasts to INT32, need AST cast to support
+    (int_gen, True),
+    (long_gen, True)
+]
+
+ast_arithmetic_descrs = ast_integral_descrs + [(float_gen, True), (double_gen, True)]
+
+# cudf AST cannot support comparing floating point until it is expressive enough to handle NaNs
+# cudf AST does not support strings yet
+ast_comparable_descrs = [
+    (boolean_gen, True),
+    (byte_gen, True),
+    (short_gen, True),
+    (int_gen, True),
+    (long_gen, True),
+    (float_gen, False),
+    (double_gen, False),
+    (timestamp_gen, True),
+    (string_gen, False)
+]
+
+ast_boolean_descr = [(boolean_gen, True)]
+ast_double_descr = [(double_gen, True)]
+
+def assert_gpu_ast(is_supported, func, conf={}):
+    exist = "GpuProjectAstExec"
+    non_exist = "GpuProjectExec"
+    if not is_supported:
+        exist = "GpuProjectExec"
+        non_exist = "GpuProjectAstExec"
+    ast_conf = conf.copy()
+    ast_conf.update({"spark.rapids.sql.projectAstEnabled": "true"})
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        func,
+        exist_classes=exist,
+        non_exist_classes=non_exist,
+        conf=ast_conf)
+
+def assert_unary_ast(data_descr, func, conf={}):
+    (data_gen, is_supported) = data_descr
+    assert_gpu_ast(is_supported, lambda spark: func(unary_op_df(spark, data_gen)), conf=conf)
+
+def assert_binary_ast(data_descr, func, conf={}):
+    (data_gen, is_supported) = data_descr
+    assert_gpu_ast(is_supported, lambda spark: func(binary_op_df(spark, data_gen)), conf=conf)
+
+@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
+def test_bitwise_not(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('~a'))
+
+@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
+def test_bitwise_not_fallback(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('~a'))
+
+# This just ends up being a pass through.  There is no good way to force
+# a unary positive into a plan, because it gets optimized out, but this
+# verifies that we can handle it.
+@pytest.mark.parametrize('data_descr', [
+    (byte_gen, True),
+    (short_gen, True),
+    (int_gen, True),
+    (long_gen, True),
+    (float_gen, True),
+    (double_gen, True)], ids=idfn)
+def test_unary_positive(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('+a'))
+
+@pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+def test_unary_minus(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('-a'))
+
+@pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+def test_abs(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('abs(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_cbrt(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('cbrt(a)'))
+
+@pytest.mark.parametrize('data_descr', ast_boolean_descr, ids=idfn)
+def test_not(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('!a'))
+
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_rint(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('rint(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_sqrt(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('sqrt(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_sin(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('sin(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_cos(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('cos(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_tan(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('tan(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_cot(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('cot(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_sinh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('sinh(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_cosh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('cosh(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_tanh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('tanh(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_asin(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('asin(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_acos(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('acos(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_atan(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('atan(a)'))
+
+# AST is not expressive enough to support the ASINH Spark emulation expression
+@approximate_float
+@pytest.mark.parametrize('data_descr', [(double_gen, False)], ids=idfn)
+def test_asinh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('asinh(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_acosh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('acosh(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_atanh(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('atanh(a)'))
+
+# The default approximate is 1e-6 or 1 in a million
+# in some cases we need to adjust this because the algorithm is different
+@approximate_float(rel=1e-4, abs=1e-12)
+# Because Spark will overflow on large exponents drop to something well below
+# what it fails at, note this is binary exponent, not base 10
+@pytest.mark.parametrize('data_descr', [(DoubleGen(min_exp=-20, max_exp=20), True)], ids=idfn)
+def test_asinh_improved(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('asinh(a)'),
+        conf={'spark.rapids.sql.improvedFloatOps.enabled': 'true'})
+
+# The default approximate is 1e-6 or 1 in a million
+# in some cases we need to adjust this because the algorithm is different
+@approximate_float(rel=1e-4, abs=1e-12)
+# Because Spark will overflow on large exponents drop to something well below
+# what it fails at, note this is binary exponent, not base 10
+@pytest.mark.parametrize('data_descr', [(DoubleGen(min_exp=-20, max_exp=20), True)], ids=idfn)
+def test_acosh_improved(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('acosh(a)'),
+        conf={'spark.rapids.sql.improvedFloatOps.enabled': 'true'})
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_exp(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('exp(a)'))
+
+@approximate_float
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_expm1(data_descr):
+    assert_unary_ast(data_descr, lambda df: df.selectExpr('expm1(a)'))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_eq(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') == s1,
+            s2 == f.col('b'),
+            f.col('a') == f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_ne(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') != s1,
+            s2 != f.col('b'),
+            f.col('a') != f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_lt(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') < s1,
+            s2 < f.col('b'),
+            f.col('a') < f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_lte(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') <= s1,
+            s2 <= f.col('b'),
+            f.col('a') <= f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_gt(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') > s1,
+            s2 > f.col('b'),
+            f.col('a') > f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
+def test_gte(data_descr):
+    (s1, s2) = gen_scalars(data_descr[0], 2)
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') >= s1,
+            s2 >= f.col('b'),
+            f.col('a') >= f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
+def test_bitwise_and(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a').bitwiseAND(f.lit(100).cast(data_type)),
+            f.lit(-12).cast(data_type).bitwiseAND(f.col('b')),
+            f.col('a').bitwiseAND(f.col('b'))))
+
+@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
+def test_bitwise_or(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a').bitwiseOR(f.lit(100).cast(data_type)),
+            f.lit(-12).cast(data_type).bitwiseOR(f.col('b')),
+            f.col('a').bitwiseOR(f.col('b'))))
+
+@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
+def test_bitwise_xor(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a').bitwiseXOR(f.lit(100).cast(data_type)),
+            f.lit(-12).cast(data_type).bitwiseXOR(f.col('b')),
+            f.col('a').bitwiseXOR(f.col('b'))))
+
+@pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+def test_addition(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') + f.lit(100).cast(data_type),
+            f.lit(-12).cast(data_type) + f.col('b'),
+            f.col('a') + f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+def test_subtraction(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') - f.lit(100).cast(data_type),
+            f.lit(-12).cast(data_type) - f.col('b'),
+            f.col('a') - f.col('b')))
+
+@pytest.mark.parametrize('data_descr', ast_arithmetic_descrs, ids=idfn)
+def test_multiplication(data_descr):
+    data_type = data_descr[0].data_type
+    assert_binary_ast(data_descr,
+        lambda df: df.select(
+            f.col('a') * f.lit(100).cast(data_type),
+            f.lit(-12).cast(data_type) * f.col('b'),
+            f.col('a') * f.col('b')))
+
+@approximate_float
+def test_scalar_pow():
+    # For the 'b' field include a lot more values that we would expect customers to use as a part of a pow
+    data_gen = [('a', DoubleGen()),('b', DoubleGen().with_special_case(lambda rand: float(rand.randint(-16, 16)), weight=100.0))]
+    assert_gpu_ast(is_supported=True,
+        func=lambda spark: gen_df(spark, data_gen).selectExpr(
+            'pow(a, 7.0)',
+            'pow(-12.0, b)'))
+
+@approximate_float
+def test_scalar_pow_fallback():
+    # AST null literals not supported until https://github.com/rapidsai/cudf/issues/8831 is fixed
+    data_gen = [('a', DoubleGen()),('b', DoubleGen().with_special_case(lambda rand: float(rand.randint(-16, 16)), weight=100.0))]
+    assert_gpu_ast(is_supported=False,
+        func=lambda spark: gen_df(spark, data_gen).selectExpr(
+            'pow(cast(null as DOUBLE), a)',
+            'pow(b, cast(null as DOUBLE))'))
+
+@approximate_float
+@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/89')
+@pytest.mark.parametrize('data_descr', ast_double_descr, ids=idfn)
+def test_columnar_pow(data_descr):
+    assert_binary_ast(data_descr, lambda df: df.selectExpr('pow(a, b)'))

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -73,10 +73,6 @@ def assert_binary_ast(data_descr, func, conf={}):
 def test_bitwise_not(data_descr):
     assert_unary_ast(data_descr, lambda df: df.selectExpr('~a'))
 
-@pytest.mark.parametrize('data_descr', ast_integral_descrs, ids=idfn)
-def test_bitwise_not_fallback(data_descr):
-    assert_unary_ast(data_descr, lambda df: df.selectExpr('~a'))
-
 # This just ends up being a pass through.  There is no good way to force
 # a unary positive into a plan, because it gets optimized out, but this
 # verifies that we can handle it.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import ai.rapids.cudf.ast
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression, SortOrder}
 import org.apache.spark.sql.types.DataType
@@ -104,6 +106,14 @@ case class GpuBoundReference(ordinal: Int, dataType: DataType, nullable: Boolean
         // the type here.
         new GpuColumnVector(fb.dataType(), fb.getBase.incRefCount())
       case cv: GpuColumnVector => cv.incRefCount()
+    }
+  }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    if (ordinal >= numFirstTableColumns) {
+      new ast.ColumnReference(ordinal - numFirstTableColumns, ast.TableReference.RIGHT)
+    } else {
+      new ast.ColumnReference(ordinal, ast.TableReference.LEFT)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -110,6 +110,12 @@ case class GpuBoundReference(ordinal: Int, dataType: DataType, nullable: Boolean
   }
 
   override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    // Spark treats all inputs as a single sequence of columns. For example, a join will put all
+    // the columns of the left table followed by all the columns of the right table. cudf AST
+    // instead uses explicit table references to distinguish which table is being indexed by a
+    // column index. To translate from Spark to AST, we check the Spark column index against the
+    // number of columns the leftmost input table to know which table is being referenced and
+    // adjust the column index accordingly.
     if (ordinal >= numFirstTableColumns) {
       new ast.ColumnReference(ordinal - numFirstTableColumns, ast.TableReference.RIGHT)
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -150,6 +150,15 @@ trait GpuExpression extends Expression with Arm {
     GpuCanonicalize.execute(withNewChildren(canonicalizedChildren))
   }
 
+  /**
+   * Build an equivalent representation of this expression in a cudf AST.
+   * @param numFirstTableColumns number of columns in the leftmost input table. Spark places the
+   *                             columns of all inputs in a single sequence, while cudf AST uses an
+   *                             explicit table reference to make column indices unique. This
+   *                             parameter helps translate input column references from Spark's
+   *                             single sequence into cudf's separate sequences.
+   * @return top node of the equivalent AST
+   */
   def convertToAst(numFirstTableColumns: Int): ast.AstNode =
     throw new IllegalStateException(s"Cannot convert ${this.getClass.getSimpleName} to AST")
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{BinaryOp, BinaryOperable, ColumnVector, DType, Scalar, UnaryOp}
+import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -148,6 +149,9 @@ trait GpuExpression extends Expression with Arm {
     val canonicalizedChildren = children.map(_.canonicalized)
     GpuCanonicalize.execute(withNewChildren(canonicalizedChildren))
   }
+
+  def convertToAst(numFirstTableColumns: Int): ast.AstNode =
+    throw new IllegalStateException(s"Cannot convert ${this.getClass.getSimpleName} to AST")
 }
 
 abstract class GpuLeafExpression extends GpuExpression {
@@ -186,10 +190,40 @@ abstract class GpuUnaryExpression extends UnaryExpression with GpuExpression {
   }
 }
 
+object CudfUnaryExpression {
+  lazy val opToAstMap: Map[UnaryOp, ast.UnaryOperator] = Map(
+    UnaryOp.ABS -> ast.UnaryOperator.ABS,
+    UnaryOp.ARCSIN -> ast.UnaryOperator.ARCSIN,
+    UnaryOp.ARCSINH -> ast.UnaryOperator.ARCSINH,
+    UnaryOp.ARCCOS -> ast.UnaryOperator.ARCCOS,
+    UnaryOp.ARCCOSH -> ast.UnaryOperator.ARCCOSH,
+    UnaryOp.ARCTAN -> ast.UnaryOperator.ARCTAN,
+    UnaryOp.ARCTANH -> ast.UnaryOperator.ARCTANH,
+    UnaryOp.BIT_INVERT -> ast.UnaryOperator.BIT_INVERT,
+    UnaryOp.CBRT -> ast.UnaryOperator.CBRT,
+    UnaryOp.COS -> ast.UnaryOperator.COS,
+    UnaryOp.COSH -> ast.UnaryOperator.COSH,
+    UnaryOp.EXP -> ast.UnaryOperator.EXP,
+    UnaryOp.NOT -> ast.UnaryOperator.NOT,
+    UnaryOp.RINT -> ast.UnaryOperator.RINT,
+    UnaryOp.SIN -> ast.UnaryOperator.SIN,
+    UnaryOp.SINH -> ast.UnaryOperator.SINH,
+    UnaryOp.SQRT -> ast.UnaryOperator.SQRT,
+    UnaryOp.TAN -> ast.UnaryOperator.TAN,
+    UnaryOp.TANH -> ast.UnaryOperator.TANH)
+}
+
 trait CudfUnaryExpression extends GpuUnaryExpression {
   def unaryOp: UnaryOp
 
   override def doColumnar(input: GpuColumnVector): ColumnVector = input.getBase.unaryOp(unaryOp)
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    val astOp = CudfUnaryExpression.opToAstMap.getOrElse(unaryOp,
+      throw new IllegalStateException(s"${this.getClass.getSimpleName} is not supported by AST"))
+    new ast.UnaryExpression(astOp,
+      child.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns))
+  }
 }
 
 trait GpuBinaryExpression extends BinaryExpression with GpuExpression {
@@ -221,6 +255,21 @@ trait GpuBinaryExpression extends BinaryExpression with GpuExpression {
 }
 
 trait GpuBinaryOperator extends BinaryOperator with GpuBinaryExpression
+
+object CudfBinaryExpression {
+  lazy val opToAstMap: Map[BinaryOp, ast.BinaryOperator] = Map(
+    BinaryOp.ADD -> ast.BinaryOperator.ADD,
+    BinaryOp.BITWISE_AND -> ast.BinaryOperator.BITWISE_AND,
+    BinaryOp.BITWISE_OR -> ast.BinaryOperator.BITWISE_OR,
+    BinaryOp.BITWISE_XOR -> ast.BinaryOperator.BITWISE_XOR,
+    BinaryOp.GREATER -> ast.BinaryOperator.GREATER,
+    BinaryOp.GREATER_EQUAL -> ast.BinaryOperator.GREATER_EQUAL,
+    BinaryOp.LESS -> ast.BinaryOperator.LESS,
+    BinaryOp.LESS_EQUAL -> ast.BinaryOperator.LESS_EQUAL,
+    BinaryOp.MUL -> ast.BinaryOperator.MUL,
+    BinaryOp.POW -> ast.BinaryOperator.POW,
+    BinaryOp.SUB -> ast.BinaryOperator.SUB)
+}
 
 trait CudfBinaryExpression extends GpuBinaryExpression {
   def binaryOp: BinaryOp
@@ -270,6 +319,15 @@ trait CudfBinaryExpression extends GpuBinaryExpression {
     withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { expandedLhs =>
       doColumnar(expandedLhs, rhs)
     }
+  }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    val astOp = CudfBinaryExpression.opToAstMap.getOrElse(binaryOp,
+      throw new IllegalStateException(s"$this is not supported by AST"))
+    assert(left.dataType == right.dataType)
+    new ast.BinaryExpression(astOp,
+      left.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns),
+      right.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns))
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -672,6 +672,12 @@ object RapidsConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_PROJECT_AST = conf("spark.rapids.sql.projectAstEnabled")
+      .doc("Enable project operations to use cudf AST expressions when possible.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   // FILE FORMATS
   val ENABLE_PARQUET = conf("spark.rapids.sql.format.parquet.enabled")
     .doc("When set to false disables all parquet input and output acceleration")
@@ -1530,6 +1536,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isCsvDoubleReadEnabled: Boolean = get(ENABLE_READ_CSV_DOUBLES)
 
   lazy val isCastDecimalToStringEnabled: Boolean = get(ENABLE_CAST_DECIMAL_TO_STRING)
+
+  lazy val isProjectAstEnabled: Boolean = get(ENABLE_PROJECT_AST)
 
   lazy val isParquetEnabled: Boolean = get(ENABLE_PARQUET)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{ByteType, DataType, DoubleType, FloatType, ShortType}
 
 trait DataFromReplacementRule {
   val operationName: String
@@ -298,7 +298,7 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
    */
   def tagSelfForGpu(): Unit
 
-  private def indent(append: StringBuilder, depth: Int): Unit =
+  protected def indent(append: StringBuilder, depth: Int): Unit =
     append.append("  " * depth)
 
   def replaceMessage: String = "run on GPU"
@@ -847,6 +847,9 @@ object DataTypeMeta {
   }
 }
 
+/** Trait to mark metadata for expressions that have AST implicit casting issues */
+trait AstImplicitCasts
+
 /**
  * Base class for metadata around `Expression`.
  */
@@ -856,6 +859,8 @@ abstract class BaseExprMeta[INPUT <: Expression](
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
   extends RapidsMeta[INPUT, Expression, Expression](expr, conf, parent, rule) {
+
+  private val cannotBeAstReasons: mutable.Set[String] = mutable.Set.empty
 
   override val childPlans: Seq[SparkPlanMeta[_]] = Seq.empty
   override val childExprs: Seq[BaseExprMeta[_]] =
@@ -914,6 +919,75 @@ abstract class BaseExprMeta[INPUT <: Expression](
    * extra checks all of the checks should have already been done.
    */
   def tagExprForGpu(): Unit = {}
+
+  final def willNotWorkInAst(because: String): Unit = cannotBeAstReasons.add(because)
+
+  final def canThisBeAst: Boolean = childExprs.forall(_.canThisBeAst) && cannotBeAstReasons.isEmpty
+
+  final def tagForAst(): Unit = {
+    if (wrapped.foldable && !GpuOverrides.isLit(wrapped)) {
+      willNotWorkInAst(s"Cannot convert to AST. Is ConstantFolding excluded? Expression " +
+          s"$wrapped is foldable and operates on non literals")
+    }
+
+    if (!TypeSig.astTypes.isSupportedByPlugin(wrapped.dataType, conf.decimalTypeEnabled)) {
+      willNotWorkInAst(s"${expr.dataType} not supported by AST expressions")
+    }
+
+    if (isInstanceOf[AstImplicitCasts]) {
+      wrapped.dataType match {
+        case ByteType | ShortType =>
+          willNotWorkInAst("AST implicitly upcasts byte or short inputs")
+        case _ =>
+      }
+    }
+
+    childExprs.foreach(_.tagForAst())
+    tagSelfForAst()
+  }
+
+  /** Called to verify that this expression will work as a GPU AST expression. */
+  protected def tagSelfForAst(): Unit = {
+    willNotWorkInAst(s"${wrapped.getClass.getSimpleName} has no AST mapping")
+  }
+
+  protected def willWorkInAstInfo: String = {
+    if (cannotBeAstReasons.isEmpty) {
+      "will run in AST"
+    } else {
+      s"cannot be converted to GPU AST because ${cannotBeAstReasons.mkString(";")}"
+    }
+  }
+
+  /**
+   * Create a string explanation for whether this expression tree can be converted to an AST
+   * @param strBuilder where to place the string representation.
+   * @param depth how far down the tree this is.
+   * @param all should all the data be printed or just what does not work in the AST?
+   */
+  protected def printAst(strBuilder: StringBuilder, depth: Int, all: Boolean): Unit = {
+    if (all || !canThisBeAst) {
+      indent(strBuilder, depth)
+      strBuilder.append(operationName)
+          .append(" <")
+          .append(wrapped.getClass.getSimpleName)
+          .append("> ")
+
+      if (printWrapped) {
+        strBuilder.append(wrapped)
+            .append(" ")
+      }
+
+      strBuilder.append(willWorkInAstInfo).append("\n")
+    }
+    childExprs.foreach(_.printAst(strBuilder, depth + 1, all))
+  }
+
+  def explainAst(all: Boolean): String = {
+    val appender = new StringBuilder()
+    printAst(appender, 0, all)
+    appender.toString()
+  }
 }
 
 abstract class ExprMeta[INPUT <: Expression](
@@ -940,6 +1014,17 @@ abstract class UnaryExprMeta[INPUT <: UnaryExpression](
     convertToGpu(childExprs.head.convertToGpu())
 
   def convertToGpu(child: Expression): GpuExpression
+}
+
+/** Base metadata class for unary expressions that support conversion to AST as well */
+abstract class UnaryAstExprMeta[INPUT <: UnaryExpression](
+    expr: INPUT,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends UnaryExprMeta[INPUT](expr, conf, parent, rule) {
+
+  override def tagSelfForAst(): Unit = {}
 }
 
 /**
@@ -1008,6 +1093,40 @@ abstract class BinaryExprMeta[INPUT <: BinaryExpression](
   }
 
   def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression
+}
+
+/** Base metadata class for binary expressions that support conversion to AST */
+abstract class BinaryAstExprMeta[INPUT <: BinaryExpression](
+    expr: INPUT,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends BinaryExprMeta[INPUT](expr, conf, parent, rule) {
+
+  override def tagSelfForAst(): Unit = {
+    if (wrapped.left.dataType != wrapped.right.dataType) {
+      willNotWorkInAst("AST binary expression operand types must match, found " +
+          s"${wrapped.left.dataType},${wrapped.right.dataType}")
+    }
+  }
+}
+
+/** Base metadata class for comparison expressions that support conversion to AST */
+abstract class BinaryAstCompareExprMeta[INPUT <: BinaryExpression](
+    expr: INPUT,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends BinaryAstExprMeta[INPUT](expr, conf, parent, rule) {
+
+  override def tagSelfForAst(): Unit = {
+    super.tagSelfForAst()
+    wrapped.left.dataType match {
+      case FloatType | DoubleType =>
+        willNotWorkInAst("AST comparison does not support floating point")
+      case _ =>
+    }
+  }
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -619,6 +619,9 @@ object TypeSig {
   val unionOfPandasUdfOut: TypeSig =
     (commonCudfTypes + BINARY + DECIMAL_64 + NULL + ARRAY + MAP).nested() + STRUCT
 
+  /** All types that can appear in AST expressions */
+  val astTypes = BOOLEAN + integral + fp + TIMESTAMP
+
   def getDataType(expr: Expression): Option[DataType] = {
     try {
       Some(expr.dataType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.annotation.tailrec
 
 import ai.rapids.cudf.{NvtxColor, Scalar, Table}
+import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
@@ -27,11 +28,30 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, NamedExpression, NullIntolerant, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, RangePartitioning, SinglePartition, UnknownPartitioning}
-import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{LeafExecNode, ProjectExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.rapids.GpuPredicateHelper
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{DataType, LongType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+class GpuProjectExecMeta(
+    proj: ProjectExec,
+    conf: RapidsConf,
+    p: Option[RapidsMeta[_, _, _]],
+    r: DataFromReplacementRule) extends SparkPlanMeta[ProjectExec](proj, conf, p, r) {
+  override def convertToGpu(): GpuExec = {
+    // Force list to avoid recursive Java serialization of lazy list Seq implementation
+    val gpuExprs = childExprs.map(_.convertToGpu()).toList
+    val gpuChild = childPlans.head.convertIfNeeded()
+    if (conf.isProjectAstEnabled) {
+      childExprs.foreach(_.tagForAst())
+      if (childExprs.forall(_.canThisBeAst)) {
+        return GpuProjectAstExec(gpuExprs, gpuChild)
+      }
+    }
+    GpuProjectExec(gpuExprs, gpuChild)
+  }
+}
 
 object GpuProjectExec extends Arm {
   def projectAndClose[A <: Expression](cb: ColumnarBatch, boundExprs: Seq[A],
@@ -117,6 +137,72 @@ case class GpuProjectExec(
       numOutputBatches += 1
       numOutputRows += cb.numRows()
       GpuProjectExec.projectAndClose(cb, boundProjectList, opTime)
+    }
+  }
+
+  // The same as what feeds us
+  override def outputBatching: CoalesceGoal = GpuExec.outputBatching(child)
+}
+
+/** Use cudf AST expressions to project columnar batches */
+case class GpuProjectAstExec(
+    // NOTE for Scala 2.12.x and below we enforce usage of (eager) List to prevent running
+    // into a deep recursion during serde of lazy lists. See
+    // https://github.com/NVIDIA/spark-rapids/issues/2036
+    //
+    // Whereas a similar issue https://issues.apache.org/jira/browse/SPARK-27100 is resolved
+    // using an Array, we opt in for List because it implements Seq while having non-recursive
+    // serde: https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/
+    //   immutable/List.scala#L516
+    projectList: List[Expression],
+    child: SparkPlan
+) extends UnaryExecNode with GpuExec {
+
+  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    OP_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME))
+
+  override def output: Seq[Attribute] = {
+    projectList.collect { case ne: NamedExpression => ne.toAttribute }
+  }
+
+  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+
+  override def outputPartitioning: Partitioning = child.outputPartitioning
+
+  override def doExecute(): RDD[InternalRow] =
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+
+  override def doExecuteColumnar() : RDD[ColumnarBatch] = {
+    val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
+    val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
+    val opTime = gpuLongMetric(OP_TIME)
+    val boundProjectList = GpuBindReferences.bindGpuReferences(projectList, child.output)
+    val outputTypes = output.map(_.dataType).toArray
+    val rdd = child.executeColumnar()
+    rdd.map { cb =>
+      withResource(cb) { _ =>
+        withResource(new NvtxWithMetrics("Project AST", NvtxColor.CYAN, opTime)) { _ =>
+          numOutputBatches += 1
+          numOutputRows += cb.numRows()
+          val compiledAstExprs = boundProjectList.safeMap { expr =>
+            val astExpr = expr.convertToAst(Int.MaxValue) match {
+              case e: ast.Expression => e
+              case e => new ast.UnaryExpression(ast.UnaryOperator.IDENTITY, e)
+            }
+            astExpr.compile()
+          }
+          val projectedTable = withResource(compiledAstExprs) { _ =>
+            withResource(GpuColumnVector.from(cb)) { table =>
+              withResource(compiledAstExprs.safeMap(_.computeColumn(table))) { projectedColumns =>
+                new Table(projectedColumns:_*)
+              }
+            }
+          }
+          withResource(projectedTable) { _ =>
+            GpuColumnVector.from(projectedTable, outputTypes)
+          }
+        }
+      }
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe.TypeTag
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Scalar}
+import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import org.json4s.JsonAST.{JField, JNull, JString}
 
@@ -633,6 +634,22 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
     // simplify the handling of result from a `expr.columnarEval`.
     GpuScalar(value, dataType)
   }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    dataType match {
+      case BooleanType => ast.Literal.ofBoolean(value.asInstanceOf[java.lang.Boolean])
+      case ByteType => ast.Literal.ofByte(value.asInstanceOf[java.lang.Byte])
+      case ShortType => ast.Literal.ofShort(value.asInstanceOf[java.lang.Short])
+      case IntegerType => ast.Literal.ofInt(value.asInstanceOf[java.lang.Integer])
+      case LongType => ast.Literal.ofLong(value.asInstanceOf[java.lang.Long])
+      case FloatType => ast.Literal.ofFloat(value.asInstanceOf[java.lang.Float])
+      case DoubleType => ast.Literal.ofDouble(value.asInstanceOf[java.lang.Double])
+      case TimestampType =>
+        ast.Literal.ofTimestampFromLong(DType.TIMESTAMP_MICROSECONDS,
+          value.asInstanceOf[java.lang.Long])
+      case _ => throw new IllegalStateException("$dataType is an unsupported literal type")
+    }
+  }
 }
 
 class LiteralExprMeta(
@@ -648,6 +665,13 @@ class LiteralExprMeta(
   override def print(append: StringBuilder, depth: Int, all: Boolean): Unit = {
     if (!this.canThisBeReplaced || cannotRunOnGpuBecauseOfSparkPlan) {
       super.print(append, depth, all)
+    }
+  }
+
+  override protected def tagSelfForAst(): Unit = {
+    // Preclude null literals until https://github.com/rapidsai/cudf/issues/8831 is fixed.
+    if (lit.value == null) {
+      willNotWorkInAst("null literals are not supported")
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.util.Objects
 
 import ai.rapids.cudf.ColumnVector
+import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -108,4 +109,9 @@ case class GpuAlias(child: Expression, name: String)(
 
   override def doColumnar(input: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("GpuAlias should never have doColumnar called")
+
+  override def convertToAst(numLeftTableColumns: Int): ast.AstNode = child match {
+    case e: GpuExpression => e.convertToAst(numLeftTableColumns)
+    case e => throw new IllegalStateException(s"Attempt to convert $e to AST")
+  }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -56,6 +56,17 @@ case class GpuUnaryMinus(child: Expression) extends GpuUnaryExpression
         }
     }
   }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    val literalZero = dataType match {
+      case LongType => ast.Literal.ofLong(0)
+      case FloatType => ast.Literal.ofFloat(0)
+      case DoubleType => ast.Literal.ofDouble(0)
+      case IntegerType => ast.Literal.ofInt(0)
+    }
+    new ast.BinaryExpression(ast.BinaryOperator.SUB, literalZero,
+      child.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns));
+  }
 }
 
 case class GpuUnaryPositive(child: Expression) extends GpuUnaryExpression
@@ -69,6 +80,10 @@ case class GpuUnaryPositive(child: Expression) extends GpuUnaryExpression
   override def sql: String = s"(+ ${child.sql})"
 
   override def doColumnar(input: GpuColumnVector) : ColumnVector = input.getBase.incRefCount()
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    child.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns)
+  }
 }
 
 case class GpuAbs(child: Expression) extends CudfUnaryExpression

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -43,6 +43,17 @@ case class GpuNot(child: Expression) extends CudfUnaryExpression
   override def sql: String = s"(NOT ${child.sql})"
 
   override def unaryOp: UnaryOp = UnaryOp.NOT
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    child match {
+      case c: GpuEqualTo =>
+        // optimize the AST expression since Spark doesn't have a NotEqual
+        new ast.BinaryExpression(ast.BinaryOperator.NOT_EQUAL,
+          c.left.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns),
+          c.right.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns))
+      case _ => super.convertToAst(numFirstTableColumns)
+    }
+  }
 }
 
 object GpuLogicHelper {
@@ -280,6 +291,15 @@ case class GpuEqualTo(left: Expression, right: Expression) extends CudfBinaryCom
     } else {
       result
     }
+  }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstNode = {
+    // Currently AST computeColumn assumes nulls compare true for EQUAL, but NOT_EQUAL will
+    // return null for null input.
+    new ast.UnaryExpression(ast.UnaryOperator.NOT,
+      new ast.BinaryExpression(ast.BinaryOperator.NOT_EQUAL,
+        left.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns),
+        right.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns)))
   }
 }
 


### PR DESCRIPTION
Adds the ability to implement a projection via cudf AST expression evaluation if the expressions are supported by cudf AST.  The `RapidsMeta` and `GpuExpression` objects are reused, extended with new `tagForAst` and `convertToAst` methods, respectively.

I covered as many unary and binary AST operators as I could get to be compatible.  Many of the missing AST operators cannot be supported to to lacking expressiveness in the AST for NaN handling, null literals, conditional execution, etc.