### PR TITLE
Add TypeSig checks for join keys and other special cases

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1056,8 +1056,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowspan="1">WindowExec</td>
-<td rowspan="1">Window-operator backend</td>
+<td rowspan="2">WindowExec</td>
+<td rowspan="2">Window-operator backend</td>
 <td>Input</td>
 <td>None</td>
 <td>S</td>
@@ -1074,9 +1074,31 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>Not supported as a partition by key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>Not supported as a partition by key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>Not supported as a partition by key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>partitionSpec</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 </table>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -110,6 +110,7 @@ Accelerator supports are described below.
 <tr>
 <th>Executor</th>
 <th>Description</th>
+<th>Context</th>
 <th>Notes</th>
 <th>BOOLEAN</th>
 <th>BYTE</th>
@@ -132,6 +133,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>CoalesceExec</td>
+<td>Input</td>
 <td>The backend for the dataframe coalesce method</td>
 <td>None</td>
 <td>S</td>
@@ -155,6 +157,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>CollectLimitExec</td>
+<td>Input</td>
 <td>Reduce to single partition and apply limit</td>
 <td>This is disabled by default because Collect Limit replacement can be slower on the GPU, if huge number of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU</td>
 <td>S</td>
@@ -178,6 +181,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ExpandExec</td>
+<td>Input</td>
 <td>The backend for the expand operator</td>
 <td>None</td>
 <td>S</td>
@@ -201,6 +205,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>FileSourceScanExec</td>
+<td>Input</td>
 <td>Reading data from files, often from Hive tables</td>
 <td>None</td>
 <td>S</td>
@@ -224,6 +229,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>FilterExec</td>
+<td>Input</td>
 <td>The backend for most filter statements</td>
 <td>None</td>
 <td>S</td>
@@ -247,6 +253,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>GenerateExec</td>
+<td>Input</td>
 <td>The backend for operations that generate more output rows than input rows like explode</td>
 <td>None</td>
 <td>S</td>
@@ -270,6 +277,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>GlobalLimitExec</td>
+<td>Input</td>
 <td>Limiting of results across partitions</td>
 <td>None</td>
 <td>S</td>
@@ -293,6 +301,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>LocalLimitExec</td>
+<td>Input</td>
 <td>Per-partition limiting of results</td>
 <td>None</td>
 <td>S</td>
@@ -316,6 +325,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ProjectExec</td>
+<td>Input</td>
 <td>The backend for most select, withColumn and dropColumn statements</td>
 <td>None</td>
 <td>S</td>
@@ -339,6 +349,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>RangeExec</td>
+<td>Input</td>
 <td>The backend for range operator</td>
 <td>None</td>
 <td> </td>
@@ -362,6 +373,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>SortExec</td>
+<td>Input</td>
 <td>The backend for the sort operator</td>
 <td>None</td>
 <td>S</td>
@@ -385,6 +397,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>TakeOrderedAndProjectExec</td>
+<td>Input</td>
 <td>Take the first limit elements as defined by the sortOrder, and do projection if needed.</td>
 <td>None</td>
 <td>S</td>
@@ -408,6 +421,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>UnionExec</td>
+<td>Input</td>
 <td>The backend for the union operator</td>
 <td>None</td>
 <td>S</td>
@@ -431,6 +445,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>CustomShuffleReaderExec</td>
+<td>Input</td>
 <td>A wrapper of shuffle query stage</td>
 <td>None</td>
 <td>S</td>
@@ -454,6 +469,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>HashAggregateExec</td>
+<td>Input</td>
 <td>The backend for hash based aggregations</td>
 <td>None</td>
 <td>S</td>
@@ -478,6 +494,7 @@ Accelerator supports are described below.
 <tr>
 <th>Executor</th>
 <th>Description</th>
+<th>Context</th>
 <th>Notes</th>
 <th>BOOLEAN</th>
 <th>BYTE</th>
@@ -500,6 +517,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ObjectHashAggregateExec</td>
+<td>Input</td>
 <td>The backend for hash based aggregations supporting TypedImperativeAggregate functions</td>
 <td>None</td>
 <td>S</td>
