### PR TITLE
Enable auto-merge from branch 21.10 to 21.12 [skip ci]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-21.08
+    - branch-21.10
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-21.08 # force to fetch from latest upstream instead of PR ref
+          ref: branch-21.10 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-21.08
-          BASE: branch-21.10
+          HEAD: branch-21.10
+          BASE: branch-21.12
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -578,7 +578,7 @@ void abortDupBuilds() {
                 if (prevExecutor != null) {
                     echo "...Aborting duplicate Build #${prevBuild.number}"
                     prevExecutor.interrupt(Result.ABORTED,
-                            new UserInterruption("Aborted by Build #${currentBuild.number}"))
+                            new UserInterruption("Build #${currentBuild.number}"))
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

enable auto-merge from branch-21.10 to branch-21.12.
also removed a duplicate phrase information in pre-merge
![image](https://user-images.githubusercontent.com/8086184/133867168-76c4451a-f7d0-4a18-81e3-6976e70f2e9d.png)

**NOTE:** please help review and allow me to merge after branch-21.12 is created