### PR TITLE
Add job commit time to task tracker stats

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/TimingUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/TimingUtils.scala
@@ -18,8 +18,7 @@ package com.nvidia.spark
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-/** Utilities derived from Apache Spark's Utils class */
-object Utils {
+object TimingUtils {
   /** Records the duration of running `body`. */
   def timeTakenMs[T](body: => T): (T, Long) = {
     val startTime = System.nanoTime()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/Utils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/Utils.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark
+
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+/** Utilities derived from Apache Spark's Utils class */
+object Utils {
+  /** Records the duration of running `body`. */
+  def timeTakenMs[T](body: => T): (T, Long) = {
+    val startTime = System.nanoTime()
+    val result = body
+    val endTime = System.nanoTime()
+    (result, math.max(NANOSECONDS.toMillis(endTime - startTime), 0))
+  }
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
@@ -72,11 +72,12 @@ trait ColumnarWriteTaskStatsTracker {
 
   /**
    * Returns the final statistics computed so far.
+   * @param taskCommitTime Time of committing the task.
    * @note This may only be called once. Further use of the object may lead to undefined behavior.
    * @return An object of subtype of `org.apache.spark.sql.execution.datasources.WriteTaskStats`,
    *         to be sent to the driver.
    */
-  def getFinalStats(): WriteTaskStats
+  def getFinalStats(taskCommitTime: Long): WriteTaskStats
 }
 
 
@@ -102,6 +103,7 @@ trait ColumnarWriteJobStatsTracker extends Serializable {
    * Process the given collection of stats computed during this job.
    * E.g. aggregate them, write them to memory / disk, issue warnings, whatever.
    * @param stats One `WriteTaskStats` object from each successful write task.
+   * @param jobCommitTime Time of committing the job.
    */
-  def processStats(stats: Seq[WriteTaskStats]): Unit
+  def processStats(stats: Seq[WriteTaskStats], jobCommitTime: Long): Unit
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ContiguousTable, OrderByArg, Table}
-import com.nvidia.spark.Utils
+import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.hadoop.fs.Path
@@ -78,7 +78,7 @@ abstract class GpuFileFormatDataWriter(
    */
   override def commit(): WriteTaskResult = {
     releaseResources()
-    val (taskCommitMessage, taskCommitTime) = Utils.timeTakenMs {
+    val (taskCommitMessage, taskCommitTime) = TimingUtils.timeTakenMs {
       committer.commitTask(taskAttemptContext)
     }
     val summary = ExecutedWriteSummary(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ContiguousTable, OrderByArg, Table}
+import com.nvidia.spark.Utils
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.hadoop.fs.Path
@@ -77,10 +78,13 @@ abstract class GpuFileFormatDataWriter(
    */
   override def commit(): WriteTaskResult = {
     releaseResources()
+    val (taskCommitMessage, taskCommitTime) = Utils.timeTakenMs {
+      committer.commitTask(taskAttemptContext)
+    }
     val summary = ExecutedWriteSummary(
       updatedPartitions = updatedPartitions.toSet,
-      stats = statsTrackers.map(_.getFinalStats()))
-    WriteTaskResult(committer.commitTask(taskAttemptContext), summary)
+      stats = statsTrackers.map(_.getFinalStats(taskCommitTime)))
+    WriteTaskResult(taskCommitMessage, summary)
   }
 
   override def abort(): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 import java.util.{Date, UUID}
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -246,7 +247,7 @@ object GpuFileFormatWriter extends Logging {
 
       val commitMsgs = ret.map(_.commitMsg)
 
-      val (_, duration) = Utils.timeTakenMs { committer.commitJob(job, commitMsgs) }
+      val (_, duration) = TimingUtils.timeTakenMs { committer.commitJob(job, commitMsgs) }
       logInfo(s"Write Job ${description.uuid} committed. Elapsed time: $duration ms.")
 
       processStats(description.statsTrackers, ret.map(_.summary.stats), duration)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -20,9 +20,13 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
 
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
+import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 
 /**
  * Tests for writing Parquet files with the GPU.
@@ -135,5 +139,43 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
       frame.write.mode("overwrite").parquet(tempFile.getAbsolutePath)
       frame
     }
+  }
+
+  test("Job commit time metrics") {
+    val slowCommitClass = "com.nvidia.spark.rapids.SlowFileCommitProtocolForTest"
+    withGpuSparkSession(spark => {
+      try {
+        spark.sql("CREATE TABLE t(id STRING) USING PARQUET")
+        val df = spark.sql("INSERT INTO TABLE t SELECT 'abc'")
+        val insert = df.queryExecution.executedPlan.find(_.isInstanceOf[GpuDataWritingCommandExec])
+        assert(insert.isDefined)
+        assert(insert.get.metrics.contains(BasicColumnarWriteJobStatsTracker.JOB_COMMIT_TIME))
+        assert(insert.get.metrics.contains(BasicColumnarWriteJobStatsTracker.TASK_COMMIT_TIME))
+        assert(insert.get.metrics(BasicColumnarWriteJobStatsTracker.JOB_COMMIT_TIME).value > 0)
+        assert(insert.get.metrics(BasicColumnarWriteJobStatsTracker.TASK_COMMIT_TIME).value > 0)
+      } finally {
+        spark.sql("DROP TABLE IF EXISTS tempmetricstable")
+      }
+    }, new SparkConf().set("spark.sql.sources.commitProtocolClass", slowCommitClass))
+  }
+}
+
+/** File committer that sleeps before committing each task and the job. */
+case class SlowFileCommitProtocolForTest(
+    jobId: String,
+    path: String,
+    dynamicPartitionOverwrite: Boolean = false)
+    extends SQLHadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite) {
+  override def commitTask(
+      taskContext: TaskAttemptContext): FileCommitProtocol.TaskCommitMessage = {
+    Thread.sleep(100)
+    super.commitTask(taskContext)
+  }
+
+  override def commitJob(
+      jobContext: JobContext,
+      taskCommits: Seq[FileCommitProtocol.TaskCommitMessage]): Unit = {
+    Thread.sleep(100)
+    super.commitJob(jobContext, taskCommits)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -23,8 +23,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
 
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol
 import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 


### PR DESCRIPTION
Fixes #3237.

Adds job and task commit time metrics to the columnar write stats tracker classes.  This corresponds to the changes in https://github.com/apache/spark/commit/a96e9e197e.