### PR TITLE
Add ExecChecks to Databricks shims for RunningWindowFunctionExec

### DIFF
--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -121,10 +121,8 @@ class Spark301dbShims extends Spark301Shims {
             "i.e. (UNBOUNDED PRECEDING TO CURRENT ROW)",
         ExecChecks(
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-              TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested() +
-              TypeSig.psNote(TypeEnum.MAP, "Not supported as a partition by key") +
-              TypeSig.psNote(TypeEnum.STRUCT, "Not supported as a partition by key") +
-              TypeSig.psNote(TypeEnum.ARRAY, "Not supported as a partition by key"),
+            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+          Map("partitionSpec" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
           TypeSig.all),
         (runningWindowFunctionExec, conf, p, r) => new GpuRunningWindowExecMeta(runningWindowFunctionExec, conf, p, r)
       ),

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -124,11 +124,9 @@ class Spark311dbShims extends Spark311Shims {
             "i.e. (UNBOUNDED PRECEDING TO CURRENT ROW)",
         ExecChecks(
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-              TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested() +
-              TypeSig.psNote(TypeEnum.MAP, "Not supported as a partition by key") +
-              TypeSig.psNote(TypeEnum.STRUCT, "Not supported as a partition by key") +
-              TypeSig.psNote(TypeEnum.ARRAY, "Not supported as a partition by key"),
-            TypeSig.all),
+            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+          Map("partitionSpec" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
+          TypeSig.all),
           (runningWindowFunctionExec, conf, p, r) => new GpuRunningWindowExecMeta(runningWindowFunctionExec, conf, p, r)
       ),
       GpuOverrides.exec[FileSourceScanExec](


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Updates Databricks shims with ExecChecks for RunningWindowFunctionExec.

This is currently untested.

Closes https://github.com/NVIDIA/spark-rapids/issues/3255