### PR TITLE
TimeAdd supports DayTimeIntervalType

### DIFF
--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
@@ -38,9 +38,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, Attribute, Cast, ElementAt, Expression, ExprId, GetArrayItem, GetMapValue, Lag, Lead, NamedExpression, NullOrdering, PlanExpression, PythonUDF, RegExpReplace, ScalaUDF, SortDirection, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, Attribute, Cast, ElementAt, Expression, ExprId, GetArrayItem, GetMapValue, Lag, Lead, Literal, NamedExpression, NullOrdering, PlanExpression, PythonUDF, RegExpReplace, ScalaUDF, SortDirection, SortOrder, TimeAdd}
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.catalyst.plans.logical.CommandResult
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
@@ -62,11 +61,11 @@ import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.execution._
 import org.apache.spark.sql.rapids.execution.python._
-import org.apache.spark.sql.rapids.shims.v2._
-import org.apache.spark.sql.rapids.shims.v2.GpuInMemoryTableScanExec
+import org.apache.spark.sql.rapids.shims.v2.{GpuInMemoryTableScanExec, GpuTimeAdd, _}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.{BlockId, BlockManagerId}
+import org.apache.spark.unsafe.types.CalendarInterval
 
 class Spark320Shims extends Spark32XShims {
   override def getSparkShimVersion: ShimVersion = SparkShimServiceProvider.VERSION320
@@ -356,6 +355,40 @@ class Spark320Shims extends Spark32XShims {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
           GpuElementAt(lhs, rhs, SQLConf.get.ansiEnabled)
         }
+      }),
+    GpuOverrides.expr[Literal](
+      "Holds a static value from the query",
+      ExprChecks.projectAndAst(
+        TypeSig.astTypes,
+        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 + TypeSig.CALENDAR
+          + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT + TypeSig.DAYTIME)
+          .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+            TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT),
+        TypeSig.all),
+      (lit, conf, p, r) => new LiteralExprMeta(lit, conf, p, r)),
+    GpuOverrides.expr[TimeAdd](
+      "Adds interval to timestamp",
+      ExprChecks.binaryProject(TypeSig.TIMESTAMP, TypeSig.TIMESTAMP,
+        ("start", TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
+        ("interval", TypeSig.lit(TypeEnum.DAYTIME) + TypeSig.lit(TypeEnum.CALENDAR),
+          TypeSig.DAYTIME + TypeSig.CALENDAR)),
+      (timeAdd, conf, p, r) => new BinaryExprMeta[TimeAdd](timeAdd, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          GpuOverrides.extractLit(timeAdd.interval).foreach { lit =>
+            lit.dataType match {
+              case CalendarIntervalType =>
+                val intvl = lit.value.asInstanceOf[CalendarInterval]
+                if (intvl.months != 0) {
+                  willNotWorkOnGpu("interval months isn't supported")
+                }
+              case _: DayTimeIntervalType => // Supported
+            }
+          }
+          checkTimeZoneId(timeAdd.timeZoneId)
+        }
+
+        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+          GpuTimeAdd(lhs, rhs)
       })
   ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
 

--- a/sql-plugin/src/main/301until320-all/scala/org/apache/spark/sql/rapids.shims.v2/datetimeExpressions.scala
+++ b/sql-plugin/src/main/301until320-all/scala/org/apache/spark/sql/rapids.shims.v2/datetimeExpressions.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.shims.v2
+
+import ai.rapids.cudf.{ColumnVector, ColumnView, Scalar}
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, TimeZoneAwareExpression}
+import org.apache.spark.sql.rapids.GpuTimeMath
+
+case class GpuTimeAdd(start: Expression,
+                      interval: Expression,
+                      timeZoneId: Option[String] = None)
+  extends GpuTimeMath(start, interval, timeZoneId) {
+
+  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
+    copy(timeZoneId = Option(timeZoneId))
+  }
+
+  override def intervalMath(us_s: Scalar, us: ColumnView): ColumnVector = {
+    us.add(us_s)
+  }
+}

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -21,7 +21,6 @@ import com.nvidia.spark.rapids.GpuOverrides.exec
 import org.apache.hadoop.fs.FileStatus
 import org.apache.parquet.schema.MessageType
 
