### PR TITLE
Catch UDF compiler exceptions and fallback to CPU

### DIFF
--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/GpuScalaUDF.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/GpuScalaUDF.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.udf
 
+import scala.util.control.NonFatal
+
 import com.nvidia.spark.rapids.shims.v2.ShimExpression
 
 import org.apache.spark.SparkException
@@ -56,7 +58,7 @@ case class GpuScalaUDFLogical(udf: ScalaUDF) extends ShimExpression with Logging
           throw e
         }
         udf
-      case e: Exception =>
+      case NonFatal(e) =>
         val udfName = udf.udfName.getOrElse("<unknown>")
         logWarning(s"Unable to translate UDF $udfName: $e")
         udf

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/GpuScalaUDF.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/GpuScalaUDF.scala
@@ -50,10 +50,15 @@ case class GpuScalaUDFLogical(udf: ScalaUDF) extends ShimExpression with Logging
       }
     } catch {
       case e: SparkException =>
-        logDebug("UDF compilation failure: " + e)
+        val udfName = udf.udfName.getOrElse("<unknown>")
+        logDebug(s"UDF $udfName compilation failure: $e")
         if (isTestEnabled) {
           throw e
         }
+        udf
+      case e: Exception =>
+        val udfName = udf.udfName.getOrElse("<unknown>")
+        logWarning(s"Unable to translate UDF $udfName: $e")
         udf
     }
   }


### PR DESCRIPTION
Fixes #3404 

Updates the UDF compiler to catch other types of exceptions besides the typical `SparkException` used to indicate a translation failure and fallback to the CPU in case of any exception.  Exceptions other than `SparkException` are logged as a warning.