### PR TITLE
Fix unreachable code warnings in GpuCast

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -478,19 +478,6 @@ object GpuCast extends Arm {
       case (ShortType | IntegerType | LongType | ByteType | StringType, BinaryType) =>
         input.asByteList(true)
 
-      case (ShortType | IntegerType | LongType, dt: DecimalType) =>
-        withResource(input.copyToColumnVector()) { inputVector =>
-          castIntegralsToDecimal(inputVector, dt, ansiMode)
-        }
-
-      case (FloatType | DoubleType, dt: DecimalType) =>
-        withResource(input.copyToColumnVector()) { inputVector =>
-          castFloatsToDecimal(inputVector, dt, ansiMode)
-        }
-
-      case (from: DecimalType, to: DecimalType) =>
-        castDecimalToDecimal(input.copyToColumnVector(), from, to, ansiMode)
-
       case (_: DecimalType, StringType) =>
         input.castTo(DType.STRING)
 


### PR DESCRIPTION
After #3162 the build emits an unreachable code warning:
```
[WARNING] [Warn] /spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:482: unreachable code
```

This removes a few of the match cases that will never be reached to resolve the build warning.