### PR TITLE
Enable AQE/DPP test for Spark 3.2

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -159,7 +159,6 @@ class AdaptiveQueryExecSuite
 
   test("Join partitioned tables DPP fallback") {
     assumeSpark301orLater
-    assumePriorToSpark320 // In 3.2.0 AQE works with DPP
 
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -195,8 +195,14 @@ class AdaptiveQueryExecSuite
       )
       df.collect()
 
-      // assert that DPP did cause this to run as a non-AQE plan
-      assert(!df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec])
+      val isAdaptiveQuery = df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec]
+      if (cmpSparkVersion(3, 2, 0) < 0) {
+        // assert that DPP did cause this to run as a non-AQE plan prior to Spark 3.2.0
+        assert(!isAdaptiveQuery)
+      } else {
+        // In 3.2.0 AQE works with DPP
+        assert(isAdaptiveQuery)
+      }
 
       // assert that both inputs to the SHJ are coalesced
       val shj = TestUtils.findOperator(df.queryExecution.executedPlan,


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This PR simply enables an AQE+DPP test for Spark 3.2 to partially address https://github.com/NVIDIA/spark-rapids/issues/1867 but we should add some more comprehensive tests before closing the issue unless we think that this existing test is sufficient.