### PR TITLE
UnionExec array and nested array support

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -438,9 +438,9 @@ Accelerator supports are described below.
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
-<td><em>PS<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, ARRAY, UDT</em></td>
-<td><em>PS<br/>unionByName will not optionally impute nulls for missing struct fields when the column is a struct and there are non-overlapping fields;<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, ARRAY, UDT</em></td>
+<td><em>PS<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>unionByName will not optionally impute nulls for missing struct fields when the column is a struct and there are non-overlapping fields;<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -46,14 +46,12 @@ map_gens = [simple_string_to_string_map_gen,
             MapGen(StringGen(pattern='key_[0-9]', nullable=False), simple_string_to_string_map_gen),
             MapGen(
                 LongGen(nullable=False),
-                ArrayGen(
+                MapGen(
+                    DecimalGen(7, 2, nullable=False),
                     MapGen(
-                        DecimalGen(7, 2, nullable=False),
-                        StructGen([
-                            ['child0', byte_gen],
-                            ['child1', simple_string_to_string_map_gen]
-                        ]),
-                        max_length=3),
+                        IntegerGen(nullable=False),
+                        StringGen(pattern='value_[0-9]', nullable=False),
+                        max_length=4),
                     max_length=7),
                 max_length=5)]
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3175,8 +3175,8 @@ object GpuOverrides {
     exec[UnionExec](
       "The backend for the union operator",
       ExecChecks(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.MAP +
-        TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL +
-          TypeSig.DECIMAL_64 + TypeSig.STRUCT + TypeSig.MAP)
+        TypeSig.ARRAY + TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL +
+          TypeSig.DECIMAL_64 + TypeSig.STRUCT + TypeSig.MAP + TypeSig.ARRAY)
         .withPsNote(TypeEnum.STRUCT,
           "unionByName will not optionally impute nulls for missing struct fields " +
           "when the column is a struct and there are non-overlapping fields"), TypeSig.all),


### PR DESCRIPTION
Resolves #1459 

Depends on https://github.com/rapidsai/cudf/pull/9130 for unionByName list of struct support. Approved but not merged yet.

Adds type support for arrays and nested arrays for `union`, `unionAll`, `unionByName`. Also includes better UnionExec testing for nested types.