### PR TITLE
Revert disabling of ctas test

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -372,7 +372,6 @@ def test_non_empty_ctas(spark_tmp_path, spark_tmp_table_factory, allow_non_empty
     data_path = spark_tmp_path + "/CTAS"
     conf = {
         "spark.sql.hive.convertCTAS": "true",
-        "spark.sql.legacy.createHiveTableByDefault": "false",
         "spark.sql.legacy.allowNonEmptyLocationInCTAS": str(allow_non_empty)
     }
     def test_it(spark):

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -366,7 +366,6 @@ def test_roundtrip_with_rebase_values(spark_tmp_path, ts_write_data_gen, date_ti
         data_path,
         conf=all_confs)
 
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/3476')
 @pytest.mark.allow_non_gpu("DataWritingCommandExec", "HiveTableScanExec")
 @pytest.mark.parametrize('allow_non_empty', [True, False])
 def test_non_empty_ctas(spark_tmp_path, spark_tmp_table_factory, allow_non_empty):


### PR DESCRIPTION
Closes #3476

I was able to reproduce this in the EGX environment after running it exactly the same way the job does.

It looks like it boils down to a config we couldn't easily unset `spark.sql.hive.metastore.version` and `spark.sql.hive.metastore.jars`. If I point the job at configs without the two, spark picks the "builtin" version, which seems ideal, so we don't have to match hive client jars to the versions of Spark we are testing.

I also reverted `"spark.sql.legacy.createHiveTableByDefault": "false",` and tested that it works without this diff as well.