### PR TITLE
Add leafNodeDefaultParallelism support

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -252,6 +252,8 @@ trait SparkShims {
   def isCustomReaderExec(x: SparkPlan): Boolean
 
   def aqeShuffleReaderExec: ExecRule[_ <: SparkPlan]
+
+  def leafNodeDefaultParallelism(ss: SparkSession): Int
 }
 
 abstract class SparkCommonShims extends SparkShims {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -379,7 +379,7 @@ case class GpuRangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range
   val end: Long = range.end
   val step: Long = range.step
   val numSlices: Int = range.numSlices.getOrElse(ShimLoader.getSparkShims
-    .leafNodeDefaultParallelism(ShimLoader.getSparkShims.sessionFromPlan(this)))
+    .leafNodeDefaultParallelism(sparkSession))
   val numElements: BigInt = range.numElements
   val isEmptyRange: Boolean = start == end || (start < end ^ 0 < step)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -378,7 +378,8 @@ case class GpuRangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range
   val start: Long = range.start
   val end: Long = range.end
   val step: Long = range.step
-  val numSlices: Int = range.numSlices.getOrElse(sparkContext.defaultParallelism)
+  val numSlices: Int = range.numSlices.getOrElse(ShimLoader.getSparkShims
+    .leafNodeDefaultParallelism(ShimLoader.getSparkShims.sessionFromPlan(this)))
   val numElements: BigInt = range.numElements
   val isEmptyRange: Boolean = start == end || (start < end ^ 0 < step)
 

--- a/sql-plugin/src/main/spark30+all/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/spark30+all/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -96,4 +96,9 @@ trait Spark30XShims extends SparkShims {
     ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.ARRAY +
         TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
     (exec, conf, p, r) => new GpuCustomShuffleReaderMeta(exec, conf, p, r))
+
+  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
+    ss.sparkContext.defaultParallelism
+  }
+
 }

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, AdaptiveSparkPlanExec, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, QueryStageExec}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -19,17 +19,17 @@ package com.nvidia.spark.rapids.shims.v2
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.GpuOverrides.exec
 import com.nvidia.spark.rapids.shims._
-
 import org.apache.hadoop.fs.FileStatus
 import org.apache.parquet.schema.MessageType
 
+import org.apache.spark.sql.Spark32XShimsUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, AdaptiveSparkPlanExec, QueryStageExec}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
@@ -131,6 +131,11 @@ trait Spark32XShims extends SparkShims {
       // we will need to change the API to pass these values in.
       enableAddPartitions = true,
       enableDropPartitions = false)
+
+  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
+    Spark32XShimsUtils.leafNodeDefaultParallelism(ss)
+  }
+
 }
 
 // TODO dedupe utils inside shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/Spark32XShimsUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/Spark32XShimsUtils.scala
@@ -16,10 +16,11 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.SparkSession
-
 object Spark32XShimsUtils {
+
   def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.leafNodeDefaultParallelism
   }
+
 }
+

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/Spark32XShimsUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/Spark32XShimsUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.SparkSession
+
+object Spark32XShimsUtils {
+  def leafNodeDefaultParallelism(ss: SparkSession): Int = {
+    ss.leafNodeDefaultParallelism
+  }
+}

--- a/tests/src/test/scala/org/apache/spark/sql/GpuSparkPlanSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/GpuSparkPlanSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.util.{Locale, TimeZone}
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkSessionHolder}
+import org.scalatest.FunSuite
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.plans.logical.Range
+
+class GpuSparkPlanSuite extends FunSuite {
+
+  test("leafNodeDefaultParallelism for GpuRangeExec") {
+
+    val conf = new SparkConf()
+      .set("spark.sql.leafNodeDefaultParallelism", "7")
+      .set("spark.rapids.sql.enabled", "true")
+
+    SparkSessionHolder.withSparkSession(conf, spark => {
+      val defaultSlice = ShimLoader.getSparkShims.leafNodeDefaultParallelism(spark)
+      val ds = new Dataset(spark, Range(0, 20, 1, None), Encoders.LONG)
+      val partitions = ds.rdd.getNumPartitions
+      assert(partitions == defaultSlice)
+    })
+
+  }
+
+}
+


### PR DESCRIPTION
This PR is to fix https://github.com/NVIDIA/spark-rapids/issues/1925 by add leafNodeDefaultParallelism to the shims layer.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
