### PR TITLE
Support for ArrayTransform

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -145,6 +145,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.And"></a>spark.rapids.sql.expression.And|`and`|Logical AND|true|None|
 <a name="sql.expression.AnsiCast"></a>spark.rapids.sql.expression.AnsiCast| |Convert a column of one type of data into another type|true|None|
 <a name="sql.expression.ArrayContains"></a>spark.rapids.sql.expression.ArrayContains|`array_contains`|Returns a boolean if the array contains the passed in key|true|None|
+<a name="sql.expression.ArrayTransform"></a>spark.rapids.sql.expression.ArrayTransform|`transform`|Transform elements in an array using the transform function. This is similar to a `map` in functional programming.|true|None|
 <a name="sql.expression.Asin"></a>spark.rapids.sql.expression.Asin|`asin`|Inverse sine|true|None|
 <a name="sql.expression.Asinh"></a>spark.rapids.sql.expression.Asinh|`asinh`|Inverse hyperbolic sine|true|None|
 <a name="sql.expression.AtLeastNNonNulls"></a>spark.rapids.sql.expression.AtLeastNNonNulls| |Checks if number of non null/Nan values is greater than a given value|true|None|
@@ -168,7 +169,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.Cos"></a>spark.rapids.sql.expression.Cos|`cos`|Cosine|true|None|
 <a name="sql.expression.Cosh"></a>spark.rapids.sql.expression.Cosh|`cosh`|Hyperbolic cosine|true|None|
 <a name="sql.expression.Cot"></a>spark.rapids.sql.expression.Cot|`cot`|Cotangent|true|None|
-<a name="sql.expression.CreateArray"></a>spark.rapids.sql.expression.CreateArray|`array`| Returns an array with the given elements|true|None|
+<a name="sql.expression.CreateArray"></a>spark.rapids.sql.expression.CreateArray|`array`|Returns an array with the given elements|true|None|
 <a name="sql.expression.CreateMap"></a>spark.rapids.sql.expression.CreateMap|`map`|Create a map|true|None|
 <a name="sql.expression.CreateNamedStruct"></a>spark.rapids.sql.expression.CreateNamedStruct|`named_struct`, `struct`|Creates a struct with the given field names and values|true|None|
 <a name="sql.expression.CurrentRow$"></a>spark.rapids.sql.expression.CurrentRow$| |Special boundary for a window frame, indicating stopping at the current row|true|None|
@@ -214,6 +215,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.KnownFloatingPointNormalized"></a>spark.rapids.sql.expression.KnownFloatingPointNormalized| |Tag to prevent redundant normalization|true|None|
 <a name="sql.expression.KnownNotNull"></a>spark.rapids.sql.expression.KnownNotNull| |Tag an expression as known to not be null|true|None|
 <a name="sql.expression.Lag"></a>spark.rapids.sql.expression.Lag|`lag`|Window function that returns N entries behind this one|true|None|
+<a name="sql.expression.LambdaFunction"></a>spark.rapids.sql.expression.LambdaFunction| |Holds a higher order SQL function|true|None|
 <a name="sql.expression.LastDay"></a>spark.rapids.sql.expression.LastDay|`last_day`|Returns the last day of the month which the date belongs to|true|None|
 <a name="sql.expression.Lead"></a>spark.rapids.sql.expression.Lead|`lead`|Window function that returns N entries ahead of this one|true|None|
 <a name="sql.expression.Least"></a>spark.rapids.sql.expression.Least|`least`|Returns the least value of all parameters, skipping null values|true|None|
@@ -236,6 +238,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.Multiply"></a>spark.rapids.sql.expression.Multiply|`*`|Multiplication|true|None|
 <a name="sql.expression.Murmur3Hash"></a>spark.rapids.sql.expression.Murmur3Hash|`hash`|Murmur3 hash operator|true|None|
 <a name="sql.expression.NaNvl"></a>spark.rapids.sql.expression.NaNvl|`nanvl`|Evaluates to `left` iff left is not NaN, `right` otherwise|true|None|
+<a name="sql.expression.NamedLambdaVariable"></a>spark.rapids.sql.expression.NamedLambdaVariable| |A parameter to a LambdaFunction, a.k.a a higher order SQL function|true|None|
 <a name="sql.expression.Not"></a>spark.rapids.sql.expression.Not|`!`, `not`|Boolean not operator|true|None|
 <a name="sql.expression.Or"></a>spark.rapids.sql.expression.Or|`or`|Logical OR|true|None|
 <a name="sql.expression.Pmod"></a>spark.rapids.sql.expression.Pmod|`pmod`|Pmod|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1896,99 +1896,77 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<td rowSpan="3">ArrayTransform</td>