@@ -523,6 +541,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>SortAggregateExec</td>
+<td>Input</td>
 <td>The backend for sort based aggregations</td>
 <td>None</td>
 <td>S</td>
@@ -546,6 +565,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>DataWritingCommandExec</td>
+<td>Input</td>
 <td>Writing data</td>
 <td>None</td>
 <td>S</td>
@@ -569,6 +589,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>BatchScanExec</td>
+<td>Input</td>
 <td>The backend for most file input</td>
 <td>None</td>
 <td>S</td>
@@ -592,6 +613,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>BroadcastExchangeExec</td>
+<td>Input</td>
 <td>The backend for broadcast exchange of data</td>
 <td>None</td>
 <td>S</td>
@@ -615,6 +637,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ShuffleExchangeExec</td>
+<td>Input</td>
 <td>The backend for most data being exchanged between processes</td>
 <td>None</td>
 <td>S</td>
@@ -638,6 +661,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>BroadcastHashJoinExec</td>
+<td>Input</td>
 <td>Implementation of join using broadcast data</td>
 <td>None</td>
 <td>S</td>
@@ -654,13 +678,62 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>BroadcastHashJoinExec</td>
+<td>Implementation of join using broadcast data</td>
+<td>leftKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>BroadcastHashJoinExec</td>
+<td>Implementation of join using broadcast data</td>
+<td>rightKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td>BroadcastNestedLoopJoinExec</td>
+<td>Input</td>
 <td>Implementation of join using brute force</td>
 <td>None</td>
 <td>S</td>
@@ -684,6 +757,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>CartesianProductExec</td>
+<td>Input</td>
 <td>Implementation of join using brute force</td>
 <td>None</td>
 <td>S</td>
@@ -707,6 +781,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ShuffledHashJoinExec</td>
+<td>Input</td>
 <td>Implementation of join using hashed shuffled data</td>
 <td>None</td>
 <td>S</td>
@@ -723,13 +798,62 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>ShuffledHashJoinExec</td>
+<td>Implementation of join using hashed shuffled data</td>
+<td>leftKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>ShuffledHashJoinExec</td>
+<td>Implementation of join using hashed shuffled data</td>
+<td>rightKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td>SortMergeJoinExec</td>
+<td>Input</td>
 <td>Sort merge join, replacing with shuffled hash join</td>
 <td>None</td>
 <td>S</td>
@@ -746,13 +870,86 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>Cannot be used as join key;<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
+<td>SortMergeJoinExec</td>
+<td>Sort merge join, replacing with shuffled hash join</td>
+<td>leftKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>SortMergeJoinExec</td>
+<td>Sort merge join, replacing with shuffled hash join</td>
+<td>rightKeys</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<th>Executor</th>
+<th>Description</th>
+<th>Context</th>
+<th>Notes</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td>AggregateInPandasExec</td>
+<td>Input</td>
 <td>The backend for an Aggregation Pandas UDF, this accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
@@ -776,6 +973,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>ArrowEvalPythonExec</td>
+<td>Input</td>
 <td>The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled</td>
 <td>None</td>
 <td>S</td>
@@ -799,6 +997,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>FlatMapGroupsInPandasExec</td>
+<td>Input</td>
 <td>The backend for Flat Map Groups Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
@@ -822,6 +1021,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>MapInPandasExec</td>
+<td>Input</td>
 <td>The backend for Map Pandas Iterator UDF. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
@@ -844,30 +1044,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<th>Executor</th>
-<th>Description</th>
-<th>Notes</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td>WindowInPandasExec</td>
+<td>Input</td>
 <td>The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled. For now it only supports row based window frame.</td>
 <td>This is disabled by default because it only supports row based frame for now</td>
 <td>S</td>
@@ -891,6 +1069,7 @@ Accelerator supports are described below.
 </tr>
 <tr>
 <td>WindowExec</td>
+<td>Input</td>
 <td>Window-operator backend</td>
 <td>None</td>
 <td>S</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -132,9 +132,9 @@ Accelerator supports are described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td>CoalesceExec</td>
+<td rowspan="1">CoalesceExec</td>
+<td rowspan="1">The backend for the dataframe coalesce method</td>
 <td>Input</td>
