### PR TITLE
Add parallel support to nightly spark standalone tests

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -90,7 +90,7 @@ else
         MEMORY_FRACTION=`python -c "print(1/($TEST_PARALLEL + 1))"`
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
     fi
-    RUN_DIR="$SCRIPTPATH"/target/run_dir
+    RUN_DIR=${RUN_DIR-"$SCRIPTPATH"/target/run_dir}
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
 

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -32,7 +32,8 @@ ARG URM_URL
 
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
-    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect
+    yum install epel-release -y && \
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect parallel
 
 # The default mvn verision is 3.0.5 on centos7 docker container.
 # The plugin: net.alchim31.maven requires a higher mvn version.

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -36,7 +36,7 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget parallel
 RUN python3.8 -m easy_install pip
 
 # Set default jdk as 1.8.0

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -87,7 +87,7 @@ export BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
 --conf spark.executor.extraJavaOptions=-Duser.timezone=UTC \
 --conf spark.sql.session.timeZone=UTC"
 
-export SEQ_CONF="--executor-memory 12G \
+export SEQ_CONF="--executor-memory 16G \
 --total-executor-cores 6"
 
 # currently we hardcode the parallelism and configs based on our CI node's hardware specs,
@@ -159,7 +159,7 @@ export -f run_test
 # integration tests
 if [[ $PARALLEL_TEST == "true" ]] && [ -x "$(command -v parallel)" ]; then
   # put most time-consuming tests at the head of queue