+<td rowSpan="3">`transform`</td>
+<td rowSpan="3">Transform elements in an array using the transform function. This is similar to a `map` in functional programming.</td>
+<td rowSpan="3">None</td>
+<td rowSpan="3">project</td>
+<td>argument</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>function</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
 <td rowSpan="4">Asin</td>
 <td rowSpan="4">`asin`</td>
 <td rowSpan="4">Inverse sine</td>
-<td rowSpan="4">None</td>
-<td rowSpan="2">project</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="2">AST</td>
-<td>input</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td>result</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-</tr>
-<tr>
-<td rowSpan="4">Asinh</td>
-<td rowSpan="4">`asinh`</td>
-<td rowSpan="4">Inverse hyperbolic sine</td>
 <td rowSpan="4">None</td>
 <td rowSpan="2">project</td>
 <td>input</td>
@@ -2100,6 +2078,96 @@ are limited.
 <th>MAP</th>
 <th>STRUCT</th>
 <th>UDT</th>
+</tr>
+<tr>
+<td rowSpan="4">Asinh</td>
+<td rowSpan="4">`asinh`</td>
+<td rowSpan="4">Inverse hyperbolic sine</td>
+<td rowSpan="4">None</td>
+<td rowSpan="2">project</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td rowSpan="2">AST</td>
+<td>input</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+</tr>
+<tr>
+<td>result</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td>S</td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
+<td> </td>
 </tr>
 <tr>
 <td rowSpan="2">AtLeastNNonNulls</td>
@@ -2377,6 +2445,32 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="3">BRound</td>
 <td rowSpan="3">`bround`</td>
 <td rowSpan="3">Round an expression to d decimal places using HALF_EVEN rounding mode</td>
@@ -2443,32 +2537,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">BitwiseAnd</td>
@@ -3768,7 +3836,7 @@ are limited.
 <tr>
 <td rowSpan="2">CreateArray</td>
 <td rowSpan="2">`array`</td>
-<td rowSpan="2"> Returns an array with the given elements</td>
+<td rowSpan="2">Returns an array with the given elements</td>
 <td rowSpan="2">None</td>
 <td rowSpan="2">project</td>
 <td>arg</td>
@@ -6834,6 +6902,74 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<td rowSpan="3">LambdaFunction</td>
+<td rowSpan="3"> </td>
+<td rowSpan="3">Holds a higher order SQL function</td>
+<td rowSpan="3">None</td>
+<td rowSpan="3">project</td>
+<td>function</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>arguments</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
+<td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
 <td rowSpan="2">LastDay</td>
 <td rowSpan="2">`last_day`</td>
 <td rowSpan="2">Returns the last day of the month which the date belongs to</td>
@@ -7017,6 +7153,32 @@ are limited.
 <td><b>NS</b></td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">Length</td>
 <td rowSpan="2">`length`, `character_length`, `char_length`</td>
 <td rowSpan="2">String character length or binary byte length</td>
@@ -7194,32 +7356,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="6">LessThanOrEqual</td>
@@ -7422,6 +7558,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">Literal</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Holds a static value from the query</td>
@@ -7562,32 +7724,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="2">Log1p</td>
@@ -7799,6 +7935,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">MakeDecimal</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Create a Decimal from an unscaled long value for some aggregation optimizations</td>
@@ -7938,32 +8100,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="1">MonotonicallyIncreasingID</td>
@@ -8171,6 +8307,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">Murmur3Hash</td>
 <td rowSpan="2">`hash`</td>
 <td rowSpan="2">Murmur3 hash operator</td>
@@ -8286,6 +8448,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<td rowSpan="1">NamedLambdaVariable</td>
+<td rowSpan="1"> </td>
+<td rowSpan="1">A parameter to a LambdaFunction, a.k.a a higher order SQL function</td>
+<td rowSpan="1">None</td>
+<td rowSpan="1">project</td>
+<td>result</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td>S</td>
+<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
+<td><b>NS</b></td>
+<td><b>NS</b></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
+</tr>
+<tr>
 <td rowSpan="4">Not</td>
 <td rowSpan="4">`!`, `not`</td>
 <td rowSpan="4">Boolean not operator</td>
@@ -8374,32 +8562,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="3">Or</td>
@@ -8536,6 +8698,32 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
+</tr>
+<tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="2">PosExplode</td>
@@ -8764,32 +8952,6 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
-</tr>
-<tr>
 <td rowSpan="2">PromotePrecision</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">PromotePrecision before arithmetic operations between DecimalType data</td>
