### PR TITLE
Add in ANSI date time fallback

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/SparkBaseShims.scala
@@ -850,4 +850,6 @@ abstract class SparkBaseShims extends Spark30XShims {
     kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
       new KryoJavaSerializer())
   }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
+++ b/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/SparkBaseShims.scala
@@ -864,4 +864,6 @@ abstract class SparkBaseShims extends Spark30XShims {
     kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
       new KryoJavaSerializer())
   }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/SparkBaseShims.scala
@@ -861,4 +861,6 @@ abstract class SparkBaseShims extends Spark30XShims {
     kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
       new KryoJavaSerializer())
   }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/SparkBaseShims.scala
@@ -848,4 +848,6 @@ abstract class SparkBaseShims extends Spark30XShims {
     kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
       new KryoJavaSerializer())
   }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/SparkBaseShims.scala
@@ -848,4 +848,6 @@ abstract class SparkBaseShims extends Spark30XShims {
     kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
       new KryoJavaSerializer())
   }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -90,10 +90,6 @@ trait Spark30XShims extends SparkShims {
         TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
     (exec, conf, p, r) => new GpuCustomShuffleReaderMeta(exec, conf, p, r))
 
-  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
-    ss.sparkContext.defaultParallelism
-  }
-
   override def findOperators(plan: SparkPlan, predicate: SparkPlan => Boolean): Seq[SparkPlan] = {
     def recurse(
         plan: SparkPlan,
@@ -116,4 +112,10 @@ trait Spark30XShims extends SparkShims {
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = false
 
   override def shouldFailDivOverflow(): Boolean = false
+
+  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
+    ss.sparkContext.defaultParallelism
+  }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 }

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -126,4 +126,5 @@ trait Spark30XShims extends SparkShims {
     ss.sparkContext.defaultParallelism
   }
 
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 }

--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -90,12 +90,6 @@ trait Spark30XShims extends SparkShims {
         TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
     (exec, conf, p, r) => new GpuCustomShuffleReaderMeta(exec, conf, p, r))
 
-  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
-    ss.sparkContext.defaultParallelism
-  }
-
-  override def shouldFailDivOverflow(): Boolean = false
-
   override def findOperators(plan: SparkPlan, predicate: SparkPlan => Boolean): Seq[SparkPlan] = {
     def recurse(
         plan: SparkPlan,
@@ -116,4 +110,12 @@ trait Spark30XShims extends SparkShims {
   }
 
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = false
+
+  override def shouldFailDivOverflow(): Boolean = false
+
+  override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
+    ss.sparkContext.defaultParallelism
+  }
+
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 }

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -137,6 +137,7 @@ trait Spark32XShims extends SparkShims {
     Spark32XShimsUtils.leafNodeDefaultParallelism(ss)
   }
 
+  override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 }
 
 // TODO dedupe utils inside shims

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -218,7 +218,13 @@ trait SparkShims {
 
   def shouldFailDivByZero(): Boolean
 
-  def shouldFailDivOverflow(): Boolean
+  def shouldFailDivOverflow: Boolean
+
+  /**
+   * This is specifically in relation to SPARK-33498 which went into 3.1.0. We cannot fully support
+   * it right now, so we fall back to the CPU in those cases.
+   */
+  def shouldFallbackOnAnsiTimestamp(): Boolean
 
   def createTable(table: CatalogTable,
     sessionCatalog: SessionCatalog,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -17,11 +17,14 @@
 
 package org.apache.spark.sql.catalyst.expressions.rapids
 
-import com.nvidia.spark.rapids.{ExprChecks, ExprRule, GpuExpression, GpuOverrides, TypeEnum, TypeSig}
+import com.nvidia.spark.rapids.{ExprChecks, ExprRule, GpuExpression, GpuOverrides, ShimLoader, TypeEnum, TypeSig}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, GetTimestamp}
 import org.apache.spark.sql.rapids.{GpuGetTimestamp, UnixTimeExprMeta}
 
+/**
+ * GetTimestamp is marked as private so we had to put it in a place that could access it.
+ */
 object TimeStamp {
 
   def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
@@ -35,6 +38,9 @@ object TimeStamp {
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[GetTimestamp](a, conf, p, r) {
+        override def shouldFallbackOnAnsiTimestamp: Boolean =
+          ShimLoader.getSparkShims.shouldFallbackOnAnsiTimestamp
+
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
           GpuGetTimestamp(lhs, rhs, sparkFormat, strfFormat)
         }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -564,7 +564,7 @@ case class GpuIntegralDivide(left: Expression, right: Expression) extends GpuDiv
   override def inputType: AbstractDataType = TypeCollection(IntegralType, DecimalType)
 
   lazy val failOnOverflow: Boolean =
-    ShimLoader.getSparkShims.shouldFailDivOverflow()
+    ShimLoader.getSparkShims.shouldFailDivOverflow
 
   override def checkDivideOverflow: Boolean = left.dataType match {
     case LongType if failOnOverflow => true

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -380,10 +380,17 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
    parent: Option[RapidsMeta[_, _, _]],
    rule: DataFromReplacementRule)
   extends BinaryExprMeta[A](expr, conf, parent, rule) {
+
+  def shouldFallbackOnAnsiTimestamp: Boolean
+
   var sparkFormat: String = _
   var strfFormat: String = _
   override def tagExprForGpu(): Unit = {
     checkTimeZoneId(expr.timeZoneId)
+
+    if (shouldFallbackOnAnsiTimestamp) {
+      willNotWorkOnGpu("ANSI mode is not supported")
+    }
 
     // Date and Timestamp work too
     if (expr.right.dataType == StringType) {


### PR DESCRIPTION
It is hard for us to match exactly what spark is doing for date/time parsing fallback in ANSI mode. I will file a follow on issue to see if we can actually support it, but for now we just fall back to the CPU. 