### PR TITLE
Minor parent pom fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -364,6 +364,7 @@
         <rapids.shuffle.manager.override>true</rapids.shuffle.manager.override>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <pytest.TEST_TAGS>not qarun</pytest.TEST_TAGS>
         <pytest.TEST_PARALLEL></pytest.TEST_PARALLEL>
         <pytest.TEST_TYPE>developer</pytest.TEST_TYPE>
@@ -604,7 +605,6 @@
                         <checkMultipleScalaVersions>true</checkMultipleScalaVersions>
                         <failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
                         <recompileMode>incremental</recompileMode>
-                        <useZincServer>true</useZincServer>
                         <args>
                             <arg>-unchecked</arg>
                             <arg>-deprecation</arg>


### PR DESCRIPTION
- remove unsupported property useZincServer from scala plugin conf
- define project.reporting.outputEncoding that is unresolved for
  scalastyle plugin outputEncoding
- replace unsupported additionalparam with the current doclint conf

Signed-off-by: Gera Shegalov <gera@apache.org>