### PR TITLE
Throw an error by default if CREATE TABLE AS SELECT overwrites data

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataWritingCommandExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019,2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,21 @@
 
 package com.nvidia.spark.rapids
 
+import java.net.URI
+
 import com.nvidia.spark.rapids.shims.v2.{ShimUnaryCommand, ShimUnaryExecNode}
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuWriteJobStatsTracker
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.SerializableConfiguration
 
@@ -52,6 +56,37 @@ trait GpuDataWritingCommand extends DataWritingCommand with ShimUnaryCommand {
   }
 
   def requireSingleBatch: Boolean
+}
+
+object GpuDataWritingCommand {
+  private val allowNonEmptyLocationInCTASKey = "spark.sql.legacy.allowNonEmptyLocationInCTAS"
+
+  private def getAllowNonEmptyLocationInCTAS: Boolean = {
+    // config only exists in Spark 3.2+, so looking it up manually for now.
+    val key = allowNonEmptyLocationInCTASKey
+    val v = SQLConf.get.getConfString(key, "false")
+    try {
+      v.trim.toBoolean
+    } catch {
+      case _: IllegalArgumentException =>
+        throw new IllegalArgumentException(s"$key should be boolean, but was $v")
+    }
+  }
+
+  def assertEmptyRootPath(tablePath: URI, saveMode: SaveMode, hadoopConf: Configuration) {
+    if (saveMode == SaveMode.ErrorIfExists && !getAllowNonEmptyLocationInCTAS) {
+      val filePath = new org.apache.hadoop.fs.Path(tablePath)
+      val fs = filePath.getFileSystem(hadoopConf)
+      if (fs.exists(filePath) &&
+          fs.getFileStatus(filePath).isDirectory &&
+          fs.listStatus(filePath).length != 0) {
+        TrampolineUtil.throwAnalysisException(
+          s"CREATE-TABLE-AS-SELECT cannot create table with location to a non-empty directory " +
+              s"${tablePath} . To allow overwriting the existing non-empty directory, " +
+              s"set '$allowNonEmptyLocationInCTASKey' to true.")
+      }
+    }
+  }
 }
 
 case class GpuDataWritingCommandExec(cmd: GpuDataWritingCommand, child: SparkPlan)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommand.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCreateDataSourceTableAsSelectCommand.scala
@@ -62,6 +62,9 @@ case class GpuCreateDataSourceTableAsSelectCommand(
       saveDataIntoTable(
         sparkSession, table, table.storage.locationUri, child, SaveMode.Append, tableExists = true)
     } else {
+      table.storage.locationUri.foreach { p =>
+        GpuDataWritingCommand.assertEmptyRootPath(p, mode, sparkSession.sessionState.newHadoopConf)
+      }
       assert(table.schema.isEmpty)
       sparkSession.sessionState.catalog.validateTableLocation(table)
       val tableLocation = if (table.tableType == CatalogTableType.MANAGED) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -23,7 +23,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.memory.TaskMemoryManager
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, IdentityBroadcastMode}
 import org.apache.spark.sql.execution.SparkPlan
@@ -135,4 +135,7 @@ object TrampolineUtil {
   def getTaskMemoryManager(): TaskMemoryManager = {
     TaskContext.get.taskMemoryManager()
   }
+
+  /** Throw a Spark analysis exception */
+  def throwAnalysisException(msg: String) = throw new AnalysisException(msg)
 }


### PR DESCRIPTION
Fixes #2758 by incorporating the changes from [SPARK-28551](https://issues.apache.org/jira/browse/SPARK-28551) into `GpuCreateDataSourceAsSelectCommand`.