### PR TITLE
Decrease parallelism for pre-merge integration tests

### DIFF
--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -52,7 +52,7 @@ mvn_verify() {
         rm -f $SPARK_HOME.tgz
 
     mvn -U -B $MVN_URM_MIRROR '-P!snapshot-shims,pre-merge' clean verify -Dpytest.TEST_TAGS='' \
-        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=4 -Dcuda.version=$CUDA_CLASSIFIER
+        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=3 -Dcuda.version=$CUDA_CLASSIFIER
 
     # The jacoco coverage should have been collected, but because of how the shade plugin
     # works and jacoco we need to clean some things up so jacoco will only report for the


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

We realize some ephemeral OOM kills for xdist process in pre-merge, lets decrease the parallelism for now.

And We have another issue to try split integration tests run in different stages/pods https://github.com/NVIDIA/spark-rapids/issues/2731