### PR TITLE
Qualification tool: Filter empty strings from Read Schema

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
@@ -367,13 +367,30 @@ object QualAppInfo extends Logging {
     // Check if it has types
     val incompleteTypes = incompleteSchema.map { x =>
       if (x.contains("...") && x.contains(":")) {
-        x.split(":", 2)(1).split("\\.\\.\\.")(0)
+        val schemaTypes = x.split(":", 2)
+        if (schemaTypes.size == 2) {
+          val partialSchema = schemaTypes(1).split("\\.\\.\\.")
+          if (partialSchema.size == 1) {
+            partialSchema(0)
+          } else {
+            ""
+          }
+        } else {
+          ""
+        }
       } else {
         ""
       }
     }
     // Omit columnName and get only schemas
-    val completeTypes = completeSchema.map(x => x.split(":", 2)(1))
+    val completeTypes = completeSchema.map { x =>
+      val schemaTypes = x.split(":", 2)
+      if (schemaTypes.size == 2) {
+        schemaTypes(1)
+      } else {
+        ""
+      }
+    }
     val schemaTypes = completeTypes ++ incompleteTypes
 
     // Filter only complex types.

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualAppInfo.scala
@@ -335,7 +335,7 @@ object QualAppInfo extends Logging {
     val individualSchema: ArrayBuffer[String] = new ArrayBuffer()
     var angleBracketsCount = 0
     var parenthesesCount = 0
-    val distinctSchema = schema.distinct.mkString(",")
+    val distinctSchema = schema.distinct.filter(_.nonEmpty).mkString(",")
 
     // Get the nested types i.e everything between < >
     for (char <- distinctSchema) {
@@ -351,8 +351,7 @@ object QualAppInfo extends Logging {
       if (angleBracketsCount == 0 && parenthesesCount == 0 && char.equals(',')) {
         individualSchema += tempStringBuilder.toString
         tempStringBuilder.setLength(0)
-      }
-      else {
+      } else {
         tempStringBuilder.append(char);
       }
     }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -357,7 +357,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
   test("test different types in ReadSchema") {
     val testSchemas: ArrayBuffer[ArrayBuffer[String]] = ArrayBuffer(
       ArrayBuffer(""),
-      ArrayBuffer("firstName:string,lastName:string"),
+      ArrayBuffer("firstName:string,lastName:string", "", "address:string"),
       ArrayBuffer("properties:map<string,string>"),
       ArrayBuffer("name:array<string>"),
       ArrayBuffer("name:string,booksInterested:array<struct<name:string,price:decimal(8,2)," +


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/3401. 

We see this error when  ReadSchema is not present in the eventlog for a job. 
In these cases we assign ""(empty string) for  read schema. We did not have test case for this where  the eventlog could contain some valid read schemas and an empty schema. Had test cases which tested above separately. Updated the tests to include this case.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
