### PR TITLE
Fix hash_aggregate tests that leaked configs

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -54,8 +54,7 @@ def assert_gpu_ast(is_supported, func, conf={}):
     if not is_supported:
         exist = "GpuProjectExec"
         non_exist = "GpuProjectAstExec"
-    ast_conf = conf.copy()
-    ast_conf.update({"spark.rapids.sql.projectAstEnabled": "true"})
+    ast_conf = copy_and_update(conf, {"spark.rapids.sql.projectAstEnabled": "true"})
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         func,
         exist_classes=exist,

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -930,6 +930,12 @@ allow_negative_scale_of_decimal_conf = {'spark.sql.legacy.allowNegativeScaleOfDe
 
 no_nans_conf = {'spark.rapids.sql.hasNans': 'false'}
 
+def copy_and_update(conf, *more_confs):
+    local_conf = conf.copy()
+    for more in more_confs:
+        local_conf.update(more)
+    return local_conf
+
 all_gen = [StringGen(), ByteGen(), ShortGen(), IntegerGen(), LongGen(),
            FloatGen(), DoubleGen(), BooleanGen(), DateGen(), TimestampGen(),
            decimal_gen_default, decimal_gen_scale_precision, decimal_gen_same_scale_precision,

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -105,8 +105,7 @@ def test_sortmerge_join(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 500)
         return left.join(right, left.a == right.r_a, join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(_sortmerge_join_conf)
+    conf = copy_and_update(_sortmerge_join_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @ignore_order(local=True)
@@ -117,8 +116,7 @@ def test_sortmerge_join_array(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_nested_df(spark, short_gen, data_gen, 500, 500)
         return left.join(right, left.key == right.r_key, join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(_sortmerge_join_conf)
+    conf = copy_and_update(_sortmerge_join_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @ignore_order(local=True)
@@ -129,8 +127,7 @@ def test_sortmerge_join_map(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_nested_df(spark, short_gen, data_gen, 500, 500)
         return left.join(right, left.key == right.r_key, join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(_sortmerge_join_conf)
+    conf = copy_and_update(_sortmerge_join_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # For floating point values the normalization is done using a higher order function. We could probably work around this
@@ -154,8 +151,7 @@ def test_sortmerge_join_struct(data_gen, join_type, batch_size):
     def do_join(spark):
         left, right = create_nested_df(spark, short_gen, data_gen, 500, 500)
         return left.join(right, left.key == right.r_key, join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(_sortmerge_join_conf)
+    conf = copy_and_update(_sortmerge_join_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # For spark to insert a shuffled hash join it has to be enabled with
@@ -255,8 +251,7 @@ def test_cartesian_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(right)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -270,8 +265,7 @@ def test_cartesian_join_special_case_count(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.crossJoin(right).selectExpr('COUNT(*)')
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -285,8 +279,7 @@ def test_cartesian_join_special_case_group_by(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(right).groupBy('a').count()
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -302,8 +295,7 @@ def test_cartesian_join_with_condition(data_gen, batch_size):
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return left.join(right, left.b >= right.r_b, "cross")
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(_sortmerge_join_conf)
+    conf = copy_and_update(_sortmerge_join_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -315,8 +307,7 @@ def test_broadcast_nested_loop_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right))
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -328,8 +319,7 @@ def test_broadcast_nested_loop_join_special_case_count(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right)).selectExpr('COUNT(*)')
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -343,8 +333,7 @@ def test_broadcast_nested_loop_join_special_case_group_by(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right)).groupBy('a').count()
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -362,8 +351,7 @@ def test_right_broadcast_nested_loop_join_with_ast_condition(data_gen, join_type
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -380,8 +368,7 @@ def test_left_broadcast_nested_loop_join_with_ast_condition(data_gen, batch_size
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return broadcast(left).join(right, (left.b >= right.r_b), 'Right')
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -399,8 +386,7 @@ def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_ty
         # that do not expose the error
         # AST does not support logical AND, so this must be implemented as a post-filter
         return left.join(broadcast(right), (left.a >= right.r_a) & (left.b >= right.r_b), join_type)
-    conf = {'spark.rapids.sql.batchSizeBytes': batch_size}
-    conf.update(allow_negative_scale_of_decimal_conf)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
 
 @allow_non_gpu('And', 'BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'CheckOverflow', 'Divide', 'GreaterThanOrEqual')

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -43,9 +43,9 @@ reader_opt_confs = [original_orc_file_reader_conf, multithreaded_orc_file_reader
 @pytest.mark.parametrize('orc_impl', ["native", "hive"])
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 def test_basic_read(std_input_path, name, read_func, v1_enabled_list, orc_impl, reader_confs):
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
-                      'spark.sql.orc.impl': orc_impl})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.orc.impl': orc_impl})
     assert_gpu_and_cpu_are_equal_collect(
             read_func(std_input_path + '/' + name),
             conf=all_confs)
@@ -116,8 +116,7 @@ def test_read_round_trip(spark_tmp_path, orc_gens, read_func, reader_confs, v1_e
     data_path = spark_tmp_path + '/ORC_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.orc(data_path))
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             read_func(data_path),
             conf=all_confs)
@@ -145,8 +144,7 @@ def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func, v1_enabled_lis
     s0 = gen_scalar(orc_gen, force_no_nulls=True)
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).orderBy('a').write.orc(data_path))
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     rf = read_func(data_path)
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: rf(spark).select(f.col('a') >= s0, f.col('s1.sa') >= s0, f.col('s2.sa.ssa') >= s0),
@@ -169,8 +167,7 @@ def test_mixed_compress_read(spark_tmp_path, v1_enabled_list, reader_confs):
                 conf={'spark.sql.orc.compression.codec': compress})
         data_pathes.append(data_path)
 
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_pathes),
             conf=all_confs)
@@ -183,8 +180,7 @@ def test_compress_read_round_trip(spark_tmp_path, compress, v1_enabled_list, rea
     with_cpu_session(
             lambda spark : binary_op_df(spark, long_gen).write.orc(data_path),
             conf={'spark.sql.orc.compression.codec': compress})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path),
             conf=all_confs)
@@ -208,8 +204,7 @@ def test_simple_partitioned_read(spark_tmp_path, v1_enabled_list, reader_confs):
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.orc(third_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path),
             conf=all_confs)
@@ -227,8 +222,7 @@ def test_partitioned_read_just_partitions(spark_tmp_path, v1_enabled_list, reade
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path).select("key"),
             conf=all_confs)
@@ -251,8 +245,7 @@ def test_merge_schema_read(spark_tmp_path, v1_enabled_list, reader_confs):
     with_cpu_session(
             lambda spark : gen_df(spark, second_gen_list).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.option('mergeSchema', 'true').orc(data_path),
             conf=all_confs)
@@ -267,8 +260,7 @@ def test_input_meta(spark_tmp_path, v1_enabled_list, reader_confs):
     with_cpu_session(
             lambda spark : unary_op_df(spark, long_gen).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path)\
                     .filter(f.col('a') > 0)\
@@ -293,9 +285,9 @@ def test_input_meta_fallback(spark_tmp_path, v1_enabled_list, reader_confs, disa
     with_cpu_session(
             lambda spark : unary_op_df(spark, long_gen).write.orc(second_data_path))
     data_path = spark_tmp_path + '/ORC_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
-    all_confs.update({disable_conf: 'false'})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        disable_conf: 'false'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path)\
                     .filter(f.col('a') > 0)\
@@ -317,10 +309,9 @@ def setup_orc_file_no_column_names(spark, table_name):
 def test_missing_column_names(spark_tmp_table_factory, reader_confs):
     table_name = spark_tmp_table_factory.get()
     with_cpu_session(lambda spark : setup_orc_file_no_column_names(spark, table_name))
-    all_confs = reader_confs.copy()
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT _col3,_col2 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
 
 def setup_orc_file_with_column_names(spark, table_name):
     drop_query = "DROP TABLE IF EXISTS {}".format(table_name)
@@ -334,44 +325,42 @@ def setup_orc_file_with_column_names(spark, table_name):
 def test_disorder_read_schema(spark_tmp_table_factory, reader_confs):
     table_name = spark_tmp_table_factory.get()
     with_cpu_session(lambda spark : setup_orc_file_with_column_names(spark, table_name))
-    all_confs = reader_confs.copy()
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_2,c_1 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_3,c_1 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_3,c_2 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_1,c_3,c_2 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_1,c_2,c_3 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_2,c_1,c_3 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_2,c_3,c_1 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_3,c_1,c_2 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT c_3,c_2,c_1 FROM {}".format(table_name)),
-        all_confs)
+        reader_confs)
 
 
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 def test_missing_column_names_filter(spark_tmp_table_factory, reader_confs):
     table_name = spark_tmp_table_factory.get()
     with_cpu_session(lambda spark : setup_orc_file_no_column_names(spark, table_name))
-    all_confs = reader_confs.copy()
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT _col3,_col2 FROM {} WHERE _col2 = '155'".format(table_name)),
-        all_confs)
+        reader_confs)
 
 
 @pytest.mark.parametrize('data_gen,read_schema', _nested_pruning_schemas, ids=idfn)
@@ -382,8 +371,8 @@ def test_read_nested_pruning(spark_tmp_path, data_gen, read_schema, reader_confs
     data_path = spark_tmp_path + '/ORC_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, data_gen).write.orc(data_path))
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
         'spark.sql.optimizer.nestedSchemaPruning.enabled': nested_enabled})
     # This is a hack to get the type in a slightly less verbose way
     rs = StructGen(read_schema, nullable=False).data_type

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -80,8 +80,9 @@ def test_read_round_trip(spark_tmp_path, parquet_gens, read_func, reader_confs, 
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
             conf=rebase_write_corrected_conf)
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list, 'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED'})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED'})
     # once https://github.com/NVIDIA/spark-rapids/issues/1126 is in we can remove spark.sql.legacy.parquet.datetimeRebaseModeInRead config which is a workaround
     # for nested timestamp/date support
     assert_gpu_and_cpu_are_equal_collect(read_func(data_path),
@@ -118,8 +119,7 @@ def test_compress_read_round_trip(spark_tmp_path, compress, v1_enabled_list, rea
     with_cpu_session(
             lambda spark : binary_op_df(spark, long_gen).write.parquet(data_path),
             conf={'spark.sql.parquet.compression.codec': compress})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -143,8 +143,7 @@ def test_pred_push_round_trip(spark_tmp_path, parquet_gen, read_func, v1_enabled
             lambda spark : gen_df(spark, gen_list).orderBy('a').write.parquet(data_path),
             conf=rebase_write_corrected_conf)
     rf = read_func(data_path)
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: rf(spark).select(f.col('a') >= s0),
             conf=all_confs)
@@ -168,8 +167,7 @@ def test_ts_read_round_trip_nested(gen, spark_tmp_path, ts_write, ts_rebase, v1_
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
                 'spark.sql.legacy.parquet.int96RebaseModeInWrite': ts_rebase,
                 'spark.sql.parquet.outputTimestampType': ts_write})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -188,8 +186,7 @@ def test_ts_read_round_trip(gen, spark_tmp_path, ts_write, ts_rebase, v1_enabled
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
                 'spark.sql.legacy.parquet.int96RebaseModeInWrite': ts_rebase,
                 'spark.sql.parquet.outputTimestampType': ts_write})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -214,8 +211,7 @@ def test_ts_read_fails_datetime_legacy(gen, spark_tmp_path, ts_write, ts_rebase,
             conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
                 'spark.sql.legacy.parquet.int96RebaseModeInWrite': ts_rebase,
                 'spark.sql.parquet.outputTimestampType': ts_write})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     with_gpu_session(
             lambda spark : readParquetCatchException(spark, data_path),
             conf=all_confs)
