### PR TITLE
Shim version utils

### DIFF
--- a/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
@@ -41,14 +41,14 @@ trait GpuCachedBatchSerializer extends CachedBatchSerializer {
  */
 class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
-  val minSupportedVer = "3.1.1"
-  val sparkVersion = ShimLoader.getSparkVersion
+  val minSupportedVer = (3, 1, 1)
+  val sparkVersion = ShimLoader.getSparkShims.getSparkShimVersion
   // Note that since the config to set the serializer wasn't added until
   // Spark 3.1.0 (https://issues.apache.org/jira/browse/SPARK-32274) this shouldn't
   // ever throw.
-  if (sparkVersion < minSupportedVer) {
+  if (sparkVersion.cmpSparkVersion(minSupportedVer: _*) < 0) {
     throw new IllegalArgumentException("ParquetCachedBaatchSerializer only supported for Spark " +
-      s"versions > 3.1.1, version found was: $sparkVersion")
+      s"versions > ${minSupportedVer.mkString('.')}, version found was: $sparkVersion")
   }
 
   private lazy val realSerializer: GpuCachedBatchSerializer = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -62,7 +62,19 @@ case object GpuBuildRight extends GpuBuildSide
 
 case object GpuBuildLeft extends GpuBuildSide
 
-sealed abstract class ShimVersion
+sealed abstract class ShimVersion {
+  def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
+    val (sparkMajor, sparkMinor, sparkBugfix) = this match {
+      case SparkShimVersion(a, b, c) => (a, b, c)
+      case DatabricksShimVersion(a, b, c) => (a, b, c)
+      case ClouderaShimVersion(a, b, c, _) => (a, b, c)
+      case EMRShimVersion(a, b, c) => (a, b, c)
+    }
+    val fullVersion = ((major.toLong * 1000) + minor) * 1000 + bugfix
+    val sparkFullVersion = ((sparkMajor.toLong * 1000) + sparkMinor) * 1000 + sparkBugfix
+    sparkFullVersion.compareTo(fullVersion)
+  }
+}
 
 case class SparkShimVersion(major: Int, minor: Int, patch: Int) extends ShimVersion {
   override def toString(): String = s"$major.$minor.$patch"

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -106,8 +106,6 @@ class AdaptiveQueryExecSuite
   }
 
   test("get row counts from executed shuffle query stages") {
-    assumeSpark301orLater
-
     skewJoinTest { spark =>
       val (_, innerAdaptivePlan) = runAdaptiveAndVerifyResult(
         spark,
@@ -166,8 +164,6 @@ class AdaptiveQueryExecSuite
   }
 
   test("Join partitioned tables DPP fallback") {
-    assumeSpark301orLater
-
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1") // force shuffle exchange
@@ -398,8 +394,6 @@ class AdaptiveQueryExecSuite
 
   test("Exchange reuse") {
     logError("Exchange reuse")
-    assumeSpark301orLater
-
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
@@ -432,8 +426,6 @@ class AdaptiveQueryExecSuite
 
   test("Change merge join to broadcast join without local shuffle reader") {
     logError("Change merge join to broadcast join without local shuffle reader")
-    assumeSpark301orLater
-
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key, "true")
@@ -464,8 +456,6 @@ class AdaptiveQueryExecSuite
 
   test("Verify the reader is LocalShuffleReaderExec") {
     logError("Verify the reader is LocalShuffleReaderExec")
-    assumeSpark301orLater
-
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "400")
@@ -585,8 +575,6 @@ class AdaptiveQueryExecSuite
   }
 
   def skewJoinTest(fun: SparkSession => Unit) {
-    assumeSpark301orLater
-
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -129,7 +129,8 @@ class AdaptiveQueryExecSuite
       val innerSmj = findTopLevelGpuShuffleHashJoin(innerAdaptivePlan)
       // Spark changed how skewed joins work and now the numbers are different
       // depending on the version being used
-      if (cmpSparkVersion(3,1,1) >= 0) {
+      val version = ShimLoader.getSparkShims.getSparkShimVersion
+      if (version.cmpSparkVersion(3,1,1) >= 0) {
         checkSkewJoin(innerSmj, 2, 1)
       } else {
         checkSkewJoin(innerSmj, 1, 1)
@@ -145,7 +146,8 @@ class AdaptiveQueryExecSuite
       val leftSmj = findTopLevelGpuShuffleHashJoin(leftAdaptivePlan)
       // Spark changed how skewed joins work and now the numbers are different
       // depending on the version being used
-      if (cmpSparkVersion(3,1,1) >= 0) {
+      val version = ShimLoader.getSparkShims.getSparkShimVersion
+      if (version.cmpSparkVersion(3,1,1) >= 0) {
         checkSkewJoin(leftSmj, 2, 0)
       } else {
         checkSkewJoin(leftSmj, 1, 0)
@@ -201,7 +203,8 @@ class AdaptiveQueryExecSuite
       df.collect()
 
       val isAdaptiveQuery = df.queryExecution.executedPlan.isInstanceOf[AdaptiveSparkPlanExec]
-      if (cmpSparkVersion(3, 2, 0) < 0) {
+      val version = ShimLoader.getSparkShims.getSparkShimVersion
+      if (version.cmpSparkVersion(3, 2, 0) < 0) {
         // assert that DPP did cause this to run as a non-AQE plan prior to Spark 3.2.0
         assert(!isAdaptiveQuery)
       } else {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CostBasedOptimizerSuite.scala
@@ -471,7 +471,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   }
 
   test("Compute estimated row count nested joins no broadcast") {
-    assumeSpark301orLater
     logError("Compute estimated row count nested joins no broadcast")
     val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
@@ -520,7 +519,6 @@ class CostBasedOptimizerSuite extends SparkQueryCompareTestSuite
   }
 
   test("Compute estimated row count nested joins with broadcast") {
-    assumeSpark301orLater
     logError("Compute estimated row count nested joins with broadcast")
     val conf = createDefaultConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1835,12 +1835,6 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     }
   }
 
-  /** most of the AQE tests requires Spark 3.0.1 or later */
-  def assumeSpark301orLater: Assertion = {
-    val version = ShimLoader.getSparkShims.getSparkShimVersion
-    assume(version.cmpSparkVersion(3, 0, 1) >= 0, "Spark version not 3.0.1+")
-  }
-
   def assumeSpark311orLater: Assertion = {
     val version = ShimLoader.getSparkShims.getSparkShimVersion
     assume(version.cmpSparkVersion(3, 1, 1) >= 0, "Spark version not 3.1.1+")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1836,34 +1836,32 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   }
 
   /** most of the AQE tests requires Spark 3.0.1 or later */
-  def assumeSpark301orLater: Assertion =
-    assume(cmpSparkVersion(3, 0, 1) >= 0, "Spark version not 3.0.1+")
-
-  def assumeSpark311orLater: Assertion =
-    assume(cmpSparkVersion(3, 1, 1) >= 0, "Spark version not 3.1.1+")
-
-  def assumePriorToSpark320: Assertion =
-    assume(isPriorToSpark320, "Spark version not before 3.2.0")
-
-  def isPriorToSpark320: Boolean = cmpSparkVersion(3, 2, 0) < 0
-
-  def assumeSpark320orLater: Assertion =
-    assume(isSpark320OrLater, "Spark version not 3.2.0+")
-
-  def isSpark320OrLater: Boolean = cmpSparkVersion(3, 2, 0) >= 0
-
-  def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
-    val sparkShimVersion = ShimLoader.getSparkShims.getSparkShimVersion
-    val (sparkMajor, sparkMinor, sparkBugfix) = sparkShimVersion match {
-      case SparkShimVersion(a, b, c) => (a, b, c)
-      case DatabricksShimVersion(a, b, c) => (a, b, c)
-      case ClouderaShimVersion(a, b, c, _) => (a, b, c)
-      case EMRShimVersion(a, b, c) => (a, b, c)
-    }
-    val fullVersion = ((major.toLong * 1000) + minor) * 1000 + bugfix
-    val sparkFullVersion = ((sparkMajor.toLong * 1000) + sparkMinor) * 1000 + sparkBugfix
-    sparkFullVersion.compareTo(fullVersion)
+  def assumeSpark301orLater: Assertion = {
+    val version = ShimLoader.getSparkShims.getSparkShimVersion
+    assume(version.cmpSparkVersion(3, 0, 1) >= 0, "Spark version not 3.0.1+")
   }
 
+  def assumeSpark311orLater: Assertion = {
+    val version = ShimLoader.getSparkShims.getSparkShimVersion
+    assume(version.cmpSparkVersion(3, 1, 1) >= 0, "Spark version not 3.1.1+")
+  }
+
+  def assumePriorToSpark320: Assertion = {
+    assume(isPriorToSpark320, "Spark version not before 3.2.0")
+  }
+
+  def isPriorToSpark320: Boolean = {
+    val version = ShimLoader.getSparkShims.getSparkShimVersion
+    version.cmpSparkVersion(3, 2, 0) < 0
+  }
+
+  def assumeSpark320orLater: Assertion = {
+    assume(isSpark320OrLater, "Spark version not 3.2.0+")
+  }
+
+  def isSpark320OrLater: Boolean = {
+    val version = ShimLoader.getSparkShims.getSparkShimVersion
+    version.cmpSparkVersion(3, 2, 0) >= 0
+  }
 
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowFunctionSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.types.DecimalType
 class WindowFunctionSuite extends SparkQueryCompareTestSuite {
   // The logical plan optimizer in Spark 3.0.x is non-deterministic when planning windows
   // over the same range, so avoid trying to compare canonicalized plans on Spark 3.0.x
-  private val skipRangeCanon = cmpSparkVersion(3, 1, 1) < 0
+  private val skipRangeCanon = ShimLoader.getSparkShims.getSparkShimVersion
+    .cmpSparkVersion(3, 1, 1) < 0
 
   def windowAggregationTester(windowSpec: WindowSpec): DataFrame => DataFrame =
     (df : DataFrame) => df.select(


### PR DESCRIPTION
This is just a small cleanup of shim version checking, with these changes:

- Move `cmpSparkVersion` from test suite to `ShimVersion` class so that we can use it in the plugin
- Update `ParquetCachedBatchSerializer` to use this mechanism instead of a version string comparison
- Remove all uses of `assumeSpark301orLater` now that 3.0.1 is the minimum supported version