### PR TITLE
Qualification tool: Fix bug to process correct listeners

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/FilterAppInfo.scala
@@ -59,10 +59,12 @@ class FilterAppInfo(
   override def processEvent(event: SparkListenerEvent): Boolean = {
     if (event.isInstanceOf[SparkListenerApplicationStart]) {
       doSparkListenerApplicationStart(event.asInstanceOf[SparkListenerApplicationStart])
-      (eventsToProcess -= 1) == 0
+      eventsToProcess -= 1
+      eventsToProcess == 0
     } else if (event.isInstanceOf[SparkListenerEnvironmentUpdate]) {
       doSparkListenerEnvironmentUpdate(event.asInstanceOf[SparkListenerEnvironmentUpdate])
-      (eventsToProcess -= 1) == 0
+      eventsToProcess -= 1
+      eventsToProcess == 0
     } else {
       false
     }


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/3720 . 
Earlier it was sending false and hence processing more listeners than required.
I ran mvn install with this change and the warnings are gone. Also now the loop exits once both the listeners are processed.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
