### PR TITLE
com.nvidia.spark.rapids.ColumnarRdd not exposed to user for XGBoost

### DIFF
--- a/dist/unshimmed-common-from-spark301.txt
+++ b/dist/unshimmed-common-from-spark301.txt
@@ -5,6 +5,7 @@ META-INF/maven/**
 com/nvidia/spark/RapidsUDF*
 com/nvidia/spark/SQLPlugin*
 com/nvidia/spark/rapids/ExecutionPlanCaptureCallback*
+com/nvidia/spark/rapids/ColumnarRdd*
 com/nvidia/spark/rapids/PlanUtils*
 com/nvidia/spark/rapids/GpuKryoRegistrator*
 com/nvidia/spark/rapids/RapidsExecutorHeartbeatMsg*

--- a/dist/unshimmed-common-from-spark301.txt
+++ b/dist/unshimmed-common-from-spark301.txt
@@ -5,8 +5,8 @@ META-INF/maven/**
 com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin*
 com/nvidia/spark/RapidsUDF*
 com/nvidia/spark/SQLPlugin*
-com/nvidia/spark/rapids/ExecutionPlanCaptureCallback*
 com/nvidia/spark/rapids/ColumnarRdd*
+com/nvidia/spark/rapids/ExecutionPlanCaptureCallback*
 com/nvidia/spark/rapids/GpuKryoRegistrator*
 com/nvidia/spark/rapids/PlanUtils*
 com/nvidia/spark/rapids/RapidsExecutorHeartbeatMsg*

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
@@ -39,11 +39,18 @@ import org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter
  * when they no longer need it.
  */
 object ColumnarRdd {
+
+  lazy val internalConverter: Class[_] = ShimLoader.newColumnarRDDClass()
+
   def apply(df: DataFrame): RDD[Table] = {
-    InternalColumnarRddConverter(df)
+    internalConverter
+      .getDeclaredMethod("apply", classOf[DataFrame])
+      .invoke(null, df).asInstanceOf[RDD[Table]]
   }
 
   def convert(df: DataFrame): RDD[Table] = {
-    InternalColumnarRddConverter.convert(df)
+    internalConverter
+      .getDeclaredMethod("convert", classOf[DataFrame])
+      .invoke(null, df).asInstanceOf[RDD[Table]]
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import java.lang.reflect.Method
+
 import ai.rapids.cudf.Table
 
 import org.apache.spark.rdd.RDD
@@ -39,15 +41,14 @@ import org.apache.spark.sql.DataFrame
  */
 object ColumnarRdd {
 
-  lazy val internalConverter: Class[_] = ShimLoader.newColumnarRDDClass()
+  lazy val convertMethod: Method = ShimLoader.newColumnarRDDClass()
+    .getDeclaredMethod("convert", classOf[DataFrame])
 
   def apply(df: DataFrame): RDD[Table] = {
     convert(df)
   }
 
   def convert(df: DataFrame): RDD[Table] = {
-    internalConverter
-      .getDeclaredMethod("convert", classOf[DataFrame])
-      .invoke(null, df).asInstanceOf[RDD[Table]]
+    convertMethod.invoke(null, df).asInstanceOf[RDD[Table]]
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
@@ -42,9 +42,7 @@ object ColumnarRdd {
   lazy val internalConverter: Class[_] = ShimLoader.newColumnarRDDClass()
 
   def apply(df: DataFrame): RDD[Table] = {
-    internalConverter
-      .getDeclaredMethod("apply", classOf[DataFrame])
-      .invoke(null, df).asInstanceOf[RDD[Table]]
+    convert(df)
   }
 
   def convert(df: DataFrame): RDD[Table] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import ai.rapids.cudf.Table
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter
 
 /**
  * This provides a way to get back out GPU Columnar data RDD[Table]. Each Table will have the same

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarRdd.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.DataFrame
  */
 object ColumnarRdd {
 
-  lazy val convertMethod: Method = ShimLoader.newColumnarRDDClass()
+  lazy val convertMethod: Method = ShimLoader.loadColumnarRDD()
     .getDeclaredMethod("convert", classOf[DataFrame])
 
   def apply(df: DataFrame): RDD[Table] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -288,6 +288,12 @@ object ShimLoader extends Logging {
     shimProviderClass = classname
   }
 
+  def newClassOf(className: String): Class[_] = {
+    val loader = getShimClassLoader()
+    logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
+    loader.loadClass(className)
+  }
+
   def newInstanceOf[T](className: String): T = {
     val loader = getShimClassLoader()
     logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
@@ -337,6 +343,10 @@ object ShimLoader extends Logging {
 
   def newUdfLogicalPlanRules(): Rule[LogicalPlan] = {
     newInstanceOf("com.nvidia.spark.udf.LogicalPlanRules")
+  }
+
+  def newColumnarRDDClass(): Class[_] = {
+    newClassOf("com.nvidia.spark.rapids.InternalColumnarRddConverter")
   }
 
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -346,7 +346,7 @@ object ShimLoader extends Logging {
   }
 
   def newColumnarRDDClass(): Class[_] = {
-    newClassOf("com.nvidia.spark.rapids.InternalColumnarRddConverter")
+    newClassOf("org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter")
   }
 
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -289,16 +289,14 @@ object ShimLoader extends Logging {
     shimProviderClass = classname
   }
 
-  def newClassOf(className: String): Class[_] = {
+  def loadClass(className: String): Class[_] = {
     val loader = getShimClassLoader()
     logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
     loader.loadClass(className)
   }
 
   def newInstanceOf[T](className: String): T = {
-    val loader = getShimClassLoader()
-    logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
-    instantiateClass(loader.loadClass(className)).asInstanceOf[T]
+    instantiateClass(loadClass(className)).asInstanceOf[T]
   }
 
   // avoid cached constructors
@@ -350,7 +348,7 @@ object ShimLoader extends Logging {
     newInstanceOf("com.nvidia.spark.rapids.InternalExclusiveModeGpuDiscoveryPlugin")
   }
 
-  def newColumnarRDDClass(): Class[_] = {
-    newClassOf("org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter")
+  def loadColumnarRDD(): Class[_] = {
+    loadClass("org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter")
   }
 }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/3601

we were not exposing ColumnarRDD as an unshimmed class.  This fixes that. I tested on xgboost with the python notebook and verified it works now.

This is a bit different since its an object and not a real class we instantiate, so if we have better ways to do this let me know, or we can followup as I'm sure we will have more things that need things like this.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
