### PR TITLE
Disable test_broadcast_nested_loop_join_condition_missing_count on Databricks

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -393,6 +393,8 @@ def test_broadcast_nested_loop_join_condition_missing(data_gen, join_type):
     conf = allow_negative_scale_of_decimal_conf
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
+@pytest.mark.xfail(condition=is_databricks_runtime(),
+                   reason='https://github.com/NVIDIA/spark-rapids/issues/3244')
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 def test_broadcast_nested_loop_join_condition_missing_count(data_gen, join_type):


### PR DESCRIPTION
Relates to #3244 

The new test_broadcast_nested_loop_join_condition_missing_count test is failing due to what appears to be a bug in hash aggregate code.  It looks like we're trying to pull out an input reference from a batch that has no columns.  Thus this looks more like a latent bug in hash aggregate on Databricks that was exposed in by the new join code rather than a bug in the new join code itself.

To unblock the build while more investigation into the hash aggregate issue occurs, this xfails the test on Databricks and references #3244.