### PR TITLE
Range window supports DayTime on 3.2+

### DIFF
--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/GpuWindows.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/GpuWindows.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuSpecifiedWindowFrameMetaBase, GpuWindowExpressionMetaBase, ParsedBoundary, RapidsConf, RapidsMeta}
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, SpecifiedWindowFrame, WindowExpression}
+import org.apache.spark.sql.types.{CalendarIntervalType, DataType, DateType, IntegerType, TimestampType}
+
+class GpuSpecifiedWindowFrameMeta(
+    windowFrame: SpecifiedWindowFrame,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_,_,_]],
+    rule: DataFromReplacementRule)
+  extends GpuSpecifiedWindowFrameMetaBase(windowFrame, conf, parent, rule) {}
+
+class GpuWindowExpressionMeta(
+    windowExpression: WindowExpression,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_,_,_]],
+    rule: DataFromReplacementRule)
+  extends GpuWindowExpressionMetaBase(windowExpression, conf, parent, rule) {}
+
+object GpuWindowUtil {
+
+  /**
+   * Check if the type of RangeFrame is valid in GpuWindowSpecDefinition
+   * @param orderSpecType the first order by data type
+   * @param ft the first frame boundary data type
+   * @return true to valid, false to invalid
+   */
+  def isValidRangeFrameType(orderSpecType: DataType, ft: DataType): Boolean = {
+    (orderSpecType, ft) match {
+      case (DateType, IntegerType) => true
+      case (TimestampType, CalendarIntervalType) => true
+      case (a, b) => a == b
+    }
+  }
+
+  def getRangeBoundaryValue(boundary: Expression): ParsedBoundary = boundary match {
+    case anything => throw new UnsupportedOperationException("Unsupported window frame" +
+      s" expression $anything")
+  }
+}
+

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -66,4 +66,7 @@ object TypeSigUtil extends com.nvidia.spark.rapids.TypeSigUtil {
    */
   override def mapDataTypeToTypeEnum(dataType: DataType): TypeEnum.Value = TypeEnum.UDT
 
+  /** Get numeric and interval TypeSig */
+  override def getNumericAndInterval(): TypeSig =
+    TypeSig.numeric + TypeSig.CALENDAR
 }

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/GpuWindows.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/GpuWindows.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuLiteral, GpuSpecifiedWindowFrameMetaBase, GpuWindowExpressionMetaBase, ParsedBoundary, RapidsConf, RapidsMeta}
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, SpecifiedWindowFrame, WindowExpression}
+import org.apache.spark.sql.rapids.shims.v2.Spark32XShimsUtils
+import org.apache.spark.sql.types.{DataType, DayTimeIntervalType}
+
+class GpuSpecifiedWindowFrameMeta(
+    windowFrame: SpecifiedWindowFrame,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_,_,_]],
+    rule: DataFromReplacementRule)
+  extends GpuSpecifiedWindowFrameMetaBase(windowFrame, conf, parent, rule) {
+
+  override def getAndTagOtherTypesForRangeFrame(bounds: Expression, isLower: Boolean): Long = {
+    bounds match {
+      case Literal(value, _: DayTimeIntervalType) => value.asInstanceOf[Long]
+      case _ =>super.getAndTagOtherTypesForRangeFrame(bounds, isLower)
+    }
+  }
+}
+
+class GpuWindowExpressionMeta(
+    windowExpression: WindowExpression,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_,_,_]],
+    rule: DataFromReplacementRule)
+  extends GpuWindowExpressionMetaBase(windowExpression, conf, parent, rule) {
+
+  override def tagOtherTypesForRangeFrame(bounds: Expression): Unit = {
+    bounds match {
+      case Literal(_, _: DayTimeIntervalType) => // Supported
+      case _ => super.tagOtherTypesForRangeFrame(bounds)
+    }
+  }
+}
+
+object GpuWindowUtil {
+
+  /**
+   * Check if the type of RangeFrame is valid in GpuWindowSpecDefinition
+   * @param orderSpecType the first order by data type
+   * @param ft the first frame boundary data type
+   * @return true to valid, false to invalid
+   */
+  def isValidRangeFrameType(orderSpecType: DataType, ft: DataType): Boolean = {
+    Spark32XShimsUtils.isValidRangeFrameType(orderSpecType, ft)
+  }
+
+  def getRangeBoundaryValue(boundary: Expression): ParsedBoundary = boundary match {
+    case GpuLiteral(value, _: DayTimeIntervalType) =>
+      var x = value.asInstanceOf[Long]
+      if (x == Long.MinValue) x = Long.MaxValue
+      ParsedBoundary(isUnbounded = false, Math.abs(x))
+    case anything => throw new UnsupportedOperationException("Unsupported window frame" +
+      s" expression $anything")
+  }
+}

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -60,4 +60,7 @@ object TypeSigUtil extends com.nvidia.spark.rapids.TypeSigUtil {
     }
   }
 
