### PR TITLE
Update empty CTAS testing to avoid Hive if possible

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -325,6 +325,7 @@ def test_non_empty_ctas(spark_tmp_path, spark_tmp_table_factory, allow_non_empty
     data_path = spark_tmp_path + "/CTAS"
     conf = {
         "spark.sql.hive.convertCTAS": "true",
+        "spark.sql.legacy.createHiveTableByDefault": "false",
         "spark.sql.legacy.allowNonEmptyLocationInCTAS": str(allow_non_empty)
     }
     def test_it(spark):


### PR DESCRIPTION
This *might* fix #3476.  I've been unable to reproduce it on the EGX YARN cluster, but it appears to be the result of trying to use Hive from the CPU.  The test is failing before it even gets to a GPU query with a pure Spark CPU backtrace.

Ultimately we don't require Hive (and don't even desire to use Hive) for this test, and it looks like we sometimes can avoid using Hive by specifying `spark.sql.legacy.createHiveTableByDefault=false`.
