### PR TITLE
Properly override Shims for int96Rebase [databricks]

### DIFF
--- a/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
+++ b/shims/spark311/src/main/scala/com/nvidia/spark/rapids/shims/spark311/Spark311Shims.scala
@@ -32,22 +32,6 @@ class Spark311Shims extends SparkBaseShims {
     classOf[RapidsShuffleManager].getCanonicalName
   }
 
-  override def int96ParquetRebaseRead(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
-  }
-
-  override def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
-  }
-
-  override def int96ParquetRebaseReadKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
-  }
-
-  override def int96ParquetRebaseWriteKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
-  }
-
   override def hasCastFloatTimestampUpcast: Boolean = false
 
   override def getParquetFilters(

--- a/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/Spark311CDHShims.scala
+++ b/shims/spark311cdh/src/main/scala/com/nvidia/spark/rapids/shims/spark311cdh/Spark311CDHShims.scala
@@ -97,22 +97,6 @@ class Spark311CDHShims extends SparkBaseShims {
     sessionCatalog.createTable(newTable, ignoreIfExists = false, validateLocation = false)
   }
 
-  override def int96ParquetRebaseRead(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
-  }
-
-  override def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
-  }
-
-  override def int96ParquetRebaseReadKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
-  }
-
-  override def int96ParquetRebaseWriteKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
-  }
-  
   override def hasCastFloatTimestampUpcast: Boolean = false
 
   override def getParquetFilters(

--- a/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
+++ b/shims/spark311db/src/main/scala/com/nvidia/spark/rapids/shims/spark311db/Spark311dbShims.scala
@@ -44,19 +44,4 @@ class Spark311dbShims extends SparkBaseShims {
     new ParquetFilters(schema, pushDownDate, pushDownTimestamp, pushDownDecimal, pushDownStartWith,
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
 
-  override def int96ParquetRebaseRead(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
-  }
-
-  override def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
-  }
-
-  override def int96ParquetRebaseReadKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
-  }
-
-  override def int96ParquetRebaseWriteKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
-  }
 }

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
@@ -34,22 +34,6 @@ class Spark312Shims extends SparkBaseShims {
 
   override def hasCastFloatTimestampUpcast: Boolean = true
 
-  override def int96ParquetRebaseRead(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
-  }
-
-  override def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
-  }
-
-  override def int96ParquetRebaseReadKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
-  }
-
-  override def int96ParquetRebaseWriteKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
-  }
-
   override def getParquetFilters(
       schema: MessageType,
       pushDownDate: Boolean,

--- a/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
+++ b/shims/spark313/src/main/scala/com/nvidia/spark/rapids/shims/spark313/Spark313Shims.scala
@@ -46,19 +46,4 @@ class Spark313Shims extends SparkBaseShims {
 
   override def hasCastFloatTimestampUpcast: Boolean = true
 
-  override def int96ParquetRebaseRead(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
-  }
-
-  override def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
-  }
-
-  override def int96ParquetRebaseReadKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
-  }
-
-  override def int96ParquetRebaseWriteKey: String = {
-    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
-  }
 }

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -50,6 +50,15 @@ trait Spark30XShims extends SparkShims {
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ)
   override def parquetRebaseWrite(conf: SQLConf): String =
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    parquetRebaseRead(conf)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    parquetRebaseWrite(conf)
+  override def int96ParquetRebaseReadKey: String =
+    parquetRebaseReadKey
+  override def int96ParquetRebaseWriteKey: String =
+    parquetRebaseWriteKey
+  override def hasSeparateINT96RebaseConf: Boolean = false
 
   override def sessionFromPlan(plan: SparkPlan): SparkSession = {
     plan.sqlContext.sparkSession
@@ -112,8 +121,6 @@ trait Spark30XShims extends SparkShims {
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = false
 
   override def shouldFailDivOverflow(): Boolean = false
-
-  override def hasSeparateINT96RebaseConf: Boolean = false
 
   override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.sparkContext.defaultParallelism

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -50,6 +50,15 @@ trait Spark30XShims extends SparkShims {
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ)
   override def parquetRebaseWrite(conf: SQLConf): String =
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    parquetRebaseRead(conf)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    parquetRebaseWrite(conf)
+  override def int96ParquetRebaseReadKey: String =
+    parquetRebaseReadKey
+  override def int96ParquetRebaseWriteKey: String =
+    parquetRebaseWriteKey
+  override def hasSeparateINT96RebaseConf: Boolean = false
 
   override def sessionFromPlan(plan: SparkPlan): SparkSession = {
     plan.sqlContext.sparkSession
@@ -125,8 +134,6 @@ trait Spark30XShims extends SparkShims {
   override def leafNodeDefaultParallelism(ss: SparkSession): Int = {
     ss.sparkContext.defaultParallelism
   }
-
-  override def hasSeparateINT96RebaseConf: Boolean = false
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 }

--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -50,6 +50,15 @@ trait Spark30XShims extends SparkShims {
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ)
   override def parquetRebaseWrite(conf: SQLConf): String =
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseReadKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
+  override def int96ParquetRebaseWriteKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
+  override def hasSeparateINT96RebaseConf: Boolean = true
 
   override def sessionFromPlan(plan: SparkPlan): SparkSession = {
     plan.sqlContext.sparkSession
@@ -110,8 +119,6 @@ trait Spark30XShims extends SparkShims {
   }
 
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = false
-
-  override def hasSeparateINT96RebaseConf: Boolean = true
 
   override def shouldFailDivOverflow(): Boolean = false
 

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -16,6 +16,17 @@
 
 package com.nvidia.spark.rapids.shims.v2
 
+import org.apache.spark.sql.internal.SQLConf
+
 trait Spark31XShims extends Spark30XShims {
   override def hasSeparateINT96RebaseConf: Boolean = true
+
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseReadKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
+  override def int96ParquetRebaseWriteKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
 }

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -53,7 +53,14 @@ trait Spark32XShims extends SparkShims {
     conf.getConf(SQLConf.PARQUET_REBASE_MODE_IN_READ)
   override final def parquetRebaseWrite(conf: SQLConf): String =
     conf.getConf(SQLConf.PARQUET_REBASE_MODE_IN_WRITE)
-
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    conf.getConf(SQLConf.PARQUET_INT96_REBASE_MODE_IN_READ)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    conf.getConf(SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseReadKey: String =
+    SQLConf.PARQUET_INT96_REBASE_MODE_IN_READ.key
+  override def int96ParquetRebaseWriteKey: String =
+    SQLConf.PARQUET_INT96_REBASE_MODE_IN_WRITE.key
   override def hasSeparateINT96RebaseConf: Boolean = true
 
   override final def aqeShuffleReaderExec: ExecRule[_ <: SparkPlan] = exec[AQEShuffleReadExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -91,22 +91,10 @@ trait SparkShims {
   def parquetRebaseWrite(conf: SQLConf): String
   def v1RepairTableCommand(tableName: TableIdentifier): RunnableCommand
   def hasSeparateINT96RebaseConf: Boolean
-
-  def int96ParquetRebaseRead(conf: SQLConf): String = {
-    parquetRebaseRead(conf)
-  }
-
-  def int96ParquetRebaseWrite(conf: SQLConf): String = {
-    parquetRebaseWrite(conf)
-  }
-
-  def int96ParquetRebaseReadKey: String = {
-    parquetRebaseReadKey
-  }
-
-  def int96ParquetRebaseWriteKey: String = {
-    parquetRebaseWriteKey
-  }
+  def int96ParquetRebaseRead(conf: SQLConf): String
+  def int96ParquetRebaseWrite(conf: SQLConf): String
+  def int96ParquetRebaseReadKey: String
+  def int96ParquetRebaseWriteKey: String
 
   def getParquetFilters(
     schema: MessageType,


### PR DESCRIPTION
Signed-off-by: Raza Jafri <rjafri@nvidia.com>

* Added methods for returning the Rebase conf for different versions of Spark in their proper Shims
* No further tests were added

closes #3642 
closes #1135 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
