### PR TITLE
Exclude slf4j classes from the spark-rapids jar

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -70,6 +70,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <artifactSet>
+            <excludes>org.slf4j:*</excludes>
+          </artifactSet>
 	  <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
 	  </transformers>


### PR DESCRIPTION
Exlcluding org.slf4j from the main plugin artifact, closes #3187

Signed-off-by: Gera Shegalov <gera@apache.org>
