### PR TITLE
Add tests for GpuInSet

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
@@ -49,9 +49,10 @@ class FilterExprSuite extends SparkQueryCompareTestSuite {
       val createDF = (ss: SparkSession) => ss.read.parquet(path)
       val fun = (df: DataFrame) => df
           // In
-          .filter(col("ints").isin(90L, 95L, Int.MaxValue))
           .filter(col("strings").isin("A", "B", "C", "d"))
           .filter(col("decimals").isin(Decimal("1.2"), Decimal("2.1")))
+          // outBound values will be removed by UnwrapCastInBinaryComparison
+          .filter(col("ints").isin(90L, 95L, Int.MaxValue.toLong + 1))
           // InSet (spark.sql.optimizer.inSetConversionThreshold = 10 by default)
           .filter(col("longs").isin(100L to 1200L: _*))
           .filter(col("doubles").isin(1 to 15: _*))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
@@ -16,7 +16,14 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.spark.SparkConf
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.Decimal
 
 class FilterExprSuite extends SparkQueryCompareTestSuite {
   testSparkResultsAreEqual("filter with decimal literals", mixedDf(_), repart = 0) { df =>
@@ -32,5 +39,27 @@ class FilterExprSuite extends SparkQueryCompareTestSuite {
     df.filter(col("ints") > 90)
       .filter(col("decimals").isNotNull)
       .select("ints", "strings", "decimals")
+  }
+
+  test("filter with In/InSet") {
+    val dir = Files.createTempDirectory("spark-rapids-test").toFile
+    val path = new File(dir, s"InSet-${System.currentTimeMillis()}.parquet").getAbsolutePath
+    try {
+      withCpuSparkSession(spark => mixedDf(spark).write.parquet(path), new SparkConf())
+      val createDF = (ss: SparkSession) => ss.read.parquet(path)
+      val fun = (df: DataFrame) => df
+          // In
+          .filter(col("ints").isin(90L, 95L, Int.MaxValue))
+          .filter(col("strings").isin("A", "B", "C", "d"))
+          .filter(col("decimals").isin(Decimal("1.2"), Decimal("2.1")))
+          // InSet (spark.sql.optimizer.inSetConversionThreshold = 10 by default)
+          .filter(col("longs").isin(100L to 1200L: _*))
+          .filter(col("doubles").isin(1 to 15: _*))
+      val conf = new SparkConf().set(RapidsConf.DECIMAL_TYPE_ENABLED.key, "true")
+      val (fromCpu, fromGpu) = runOnCpuAndGpu(createDF, fun, conf, repart = 0)
+      compareResults(false, 0.0, fromCpu, fromGpu)
+    } finally {
+      dir.delete()
+    }
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FilterExprSuite.scala
@@ -20,7 +20,6 @@ import java.io.File
 import java.nio.file.Files
 
 import org.apache.spark.SparkConf
-
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.Decimal


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Closes #2764

After tests, I found that current implementation of `GpuInSet` can fully adapt SPARK-35316. If I understand correctly, the datatype of needles is the same as haystack,  since we build the needles from child's datatype.  The potential problem is what if some values in needles can not cast to child's datatype, such as: `select cast(a as int) in (1L, 2L, 3147483647L)`. The lit value `3147483647L` can not be casted to INT32 due to out of range.  It seems we don't need to worry about that, because these outliers will be removed in [`UnwrapCastInBinaryComparsion`](https://github.com/apache/spark/blob/branch-3.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala#L242).