### PR TITLE
Databricks build fixes for missing shouldFailDivOverflow and removal of needed imports

### DIFF
--- a/shims/spark301db/pom.xml
+++ b/shims/spark301db/pom.xml
@@ -174,6 +174,12 @@
                     <version>${spark301db.version}</version>
                     <scope>provided</scope>
                 </dependency>
+		<dependency>
+                    <groupId>org.json4s</groupId>
+                    <artifactId>JsonAST</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
 
 </project>

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
@@ -56,7 +56,9 @@ import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub, ShuffleManagerShimBase}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.rapids.execution.python.{GpuFlatMapGroupsInPandasExecMeta, GpuPythonUDF}
+import org.apache.spark.sql.rapids.execution.python.shims.spark301db._
 import org.apache.spark.sql.rapids.shims.spark301db._
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
@@ -55,8 +55,7 @@ import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub, ShuffleManagerShimBase}
-import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks}
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, TrampolineUtil}
 import org.apache.spark.sql.rapids.execution.python.{GpuFlatMapGroupsInPandasExecMeta, GpuPythonUDF}
 import org.apache.spark.sql.rapids.execution.python.shims.spark301db._
 import org.apache.spark.sql.rapids.shims.spark301db._

--- a/shims/spark311db/pom.xml
+++ b/shims/spark311db/pom.xml
@@ -174,5 +174,11 @@
                     <version>${spark311db.version}</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.json4s</groupId>
+                    <artifactId>JsonAST</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
 </project>

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -91,4 +91,6 @@ trait Spark30XShims extends SparkShims {
   override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.sparkContext.defaultParallelism
   }
+
+  override def shouldFailDivOverflow(): Boolean = false
 }

--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -91,4 +91,6 @@ trait Spark30XShims extends SparkShims {
   override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.sparkContext.defaultParallelism
   }
+
+  override def shouldFailDivOverflow(): Boolean = false
 }

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -104,6 +104,12 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
+                    <groupId>org.json4s</groupId>
+                    <artifactId>JsonAST</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.spark</groupId>
                     <artifactId>spark-unsafe_${scala.binary.version}</artifactId>
                     <version>${spark.version}</version>


### PR DESCRIPTION
Fixes multiple issues.  

1) https://github.com/NVIDIA/spark-rapids/commit/a4e51fd655ba59d9da6c2eff904137c7d4db8d9d for got to add shouldFailDivOverflow to Databricks

2) https://github.com/NVIDIA/spark-rapids/commit/906af85e36047a54bee7147dcc2152d76ecfcdf9 accidentally removed imports that were needed.

3) Fix a couple of import issues with the scala doc generation on databricks.  Note that the verify target fails in dist package still but that can be handled separately from this.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