-<td>The backend for the dataframe coalesce method</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -156,9 +156,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>CollectLimitExec</td>
+<td rowspan="1">CollectLimitExec</td>
+<td rowspan="1">Reduce to single partition and apply limit</td>
 <td>Input</td>
-<td>Reduce to single partition and apply limit</td>
 <td>This is disabled by default because Collect Limit replacement can be slower on the GPU, if huge number of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU</td>
 <td>S</td>
 <td>S</td>
@@ -180,9 +180,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ExpandExec</td>
+<td rowspan="1">ExpandExec</td>
+<td rowspan="1">The backend for the expand operator</td>
 <td>Input</td>
-<td>The backend for the expand operator</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -204,9 +204,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>FileSourceScanExec</td>
+<td rowspan="1">FileSourceScanExec</td>
+<td rowspan="1">Reading data from files, often from Hive tables</td>
 <td>Input</td>
-<td>Reading data from files, often from Hive tables</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -228,9 +228,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>FilterExec</td>
+<td rowspan="1">FilterExec</td>
+<td rowspan="1">The backend for most filter statements</td>
 <td>Input</td>
-<td>The backend for most filter statements</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -252,9 +252,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>GenerateExec</td>
+<td rowspan="1">GenerateExec</td>
+<td rowspan="1">The backend for operations that generate more output rows than input rows like explode</td>
 <td>Input</td>
-<td>The backend for operations that generate more output rows than input rows like explode</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -276,9 +276,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>GlobalLimitExec</td>
+<td rowspan="1">GlobalLimitExec</td>
+<td rowspan="1">Limiting of results across partitions</td>
 <td>Input</td>
-<td>Limiting of results across partitions</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -300,9 +300,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>LocalLimitExec</td>
+<td rowspan="1">LocalLimitExec</td>
+<td rowspan="1">Per-partition limiting of results</td>
 <td>Input</td>
-<td>Per-partition limiting of results</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -324,9 +324,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ProjectExec</td>
+<td rowspan="1">ProjectExec</td>
+<td rowspan="1">The backend for most select, withColumn and dropColumn statements</td>
 <td>Input</td>
-<td>The backend for most select, withColumn and dropColumn statements</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -348,9 +348,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>RangeExec</td>
+<td rowspan="1">RangeExec</td>
+<td rowspan="1">The backend for range operator</td>
 <td>Input</td>
-<td>The backend for range operator</td>
 <td>None</td>
 <td> </td>
 <td> </td>
@@ -372,33 +372,9 @@ Accelerator supports are described below.
 <td> </td>
 </tr>
 <tr>
-<td>SortExec</td>
+<td rowspan="1">SortExec</td>
+<td rowspan="1">The backend for the sort operator</td>
 <td>Input</td>
-<td>The backend for the sort operator</td>
-<td>None</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>TakeOrderedAndProjectExec</td>
-<td>Input</td>
-<td>Take the first limit elements as defined by the sortOrder, and do projection if needed.</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -420,9 +396,33 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>UnionExec</td>
+<td rowspan="1">TakeOrderedAndProjectExec</td>
+<td rowspan="1">Take the first limit elements as defined by the sortOrder, and do projection if needed.</td>
 <td>Input</td>
-<td>The backend for the union operator</td>
+<td>None</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td rowspan="1">UnionExec</td>
+<td rowspan="1">The backend for the union operator</td>
+<td>Input</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -444,9 +444,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>CustomShuffleReaderExec</td>
+<td rowspan="1">CustomShuffleReaderExec</td>
+<td rowspan="1">A wrapper of shuffle query stage</td>
 <td>Input</td>
-<td>A wrapper of shuffle query stage</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -468,9 +468,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>HashAggregateExec</td>
+<td rowspan="1">HashAggregateExec</td>
+<td rowspan="1">The backend for hash based aggregations</td>
 <td>Input</td>
-<td>The backend for hash based aggregations</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -516,9 +516,9 @@ Accelerator supports are described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td>ObjectHashAggregateExec</td>
+<td rowspan="1">ObjectHashAggregateExec</td>
+<td rowspan="1">The backend for hash based aggregations supporting TypedImperativeAggregate functions</td>
 <td>Input</td>
