### PR TITLE
Fix spark version classifier being applied properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <spark.version>${spark301.version}</spark.version>
         <spark.test.version>${spark301.version}</spark.test.version>
+        <spark.version.classifier></spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <cudf.version>21.10.0-SNAPSHOT</cudf.version>
         <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
The classifier and buildver variables aren't being applied properly now.

[INFO] Building jar: /home/ubuntu/spark-rapids/tests/target/rapids-4-spark-tests_2.12-21.10.0-SNAPSHOT-spark${buildver}tests.jar

The problem is the default profile was updated but if any other profiles are supplied then the default one doesn't apply anymore.  So like databricks build that specifies profiles doesn't get the change to blank the spark.version.classifier and breaks.

I decided just to put back the way it was to specify for certain ones. It's either that or we would have to update a bunch of profiles null it out, this seems more clear to me and about the same amount of changes to do it this way.  We can consolidate things later when we remove the old profiles.

fixes https://github.com/NVIDIA/spark-rapids/issues/3324

built on both databricks runtimes and locally with default build and new builds.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
