### PR TITLE
Fix typo in Spark311dbShims

### DIFF
--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -185,7 +185,7 @@ class Spark311dbShims extends Spark311Shims {
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP),
+            TypeSig.STRUCT + TypeSig.MAP)
           .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
             TypeSig.DECIMAL_64),
         Map("leftKeys" -> TypeSig.joinKeyTypes,


### PR DESCRIPTION
#3183 had a typo in Spark311dbShims that breaks the Databricks build.