+  /** Get numeric and interval TypeSig */
+  override def getNumericAndInterval(): TypeSig =
+    TypeSig.numeric + TypeSig.CALENDAR + TypeSig.DAYTIME + TypeSig.YEARMONTH
 }

--- a/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/Spark32XShimsUtils.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/v2/Spark32XShimsUtils.scala
@@ -17,11 +17,23 @@
 package org.apache.spark.sql.rapids.shims.v2
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{CalendarIntervalType, DataType, DateType, DayTimeIntervalType, IntegerType, TimestampNTZType, TimestampType, YearMonthIntervalType}
 
 object Spark32XShimsUtils {
 
   def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.leafNodeDefaultParallelism
+  }
+
+  def isValidRangeFrameType(orderSpecType: DataType, ft: DataType): Boolean = {
+    (orderSpecType, ft) match {
+      case (DateType, IntegerType) => true
+      case (DateType, _: YearMonthIntervalType) => true
+      case (TimestampType | TimestampNTZType, CalendarIntervalType) => true
+      case (TimestampType | TimestampNTZType, _: YearMonthIntervalType) => true
+      case (TimestampType | TimestampNTZType, _: DayTimeIntervalType) => true
+      case (a, b) => a == b
+    }
   }
 
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -23,6 +23,7 @@ import scala.reflect.ClassTag
 
 import ai.rapids.cudf.DType
 import com.nvidia.spark.rapids.GpuOverrides.exec
+import com.nvidia.spark.rapids.shims.v2.{GpuSpecifiedWindowFrameMeta, GpuWindowExpressionMeta}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{AggregationOverWindow, DType, GroupByOptions, GroupByScanAggregation, NullPolicy, NvtxColor, ReplacePolicy, ReplacePolicyWithColumn, Scalar, ScanAggregation, ScanType, Table, WindowOptions}
-import com.nvidia.spark.rapids.shims.v2.ShimUnaryExecNode
+import com.nvidia.spark.rapids.shims.v2.{GpuWindowUtil, ShimUnaryExecNode}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
@@ -633,8 +633,7 @@ object GroupedAggregations extends Arm {
       var x = value.asInstanceOf[Long]
       if (x == Long.MinValue) x = Long.MaxValue
       ParsedBoundary(isUnbounded = false, Math.abs(x))
-    case anything => throw new UnsupportedOperationException("Unsupported window frame" +
-        s" expression $anything")
+    case anything => GpuWindowUtil.getRangeBoundaryValue(anything)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -66,6 +66,8 @@ trait TypeSigUtil {
    */
   def mapDataTypeToTypeEnum(dataType: DataType): TypeEnum.Value
 
+  /** Get numeric and interval TypeSig */
+  def getNumericAndInterval(): TypeSig
 }
 
 /**
@@ -654,7 +656,7 @@ object TypeSig {
   /**
    * numeric + CALENDAR
    */
-  val numericAndInterval: TypeSig = numeric + CALENDAR
+  val numericAndInterval: TypeSig = TypeSigUtil.getNumericAndInterval()
 
   /**
    * All types that CUDF supports sorting/ordering on.


### PR DESCRIPTION
This PR is to fix window failed unit tests and some window failed integration tests caused by the new DayTime/YearMonth types. See https://github.com/NVIDIA/spark-rapids/issues/3415 

With this PR, all window unit tests can pass and most of window integration tests can pass also except 

``` console
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Byte-1000]
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Byte-1g]
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Short-1000]
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Short-1g]
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Integer-1000]
FAILED ../../src/main/python/window_function_test.py::test_window_running_no_part[data:Integer-1g]
FAILED ../../src/main/python/window_function_test.py::test_running_float_sum_no_part[1000][APPROXIMATE_FLOAT]
FAILED ../../src/main/python/window_function_test.py::test_running_float_sum_no_part[1g][APPROXIMATE_FLOAT]
```

I will file a following issue for the failed integration tests.