@@ -232,8 +228,7 @@ def test_decimal_read_legacy(spark_tmp_path, parquet_gens, read_func, reader_con
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
             conf={'spark.sql.parquet.writeLegacyFormat': 'true'})
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(read_func(data_path), conf=all_confs)
 
 
@@ -252,8 +247,7 @@ def test_read_round_trip_legacy(spark_tmp_path, parquet_gens, v1_enabled_list, r
     with_cpu_session(
             lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
             conf=rebase_write_legacy_conf)
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -280,8 +274,7 @@ def test_simple_partitioned_read(spark_tmp_path, v1_enabled_list, reader_confs):
             lambda spark : gen_df(spark, gen_list).write.parquet(third_data_path),
             conf=rebase_write_corrected_conf)
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -301,8 +294,7 @@ def test_partitioned_read_just_partitions(spark_tmp_path, v1_enabled_list, reade
             lambda spark : gen_df(spark, gen_list).write.parquet(second_data_path),
             conf=rebase_write_corrected_conf)
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path).select("key"),
             conf=all_confs)
@@ -324,10 +316,10 @@ def test_read_schema_missing_cols(spark_tmp_path, v1_enabled_list, reader_confs)
     with_cpu_session(
             lambda spark : gen_df(spark, second_gen_list, 1).write.parquet(second_data_path))
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
-          'spark.sql.files.maxPartitionBytes': "1g",
-          'spark.sql.files.minPartitionNum': '1'})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.files.maxPartitionBytes': '1g',
+        'spark.sql.files.minPartitionNum': '1'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
             conf=all_confs)
