### PR TITLE
GpuAdd supports ANSI mode.

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -14,10 +14,11 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect
 from data_gen import *
-from marks import incompat, approximate_float
+from marks import incompat, approximate_float, allow_non_gpu
 from pyspark.sql.types import *
+from pyspark.sql.types import IntegralType
 from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_311, is_before_spark_320
 import pyspark.sql.functions as f
 from pyspark.sql.utils import IllegalArgumentException
@@ -61,6 +62,26 @@ def test_multiplication(data_gen):
                 f.col('b') * f.lit(None).cast(data_type),
                 f.col('a') * f.col('b')),
             conf=allow_negative_scale_of_decimal_conf)
+
+# No overflow gens here because we just focus on verifying the fallback to CPU when
+# enabling ansi mode. But overflows will fail the tests because CPU runs raise
+# exceptions.
+_no_overflow_multiply_gens = [
+    ByteGen(min_val = 1, max_val = 10, special_cases=[]),
+    ShortGen(min_val = 1, max_val = 100, special_cases=[]),
+    IntegerGen(min_val = 1, max_val = 1000, special_cases=[]),
+    LongGen(min_val = 1, max_val = 3000, special_cases=[]),
+    float_gen, double_gen,
+    decimal_gen_scale_precision, decimal_gen_same_scale_precision, DecimalGen(8, 8)]
+
+@allow_non_gpu('ProjectExec', 'Alias', 'CheckOverflow', 'Multiply', 'PromotePrecision', 'Cast')
+@pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
+def test_multiplication_fallback_when_ansi_enabled(data_gen):
+    assert_gpu_fallback_collect(
+            lambda spark : binary_op_df(spark, data_gen).select(
+                f.col('a') * f.col('b')),
+            'ProjectExec',
+            conf={'spark.sql.ansi.enabled': 'true'})
 
 @pytest.mark.parametrize('lhs', [DecimalGen(6, 5), DecimalGen(6, 4), DecimalGen(5, 4), DecimalGen(5, 3), DecimalGen(4, 2), DecimalGen(3, -2)], ids=idfn)
 @pytest.mark.parametrize('rhs', [DecimalGen(6, 3)], ids=idfn)
@@ -576,4 +597,49 @@ def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
 def test_div_overflow_no_exception_when_ansi(expr, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
         func=lambda spark: _get_div_overflow_df(spark, expr),
+        conf={'spark.sql.ansi.enabled': ansi_enabled})
+
+
+def _get_add_overflow_df(spark, data, data_type, expr):
+    return spark.createDataFrame(
+        SparkContext.getOrCreate().parallelize([data]),
+        StructType([StructField('a', data_type)])
+    ).selectExpr(expr)
+
+_data_type_expr_for_add_overflow = [
+    ([127], ByteType(), 'a + 1Y'), ([-128], ByteType(), '-1Y + a'),
+    ([32767], ShortType(), 'a + 1S'), ([-32768], ShortType(), '-1S + a'),
+    ([2147483647], IntegerType(), 'a + 1'), ([-2147483648], IntegerType(), '-1 + a'),
+    ([9223372036854775807],  LongType(), 'a + 1L'),
+    ([-9223372036854775808], LongType(), '-1L + a'),
+    ([3.4028235E38],  FloatType(), 'a + a'),
+    ([-3.4028235E38], FloatType(), 'a + a'),
+    ([1.7976931348623157E308],  DoubleType(), 'a + a'),
+    ([-1.7976931348623157E308], DoubleType(), 'a + a'),
+    ([Decimal('9'*18 + 'e-0')], DecimalType(precision=18), 'a + a'),
+    ([Decimal('-' + '9'*18 + 'e-0')], DecimalType(precision=18), 'a + a'),
+]
+
+@pytest.mark.parametrize('data,tp,expr', _data_type_expr_for_add_overflow[:12])
+def test_add_overflow_with_ansi_enabled(data, tp, expr):
+    ansi_conf = {'spark.sql.ansi.enabled': 'true'}
+    if isinstance(tp, IntegralType):
+        assert_gpu_and_cpu_error(
+            lambda spark: _get_add_overflow_df(spark, data, tp, expr).collect(),
+            conf=ansi_conf,
+            error_message='overflow')
+    else:
+        assert_gpu_and_cpu_are_equal_collect(
+            func=lambda spark: _get_add_overflow_df(spark, data, tp, expr),
+            conf=ansi_conf)
+
+
+@allow_non_gpu('ProjectExec', 'Alias', 'CheckOverflow', 'Add', 'PromotePrecision', 'Cast')
+@pytest.mark.parametrize('data,tp,expr', _data_type_expr_for_add_overflow[12:])
+@pytest.mark.parametrize('ansi_enabled', ['false','true'])
+def test_add_overflow_fallback_for_decimal(data, tp, expr, ansi_enabled):
+    # Spark will try to promote the precision (to 19) which GPU does not supported now.
+    assert_gpu_fallback_collect(
+        lambda spark: _get_add_overflow_df(spark, data, tp, expr),
+        'ProjectExec',
         conf={'spark.sql.ansi.enabled': ansi_enabled})

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,8 @@ object GpuCanonicalize {
 
   /** Rearrange expressions that are commutative or associative. */
   private def expressionReorder(e: Expression): Expression = e match {
-    case a: GpuAdd => orderCommutative(a, { case GpuAdd(l, r) => Seq(l, r) }).reduce(GpuAdd)
+    case a @ GpuAdd(_, _, f) =>
+      orderCommutative(a, { case GpuAdd(l, r, _) => Seq(l, r) }).reduce(GpuAdd(_, _, f))
     case m: GpuMultiply =>
       orderCommutative(m, { case GpuMultiply(l, r) => Seq(l, r) }).reduce(GpuMultiply)
     case o: GpuOr =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/LogOperatorUnitTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/LogOperatorUnitTestSuite.scala
@@ -50,7 +50,7 @@ class LogOperatorUnitTestSuite extends GpuExpressionTestSuite {
     }
 
     checkEvaluateGpuUnaryMathExpression(GpuLog(GpuAdd(childExpr, GpuLiteral(1d,
-      DataTypes.DoubleType))), expectedFun, schema)
+      DataTypes.DoubleType), false)), expectedFun, schema)
   }
 
   test("log2") {


### PR DESCRIPTION
And let Multiply fall back to CPU when ANSI mode is enabled.

This closes https://github.com/NVIDIA/spark-rapids/issues/3472

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
