### PR TITLE
Add IDEA profile switch workarounds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,16 @@ Spark version, open [Maven tool window](https://www.jetbrains.com/help/idea/2021
 select one of the `release3xx` profiles (e.g, `release320`) for Apache Spark 3.2.0, and click "Reload" 
 if not triggered automatically.
 
+There is a known issue with the shims/spark3xx submodules. After being enabled once, a module such as shims/spark312 
+may remain active in IDEA even though you explicitly disable the Maven profile `release312` in the Maven tool window.
+With an extra IDEA shim module loaded the IDEA internal build "Build->Build Project" is likely to fail 
+(whereas it has no adverse effect on Maven build). As a workaround, locate the pom.xml under the extraneous IDEA module,
+right-click on it and select "Maven->Ignore Projects".
+
+If you see Scala symbols unresolved (highlighted red) in IDEA please try the following steps to resolve it:
+- Make sure there are no relevant poms in "File->Settings->Build Tools->Maven->Ignored Files" 
+- Restart IDEA and click "Reload All Maven Projects" again 
+
 #### Other IDEs
 We welcome pull requests with tips how to setup your favorite IDE!
 


### PR DESCRIPTION
explain how to deal with sticky shim IDEA modules that should have been deactivated based on the release3xx profile

Signed-off-by: Gera Shegalov <gera@apache.org>
