### PR TITLE
Update GpuInSet for SPARK-35422 changes

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
@@ -49,11 +49,22 @@ case class GpuInSet(
   private def buildNeedles: ColumnVector =
     GpuScalar.columnVectorFromLiterals(list, child.dataType)
 
-  override def toString: String = s"$child INSET ${list.mkString("(", ",", ")")}"
+  override def toString: String = {
+    val listString = list
+        .map(elem => Literal(elem, child.dataType).toString)
+        // Sort elements for deterministic behaviours
+        .sorted
+        .mkString(", ")
+    s"$child INSET $listString"
+  }
 
   override def sql: String = {
     val valueSQL = child.sql
-    val listSQL = list.map(Literal(_).sql).mkString(", ")
+    val listSQL = list
+        .map(elem => Literal(elem, child.dataType).sql)
+        // Sort elements for deterministic behaviours
+        .sorted
+        .mkString(", ")
     s"($valueSQL IN ($listSQL))"
   }
 }


### PR DESCRIPTION
Fixes #3087

This updates `GpuInSet` to match the corresponding changes made to Spark's `InSet` as part of [SPARK-35422](https://issues.apache.org/jira/browse/SPARK-35422).