### PR TITLE
Avoid using AST on inner joins and avoid coalesce after post-join filter

### DIFF
--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
@@ -83,7 +83,9 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
@@ -70,7 +70,9 @@ class GpuShuffledHashJoinMeta(
       isSkewJoin = false)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinExec.scala
@@ -89,7 +89,9 @@ class GpuSortMergeJoinMeta(
       join.isSkewJoin)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 
   /**

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
@@ -83,7 +83,9 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map { c =>
+      GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
@@ -69,7 +69,9 @@ class GpuShuffledHashJoinMeta(
       isSkewJoin = false)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinMeta.scala
@@ -88,7 +88,9 @@ class GpuSortMergeJoinMeta(
       join.isSkewJoin)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 
   /**

--- a/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/GpuShuffledHashJoinExec.scala
@@ -70,7 +70,9 @@ class GpuShuffledHashJoinMeta(
       isSkewJoin = false)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinExec.scala
+++ b/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/GpuSortMergeJoinExec.scala
@@ -89,7 +89,9 @@ class GpuSortMergeJoinMeta(
       join.isSkewJoin)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 
   /**

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
@@ -85,7 +85,9 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/GpuBroadcastHashJoinExec.scala
@@ -83,7 +83,9 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // The GPU does not yet support conditional joins, so conditions are implemented
     // as a filter after the join when possible.
-    condition.map(c => GpuFilterExec(c.convertToGpu(), joinExec)).getOrElse(joinExec)
+    condition.map {
+      c => GpuFilterExec(c.convertToGpu(), joinExec, coalesceAfter = false)
+    }.getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -310,7 +310,10 @@ object GpuFilter extends Arm {
   }
 }
 
-case class GpuFilterExec(condition: Expression, child: SparkPlan)
+case class GpuFilterExec(
+    condition: Expression,
+    child: SparkPlan,
+    override val coalesceAfter: Boolean = true)
     extends ShimUnaryExecNode with GpuPredicateHelper with GpuExec {
 
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
@@ -321,11 +324,6 @@ case class GpuFilterExec(condition: Expression, child: SparkPlan)
     case GpuIsNotNull(a) => isNullIntolerant(a) && a.references.subsetOf(child.outputSet)
     case _ => false
   }
-
-  /**
-   * Potentially a lot is removed.
-   */
-  override def coalesceAfter: Boolean = true
 
   // If one expression and its children are null intolerant, it is null intolerant.
   private def isNullIntolerant(expr: Expression): Boolean = expr match {


### PR DESCRIPTION
Fixes #3736.

@abellina and I looked into the nested loop join performance degradation and there were primarily two issues:
1. Computing the AST during the join was particularly expensive, resulting in approximately 4X performance improvement for the microbenchmark nested loop join if we revert back to generating a full cross join output and then post-filtering the results.
2. The `GpuFilterExec` extracted from the join in #3105 was causing a subsequent batch coalesce to occur that wasn't there before.  Traces showed `contiguous_split` was quite expensive on the post-join output for this query.  Updating the post-join filter to not coalesce batches resulted in another approximate 4X speedup from the previous change.

This updates nested loop joins to avoid using the AST if a post-filter can be used and also updates the post-filter injection code for joins to specify no coalesce after goal on the filter node.