### PR TITLE
Ignore order for the test_no_fallback_when_ansi_enabled

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1158,7 +1158,7 @@ def test_count_fallback_when_ansi_enabled(data_gen):
     assert_gpu_fallback_collect(do_it, 'Count',
         conf={'spark.sql.ansi.enabled': 'true'})
 
-@ignore_order
+@ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
 def test_no_fallback_when_ansi_enabled(data_gen):
     def do_it(spark):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1158,7 +1158,7 @@ def test_count_fallback_when_ansi_enabled(data_gen):
     assert_gpu_fallback_collect(do_it, 'Count',
         conf={'spark.sql.ansi.enabled': 'true'})
 
-
+@ignore_order
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
 def test_no_fallback_when_ansi_enabled(data_gen):
     def do_it(spark):


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes #3611 

This was a dumb mistake that @razajafri found in https://github.com/NVIDIA/spark-rapids/pull/3330. As @jlowe nicely put it, yeah what I was trying to do is not deterministic given the hash tables involved (partitioning and in the group by), since I didn't have a sort _after_ the operation.