### PR TITLE
Disable snapshot shims by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ mvn verify
 
 After a successful build the RAPIDS Accelerator jar will be in the `dist/target/` directory.
 
+### Building Shims for Spark Snapshot Versions
+
+By default the build will only include shims for released versions of Spark. To include shims
+for snapshot versions of Spark still under development, use the `snapshot-shims` Maven profile
+(e.g.: add `-Psnapshot-shims` to the Maven command-line). Note that when a snapshot Spark version
+later becomes an official release, the snapshot shim for that version may no longer build due to
+missing snapshot artifacts for that Spark version.
+
 ### Building against different CUDA Toolkit versions
 
 You can build against different versions of the CUDA Toolkit by using one of the following profiles:

--- a/shims/aggregator/pom.xml
+++ b/shims/aggregator/pom.xml
@@ -98,7 +98,7 @@
         <profile>
             <id>snapshot-shims</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -53,7 +53,7 @@
         <profile>
             <id>snapshot-shims</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <modules>
                 <module>spark304</module>


### PR DESCRIPTION
Fixes #3166.

This disables the shims for Spark snapshot versions by default.  The `snapshot-shims` profile must be explicitly specified to include snapshot shims. After this change, RAPIDS Accelerator source should continue to build even after new Spark versions release since it won't try to pull Spark snapshot artifacts by default.