### PR TITLE
Fix databricks 3.1.1 arrow dependency version

### DIFF
--- a/shims/spark311db/pom.xml
+++ b/shims/spark311db/pom.xml
@@ -105,7 +105,7 @@
             </activation>
             <properties>
                 <parquet.version>1.10.1</parquet.version>
-                <arrow.version>0.15.1</arrow.version>
+                <arrow.version>2.0.0</arrow.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
So this was previous bug with arrow version number in hte spark311db shim layer.  It referenced 0.15.1 but should have been 2.0.0. Previously the Databricks 3.1.1 shim used the arrow functionality from the Spark 3.1.1 shim which had the correct arrow dependency and the dependency in the spark311db shim was never used. Once we changed to build everything per shim this broke and I didn't catch the failing test because other tests were failing.

The datasource arrow test now passing, I'm in progress of running them all as well.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