-<td>The backend for hash based aggregations supporting TypedImperativeAggregate functions</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -540,9 +540,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>SortAggregateExec</td>
+<td rowspan="1">SortAggregateExec</td>
+<td rowspan="1">The backend for sort based aggregations</td>
 <td>Input</td>
-<td>The backend for sort based aggregations</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -564,9 +564,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>DataWritingCommandExec</td>
+<td rowspan="1">DataWritingCommandExec</td>
+<td rowspan="1">Writing data</td>
 <td>Input</td>
-<td>Writing data</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -588,9 +588,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BatchScanExec</td>
+<td rowspan="1">BatchScanExec</td>
+<td rowspan="1">The backend for most file input</td>
 <td>Input</td>
-<td>The backend for most file input</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -612,9 +612,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BroadcastExchangeExec</td>
+<td rowspan="1">BroadcastExchangeExec</td>
+<td rowspan="1">The backend for broadcast exchange of data</td>
 <td>Input</td>
-<td>The backend for broadcast exchange of data</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -636,9 +636,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ShuffleExchangeExec</td>
+<td rowspan="1">ShuffleExchangeExec</td>
+<td rowspan="1">The backend for most data being exchanged between processes</td>
 <td>Input</td>
-<td>The backend for most data being exchanged between processes</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -660,9 +660,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BroadcastHashJoinExec</td>
+<td rowspan="3">BroadcastHashJoinExec</td>
+<td rowspan="3">Implementation of join using broadcast data</td>
 <td>Input</td>
-<td>Implementation of join using broadcast data</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -684,8 +684,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BroadcastHashJoinExec</td>
-<td>Implementation of join using broadcast data</td>
+<td></td>
+<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -708,8 +708,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BroadcastHashJoinExec</td>
-<td>Implementation of join using broadcast data</td>
+<td></td>
+<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>
@@ -732,9 +732,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>BroadcastNestedLoopJoinExec</td>
+<td rowspan="1">BroadcastNestedLoopJoinExec</td>
+<td rowspan="1">Implementation of join using brute force</td>
 <td>Input</td>
-<td>Implementation of join using brute force</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -756,9 +756,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>CartesianProductExec</td>
+<td rowspan="1">CartesianProductExec</td>
+<td rowspan="1">Implementation of join using brute force</td>
 <td>Input</td>
-<td>Implementation of join using brute force</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -780,9 +780,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ShuffledHashJoinExec</td>
+<td rowspan="3">ShuffledHashJoinExec</td>
+<td rowspan="3">Implementation of join using hashed shuffled data</td>
 <td>Input</td>
-<td>Implementation of join using hashed shuffled data</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -804,8 +804,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ShuffledHashJoinExec</td>
-<td>Implementation of join using hashed shuffled data</td>
+<td></td>
+<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -828,8 +828,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ShuffledHashJoinExec</td>
-<td>Implementation of join using hashed shuffled data</td>
+<td></td>
+<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>
@@ -852,9 +852,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>SortMergeJoinExec</td>
+<td rowspan="3">SortMergeJoinExec</td>
+<td rowspan="3">Sort merge join, replacing with shuffled hash join</td>
 <td>Input</td>
-<td>Sort merge join, replacing with shuffled hash join</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -876,8 +876,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>SortMergeJoinExec</td>
-<td>Sort merge join, replacing with shuffled hash join</td>
+<td></td>
+<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -900,8 +900,8 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>SortMergeJoinExec</td>
-<td>Sort merge join, replacing with shuffled hash join</td>
+<td></td>
+<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>
@@ -948,9 +948,9 @@ Accelerator supports are described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td>AggregateInPandasExec</td>
+<td rowspan="1">AggregateInPandasExec</td>
+<td rowspan="1">The backend for an Aggregation Pandas UDF, this accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>Input</td>
-<td>The backend for an Aggregation Pandas UDF, this accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -972,9 +972,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>ArrowEvalPythonExec</td>
+<td rowspan="1">ArrowEvalPythonExec</td>
+<td rowspan="1">The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled</td>
 <td>Input</td>