@@ -351,8 +343,7 @@ def test_read_merge_schema(spark_tmp_path, v1_enabled_list, reader_confs):
             lambda spark : gen_df(spark, second_gen_list).write.parquet(second_data_path),
             conf=rebase_write_corrected_conf)
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.option('mergeSchema', 'true').parquet(data_path),
             conf=all_confs)
@@ -375,9 +366,9 @@ def test_read_merge_schema_from_conf(spark_tmp_path, v1_enabled_list, reader_con
     with_cpu_session(
             lambda spark : gen_df(spark, second_gen_list).write.parquet(second_data_path),
             conf=rebase_write_corrected_conf)
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
-          'spark.sql.parquet.mergeSchema': "true"})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.parquet.mergeSchema': 'true'})
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path),
@@ -393,8 +384,7 @@ def test_input_meta(spark_tmp_path, v1_enabled_list, reader_confs):
     with_cpu_session(
             lambda spark : unary_op_df(spark, long_gen).write.parquet(second_data_path))
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path)\
                     .filter(f.col('a') > 0)\
@@ -419,9 +409,9 @@ def test_input_meta_fallback(spark_tmp_path, v1_enabled_list, reader_confs, disa
     with_cpu_session(
             lambda spark : unary_op_df(spark, long_gen).write.parquet(second_data_path))
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
-    all_confs.update({disable_conf: 'false'})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        disable_conf: 'false'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.parquet(data_path)\
                     .filter(f.col('a') > 0)\
@@ -444,9 +434,9 @@ def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 # this test would be better if we could ensure exchanges didn't exist - ie used buckets
 def test_buckets(spark_tmp_path, v1_enabled_list, reader_confs, spark_tmp_table_factory):
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
-          "spark.sql.autoBroadcastJoinThreshold": '-1'})
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.sql.autoBroadcastJoinThreshold': '-1'})
     def do_it(spark):
         return createBucketedTableAndJoin(spark, spark_tmp_table_factory.get(),
                 spark_tmp_table_factory.get())
