### PR TITLE
Interpolate spark.version.classifier in build.dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -799,6 +799,7 @@
     </dependencyManagement>
 
     <build>
+        <directory>target/${spark.version.classifier}</directory>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
This enables parallel build of shims. Local testing:

Sequential (P1) build time:
```
time (echo -n 302 312 311cdh 320 | \
  xargs -P 1 -d " " -n 1 -i mvn clean install -Dbuildver='{}' \
  -Dskip -Dmaven.scalastyle.skip -DskipTests -Dmaven.javadoc.skip \
  -pl aggregator -am  && mvn clean package -PminimumFeatureVersionMix -pl dist)

real	5m26.615s
user	20m33.100s
sys	0m19.473s
```

P2 build time:
```
time (echo -n 302 312 311cdh 320 | \
  xargs -P 2 -d " " -n 1 -i mvn clean install -Dbuildver='{}' \
  -Dskip -Dmaven.scalastyle.skip -DskipTests -Dmaven.javadoc.skip \
  -pl aggregator -am  && mvn clean package -PminimumFeatureVersionMix -pl dist)

real	3m22.768s
user	24m35.737s
sys	0m19.599s
```

P3 build time:
```
time (echo -n 302 312 311cdh 320 | \
  xargs -P 1 -d " " -n 1 -i mvn clean install -Dbuildver='{}' \
  -Dskip -Dmaven.scalastyle.skip -DskipTests -Dmaven.javadoc.skip \
  -pl aggregator -am  && mvn clean package -PminimumFeatureVersionMix -pl dist)

real	3m31.987s
user	26m31.421s
sys	0m21.474s
```

The P2 speedup of 1.61x  on my machine is waning at P3. For beefier build machines this point is likely reached at much higher P.
 
Signed-off-by: Gera Shegalov <gera@apache.org>