### PR TITLE
Auto-dedupe ASM-relocated shim dependencies

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -30,7 +30,11 @@
     <version>21.10.0-SNAPSHOT</version>
 
     <properties>
-        <rapids.shade.package>com.nvidia.shaded.${spark.version.classifier}.spark</rapids.shade.package>
+        <!--
+        we store ASM-relocated packages in /spark3xx parallel worlds in dist
+        and they are auto-deduped using binary diff
+        -->
+        <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
     </properties>
     <dependencies>
         <dependency>

--- a/dist/scripts/binary-dedupe.sh
+++ b/dist/scripts/binary-dedupe.sh
@@ -66,7 +66,7 @@ echo PWD
 # it's now safe to delete duplicate .class files from the original locations
 # don't use rm */% because globbing is broken for files containing $
 for shimDir in $SHIM_DIRS; do
-  xargs --arg-file="$SPARK3XX_COMMON_TXT" -n 100 -I% rm "$PARALLEL_WORLDS_DIR/$shimDir/%"
+  xargs --arg-file="$SPARK3XX_COMMON_TXT" -P 4 -n 100 -I% rm "$PARALLEL_WORLDS_DIR/$shimDir/%"
 done
 
 mv "$SPARK3XX_COMMON_DIR" $PARALLEL_WORLDS_DIR/

--- a/dist/unshimmed-base.txt
+++ b/dist/unshimmed-base.txt
@@ -2,7 +2,6 @@ META-INF/DEPENDENCIES
 META-INF/LICENSE
 META-INF/NOTICE
 META-INF/maven/**
-com/nvidia/shaded/**
 com/nvidia/spark/RapidsUDF*
 com/nvidia/spark/SQLPlugin*
 com/nvidia/spark/rapids/ExecutionPlanCaptureCallback*


### PR DESCRIPTION
1. Remove the spark version classifier from the package name and just
   com.nvidia.spark.shaded for ASM-based relocation
2. Remove com/nvidia/spark/shaded from unshimmed classes
3. As a result they get auto-deduped in spark3xx-common

For minimumFeatureVersionMix profile consisting of
 - spark302
 - spark311cdh
 - spark312
 - spark320

the jar size goes down from 29M to 17M after compression

Pre-compression breakdown
```
$ du -h -s dist/target/parallel-world/spark*/com/nvidia/shaded
372K	dist/target/parallel-world/spark302/com/nvidia/shaded
372K	dist/target/parallel-world/spark311cdh/com/nvidia/shaded
372K	dist/target/parallel-world/spark312/com/nvidia/shaded
372K	dist/target/parallel-world/spark320/com/nvidia/shaded
15M	dist/target/parallel-world/spark3xx-common/com/nvidia/shade
```

Instead of storing 15M per shim we end up storing 312K delta per shim

This will only improve once we have commons per FEATURE versions lines:
3.0.x, 3.1.x, 3.2.x

Signed-off-by: Gera Shegalov <gera@apache.org>