### PR TITLE
ANSI Support for Abs, UnaryMinus, and Subtract

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -714,7 +714,7 @@ _data_type_expr_for_sub_overflow = [
     ([-32768], ShortType(), 'a -1S'),
     ([-2147483648], IntegerType(), 'a - 1'),
     ([-9223372036854775808], LongType(), 'a - 1L'),
-    ([-3.4028235E38], FloatType(), 'a - 1.0f'),
+    ([-3.4028235E38], FloatType(), 'a - cast(1.0 as float)'),
     ([-1.7976931348623157E308], DoubleType(), 'a - 1.0')]
 
 @pytest.mark.parametrize('data,tp,expr', _data_type_expr_for_sub_overflow)

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -83,7 +83,7 @@ def test_cast_string_ts_valid_format():
 def test_cast_string_date_fallback():
     assert_gpu_fallback_collect(
             # Cast back to String because this goes beyond what python can support for years
-            lambda spark : unary_op_df(spark, StringGen('([0-9]|-|\+){4,12}')).select(f.col('a').cast(DateType()).cast(StringType())),
+            lambda spark : unary_op_df(spark, StringGen('([0-9]|-|\\+){4,12}')).select(f.col('a').cast(DateType()).cast(StringType())),
             'Cast')
 
 @allow_non_gpu('ProjectExec', 'Cast', 'Alias')
@@ -91,7 +91,7 @@ def test_cast_string_date_fallback():
 def test_cast_string_timestamp_fallback():
     assert_gpu_fallback_collect(
             # Cast back to String because this goes beyond what python can support for years
-            lambda spark : unary_op_df(spark, StringGen('([0-9]|-|\+){4,12}')).select(f.col('a').cast(TimestampType()).cast(StringType())),
+            lambda spark : unary_op_df(spark, StringGen('([0-9]|-|\\+){4,12}')).select(f.col('a').cast(TimestampType()).cast(StringType())),
             'Cast',
             conf = {'spark.rapids.sql.castStringToTimestamp.enabled': 'true'})
 

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -176,11 +176,11 @@ class StringGen(DataGen):
             length = _MAX_CHOICES
         self._start(rand, lambda : strs[rand.randrange(0, length)])
 
-_BYTE_MIN = -(1 << 7)
-_BYTE_MAX = (1 << 7) - 1
+BYTE_MIN = -(1 << 7)
+BYTE_MAX = (1 << 7) - 1
 class ByteGen(DataGen):
     """Generate Bytes"""
-    def __init__(self, nullable=True, min_val =_BYTE_MIN, max_val = _BYTE_MAX, special_cases=[]):
+    def __init__(self, nullable=True, min_val = BYTE_MIN, max_val = BYTE_MAX, special_cases=[]):
         super().__init__(ByteType(), nullable=nullable, special_cases=special_cases)
         self._min_val = min_val
         self._max_val = max_val

--- a/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
+++ b/shims/spark301/src/main/scala/com/nvidia/spark/rapids/shims/spark301/SparkBaseShims.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNes
 import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPythonExec, FlatMapGroupsInPandasExec, MapInPandasExec, WindowInPandasExec}
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDF
 import org.apache.spark.sql.rapids.execution.python.shims.spark301._
@@ -301,6 +301,14 @@ abstract class SparkBaseShims extends Spark30XShims {
           }
 
           override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+        }),
+      GpuOverrides.expr[Abs](
+        "Absolute value",
+        ExprChecks.unaryProjectAndAstInputMatchesOutput(
+          TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+        (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+          // ANSI support for ABS was added in 3.2.0 SPARK-33275
+          override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
         }),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",

--- a/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
+++ b/shims/spark301db/src/main/scala/com/nvidia/spark/rapids/shims/spark301db/SparkBaseShims.scala
@@ -57,7 +57,7 @@ import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch, TrampolineUtil}
 import org.apache.spark.sql.rapids.execution.python.{GpuFlatMapGroupsInPandasExecMeta, GpuPythonUDF}
 import org.apache.spark.sql.rapids.execution.python.shims.spark301db._
