### PR TITLE
Avoid RAT checks on any CSV file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -844,7 +844,7 @@
                         <exclude>dependency-reduced-pom.xml</exclude>
                         <exclude>**/.*/**</exclude>
                         <exclude>src/main/java/com/nvidia/spark/rapids/format/*</exclude>
-                        <exclude>src/main/resources/supportedDataSource.csv</exclude>
+                        <exclude>**/*.csv</exclude>
                         <!-- Apache Rat excludes target folder for projects that are included by
                         default, but there are some projects that are conditionally included.  -->
                         <exclude>**/target/**/*</exclude>


### PR DESCRIPTION
We cannot add license headers to CSV files, so generalize the `supportedDataSource.csv` rule to all CSV files.