### PR TITLE
Add commons-lang3 dependency to tests [databricks]

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -189,6 +189,12 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
                     <version>${spark.version}</version>


### PR DESCRIPTION
#3504 added a test that uses commons lang3 but this was missing from the dependency list on Databricks for the test pom.