@@ -324,6 +324,14 @@ abstract class SparkBaseShims extends Spark30XShims {
           }
 
           override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+        }),
+      GpuOverrides.expr[Abs](
+        "Absolute value",
+        ExprChecks.unaryProjectAndAstInputMatchesOutput(
+          TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+        (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+          // ANSI support for ABS was added in 3.2.0 SPARK-33275
+          override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
         }),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",

--- a/shims/spark302/src/main/scala/com/nvidia/spark/rapids/shims/spark302/SparkBaseShims.scala
+++ b/shims/spark302/src/main/scala/com/nvidia/spark/rapids/shims/spark302/SparkBaseShims.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNes
 import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPythonExec, FlatMapGroupsInPandasExec, MapInPandasExec, WindowInPandasExec}
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDF
 import org.apache.spark.sql.rapids.execution.python.shims.spark302._
@@ -301,6 +301,14 @@ abstract class SparkBaseShims extends Spark30XShims {
           }
 
           override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+        }),
+      GpuOverrides.expr[Abs](
+        "Absolute value",
+        ExprChecks.unaryProjectAndAstInputMatchesOutput(
+          TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+        (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+          // ANSI support for ABS was added in 3.2.0 SPARK-33275
+          override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
         }),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",

--- a/shims/spark303/src/main/scala/com/nvidia/spark/rapids/shims/spark303/SparkBaseShims.scala
+++ b/shims/spark303/src/main/scala/com/nvidia/spark/rapids/shims/spark303/SparkBaseShims.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNes
 import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPythonExec, FlatMapGroupsInPandasExec, MapInPandasExec, WindowInPandasExec}
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDF
 import org.apache.spark.sql.rapids.execution.python.shims.spark303._
@@ -301,6 +301,14 @@ abstract class SparkBaseShims extends Spark30XShims {
           }
 
           override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+        }),
+      GpuOverrides.expr[Abs](
+        "Absolute value",
+        ExprChecks.unaryProjectAndAstInputMatchesOutput(
+          TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+        (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+          // ANSI support for ABS was added in 3.2.0 SPARK-33275
+          override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
         }),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",

--- a/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/SparkBaseShims.scala
+++ b/shims/spark304/src/main/scala/com/nvidia/spark/rapids/shims/spark304/SparkBaseShims.scala
@@ -54,7 +54,7 @@ import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNes
 import org.apache.spark.sql.execution.python.{AggregateInPandasExec, ArrowEvalPythonExec, FlatMapGroupsInPandasExec, MapInPandasExec, WindowInPandasExec}
 import org.apache.spark.sql.execution.window.WindowExecBase
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.{GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAverage, GpuFileSourceScanExec, GpuStringReplace, GpuTimeSub}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExecBase, GpuBroadcastNestedLoopJoinExecBase, GpuShuffleExchangeExecBase, JoinTypeChecks, SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDF
 import org.apache.spark.sql.rapids.execution.python.shims.spark304._
@@ -301,6 +301,14 @@ abstract class SparkBaseShims extends Spark30XShims {
           }
 
           override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+        }),
+      GpuOverrides.expr[Abs](
+        "Absolute value",
+        ExprChecks.unaryProjectAndAstInputMatchesOutput(
+          TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+        (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+          // ANSI support for ABS was added in 3.2.0 SPARK-33275
+          override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
         }),
       GpuOverrides.expr[RegExpReplace](
         "RegExpReplace support for string literal input patterns",

--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
@@ -235,6 +235,14 @@ abstract class SparkBaseShims extends Spark30XShims {
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
       }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
+      }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,

--- a/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
+++ b/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
@@ -249,6 +249,14 @@ abstract class SparkBaseShims extends Spark30XShims {
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
       }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
+      }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
@@ -221,6 +221,14 @@ abstract class SparkBaseShims extends Spark30XShims {
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
       }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
