### PR TITLE
Add note referencing known issues in approx_percentile implementation

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -568,3 +568,7 @@ The GPU implementation of `approximate_percentile` uses
 distribution. Because the results are not bit-for-bit identical with the Apache Spark implementation of
 `approximate_percentile`, this feature is disabled by default and can be enabled by setting
 `spark.rapids.approxPercentileEnabled=true`.
+
+There are known issues with the approximate percentile implementation
+([#3706](https://github.com/NVIDIA/spark-rapids/issues/3706),
+[#3692](https://github.com/NVIDIA/spark-rapids/issues/3692)) and the feature should be considered experimental.


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Add note referencing known issues in approx_percentile implementation