### PR TITLE
Temporarily disable cache test except for spark 3.1.1

### DIFF
--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -64,11 +64,12 @@ if [ -d "$LOCAL_JAR_PATH" ]; then
     ## Run tests with jars in the LOCAL_JAR_PATH dir downloading from the denpedency repo
     LOCAL_JAR_PATH=$LOCAL_JAR_PATH bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh  --runtime_env="databricks" --test_type=$TEST_TYPE
 
+    # Temporarily only run on Spark 3.1.1 (https://github.com/NVIDIA/spark-rapids/issues/3311)
     ## Run cache tests
-    if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
-      PYSP_TEST_spark_sql_cache_serializer=${PCBS_CONF} \
-       LOCAL_JAR_PATH=$LOCAL_JAR_PATH bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh  --runtime_env="databricks" --test_type=$TEST_TYPE -k cache_test
-    fi
+    #if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
+    #  PYSP_TEST_spark_sql_cache_serializer=${PCBS_CONF} \
+    #   LOCAL_JAR_PATH=$LOCAL_JAR_PATH bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh  --runtime_env="databricks" --test_type=$TEST_TYPE -k cache_test
+    #fi
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
@@ -79,11 +80,12 @@ else
     ## Run tests with jars building from the spark-rapids source code
     bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" --test_type=$TEST_TYPE
 
+    # Temporarily only run on Spark 3.1.1 (https://github.com/NVIDIA/spark-rapids/issues/3311)
     ## Run cache tests
-    if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
-      PYSP_TEST_spark_sql_cache_serializer=${PCBS_CONF} \
-       bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" --test_type=$TEST_TYPE -k cache_test
-    fi
+    #if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
+    #  PYSP_TEST_spark_sql_cache_serializer=${PCBS_CONF} \
+    #   bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" --test_type=$TEST_TYPE -k cache_test
+    #fi
 
     ## Run cudf-udf tests
     CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls /home/ubuntu/spark-rapids/dist/target/rapids-4-spark_*.jar | grep -v 'tests.jar'`"

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -66,6 +66,9 @@ IS_SPARK_311_OR_LATER=0
 export SPARK_TASK_MAXFAILURES=1
 [[ "$IS_SPARK_311_OR_LATER" -eq "0" ]] && SPARK_TASK_MAXFAILURES=4
 
+IS_SPARK_311=0
+[[ "$SPARK_VER" == "3.1.1" ]] && IS_SPARK_311=1
+
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 
 #stop and restart SPARK ETL
@@ -171,8 +174,9 @@ else
 fi
 # cudf_udf_test
 run_test cudf_udf_test
-# only run cache tests with our serializer in nightly test for Spark version >= 3.1.1
-if [[ "$IS_SPARK_311_OR_LATER" -eq "1" ]]; then
+
+# Temporarily only run on Spark 3.1.1 (https://github.com/NVIDIA/spark-rapids/issues/3311)
+if [[ "$IS_SPARK_311" -eq "1" ]]; then
   run_test cache_serializer
 fi
 


### PR DESCRIPTION
Temporarily disable while build changes going on and we can investigate more or dedup that file.

relates to https://github.com/NVIDIA/spark-rapids/issues/3311

I have not tested these on real ci build

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
