### PR TITLE
Initialze RAPIDS Shuffle Manager at driver/executor startup

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -152,12 +152,14 @@ class RapidsDriverPlugin extends DriverPlugin with Logging {
       ShimLoader.setSparkShimProviderClass(conf.shimsProviderOverride.get)
     }
 
-    if (GpuShuffleEnv.isRapidsShuffleAvailable &&
-        conf.shuffleTransportEarlyStart) {
-      rapidsShuffleHeartbeatManager =
+    if (GpuShuffleEnv.isRapidsShuffleAvailable) {
+      GpuShuffleEnv.initShuffleManager()
+      if (conf.shuffleTransportEarlyStart) {
+        rapidsShuffleHeartbeatManager =
           new RapidsShuffleHeartbeatManager(
             conf.shuffleTransportEarlyStartHeartbeatInterval,
             conf.shuffleTransportEarlyStartHeartbeatTimeout)
+      }
     }
     conf.rapidsConfMap
   }
@@ -188,11 +190,13 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       if (!GpuDeviceManager.rmmTaskInitEnabled) {
         logInfo("Initializing memory from Executor Plugin")
         GpuDeviceManager.initializeGpuAndMemory(pluginContext.resources().asScala.toMap)
-        if (GpuShuffleEnv.isRapidsShuffleAvailable &&
-            conf.shuffleTransportEarlyStart) {
-          logInfo("Initializing shuffle manager heartbeats")
-          rapidsShuffleHeartbeatEndpoint = new RapidsShuffleHeartbeatEndpoint(pluginContext, conf)
-          rapidsShuffleHeartbeatEndpoint.registerShuffleHeartbeat()
+        if (GpuShuffleEnv.isRapidsShuffleAvailable) {
+          GpuShuffleEnv.initShuffleManager()
+          if (conf.shuffleTransportEarlyStart) {
+            logInfo("Initializing shuffle manager heartbeats")
+            rapidsShuffleHeartbeatEndpoint = new RapidsShuffleHeartbeatEndpoint(pluginContext, conf)
+            rapidsShuffleHeartbeatEndpoint.registerShuffleHeartbeat()
+          }
         }
       }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -84,6 +84,19 @@ object GpuShuffleEnv extends Logging {
     SparkEnv.get.blockManager.externalShuffleServiceEnabled
   }
 
+  //
+  // The actual instantiation of the RAPIDS Shuffle Manager is lazy, and
+  // this forces the initialization when we know we are ready in the driver and executor.
+  //
+  def initShuffleManager(): Unit = {
+    SparkEnv.get.shuffleManager match {
+      case visibleMgr: VisibleShuffleManager=>
+        visibleMgr.initialize
+      case _ =>
+        throw new IllegalStateException(s"Cannot initialize the RAPIDS Shuffle Manager")
+    }
+  }
+
   def isRapidsShuffleAvailable: Boolean = {
     // the driver has `mgr` defined when this is checked
     val sparkEnv = SparkEnv.get

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -70,10 +70,14 @@ object GpuShuffleEnv extends Logging {
 
   def shutdown() = {
     // check for nulls in tests
-    val shuffleManager = Option(SparkEnv.get)
+    Option(SparkEnv.get)
       .map(_.shuffleManager)
       .collect { case sm: VisibleShuffleManager => sm }
       .foreach(_.stop())
+
+    // when we shut down, make sure we clear `env`, as the convention is that
+    // `GpuShuffleEnv.init` will be called to re-establish it
+    env = null
   }
 
   //

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -94,7 +94,7 @@ object GpuShuffleEnv extends Logging {
   //
   def initShuffleManager(): Unit = {
     SparkEnv.get.shuffleManager match {
-      case visibleMgr: VisibleShuffleManager=>
+      case visibleMgr: VisibleShuffleManager =>
         visibleMgr.initialize
       case _ =>
         throw new IllegalStateException(s"Cannot initialize the RAPIDS Shuffle Manager")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -426,6 +426,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
 
 trait VisibleShuffleManager {
   def isDriver: Boolean
+  def initialize: Unit
 }
 
 abstract class ProxyRapidsShuffleInternalManagerBase(
@@ -438,6 +439,12 @@ abstract class ProxyRapidsShuffleInternalManagerBase(
   override lazy val self: ShuffleManager =
     ShimLoader.newInternalShuffleManager(conf, isDriver)
         .asInstanceOf[ShuffleManager]
+
+  // This function touches the lazy val `self` so we actually instantiate
+  // the manager. This is called from both the driver and executor.
+  // In the driver, it's mostly to display information on how to enable/disable the manager,
+  // in the executor, the UCXShuffleTransport starts and allocates memory at this time.
+  override def initialize: Unit = self
 
   //
   // Signatures unchanged since 3.0.1 follow


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/3450. 

Given changes added to support Spark 3.2.0, a proxy system was put in place wrapping the RAPIDS Shuffle Manager. The proxy class has a `self` property that it uses to refer to the actual shuffle manager, the one that instantiates the transport. This all worked where the manager gets instantiated (for real) when the first shuffle is registered, or when `self` is used with early startup in the driver, but it was not convenient since it didn't print a message meant for a user to be able to turn off the shuffle, and also the executor didn't allocate memory until the first shuffle was registered, which it could have been doing all along.

This PR makes the initialization explicit, and hooks it in the driver/executor after we decide that the RAPIDS Shuffle Manager is configured.