@@ -497,8 +487,8 @@ def test_nested_pruning(spark_tmp_path, data_gen, read_schema, reader_confs, v1_
     with_cpu_session(
             lambda spark : gen_df(spark, data_gen).write.parquet(data_path),
             conf=rebase_write_corrected_conf)
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list,
+    all_confs = copy_and_update(reader_confs, {
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
         'spark.sql.optimizer.nestedSchemaPruning.enabled': nested_enabled,
         'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED'})
     # This is a hack to get the type in a slightly less verbose way
@@ -538,8 +528,7 @@ def setup_parquet_file_with_column_names(spark, table_name):
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 def test_disorder_read_schema(spark_tmp_table_factory, reader_confs, v1_enabled_list):
-    all_confs = reader_confs.copy()
-    all_confs.update({'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     table_name = spark_tmp_table_factory.get()
     with_cpu_session(lambda spark : setup_parquet_file_with_column_names(spark, table_name))
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/qa_nightly_select_test.py
+++ b/integration_tests/src/main/python/qa_nightly_select_test.py
@@ -24,6 +24,7 @@ from qa_nightly_sql import *
 import pytest
 from spark_session import with_cpu_session
 from marks import approximate_float, ignore_order, incompat, qarun
+from data_gen import copy_and_update
 
 # Mark all tests in current file as premerge_ci_1 in order to be run in first k8s pod for parallel build premerge job
 pytestmark = pytest.mark.premerge_ci_1
@@ -152,11 +153,9 @@ _qa_conf = {
         'spark.rapids.sql.castFloatToString.enabled': 'true'
         }
 
-_first_last_qa_conf = _qa_conf.copy()
-_first_last_qa_conf.update({
+_first_last_qa_conf = copy_and_update(_qa_conf, {
     # some of the first/last tests need a single partition to work reliably when run on a large cluster.
-    'spark.sql.shuffle.partitions': '1'
-    })
+    'spark.sql.shuffle.partitions': '1'})
 
 @approximate_float
 @incompat


### PR DESCRIPTION
There were some tests in hash_aggregate_test.py that leaked ANSI mode configs.  This only caused issues in a few rare cases, but I went through all of the other tests and added in a new API to be sure we always do this right. To hopefully make everything consistent so if someone copy/pastes a test they get the right thing. It also makes it simpler to look for suspicious code because there is only one place in the code that should be calling update on a config now.