@@ -9013,6 +9175,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">Quarter</td>
 <td rowSpan="2">`quarter`</td>
 <td rowSpan="2">Returns the quarter of the year for date, in the range 1 to 4</td>
@@ -9152,32 +9340,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">RegExpReplace</td>
@@ -9427,6 +9589,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="3">Round</td>
 <td rowSpan="3">`round`</td>
 <td rowSpan="3">Round an expression to d decimal places using HALF_UP rounding mode</td>
@@ -9519,32 +9707,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="2">ScalaUDF</td>
@@ -9845,6 +10007,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">Signum</td>
 <td rowSpan="2">`sign`, `signum`</td>
 <td rowSpan="2">Returns -1.0, 0.0 or 1.0 as expr is negative, 0 or positive</td>
@@ -9890,32 +10078,6 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="4">Sin</td>
@@ -10213,6 +10375,32 @@ are limited.
 <td> </td>
 </tr>
 <tr>
+<th>Expression</th>
+<th>SQL Functions(s)</th>
+<th>Description</th>
+<th>Notes</th>
+<th>Context</th>
+<th>Param/Output</th>
+<th>BOOLEAN</th>
+<th>BYTE</th>
+<th>SHORT</th>
+<th>INT</th>
+<th>LONG</th>
+<th>FLOAT</th>
+<th>DOUBLE</th>
+<th>DATE</th>
+<th>TIMESTAMP</th>
+<th>STRING</th>
+<th>DECIMAL</th>
+<th>NULL</th>
+<th>BINARY</th>
+<th>CALENDAR</th>
+<th>ARRAY</th>
+<th>MAP</th>
+<th>STRUCT</th>
+<th>UDT</th>
+</tr>
+<tr>
 <td rowSpan="2">SortOrder</td>
 <td rowSpan="2"> </td>
 <td rowSpan="2">Sort order</td>
@@ -10258,32 +10446,6 @@ are limited.
 <td> </td>
 <td><em>PS<br/>max nested DECIMAL precision of 18;<br/>UTC is only supported TZ for nested TIMESTAMP;<br/>missing nested BINARY, CALENDAR, ARRAY, UDT</em></td>
 <td><b>NS</b></td>
-</tr>
-<tr>
-<th>Expression</th>
-<th>SQL Functions(s)</th>
-<th>Description</th>
-<th>Notes</th>
-<th>Context</th>
-<th>Param/Output</th>
-<th>BOOLEAN</th>
-<th>BYTE</th>
-<th>SHORT</th>
-<th>INT</th>
-<th>LONG</th>
-<th>FLOAT</th>
-<th>DOUBLE</th>
-<th>DATE</th>
-<th>TIMESTAMP</th>
-<th>STRING</th>
-<th>DECIMAL</th>
-<th>NULL</th>
-<th>BINARY</th>
-<th>CALENDAR</th>
-<th>ARRAY</th>
-<th>MAP</th>
-<th>STRUCT</th>
-<th>UDT</th>
 </tr>
 <tr>
 <td rowSpan="1">SparkPartitionID</td>

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/GpuWindowInPandasExec.scala
@@ -17,10 +17,11 @@
 package com.nvidia.spark.rapids.shims.spark301db
 
 import com.nvidia.spark.rapids.{GpuBindReferences, GpuBoundReference, GpuProjectExec, GpuWindowExpression}
