### PR TITLE
Add ignore_order to other fallback tests for the aggregate

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1123,6 +1123,7 @@ def test_hash_reduction_avg_nulls_ansi(data_gen, conf):
     )
 
 
+@ignore_order(local=True)
 @allow_non_gpu('HashAggregateExec', 'Alias', 'AggregateExpression', 'Cast',
   'HashPartitioning', 'ShuffleExchangeExec', 'Sum')
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
@@ -1135,6 +1136,7 @@ def test_sum_fallback_when_ansi_enabled(data_gen):
         conf={'spark.sql.ansi.enabled': 'true'})
 
 
+@ignore_order(local=True)
 @allow_non_gpu('HashAggregateExec', 'Alias', 'AggregateExpression', 'Cast',
   'HashPartitioning', 'ShuffleExchangeExec', 'Average')
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
@@ -1147,6 +1149,7 @@ def test_avg_fallback_when_ansi_enabled(data_gen):
         conf={'spark.sql.ansi.enabled': 'true'})
 
 
+@ignore_order(local=True)
 @allow_non_gpu('HashAggregateExec', 'Alias', 'AggregateExpression',
   'HashPartitioning', 'ShuffleExchangeExec', 'Count', 'Literal')
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
@@ -1160,7 +1163,6 @@ def test_count_fallback_when_ansi_enabled(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _no_overflow_ansi_gens, ids=idfn)
-@ignore_order(local=True)
 def test_no_fallback_when_ansi_enabled(data_gen):
     def do_it(spark):
         df = gen_df(spark, [('a', data_gen), ('b', data_gen)], length=100)


### PR DESCRIPTION
I saw these failures in one of the yarn tests last night, we need ignore_order for more of these tests:

```
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_sum_fallback_when_ansi_enabled[Short][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,Cast,HashPartitioning,ShuffleExchangeExec,Sum)]
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_sum_fallback_when_ansi_enabled[Integer][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,Cast,HashPartitioning,ShuffleExchangeExec,Sum)]
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_avg_fallback_when_ansi_enabled[Integer][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,Cast,HashPartitioning,ShuffleExchangeExec,Average)]
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_avg_fallback_when_ansi_enabled[Long][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,Cast,HashPartitioning,ShuffleExchangeExec,Average)]
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_count_fallback_when_ansi_enabled[Short][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,HashPartitioning,ShuffleExchangeExec,Count,Literal)]
FAILED integration_tests/src/main/python/hash_aggregate_test.py::test_count_fallback_when_ansi_enabled[Integer][ALLOW_NON_GPU(HashAggregateExec,Alias,AggregateExpression,HashPartitioning,ShuffleExchangeExec,Count,Literal)]
```