### PR TITLE
Support transforming BinaryType between Row and Columnar

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -251,6 +251,8 @@ public class GpuColumnVector extends GpuColumnVectorBase {
         children[i] = convertFrom(fields[i].dataType(), fields[i].nullable());
       }
       return new HostColumnVector.StructType(nullable, children);
+    } else if (spark instanceof BinaryType) {
+      return new HostColumnVector.ListType(nullable, convertFrom(DataTypes.ByteType, false));
     } else {
       // Only works for basic types
       return new HostColumnVector.BasicType(nullable, getNonNestedRapidsType(spark));
@@ -472,8 +474,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       return DType.TIMESTAMP_DAYS;
     } else if (type instanceof TimestampType) {
       return DType.TIMESTAMP_MICROSECONDS;
-    } else if (type instanceof StringType || type instanceof BinaryType) {
+    } else if (type instanceof StringType) {
       return DType.STRING;
+    } else if (type instanceof BinaryType) {
+      return DType.LIST;
     } else if (type instanceof NullType) {
       // INT8 is used for both in this case
       return DType.INT8;

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -472,7 +472,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       return DType.TIMESTAMP_DAYS;
     } else if (type instanceof TimestampType) {
       return DType.TIMESTAMP_MICROSECONDS;
-    } else if (type instanceof StringType) {
+    } else if (type instanceof StringType || type instanceof BinaryType) {
       return DType.STRING;
     } else if (type instanceof NullType) {
       // INT8 is used for both in this case

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnVectorCore.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnVectorCore.java
@@ -179,7 +179,7 @@ public class RapidsHostColumnVectorCore extends ColumnVector {
 
   @Override
   public final byte[] getBinary(int rowId) {
-    throw new IllegalStateException("Binary data access is currently not supported by rapids cudf");
+    return cudfCv.getUTF8(rowId);
   }
 
   @Override

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -181,8 +181,8 @@ class ColumnarToRowIterator(batches: Iterator[ColumnarBatch],
     opTime: GpuMetric,
     fetchTime: GpuMetric) extends Iterator[InternalRow] with Arm {
   // GPU batches read in must be closed by the receiver (us)
-  @transient var cb: ColumnarBatch = null
-  var it: java.util.Iterator[InternalRow] = null
+  @transient private var cb: ColumnarBatch = null
+  private var it: java.util.Iterator[InternalRow] = null
 
   Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => closeCurrentBatch()))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -114,6 +114,8 @@ private object GpuRowToColumnConverter {
       case (TimestampType, false) => NotNullLongConverter
       case (StringType, true) => StringConverter
       case (StringType, false) => NotNullStringConverter
+      case (BinaryType, true) => BinaryConverter
+      case (BinaryType, false) => NotNullBinaryConverter
       // NOT SUPPORTED YET
       // case CalendarIntervalType => CalendarConverter
       case (at: ArrayType, true) =>
@@ -352,6 +354,32 @@ private object GpuRowToColumnConverter {
       column: Int,
       builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
       val bytes = row.getUTF8String(column).getBytes
+      builder.appendUTF8String(bytes)
+      bytes.length + OFFSET
+    }
+
+    override def getNullSize: Double = OFFSET + VALIDITY
+  }
+
+  private object BinaryConverter extends TypeConverter {
+    override def append(row: SpecializedGetters,
+        column: Int,
+        builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double =
+      if (row.isNullAt(column)) {
+        builder.appendNull()
+        VALIDITY_N_OFFSET
+      } else {
+        NotNullBinaryConverter.append(row, column, builder) + VALIDITY
+      }
+
+    override def getNullSize: Double = OFFSET + VALIDITY
+  }
+
+  private object NotNullBinaryConverter extends TypeConverter {
+    override def append(row: SpecializedGetters,
+        column: Int,
+        builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
+      val bytes = row.getBinary(column)
       builder.appendUTF8String(bytes)
       bytes.length + OFFSET
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -379,8 +379,10 @@ private object GpuRowToColumnConverter {
     override def append(row: SpecializedGetters,
         column: Int,
         builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
+      val child = builder.getChild(0)
       val bytes = row.getBinary(column)
-      builder.appendUTF8String(bytes)
+      bytes.foreach(child.append)
+      builder.endList()
       bytes.length + OFFSET
     }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
@@ -158,7 +158,7 @@ class GpuBatchUtilsSuite extends FunSuite {
   }
 
   private def compareEstimateWithActual(schema: StructType, rowCount: Int) {
-    val rows = createRows(schema, rowCount)
+    val rows = GpuBatchUtilsSuite.createRows(schema, rowCount)
     val estimate = GpuBatchUtils.estimateGpuMemory(schema, rows.length)
     val actual = calculateGpuMemory(schema, rows)
     assert(estimate == actual)
@@ -184,8 +184,11 @@ class GpuBatchUtilsSuite extends FunSuite {
       builders.close()
     }
   }
+}
 
-  private def createRows(schema: StructType, rowCount: Int): Array[InternalRow] = {
+object GpuBatchUtilsSuite {
+
+  def createRows(schema: StructType, rowCount: Int): Array[InternalRow] = {
     val rows = new mutable.ArrayBuffer[InternalRow](rowCount)
     val r = new Random(0)
     for (i <- 0 until rowCount) {
@@ -212,7 +215,7 @@ class GpuBatchUtilsSuite extends FunSuite {
           if (field.nullable) {
             // since we want a deterministic test that compares the estimate with actual
             // usage we need to make sure the average length of strings is `dataType.defaultSize`
-            if (i%2 == 0) {
+            if (i % 2 == 0) {
               null
             } else {
               createString(dataType.defaultSize * 2)
@@ -238,7 +241,7 @@ class GpuBatchUtilsSuite extends FunSuite {
   }
 
   private def maybeNull(field: StructField, i: Int, value: Any): Any = {
-    if (field.nullable && i%2==0) {
+    if (field.nullable && i % 2 == 0) {
       null
     } else {
       value
@@ -249,6 +252,5 @@ class GpuBatchUtilsSuite extends FunSuite {
     // avoid multi byte characters to keep the test simple
     val str = (0 until size).map(_ => 'a').mkString
     UTF8String.fromString(str)
-
   }
 }


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Closes #3367

Current PR is to enable GpuRowToColumnar and GpuColumnarToRow with BinaryType. During transforming,  BinaryType will be mapped to DType.LIST (with DType.INT8 as child type).