### PR TITLE
Fix input_file_xxx issue when FileScan is running on CPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3459,7 +3459,6 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       } else {
         Seq.empty
       }
-      InputFileBlockRule.apply(wrap)
       wrap.runAfterTagRules()
       if (conf.shouldExplain) {
         wrap.tagForExplain()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3459,6 +3459,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       } else {
         Seq.empty
       }
+      InputFileBlockRule.apply(wrap)
       wrap.runAfterTagRules()
       if (conf.shouldExplain) {
         wrap.tagForExplain()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -282,7 +282,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
    * the ones that might have issues with coalesce here.
    */
   private def disableCoalesceUntilInput(plan: SparkPlan): Boolean = {
-    plan.expressions.exists(GpuTransitionOverrides.checkHasInputExpressions)
+    plan.expressions.exists(GpuTransitionOverrides.checkHasInputFileExpressions)
   }
 
   private def disableScanUntilInput(exec: Expression): Boolean = {
@@ -567,15 +567,15 @@ object GpuTransitionOverrides {
   }
 
   /**
-   * Check the Expression is or has Input expressions.
+   * Check the Expression is or has Input File expressions.
    * @param exec expression to check
    * @return true or false
    */
-  def checkHasInputExpressions(exec: Expression): Boolean = exec match {
+  def checkHasInputFileExpressions(exec: Expression): Boolean = exec match {
     case _: InputFileName => true
     case _: InputFileBlockStart => true
     case _: InputFileBlockLength => true
-    case e => e.children.exists(checkHasInputExpressions)
+    case e => e.children.exists(checkHasInputFileExpressions)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
@@ -30,15 +30,8 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
  */
 object InputFileBlockRule {
 
-  private def checkHasInputFileExpressions(exec: Expression): Boolean = exec match {
-    case _: InputFileName => true
-    case _: InputFileBlockStart => true
-    case _: InputFileBlockLength => true
-    case e => e.children.exists(checkHasInputFileExpressions)
-  }
-
   private def checkHasInputFileExpressions(plan: SparkPlan): Boolean = {
-    plan.expressions.exists(checkHasInputFileExpressions)
+    plan.expressions.exists(GpuTransitionOverrides.checkHasInputExpressions)
   }
 
   // Apply the rule on SparkPlanMeta

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
@@ -17,7 +17,6 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, InputFileBlockLength, InputFileBlockStart, InputFileName}
 import org.apache.spark.sql.execution.{FileSourceScanExec, LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -31,7 +30,7 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 object InputFileBlockRule {
 
   private def checkHasInputFileExpressions(plan: SparkPlan): Boolean = {
-    plan.expressions.exists(GpuTransitionOverrides.checkHasInputExpressions)
+    plan.expressions.exists(GpuTransitionOverrides.checkHasInputFileExpressions)
   }
 
   // Apply the rule on SparkPlanMeta
@@ -73,7 +72,7 @@ object InputFileBlockRule {
         key.map(p => resultOps.remove(p)) // Remove the chain from Map
       case _ =>
         val newKey = if (key.isDefined) {
-          // The node is in the chain of input_file_xx to FileScan
+          // The node is in the middle of chain [SparkPlan with input_file_xxx, FileScan)
           resultOps.getOrElseUpdate(key.get,  new ArrayBuffer[SparkPlanMeta[SparkPlan]]) += plan
           key
         } else { // There is no parent Node who has input_file_xxx

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InputFileBlockRule.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids
+
+import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, InputFileBlockLength, InputFileBlockStart, InputFileName}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.{FileSourceScanExec, LeafExecNode, SparkPlan}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+
+/**
+ * InputFileBlockRule is to revert the converting between the SparkPlan with
+ * input_file_name/InputFileBlockStart/InputFileBlockLength expression
+ * and FileScan which can't be replaced.
+ *
+ * See https://github.com/NVIDIA/spark-rapids/issues/3333
+ */
+object InputFileBlockRule {
+
+  private def checkHasInputFileExpressions(exec: Expression): Boolean = exec match {
+    case _: InputFileName => true
+    case _: InputFileBlockStart => true
+    case _: InputFileBlockLength => true
+    case e => e.children.exists(checkHasInputFileExpressions)
+  }
+
+  private def checkHasInputFileExpressions(plan: SparkPlan): Boolean = {
+    plan.expressions.exists(checkHasInputFileExpressions)
+  }
+
+  // Apply the rule on SparkPlanMeta
+  def apply(plan: SparkPlanMeta[SparkPlan]) = {
+    // The key is the SparkPlanMeta where has the first InputFile expression
+    // The value is an array with the SparkPlanMeta chain from SparkPlan (with first input_file_xxx)
+    //    to FileScan (exclusive)
+    val resultOps = LinkedHashMap[SparkPlanMeta[SparkPlan], ArrayBuffer[SparkPlanMeta[SparkPlan]]]()
+    recursivelyResolve(plan, None, resultOps)
+
+    // If we've found some chain, we should prevent the transition.
+    resultOps.foreach { item =>
+      item._2.foreach(p => p.inputFilePreventsRunningOnGpu())
+    }
+  }
+
+  /**
+   * Recursively to apply the rule on the plan
+   * @param plan the plan to be resolved.
+   * @param key  the SparkPlanMeta with the first input_file_xxx
+   * @param resultOps
+   */
+  private def recursivelyResolve(
+      plan: SparkPlanMeta[SparkPlan],
+      key: Option[SparkPlanMeta[SparkPlan]],
+      resultOps: LinkedHashMap[SparkPlanMeta[SparkPlan],
+        ArrayBuffer[SparkPlanMeta[SparkPlan]]]): Unit = {
+
+    plan.wrapped match {
+      case _: ShuffleExchangeExec => // Exchange will invalid the input_file_xxx
+        key.map(p => resultOps.remove(p)) // Remove the chain from Map
+        plan.childPlans.foreach(p => recursivelyResolve(p, None, resultOps))
+      case _: FileSourceScanExec | _: BatchScanExec =>
+        if (plan.canThisBeReplaced) { // FileScan can be replaced
+          key.map(p => resultOps.remove(p)) // Remove the chain from Map
+        }
+      case _: LeafExecNode => // We've reached the LeafNode but without any FileScan
+        key.map(p => resultOps.remove(p)) // Remove the chain from Map
+      case _ =>
+        val newKey = if (key.isDefined) {
+          // The node is in the chain of input_file_xx to FileScan
+          resultOps.getOrElseUpdate(key.get,  new ArrayBuffer[SparkPlanMeta[SparkPlan]]) += plan
+          key
+        } else { // There is no parent Node who has input_file_xx
+          if (checkHasInputFileExpressions(plan.wrapped)) {
+            // Current node has input_file_xxx. Mark it as the first Node with input_file_xxx
+            resultOps.getOrElseUpdate(plan, new ArrayBuffer[SparkPlanMeta[SparkPlan]]) += plan
+            Some(plan)
+          } else {
+            None
+          }
+        }
+
+        plan.childPlans.foreach(p => recursivelyResolve(p, newKey, resultOps))
+    }
+  }
+
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -158,7 +158,8 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
 
   final def inputFilePreventsRunningOnGpu(): Unit = {
     if (canThisBeReplaced) {
-      willNotWorkOnGpu("Removed by InputFileBlockRule")
+      willNotWorkOnGpu("Removed by InputFileBlockRule preventing plans " +
+        "[SparkPlan(with input_file_xxx), FileScan) running on GPU")
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -156,6 +156,12 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
     childDataWriteCmds.foreach(_.recursiveSparkPlanRemoved())
   }
 
+  final def inputFilePreventsRunningOnGpu(): Unit = {
+    if (canThisBeReplaced) {
+      willNotWorkOnGpu("Removed by InputFileBlockRule")
+    }
+  }
+
   /**
    * Call this to indicate that this should not be replaced with a GPU enabled version
    * @param because why it should not be replaced.


### PR DESCRIPTION
This PR tries to force plans ( from SparkPlan (with the first input_file_xxx) to FileScan ) to run on CPU, Please see the detail from issue https://github.com/NVIDIA/spark-rapids/issues/3333

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