-<td>The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -996,9 +996,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>FlatMapGroupsInPandasExec</td>
+<td rowspan="1">FlatMapGroupsInPandasExec</td>
+<td rowspan="1">The backend for Flat Map Groups Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>Input</td>
-<td>The backend for Flat Map Groups Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -1020,9 +1020,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>MapInPandasExec</td>
+<td rowspan="1">MapInPandasExec</td>
+<td rowspan="1">The backend for Map Pandas Iterator UDF. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>Input</td>
-<td>The backend for Map Pandas Iterator UDF. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>
@@ -1044,9 +1044,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>WindowInPandasExec</td>
+<td rowspan="1">WindowInPandasExec</td>
+<td rowspan="1">The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled. For now it only supports row based window frame.</td>
 <td>Input</td>
-<td>The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled. For now it only supports row based window frame.</td>
 <td>This is disabled by default because it only supports row based frame for now</td>
 <td>S</td>
 <td>S</td>
@@ -1068,9 +1068,9 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>WindowExec</td>
+<td rowspan="1">WindowExec</td>
+<td rowspan="1">Window-operator backend</td>
 <td>Input</td>
-<td>Window-operator backend</td>
 <td>None</td>
 <td>S</td>
 <td>S</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -684,8 +684,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -708,8 +706,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>
@@ -804,8 +800,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -828,8 +822,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>
@@ -876,8 +868,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>leftKeys</td>
 <td>None</td>
 <td>S</td>
@@ -900,8 +890,6 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td></td>
-<td></td>
 <td>rightKeys</td>
 <td>None</td>
 <td>S</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -702,7 +702,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -724,7 +724,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -818,7 +818,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -840,7 +840,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -886,7 +886,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -908,7 +908,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
@@ -44,6 +44,9 @@ class GpuBroadcastHashJoinMeta(
   val condition: Option[BaseExprMeta[_]] =
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override def tagPlanForGpu(): Unit = {

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
@@ -52,6 +52,9 @@ class GpuShuffledHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
   }

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
@@ -42,6 +42,9 @@ class GpuSortMergeJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
@@ -234,8 +234,8 @@ abstract class SparkBaseShims extends SparkShims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
@@ -244,8 +244,8 @@ abstract class SparkBaseShims extends SparkShims {
             TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
             TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
@@ -254,8 +254,8 @@ abstract class SparkBaseShims extends SparkShims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
             TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
@@ -232,31 +232,31 @@ abstract class SparkBaseShims extends SparkShims {
         "Sort merge join, replacing with shuffled hash join",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+            TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64), TypeSig.all),
+            TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64), TypeSig.all),
+            TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
@@ -46,6 +46,10 @@ class GpuBroadcastHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
     val Seq(leftChild, rightChild) = childPlans

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
@@ -53,6 +53,9 @@ class GpuShuffledHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
   }

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuSortMergeJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuSortMergeJoinExec.scala
@@ -43,6 +43,9 @@ class GpuSortMergeJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -185,8 +185,8 @@ class Spark301dbShims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
@@ -195,8 +195,8 @@ class Spark301dbShims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
@@ -205,8 +205,8 @@ class Spark301dbShims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -183,32 +183,31 @@ class Spark301dbShims extends Spark301Shims {
         "Sort merge join, replacing with shuffled hash join",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64)
-          , TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuBroadcastHashJoinExec.scala
@@ -51,6 +51,9 @@ class GpuBroadcastHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
     val Seq(leftChild, rightChild) = childPlans

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
@@ -53,6 +53,9 @@ class GpuShuffledHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
   }

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
@@ -43,6 +43,9 @@ class GpuSortMergeJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -395,8 +395,8 @@ class Spark311Shims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
@@ -405,8 +405,8 @@ class Spark311Shims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
@@ -415,8 +415,8 @@ class Spark311Shims extends Spark301Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r))
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r))

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -393,32 +393,31 @@ class Spark311Shims extends Spark301Shims {
         "Sort merge join, replacing with shuffled hash join",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64)
