### PR TITLE
Allow spark320 tests to run with 320 or 321

### DIFF
--- a/shims/spark320/src/test/scala/com/nvidia/spark/rapids/shims/spark320/Spark320ShimsSuite.scala
+++ b/shims/spark320/src/test/scala/com/nvidia/spark/rapids/shims/spark320/Spark320ShimsSuite.scala
@@ -25,7 +25,8 @@ class Spark320ShimsSuite extends FunSuite {
   val sparkShims: SparkShims = new SparkShimServiceProvider().buildShim
   test("spark shims version") {
     // temporarily allow 3.2.1 while 3.2.0 release candidates are being produced
-    assert(sparkShims.getSparkShimVersion === SparkShimVersion(3, 2, 1))
+    assert(sparkShims.getSparkShimVersion === SparkShimVersion(3, 2, 0) ||
+      sparkShims.getSparkShimVersion === SparkShimVersion(3, 2, 1))
   }
 
   test("shuffle manager class") {


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Allow spark320 tests to run with 3.2.0 and 3.2.1