### PR TITLE
Fix ClassCastException for unsupported TypedImperativeAggregate functions

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -547,6 +547,20 @@ def test_hash_groupby_collect_partial_replace_fallback_with_other_agg(conf, aqe_
     group by k1""",
         conf=local_conf)
 
+@ignore_order(local=True)
+@allow_non_gpu('ObjectHashAggregateExec', 'ShuffleExchangeExec',
+               'HashAggregateExec', 'HashPartitioning',
+               'ApproximatePercentile', 'Alias', 'Literal', 'AggregateExpression')
+def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback():
+    assert_cpu_and_gpu_are_equal_sql_with_capture(
+        lambda spark: gen_df(spark, [('k', RepeatSeqGen(LongGen(), length=20)),
+                                     ('v', LongRangeGen())], length=100),
+        exist_classes='ApproximatePercentile,ObjectHashAggregateExec',
+        non_exist_classes='GpuApproximatePercentile,GpuObjectHashAggregateExec',
+        table_name='table',
+        sql="""select k,
+        approx_percentile(v, array(0.25, 0.5, 0.75)) from table group by k""")
+
 @approximate_float
 @ignore_order
 @incompat

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -1071,19 +1071,13 @@ abstract class GpuTypedImperativeSupportedAggregateExecMeta[INPUT <: SparkPlan](
     val desiredInputAggBufTypes = mutable.HashMap.empty[ExprId, DataType]
     // Collects exprId from TypedImperativeAggBufferAttributes, and maps them to the data type
     // of `TypedImperativeAggExprMeta.aggBufferAttribute`.
-    agg.aggregateExpressions.zipWithIndex.foreach {
-      case (expr, i) if expr.aggregateFunction.isInstanceOf[TypedImperativeAggregate[_]] =>
+    aggregateExpressions.map(_.childExprs.head).foreach {
+      case aggMeta: TypedImperativeAggExprMeta[_] =>
+        val aggFn = aggMeta.wrapped.asInstanceOf[TypedImperativeAggregate[_]]
+        val desiredType = aggMeta.aggBufferAttribute.dataType
 
-        val aggFn = expr.aggregateFunction
-        val aggMeta = aggregateExpressions(i).childExprs.head
-            .asInstanceOf[TypedImperativeAggExprMeta[_]]
-        val desiredDataType = aggMeta.aggBufferAttribute.dataType
-
-        var buf = aggFn.aggBufferAttributes.head
-        desiredAggBufTypes(buf.exprId) = desiredDataType
-
-        buf = aggFn.inputAggBufferAttributes.head
-        desiredInputAggBufTypes(buf.exprId) = desiredDataType
+        desiredAggBufTypes(aggFn.aggBufferAttributes.head.exprId) = desiredType
+        desiredInputAggBufTypes(aggFn.inputAggBufferAttributes.head.exprId) = desiredType
 
       case _ =>
     }


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Fixes #3253 

The ClassCastException occurred during overriding the buffer types of TypedImperativeAggregate functions. The code for overriding assumed that  `TypedImperativeAggreagte` must be wrapped by `TypedImperativeAggExprMeta`. But there are exceptions: for  `TypedImperativeAggreagte` without GPU implementation , they are wrapped by `RuleNotFoundExprMeta`.