### PR TITLE
Profile tool: Fix reporting app contains Dataset

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -296,8 +296,6 @@ case class TaskCase(
     output_bytesWritten: Long,
     output_recordsWritten: Long)
 
-case class DatasetSQLCase(sqlID: Long)
-
 case class UnsupportedSQLPlan(sqlID: Long, nodeID: Long, nodeName: String,
     nodeDesc: String, reason: String)
 

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -233,7 +233,6 @@ class ApplicationInfo(
   val accumIdToStageId: mutable.HashMap[Long, Int] = new mutable.HashMap[Long, Int]()
   var taskEnd: ArrayBuffer[TaskCase] = ArrayBuffer[TaskCase]()
   var unsupportedSQLplan: ArrayBuffer[UnsupportedSQLPlan] = ArrayBuffer[UnsupportedSQLPlan]()
-  var datasetSQL: ArrayBuffer[DatasetSQLCase] = ArrayBuffer[DatasetSQLCase]()
 
   private lazy val eventProcessor =  new EventsProcessor()
 
@@ -273,7 +272,9 @@ class ApplicationInfo(
       for (node <- allnodes) {
         checkGraphNodeForBatchScan(sqlID, node)
         if (isDataSetPlan(node.desc)) {
-          datasetSQL += DatasetSQLCase(sqlID)
+          sqlIdToInfo.get(sqlID).foreach { sql =>
+            sql.hasDataset = true
+          }
           if (gpuMode) {
             val thisPlan = UnsupportedSQLPlan(sqlID, node.id, node.name, node.desc,
               "Contains Dataset")

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -347,7 +347,6 @@ class EventsProcessor() extends EventProcessorBase with  Logging {
     app.sqlIdToInfo.get(event.executionId).foreach { sql =>
       sql.endTime = Some(event.time)
       sql.duration = ProfileUtils.OptionLongMinusLong(sql.endTime, sql.startTime)
-      sql.hasDataset = app.datasetSQL.exists(_.sqlID == event.executionId)
     }
   }
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AnalysisSuite.scala
@@ -124,4 +124,15 @@ class AnalysisSuite extends FunSuite {
     val containsDs = sqlDurAndCpu.filter(_.containsDataset === true)
     assert(containsDs.isEmpty)
   }
+
+  test("test contains dataset true") {
+    val qualLogDir = ToolTestUtils.getTestResourcePath("spark-events-qualification")
+    val logs = Array(s"$qualLogDir/dataset_eventlog")
+
+    val apps = ToolTestUtils.processProfileApps(logs, sparkSession)
+    val analysis = new Analysis(apps, None, 1000)
+    val sqlDurAndCpu = analysis.sqlMetricsAggregationDurationAndCpuTime()
+    val containsDs = sqlDurAndCpu.filter(_.containsDataset === true)
+    assert(containsDs.size == 1)
+  }
 }


### PR DESCRIPTION
Found a bug where we aren't reporting the plan contains dataset properly. The issue here is timing when we set it and when we discover the dataset, which happens later. 

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
