### PR TITLE
Improve dedupe script

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -314,7 +314,9 @@
                                         />
                                         <copy file="com.nvidia.spark.rapids.SparkShimServiceProvider.sparkNonSnapshotDB" tofile="${project.build.directory}/parallel-world/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
                                         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
-                                              dir="${project.build.directory}"/>
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"
@@ -570,7 +572,9 @@
                                         />
                                         <copy file="com.nvidia.spark.rapids.SparkShimServiceProvider.sparkNonSnapshot" tofile="${project.build.directory}/parallel-world/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
                                         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
-                                              dir="${project.build.directory}"/>
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"
@@ -791,7 +795,9 @@
                                         />
                                         <copy file="com.nvidia.spark.rapids.SparkShimServiceProvider.sparkSnapshot" tofile="${project.build.directory}/parallel-world/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
                                         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
-                                              dir="${project.build.directory}"/>
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"
@@ -1109,7 +1115,9 @@
                                         />
                                         <copy file="com.nvidia.spark.rapids.SparkShimServiceProvider.sparkSnapshot" tofile="${project.build.directory}/parallel-world/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
                                         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
-                                              dir="${project.build.directory}"/>
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"
@@ -1469,7 +1477,9 @@
                                         />
                                         <copy file="com.nvidia.spark.rapids.SparkShimServiceProvider.sparkSnapshotDB" tofile="${project.build.directory}/parallel-world/META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
                                         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
-                                              dir="${project.build.directory}"/>
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"

--- a/dist/scripts/binary-dedupe.sh
+++ b/dist/scripts/binary-dedupe.sh
@@ -33,8 +33,12 @@ SPARK3XX_COMMON_DIR=$PWD/spark3xx-common
 # We compute and compare checksum signatures of same-named classes
 
 # The following pipeline determines identical classes across shims in this build.
-# If the files are absent in some shims but are identical in the same shim
-#
+# - checksum all class files
+# - move the varying-prefix shim3xy to the left so it can be easily skipped for uniq and sort
+# - sort by path, secondary sort by checksum, print one line per group
+# - produce uniq count for paths
+# - filter the paths with count=1, the class files without diverging checksums
+# - put the path starting with /spark3xy back together for the final list
 echo "Retrieving class files hashing to a single value"
 find . -path './parallel-world/spark*' -type f -name '*class' | \
   xargs -L 1000 sha1sum -b | \


### PR DESCRIPTION
closes #3686 

- bug: fail build on error is missing
- make it skippable via environment variable `SKIP_BINARY_DEDUPE`
- replace md5 with sha1 https://www.avira.com/en/blog/md5-the-broken-algorithm
- replace diff with sha1 
- more general dedupe logic leaving only a single copy of files with a single hash value 

Signed-off-by: Gera Shegalov <gera@apache.org>