### PR TITLE
Remove commented-out semanticEquals overrides

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1451,22 +1451,6 @@ case class GpuCast(
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
-  /**
-   * Under certain conditions during hash partitioning, Spark will attempt to replace casts
-   * with semantically equivalent expressions. This method is overridden to prevent Spark
-   * from substituting non-GPU expressions.
-   */
-  // TODO SPARK-35742 canonicalize
-  //  override def semanticEquals(other: Expression): Boolean = other match {
-  //    case g: GpuExpression =>
-  //      if (this == g) {
-  //        true
-  //      } else {
-  //        super.semanticEquals(g)
-  //      }
-  //    case _ => false
-  //  }
-
   // When this cast involves TimeZone, it's only resolved if the timeZoneId is set;
   // Otherwise behave like Expression.resolved.
   override lazy val resolved: Boolean =

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
@@ -41,12 +41,6 @@ case class GpuScalarSubquery(
   override def toString: String = plan.simpleString(SQLConf.get.maxToStringFields)
   override def withNewPlan(query: BaseSubqueryExec): GpuScalarSubquery = copy(plan = query)
 
-  // TODO SPARK-35742 canonicalize
-//  override def semanticEquals(other: Expression): Boolean = other match {
-//    case s: GpuScalarSubquery => plan.sameResult(s.plan)
-//    case _ => false
-//  }
-
   // the first column in first row from `query`.
   @volatile private var result: Any = _
   @volatile private var updated: Boolean = false


### PR DESCRIPTION
Fixes #3375 

Removes commented-out `semanticEquals` overrides.  As far as I could tell, the logic being removed should match the behavior of the default `semanticEquals` since it should canonicalize the plan as GPU case classes, therefore we shouldn't inadvertently match against a CPU plan.