### PR TITLE
Generate docs for AST from checks

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1211,7 +1211,7 @@ be done in the GPU kernel itself. An example of this is conditional joins. If yo
 want to join on `A.a >= B.b + 1` where `A` and `B` are separate tables or data
 frames, the `+` and `>=` operations cannot run as separate independent kernels
 because it is done on a combination of rows in both `A` and `B`. Instead part of the
-plan that Spark developed is turned into an abstract syntax tree and set to the GPU
+plan that Spark developed is turned into an abstract syntax tree and sent to the GPU
 where it can be interpreted. The number and types of operations supported in this
 are limited.
 <table>
@@ -1289,7 +1289,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -1379,7 +1379,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -1469,7 +1469,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -1580,7 +1580,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -1717,7 +1717,7 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td>S</td>
 <td>S</td>
@@ -1943,7 +1943,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2033,7 +2033,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2196,7 +2196,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2286,7 +2286,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2355,7 +2355,7 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="1">ast</td>
+<td rowSpan="1">AST</td>
 <td>result</td>
 <td>S</td>
 <td>S</td>
@@ -2539,7 +2539,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -2650,7 +2650,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -2761,7 +2761,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -2919,7 +2919,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -3098,7 +3098,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -3517,7 +3517,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -3633,7 +3633,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -3723,7 +3723,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -4900,7 +4900,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td>S</td>
 <td>S</td>
@@ -5011,7 +5011,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -5174,7 +5174,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -5745,7 +5745,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td>S</td>
 <td>S</td>
@@ -5877,7 +5877,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td>S</td>
 <td>S</td>
@@ -7132,7 +7132,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td>S</td>
 <td>S</td>
@@ -7290,7 +7290,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td>S</td>
 <td>S</td>
@@ -7448,7 +7448,7 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="1">ast</td>
+<td rowSpan="1">AST</td>
 <td>result</td>
 <td>S</td>
 <td>S</td>
@@ -8107,7 +8107,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -8333,7 +8333,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td>S</td>
 <td> </td>
@@ -8653,7 +8653,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td> </td>
@@ -9384,7 +9384,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -9965,7 +9965,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -10055,7 +10055,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -10427,7 +10427,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -11579,7 +11579,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">ast</td>
+<td rowSpan="3">AST</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -11690,7 +11690,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -11780,7 +11780,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -12194,7 +12194,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
@@ -12310,7 +12310,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">ast</td>
+<td rowSpan="2">AST</td>
 <td>input</td>
 <td> </td>
 <td>S</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -110,8 +110,8 @@ Accelerator supports are described below.
 <tr>
 <th>Executor</th>
 <th>Description</th>
-<th>Context</th>
 <th>Notes</th>
+<th>Param(s)</th>
 <th>BOOLEAN</th>
 <th>BYTE</th>
 <th>SHORT</th>
@@ -134,8 +134,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">CoalesceExec</td>
 <td rowspan="1">The backend for the dataframe coalesce method</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -158,8 +158,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">CollectLimitExec</td>
 <td rowspan="1">Reduce to single partition and apply limit</td>
-<td>Input</td>
-<td>This is disabled by default because Collect Limit replacement can be slower on the GPU, if huge number of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU</td>
+<td rowspan="1">This is disabled by default because Collect Limit replacement can be slower on the GPU, if huge number of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -182,8 +182,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">ExpandExec</td>
 <td rowspan="1">The backend for the expand operator</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -206,8 +206,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">FileSourceScanExec</td>
 <td rowspan="1">Reading data from files, often from Hive tables</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -230,8 +230,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">FilterExec</td>
 <td rowspan="1">The backend for most filter statements</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -254,8 +254,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">GenerateExec</td>
 <td rowspan="1">The backend for operations that generate more output rows than input rows like explode</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -278,8 +278,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">GlobalLimitExec</td>
 <td rowspan="1">Limiting of results across partitions</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -302,8 +302,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">LocalLimitExec</td>
 <td rowspan="1">Per-partition limiting of results</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -326,8 +326,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">ProjectExec</td>
 <td rowspan="1">The backend for most select, withColumn and dropColumn statements</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -350,8 +350,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">RangeExec</td>
 <td rowspan="1">The backend for range operator</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -374,8 +374,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">SortExec</td>
 <td rowspan="1">The backend for the sort operator</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -398,8 +398,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">TakeOrderedAndProjectExec</td>
 <td rowspan="1">Take the first limit elements as defined by the sortOrder, and do projection if needed.</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -422,8 +422,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">UnionExec</td>
 <td rowspan="1">The backend for the union operator</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -446,8 +446,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">CustomShuffleReaderExec</td>
 <td rowspan="1">A wrapper of shuffle query stage</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -470,8 +470,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">HashAggregateExec</td>
 <td rowspan="1">The backend for hash based aggregations</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -494,8 +494,8 @@ Accelerator supports are described below.
 <tr>
 <th>Executor</th>
 <th>Description</th>
-<th>Context</th>
 <th>Notes</th>
+<th>Param(s)</th>
 <th>BOOLEAN</th>
 <th>BYTE</th>
 <th>SHORT</th>
@@ -518,8 +518,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">ObjectHashAggregateExec</td>
 <td rowspan="1">The backend for hash based aggregations supporting TypedImperativeAggregate functions</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -542,8 +542,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">SortAggregateExec</td>
 <td rowspan="1">The backend for sort based aggregations</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -566,8 +566,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">DataWritingCommandExec</td>
 <td rowspan="1">Writing data</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -590,8 +590,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">BatchScanExec</td>
 <td rowspan="1">The backend for most file input</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -614,8 +614,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">BroadcastExchangeExec</td>
 <td rowspan="1">The backend for broadcast exchange of data</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -638,8 +638,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">ShuffleExchangeExec</td>
 <td rowspan="1">The backend for most data being exchanged between processes</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -660,32 +660,10 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowspan="3">BroadcastHashJoinExec</td>
-<td rowspan="3">Implementation of join using broadcast data</td>
-<td>Input</td>
-<td>None</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
+<td rowspan="4">BroadcastHashJoinExec</td>
+<td rowspan="4">Implementation of join using broadcast data</td>
+<td rowspan="4">None</td>
 <td>leftKeys</td>
-<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -701,13 +679,12 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td>rightKeys</td>
-<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -723,15 +700,33 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowspan="1">BroadcastNestedLoopJoinExec</td>
-<td rowspan="1">Implementation of join using brute force</td>
-<td>Input</td>
-<td>None</td>
+<td>condition</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -746,16 +741,61 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td rowspan="2">BroadcastNestedLoopJoinExec</td>
+<td rowspan="2">Implementation of join using brute force</td>
+<td rowspan="2">None</td>
+<td>condition<br/>(A non-inner join only is supported if the condition expression can be converted to a GPU AST expression)</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>Input/Output</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td rowspan="1">CartesianProductExec</td>
 <td rowspan="1">Implementation of join using brute force</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -776,32 +816,10 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowspan="3">ShuffledHashJoinExec</td>
-<td rowspan="3">Implementation of join using hashed shuffled data</td>
-<td>Input</td>
-<td>None</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
+<td rowspan="4">ShuffledHashJoinExec</td>
+<td rowspan="4">Implementation of join using hashed shuffled data</td>
+<td rowspan="4">None</td>
 <td>leftKeys</td>
-<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -817,13 +835,12 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td>rightKeys</td>
-<td>None</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -839,37 +856,33 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowspan="3">SortMergeJoinExec</td>
-<td rowspan="3">Sort merge join, replacing with shuffled hash join</td>
-<td>Input</td>
-<td>None</td>
+<td>condition</td>
 <td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><b>NS</b></td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
 </tr>
 <tr>
-<td>leftKeys</td>
-<td>None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -884,38 +897,16 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>rightKeys</td>
-<td>None</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, MAP, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <th>Executor</th>
 <th>Description</th>
-<th>Context</th>
 <th>Notes</th>
+<th>Param(s)</th>
 <th>BOOLEAN</th>
 <th>BYTE</th>
 <th>SHORT</th>
@@ -936,10 +927,97 @@ Accelerator supports are described below.
 <th>UDT</th>
 </tr>
 <tr>
+<td rowspan="4">SortMergeJoinExec</td>
+<td rowspan="4">Sort merge join, replacing with shuffled hash join</td>
+<td rowspan="4">None</td>
+<td>leftKeys</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>rightKeys</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>condition</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>Input/Output</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
 <td rowspan="1">AggregateInPandasExec</td>
 <td rowspan="1">The backend for an Aggregation Pandas UDF, this accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -962,8 +1040,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">ArrowEvalPythonExec</td>
 <td rowspan="1">The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -986,8 +1064,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">FlatMapGroupsInPandasExec</td>
 <td rowspan="1">The backend for Flat Map Groups Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -1010,8 +1088,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">MapInPandasExec</td>
 <td rowspan="1">The backend for Map Pandas Iterator UDF. Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled.</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="1">None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -1034,8 +1112,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="1">WindowInPandasExec</td>
 <td rowspan="1">The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between the Java process and the Python process. It also supports scheduling GPU resources for the Python process when enabled. For now it only supports row based window frame.</td>
-<td>Input</td>
-<td>This is disabled by default because it only supports row based frame for now</td>
+<td rowspan="1">This is disabled by default because it only supports row based frame for now</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -1058,8 +1136,8 @@ Accelerator supports are described below.
 <tr>
 <td rowspan="2">WindowExec</td>
 <td rowspan="2">Window-operator backend</td>
-<td>Input</td>
-<td>None</td>
+<td rowspan="2">None</td>
+<td>partitionSpec</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -1074,14 +1152,13 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td>partitionSpec</td>
-<td>None</td>
+<td>Input/Output</td>
 <td>S</td>
 <td>S</td>
 <td>S</td>
