### PR TITLE
Fix GpuSum type to match resultType

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -537,6 +537,7 @@ case class GpuSum(child: Expression, resultType: DataType)
 
   override lazy val inputProjection: Seq[Expression] = Seq(child)
   override lazy val updateExpressions: Seq[Expression] = Seq(new CudfSum(cudfSum))
+  override lazy val preUpdate: Seq[Expression] = Seq(GpuCast(cudfSum, resultType))
   override lazy val mergeExpressions: Seq[Expression] = Seq(new CudfSum(cudfSum))
   override lazy val evaluateExpression: Expression = cudfSum
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -537,6 +537,8 @@ case class GpuSum(child: Expression, resultType: DataType)
 
   override lazy val inputProjection: Seq[Expression] = Seq(child)
   override lazy val updateExpressions: Seq[Expression] = Seq(new CudfSum(cudfSum))
+  // we need to cast to `resultType` here, since Spark is not widening types
+  // as done before Spark 3.2.0. See CudfSum for more info.
   override lazy val preUpdate: Seq[Expression] = Seq(GpuCast(cudfSum, resultType))
   override lazy val mergeExpressions: Seq[Expression] = Seq(new CudfSum(cudfSum))
   override lazy val evaluateExpression: Expression = cudfSum


### PR DESCRIPTION
This fixes an issue that @andygrove had found in Spark 3.2.0. The explicit casting was removed as part of https://github.com/NVIDIA/spark-rapids/pull/3417, and I am adding it here in the `preUpdate` step. Some of this could be folded into the input projection, as done with `GpuAverage`, but for now this works and should unblock those testing with 3.2.0.

The binding is odd and we are cleaning up as part of https://github.com/NVIDIA/spark-rapids/issues/3194