+
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, NamedExpression, SortOrder}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.rapids.execution.python.GpuWindowInPandasExecBase
-import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 /*
  * This GpuWindowInPandasExec aims at accelerating the data transfer between
@@ -62,7 +63,8 @@ case class GpuWindowInPandasExec(
     val allExpressions = windowFramesWithExpressions.map(_._2).flatten
     val references = allExpressions.zipWithIndex.map { case (e, i) =>
       // Results of window expressions will be on the right side of child's output
-      GpuBoundReference(child.output.size + i, e.dataType, e.nullable)
+      GpuBoundReference(child.output.size + i, e.dataType,
+        e.nullable)(NamedExpression.newExprId, s"gpu_win_$i")
     }
     val unboundToRefMap = allExpressions.zip(references).toMap
     // Bound the project list for GPU

--- a/shims/spark311db/src/main/scala/org/apache/spark/sql/rapids/execution/python/shims/spark311db/GpuWindowInPandasExec.scala
+++ b/shims/spark311db/src/main/scala/org/apache/spark/sql/rapids/execution/python/shims/spark311db/GpuWindowInPandasExec.scala
@@ -72,7 +72,8 @@ case class GpuWindowInPandasExec(
     val allExpressions = windowFramesWithExpressions.map(_._2).flatten
     val references = allExpressions.zipWithIndex.map { case (e, i) =>
       // Results of window expressions will be on the right side of child's output
-      GpuBoundReference(child.output.size + i, e.dataType, e.nullable)
+      GpuBoundReference(child.output.size + i, e.dataType,
+        e.nullable)(NamedExpression.newExprId, s"gpu_win_$i")
     }
     val unboundToRefMap = allExpressions.zip(references).toMap
     // Bound the project list for GPU

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -27,7 +27,7 @@ trait Arm {
     try {
       block(r)
     } finally {
-      r.close()
+      r.safeClose()
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2491,7 +2491,7 @@ object GpuOverrides {
       }
     ),
     expr[CreateArray](
-      " Returns an array with the given elements",
+      "Returns an array with the given elements",
       ExprChecks.projectOnly(
         TypeSig.ARRAY.nested(TypeSig.gpuNumeric + TypeSig.NULL + TypeSig.STRING +
             TypeSig.BOOLEAN + TypeSig.DATE + TypeSig.TIMESTAMP + TypeSig.ARRAY),
@@ -2515,6 +2515,60 @@ object GpuOverrides {
 
         override def convertToGpu(): GpuExpression =
           GpuCreateArray(childExprs.map(_.convertToGpu()), wrapped.useStringTypeWhenEmpty)
+      }),
+    expr[LambdaFunction](
+      "Holds a higher order SQL function",
+      ExprChecks.projectOnly(
+        (TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL + TypeSig.ARRAY +
+            TypeSig.STRUCT + TypeSig.MAP).nested(),
+        TypeSig.all,
+        Seq(ParamCheck("function",
+          (TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL + TypeSig.ARRAY +
+              TypeSig.STRUCT + TypeSig.MAP).nested(),
+          TypeSig.all)),
+        Some(RepeatingParamCheck("arguments",
+          (TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL + TypeSig.ARRAY +
+              TypeSig.STRUCT + TypeSig.MAP).nested(),
+          TypeSig.all))),
+      (in, conf, p, r) => new ExprMeta[LambdaFunction](in, conf, p, r) {
+        override def convertToGpu(): GpuExpression = {
+          val func = childExprs.head
+          val args = childExprs.tail
+          GpuLambdaFunction(func.convertToGpu(),
+            args.map(_.convertToGpu().asInstanceOf[NamedExpression]),
+            in.hidden)
+        }
+      }),
+    expr[NamedLambdaVariable](
+      "A parameter to a LambdaFunction, a.k.a a higher order SQL function",
+      ExprChecks.projectOnly(
+        (TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL + TypeSig.ARRAY +
+            TypeSig.STRUCT + TypeSig.MAP).nested(),
+        TypeSig.all),
+      (in, conf, p, r) => new ExprMeta[NamedLambdaVariable](in, conf, p, r) {
+        override def convertToGpu(): GpuExpression = {
+          GpuNamedLambdaVariable(in.name, in.dataType, in.nullable, in.exprId)
+        }
+      }),
+    expr[ArrayTransform](
+      "Transform elements in an array using the transform function. This is similar to a `map` " +
+          "in functional programming.",
+      ExprChecks.projectOnly(TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 +
+          TypeSig.NULL + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP),
+        TypeSig.ARRAY.nested(TypeSig.all),
+        Seq(
+          ParamCheck("argument",
+            TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL +
+                TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP),
+            TypeSig.ARRAY.nested(TypeSig.all)),
+          ParamCheck("function",
+            (TypeSig.commonCudfTypes + TypeSig.DECIMAL_64 + TypeSig.NULL +
+                TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(),
+            TypeSig.all))),
+      (in, conf, p, r) => new ExprMeta[ArrayTransform](in, conf, p, r) {
+        override def convertToGpu(): GpuExpression = {
+          GpuArrayTransform(childExprs.head.convertToGpu(), childExprs(1).convertToGpu())
+        }
       }),
     expr[StringLocate](
       "Substring search operator",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.Optional
+
+import scala.collection.mutable
+
+import ai.rapids.cudf
+import ai.rapids.cudf.{ColumnView, DType}
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression}
+import org.apache.spark.sql.types.{ArrayType, DataType, Metadata}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+
+/**
+ * A named lambda variable. In Spark on the CPU this includes an AtomicReference to the value that
+ * is updated each time a lambda function is called. On the GPU we have to bind this and turn it
+ * into a GpuBoundReference for a modified input batch. In the future this should also work with AST
+ * when cudf supports that type of operation.
+ */
+case class GpuNamedLambdaVariable(
+    name: String,
+    dataType: DataType,
+    nullable: Boolean,
+    exprId: ExprId = NamedExpression.newExprId)
+    extends GpuLeafExpression
+        with NamedExpression
+        with GpuUnevaluable {
+
+  override def qualifier: Seq[String] = Seq.empty
+
+  override def newInstance(): NamedExpression =
+    copy(exprId = NamedExpression.newExprId)
+
+  override def toAttribute: Attribute = {
+    AttributeReference(name, dataType, nullable, Metadata.empty)(exprId, Seq.empty)
+  }
+
+  override def toString: String = s"lambda $name#${exprId.id}$typeSuffix"
+
+  override def simpleString(maxFields: Int): String = {
+    s"lambda $name#${exprId.id}: ${dataType.simpleString(maxFields)}"
+  }
+}
+
+/**
+ * A lambda function and its arguments on the GPU. This is mostly just a wrapper around the
+ * function expression, but it holds references to the arguments passed into it.
+ */
+case class GpuLambdaFunction(
+    function: Expression,
+    arguments: Seq[NamedExpression],
+    hidden: Boolean = false)
+    extends GpuExpression {
+
+  override def children: Seq[Expression] = function +: arguments
+  override def dataType: DataType = function.dataType
+  override def nullable: Boolean = function.nullable
+
+  override def columnarEval(batch: ColumnarBatch): Any =
+    function.asInstanceOf[GpuExpression].columnarEval(batch)
+}
+
+/**
+ * A higher order function takes one or more (lambda) functions and applies these to some objects.
+ * The function produces a number of variables which can be consumed by some lambda function.
+ */
+trait GpuHigherOrderFunction extends GpuExpression {
+
+  override def nullable: Boolean = arguments.exists(_.nullable)
+
+  override def children: Seq[Expression] = arguments ++ functions
+
+  /**
+   * Arguments of the higher ordered function.
+   */
+  def arguments: Seq[Expression]
+
+  /**
+   * Functions applied by the higher order function.
+   */
+  def functions: Seq[Expression]
+}
+
+/**
+ * Trait for functions having as input one argument and one function.
+ */
+trait SimpleGpuHigherOrderFunction extends GpuHigherOrderFunction  {
+
+  def argument: Expression
+
+  override def arguments: Seq[Expression] = argument :: Nil
+
+  def function: Expression
+
+  override def functions: Seq[Expression] = function :: Nil
+}
+
+case class GpuArrayTransform(
+    argument: Expression,
+    function: Expression,
+    isBound: Boolean = false,
+    boundIntermediate: Seq[GpuExpression] = Seq.empty)
+    extends SimpleGpuHigherOrderFunction
+        with GpuBind {
+
+  override def dataType: ArrayType = ArrayType(function.dataType, function.nullable)
+
+  override def prettyName: String = "transform"
+
+  private val lambdaFunction = function.asInstanceOf[GpuLambdaFunction]
+
+  private lazy val inputToLambda: Seq[DataType] = {
+    assert(isBound)
+    boundIntermediate.map(_.dataType) ++ lambdaFunction.arguments.map(_.dataType)
+  }
+
+  override def bind(input: AttributeSeq): GpuExpression = {
+    if (isBound) {
+      // Because of how the transformations work we can end up trying to bind an argument twice
+      // and the later ones will have the wrong set of input attributes, so don't change once
+      // we are bound the first time...
+      return this
+    }
+
+    val boundArg = GpuBindReferences.bindGpuReference(argument, input)
+
+    // `function` is a lambda function. In CPU Spark a lambda function's parameters are wrapping
+    // AtomicReference values and the parent expression sets the values before they are processed.
+    // That does not work for us. When processing a lambda function we pass in a modified
+    // columnar batch, which includes the arguments to that lambda function. To make this work
+    // we have to bind the GpuNamedLambdaVariable to a GpuBoundReference and also handle the
+    // binding of AttributeReference to GpuBoundReference based on the attributes in the new batch
+    // that will be passed to the lambda function. This get especially tricky when dealing with
+    // nested lambda functions. So to make that work we first have to find all of the
+    // GpuNamedLambdaVariable instances that are provided by lambda expressions below us in the
+    // expression tree
+
+    val namedVariablesProvidedByChildren = mutable.HashSet[ExprId]()
+    // We purposely include the arguments to the lambda function just below us because
+    // we will add them in as a special case later on.
+    lambdaFunction.foreach {
+      case childLambda: GpuLambdaFunction =>
+        namedVariablesProvidedByChildren ++= childLambda.arguments.map(_.exprId)
+      case _ => // ignored
+    }
+    // With this information we can now find all of the AttributeReference and
+    // GpuNamedLambdaVariable instances below us so we know what columns in `input` we have
+    // to pass on. This is a performance and memory optimization because we are going to explode
+    // the columns that are used below us, which can end up using a lot of memory
+    val usedReferences = new mutable.HashMap[ExprId, Attribute]()
+    function.foreach {
+      case att: AttributeReference => usedReferences(att.exprId) = att
+      case namedLambda: GpuNamedLambdaVariable =>
+        if (!namedVariablesProvidedByChildren.contains(namedLambda.exprId)) {
+          usedReferences(namedLambda.exprId) = namedLambda.toAttribute
+        } // else it is provided by something else so ignore it
+      case _ => // ignored
+    }
+    val references = usedReferences.toSeq.sortBy(_._1.id)
+
+    // The format of the columnar batch passed to `lambdaFunction` will be
+    // `references ++ lambdaFunction.arguments` We are going to take the references
+    // and turn them into bound references from `input` so the bound version of this operator
+    // knows how to create the `references` part of the batch that is passed down.
+
+    val boundIntermediate = references.map {
+      case (_, att) => GpuBindReferences.bindGpuReference(att, input)
+    }
+
+    // Now get the full set of attributes that we will pass to `lambdaFunction` so any nested
+    // higher order functions know how to bind their arguments, and also so we can build a
+    // mapping to know how to replace expressions
+
+    val argsAndReferences = references ++ lambdaFunction.arguments.map { expr =>
+      (expr.exprId, expr)
+    }
+
+    val argsAndRefsAtters = argsAndReferences.map {
+      case (_, named: NamedExpression) => named.toAttribute
+    }
+
+    val replacementMap = argsAndReferences.zipWithIndex.map {
+      case ((exprId, expr), ordinal) =>
+        (exprId, GpuBoundReference(ordinal, expr.dataType, expr.nullable)(exprId, expr.name))
+    }.toMap
+
+    // Now we actually bind all of the attribute references and GpuNamedLambdaVariables
+    // with the appropriate replacements.  Note that we need to make sure that we call
+    // GpuBind.bind as we do the other replacements, because we don't want to descend down
+    // below it to try and replace anything.  This only works because bind should replace
+    // everything it needs to with GpuBoundReference instances so then nothing under it
+    // would match the patterns we are using to transform it.
+
+    val childFunction = lambdaFunction.function.transform {
+      case bind: GpuBind =>
+        bind.bind(argsAndRefsAtters)
+      case a: AttributeReference =>
+        replacementMap(a.exprId)
+      case lr: GpuNamedLambdaVariable if replacementMap.contains(lr.exprId) =>
+        replacementMap(lr.exprId)
+    }
+    val boundFunc =
+      GpuLambdaFunction(childFunction, lambdaFunction.arguments, lambdaFunction.hidden)
+    val boundThis = GpuArrayTransform(boundArg, boundFunc, isBound = true, boundIntermediate)
+    assert(boundThis.inputToLambda == argsAndRefsAtters.map(_.dataType))
+    boundThis
+  }
+
+  // okay so I need to know the expression ids at this point, or at least all of the original inputs
+  private[this] def makeElementProjectBatch(
+      inputBatch: ColumnarBatch,
+      listColumn: cudf.ColumnVector): ColumnarBatch = {
+    assert(listColumn.getType.equals(DType.LIST))
+    assert(isBound, "Trying to execute an un-bound transform expression")
+
+    if (function.asInstanceOf[GpuLambdaFunction].arguments.length >= 2) {
+      // Need to do an explodePosition
+      val boundProject = boundIntermediate :+ argument
+      val explodedTable = withResource(GpuProjectExec.project(inputBatch, boundProject)) {
+        projectedBatch =>
+          withResource(GpuColumnVector.from(projectedBatch)) { projectedTable =>
+            projectedTable.explodePosition(boundIntermediate.length)
+          }
+      }
+      val reorderedTable = withResource(explodedTable) { explodedTable =>
+        // The column order is wrong after an explodePosition. It is
+        // [other_columns*, position, entry]
+        // but we want
+        // [other_columns*, entry, position]
+        // So we have to remap it
+        val cols = new Array[cudf.ColumnVector](explodedTable.getNumberOfColumns)
+        val numOtherColumns = explodedTable.getNumberOfColumns - 2
+        (0 until numOtherColumns).foreach { index =>
+          cols(index) = explodedTable.getColumn(index)
+        }
+        cols(numOtherColumns) = explodedTable.getColumn(numOtherColumns + 1)
+        cols(numOtherColumns + 1) = explodedTable.getColumn(numOtherColumns)
+
+        new cudf.Table(cols: _*)
+      }
+      withResource(reorderedTable) { reorderedTable =>
+        GpuColumnVector.from(reorderedTable, inputToLambda.toArray)
+      }
+    } else {
+      // Need to do an explode
+      val boundProject = boundIntermediate :+ argument
+      val explodedTable = withResource(GpuProjectExec.project(inputBatch, boundProject)) {
+        projectedBatch =>
+          withResource(GpuColumnVector.from(projectedBatch)) { projectedTable =>
+            projectedTable.explode(boundIntermediate.length)
+          }
+      }
+      withResource(explodedTable) { explodedTable =>
+        GpuColumnVector.from(explodedTable, inputToLambda.toArray)
+      }
+    }
+  }
+
+  private[this] def makeListFrom(
+      dataCol: cudf.ColumnVector,
+      listCol: cudf.ColumnVector,
+      resultType: DataType): GpuColumnVector = {
+    withResource(listCol.getOffsets) { offsets =>
+      withResource(listCol.getValid) { validity =>
+        withResource(new ColumnView(DType.LIST, listCol.getRowCount,
+          Optional.of[java.lang.Long](listCol.getNullCount), validity, offsets,
+          Array[ColumnView](dataCol))) { view =>
+          GpuColumnVector.from(view.copyToColumnVector(), resultType)
+        }
+      }
+    }
+  }
+
+  override def columnarEval(batch: ColumnarBatch): Any = {
+    withResource(GpuExpressionsUtils.columnarEvalToColumn(argument, batch)) { arg =>
+      val dataCol = withResource(
+        makeElementProjectBatch(batch, arg.getBase)) { cb =>
+        GpuExpressionsUtils.columnarEvalToColumn(function, cb)
+      }
+      withResource(dataCol) { dataCol =>
+        makeListFrom(dataCol.getBase, arg.getBase, dataType)
+      }
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,14 +47,16 @@ object RapidsPluginImplicits {
      * @param e Exception which we don't want to suppress
      */
     def safeClose(e: Throwable = null): Unit = {
-      if (e != null) {
-        try {
+      if (autoCloseable != null) {
+        if (e != null) {
+          try {
+            autoCloseable.close()
+          } catch {
+            case suppressed: Throwable => e.addSuppressed(suppressed)
+          }
+        } else {
           autoCloseable.close()
-        } catch {
-          case suppressed: Throwable => e.addSuppressed(suppressed)
         }
-      } else {
-        autoCloseable.close()
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, CastBase}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, CastBase, NamedExpression}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -402,7 +402,8 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
     val checks = GpuOverrides.expressions(classOf[AnsiCast]).getChecks.get.asInstanceOf[CastChecks]
     assert(checks.gpuCanCast(dataType, DataTypes.StringType))
     val schema = FuzzerUtils.createSchema(Seq(dataType))
-    val childExpr: GpuBoundReference = GpuBoundReference(0, dataType, nullable = false)
+    val childExpr: GpuBoundReference =
+      GpuBoundReference(0, dataType, nullable = false)(NamedExpression.newExprId, "arg")
     checkEvaluateGpuUnaryExpression(GpuCast(childExpr, DataTypes.StringType, ansiMode = true),
       dataType,
       DataTypes.StringType,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -28,7 +28,7 @@ import scala.util.{Failure, Random, Success, Try}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Cast}
+import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Cast, NamedExpression}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -440,7 +440,8 @@ class CastOpSuite extends GpuExpressionTestSuite {
 
     assert(checks.gpuCanCast(dataType, DataTypes.StringType))
     val schema = FuzzerUtils.createSchema(Seq(dataType))
-    val childExpr: GpuBoundReference = GpuBoundReference(0, dataType, nullable = false)
+    val childExpr: GpuBoundReference =
+      GpuBoundReference(0, dataType, nullable = false)(NamedExpression.newExprId, "arg")
     checkEvaluateGpuUnaryExpression(GpuCast(childExpr, DataTypes.StringType),
       dataType,
       DataTypes.StringType,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.DType
 
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.rapids.{GpuEqualTo, GpuGreaterThan, GpuGreaterThanOrEqual, GpuLessThan, GpuLessThanOrEqual}
 import org.apache.spark.sql.types.{DataTypes, Decimal, DecimalType}
 
@@ -27,14 +28,18 @@ class DecimalBinaryOpSuite extends GpuExpressionTestSuite {
     DecimalType(DType.DECIMAL32_MAX_PRECISION, 2)))
   private val litValue = Decimal(12345.678)
   private val lit = GpuLiteral(litValue, DecimalType(DType.DECIMAL32_MAX_PRECISION, 3))
-  private val leftExpr = GpuBoundReference(0, schema.head.dataType, nullable = true)
-  private val rightExpr = GpuBoundReference(1, schema(1).dataType, nullable = true)
+  private val leftExpr =
+    GpuBoundReference(0, schema.head.dataType, nullable = true)(NamedExpression.newExprId, "left")
+  private val rightExpr =
+    GpuBoundReference(1, schema(1).dataType, nullable = true)(NamedExpression.newExprId, "right")
 
   private val schemaSame = FuzzerUtils.createSchema(Seq(
     DecimalType(DType.DECIMAL32_MAX_PRECISION, 3),
     DecimalType(DType.DECIMAL32_MAX_PRECISION, 3)))
-  private val leftExprSame = GpuBoundReference(0, schemaSame.head.dataType, nullable = true)
-  private val rightExprSame = GpuBoundReference(1, schemaSame(1).dataType, nullable = true)
+  private val leftExprSame = GpuBoundReference(0, schemaSame.head.dataType,
+    nullable = true)(NamedExpression.newExprId, "left")
+  private val rightExprSame = GpuBoundReference(1, schemaSame(1).dataType,
+    nullable = true)(NamedExpression.newExprId, "right")
 
   test("GpuEqualTo") {
     val expectedFun = (l: Decimal, r: Decimal) => Option(l == r)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/LogOperatorUnitTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/LogOperatorUnitTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package com.nvidia.spark.rapids
 
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.rapids.{GpuAdd, GpuLog, GpuLogarithm}
-import org.apache.spark.sql.types.{DataType, DataTypes, StructType}
+import org.apache.spark.sql.types.{DataTypes, StructType}
 
 class LogOperatorUnitTestSuite extends GpuExpressionTestSuite {
 
   private val schema = FuzzerUtils.createSchema(Seq(DataTypes.DoubleType))
-  private val childExpr: GpuBoundReference = GpuBoundReference(0, DataTypes.DoubleType,
-    nullable = false)
+  private val childExpr: GpuBoundReference =
+    GpuBoundReference(0, DataTypes.DoubleType, nullable = false)(NamedExpression.newExprId, "input")
 
   test("log") {
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.unit
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuLiteral, GpuUnitTests}
 
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.rapids.{GpuDateAdd, GpuDateSub}
 import org.apache.spark.sql.types.{DataTypes, DateType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -42,8 +43,10 @@ class DateTimeUnitTest extends GpuUnitTests {
               withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6),
                 IntegerType)) {
                 daysVector =>
-                  val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType, false)
-                  val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType, false)
+                  val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType,
+                    false)(NamedExpression.newExprId, "date")
+                  val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType,
+                    false)(NamedExpression.newExprId, "days")
                   val batch = new ColumnarBatch(List(datesVector, daysVector).toArray,
                      TIMES_DAY.length)
 
@@ -78,8 +81,10 @@ class DateTimeUnitTest extends GpuUnitTests {
               withResource(GpuColumnVector.from(ColumnVector.fromInts(2, 32, 6, 9, 6),
                 IntegerType)) {
                 daysVector =>
-                  val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType, false)
-                  val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType, false)
+                  val datesExpressionVector = GpuBoundReference(0, DataTypes.DateType,
+                    false)(NamedExpression.newExprId, "date")
+                  val daysExpressionVector = GpuBoundReference(1, DataTypes.IntegerType,
+                    false)(NamedExpression.newExprId, "days")
                   val batch = new ColumnarBatch(List(datesVector, daysVector).toArray,
                     TIMES_DAY.length)
 


### PR DESCRIPTION
This adds in full support for array transform.  The same code can probably be mostly reused to be able to support TransformValue, which transforms map values.  It also begins to setup a basic framework to be able to support lambda functions in the plugin.  There is probably more work and generalization that needs to happen, but it provides a starting point. 