-          , TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r))
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r))
   }

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
@@ -46,6 +46,9 @@ class GpuBroadcastHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
     val Seq(leftChild, rightChild) = childPlans

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuShuffledHashJoinExec.scala
@@ -53,6 +53,9 @@ class GpuShuffledHashJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)
   }

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuSortMergeJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuSortMergeJoinExec.scala
@@ -43,6 +43,9 @@ class GpuSortMergeJoinMeta(
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
+  override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
+    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -170,33 +170,32 @@ class Spark311dbShims extends Spark311Shims {
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
+            TypeSig.STRUCT + TypeSig.MAP),
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64), TypeSig.all),
+            TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64)
-          , TypeSig.all),
+          TypeSig.DECIMAL_64),
+          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
          ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.MAP)
-          .withPsNote(TypeEnum.ARRAY, "Cannot be used as join key")
-          .withPsNote(TypeEnum.STRUCT, "Cannot be used as join key")
-          .withPsNote(TypeEnum.MAP, "Cannot be used as join key")
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64), TypeSig.all),
+          TypeSig.DECIMAL_64),
+           Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+             "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+           TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -173,8 +173,8 @@ class Spark311dbShims extends Spark311Shims {
             TypeSig.STRUCT + TypeSig.MAP),
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
             TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+        Map("leftKeys" -> TypeSig.joinKeyTypes,
+          "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
@@ -183,8 +183,8 @@ class Spark311dbShims extends Spark311Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
           TypeSig.DECIMAL_64),
-          Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-            "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          Map("leftKeys" -> TypeSig.joinKeyTypes,
+            "rightKeys" -> TypeSig.joinKeyTypes),
           TypeSig.all),
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
@@ -193,8 +193,8 @@ class Spark311dbShims extends Spark311Shims {
             TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
           TypeSig.DECIMAL_64),
