### PR TITLE
Update hashing to normalize -0.0 on 3.2+

### DIFF
--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/HashUtils.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/HashUtils.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims.v2
+
+import ai.rapids.cudf
+import com.nvidia.spark.rapids.{Arm, ColumnCastUtil}
+
+object HashUtils extends Arm {
+  /**
+   * In Spark 3.2.0+ -0.0 is normalized to 0.0, but for everyone else this is a noop
+   * @param in the input to normalize
+   * @return the result
+   */
+  def normalizeInput(in: cudf.ColumnVector): cudf.ColumnVector =
+    in.incRefCount()
+}

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/HashUtils.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/HashUtils.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims.v2
+
+import ai.rapids.cudf
+import com.nvidia.spark.rapids.{Arm, ColumnCastUtil}
+
+object HashUtils extends Arm {
+  /**
+   * In Spark 3.2.0+ -0.0 is normalized to 0.0
+   * @param in the input to normalize
+   * @return the result
+   */
+  def normalizeInput(in: cudf.ColumnVector): cudf.ColumnVector = {
+    // This looks really stupid, but -0.0 in cudf is equal to  0.0 so we can check if they are
+    // equal and replace it with the same thing to normalize it.
+    ColumnCastUtil.deepTransform(in) {
+      case cv if cv.getType == cudf.DType.FLOAT32 =>
+        withResource(cudf.Scalar.fromFloat(0.0f)) { zero =>
+          withResource(cv.equalTo(zero)) { areEqual =>
+            areEqual.ifElse(zero, cv)
+          }
+        }
+      case cv if cv.getType == cudf.DType.FLOAT64 =>
+        withResource(cudf.Scalar.fromDouble(0.0)) { zero =>
+          withResource(cv.equalTo(zero)) { areEqual =>
+            areEqual.ifElse(zero, cv)
+          }
+        }
+    }
+  }
+}

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnCastUtil.scala
@@ -16,9 +16,11 @@
 
 package com.nvidia.spark.rapids
 
+import java.util.Optional
+
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder}
 
-import ai.rapids.cudf.{ColumnVector, ColumnView}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
 
 import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
 
@@ -29,6 +31,105 @@ import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
  * At this time this is strictly a place for casting methods
  */
 object ColumnCastUtil extends Arm {
+
+  /**
+   * Transforms a ColumnView into a new ColumnView using a `PartialFunction` or returns None
+   * indicating that no transformation happened (nothing matched). If the partial function matches
+   * it is assumed that this takes ownership of the returned view. A lot of caution needs to be
+   * taken when using this method because of ownership of the data. This will handle
+   * reference counting and return not just the updated ColumnView but also any views and or data
+   * that were generated along the way and need to be closed. This includes the returned view
+   * itself. So you should not explicitly close the returned view. It will be closed by closing
+   * everything in the returned collection of AutoCloseable values.
+   *
+   * @param cv the view to be updated
+   * @param convert the partial function used to convert the data. If this matches and returns
+   *                a updated view this function takes ownership of that view.
+   * @return None if there were no changes to the view or the updated view along with anything else
+   *         that needs to be closed.
+   */
+  def deepTransformView(cv: ColumnView)
+      (convert: PartialFunction[ColumnView, ColumnView]):
+  (Option[ColumnView], ArrayBuffer[AutoCloseable]) = {
+    closeOnExcept(ArrayBuffer.empty[AutoCloseable]) { needsClosing =>
+      val updated = convert.lift(cv)
+      needsClosing ++= updated
+
+      updated match {
+        case Some(newCv) =>
+          (Some(newCv), needsClosing)
+        case None =>
+          // Recurse down if needed and check children
+          cv.getType.getTypeId match {
+            case DType.DTypeEnum.STRUCT =>
+              withResource(ArrayBuffer.empty[ColumnView]) { tmpNeedsClosed =>
+                var childrenUpdated = false
+                val newChildren = ArrayBuffer.empty[ColumnView]
+                (0 until cv.getNumChildren).foreach { index =>
+                  val child = cv.getChildColumnView(index)
+                  tmpNeedsClosed += child
+                  val (updatedChild, needsClosingChild) = deepTransformView(child)(convert)
+                  needsClosing ++= needsClosingChild
+                  updatedChild match {
+                    case Some(newChild) =>
+                      newChildren += newChild
+                      childrenUpdated = true
+                    case None =>
+                      newChildren += child
+                  }
+                }
+                if (childrenUpdated) {
+                  withResource(cv.getValid) { valid =>
+                    val ret = new ColumnView(DType.STRUCT, cv.getRowCount,
+                      Optional.empty[java.lang.Long](), valid, null, newChildren.toArray)
+                    (Some(ret), needsClosing)
+                  }
+                } else {
+                  (None, needsClosing)
+                }
+              }
+            case DType.DTypeEnum.LIST =>
+              withResource(cv.getChildColumnView(0)) { dataView =>
+                val (updatedData, needsClosingData) = deepTransformView(dataView)(convert)
+                needsClosing ++= needsClosingData
+                updatedData match {
+                  case Some(updated) =>
+                    (Some(GpuListUtils.replaceListDataColumnAsView(cv, updated)), needsClosing)
+                  case None =>
+                    (None, needsClosing)
+                }
+              }
+
+            case _ =>
+              (None, needsClosing)
+          }
+      }
+    }
+  }
+
+  /**
+   * Transforms a ColumnVector into a new ColumnVector using a `PartialFunction`.
+   * If the partial function matches it is assumed that this takes ownership of the returned view.
+   * A lot of caution needs to be taken when using this method because of ownership of the data.
+   *
+   * @param cv the vector to be updated
+   * @param convert the partial function used to convert the data. If this matches and returns
+   *                a updated view this function takes ownership of that view.
+   * @return the updated vector
+   */
+  def deepTransform(cv: ColumnVector)
+      (convert: PartialFunction[ColumnView, ColumnView]): ColumnVector = {
+    val (retView, needsClosed) = deepTransformView(cv)(convert)
+    withResource(needsClosed) { _ =>
+      retView match {
+        case Some(updated) =>
+          // Don't need to close updated because it is covered by needsClosed
+          updated.copyToColumnVector()
+        case None =>
+          cv.incRefCount()
+      }
+    }
+  }
 
   /**
    * This method deep casts the input ColumnView to a new column if the predicate passed to this

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -125,6 +125,16 @@ trait Arm {
     }
   }
 
+  /** Executes the provided code block, closing the resources only if an exception occurs */
+  def closeOnExcept[T <: AutoCloseable, V](r: Option[T])(block: Option[T] => V): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.foreach(_.safeClose(t))
+        throw t
+    }
+  }
 
   /** Executes the provided code block, freeing the RapidsBuffer only if an exception occurs */
   def freeOnExcept[T <: RapidsBuffer, V](r: T)(block: T => V): V = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
 import scala.collection.{mutable, SeqLike}
 import scala.collection.generic.CanBuildFrom
 import scala.reflect.ClassTag


### PR DESCRIPTION
This fixes issues with hash normalization related to SPARK-35207 (Thanks @jlowe for finding the root cause of the issue).

This adds in some new APIs that should make this type of transformation simpler for other code, but because this is late in the 21.10 release I didn't want to update any existing code to use it yet.