+      }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
@@ -235,6 +235,14 @@ abstract class SparkBaseShims extends Spark30XShims {
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
       }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
+      }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
@@ -235,6 +235,14 @@ abstract class SparkBaseShims extends Spark30XShims {
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
       }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, false)
+      }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",
       ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,

--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, Attribute, Cast, ElementAt, Expression, ExprId, GetArrayItem, GetMapValue, Lag, Lead, Literal, NamedExpression, NullOrdering, PlanExpression, PythonUDF, RegExpReplace, ScalaUDF, SortDirection, SortOrder, SpecifiedWindowFrame, TimeAdd, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Alias, AnsiCast, Attribute, Cast, ElementAt, Expression, ExprId, GetArrayItem, GetMapValue, Lag, Lead, Literal, NamedExpression, NullOrdering, PlanExpression, PythonUDF, RegExpReplace, ScalaUDF, SortDirection, SortOrder, SpecifiedWindowFrame, TimeAdd, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.Average
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
@@ -233,6 +233,22 @@ class Spark320Shims extends Spark32XShims {
         }
 
         override def convertToGpu(child: Expression): GpuExpression = GpuAverage(child)
+      }),
+    GpuOverrides.expr[Abs](
+      "Absolute value",
+      ExprChecks.unaryProjectAndAstInputMatchesOutput(
+        TypeSig.implicitCastsAstTypes, TypeSig.gpuNumeric, TypeSig.numeric),
+      (a, conf, p, r) => new UnaryAstExprMeta[Abs](a, conf, p, r) {
+        val ansiEnabled = SQLConf.get.ansiEnabled
+
+        override def tagSelfForAst(): Unit = {
+          if (ansiEnabled && GpuAnsi.needBasicOpOverflowCheck(a.dataType)) {
+            willNotWorkInAst("AST unary minus does not support ANSI mode.")
+          }
+        }
+
+        // ANSI support for ABS was added in 3.2.0 SPARK-33275
+        override def convertToGpu(child: Expression): GpuExpression = GpuAbs(child, ansiEnabled)
       }),
     GpuOverrides.expr[RegExpReplace](
       "RegExpReplace support for string literal input patterns",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1664,7 +1664,7 @@ object GpuOverrides extends Logging {
         ("lhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval),
         ("rhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval)),
       (a, conf, p, r) => new BinaryAstExprMeta[Add](a, conf, p, r) {
-        val ansiEnabled = SQLConf.get.ansiEnabled
+        private val ansiEnabled = SQLConf.get.ansiEnabled
 
         override def tagSelfForAst(): Unit = {
           if (ansiEnabled && GpuAnsi.needBasicOpOverflowCheck(a.dataType)) {
@@ -1683,8 +1683,16 @@ object GpuOverrides extends Logging {
         ("lhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval),
         ("rhs", TypeSig.gpuNumeric, TypeSig.numericAndInterval)),
       (a, conf, p, r) => new BinaryAstExprMeta[Subtract](a, conf, p, r) {
+        private val ansiEnabled = SQLConf.get.ansiEnabled
+
+        override def tagSelfForAst(): Unit = {
+          if (ansiEnabled && GpuAnsi.needBasicOpOverflowCheck(a.dataType)) {
+            willNotWorkInAst("AST Subtraction does not support ANSI mode.")
+          }
+        }
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuSubtract(lhs, rhs)
+          GpuSubtract(lhs, rhs, ansiEnabled)
       }),
     expr[Multiply](
       "Multiplication",


### PR DESCRIPTION
I will do divide, IntegralDivide, Remainder, and Pmod as a separate PR because there are some parts that are done, but other parts that are not and each is spread out among different Spark versions, which makes this fun to try and shim correctly.