### PR TITLE
Use devel cuda image for premerge CI

### DIFF
--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -26,7 +26,7 @@
 ARG CUDA_VER=11.0
 ARG UBUNTU_VER=18.04
 ARG UCX_VER=v1.11.0
-FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
+FROM nvidia/cuda:${CUDA_VER}-devel-ubuntu${UBUNTU_VER}
 ARG CUDA_VER
 ARG UBUNTU_VER
 ARG UCX_VER
@@ -42,6 +42,7 @@ RUN python3.8 -m easy_install pip
 
 # Set default jdk as 1.8.0
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV JAVA_HOME "/usr/lib/jvm/java-8-openjdk-amd64/"
 
 RUN ln -s /usr/bin/python3.8 /usr/bin/python
 RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit
@@ -54,3 +55,12 @@ RUN mkdir -p /tmp/ucx && \
     wget https://github.com/openucx/ucx/releases/download/${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5.x-cuda${CUDA_VER}.deb && \
     dpkg -i *.deb && \
     rm -rf /tmp/ucx
+
+ARG CMAKE_VERSION=3.20.5
+RUN cd /usr/local/ && wget --quiet https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
+   tar zxf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
+   rm cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz
+ENV PATH /usr/local/cmake-${CMAKE_VERSION}-linux-x86_64/bin:$PATH
+
+# used to build rapids ml submodule
+RUN apt install ninja-build -y


### PR DESCRIPTION
To be able to build the upcoming `ml` module which includes native code:
- use devel cuda image
- set JAVA_HOME to JDK folder
- install cmake and ninja


Signed-off-by: Allen Xu <allxu@nvidia.com>