-  time_consuming_tests="join_test.py generate_expr_test.py"
+  time_consuming_tests="join_test.py generate_expr_test.py parquet_write_test.py"
   tests_list=$(find "$SCRIPT_PATH"/src/main/python/ -name "*_test.py" -printf "%f ")
   tests=$(echo "$time_consuming_tests $tests_list" | tr ' ' '\n' | awk '!x[$0]++' | xargs)
   # --halt "now,fail=1": exit when the first job fail, and kill running jobs.

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -148,7 +148,7 @@ run_test() {
         if [[ $CODE == "0" ]]; then
           sed -n -e '/test session starts/,/deselected,/ p' "$LOG_FILE" || true
         else
-	        cat "$LOG_FILE" || true
+          cat "$LOG_FILE" || true
         fi
         return $CODE
         ;;

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -41,7 +41,7 @@ if [ "$CUDA_CLASSIFIER"x == x ];then
 else
     CUDF_JAR="$ARTF_ROOT/cudf-$CUDF_VER-$CUDA_CLASSIFIER.jar"
 fi
-RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
+export RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
 RAPIDS_UDF_JAR="$ARTF_ROOT/rapids-4-spark-udf-examples_${SCALA_BINARY_VER}-$PROJECT_TEST_VER.jar"
 RAPIDS_TEST_JAR="$ARTF_ROOT/rapids-4-spark-integration-tests_${SCALA_BINARY_VER}-$PROJECT_TEST_VER.jar"
 
@@ -55,7 +55,7 @@ tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 $MVN_GET_CMD -DremoteRepositories=$SPARK_REPO \
     -DgroupId=org.apache -DartifactId=spark -Dversion=$SPARK_VER -Dclassifier=bin-hadoop3.2 -Dpackaging=tgz
 
-SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3.2"
+export SPARK_HOME="$ARTF_ROOT/spark-$SPARK_VER-bin-hadoop3.2"
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
     rm -f $SPARK_HOME.tgz
@@ -63,29 +63,8 @@ tar zxf $SPARK_HOME.tgz -C $ARTF_ROOT && \
 IS_SPARK_311_OR_LATER=0
 [[ "$(printf '%s\n' "3.1.1" "$SPARK_VER" | sort -V | head -n1)" = "3.1.1" ]] && IS_SPARK_311_OR_LATER=1
 
-SPARK_TASK_MAXFAILURES=1
+export SPARK_TASK_MAXFAILURES=1
 [[ "$IS_SPARK_311_OR_LATER" -eq "0" ]] && SPARK_TASK_MAXFAILURES=4
-
-BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
-    --master spark://$HOSTNAME:7077 \
-    --executor-memory 12G \
-    --total-executor-cores 6 \
-    --conf spark.sql.shuffle.partitions=12 \
-    --conf spark.task.maxFailures=$SPARK_TASK_MAXFAILURES \
-    --conf spark.dynamicAllocation.enabled=false \
-    --conf spark.driver.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
-    --conf spark.executor.extraClassPath=${CUDF_JAR}:${RAPIDS_PLUGIN_JAR}:${RAPIDS_UDF_JAR} \
-    --conf spark.driver.extraJavaOptions=-Duser.timezone=UTC \
-    --conf spark.executor.extraJavaOptions=-Duser.timezone=UTC \
-    --conf spark.sql.session.timeZone=UTC"
-
-CUDF_UDF_TEST_ARGS="--conf spark.rapids.memory.gpu.allocFraction=0.1 \
-    --conf spark.rapids.memory.gpu.minAllocFraction=0 \
-    --conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
-    --conf spark.rapids.python.concurrentPythonWorkers=2 \
-    --conf spark.executorEnv.PYTHONPATH=${RAPIDS_PLUGIN_JAR} \
-    --conf spark.pyspark.python=/opt/conda/bin/python \
-    --py-files ${RAPIDS_PLUGIN_JAR}" # explicitly specify python binary path in env w/ multiple python versions
 
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 
@@ -98,14 +77,105 @@ jps
 
 echo "----------------------------START TEST------------------------------------"
 pushd $RAPIDS_INT_TESTS_HOME
-TEST_TYPE="nightly"
-spark-submit $BASE_SPARK_SUBMIT_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/" --test_type=$TEST_TYPE
-spark-submit $BASE_SPARK_SUBMIT_ARGS $CUDF_UDF_TEST_ARGS --jars $RAPIDS_TEST_JAR ./runtests.py -m "cudf_udf" -v -rfExXs --cudf_udf --test_type=$TEST_TYPE
-#only run cache tests with our serializer in nightly test for Spark version >= 3.1.1
-if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
-  spark-submit ${BASE_SPARK_SUBMIT_ARGS} --conf spark.sql.cache.serializer=com.nvidia.spark.rapids.shims.spark311.ParquetCachedBatchSerializer --jars $RAPIDS_TEST_JAR \
-  ./runtests.py -v -rfExXs --std_input_path="$WORKSPACE/integration_tests/src/test/resources/" -k cache_test.py -x
+
+export BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
+--master spark://$HOSTNAME:7077 \
+--conf spark.sql.shuffle.partitions=12 \
+--conf spark.task.maxFailures=$SPARK_TASK_MAXFAILURES \
+--conf spark.dynamicAllocation.enabled=false \
+--conf spark.driver.extraJavaOptions=-Duser.timezone=UTC \
+--conf spark.executor.extraJavaOptions=-Duser.timezone=UTC \
+--conf spark.sql.session.timeZone=UTC"
+
+export SEQ_CONF="--executor-memory 12G \
+--total-executor-cores 6"
+
+# currently we hardcode the parallelism and configs based on our CI node's hardware specs,
+# we can make it dynamically generated if this script is going to be used in other scenarios in the future
+export PARALLEL_CONF="--executor-memory 4G \
+--total-executor-cores 2 \
+--conf spark.executor.cores=2 \
+--conf spark.task.cpus=1 \
+--conf spark.rapids.sql.concurrentGpuTasks=2 \
+--conf spark.rapids.memory.gpu.allocFraction=0.15 \
+--conf spark.rapids.memory.gpu.minAllocFraction=0 \
+--conf spark.rapids.memory.gpu.maxAllocFraction=0.15"
+
+export CUDF_UDF_TEST_ARGS="--conf spark.rapids.memory.gpu.allocFraction=0.1 \
+--conf spark.rapids.memory.gpu.minAllocFraction=0 \
+--conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
+--conf spark.rapids.python.concurrentPythonWorkers=2 \
+--conf spark.executorEnv.PYTHONPATH=${RAPIDS_PLUGIN_JAR} \
+--conf spark.pyspark.python=/opt/conda/bin/python \
+--py-files ${RAPIDS_PLUGIN_JAR}"
+
+export TEST_PARALLEL=0  # disable spark local parallel in run_pyspark_from_build.sh
+export TEST_TYPE="nightly"
+export LOCAL_JAR_PATH=$ARTF_ROOT
+export SCRIPT_PATH="$(pwd -P)"
+export TARGET_DIR="$SCRIPT_PATH/target"
+mkdir -p $TARGET_DIR
+
+run_test() {
+    local TEST=${1//\.py/}
+    local LOG_FILE
+    case $TEST in
+      all)
+        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF" \
+          ./run_pyspark_from_build.sh
+        ;;
+
+      cudf_udf_test)
+        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF $CUDF_UDF_TEST_ARGS" \
+          ./run_pyspark_from_build.sh -m cudf_udf --cudf_udf
+        ;;
+
+      cache_serializer)
+        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF \
+        --conf spark.sql.cache.serializer=com.nvidia.spark.rapids.shims.spark311.ParquetCachedBatchSerializer" \
+          ./run_pyspark_from_build.sh -k cache_test
+        ;;
+
+      *)
+        echo -e "\n\n>>>>> $TEST...\n"
+        LOG_FILE="$TARGET_DIR/$TEST.log"
+        # set dedicated RUN_DIRs here to avoid conflict between parallel tests
+        RUN_DIR="$TARGET_DIR/run_dir_$TEST" \
+          SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $PARALLEL_CONF" \
+          ./run_pyspark_from_build.sh -k $TEST >"$LOG_FILE" 2>&1
+
+        CODE="$?"
+        if [[ $CODE == "0" ]]; then
+          sed -n -e '/test session starts/,/deselected,/ p' "$LOG_FILE" || true
+        else
+	        cat "$LOG_FILE" || true
+        fi
+        return $CODE
+        ;;
+    esac
+}
+export -f run_test
+
+# integration tests
+if [[ $PARALLEL_TEST == "true" ]] && [ -x "$(command -v parallel)" ]; then
+  # put most time-consuming tests at the head of queue
+  time_consuming_tests="join_test.py generate_expr_test.py"
+  tests_list=$(find "$SCRIPT_PATH"/src/main/python/ -name "*_test.py" -printf "%f ")
+  tests=$(echo "$time_consuming_tests $tests_list" | tr ' ' '\n' | awk '!x[$0]++' | xargs)
+  # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
+  #                      we can set it to "never" and print failed ones after finish running all tests if needed
+  # --group: print stderr after test finished for better readability
+  parallel --group --halt "now,fail=1" -j5 run_test ::: $tests
+else
+  run_test all
 fi
+# cudf_udf_test
+run_test cudf_udf_test
+# only run cache tests with our serializer in nightly test for Spark version >= 3.1.1
+if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
+  run_test cache_serializer
+fi
+
 popd
 stop-slave.sh
 stop-master.sh


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #2802

To speed our nightly spark standalone integrations tests,
spark 3.0.x total time: ~3h 40m to ~1h 15m
spark 3.1.x total time: ~4h to ~1h 35m (include extra ParquetCachedBatchSerializer cache_test)

I am still doing more verification on other scenarios, submit first to collect feedbacks, thanks!

This requires to be enabled in nightly pipelines' Jenkinsfile separately