### PR TITLE
[auto-merge] branch-21.08 to branch-21.10 [skip ci] [bot]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Generated on 2021-08-12
 ### PRs
 |||
 |:---|:---|
+|[#3214](https://github.com/NVIDIA/spark-rapids/pull/3214)|Update download and databricks doc for 21.06.2 [skip ci]|
+|[#3210](https://github.com/NVIDIA/spark-rapids/pull/3210)|Update 21.08.0 changelog to latest [skip ci]|
 |[#3197](https://github.com/NVIDIA/spark-rapids/pull/3197)|Databricks parquetFilters api change in db 8.2 runtime|
 |[#3168](https://github.com/NVIDIA/spark-rapids/pull/3168)|Update 21.08 changelog to latest [skip ci]|
 |[#3146](https://github.com/NVIDIA/spark-rapids/pull/3146)|update cudf Java binding version to 21.08.2|


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-21.08` to create a PR keeping `branch-21.10` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.