### PR TITLE
Bring back setRapidsShuffleManager in the driver side

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -236,6 +236,8 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
 
   protected val wrapped = new SortShuffleManager(conf)
 
+  GpuShuffleEnv.setRapidsShuffleManager(Some(this))
+
   private[this] val transportEnabledMessage = if (!rapidsConf.shuffleTransportEnabled) {
     "Transport disabled (local cached blocks only)"
   } else {


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This should fix the failure reported here: #3379. 

This was an inadvertent change introduced in https://github.com/NVIDIA/spark-rapids/pull/3323, that effectively breaks the UCX shuffle manager in HEAD.