### PR TITLE
Test with Spark 3.2.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,7 +632,7 @@
         <spark311cdh.version>3.1.1.3.1.7270.0-253</spark311cdh.version>
         <spark312.version>3.1.2</spark312.version>
         <spark313.version>3.1.3-SNAPSHOT</spark313.version>
-        <spark320.version>3.2.0-SNAPSHOT</spark320.version>
+        <spark320.version>3.2.1-SNAPSHOT</spark320.version>
         <mockito.version>3.6.0</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimServiceProvider.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimServiceProvider.scala
@@ -20,8 +20,9 @@ import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
   // temporarily allow 3.2.1 while 3.2.0 release candidates are being produced
-  val VERSION320 = SparkShimVersion(3, 2, 1)
-  val VERSIONNAMES: Seq[String] = Seq(VERSION320)
+  val VERSION320 = SparkShimVersion(3, 2, 0)
+  val VERSION321 = SparkShimVersion(3, 2, 1)
+  val VERSIONNAMES: Seq[String] = Seq(VERSION320, VERSION321)
     .flatMap(v => Seq(s"$v", s"$v-SNAPSHOT"))
 }
 

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimServiceProvider.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimServiceProvider.scala
@@ -19,7 +19,8 @@ package com.nvidia.spark.rapids.shims.spark320
 import com.nvidia.spark.rapids.{SparkShims, SparkShimVersion}
 
 object SparkShimServiceProvider {
-  val VERSION320 = SparkShimVersion(3, 2, 0)
+  // temporarily allow 3.2.1 while 3.2.0 release candidates are being produced
+  val VERSION320 = SparkShimVersion(3, 2, 1)
   val VERSIONNAMES: Seq[String] = Seq(VERSION320)
     .flatMap(v => Seq(s"$v", s"$v-SNAPSHOT"))
 }

--- a/shims/spark320/src/test/scala/com/nvidia/spark/rapids/shims/spark320/Spark320ShimsSuite.scala
+++ b/shims/spark320/src/test/scala/com/nvidia/spark/rapids/shims/spark320/Spark320ShimsSuite.scala
@@ -22,7 +22,8 @@ import org.scalatest.FunSuite
 class Spark320ShimsSuite extends FunSuite {
   val sparkShims: SparkShims = new SparkShimServiceProvider().buildShim
   test("spark shims version") {
-    assert(sparkShims.getSparkShimVersion === SparkShimVersion(3, 2, 0))
+    // temporarily allow 3.2.1 while 3.2.0 release candidates are being produced
+    assert(sparkShims.getSparkShimVersion === SparkShimVersion(3, 2, 1))
   }
 
   test("shuffle manager class") {


### PR DESCRIPTION
Change spark320 version to 3.2.1-SNAPSHOT so we can test Spark 3.2 support in CI. This is necessary as a temporary measure until 3.2.0 is released because Spark no longer publishes 3.2.0-SNAPSHOT releases and we depend on a fix that went in since they stopped publishing them.

