### PR TITLE
Fix Scaladoc warnings in GpuScalaUDF and BufferSendState

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -155,7 +155,8 @@ class BufferSendState(
    * Prepares and returns a `MemoryBuffer` that can be used in a send.
    * @return - a memory buffer slice backed by either a host or device bounce buffer, depending on
    *         the tier location for buffers we are sending.
-   * @throws `RapidsShuffleSendPrepareException` when copies to the bounce buffer fail.
+   * @throws org.apache.spark.shuffle.RapidsShuffleSendPrepareException when copies to the
+   *                                                                    bounce buffer fail.
    */
   def getBufferToSend(): MemoryBuffer = synchronized {
     require(acquiredBuffs.isEmpty,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -68,9 +68,9 @@ object GpuScalaUDF {
     })
 
   /**
-   * Determine if the UDF function implements the [[RapidsUDF]] interface, returning the instance
-   * if it does. The lambda wrapper that Spark applies to Java UDFs will be inspected if necessary
-   * to locate the user's UDF instance.
+   * Determine if the UDF function implements the [[com.nvidia.spark.RapidsUDF]] interface,
+   * returning the instance if it does. The lambda wrapper that Spark applies to Java UDFs will be
+   * inspected if necessary to locate the user's UDF instance.
    */
   def getRapidsUDFInstance(function: AnyRef): Option[RapidsUDF] = {
     function match {


### PR DESCRIPTION
Fixes the following Scaladoc warnings that appear during the build:
```
[INFO] --- scala-maven-plugin:4.3.0:doc-jar (attach-scaladocs) @ rapids-4-spark-sql_2.12 ---
model contains 913 documentable templates
/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala:70: warning: Could not find any member to link for "RapidsUDF".
  /**
  ^
/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala:154: warning: Could not find any member to link for "`RapidsShuffleSendPrepareException`".
  /**
  ^
two warnings found
```
