### PR TITLE
Temporarily disable failing cast string to date tests

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -147,11 +147,15 @@ class CastOpSuite extends GpuExpressionTestSuite {
     testCastStringTo(DataTypes.DoubleType, generateRandomStrings(Some(NUMERIC_CHARS)))
   }
 
-  test("Cast from string to date using random inputs") {
+  ignore("Cast from string to date using random inputs") {
+    // Test ignored due to known issues
+    // https://github.com/NVIDIA/spark-rapids/issues/3478
     testCastStringTo(DataTypes.DateType, generateRandomStrings(Some(DATE_CHARS), maxStringLen = 8))
   }
 
-  test("Cast from string to date using random inputs with valid year prefix") {
+  ignore("Cast from string to date using random inputs with valid year prefix") {
+    // Test ignored due to known issues
+    // https://github.com/NVIDIA/spark-rapids/issues/3478
     testCastStringTo(DataTypes.DateType,
       generateRandomStrings(Some(DATE_CHARS), maxStringLen = 8, Some("2021")))
   }
@@ -260,7 +264,9 @@ class CastOpSuite extends GpuExpressionTestSuite {
     }
   }
 
-  test("Test all supported casts with in-range values") {
+  ignore("Test all supported casts with in-range values") {
+    // Test ignored due to known issues
+    // https://github.com/NVIDIA/spark-rapids/issues/2889
     // test cast() and ansi_cast()
     Seq(false, true).foreach { ansiEnabled =>
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -266,7 +266,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
 
   ignore("Test all supported casts with in-range values") {
     // Test ignored due to known issues
-    // https://github.com/NVIDIA/spark-rapids/issues/2889
+    // https://github.com/NVIDIA/spark-rapids/issues/3478
     // test cast() and ansi_cast()
     Seq(false, true).foreach { ansiEnabled =>
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -57,11 +57,16 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0"), "dd/MM/yy"))
   }
 
+
+  // Test removed temporarily due to known issues
+  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  /*
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
+  */
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd LEGACY",
     datesAsStrings,
@@ -99,11 +104,15 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
+  // Test removed temporarily due to known issues
+  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  /*
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
       timestampsAsStrings,
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
   }
+  */
 
   testSparkResultsAreEqual("to_timestamp dd/MM/yyyy",
       timestampsAsStrings,
@@ -117,11 +126,15 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0")))
   }
 
+  // Test removed temporarily due to known issues
+  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  /*
   testSparkResultsAreEqual("unix_timestamp parse date",
       timestampsAsStrings,
       CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
   }
+  */
 
   testSparkResultsAreEqual("unix_timestamp parse yyyy/MM",
     timestampsAsStrings,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -59,7 +59,7 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
 
   // Test removed temporarily due to known issues
-  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  // https://github.com/NVIDIA/spark-rapids/issues/3478
   /*
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
@@ -105,7 +105,7 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
   }
 
   // Test removed temporarily due to known issues
-  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  // https://github.com/NVIDIA/spark-rapids/issues/3478
   /*
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
       timestampsAsStrings,
@@ -127,7 +127,7 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
   }
 
   // Test removed temporarily due to known issues
-  // https://github.com/NVIDIA/spark-rapids/issues/2889
+  // https://github.com/NVIDIA/spark-rapids/issues/3478
   /*
   testSparkResultsAreEqual("unix_timestamp parse date",
       timestampsAsStrings,


### PR DESCRIPTION
relates to https://github.com/NVIDIA/spark-rapids/issues/3478. here we disable tests until we can decide what to do with that issue.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
