### PR TITLE
Fix canonicalization regression with Spark 3.2

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -149,12 +149,13 @@ case class GpuAggregateExpression(origAggregateFunction: GpuAggregateFunction,
   // We compute the same thing regardless of our final result.
   override lazy val canonicalized: Expression = {
     val normalizedAggFunc = mode match {
-      // For PartialMerge or Final mode, the input to the `aggregateFunction` is aggregate buffers,
-      // and the actual children of `aggregateFunction` is not used, here we normalize the expr id.
-      case PartialMerge | Final => aggregateFunction.transform {
+      // For Partial, PartialMerge, or Final mode, the input to the `aggregateFunction` is
+      // aggregate buffers, and the actual children of `aggregateFunction` is not used,
+      // here we normalize the expr id.
+      case Partial | PartialMerge | Final => aggregateFunction.transform {
         case a: AttributeReference => a.withExprId(ExprId(0))
       }
-      case Partial | Complete => aggregateFunction
+      case Complete => aggregateFunction
     }
 
     GpuAggregateExpression(


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Partially address #3400 

This PR extends the `exprId` normalization logic to also apply to aggregate expressions where `mode=Partial` and fixes two test failures (HashAggregatesSuite and ExpandExecSuite) when running against Spark 3.2.

See #3400 for more detail on why the behavior is different with Spark 3.2