@@ -1096,9 +1173,9 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 </table>
@@ -1122,9 +1199,21 @@ Aggregation operations like count or sum can take place in either the `aggregati
 grouping the data by one or more keys. `reduction` is when there is no group by and
 there is a single result for an entire column. `window` is for window operations.
 
-The final expression context is `lambda` which happens primarily for higher order
-functions in SQL.
-Accelerator support is described below.
+The final expression context is `AST` or Abstract Syntax Tree.
+Before explaining AST we first need to explain in detail how project context operations
+work. Generally for a project context operation the plan Spark developed is read
+on the CPU and an appropriate set of GPU kernels are selected to do those
+operations. For example `a >= b + 1`. Would result in calling a GPU kernel to add
+`1` to `b`, followed by another kernel that is called to compare `a` to that result.
+The interpretation is happening on the CPU, and the GPU is used to do the processing.
+For AST the interpretation for some reason cannot happen on the CPU and instead must
+be done in the GPU kernel itself. An example of this is conditional joins. If you
+want to join on `A.a >= B.b + 1` where `A` and `B` are separate tables or data
+frames, the `+` and `>=` operations cannot run as separate independent kernels
+because it is done on a combination of rows in both `A` and `B`. Instead part of the
+plan that Spark developed is turned into an abstract syntax tree and set to the GPU
+where it can be interpreted. The number and types of operations supported in this
+are limited.
 <table>
 <tr>
 <th>Expression</th>
@@ -1200,15 +1289,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1226,10 +1315,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1290,7 +1379,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -1298,7 +1387,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1319,7 +1408,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1380,7 +1469,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -1388,7 +1477,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1409,7 +1498,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1491,15 +1580,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1517,10 +1606,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1538,10 +1627,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -1628,17 +1717,17 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -1651,15 +1740,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -1671,10 +1760,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="6">And</td>
-<td rowSpan="6">`and`</td>
-<td rowSpan="6">Logical AND</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">And</td>
+<td rowSpan="3">`and`</td>
+<td rowSpan="3">Logical AND</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td>S</td>
@@ -1739,74 +1828,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">ArrayContains</td>
-<td rowSpan="6">`array_contains`</td>
-<td rowSpan="6">Returns a boolean if the array contains the passed in key</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ArrayContains</td>
+<td rowSpan="3">`array_contains`</td>
+<td rowSpan="3">Returns a boolean if the array contains the passed in key</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>array</td>
 <td> </td>
@@ -1871,96 +1896,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>array</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>key</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="4">Asin</td>
 <td rowSpan="4">`asin`</td>
 <td rowSpan="4">Inverse sine</td>
@@ -2008,7 +1943,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2016,7 +1951,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2037,7 +1972,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2098,7 +2033,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2106,7 +2041,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2127,7 +2062,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2141,10 +2076,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">AtLeastNNonNulls</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Checks if number of non null/Nan values is greater than a given value</td>
-<td rowSpan="4">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="2">AtLeastNNonNulls</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Checks if number of non null/Nan values is greater than a given value</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td>S</td>
@@ -2169,49 +2130,6 @@ Accelerator support is described below.
 <tr>
 <td>result</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2278,7 +2196,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2286,7 +2204,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2307,7 +2225,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2319,32 +2237,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">Atanh</td>
@@ -2394,7 +2286,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -2402,7 +2294,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2423,7 +2315,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2463,17 +2355,17 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="1">lambda</td>
+<td rowSpan="1">ast</td>
 <td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -2485,10 +2377,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="6">BRound</td>
-<td rowSpan="6">`bround`</td>
-<td rowSpan="6">Round an expression to d decimal places using HALF_EVEN rounding mode</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">BRound</td>
+<td rowSpan="3">`bround`</td>
+<td rowSpan="3">Round an expression to d decimal places using HALF_EVEN rounding mode</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -2553,68 +2445,30 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>scale</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">BitwiseAnd</td>
@@ -2685,13 +2539,13 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2711,8 +2565,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2732,8 +2586,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2747,32 +2601,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">BitwiseNot</td>
@@ -2822,13 +2650,13 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2848,8 +2676,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2933,13 +2761,13 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2959,8 +2787,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2980,8 +2808,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -2995,6 +2823,32 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
+</tr>
+<tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">BitwiseXor</td>
@@ -3065,13 +2919,13 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3091,8 +2945,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3112,8 +2966,8 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3129,36 +2983,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">CaseWhen</td>
-<td rowSpan="6">`when`</td>
-<td rowSpan="6">CASE WHEN expression</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">CaseWhen</td>
+<td rowSpan="3">`when`</td>
+<td rowSpan="3">CASE WHEN expression</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>predicate</td>
 <td>S</td>
@@ -3223,70 +3051,6 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>predicate</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>value</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
 <td rowSpan="4">Cbrt</td>
 <td rowSpan="4">`cbrt`</td>
 <td rowSpan="4">Cube root</td>
@@ -3334,7 +3098,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -3342,7 +3106,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3363,7 +3127,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3377,10 +3141,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Ceil</td>
-<td rowSpan="4">`ceiling`, `ceil`</td>
-<td rowSpan="4">Ceiling of a number</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Ceil</td>
+<td rowSpan="2">`ceiling`, `ceil`</td>
+<td rowSpan="2">Ceiling of a number</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -3415,139 +3179,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">CheckOverflow</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">CheckOverflow after arithmetic operations between DecimalType data</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -3583,10 +3214,57 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="4">Coalesce</td>
-<td rowSpan="4">`coalesce`</td>
-<td rowSpan="4">Returns the first non-null argument if exists. Otherwise, null</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">CheckOverflow</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">CheckOverflow after arithmetic operations between DecimalType data</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">Coalesce</td>
+<td rowSpan="2">`coalesce`</td>
+<td rowSpan="2">Returns the first non-null argument if exists. Otherwise, null</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -3630,53 +3308,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="4">Concat</td>
-<td rowSpan="4">`concat`</td>
-<td rowSpan="4">List/String concatenate</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Concat</td>
+<td rowSpan="2">`concat`</td>
+<td rowSpan="2">List/String concatenate</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -3720,53 +3355,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">ConcatWs</td>
-<td rowSpan="4">`concat_ws`</td>
-<td rowSpan="4">Concatenates multiple input strings or array of strings into a single string using a given separator</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">ConcatWs</td>
+<td rowSpan="2">`concat_ws`</td>
+<td rowSpan="2">Concatenates multiple input strings or array of strings into a single string using a given separator</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -3810,53 +3402,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">Contains</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Contains</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Contains</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Contains</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -3921,96 +3470,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>search</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="4">Cos</td>
 <td rowSpan="4">`cos`</td>
 <td rowSpan="4">Cosine</td>
@@ -4058,7 +3517,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -4066,7 +3525,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4087,7 +3546,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4099,6 +3558,32 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
+</tr>
+<tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">Cosh</td>
@@ -4148,7 +3633,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -4156,7 +3641,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4177,7 +3662,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4238,7 +3723,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -4246,7 +3731,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4267,7 +3752,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -4281,10 +3766,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">CreateArray</td>
-<td rowSpan="4">`array`</td>
-<td rowSpan="4"> Returns an array with the given elements</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">CreateArray</td>
+<td rowSpan="2">`array`</td>
+<td rowSpan="2"> Returns an array with the given elements</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>arg</td>
 <td>S</td>
@@ -4326,75 +3811,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>arg</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="2">CreateMap</td>
@@ -4444,10 +3860,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">CreateNamedStruct</td>
-<td rowSpan="6">`named_struct`, `struct`</td>
-<td rowSpan="6">Creates a struct with the given field names and values</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">CreateNamedStruct</td>
+<td rowSpan="3">`named_struct`, `struct`</td>
+<td rowSpan="3">Creates a struct with the given field names and values</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>name</td>
 <td> </td>
@@ -4512,68 +3928,30 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>name</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>value</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="1">CurrentRow$</td>
@@ -4602,10 +3980,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">DateAdd</td>
-<td rowSpan="6">`date_add`</td>
-<td rowSpan="6">Returns the date that is num_days after start_date</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">DateAdd</td>
+<td rowSpan="3">`date_add`</td>
+<td rowSpan="3">Returns the date that is num_days after start_date</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>startDate</td>
 <td> </td>
@@ -4670,100 +4048,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>startDate</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>days</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">DateAddInterval</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Adds interval to date</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">DateAddInterval</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Adds interval to date</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>start</td>
 <td> </td>
@@ -4828,74 +4116,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>start</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>interval</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">DateDiff</td>
-<td rowSpan="6">`datediff`</td>
-<td rowSpan="6">Returns the number of days from startDate to endDate</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">DateDiff</td>
+<td rowSpan="3">`datediff`</td>
+<td rowSpan="3">Returns the number of days from startDate to endDate</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -4960,74 +4184,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">DateFormatClass</td>
-<td rowSpan="6">`date_format`</td>
-<td rowSpan="6">Converts timestamp to a value of string in the format specified by the date format</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">DateFormatClass</td>
+<td rowSpan="3">`date_format`</td>
+<td rowSpan="3">Converts timestamp to a value of string in the format specified by the date format</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>timestamp</td>
 <td> </td>
@@ -5092,100 +4252,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>timestamp</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>strfmt</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">DateSub</td>
-<td rowSpan="6">`date_sub`</td>
-<td rowSpan="6">Returns the date that is num_days before start_date</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">DateSub</td>
+<td rowSpan="3">`date_sub`</td>
+<td rowSpan="3">Returns the date that is num_days before start_date</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>startDate</td>
 <td> </td>
@@ -5250,340 +4320,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>startDate</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>days</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">DayOfMonth</td>
-<td rowSpan="4">`dayofmonth`, `day`</td>
-<td rowSpan="4">Returns the day of the month from a date or timestamp</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">DayOfWeek</td>
-<td rowSpan="4">`dayofweek`</td>
-<td rowSpan="4">Returns the day of the week (1 = Sunday...7=Saturday)</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">DayOfYear</td>
-<td rowSpan="4">`dayofyear`</td>
-<td rowSpan="4">Returns the day of the year from a date or timestamp</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
 <th>Expression</th>
 <th>SQL Functions(s)</th>
 <th>Description</th>
@@ -5608,6 +4344,147 @@ Accelerator support is described below.
 <th>MAP</th>
 <th>STRUCT</th>
 <th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="2">DayOfMonth</td>
+<td rowSpan="2">`dayofmonth`, `day`</td>
+<td rowSpan="2">Returns the day of the month from a date or timestamp</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">DayOfWeek</td>
+<td rowSpan="2">`dayofweek`</td>
+<td rowSpan="2">Returns the day of the week (1 = Sunday...7=Saturday)</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">DayOfYear</td>
+<td rowSpan="2">`dayofyear`</td>
+<td rowSpan="2">Returns the day of the year from a date or timestamp</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
 </tr>
 <tr>
 <td rowSpan="2">DenseRank</td>
@@ -5657,10 +4534,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">Divide</td>
-<td rowSpan="6">`/`</td>
-<td rowSpan="6">Division</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Divide</td>
+<td rowSpan="3">`/`</td>
+<td rowSpan="3">Division</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -5725,74 +4602,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">ElementAt</td>
-<td rowSpan="6">`element_at`</td>
-<td rowSpan="6">Returns element of array at given(1-based) index in value if column is array. Returns value for the given key in value if column is map.</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ElementAt</td>
+<td rowSpan="3">`element_at`</td>
+<td rowSpan="3">Returns element of array at given(1-based) index in value if column is array. Returns value for the given key in value if column is map.</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>array/map</td>
 <td> </td>
@@ -5857,74 +4670,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>array/map</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>index/key</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="6">EndsWith</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Ends with</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">EndsWith</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Ends with</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -5989,70 +4738,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>search</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
 <th>Expression</th>
 <th>SQL Functions(s)</th>
 <th>Description</th>
@@ -6079,10 +4764,10 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="6">EqualNullSafe</td>
-<td rowSpan="6">`<=>`</td>
-<td rowSpan="6">Check if the values are equal including nulls <=></td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">EqualNullSafe</td>
+<td rowSpan="3">`<=>`</td>
+<td rowSpan="3">Check if the values are equal including nulls <=></td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td>S</td>
@@ -6128,70 +4813,6 @@ Accelerator support is described below.
 <tr>
 <td>result</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>rhs</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6279,17 +4900,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -6302,15 +4923,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>rhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -6323,7 +4944,7 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6390,7 +5011,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -6398,7 +5019,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6419,7 +5040,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6431,32 +5052,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="2">Explode</td>
@@ -6506,6 +5101,32 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="4">Expm1</td>
 <td rowSpan="4">`expm1`</td>
 <td rowSpan="4">Euler's number e raised to a power minus 1</td>
@@ -6553,7 +5174,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -6561,7 +5182,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6582,7 +5203,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -6596,10 +5217,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Floor</td>
-<td rowSpan="4">`floor`</td>
-<td rowSpan="4">Floor of a number</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Floor</td>
+<td rowSpan="2">`floor`</td>
+<td rowSpan="2">Floor of a number</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -6643,53 +5264,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">FromUnixTime</td>
-<td rowSpan="6">`from_unixtime`</td>
-<td rowSpan="6">Get the string from a unix timestamp</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">FromUnixTime</td>
+<td rowSpan="3">`from_unixtime`</td>
+<td rowSpan="3">Get the string from a unix timestamp</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>sec</td>
 <td> </td>
@@ -6754,100 +5332,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>sec</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>format</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">GetArrayItem</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Gets the field at `ordinal` in the Array</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">GetArrayItem</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Gets the field at `ordinal` in the Array</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>array</td>
 <td> </td>
@@ -6909,70 +5397,6 @@ Accelerator support is described below.
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>array</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>ordinal</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
@@ -7044,10 +5468,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">GetMapValue</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Gets Value from a Map based on a key</td>
-<td rowSpan="6">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="3">GetMapValue</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Gets Value from a Map based on a key</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>map</td>
 <td> </td>
@@ -7112,100 +5562,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>map</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>key</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">GetStructField</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Gets the named field of the struct</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">GetStructField</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Gets the named field of the struct</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -7249,53 +5609,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="6">GetTimestamp</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Gets timestamps from strings using given pattern.</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">GetTimestamp</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Gets timestamps from strings using given pattern.</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>timeExp</td>
 <td> </td>
@@ -7349,70 +5666,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>timeExp</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>format</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -7492,17 +5745,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -7515,15 +5768,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>rhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -7536,7 +5789,7 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -7554,32 +5807,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">GreaterThanOrEqual</td>
@@ -7650,17 +5877,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -7673,15 +5900,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>rhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -7694,7 +5921,7 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -7714,10 +5941,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Greatest</td>
-<td rowSpan="4">`greatest`</td>
-<td rowSpan="4">Returns the greatest value of all parameters, skipping null values</td>
-<td rowSpan="4">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="2">Greatest</td>
+<td rowSpan="2">`greatest`</td>
+<td rowSpan="2">Returns the greatest value of all parameters, skipping null values</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -7761,53 +6014,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="4">Hour</td>
-<td rowSpan="4">`hour`</td>
-<td rowSpan="4">Returns the hour component of the string/timestamp</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Hour</td>
+<td rowSpan="2">`hour`</td>
+<td rowSpan="2">Returns the hour component of the string/timestamp</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -7851,53 +6061,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">If</td>
-<td rowSpan="8">`if`</td>
-<td rowSpan="8">IF expression</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">If</td>
+<td rowSpan="4">`if`</td>
+<td rowSpan="4">IF expression</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>predicate</td>
 <td>S</td>
@@ -7983,121 +6150,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>predicate</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>trueValue</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>falseValue</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">In</td>
-<td rowSpan="6">`in`</td>
-<td rowSpan="6">IN operator</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">In</td>
+<td rowSpan="3">`in`</td>
+<td rowSpan="3">IN operator</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td>S</td>
@@ -8162,74 +6218,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>list</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">InSet</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">INSET operator</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">InSet</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">INSET operator</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td>S</td>
@@ -8273,53 +6265,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">InitCap</td>
-<td rowSpan="4">`initcap`</td>
-<td rowSpan="4">Returns str with the first letter of each word in uppercase. All other letters are in lowercase</td>
-<td rowSpan="4">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
+<td rowSpan="2">InitCap</td>
+<td rowSpan="2">`initcap`</td>
+<td rowSpan="2">Returns str with the first letter of each word in uppercase. All other letters are in lowercase</td>
+<td rowSpan="2">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -8363,97 +6312,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">InputFileBlockLength</td>
-<td rowSpan="2">`input_file_block_length`</td>
-<td rowSpan="2">Returns the length of the block being read, or -1 if not available</td>
-<td rowSpan="2">None</td>
-<td rowSpan="1">project</td>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="1">lambda</td>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
 <th>Expression</th>
 <th>SQL Functions(s)</th>
 <th>Description</th>
@@ -8480,10 +6338,10 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="2">InputFileBlockStart</td>
-<td rowSpan="2">`input_file_block_start`</td>
-<td rowSpan="2">Returns the start offset of the block being read, or -1 if not available</td>
-<td rowSpan="2">None</td>
+<td rowSpan="1">InputFileBlockLength</td>
+<td rowSpan="1">`input_file_block_length`</td>
+<td rowSpan="1">Returns the length of the block being read, or -1 if not available</td>
+<td rowSpan="1">None</td>
 <td rowSpan="1">project</td>
 <td>result</td>
 <td> </td>
@@ -8506,13 +6364,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="1">lambda</td>
+<td rowSpan="1">InputFileBlockStart</td>
+<td rowSpan="1">`input_file_block_start`</td>
+<td rowSpan="1">Returns the start offset of the block being read, or -1 if not available</td>
+<td rowSpan="1">None</td>
+<td rowSpan="1">project</td>
 <td>result</td>
 <td> </td>
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -8528,10 +6390,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">InputFileName</td>
-<td rowSpan="2">`input_file_name`</td>
-<td rowSpan="2">Returns the name of the file being read, or empty string if not available</td>
-<td rowSpan="2">None</td>
+<td rowSpan="1">InputFileName</td>
+<td rowSpan="1">`input_file_name`</td>
+<td rowSpan="1">Returns the name of the file being read, or empty string if not available</td>
+<td rowSpan="1">None</td>
 <td rowSpan="1">project</td>
 <td>result</td>
 <td> </td>
@@ -8554,32 +6416,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="1">lambda</td>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">IntegralDivide</td>
-<td rowSpan="6">`div`</td>
-<td rowSpan="6">Division with a integer result</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">IntegralDivide</td>
+<td rowSpan="3">`div`</td>
+<td rowSpan="3">Division with a integer result</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -8644,74 +6484,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">IsNaN</td>
-<td rowSpan="4">`isnan`</td>
-<td rowSpan="4">Checks if a value is NaN</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">IsNaN</td>
+<td rowSpan="2">`isnan`</td>
+<td rowSpan="2">Checks if a value is NaN</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -8755,53 +6531,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">IsNotNull</td>
-<td rowSpan="4">`isnotnull`</td>
-<td rowSpan="4">Checks if a value is not null</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">IsNotNull</td>
+<td rowSpan="2">`isnotnull`</td>
+<td rowSpan="2">Checks if a value is not null</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td>S</td>
@@ -8845,47 +6578,145 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">IsNull</td>
+<td rowSpan="2">`isnull`</td>
+<td rowSpan="2">Checks if a value is null</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
 <td>input</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>
 <td>result</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">KnownFloatingPointNormalized</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Tag to prevent redundant normalization</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">KnownNotNull</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Tag an expression as known to not be null</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
 <td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
+<td><b>NS</b></td>
 </tr>
 <tr>
 <th>Expression</th>
@@ -8912,276 +6743,6 @@ Accelerator support is described below.
 <th>MAP</th>
 <th>STRUCT</th>
 <th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">IsNull</td>
-<td rowSpan="4">`isnull`</td>
-<td rowSpan="4">Checks if a value is null</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td>S</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">KnownFloatingPointNormalized</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Tag to prevent redundant normalization</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">KnownNotNull</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Tag an expression as known to not be null</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td><b>NS</b></td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td><b>NS</b></td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested NULL, UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 </tr>
 <tr>
 <td rowSpan="4">Lag</td>
@@ -9273,36 +6834,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">LastDay</td>
-<td rowSpan="4">`last_day`</td>
-<td rowSpan="4">Returns the last day of the month which the date belongs to</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">LastDay</td>
+<td rowSpan="2">`last_day`</td>
+<td rowSpan="2">Returns the last day of the month which the date belongs to</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -9334,49 +6869,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -9478,10 +6970,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="4">Least</td>
-<td rowSpan="4">`least`</td>
-<td rowSpan="4">Returns the least value of all parameters, skipping null values</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Least</td>
+<td rowSpan="2">`least`</td>
+<td rowSpan="2">Returns the least value of all parameters, skipping null values</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -9525,53 +7017,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="4">Length</td>
-<td rowSpan="4">`length`, `character_length`, `char_length`</td>
-<td rowSpan="4">String character length or binary byte length</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Length</td>
+<td rowSpan="2">`length`, `character_length`, `char_length`</td>
+<td rowSpan="2">String character length or binary byte length</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -9613,75 +7062,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">LessThan</td>
@@ -9752,17 +7132,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -9775,15 +7155,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>rhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -9796,7 +7176,7 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -9814,6 +7194,32 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
+</tr>
+<tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">LessThanOrEqual</td>
@@ -9884,17 +7290,17 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -9907,15 +7313,15 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>rhs</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -9928,7 +7334,7 @@ Accelerator support is described below.
 </tr>
 <tr>
 <td>result</td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -9948,10 +7354,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">Like</td>
-<td rowSpan="6">`like`</td>
-<td rowSpan="6">Like</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Like</td>
+<td rowSpan="3">`like`</td>
+<td rowSpan="3">Like</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -10016,96 +7422,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>search</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="2">Literal</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Holds a static value from the query</td>
@@ -10132,17 +7448,17 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="1">lambda</td>
+<td rowSpan="1">ast</td>
 <td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -10154,10 +7470,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="4">Log</td>
-<td rowSpan="4">`ln`</td>
-<td rowSpan="4">Natural log</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Log</td>
+<td rowSpan="2">`ln`</td>
+<td rowSpan="2">Natural log</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -10201,53 +7517,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Log10</td>
-<td rowSpan="4">`log10`</td>
-<td rowSpan="4">Log base 10</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Log10</td>
+<td rowSpan="2">`log10`</td>
+<td rowSpan="2">Log base 10</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -10278,229 +7551,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Log1p</td>
-<td rowSpan="4">`log1p`</td>
-<td rowSpan="4">Natural log 1 + expr</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Log2</td>
-<td rowSpan="4">`log2`</td>
-<td rowSpan="4">Log base 2</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -10540,10 +7590,104 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="6">Logarithm</td>
-<td rowSpan="6">`log`</td>
-<td rowSpan="6">Log variable base</td>
-<td rowSpan="6">None</td>
+<td rowSpan="2">Log1p</td>
+<td rowSpan="2">`log1p`</td>
+<td rowSpan="2">Natural log 1 + expr</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">Log2</td>
+<td rowSpan="2">`log2`</td>
+<td rowSpan="2">Log base 2</td>
+<td rowSpan="2">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="3">Logarithm</td>
+<td rowSpan="3">`log`</td>
+<td rowSpan="3">Log variable base</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -10608,74 +7752,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>base</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Lower</td>
-<td rowSpan="4">`lower`, `lcase`</td>
-<td rowSpan="4">String lowercase operator</td>
-<td rowSpan="4">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
+<td rowSpan="2">Lower</td>
+<td rowSpan="2">`lower`, `lcase`</td>
+<td rowSpan="2">String lowercase operator</td>
+<td rowSpan="2">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -10709,49 +7789,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -10809,10 +7846,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Md5</td>
-<td rowSpan="4">`md5`</td>
-<td rowSpan="4">MD5 hash operator</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Md5</td>
+<td rowSpan="2">`md5`</td>
+<td rowSpan="2">MD5 hash operator</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -10856,79 +7893,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Minute</td>
-<td rowSpan="4">`minute`</td>
-<td rowSpan="4">Returns the minute component of the string/timestamp</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Minute</td>
+<td rowSpan="2">`minute`</td>
+<td rowSpan="2">Returns the minute component of the string/timestamp</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -10972,53 +7940,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">MonotonicallyIncreasingID</td>
-<td rowSpan="2">`monotonically_increasing_id`</td>
-<td rowSpan="2">Returns monotonically increasing 64-bit integers</td>
-<td rowSpan="2">None</td>
+<td rowSpan="1">MonotonicallyIncreasingID</td>
+<td rowSpan="1">`monotonically_increasing_id`</td>
+<td rowSpan="1">Returns monotonically increasing 64-bit integers</td>
+<td rowSpan="1">None</td>
 <td rowSpan="1">project</td>
 <td>result</td>
 <td> </td>
@@ -11041,32 +7992,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="1">lambda</td>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Month</td>
-<td rowSpan="4">`month`</td>
-<td rowSpan="4">Returns the month from a date or timestamp</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Month</td>
+<td rowSpan="2">`month`</td>
+<td rowSpan="2">Returns the month from a date or timestamp</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -11094,49 +8023,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11221,15 +8107,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11247,10 +8133,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11268,10 +8154,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11285,36 +8171,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Murmur3Hash</td>
-<td rowSpan="4">`hash`</td>
-<td rowSpan="4">Murmur3 hash operator</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Murmur3Hash</td>
+<td rowSpan="2">`hash`</td>
+<td rowSpan="2">Murmur3 hash operator</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td>S</td>
@@ -11358,53 +8218,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">NaNvl</td>
-<td rowSpan="6">`nanvl`</td>
-<td rowSpan="6">Evaluates to `left` iff left is not NaN, `right` otherwise</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">NaNvl</td>
+<td rowSpan="3">`nanvl`</td>
+<td rowSpan="3">Evaluates to `left` iff left is not NaN, `right` otherwise</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -11456,70 +8273,6 @@ Accelerator support is described below.
 <td> </td>
 <td>S</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11580,76 +8333,8 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">Or</td>
-<td rowSpan="6">`or`</td>
-<td rowSpan="6">Logical OR</td>
-<td rowSpan="6">None</td>
-<td rowSpan="3">project</td>
-<td>lhs</td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
 <td>S</td>
 <td> </td>
 <td> </td>
@@ -11672,70 +8357,6 @@ Accelerator support is described below.
 <tr>
 <td>result</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11781,10 +8402,78 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="6">Pmod</td>
-<td rowSpan="6">`pmod`</td>
-<td rowSpan="6">Pmod</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Or</td>
+<td rowSpan="3">`or`</td>
+<td rowSpan="3">Logical OR</td>
+<td rowSpan="3">None</td>
+<td rowSpan="3">project</td>
+<td>lhs</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>rhs</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="3">Pmod</td>
+<td rowSpan="3">`pmod`</td>
+<td rowSpan="3">Pmod</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -11836,70 +8525,6 @@ Accelerator support is described below.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12028,7 +8653,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td> </td>
@@ -12036,7 +8661,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12057,7 +8682,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12078,7 +8703,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12092,10 +8717,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">PreciseTimestampConversion</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Expression used internally to convert the TimestampType to Long and back without losing precision, i.e. in microseconds. Used in time windowing.</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">PreciseTimestampConversion</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Expression used internally to convert the TimestampType to Long and back without losing precision, i.e. in microseconds. Used in time windowing.</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -12128,49 +8753,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12208,10 +8790,10 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="4">PromotePrecision</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">PromotePrecision before arithmetic operations between DecimalType data</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">PromotePrecision</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">PromotePrecision before arithmetic operations between DecimalType data</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -12246,49 +8828,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12474,10 +9013,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Quarter</td>
-<td rowSpan="4">`quarter`</td>
-<td rowSpan="4">Returns the quarter of the year for date, in the range 1 to 4</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Quarter</td>
+<td rowSpan="2">`quarter`</td>
+<td rowSpan="2">Returns the quarter of the year for date, in the range 1 to 4</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -12521,79 +9060,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Rand</td>
-<td rowSpan="4">`random`, `rand`</td>
-<td rowSpan="4">Generate a random column with i.i.d. uniformly distributed values in [0, 1)</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Rand</td>
+<td rowSpan="2">`random`, `rand`</td>
+<td rowSpan="2">Generate a random column with i.i.d. uniformly distributed values in [0, 1)</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>seed</td>
 <td> </td>
@@ -12624,49 +9094,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>seed</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -12727,10 +9154,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="8">RegExpReplace</td>
-<td rowSpan="8">`regexp_replace`</td>
-<td rowSpan="8">RegExpReplace support for string literal input patterns</td>
-<td rowSpan="8">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="4">RegExpReplace</td>
+<td rowSpan="4">`regexp_replace`</td>
+<td rowSpan="4">RegExpReplace support for string literal input patterns</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -12816,95 +9269,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>regex</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rep</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">Remainder</td>
-<td rowSpan="6">`%`, `mod`</td>
-<td rowSpan="6">Remainder or modulo</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Remainder</td>
+<td rowSpan="3">`%`, `mod`</td>
+<td rowSpan="3">Remainder or modulo</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>lhs</td>
 <td> </td>
@@ -12967,96 +9335,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>lhs</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>rhs</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">Rint</td>
@@ -13106,7 +9384,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -13114,7 +9392,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -13135,7 +9413,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -13149,10 +9427,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">Round</td>
-<td rowSpan="6">`round`</td>
-<td rowSpan="6">Round an expression to d decimal places using HALF_UP rounding mode</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">Round</td>
+<td rowSpan="3">`round`</td>
+<td rowSpan="3">Round an expression to d decimal places using HALF_UP rounding mode</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -13208,70 +9486,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>scale</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -13307,10 +9521,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">ScalaUDF</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">User Defined Function, support requires the UDF to implement a RAPIDS accelerated interface</td>
-<td rowSpan="4">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="2">ScalaUDF</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">User Defined Function, support requires the UDF to implement a RAPIDS accelerated interface</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -13354,79 +9594,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Second</td>
-<td rowSpan="4">`second`</td>
-<td rowSpan="4">Returns the second component of the string/timestamp</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Second</td>
+<td rowSpan="2">`second`</td>
+<td rowSpan="2">Returns the second component of the string/timestamp</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -13470,53 +9641,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">ShiftLeft</td>
-<td rowSpan="6">`shiftleft`</td>
-<td rowSpan="6">Bitwise shift left (<<)</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ShiftLeft</td>
+<td rowSpan="3">`shiftleft`</td>
+<td rowSpan="3">Bitwise shift left (<<)</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -13581,74 +9709,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>amount</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">ShiftRight</td>
-<td rowSpan="6">`shiftright`</td>
-<td rowSpan="6">Bitwise shift right (>>)</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ShiftRight</td>
+<td rowSpan="3">`shiftright`</td>
+<td rowSpan="3">Bitwise shift right (>>)</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -13713,100 +9777,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>amount</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">ShiftRightUnsigned</td>
-<td rowSpan="6">`shiftrightunsigned`</td>
-<td rowSpan="6">Bitwise unsigned shift right (>>>)</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ShiftRightUnsigned</td>
+<td rowSpan="3">`shiftrightunsigned`</td>
+<td rowSpan="3">Bitwise unsigned shift right (>>>)</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>value</td>
 <td> </td>
@@ -13871,74 +9845,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>value</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>amount</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Signum</td>
-<td rowSpan="4">`sign`, `signum`</td>
-<td rowSpan="4">Returns -1.0, 0.0 or 1.0 as expr is negative, 0 or positive</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Signum</td>
+<td rowSpan="2">`sign`, `signum`</td>
+<td rowSpan="2">Returns -1.0, 0.0 or 1.0 as expr is negative, 0 or positive</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -13982,47 +9892,30 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">Sin</td>
@@ -14072,7 +9965,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -14080,7 +9973,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14101,7 +9994,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14162,7 +10055,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -14170,7 +10063,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14191,7 +10084,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14205,36 +10098,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Size</td>
-<td rowSpan="4">`size`, `cardinality`</td>
-<td rowSpan="4">The size of an array or a map</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Size</td>
+<td rowSpan="2">`size`, `cardinality`</td>
+<td rowSpan="2">The size of an array or a map</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -14278,53 +10145,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">SortArray</td>
-<td rowSpan="6">`sort_array`</td>
-<td rowSpan="6">Returns a sorted array with the input array and the ascending / descending order</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">SortArray</td>
+<td rowSpan="3">`sort_array`</td>
+<td rowSpan="3">Returns a sorted array with the input array and the ascending / descending order</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>array</td>
 <td> </td>
@@ -14389,70 +10213,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>array</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>ascendingOrder</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
 <td rowSpan="2">SortOrder</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Sort order</td>
@@ -14500,38 +10260,42 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">SparkPartitionID</td>
-<td rowSpan="2">`spark_partition_id`</td>
-<td rowSpan="2">Returns the current partition id</td>
-<td rowSpan="2">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="1">SparkPartitionID</td>
+<td rowSpan="1">`spark_partition_id`</td>
+<td rowSpan="1">Returns the current partition id</td>
+<td rowSpan="1">None</td>
 <td rowSpan="1">project</td>
 <td>result</td>
 <td> </td>
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="1">lambda</td>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14616,32 +10380,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="4">Sqrt</td>
 <td rowSpan="4">`sqrt`</td>
 <td rowSpan="4">Square root</td>
@@ -14689,7 +10427,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -14697,7 +10435,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14718,7 +10456,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -14732,10 +10470,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">StartsWith</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Starts with</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">StartsWith</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Starts with</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -14800,74 +10538,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>search</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">StringLPad</td>
-<td rowSpan="8">`lpad`</td>
-<td rowSpan="8">Pad a string on the left</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">StringLPad</td>
+<td rowSpan="4">`lpad`</td>
+<td rowSpan="4">Pad a string on the left</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -14953,91 +10627,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>len</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>pad</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
 <th>Expression</th>
 <th>SQL Functions(s)</th>
 <th>Description</th>
@@ -15064,10 +10653,10 @@ Accelerator support is described below.
 <th>UDT</th>
 </tr>
 <tr>
-<td rowSpan="8">StringLocate</td>
-<td rowSpan="8">`position`, `locate`</td>
-<td rowSpan="8">Substring search operator</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">StringLocate</td>
+<td rowSpan="4">`position`, `locate`</td>
+<td rowSpan="4">Substring search operator</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>substr</td>
 <td> </td>
@@ -15153,95 +10742,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>substr</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>start</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">StringRPad</td>
-<td rowSpan="8">`rpad`</td>
-<td rowSpan="8">Pad a string on the right</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">StringRPad</td>
+<td rowSpan="4">`rpad`</td>
+<td rowSpan="4">Pad a string on the right</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -15327,121 +10831,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>len</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>pad</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">StringRepeat</td>
-<td rowSpan="6">`repeat`</td>
-<td rowSpan="6">StringRepeat operator that repeats the given strings with numbers of times given by repeatTimes</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">StringRepeat</td>
+<td rowSpan="3">`repeat`</td>
+<td rowSpan="3">StringRepeat operator that repeats the given strings with numbers of times given by repeatTimes</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>input</td>
 <td> </td>
@@ -15506,74 +10899,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>repeatTimes</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">StringReplace</td>
-<td rowSpan="8">`replace`</td>
-<td rowSpan="8">StringReplace operator</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">StringReplace</td>
+<td rowSpan="4">`replace`</td>
+<td rowSpan="4">StringReplace operator</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>src</td>
 <td> </td>
@@ -15659,95 +10988,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
-<td>search</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>replace</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">StringSplit</td>
-<td rowSpan="8">`split`</td>
-<td rowSpan="8">Splits `str` around occurrences that match `regex`</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">StringSplit</td>
+<td rowSpan="4">`split`</td>
+<td rowSpan="4">Splits `str` around occurrences that match `regex`</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -15833,121 +11103,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>regexp</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>limit</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">StringTrim</td>
-<td rowSpan="6">`trim`</td>
-<td rowSpan="6">StringTrim operator</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">StringTrim</td>
+<td rowSpan="3">`trim`</td>
+<td rowSpan="3">StringTrim operator</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -16012,74 +11171,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>trimStr</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">StringTrimLeft</td>
-<td rowSpan="6">`ltrim`</td>
-<td rowSpan="6">StringTrimLeft operator</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">StringTrimLeft</td>
+<td rowSpan="3">`ltrim`</td>
+<td rowSpan="3">StringTrimLeft operator</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -16144,74 +11239,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>trimStr</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">StringTrimRight</td>
-<td rowSpan="6">`rtrim`</td>
-<td rowSpan="6">StringTrimRight operator</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">StringTrimRight</td>
+<td rowSpan="3">`rtrim`</td>
+<td rowSpan="3">StringTrimRight operator</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>src</td>
 <td> </td>
@@ -16276,100 +11307,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>src</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>trimStr</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="8">Substring</td>
-<td rowSpan="8">`substr`, `substring`</td>
-<td rowSpan="8">Substring operator</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">Substring</td>
+<td rowSpan="4">`substr`, `substring`</td>
+<td rowSpan="4">Substring operator</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -16455,95 +11396,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
-<td>pos</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>len</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="8">SubstringIndex</td>
-<td rowSpan="8">`substring_index`</td>
-<td rowSpan="8">substring_index operator</td>
-<td rowSpan="8">None</td>
+<td rowSpan="4">SubstringIndex</td>
+<td rowSpan="4">`substring_index`</td>
+<td rowSpan="4">substring_index operator</td>
+<td rowSpan="4">None</td>
 <td rowSpan="4">project</td>
 <td>str</td>
 <td> </td>
@@ -16629,117 +11511,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">lambda</td>
-<td>str</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>delim</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>count</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="6">Subtract</td>
 <td rowSpan="6">`-`</td>
 <td rowSpan="6">Subtraction</td>
@@ -16808,15 +11579,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
+<td rowSpan="3">ast</td>
 <td>lhs</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -16834,10 +11605,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -16855,10 +11626,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -16919,7 +11690,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -16927,7 +11698,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -16948,7 +11719,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17009,7 +11780,7 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -17017,7 +11788,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17038,7 +11809,7 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17052,10 +11823,36 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">TimeAdd</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Adds interval to timestamp</td>
-<td rowSpan="6">None</td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="3">TimeAdd</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Adds interval to timestamp</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>start</td>
 <td> </td>
@@ -17120,100 +11917,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>start</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>interval</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="6">TimeSub</td>
-<td rowSpan="6"> </td>
-<td rowSpan="6">Subtracts interval from timestamp</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">TimeSub</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Subtracts interval from timestamp</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>start</td>
 <td> </td>
@@ -17278,74 +11985,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>start</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>interval</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">ToDegrees</td>
-<td rowSpan="4">`degrees`</td>
-<td rowSpan="4">Converts radians to degrees</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">ToDegrees</td>
+<td rowSpan="2">`degrees`</td>
+<td rowSpan="2">Converts radians to degrees</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -17389,53 +12032,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">ToRadians</td>
-<td rowSpan="4">`radians`</td>
-<td rowSpan="4">Converts degrees to radians</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">ToRadians</td>
+<td rowSpan="2">`radians`</td>
+<td rowSpan="2">Converts degrees to radians</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -17479,53 +12079,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="6">ToUnixTimestamp</td>
-<td rowSpan="6">`to_unix_timestamp`</td>
-<td rowSpan="6">Returns the UNIX timestamp of the given time</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">ToUnixTimestamp</td>
+<td rowSpan="3">`to_unix_timestamp`</td>
+<td rowSpan="3">Returns the UNIX timestamp of the given time</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>timeExp</td>
 <td> </td>
@@ -17590,96 +12147,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>timeExp</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>format</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="4">UnaryMinus</td>
 <td rowSpan="4">`negative`</td>
 <td rowSpan="4">Negate a numeric value</td>
@@ -17727,15 +12194,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17753,10 +12220,10 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17768,6 +12235,32 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
+</tr>
+<tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">UnaryPositive</td>
@@ -17817,15 +12310,15 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
+<td rowSpan="2">ast</td>
 <td>input</td>
 <td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17841,12 +12334,12 @@ Accelerator support is described below.
 <tr>
 <td>result</td>
 <td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17912,10 +12405,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="6">UnixTimestamp</td>
-<td rowSpan="6">`unix_timestamp`</td>
-<td rowSpan="6">Returns the UNIX timestamp of current or specified time</td>
-<td rowSpan="6">None</td>
+<td rowSpan="3">UnixTimestamp</td>
+<td rowSpan="3">`unix_timestamp`</td>
+<td rowSpan="3">Returns the UNIX timestamp of current or specified time</td>
+<td rowSpan="3">None</td>
 <td rowSpan="3">project</td>
 <td>timeExp</td>
 <td> </td>
@@ -17980,96 +12473,6 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="3">lambda</td>
-<td>timeExp</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>format</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="2">UnscaledValue</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Convert a Decimal to an unscaled long value for some aggregation optimizations</td>
@@ -18117,10 +12520,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">Upper</td>
-<td rowSpan="4">`upper`, `ucase`</td>
-<td rowSpan="4">String uppercase operator</td>
-<td rowSpan="4">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
+<td rowSpan="2">Upper</td>
+<td rowSpan="2">`upper`, `ucase`</td>
+<td rowSpan="2">String uppercase operator</td>
+<td rowSpan="2">This is not 100% compatible with the Spark version because the Unicode version used by cuDF and the JVM may differ, resulting in some corner-case characters not changing case correctly.</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -18164,53 +12567,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">WeekDay</td>
-<td rowSpan="4">`weekday`</td>
-<td rowSpan="4">Returns the day of the week (0 = Monday...6=Sunday)</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">WeekDay</td>
+<td rowSpan="2">`weekday`</td>
+<td rowSpan="2">Returns the day of the week (0 = Monday...6=Sunday)</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -18254,47 +12614,30 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="3">WindowExpression</td>
@@ -18433,36 +12776,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">Year</td>
-<td rowSpan="4">`year`</td>
-<td rowSpan="4">Returns the year from a date or timestamp</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">Year</td>
+<td rowSpan="2">`year`</td>
+<td rowSpan="2">Returns the year from a date or timestamp</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -18490,49 +12807,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -18745,6 +13019,32 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="6">Average</td>
 <td rowSpan="6">`avg`, `mean`</td>
 <td rowSpan="6">Average aggregate operator</td>
@@ -18876,32 +13176,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">CollectList</td>
@@ -19170,6 +13444,32 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="6">Count</td>
 <td rowSpan="6">`count`</td>
 <td rowSpan="6">Count aggregate operator</td>
@@ -19301,32 +13601,6 @@ Accelerator support is described below.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">First</td>
@@ -19595,6 +13869,32 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="6">Max</td>
 <td rowSpan="6">`max`</td>
 <td rowSpan="6">Max aggregate operator</td>
@@ -19726,32 +14026,6 @@ Accelerator support is described below.
 <td> </td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">Min</td>
@@ -20019,6 +14293,32 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="6">Sum</td>
 <td rowSpan="6">`sum`</td>
 <td rowSpan="6">Sum aggregate operator</td>
@@ -20152,36 +14452,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
-<td rowSpan="4">NormalizeNaNAndZero</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Normalize NaN and zero</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">NormalizeNaNAndZero</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Normalize NaN and zero</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
 <td> </td>
@@ -20212,49 +14486,6 @@ Accelerator support is described below.
 <td> </td>
 <td>S</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -20294,10 +14525,10 @@ Accelerator support is described below.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="4">HiveGenericUDF</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Hive Generic UDF, support requires the UDF to implement a RAPIDS accelerated interface</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">HiveGenericUDF</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Hive Generic UDF, support requires the UDF to implement a RAPIDS accelerated interface</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -20341,53 +14572,10 @@ Accelerator support is described below.
 <td><b>NS</b></td>
 </tr>
 <tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="4">HiveSimpleUDF</td>
-<td rowSpan="4"> </td>
-<td rowSpan="4">Hive UDF, support requires the UDF to implement a RAPIDS accelerated interface</td>
-<td rowSpan="4">None</td>
+<td rowSpan="2">HiveSimpleUDF</td>
+<td rowSpan="2"> </td>
+<td rowSpan="2">Hive UDF, support requires the UDF to implement a RAPIDS accelerated interface</td>
+<td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>param</td>
 <td>S</td>
@@ -20428,49 +14616,6 @@ Accelerator support is described below.
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested UDT</em></td>
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested UDT</em></td>
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested UDT</em></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td rowSpan="2">lambda</td>
-<td>param</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-</tr>
-<tr>
-<td>result</td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><b>NS</b></td>
 <td><b>NS</b></td>
 </tr>
 </table>

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -45,7 +45,7 @@ class GpuBroadcastHashJoinMeta(
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuShuffledHashJoinExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide, ShuffledHashJoinExec}
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 object GpuJoinUtils {
   def getGpuBuildSide(buildSide: BuildSide): GpuBuildSide = {
@@ -53,7 +53,7 @@ class GpuShuffledHashJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/GpuSortMergeJoinMeta.scala
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, SortMergeJoinExec}
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -43,7 +43,7 @@ class GpuSortMergeJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPy
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub, ShuffleManagerShimBase}
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
 import org.apache.spark.sql.rapids.execution.python.{GpuAggregateInPandasExecMeta, GpuArrowEvalPythonExec, GpuFlatMapGroupsInPandasExecMeta, GpuMapInPandasExecMeta, GpuPythonUDF, GpuWindowInPandasExecMetaBase}
 import org.apache.spark.sql.rapids.shims.spark301.{GpuSchemaUtils, ShuffleManagerShim}
 import org.apache.spark.sql.sources.BaseRelation
@@ -230,33 +230,15 @@ abstract class SparkBaseShims extends SparkShims {
         }),
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-            TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-            TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-            TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +
@@ -318,7 +300,7 @@ abstract class SparkBaseShims extends SparkShims {
         (cast, conf, p, r) => new CastExprMeta[AnsiCast](cast, true, conf, p, r)),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",
-        ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+        ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
           Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
             ParamCheck("regex", TypeSig.lit(TypeEnum.STRING)
                 .withPsNote(TypeEnum.STRING, "very limited regex support"), TypeSig.STRING),
@@ -340,7 +322,7 @@ abstract class SparkBaseShims extends SparkShims {
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     getExprsSansTimeSub + (classOf[TimeSub] -> GpuOverrides.expr[TimeSub](
       "Subtracts interval from timestamp",
-      ExprChecks.binaryProjectNotLambda(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
+      ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
         ("start", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
         ("interval", TypeSig.lit(TypeEnum.CALENDAR)
             .withPsNote(TypeEnum.CALENDAR, "months not supported"), TypeSig.CALENDAR)),

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -44,11 +44,10 @@ class GpuBroadcastHashJoinMeta(
   val condition: Option[BaseExprMeta[_]] =
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
-  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
-
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
+  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuShuffledHashJoinExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 object GpuJoinUtils {
   def getGpuBuildSide(buildSide: BuildSide): GpuBuildSide = {
@@ -54,7 +54,7 @@ class GpuShuffledHashJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/Spark301dbShims.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPy
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
 import org.apache.spark.sql.rapids.execution.python.{GpuAggregateInPandasExecMeta, GpuArrowEvalPythonExec, GpuFlatMapGroupsInPandasExecMeta, GpuMapInPandasExecMeta, GpuPythonUDF, GpuWindowInPandasExecMetaBase}
 import org.apache.spark.sql.types._
 
@@ -181,33 +181,15 @@ class Spark301dbShims extends Spark301Shims {
         }),
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuBroadcastHashJoinExec.scala
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids.shims.spark301.GpuBroadcastExchangeExec
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.{FullOuter, JoinType}
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, Distribution, UnspecifiedDistribution}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -49,10 +49,10 @@ class GpuBroadcastHashJoinMeta(
   val condition: Option[BaseExprMeta[_]] =
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
-  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
-
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
+
+  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuShuffledHashJoinExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 object GpuJoinUtils {
   def getGpuBuildSide(buildSide: BuildSide): GpuBuildSide = {
@@ -54,7 +54,7 @@ class GpuShuffledHashJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/GpuSortMergeJoinExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -44,7 +44,7 @@ class GpuSortMergeJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExch
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashJoin, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.rapids.{GpuElementAt, GpuFileSourceScanExec, GpuGetArrayItem, GpuGetArrayItemMeta, GpuGetMapValue, GpuGetMapValueMeta, GpuStringReplace, ShuffleManagerShimBase}
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
 import org.apache.spark.sql.rapids.shims.spark311._
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
@@ -181,7 +181,7 @@ class Spark311Shims extends Spark301Shims {
       }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("regex", TypeSig.lit(TypeEnum.STRING)
               .withPsNote(TypeEnum.STRING, "very limited regex support"), TypeSig.STRING),
@@ -259,7 +259,7 @@ class Spark311Shims extends Spark301Shims {
       }),
   GpuOverrides.expr[GetArrayItem](
     "Gets the field at `ordinal` in the Array",
-    ExprChecks.binaryProjectNotLambda(
+    ExprChecks.binaryProject(
       (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
         TypeSig.DECIMAL_64 + TypeSig.MAP).nested(),
       TypeSig.all,
@@ -273,7 +273,7 @@ class Spark311Shims extends Spark301Shims {
     }),
     GpuOverrides.expr[GetMapValue](
       "Gets Value from a Map based on a key",
-      ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.all,
+      ExprChecks.binaryProject(TypeSig.STRING, TypeSig.all,
         ("map", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.all)),
         ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all)),
       (in, conf, p, r) => new GpuGetMapValueMeta(in, conf, p, r){
@@ -283,7 +283,7 @@ class Spark311Shims extends Spark301Shims {
     GpuOverrides.expr[ElementAt](
       "Returns element of array at given(1-based) index in value if column is array. " +
         "Returns value for the given key in value if column is map.",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
           TypeSig.DECIMAL_64 + TypeSig.MAP).nested(), TypeSig.all,
         ("array/map", TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.ARRAY +
@@ -303,12 +303,12 @@ class Spark311Shims extends Spark301Shims {
           val checks = in.left.dataType match {
             case _: MapType =>
               // Match exactly with the checks for GetMapValue
-              ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.all,
+              ExprChecks.binaryProject(TypeSig.STRING, TypeSig.all,
                 ("map", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.all)),
                 ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all))
             case _: ArrayType =>
               // Match exactly with the checks for GetArrayItem
-              ExprChecks.binaryProjectNotLambda(
+              ExprChecks.binaryProject(
                 (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
                   TypeSig.DECIMAL_64 + TypeSig.MAP).nested(),
                 TypeSig.all,
@@ -391,33 +391,15 @@ class Spark311Shims extends Spark301Shims {
         }),
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r))
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r))
   }

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuBroadcastHashJoinExec.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.BroadcastQueryStageExec
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins._
-import org.apache.spark.sql.rapids.execution.{GpuHashJoin, SerializeConcatHostBuffersDeserializeBatch}
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuBroadcastHashJoinMeta(
@@ -44,10 +44,10 @@ class GpuBroadcastHashJoinMeta(
   val condition: Option[BaseExprMeta[_]] =
     join.condition.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
-  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
-
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
+
+  override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuShuffledHashJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuShuffledHashJoinExec.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 object GpuJoinUtils {
   def getGpuBuildSide(buildSide: BuildSide): GpuBuildSide = {
@@ -54,7 +54,7 @@ class GpuShuffledHashJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     GpuHashJoin.tagJoin(this, join.joinType, join.leftKeys, join.rightKeys, join.condition)

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuSortMergeJoinExec.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/GpuSortMergeJoinExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
-import org.apache.spark.sql.rapids.execution.GpuHashJoin
+import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
 
 /**
  * HashJoin changed in Spark 3.1 requiring Shim
@@ -44,7 +44,7 @@ class GpuSortMergeJoinMeta(
   override val childExprs: Seq[BaseExprMeta[_]] = leftKeys ++ rightKeys ++ condition
 
   override val namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] =
-    Map("leftKeys" -> leftKeys, "rightKeys" -> rightKeys)
+    JoinTypeChecks.equiJoinMeta(leftKeys, rightKeys, condition)
 
   override def tagPlanForGpu(): Unit = {
     // Use conditions from Hash Join

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPy
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
 import org.apache.spark.sql.rapids.execution.python.{GpuPythonUDF, GpuWindowInPandasExecMetaBase}
 import org.apache.spark.sql.rapids.execution.python.shims.spark311db.{GpuAggregateInPandasExecMeta, GpuArrowEvalPythonExec, GpuFlatMapGroupsInPandasExecMeta, GpuMapInPandasExecMeta, GpuWindowInPandasExec}
 import org.apache.spark.sql.types._
@@ -184,33 +184,15 @@ class Spark311dbShims extends Spark311Shims {
         }),
       GpuOverrides.exec[SortMergeJoinExec](
         "Sort merge join, replacing with shuffled hash join",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-            TypeSig.DECIMAL_64),
-        Map("leftKeys" -> TypeSig.joinKeyTypes,
-          "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuSortMergeJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[BroadcastHashJoinExec](
         "Implementation of join using broadcast data",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT +
-          TypeSig.DECIMAL_64),
-          Map("leftKeys" -> TypeSig.joinKeyTypes,
-            "rightKeys" -> TypeSig.joinKeyTypes),
-          TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuBroadcastHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ShuffledHashJoinExec](
         "Implementation of join using hashed shuffled data",
-         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
-            TypeSig.STRUCT + TypeSig.MAP)
-          .nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64),
-           Map("leftKeys" -> TypeSig.joinKeyTypes,
-             "rightKeys" -> TypeSig.joinKeyTypes),
-           TypeSig.all),
+        JoinTypeChecks.equiJoinExecChecks,
         (join, conf, p, r) => new GpuShuffledHashJoinMeta(join, conf, p, r)),
       GpuOverrides.exec[ArrowEvalPythonExec](
         "The backend of the Scalar Pandas UDFs. Accelerates the data transfer between the" +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3279,9 +3279,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
     val wrap = GpuOverrides.wrapPlan(plan, conf, None)
     wrap.tagForGpu()
     val reasonsToNotReplaceEntirePlan = wrap.getReasonsNotToReplaceEntirePlan
-    val exp = conf.explain
     if (conf.allowDisableEntirePlan && reasonsToNotReplaceEntirePlan.nonEmpty) {
-      if (!exp.equalsIgnoreCase("NONE")) {
+      if (conf.shouldExplain) {
         logWarning("Can't replace any part of this plan due to: " +
             s"${reasonsToNotReplaceEntirePlan.mkString(",")}")
       }
@@ -3302,12 +3301,12 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         Seq.empty
       }
       wrap.runAfterTagRules()
-      if (!exp.equalsIgnoreCase("NONE")) {
+      if (conf.shouldExplain) {
         wrap.tagForExplain()
-        val explain = wrap.explain(exp.equalsIgnoreCase("ALL"))
+        val explain = wrap.explain(conf.shouldExplainAll)
         if (explain.nonEmpty) {
           logWarning(s"\n$explain")
-          if (conf.optimizerExplain.equalsIgnoreCase("ALL") && optimizations.nonEmpty) {
+          if (conf.optimizerShouldExplainAll && optimizations.nonEmpty) {
             logWarning(s"Cost-based optimizations applied:\n${optimizations.mkString("\n")}")
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -52,7 +52,7 @@ import org.apache.spark.sql.hive.rapids.GpuHiveOverrides
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastMeta, GpuBroadcastNestedLoopJoinMeta, GpuCustomShuffleReaderExec, GpuShuffleExchangeExecBase, GpuShuffleMeta}
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastMeta, GpuBroadcastNestedLoopJoinMeta, GpuCustomShuffleReaderExec, GpuShuffleExchangeExecBase, GpuShuffleMeta, JoinTypeChecks}
 import org.apache.spark.sql.rapids.execution.python._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -777,7 +777,8 @@ object GpuOverrides {
   val commonExpressions: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     expr[Literal](
       "Holds a static value from the query",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectAndAst(
+        TypeSig.astTypes,
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.CALENDAR
             + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT)
             .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
@@ -792,7 +793,8 @@ object GpuOverrides {
       }),
     expr[Alias](
       "Gives a column a name",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.astTypes,
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT
             + TypeSig.DECIMAL_64).nested(),
         TypeSig.all),
@@ -802,8 +804,11 @@ object GpuOverrides {
       }),
     expr[AttributeReference](
       "References an input column",
-      ExprChecks.projectNotLambda((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP +
-                TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.DECIMAL_64).nested(), TypeSig.all),
+      ExprChecks.projectAndAst(
+        TypeSig.astTypes,
+        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
+            TypeSig.STRUCT + TypeSig.DECIMAL_64).nested(),
+        TypeSig.all),
       (att, conf, p, r) => new BaseExprMeta[AttributeReference](att, conf, p, r) {
         // This is the only NOOP operator.  It goes away when things are bound
         override def convertToGpu(): Expression = att
@@ -815,19 +820,17 @@ object GpuOverrides {
             super.print(append, depth, all)
           }
         }
-
-        override def tagSelfForAst(): Unit = {}
       }),
     expr[PromotePrecision](
       "PromotePrecision before arithmetic operations between DecimalType data",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.DECIMAL_64,
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.DECIMAL_64,
         TypeSig.DECIMAL_128_FULL),
       (a, conf, p, r) => new UnaryExprMeta[PromotePrecision](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuPromotePrecision(child)
       }),
     expr[CheckOverflow](
       "CheckOverflow after arithmetic operations between DecimalType data",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.DECIMAL_64,
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.DECIMAL_64,
         TypeSig.DECIMAL_128_FULL),
       (a, conf, p, r) => new UnaryExprMeta[CheckOverflow](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression =
@@ -972,7 +975,7 @@ object GpuOverrides {
     expr[PreciseTimestampConversion](
       "Expression used internally to convert the TimestampType to Long and back without losing " +
           "precision, i.e. in microseconds. Used in time windowing.",
-      ExprChecks.unaryProjectNotLambda(
+      ExprChecks.unaryProject(
         TypeSig.TIMESTAMP + TypeSig.LONG,
         TypeSig.TIMESTAMP + TypeSig.LONG,
         TypeSig.TIMESTAMP + TypeSig.LONG,
@@ -983,15 +986,17 @@ object GpuOverrides {
       }),
     expr[UnaryMinus](
       "Negate a numeric value",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes,
         TypeSig.gpuNumeric,
         TypeSig.numericAndInterval),
-      (a, conf, p, r) => new UnaryAstExprMeta[UnaryMinus](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new UnaryAstExprMeta[UnaryMinus](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuUnaryMinus(child)
       }),
     expr[UnaryPositive](
       "A numeric value with a + in front of it",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.astTypes,
         TypeSig.gpuNumeric,
         TypeSig.numericAndInterval),
       (a, conf, p, r) => new UnaryAstExprMeta[UnaryPositive](a, conf, p, r) {
@@ -999,50 +1004,50 @@ object GpuOverrides {
       }),
     expr[Year](
       "Returns the year from a date or timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[Year](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuYear(child)
       }),
     expr[Month](
       "Returns the month from a date or timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[Month](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuMonth(child)
       }),
     expr[Quarter](
       "Returns the quarter of the year for date, in the range 1 to 4",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[Quarter](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuQuarter(child)
       }),
     expr[DayOfMonth](
       "Returns the day of the month from a date or timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[DayOfMonth](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuDayOfMonth(child)
       }),
     expr[DayOfYear](
       "Returns the day of the year from a date or timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT, TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[DayOfYear](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuDayOfYear(child)
       }),
     expr[Abs](
       "Absolute value",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
-        TypeSig.gpuNumeric, TypeSig.numeric),
-      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) with AstImplicitCasts {
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child)
       }),
     expr[Acos](
       "Inverse cosine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Acos](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuAcos(child)
       }),
     expr[Acosh](
       "Inverse hyperbolic cosine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Acosh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression =
           if (conf.includeImprovedFloat) {
@@ -1053,13 +1058,13 @@ object GpuOverrides {
       }),
     expr[Asin](
       "Inverse sine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Asin](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuAsin(child)
       }),
     expr[Asinh](
       "Inverse hyperbolic sine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Asinh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression =
           if (conf.includeImprovedFloat) {
@@ -1079,19 +1084,19 @@ object GpuOverrides {
       }),
     expr[Sqrt](
       "Square root",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Sqrt](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuSqrt(child)
       }),
     expr[Cbrt](
       "Cube root",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Cbrt](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuCbrt(child)
       }),
     expr[Floor](
       "Floor of a number",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectInputMatchesOutput(
         TypeSig.DOUBLE + TypeSig.LONG + TypeSig.DECIMAL_64,
         TypeSig.DOUBLE + TypeSig.LONG + TypeSig.DECIMAL_128_FULL),
       (a, conf, p, r) => new UnaryExprMeta[Floor](a, conf, p, r) {
@@ -1099,7 +1104,7 @@ object GpuOverrides {
       }),
     expr[Ceil](
       "Ceiling of a number",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectInputMatchesOutput(
         TypeSig.DOUBLE + TypeSig.LONG + TypeSig.DECIMAL_64,
         TypeSig.DOUBLE + TypeSig.LONG + TypeSig.DECIMAL_128_FULL),
       (a, conf, p, r) => new UnaryExprMeta[Ceil](a, conf, p, r) {
@@ -1107,13 +1112,14 @@ object GpuOverrides {
       }),
     expr[Not](
       "Boolean not operator",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.BOOLEAN, TypeSig.BOOLEAN),
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.astTypes, TypeSig.BOOLEAN, TypeSig.BOOLEAN),
       (a, conf, p, r) => new UnaryAstExprMeta[Not](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuNot(child)
       }),
     expr[IsNull](
       "Checks if a value is null",
-      ExprChecks.unaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.DECIMAL_64).nested(),
         TypeSig.all),
@@ -1122,7 +1128,7 @@ object GpuOverrides {
       }),
     expr[IsNotNull](
       "Checks if a value is not null",
-      ExprChecks.unaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
             TypeSig.STRUCT + TypeSig.DECIMAL_64).nested(),
         TypeSig.all),
@@ -1131,27 +1137,27 @@ object GpuOverrides {
       }),
     expr[IsNaN](
       "Checks if a value is NaN",
-      ExprChecks.unaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         TypeSig.DOUBLE + TypeSig.FLOAT, TypeSig.DOUBLE + TypeSig.FLOAT),
       (a, conf, p, r) => new UnaryExprMeta[IsNaN](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuIsNan(child)
       }),
     expr[Rint](
       "Rounds up a double value to the nearest double equal to an integer",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Rint](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuRint(child)
       }),
     expr[BitwiseNot](
       "Returns the bitwise NOT of the operands",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
-        TypeSig.integral, TypeSig.integral),
-      (a, conf, p, r) => new UnaryAstExprMeta[BitwiseNot](a, conf, p, r) with AstImplicitCasts {
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.integral, TypeSig.integral),
+      (a, conf, p, r) => new UnaryAstExprMeta[BitwiseNot](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuBitwiseNot(child)
       }),
     expr[AtLeastNNonNulls](
       "Checks if number of non null/Nan values is greater than a given value",
-      ExprChecks.projectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.projectOnly(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         repeatingParamCheck = Some(RepeatingParamCheck("input",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.MAP +
               TypeSig.ARRAY + TypeSig.STRUCT).nested(),
@@ -1162,7 +1168,7 @@ object GpuOverrides {
       }),
     expr[DateAdd](
       "Returns the date that is num_days after start_date",
-      ExprChecks.binaryProjectNotLambda(TypeSig.DATE, TypeSig.DATE,
+      ExprChecks.binaryProject(TypeSig.DATE, TypeSig.DATE,
         ("startDate", TypeSig.DATE, TypeSig.DATE),
         ("days",
             TypeSig.INT + TypeSig.SHORT + TypeSig.BYTE,
@@ -1173,7 +1179,7 @@ object GpuOverrides {
       }),
     expr[DateSub](
       "Returns the date that is num_days before start_date",
-      ExprChecks.binaryProjectNotLambda(TypeSig.DATE, TypeSig.DATE,
+      ExprChecks.binaryProject(TypeSig.DATE, TypeSig.DATE,
         ("startDate", TypeSig.DATE, TypeSig.DATE),
         ("days",
             TypeSig.INT + TypeSig.SHORT + TypeSig.BYTE,
@@ -1184,7 +1190,7 @@ object GpuOverrides {
       }),
     expr[NaNvl](
       "Evaluates to `left` iff left is not NaN, `right` otherwise",
-      ExprChecks.binaryProjectNotLambda(TypeSig.fp, TypeSig.fp,
+      ExprChecks.binaryProject(TypeSig.fp, TypeSig.fp,
         ("lhs", TypeSig.fp, TypeSig.fp),
         ("rhs", TypeSig.fp, TypeSig.fp)),
       (a, conf, p, r) => new BinaryExprMeta[NaNvl](a, conf, p, r) {
@@ -1193,7 +1199,7 @@ object GpuOverrides {
       }),
     expr[ShiftLeft](
       "Bitwise shift left (<<)",
-      ExprChecks.binaryProjectNotLambda(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
+      ExprChecks.binaryProject(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
         ("value", TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG),
         ("amount", TypeSig.INT, TypeSig.INT)),
       (a, conf, p, r) => new BinaryExprMeta[ShiftLeft](a, conf, p, r) {
@@ -1202,7 +1208,7 @@ object GpuOverrides {
       }),
     expr[ShiftRight](
       "Bitwise shift right (>>)",
-      ExprChecks.binaryProjectNotLambda(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
+      ExprChecks.binaryProject(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
         ("value", TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG),
         ("amount", TypeSig.INT, TypeSig.INT)),
       (a, conf, p, r) => new BinaryExprMeta[ShiftRight](a, conf, p, r) {
@@ -1211,7 +1217,7 @@ object GpuOverrides {
       }),
     expr[ShiftRightUnsigned](
       "Bitwise unsigned shift right (>>>)",
-      ExprChecks.binaryProjectNotLambda(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
+      ExprChecks.binaryProject(TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG,
         ("value", TypeSig.INT + TypeSig.LONG, TypeSig.INT + TypeSig.LONG),
         ("amount", TypeSig.INT, TypeSig.INT)),
       (a, conf, p, r) => new BinaryExprMeta[ShiftRightUnsigned](a, conf, p, r) {
@@ -1220,34 +1226,37 @@ object GpuOverrides {
       }),
     expr[BitwiseAnd](
       "Returns the bitwise AND of the operands",
-      ExprChecks.binaryProjectNotLambda(TypeSig.integral, TypeSig.integral,
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes, TypeSig.integral, TypeSig.integral,
         ("lhs", TypeSig.integral, TypeSig.integral),
         ("rhs", TypeSig.integral, TypeSig.integral)),
-      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseAnd](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseAnd](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuBitwiseAnd(lhs, rhs)
       }),
     expr[BitwiseOr](
       "Returns the bitwise OR of the operands",
-      ExprChecks.binaryProjectNotLambda(TypeSig.integral, TypeSig.integral,
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes, TypeSig.integral, TypeSig.integral,
         ("lhs", TypeSig.integral, TypeSig.integral),
         ("rhs", TypeSig.integral, TypeSig.integral)),
-      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseOr](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseOr](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuBitwiseOr(lhs, rhs)
       }),
     expr[BitwiseXor](
       "Returns the bitwise XOR of the operands",
-      ExprChecks.binaryProjectNotLambda(TypeSig.integral, TypeSig.integral,
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes, TypeSig.integral, TypeSig.integral,
         ("lhs", TypeSig.integral, TypeSig.integral),
         ("rhs", TypeSig.integral, TypeSig.integral)),
-      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseXor](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[BitwiseXor](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuBitwiseXor(lhs, rhs)
       }),
     expr[Coalesce] (
       "Returns the first non-null argument if exists. Otherwise, null",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectOnly(
         (_gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT).nested(),
         TypeSig.all,
         repeatingParamCheck = Some(RepeatingParamCheck("param",
@@ -1258,7 +1267,7 @@ object GpuOverrides {
       }),
     expr[Least] (
       "Returns the least value of all parameters, skipping null values",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectOnly(
         TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable,
         repeatingParamCheck = Some(RepeatingParamCheck("param",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64,
@@ -1268,7 +1277,7 @@ object GpuOverrides {
       }),
     expr[Greatest] (
       "Returns the greatest value of all parameters, skipping null values",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectOnly(
         TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable,
         repeatingParamCheck = Some(RepeatingParamCheck("param",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64,
@@ -1278,38 +1287,38 @@ object GpuOverrides {
       }),
     expr[Atan](
       "Inverse tangent",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Atan](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuAtan(child)
       }),
     expr[Atanh](
       "Inverse hyperbolic tangent",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Atanh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuAtanh(child)
       }),
     expr[Cos](
       "Cosine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Cos](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuCos(child)
       }),
     expr[Exp](
       "Euler's number e raised to a power",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Exp](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuExp(child)
       }),
     expr[Expm1](
       "Euler's number e raised to a power minus 1",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Expm1](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuExpm1(child)
       }),
     expr[InitCap](
       "Returns str with the first letter of each word in uppercase. " +
       "All other letters are in lowercase",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
       (a, conf, p, r) => new UnaryExprMeta[InitCap](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuInitCap(child)
       }).incompat(CASE_MODIFICATION_INCOMPAT),
@@ -1342,7 +1351,7 @@ object GpuOverrides {
       }),
     expr[Logarithm](
       "Log variable base",
-      ExprChecks.binaryProjectNotLambda(TypeSig.DOUBLE, TypeSig.DOUBLE,
+      ExprChecks.binaryProject(TypeSig.DOUBLE, TypeSig.DOUBLE,
         ("value", TypeSig.DOUBLE, TypeSig.DOUBLE),
         ("base", TypeSig.DOUBLE, TypeSig.DOUBLE)),
       (a, conf, p, r) => new BinaryExprMeta[Logarithm](a, conf, p, r) {
@@ -1352,43 +1361,43 @@ object GpuOverrides {
       }),
     expr[Sin](
       "Sine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Sin](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuSin(child)
       }),
     expr[Sinh](
       "Hyperbolic sine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Sinh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuSinh(child)
       }),
     expr[Cosh](
       "Hyperbolic cosine",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Cosh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuCosh(child)
       }),
     expr[Cot](
       "Cotangent",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Cot](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuCot(child)
       }),
     expr[Tanh](
       "Hyperbolic tangent",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Tanh](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuTanh(child)
       }),
     expr[Tan](
       "Tangent",
-      ExprChecks.mathUnary,
+      ExprChecks.mathUnaryWithAst,
       (a, conf, p, r) => new UnaryAstExprMeta[Tan](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuTan(child)
       }),
     expr[NormalizeNaNAndZero](
       "Normalize NaN and zero",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectInputMatchesOutput(
         TypeSig.DOUBLE + TypeSig.FLOAT,
         TypeSig.DOUBLE + TypeSig.FLOAT),
       (a, conf, p, r) => new UnaryExprMeta[NormalizeNaNAndZero](a, conf, p, r) {
@@ -1397,7 +1406,7 @@ object GpuOverrides {
       }),
     expr[KnownFloatingPointNormalized](
       "Tag to prevent redundant normalization",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectInputMatchesOutput(
         TypeSig.DOUBLE + TypeSig.FLOAT,
         TypeSig.DOUBLE + TypeSig.FLOAT),
       (a, conf, p, r) => new UnaryExprMeta[KnownFloatingPointNormalized](a, conf, p, r) {
@@ -1406,7 +1415,7 @@ object GpuOverrides {
       }),
     expr[KnownNotNull](
       "Tag an expression as known to not be null",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(
+      ExprChecks.unaryProjectInputMatchesOutput(
         _notNullCudfTypes, TypeSig.all),
       (k, conf, p, r) => new UnaryExprMeta[KnownNotNull](k, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression =
@@ -1414,7 +1423,7 @@ object GpuOverrides {
       }),
     expr[DateDiff](
       "Returns the number of days from startDate to endDate",
-      ExprChecks.binaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.binaryProject(TypeSig.INT, TypeSig.INT,
         ("lhs", TypeSig.DATE, TypeSig.DATE),
         ("rhs", TypeSig.DATE, TypeSig.DATE)),
       (a, conf, p, r) => new BinaryExprMeta[DateDiff](a, conf, p, r) {
@@ -1424,7 +1433,7 @@ object GpuOverrides {
     }),
     expr[TimeAdd](
       "Adds interval to timestamp",
-      ExprChecks.binaryProjectNotLambda(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
+      ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
         ("start", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
         ("interval", TypeSig.lit(TypeEnum.CALENDAR)
           .withPsNote(TypeEnum.CALENDAR, "month intervals are not supported"),
@@ -1445,7 +1454,7 @@ object GpuOverrides {
     }),
     expr[DateAddInterval](
       "Adds interval to date",
-      ExprChecks.binaryProjectNotLambda(TypeSig.DATE, TypeSig.DATE,
+      ExprChecks.binaryProject(TypeSig.DATE, TypeSig.DATE,
         ("start", TypeSig.DATE, TypeSig.DATE),
         ("interval", TypeSig.lit(TypeEnum.CALENDAR)
           .withPsNote(TypeEnum.CALENDAR, "month intervals are not supported"),
@@ -1467,7 +1476,7 @@ object GpuOverrides {
         }),
     expr[DateFormatClass](
       "Converts timestamp to a value of string in the format specified by the date format",
-      ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.binaryProject(TypeSig.STRING, TypeSig.STRING,
         ("timestamp", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
         ("strfmt", TypeSig.lit(TypeEnum.STRING)
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
@@ -1479,7 +1488,7 @@ object GpuOverrides {
     ),
     expr[ToUnixTimestamp](
       "Returns the UNIX timestamp of the given time",
-      ExprChecks.binaryProjectNotLambda(TypeSig.LONG, TypeSig.LONG,
+      ExprChecks.binaryProject(TypeSig.LONG, TypeSig.LONG,
         ("timeExp",
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP,
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP),
@@ -1498,7 +1507,7 @@ object GpuOverrides {
       }),
     expr[UnixTimestamp](
       "Returns the UNIX timestamp of current or specified time",
-      ExprChecks.binaryProjectNotLambda(TypeSig.LONG, TypeSig.LONG,
+      ExprChecks.binaryProject(TypeSig.LONG, TypeSig.LONG,
         ("timeExp",
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP,
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP),
@@ -1517,7 +1526,7 @@ object GpuOverrides {
       }),
     expr[Hour](
       "Returns the hour component of the string/timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (hour, conf, p, r) => new UnaryExprMeta[Hour](hour, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -1528,7 +1537,7 @@ object GpuOverrides {
       }),
     expr[Minute](
       "Returns the minute component of the string/timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (minute, conf, p, r) => new UnaryExprMeta[Minute](minute, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -1540,7 +1549,7 @@ object GpuOverrides {
       }),
     expr[Second](
       "Returns the second component of the string/timestamp",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (second, conf, p, r) => new UnaryExprMeta[Second](second, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -1552,7 +1561,7 @@ object GpuOverrides {
       }),
     expr[WeekDay](
       "Returns the day of the week (0 = Monday...6=Sunday)",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[WeekDay](a, conf, p, r) {
         override def convertToGpu(expr: Expression): GpuExpression =
@@ -1560,7 +1569,7 @@ object GpuOverrides {
       }),
     expr[DayOfWeek](
       "Returns the day of the week (1 = Sunday...7=Saturday)",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[DayOfWeek](a, conf, p, r) {
         override def convertToGpu(expr: Expression): GpuExpression =
@@ -1568,14 +1577,14 @@ object GpuOverrides {
       }),
     expr[LastDay](
       "Returns the last day of the month which the date belongs to",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.DATE, TypeSig.DATE),
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.DATE, TypeSig.DATE),
       (a, conf, p, r) => new UnaryExprMeta[LastDay](a, conf, p, r) {
         override def convertToGpu(expr: Expression): GpuExpression =
           GpuLastDay(expr)
       }),
     expr[FromUnixTime](
       "Get the string from a unix timestamp",
-      ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.binaryProject(TypeSig.STRING, TypeSig.STRING,
         ("sec", TypeSig.LONG, TypeSig.LONG),
         ("format", TypeSig.lit(TypeEnum.STRING)
             .withPsNote(TypeEnum.STRING, "Only a limited number of formats are supported"),
@@ -1587,7 +1596,7 @@ object GpuOverrides {
       }),
     expr[Pmod](
       "Pmod",
-      ExprChecks.binaryProjectNotLambda(TypeSig.integral + TypeSig.fp, TypeSig.numeric,
+      ExprChecks.binaryProject(TypeSig.integral + TypeSig.fp, TypeSig.numeric,
         ("lhs", TypeSig.integral + TypeSig.fp, TypeSig.numeric),
         ("rhs", TypeSig.integral + TypeSig.fp, TypeSig.numeric)),
       (a, conf, p, r) => new BinaryExprMeta[Pmod](a, conf, p, r) {
@@ -1596,34 +1605,37 @@ object GpuOverrides {
       }),
     expr[Add](
       "Addition",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes,
         TypeSig.gpuNumeric, TypeSig.numericAndInterval,
         ("lhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval),
         ("rhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Add](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[Add](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuAdd(lhs, rhs)
       }),
     expr[Subtract](
       "Subtraction",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes,
         TypeSig.gpuNumeric, TypeSig.numericAndInterval,
         ("lhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval),
         ("rhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Subtract](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[Subtract](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuSubtract(lhs, rhs)
       }),
     expr[Multiply](
       "Multiplication",
-      ExprChecks.binaryProjectNotLambda(TypeSig.gpuNumeric +
-          TypeSig.psNote(TypeEnum.DECIMAL,
-            "Because of Spark's inner workings the full range of decimal precision " +
-                "(even for 64-bit values) is not supported."),
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes,
+        TypeSig.gpuNumeric + TypeSig.psNote(TypeEnum.DECIMAL,
+          "Because of Spark's inner workings the full range of decimal precision " +
+              "(even for 64-bit values) is not supported."),
         TypeSig.numeric,
         ("lhs", TypeSig.gpuNumeric, TypeSig.numeric),
         ("rhs", TypeSig.gpuNumeric, TypeSig.numeric)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Multiply](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[Multiply](a, conf, p, r) {
         override def tagExprForGpu(): Unit = {
           // Multiplication of Decimal types is a little odd. Spark will cast the inputs
           // to a common wider value where scale is max of the two input scales, and precision is
@@ -1657,7 +1669,7 @@ object GpuOverrides {
       }),
     expr[And](
       "Logical AND",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.BOOLEAN, TypeSig.BOOLEAN),
         ("rhs", TypeSig.BOOLEAN, TypeSig.BOOLEAN)),
       (a, conf, p, r) => new BinaryExprMeta[And](a, conf, p, r) {
@@ -1666,7 +1678,7 @@ object GpuOverrides {
       }),
     expr[Or](
       "Logical OR",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.BOOLEAN, TypeSig.BOOLEAN),
         ("rhs", TypeSig.BOOLEAN, TypeSig.BOOLEAN)),
       (a, conf, p, r) => new BinaryExprMeta[Or](a, conf, p, r) {
@@ -1675,7 +1687,7 @@ object GpuOverrides {
       }),
     expr[EqualNullSafe](
       "Check if the values are equal including nulls <=>",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.comparable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.comparable)),
@@ -1685,37 +1697,40 @@ object GpuOverrides {
       }),
     expr[EqualTo](
       "Check if the values are equal",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.comparisonAstTypes,
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.comparable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.comparable)),
-      (a, conf, p, r) => new BinaryAstCompareExprMeta[EqualTo](a, conf, p, r) {
+      (a, conf, p, r) => new BinaryAstExprMeta[EqualTo](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuEqualTo(lhs, rhs)
       }),
     expr[GreaterThan](
       "> operator",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.comparisonAstTypes,
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable)),
-      (a, conf, p, r) => new BinaryAstCompareExprMeta[GreaterThan](a, conf, p, r) {
+      (a, conf, p, r) => new BinaryAstExprMeta[GreaterThan](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuGreaterThan(lhs, rhs)
       }),
     expr[GreaterThanOrEqual](
       ">= operator",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.comparisonAstTypes,
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable)),
-      (a, conf, p, r) => new BinaryAstCompareExprMeta[GreaterThanOrEqual](a, conf, p, r) {
+      (a, conf, p, r) => new BinaryAstExprMeta[GreaterThanOrEqual](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuGreaterThanOrEqual(lhs, rhs)
       }),
     expr[In](
       "IN operator",
-      ExprChecks.projectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.projectOnly(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         Seq(ParamCheck("value", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64,
           TypeSig.comparable)),
         Some(RepeatingParamCheck("list",
@@ -1737,7 +1752,7 @@ object GpuOverrides {
       }),
     expr[InSet](
       "INSET operator",
-      ExprChecks.unaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.comparable),
       (in, conf, p, r) => new ExprMeta[InSet](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -1750,21 +1765,23 @@ object GpuOverrides {
       }),
     expr[LessThan](
       "< operator",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.comparisonAstTypes,
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable)),
-      (a, conf, p, r) => new BinaryAstCompareExprMeta[LessThan](a, conf, p, r) {
+      (a, conf, p, r) => new BinaryAstExprMeta[LessThan](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuLessThan(lhs, rhs)
       }),
     expr[LessThanOrEqual](
       "<= operator",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.comparisonAstTypes,
         TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable),
         ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.orderable)),
-      (a, conf, p, r) => new BinaryAstCompareExprMeta[LessThanOrEqual](a, conf, p, r) {
+      (a, conf, p, r) => new BinaryAstExprMeta[LessThanOrEqual](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuLessThanOrEqual(lhs, rhs)
       }),
@@ -1787,7 +1804,7 @@ object GpuOverrides {
       }),
     expr[If](
       "IF expression",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectOnly(
         (_gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(),
         TypeSig.all,
         Seq(ParamCheck("predicate", TypeSig.BOOLEAN, TypeSig.BOOLEAN),
@@ -1805,17 +1822,17 @@ object GpuOverrides {
       }),
     expr[Pow](
       "lhs ^ rhs",
-      ExprChecks.binaryProjectNotLambda(
-        TypeSig.DOUBLE, TypeSig.DOUBLE,
+      ExprChecks.binaryProjectAndAst(
+        TypeSig.implicitCastsAstTypes, TypeSig.DOUBLE, TypeSig.DOUBLE,
         ("lhs", TypeSig.DOUBLE, TypeSig.DOUBLE),
         ("rhs", TypeSig.DOUBLE, TypeSig.DOUBLE)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Pow](a, conf, p, r) with AstImplicitCasts {
+      (a, conf, p, r) => new BinaryAstExprMeta[Pow](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuPow(lhs, rhs)
       }),
     expr[Divide](
       "Division",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.DOUBLE +
             TypeSig.psNote(TypeEnum.DECIMAL,
               "Because of Spark's inner workings the full range of decimal precision " +
@@ -1889,7 +1906,7 @@ object GpuOverrides {
       }),
     expr[IntegralDivide](
       "Division with a integer result",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.LONG, TypeSig.LONG,
         ("lhs", TypeSig.LONG + TypeSig.DECIMAL_64, TypeSig.LONG + TypeSig.DECIMAL_128_FULL),
         ("rhs", TypeSig.LONG + TypeSig.DECIMAL_64, TypeSig.LONG + TypeSig.DECIMAL_128_FULL)),
@@ -1899,7 +1916,7 @@ object GpuOverrides {
       }),
     expr[Remainder](
       "Remainder or modulo",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.integral + TypeSig.fp, TypeSig.numeric,
         ("lhs", TypeSig.integral + TypeSig.fp, TypeSig.numeric),
         ("rhs", TypeSig.integral + TypeSig.fp, TypeSig.numeric)),
@@ -2166,7 +2183,7 @@ object GpuOverrides {
       }),
     expr[BRound](
       "Round an expression to d decimal places using HALF_EVEN rounding mode",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.gpuNumeric, TypeSig.numeric,
         ("value", TypeSig.gpuNumeric +
             TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
@@ -2187,7 +2204,7 @@ object GpuOverrides {
       }),
     expr[Round](
       "Round an expression to d decimal places using HALF_UP rounding mode",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.gpuNumeric, TypeSig.numeric,
         ("value", TypeSig.gpuNumeric +
             TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
@@ -2235,7 +2252,7 @@ object GpuOverrides {
         }),
     expr[Rand](
       "Generate a random column with i.i.d. uniformly distributed values in [0, 1)",
-      ExprChecks.projectNotLambda(TypeSig.DOUBLE, TypeSig.DOUBLE,
+      ExprChecks.projectOnly(TypeSig.DOUBLE, TypeSig.DOUBLE,
         Seq(ParamCheck("seed",
           (TypeSig.INT + TypeSig.LONG).withAllLit(),
           (TypeSig.INT + TypeSig.LONG).withAllLit()))),
@@ -2244,58 +2261,58 @@ object GpuOverrides {
       }),
     expr[SparkPartitionID] (
       "Returns the current partition id",
-      ExprChecks.projectNotLambda(TypeSig.INT, TypeSig.INT),
+      ExprChecks.projectOnly(TypeSig.INT, TypeSig.INT),
       (a, conf, p, r) => new ExprMeta[SparkPartitionID](a, conf, p, r) {
         override def convertToGpu(): GpuExpression = GpuSparkPartitionID()
       }),
     expr[MonotonicallyIncreasingID] (
       "Returns monotonically increasing 64-bit integers",
-      ExprChecks.projectNotLambda(TypeSig.LONG, TypeSig.LONG),
+      ExprChecks.projectOnly(TypeSig.LONG, TypeSig.LONG),
       (a, conf, p, r) => new ExprMeta[MonotonicallyIncreasingID](a, conf, p, r) {
         override def convertToGpu(): GpuExpression = GpuMonotonicallyIncreasingID()
       }),
     expr[InputFileName] (
       "Returns the name of the file being read, or empty string if not available",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING),
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING),
       (a, conf, p, r) => new ExprMeta[InputFileName](a, conf, p, r) {
         override def convertToGpu(): GpuExpression = GpuInputFileName()
       }),
     expr[InputFileBlockStart] (
       "Returns the start offset of the block being read, or -1 if not available",
-      ExprChecks.projectNotLambda(TypeSig.LONG, TypeSig.LONG),
+      ExprChecks.projectOnly(TypeSig.LONG, TypeSig.LONG),
       (a, conf, p, r) => new ExprMeta[InputFileBlockStart](a, conf, p, r) {
         override def convertToGpu(): GpuExpression = GpuInputFileBlockStart()
       }),
     expr[InputFileBlockLength] (
       "Returns the length of the block being read, or -1 if not available",
-      ExprChecks.projectNotLambda(TypeSig.LONG, TypeSig.LONG),
+      ExprChecks.projectOnly(TypeSig.LONG, TypeSig.LONG),
       (a, conf, p, r) => new ExprMeta[InputFileBlockLength](a, conf, p, r) {
         override def convertToGpu(): GpuExpression = GpuInputFileBlockLength()
       }),
     expr[Md5] (
       "MD5 hash operator",
-      ExprChecks.unaryProjectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.unaryProject(TypeSig.STRING, TypeSig.STRING,
         TypeSig.BINARY, TypeSig.BINARY),
       (a, conf, p, r) => new UnaryExprMeta[Md5](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuMd5(child)
       }),
     expr[Upper](
       "String uppercase operator",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
       (a, conf, p, r) => new UnaryExprMeta[Upper](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuUpper(child)
       })
       .incompat(CASE_MODIFICATION_INCOMPAT),
     expr[Lower](
       "String lowercase operator",
-      ExprChecks.unaryProjectNotLambdaInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
+      ExprChecks.unaryProjectInputMatchesOutput(TypeSig.STRING, TypeSig.STRING),
       (a, conf, p, r) => new UnaryExprMeta[Lower](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuLower(child)
       })
       .incompat(CASE_MODIFICATION_INCOMPAT),
     expr[StringLPad](
       "Pad a string on the left",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("len", TypeSig.lit(TypeEnum.INT), TypeSig.INT),
           ParamCheck("pad", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2316,7 +2333,7 @@ object GpuOverrides {
       }),
     expr[StringRPad](
       "Pad a string on the right",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("len", TypeSig.lit(TypeEnum.INT), TypeSig.INT),
           ParamCheck("pad", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2337,7 +2354,7 @@ object GpuOverrides {
       }),
     expr[StringSplit](
        "Splits `str` around occurrences that match `regex`",
-      ExprChecks.projectNotLambda(TypeSig.ARRAY.nested(TypeSig.STRING),
+      ExprChecks.projectOnly(TypeSig.ARRAY.nested(TypeSig.STRING),
         TypeSig.ARRAY.nested(TypeSig.STRING),
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("regexp", TypeSig.lit(TypeEnum.STRING)
@@ -2347,7 +2364,7 @@ object GpuOverrides {
       (in, conf, p, r) => new GpuStringSplitMeta(in, conf, p, r)),
     expr[GetStructField](
       "Gets the named field of the struct",
-      ExprChecks.unaryProjectNotLambda(
+      ExprChecks.unaryProject(
         (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP + TypeSig.NULL +
             TypeSig.DECIMAL_64).nested(),
         TypeSig.all,
@@ -2360,7 +2377,7 @@ object GpuOverrides {
       }),
     expr[GetArrayItem](
       "Gets the field at `ordinal` in the Array",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
             TypeSig.DECIMAL_64 + TypeSig.MAP).nested(),
         TypeSig.all,
@@ -2371,14 +2388,14 @@ object GpuOverrides {
       (in, conf, p, r) => new GpuGetArrayItemMeta(in, conf, p, r)),
     expr[GetMapValue](
       "Gets Value from a Map based on a key",
-      ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.all,
+      ExprChecks.binaryProject(TypeSig.STRING, TypeSig.all,
         ("map", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.all)),
         ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all)),
       (in, conf, p, r) => new GpuGetMapValueMeta(in, conf, p, r)),
     expr[ElementAt](
       "Returns element of array at given(1-based) index in value if column is array. " +
         "Returns value for the given key in value if column is map.",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
           TypeSig.DECIMAL_64 + TypeSig.MAP).nested(), TypeSig.all,
         ("array/map", TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.ARRAY +
@@ -2398,12 +2415,12 @@ object GpuOverrides {
           val checks = in.left.dataType match {
             case _: MapType =>
               // Match exactly with the checks for GetMapValue
-              ExprChecks.binaryProjectNotLambda(TypeSig.STRING, TypeSig.all,
+              ExprChecks.binaryProject(TypeSig.STRING, TypeSig.all,
                 ("map", TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.all)),
                 ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all))
             case _: ArrayType =>
               // Match exactly with the checks for GetArrayItem
-              ExprChecks.binaryProjectNotLambda(
+              ExprChecks.binaryProject(
                 (TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.NULL +
                   TypeSig.DECIMAL_64 + TypeSig.MAP).nested(),
                 TypeSig.all,
@@ -2430,7 +2447,7 @@ object GpuOverrides {
       }),
     expr[ArrayContains](
       "Returns a boolean if the array contains the passed in key",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.BOOLEAN,
         TypeSig.BOOLEAN,
         ("array", TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.NULL),
@@ -2461,7 +2478,7 @@ object GpuOverrides {
       }),
     expr[SortArray](
       "Returns a sorted array with the input array and the ascending / descending order",
-      ExprChecks.binaryProjectNotLambda(
+      ExprChecks.binaryProject(
         TypeSig.ARRAY.nested(_gpuCommonTypes),
         TypeSig.ARRAY.nested(TypeSig.all),
         ("array", TypeSig.ARRAY.nested(_gpuCommonTypes),
@@ -2475,7 +2492,7 @@ object GpuOverrides {
     ),
     expr[CreateArray](
       " Returns an array with the given elements",
-      ExprChecks.projectNotLambda(
+      ExprChecks.projectOnly(
         TypeSig.ARRAY.nested(TypeSig.gpuNumeric + TypeSig.NULL + TypeSig.STRING +
             TypeSig.BOOLEAN + TypeSig.DATE + TypeSig.TIMESTAMP + TypeSig.ARRAY),
         TypeSig.ARRAY.nested(TypeSig.all),
@@ -2501,7 +2518,7 @@ object GpuOverrides {
       }),
     expr[StringLocate](
       "Substring search operator",
-      ExprChecks.projectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.projectOnly(TypeSig.INT, TypeSig.INT,
         Seq(ParamCheck("substr", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING),
           ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("start", TypeSig.lit(TypeEnum.INT), TypeSig.INT))),
@@ -2514,7 +2531,7 @@ object GpuOverrides {
       }),
     expr[Substring](
       "Substring operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING + TypeSig.BINARY,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING + TypeSig.BINARY,
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING + TypeSig.BINARY),
           ParamCheck("pos", TypeSig.lit(TypeEnum.INT), TypeSig.INT),
           ParamCheck("len", TypeSig.lit(TypeEnum.INT), TypeSig.INT))),
@@ -2527,7 +2544,7 @@ object GpuOverrides {
       }),
     expr[SubstringIndex](
       "substring_index operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("delim", TypeSig.lit(TypeEnum.STRING)
               .withPsNote(TypeEnum.STRING, "only a single character is allowed"), TypeSig.STRING),
@@ -2536,7 +2553,7 @@ object GpuOverrides {
     expr[StringRepeat](
       "StringRepeat operator that repeats the given strings with numbers of times " +
         "given by repeatTimes",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("input", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("repeatTimes", TypeSig.INT, TypeSig.INT))),
       (in, conf, p, r) => new BinaryExprMeta[StringRepeat](in, conf, p, r) {
@@ -2546,7 +2563,7 @@ object GpuOverrides {
       }),
     expr[StringReplace](
       "StringReplace operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("src", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING),
           ParamCheck("replace", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2559,7 +2576,7 @@ object GpuOverrides {
       }),
     expr[StringTrim](
       "StringTrim operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("src", TypeSig.STRING, TypeSig.STRING)),
         // Should really be an OptionalParam
         Some(RepeatingParamCheck("trimStr", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2571,7 +2588,7 @@ object GpuOverrides {
       }),
     expr[StringTrimLeft](
       "StringTrimLeft operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("src", TypeSig.STRING, TypeSig.STRING)),
         // Should really be an OptionalParam
         Some(RepeatingParamCheck("trimStr", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2584,7 +2601,7 @@ object GpuOverrides {
         }),
     expr[StringTrimRight](
       "StringTrimRight operator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         Seq(ParamCheck("src", TypeSig.STRING, TypeSig.STRING)),
         // Should really be an OptionalParam
         Some(RepeatingParamCheck("trimStr", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
@@ -2597,7 +2614,7 @@ object GpuOverrides {
         }),
     expr[StartsWith](
       "Starts with",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("src", TypeSig.STRING, TypeSig.STRING),
         ("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING)),
       (a, conf, p, r) => new BinaryExprMeta[StartsWith](a, conf, p, r) {
@@ -2606,7 +2623,7 @@ object GpuOverrides {
       }),
     expr[EndsWith](
       "Ends with",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("src", TypeSig.STRING, TypeSig.STRING),
         ("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING)),
       (a, conf, p, r) => new BinaryExprMeta[EndsWith](a, conf, p, r) {
@@ -2615,7 +2632,7 @@ object GpuOverrides {
       }),
     expr[Concat](
       "List/String concatenate",
-      ExprChecks.projectNotLambda((TypeSig.STRING + TypeSig.ARRAY).nested(
+      ExprChecks.projectOnly((TypeSig.STRING + TypeSig.ARRAY).nested(
         TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
         (TypeSig.STRING + TypeSig.BINARY + TypeSig.ARRAY).nested(TypeSig.all),
         repeatingParamCheck = Some(RepeatingParamCheck("input",
@@ -2628,7 +2645,7 @@ object GpuOverrides {
     expr[ConcatWs](
       "Concatenates multiple input strings or array of strings into a single " +
         "string using a given separator",
-      ExprChecks.projectNotLambda(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
         repeatingParamCheck = Some(RepeatingParamCheck("input",
           (TypeSig.STRING + TypeSig.ARRAY).nested(TypeSig.STRING),
           (TypeSig.STRING + TypeSig.ARRAY).nested(TypeSig.STRING)))),
@@ -2646,7 +2663,7 @@ object GpuOverrides {
       }),
     expr[Murmur3Hash] (
       "Murmur3 hash operator",
-      ExprChecks.projectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.projectOnly(TypeSig.INT, TypeSig.INT,
         repeatingParamCheck = Some(RepeatingParamCheck("input",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.STRUCT).nested(),
           TypeSig.all))),
@@ -2658,7 +2675,7 @@ object GpuOverrides {
       }),
     expr[Contains](
       "Contains",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("src", TypeSig.STRING, TypeSig.STRING),
         ("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING)),
       (a, conf, p, r) => new BinaryExprMeta[Contains](a, conf, p, r) {
@@ -2667,7 +2684,7 @@ object GpuOverrides {
       }),
     expr[Like](
       "Like",
-      ExprChecks.binaryProjectNotLambda(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+      ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
         ("src", TypeSig.STRING, TypeSig.STRING),
         ("search", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING)),
       (a, conf, p, r) => new BinaryExprMeta[Like](a, conf, p, r) {
@@ -2676,14 +2693,14 @@ object GpuOverrides {
       }),
     expr[Length](
       "String character length or binary byte length",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.STRING, TypeSig.STRING + TypeSig.BINARY),
       (a, conf, p, r) => new UnaryExprMeta[Length](a, conf, p, r) {
         override def convertToGpu(child: Expression): GpuExpression = GpuLength(child)
       }),
     expr[Size](
       "The size of an array or a map",
-      ExprChecks.unaryProjectNotLambda(TypeSig.INT, TypeSig.INT,
+      ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         (TypeSig.ARRAY + TypeSig.MAP).nested(TypeSig.commonCudfTypes + TypeSig.NULL
             + TypeSig.DECIMAL_64 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP),
         (TypeSig.ARRAY + TypeSig.MAP).nested(TypeSig.all)),
@@ -3083,9 +3100,7 @@ object GpuOverrides {
       (exchange, conf, p, r) => new GpuBroadcastMeta(exchange, conf, p, r)),
     exec[BroadcastNestedLoopJoinExec](
       "Implementation of join using brute force",
-      ExecChecks(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-          TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
-        TypeSig.all),
+      JoinTypeChecks.nonEquiJoinChecks,
       (join, conf, p, r) => new GpuBroadcastNestedLoopJoinMeta(join, conf, p, r)),
     exec[CartesianProductExec](
       "Implementation of join using brute force",
@@ -3159,11 +3174,11 @@ object GpuOverrides {
       (expand, conf, p, r) => new GpuExpandExecMeta(expand, conf, p, r)),
     exec[WindowExec](
       "Window-operator backend",
-      ExecChecks(
-        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
-        Map("partitionSpec" -> (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64)),
-        TypeSig.all),
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+        TypeSig.all,
+        Map("partitionSpec" ->
+            InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.all))),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)
     ),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1473,6 +1473,10 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val explain: String = get(EXPLAIN)
 
+  lazy val shouldExplain: Boolean = !explain.equalsIgnoreCase("NONE")
+
+  lazy val shouldExplainAll: Boolean = explain.equalsIgnoreCase("ALL")
+
   lazy val isImprovedTimestampOpsEnabled: Boolean = get(IMPROVED_TIMESTAMP_OPS)
 
   lazy val maxReadBatchSizeRows: Int = get(MAX_READER_BATCH_SIZE_ROWS)
@@ -1649,6 +1653,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val optimizerEnabled: Boolean = get(OPTIMIZER_ENABLED)
 
   lazy val optimizerExplain: String = get(OPTIMIZER_EXPLAIN)
+
+  lazy val optimizerShouldExplainAll: Boolean = optimizerExplain.equalsIgnoreCase("ALL")
 
   lazy val optimizerClassName: String = get(OPTIMIZER_CLASS_NAME)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -712,7 +712,6 @@ case class ContextChecks(
     tagBase(exprMeta, exprMeta.willNotWorkInAst)
   }
 
-
   override def tag(rapidsMeta: RapidsMeta[_, _, _]): Unit = {
     tagBase(rapidsMeta, rapidsMeta.willNotWorkOnGpu)
   }
@@ -984,7 +983,7 @@ case class ExprChecksImpl(contexts: Map[ExpressionContext, ContextChecks])
   override def tagAst(exprMeta: BaseExprMeta[_]): Unit = {
     val checks = contexts.get(AstExprContext)
     if (checks.isEmpty) {
-      exprMeta.willNotWorkInAst(s"this is not supported by AST")
+      exprMeta.willNotWorkInAst(AstExprContext.notSupportedMsg)
     } else {
       checks.get.tagAst(exprMeta)
     }
@@ -1001,7 +1000,7 @@ object CaseWhenCheck extends ExprChecks {
   val sparkSig: TypeSig = TypeSig.all
 
   override def tagAst(meta: BaseExprMeta[_]): Unit = {
-    meta.willNotWorkInAst("AST is not supported")
+    meta.willNotWorkInAst(AstExprContext.notSupportedMsg)
     // when this supports AST tagBase(exprMeta, meta.willNotWorkInAst)
   }
 
@@ -1051,7 +1050,7 @@ object WindowSpecCheck extends ExprChecks {
   val sparkSig: TypeSig = TypeSig.all
 
   override def tagAst(meta: BaseExprMeta[_]): Unit = {
-    meta.willNotWorkInAst("AST is not supported")
+    meta.willNotWorkInAst(AstExprContext.notSupportedMsg)
     // when this supports AST tagBase(exprMeta, meta.willNotWorkInAst)
   }
 
@@ -1136,7 +1135,7 @@ object CreateNamedStructCheck extends ExprChecks {
   val sparkResultSig: TypeSig = TypeSig.STRUCT.nested(sparkValueSig)
 
   override def tagAst(meta: BaseExprMeta[_]): Unit = {
-    meta.willNotWorkInAst("AST is not supported")
+    meta.willNotWorkInAst(AstExprContext.notSupportedMsg)
     // when this supports AST tagBase(exprMeta, meta.willNotWorkInAst)
   }
 
@@ -1271,7 +1270,7 @@ class CastChecks extends ExprChecks {
   }
 
   override def tagAst(meta: BaseExprMeta[_]): Unit = {
-    meta.willNotWorkInAst("AST is not support by cast")
+    meta.willNotWorkInAst(AstExprContext.notSupportedMsg)
     // when this supports AST tagBase(meta, meta.willNotWorkInAst)
   }
 
@@ -1782,7 +1781,7 @@ object SupportedOpsDocs {
     println("want to join on `A.a >= B.b + 1` where `A` and `B` are separate tables or data")
     println("frames, the `+` and `>=` operations cannot run as separate independent kernels")
     println("because it is done on a combination of rows in both `A` and `B`. Instead part of the")
-    println("plan that Spark developed is turned into an abstract syntax tree and set to the GPU")
+    println("plan that Spark developed is turned into an abstract syntax tree and sent to the GPU")
     println("where it can be interpreted. The number and types of operations supported in this")
     println("are limited.")
     println("<table>")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -49,9 +49,8 @@ class GpuProjectExecMeta(
         return GpuProjectAstExec(gpuExprs, gpuChild)
       }
       // explain AST because this is optional and it is sometimes hard to debug
-      val exp = conf.explain
-      if (!exp.equalsIgnoreCase("NONE")) {
-        val explain = childExprs.map(_.explainAst(exp.equalsIgnoreCase("ALL")))
+      if (conf.shouldExplain) {
+        val explain = childExprs.map(_.explainAst(conf.shouldExplainAll))
             .filter(_.nonEmpty)
         if (explain.nonEmpty) {
           logWarning(s"AST PROJECT\n$explain")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -27,7 +27,7 @@ object TimeStamp {
   def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[GetTimestamp](
       "Gets timestamps from strings using given pattern.",
-      ExprChecks.binaryProjectNotLambda(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
+      ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
         ("timeExp",
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP,
             TypeSig.STRING + TypeSig.DATE + TypeSig.TIMESTAMP),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveOverrides.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveOverrides.scala
@@ -48,7 +48,7 @@ object GpuHiveOverrides {
     Seq(
       GpuOverrides.expr[HiveSimpleUDF](
         "Hive UDF, support requires the UDF to implement a RAPIDS accelerated interface",
-        ExprChecks.projectNotLambda(
+        ExprChecks.projectOnly(
           udfTypeSig,
           TypeSig.all,
           repeatingParamCheck = Some(RepeatingParamCheck("param", udfTypeSig, TypeSig.all))),
@@ -76,7 +76,7 @@ object GpuHiveOverrides {
       GpuOverrides.expr[HiveGenericUDF](
         "Hive Generic UDF, support requires the UDF to implement a " +
             "RAPIDS accelerated interface",
-        ExprChecks.projectNotLambda(
+        ExprChecks.projectOnly(
           udfTypeSig,
           TypeSig.all,
           repeatingParamCheck = Some(RepeatingParamCheck("param", udfTypeSig, TypeSig.all))),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -42,7 +42,7 @@ case class GpuScalaUDF(
 object GpuScalaUDF {
   def exprMeta: ExprRule[ScalaUDF] = GpuOverrides.expr[ScalaUDF](
     "User Defined Function, support requires the UDF to implement a RAPIDS accelerated interface",
-    ExprChecks.projectNotLambda(
+    ExprChecks.projectOnly(
       udfTypeSig,
       TypeSig.all,
       repeatingParamCheck = Some(RepeatingParamCheck("param", udfTypeSig, TypeSig.all))),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -54,7 +54,6 @@ class GpuBroadcastNestedLoopJoinMeta(
     join.joinType match {
       case _: InnerLike =>
       case LeftOuter | RightOuter | LeftSemi | LeftAnti =>
-      case LeftSemi | LeftAnti =>
         conditionMeta.foreach(requireAstForGpuOn)
       case _ => willNotWorkOnGpu(s"${join.joinType} currently is not supported")
     }


### PR DESCRIPTION
This fixes #3172 

Please take a close look. I think I matched everything correctly, but it would be good to have a second pair of eyes check it over.

This updates explain for operations that require AST so that the expressions that would not work with AST are shown in the standard place and not repeated in the reason why the parent operator cannot work.

This drops the lambda expression context entirely.