### PR TITLE
Add UCX 1.11.0 to the pre-merge Docker image

### DIFF
--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -25,7 +25,11 @@
 
 ARG CUDA_VER=11.0
 ARG UBUNTU_VER=18.04
+ARG UCX_VER=v1.11.0
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
+ARG CUDA_VER
+ARG UBUNTU_VER
+ARG UCX_VER
 
 # Install jdk-8, jdk-11, maven, docker image
 RUN apt-get update -y && \
@@ -42,4 +46,7 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
 RUN ln -s /usr/bin/python3.8 /usr/bin/python
 RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit
 
-RUN apt install -y inetutils-ping expect
+# libnuma1 and libgomp1 are required by ucx packaging
+RUN apt install -y inetutils-ping expect wget libnuma1 libgomp1
+
+RUN mkdir -p /tmp/ucx && cd /tmp/ucx && wget https://github.com/openucx/ucx/releases/download/${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5.x-cuda${CUDA_VER}.deb && dpkg -i *.deb && rm -rf /tmp/ucx

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -49,4 +49,8 @@ RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pyt
 # libnuma1 and libgomp1 are required by ucx packaging
 RUN apt install -y inetutils-ping expect wget libnuma1 libgomp1
 
-RUN mkdir -p /tmp/ucx && cd /tmp/ucx && wget https://github.com/openucx/ucx/releases/download/${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5.x-cuda${CUDA_VER}.deb && dpkg -i *.deb && rm -rf /tmp/ucx
+RUN mkdir -p /tmp/ucx && \
+    cd /tmp/ucx && \
+    wget https://github.com/openucx/ucx/releases/download/${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5.x-cuda${CUDA_VER}.deb && \
+    dpkg -i *.deb && \
+    rm -rf /tmp/ucx


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Splits off the addition of UCX 1.11 to the CI dockerfile we use for premerge. The next PR should enable tests, but this needs to be done first so we have the image with UCX pushed.