-           Map("leftKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-             "rightKeys" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+           Map("leftKeys" -> TypeSig.joinKeyTypes,
+             "rightKeys" -> TypeSig.joinKeyTypes),
            TypeSig.all),
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3127,10 +3127,8 @@ object GpuOverrides {
       "Window-operator backend",
       ExecChecks(
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested() +
-            TypeSig.psNote(TypeEnum.MAP, "Not supported as a partition by key") +
-            TypeSig.psNote(TypeEnum.STRUCT, "Not supported as a partition by key") +
-            TypeSig.psNote(TypeEnum.ARRAY, "Not supported as a partition by key"),
+            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+        Map("partitionSpec" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
         TypeSig.all),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -562,6 +562,8 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
   override val childParts: Seq[PartMeta[_]] = Seq.empty
   override val childDataWriteCmds: Seq[DataWritingCommandMeta[_]] = Seq.empty
 
+  def namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] = Map.empty
+
   var cpuCost: Double = 0
   var gpuCost: Double = 0
   var estimatedOutputRows: Option[BigInt] = None

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -1559,9 +1559,15 @@ object SupportedOpsDocs {
           nextOutputAt = totalCount + headerEveryNLines
         }
         println("<tr>")
-        println(s"<td>${rule.tag.runtimeClass.getSimpleName}</td>")
+        val count = if (checks.isDefined) {
+          val exprChecks = checks.get.asInstanceOf[ExecChecks]
+          1 + exprChecks.extendedChecks.size
+        } else {
+          1
+        }
+        println(s"""<td rowspan="$count">${rule.tag.runtimeClass.getSimpleName}</td>""")
+        println(s"""<td rowspan="$count">${rule.description}</td>""")
         println(s"<td>Input</td>")
-        println(s"<td>${rule.description}</td>")
         println(s"<td>${rule.notes().getOrElse("None")}</td>")
         if (checks.isDefined) {
           val exprChecks = checks.get.asInstanceOf[ExecChecks]
@@ -1581,8 +1587,8 @@ object SupportedOpsDocs {
           val exprChecks = checks.get.asInstanceOf[ExecChecks]
           exprChecks.extendedChecks.keys.toSeq.sorted.foreach { ctx =>
             println("<tr>")
-            println(s"<td>${rule.tag.runtimeClass.getSimpleName}</td>")
-            println(s"<td>${rule.description}</td>")
+            println(s"<td></td>")
+            println(s"<td></td>")
             println(s"<td>$ctx</td>")
             println(s"<td>${rule.notes().getOrElse("None")}</td>")
             TypeEnum.values.foreach { t =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -814,12 +814,10 @@ class ExecChecks private(
 
     extendedChecks.foreach {
       case (fieldName, typeSig) =>
-        val field = meta.getClass.getMethod(fieldName)
-        val fieldMeta = field.invoke(meta).asInstanceOf[Seq[BaseExprMeta[_]]]
-          .map(_.typeMeta)
-          .filter(_.dataType.isDefined)
+        val fieldMeta = meta.namedChildExprs(fieldName)
+          .flatMap(_.typeMeta.dataType)
           .zipWithIndex
-          .map(t => StructField(s"c${t._2}", t._1.dataType.get))
+          .map(t => StructField(s"c${t._2}", t._1))
         tagUnsupportedTypes(meta, typeSig, allowDecimal, fieldMeta,
           s"unsupported data types in '$fieldName': %s")
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -1559,14 +1559,14 @@ object SupportedOpsDocs {
           nextOutputAt = totalCount + headerEveryNLines
         }
         println("<tr>")
-        val count = if (checks.isDefined) {
+        val rowSpan = if (checks.isDefined) {
           val exprChecks = checks.get.asInstanceOf[ExecChecks]
           1 + exprChecks.extendedChecks.size
         } else {
           1
         }
-        println(s"""<td rowspan="$count">${rule.tag.runtimeClass.getSimpleName}</td>""")
-        println(s"""<td rowspan="$count">${rule.description}</td>""")
+        println(s"""<td rowspan="$rowSpan">${rule.tag.runtimeClass.getSimpleName}</td>""")
+        println(s"""<td rowspan="$rowSpan">${rule.description}</td>""")
         println(s"<td>Input</td>")
         println(s"<td>${rule.notes().getOrElse("None")}</td>")
         if (checks.isDefined) {
@@ -1587,8 +1587,6 @@ object SupportedOpsDocs {
           val exprChecks = checks.get.asInstanceOf[ExecChecks]
           exprChecks.extendedChecks.keys.toSeq.sorted.foreach { ctx =>
             println("<tr>")
-            println(s"<td></td>")
-            println(s"<td></td>")
             println(s"<td>$ctx</td>")
             println(s"<td>${rule.notes().getOrElse("None")}</td>")
             TypeEnum.values.foreach { t =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -546,6 +546,11 @@ object TypeSig {
       TIMESTAMP + STRING
 
   /**
+   * A signature for types that are generally supported for join keys.
+   */
+  val joinKeyTypes: TypeSig = (commonCudfTypes + NULL + DECIMAL_64 + STRUCT).nested()
+
+  /**
    * All floating point types
    */
   val fp: TypeSig = FLOAT + DOUBLE

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -812,9 +812,17 @@ class ExecChecks private(
       meta.childPlans.flatMap(_.outputAttributes.map(toStructField)),
       "unsupported data types in input: %s")
 
+    val namedChildExprs = meta.namedChildExprs
+
+    val missing = namedChildExprs.keys.filterNot(extendedChecks.contains)
+    if (missing.nonEmpty) {
+      throw new IllegalStateException(s"${meta.getClass.getSimpleName} " +
+        s"is missing ExecChecks for ${missing.mkString(",")}")
+    }
+
     extendedChecks.foreach {
       case (fieldName, typeSig) =>
-        val fieldMeta = meta.namedChildExprs(fieldName)
+        val fieldMeta = namedChildExprs(fieldName)
           .flatMap(_.typeMeta.dataType)
           .zipWithIndex
           .map(t => StructField(s"c${t._2}", t._1))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -68,10 +68,6 @@ object GpuHashJoin extends Arm {
       rightKeys: Seq[Expression],
       condition: Option[Expression]): Unit = {
     val keyDataTypes = (leftKeys ++ rightKeys).map(_.dataType)
-    if (keyDataTypes.exists(dType =>
-      dType.isInstanceOf[ArrayType] || dType.isInstanceOf[MapType])) {
-      meta.willNotWorkOnGpu("ArrayType or MapType in join keys are not supported")
-    }
 
     def unSupportNonEqualCondition(): Unit = if (condition.isDefined) {
       meta.willNotWorkOnGpu(s"$joinType joins currently do not support conditions")


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes #2102 

This PR allows us to provide TypeSig signatures for join keys and generates appropriate documentation in support_ops.md

This is implemented for joins and WindowExec.