-import org.apache.spark.sql.Spark32XShimsUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
@@ -36,6 +35,7 @@ import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.GpuCustomShuffleReaderExec
+import org.apache.spark.sql.rapids.shims.v2.Spark32XShimsUtils
 
 /**
 * Shim base class that can be compiled with every supported 3.2.x

--- a/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/Spark32XShimsUtils.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/Spark32XShimsUtils.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql
+package org.apache.spark.sql.rapids.shims.v2
+
+import org.apache.spark.sql.SparkSession
 
 object Spark32XShimsUtils {
 
@@ -23,4 +25,3 @@ object Spark32XShimsUtils {
   }
 
 }
-

--- a/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/datetimeExpressions.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/datetimeExpressions.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.shims.v2
+
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuScalar}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, TimeZoneAwareExpression}
+import org.apache.spark.sql.rapids.GpuTimeMath
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.unsafe.types.CalendarInterval
+
+case class GpuTimeAdd(start: Expression,
+                      interval: Expression,
+                      timeZoneId: Option[String] = None)
+  extends GpuTimeMath(start, interval, timeZoneId) {
+
+  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
+    copy(timeZoneId = Option(timeZoneId))
+  }
+
+  override def intervalMath(us_s: Scalar, us: ColumnView): ColumnVector = {
+    us.add(us_s)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] =
+    Seq(AnyTimestampType, TypeCollection(CalendarIntervalType, DayTimeIntervalType))
+
+  override def dataType: DataType = start.dataType
+
+  override def columnarEval(batch: ColumnarBatch): Any = {
+    withResourceIfAllowed(left.columnarEval(batch)) { lhs =>
+      withResourceIfAllowed(right.columnarEval(batch)) { rhs =>
+        (lhs, rhs) match {
+          case (l: GpuColumnVector, intvlS: GpuScalar) =>
+            val interval = intvlS.dataType match {
+              case CalendarIntervalType =>
+                // Scalar does not support 'CalendarInterval' now, so use
+                // the Scala value instead.
+                // Skip the null check because it wll be detected by the following calls.
+                val intvl = intvlS.getValue.asInstanceOf[CalendarInterval]
+                if (intvl.months != 0) {
+                  throw new UnsupportedOperationException("Months aren't supported at the moment")
+                }
+                intvl.days * microSecondsInOneDay + intvl.microseconds
+              case _: DayTimeIntervalType =>
+                // Scalar does not support 'DayTimeIntervalType' now, so use
+                // the Scala value instead.
+                intvlS.getValue.asInstanceOf[Long]
+              case _ =>
+                throw new UnsupportedOperationException("GpuTimeAdd unsupported data type: " +
+                  intvlS.dataType)
+            }
+
+            if (interval != 0) {
+              withResource(Scalar.fromLong(interval)) { us_s =>
+                withResource(l.getBase.bitCastTo(DType.INT64)) { us =>
+                  withResource(intervalMath(us_s, us)) { longResult =>
+                    GpuColumnVector.from(longResult.castTo(DType.TIMESTAMP_MICROSECONDS),
+                      dataType)
+                  }
+                }
+              }
+            } else {
+              l.incRefCount()
+            }
+          case _ =>
+            throw new UnsupportedOperationException("GpuTimeAdd takes column and interval as an " +
+              "argument only")
+        }
+      }
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -56,6 +56,7 @@ import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
 import org.apache.spark.sql.rapids.execution._
 import org.apache.spark.sql.rapids.execution.python._
+import org.apache.spark.sql.rapids.shims.v2.GpuTimeAdd
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -177,20 +177,6 @@ abstract class GpuTimeMath(
   def intervalMath(us_s: Scalar, us: ColumnView): ColumnVector
 }
 
-case class GpuTimeAdd(start: Expression,
-                      interval: Expression,
-                      timeZoneId: Option[String] = None)
-  extends GpuTimeMath(start, interval, timeZoneId) {
-
-  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
-    copy(timeZoneId = Option(timeZoneId))
-  }
-
-  override def intervalMath(us_s: Scalar, us: ColumnView): ColumnVector = {
-    us.add(us_s)
-  }
-}
-
 case class GpuTimeSub(start: Expression,
                        interval: Expression,
                        timeZoneId: Option[String] = None)


### PR DESCRIPTION
This PR is to fix https://github.com/NVIDIA/spark-rapids/issues/3502 by adding DayTimeIntervalType support for TimeAdd.

Tested date_time_test.py against spark 3.2.0, and pass

BTW,  This RP didn't add DayTimeIntervalType support for TimeSub since it has been deleted from Spark 3.1