### PR TITLE
Update the doc of GpuListUtils to eliminate a linkage warning.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
@@ -30,7 +30,7 @@ object GpuListUtils extends Arm {
    * both listCol and newDataCol alive longer than the returned ColumnView.
    * @param listCol the list column to use as a template
    * @param newDataCol the new data column.
-   * @return a new ColumnView. But throws an scala.IllegalArgumentException if data column does
+   * @return a new ColumnView. Throws IllegalArgumentException if data column does
    *                           not match the original data column in size.
    */
   def replaceListDataColumnAsView(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
@@ -30,9 +30,8 @@ object GpuListUtils extends Arm {
    * both listCol and newDataCol alive longer than the returned ColumnView.
    * @param listCol the list column to use as a template
    * @param newDataCol the new data column.
-   * @return a new ColumnView.
-   * @throws scala.IllegalArgumentException if data column does not match the original data column
-   *                                        in size.
+   * @return a new ColumnView. But throws an scala.IllegalArgumentException if data column does
+   *                           not match the original data column in size.
    */
   def replaceListDataColumnAsView(
       listCol: ColumnView,


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/3520.

And the warning log on `GpuPythonUDF` is no longer found in recent builds.

Scaladoc will always try to create a link for the first word after the `@throws`, so here chooses to change it to a common comment instead of a tag.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
