### PR TITLE
[DOC ]Fix gh-pages for tools doc based on 21.08 tools doc

### DIFF
--- a/docs/additional-functionality/qualification-profiling-tools.md
+++ b/docs/additional-functionality/qualification-profiling-tools.md
@@ -310,7 +310,10 @@ for [Downloading Apache Spark 3.x](http://spark.apache.org/downloads.html)
 
 ### Profiling tool functions
 
-#### A. Collect Information or Compare Information(if more than 1 event logs are as input and option -c is specified)
+#### A. Collect Information or Compare Information
+
+Note: Compare mode is enabled by `-c` option if more than 1 event logs are as input.
+
 - Application information
 - Executors information
 - Rapids related parameters


### PR DESCRIPTION
This is to fix gh-pages branch based on 21.08 tools doc.
This is similar to the changes in https://github.com/NVIDIA/spark-rapids/pull/3294 which is made to 21.10 branch.

Other than that, this PR will use the `TOC` (Table of Content) in tools doc so that the sub-titles link can work on the web pages.

Here is the viewable page for this change for better review.
https://viadea.github.io/spark-rapids/docs/additional-functionality/qualification-profiling-tools.html
