### PR TITLE
Update supported docs to clarify casting floating point to string

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -15461,7 +15461,7 @@ and the accelerator produces the same result.
 <td>S</td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
+<td><em>PS<br/>Conversion may produce different results and requires spark.rapids.sql.castFloatToString.enabled to be true.</em></td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
 <td> </td>
 <td> </td>
@@ -15482,7 +15482,7 @@ and the accelerator produces the same result.
 <td>S</td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
+<td><em>PS<br/>Conversion may produce different results and requires spark.rapids.sql.castFloatToString.enabled to be true.</em></td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
 <td> </td>
 <td> </td>
@@ -15865,7 +15865,7 @@ and the accelerator produces the same result.
 <td>S</td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
+<td><em>PS<br/>Conversion may produce different results and requires spark.rapids.sql.castFloatToString.enabled to be true.</em></td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
 <td> </td>
 <td> </td>
@@ -15886,7 +15886,7 @@ and the accelerator produces the same result.
 <td>S</td>
 <td> </td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
+<td><em>PS<br/>Conversion may produce different results and requires spark.rapids.sql.castFloatToString.enabled to be true.</em></td>
 <td><em>PS<br/>max DECIMAL precision of 18</em></td>
 <td> </td>
 <td> </td>

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
@@ -168,7 +168,8 @@ abstract class SparkBaseShims extends Spark30XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
+++ b/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
@@ -182,7 +182,8 @@ abstract class SparkBaseShims extends Spark30XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
@@ -154,7 +154,8 @@ abstract class SparkBaseShims extends Spark30XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
@@ -168,7 +168,8 @@ abstract class SparkBaseShims extends Spark30XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
@@ -168,7 +168,8 @@ abstract class SparkBaseShims extends Spark30XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
@@ -154,7 +154,8 @@ class Spark320Shims extends Spark32XShims {
         override val integralChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
         override val sparkIntegralSig: TypeSig = numeric + BOOLEAN + STRING
 
-        override val fpChecks: TypeSig = gpuNumeric + BOOLEAN + STRING
+        override val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + STRING)
+            .withPsNote(TypeEnum.STRING, fpToStringPsNote)
         override val sparkFpSig: TypeSig = numeric + BOOLEAN + STRING
 
         override val dateChecks: TypeSig = TIMESTAMP + DATE + STRING

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -1210,7 +1210,10 @@ class CastChecks extends ExprChecks {
   val integralChecks: TypeSig = gpuNumeric + BOOLEAN + TIMESTAMP + STRING + BINARY
   val sparkIntegralSig: TypeSig = numeric + BOOLEAN + TIMESTAMP + STRING + BINARY
 
-  val fpChecks: TypeSig = gpuNumeric + BOOLEAN + TIMESTAMP + STRING
+  val fpToStringPsNote: String = s"Conversion may produce different results and requires " +
+      s"${RapidsConf.ENABLE_CAST_FLOAT_TO_STRING} to be true."
+  val fpChecks: TypeSig = (gpuNumeric + BOOLEAN + TIMESTAMP + STRING)
+      .withPsNote(TypeEnum.STRING, fpToStringPsNote)
   val sparkFpSig: TypeSig = numeric + BOOLEAN + TIMESTAMP + STRING
 
   val dateChecks: TypeSig = integral + fp + BOOLEAN + TIMESTAMP + DATE + STRING


### PR DESCRIPTION
Cast documentation states casting from a floating point number to a string "just works," but this is actually disabled by default and must be enabled by a config.  Updated the documentation to better reflect the level of support.