### PR TITLE
Throw Exception if failure to load ParquetCachedBatchSerializer class [databricks]

### DIFF
--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
@@ -465,6 +465,11 @@ abstract class SparkBaseShims extends Spark30XShims {
             if (!scan.relation.cacheBuilder.serializer
                 .isInstanceOf[com.nvidia.spark.ParquetCachedBatchSerializer]) {
               willNotWorkOnGpu("ParquetCachedBatchSerializer is not being used")
+              if (SQLConf.get.getConf(StaticSQLConf.SPARK_CACHE_SERIALIZER)
+                  .equals("com.nvidia.spark.ParquetCachedBatchSerializer")) {
+                throw new IllegalStateException("Cache serializer failed to load! " +
+                    "Something went wrong while loading ParquetCachedBatchSerializer class")
+              }
             }
           }
 

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
@@ -438,6 +438,11 @@ abstract class SparkBaseShims extends Spark31XShims {
             if (!scan.relation.cacheBuilder.serializer
                 .isInstanceOf[com.nvidia.spark.ParquetCachedBatchSerializer]) {
               willNotWorkOnGpu("ParquetCachedBatchSerializer is not being used")
+              if (SQLConf.get.getConf(StaticSQLConf.SPARK_CACHE_SERIALIZER)
+                  .equals("com.nvidia.spark.ParquetCachedBatchSerializer")) {
+                throw new IllegalStateException("Cache serializer failed to load! " +
+                    "Something went wrong while loading ParquetCachedBatchSerializer class")
+              }
             }
           }
 


### PR DESCRIPTION
* Added defensive code to protect against a case when PCBS class isn't loaded but the serializer is set to it
* No straight forward way to test this besides changing the code to match a different class in the match block. 

fixes #3311 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
