### PR TITLE
Simplify shim classloader logic

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1586,6 +1586,10 @@
                                                 dest="${project.build.directory}/parallel-world/${spark.version.classifier}"
                                         >
                                         </unzip>
+                                        <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"
@@ -1684,6 +1688,10 @@
                                                 dest="${project.build.directory}/parallel-world/${spark.version.classifier}"
                                         >
                                         </unzip>
+                                        <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
+                                              dir="${project.build.directory}"
+                                              failonerror="true"
+                                        />
                                         <jar
                                                 destfile="${project.build.directory}/rapids-4-spark_${scala.binary.version}-${project.version}.jar"
                                                 basedir="${project.build.directory}/parallel-world"

--- a/sql-plugin/src/main/301until320-all/scala/org/apache/spark/rapids/shims/v2/storage/ShimDiskBlockManager.scala
+++ b/sql-plugin/src/main/301until320-all/scala/org/apache/spark/rapids/shims/v2/storage/ShimDiskBlockManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.rapids
-
-import java.io.File
+package org.apache.spark.rapids.shims.v2.storage
 
 import org.apache.spark.SparkConf
-import org.apache.spark.rapids.shims.v2.storage.ShimDiskBlockManager
-import org.apache.spark.storage.BlockId
+import org.apache.spark.storage.DiskBlockManager
 
-/** Maps logical blocks to local disk locations. */
-class RapidsDiskBlockManager(conf: SparkConf) {
-  private[this] val blockManager = new ShimDiskBlockManager(conf, true)
 
-  def getFile(blockId: BlockId): File = blockManager.getFile(blockId)
-
-  def getFile(file: String): File = blockManager.getFile(file)
-}
+class ShimDiskBlockManager(conf: SparkConf, deleteFilesOnStop: Boolean)
+  extends DiskBlockManager(conf, deleteFilesOnStop)

--- a/sql-plugin/src/main/320/scala/org/apache/spark/rapids/shims/v2/storage/ShimDiskBlockManager.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/rapids/shims/v2/storage/ShimDiskBlockManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.rapids
-
-import java.io.File
+package org.apache.spark.rapids.shims.v2.storage
 
 import org.apache.spark.SparkConf
-import org.apache.spark.rapids.shims.v2.storage.ShimDiskBlockManager
-import org.apache.spark.storage.BlockId
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.storage.DiskBlockManager
 
-/** Maps logical blocks to local disk locations. */
-class RapidsDiskBlockManager(conf: SparkConf) {
-  private[this] val blockManager = new ShimDiskBlockManager(conf, true)
 
-  def getFile(blockId: BlockId): File = blockManager.getFile(blockId)
-
-  def getFile(file: String): File = blockManager.getFile(file)
-}
+class ShimDiskBlockManager(
+  conf: SparkConf,
+  deleteFilesOnStop: Boolean) extends DiskBlockManager(
+    conf,
+    deleteFilesOnStop,
+    TrampolineUtil.isDriver(conf)
+  )

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -18,16 +18,18 @@ package com.nvidia.spark.rapids
 
 import java.net.URL
 
+import org.apache.commons.lang3.reflect.MethodUtils
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{SPARK_BUILD_USER, SPARK_VERSION, SparkConf, SparkEnv}
+import org.apache.spark.{SPARK_BRANCH, SPARK_BUILD_DATE, SPARK_BUILD_USER, SPARK_REPO_URL, SPARK_REVISION, SPARK_VERSION, SparkConf, SparkEnv}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin}
 import org.apache.spark.api.resource.ResourceDiscoveryPlugin
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
-import org.apache.spark.util.{MutableURLClassLoader, ParentClassLoader}
+import org.apache.spark.util.MutableURLClassLoader
 
 /*
     Plugin jar uses non-standard class file layout. It consists of three types of areas,
@@ -73,7 +75,6 @@ object ShimLoader extends Logging {
   }
 
   private val shimCommonURL = new URL(s"${shimRootURL.toString}spark3xx-common/")
-
   @volatile private var shimProviderClass: String = _
   @volatile private var sparkShims: SparkShims = _
   @volatile private var shimURL: URL = _
@@ -83,6 +84,11 @@ object ShimLoader extends Logging {
   @volatile private var tmpClassLoader: MutableURLClassLoader = _
 
   private def shimId: String = shimIdFromPackageName(shimProviderClass)
+
+  private def urlsForSparkClassLoader = Seq(
+    shimCommonURL,
+    shimURL
+  )
 
   // defensively call findShimProvider logic on all entry points to avoid uninitialized
   // this won't be necessary if we can upstream changes to the plugin and shuffle
@@ -101,7 +107,7 @@ object ShimLoader extends Logging {
   // This is not possible at the current stage of the shim layer rewrite because of the combination
   // of the following two reasons:
   // 1) Spark processes ShuffleManager config before any of the plugin code initialized
-  // 2) We can't combine the implementation of the ShuffleManaeger trait for different Spark
+  // 2) We can't combine the implementation of the ShuffleManager trait for different Spark
   //    versions in the same Scala class. A method was changed to final
   //    https://github.com/apache/spark/blame/v3.2.0-rc2/core/src/main/scala/
   //    org/apache/spark/shuffle/ShuffleManager.scala#L57
@@ -119,41 +125,93 @@ object ShimLoader extends Logging {
     s"org.apache.spark.sql.rapids.shims.$shimId.RapidsShuffleInternalManager"
   }
 
+  private def serializerClassloader() = {
+    // Hypothesis: serializer is the most universal way to intercept classloaders
+
+    // https://github.com/apache/spark/blob/master/core/src/main/scala/
+    // org/apache/spark/serializer/JavaSerializer.scala#L147
+
+    // https://github.com/apache/spark/blob/master/core/src/main/scala/
+    // org/apache/spark/serializer/KryoSerializer.scala#L134
+
+    Option(SparkEnv.get)
+      .map(_.serializer)
+      .flatMap { serializer =>
+        logInfo("Looking for a mutable classloader (defaultClassLoader) in SparkEnv.serializer " +
+          serializer)
+        // scalac generates accessor methods
+        val serdeClassLoader = MethodUtils
+          .invokeMethod(serializer, true, "defaultClassLoader")
+          .asInstanceOf[Option[ClassLoader]]
+          .getOrElse {
+            val threadContextClassLoader = Thread.currentThread().getContextClassLoader
+            logInfo(s"No defaultClassLoader found in $serializer, falling back " +
+              s"on Thread context classloader: " + threadContextClassLoader)
+            threadContextClassLoader
+          }
+
+        logInfo("Extracted Spark classloader from SparkEnv.serializer " + serdeClassLoader)
+        findURLClassLoader(serdeClassLoader)
+      }.orElse {
+        logInfo("Spark-less use case: RapidsConf.help?")
+        Option(getClass.getClassLoader)
+      }
+  }
+
+
+  @tailrec
+  private def findURLClassLoader(classLoader: ClassLoader): Option[ClassLoader] = {
+    // walk up the classloader hierarchy until we hit a classloader we can mutate
+    // in the upstream Spark, non-REPL/batch mode serdeClassLoader is already mutable
+    // in REPL use-cases, and blackbox Spark apps it may take several iterations
+
+    // ignore different flavors of URL classloaders in different REPLs
+    // brute-force call addURL using reflection
+    classLoader match {
+      case nullClassLoader if nullClassLoader == null =>
+        logInfo("findURLClassLoader failed to locate a mutable classloader")
+        None
+      case urlCl: java.net.URLClassLoader =>
+        // fast path
+        logInfo(s"findURLClassLoader found a URLClassLoader $urlCl")
+        Option(urlCl)
+      case urlAddable: ClassLoader if null != MethodUtils.getMatchingMethod(
+          urlAddable.getClass, "addURL", classOf[java.net.URL]) =>
+        // slow defensive path
+        logInfo(s"findURLClassLoader found a urLAddable classloader $urlAddable")
+        Option(urlAddable)
+      case root if root.getParent == null || root.getParent == root =>
+        logInfo(s"findURLClassLoader hit the Boostrap classloader $root, " +
+          s"failed to find a mutable classloader!")
+        None
+      case cl =>
+        val parentClassLoader = cl.getParent
+        logInfo(s"findURLClassLoader found an immutable $cl, trying parent=$parentClassLoader")
+        findURLClassLoader(parentClassLoader)
+    }
+  }
+
   private def updateSparkClassLoader(): Unit = {
     // TODO propose a proper addClassPathURL API to Spark similar to addJar but
     //  accepting non-file-based URI
-    val contextClassLoader = Thread.currentThread().getContextClassLoader
-    // First check if we can get a MutableURLClassLoader to update. This works on the
-    // executor and in some cases for the driver (when there is no REPL)
-    Option(contextClassLoader).collect {
-      case mutable: MutableURLClassLoader => mutable
-      case replCL if replCL.getClass.getName == "org.apache.spark.repl.ExecutorClassLoader" =>
-        val parentLoaderField = replCL.getClass.getDeclaredMethod("parentLoader")
-        val parentLoader = parentLoaderField.invoke(replCL).asInstanceOf[ParentClassLoader]
-        parentLoader.getParent.asInstanceOf[MutableURLClassLoader]
-    }.foreach { mutable =>
-      // MutableURLClassloader dedupes for us
-      pluginClassLoader = contextClassLoader
-      mutable.addURL(shimURL)
-      mutable.addURL(shimCommonURL)
-    }
-
-    if (pluginClassLoader == null) {
-      // Next we should check for the scala built in REPL interpreter class loader.
-      // This happens on the driver side as a part of the REPL. It does not use a
-      // MutableURLClassLoader, but has essentially done the same thing.
-      Option(contextClassLoader).foreach { loader =>
-        if (loader.getClass.getName ==
-            "scala.tools.nsc.interpreter.IMain$TranslatingClassLoader") {
-          val parentLoader = loader.getParent
-          // Unfortunately this class is internal to scala and so we will add URLs through
-          // reflection.
-          val addURL = parentLoader.getClass.getDeclaredMethod("addURL", classOf[java.net.URL])
-          addURL.invoke(parentLoader, shimURL)
-          addURL.invoke(parentLoader, shimCommonURL)
-          pluginClassLoader = contextClassLoader
-        }
+    serializerClassloader().foreach { urlAddable =>
+      logInfo(s"Updating spark classloader $urlAddable with the URLs: " +
+        urlsForSparkClassLoader.mkString(", "))
+      urlsForSparkClassLoader.foreach { url =>
+        MethodUtils.invokeMethod(urlAddable, true,"addURL", url)
       }
+      logInfo(s"Spark classLoader $urlAddable updated successfully")
+      urlAddable match {
+        case urlCl: java.net.URLClassLoader =>
+          if (!urlCl.getURLs.contains(shimCommonURL)) {
+            // infeasible, defensive diagnostics
+            logWarning(s"Didn't find expected URL $shimCommonURL in the spark " +
+              s"classloader $urlCl although addURL succeeded, maybe pushed up to the " +
+              s"parent classloader ${urlCl.getParent}")
+          }
+        case _ => ()
+      }
+      pluginClassLoader = urlAddable
     }
   }
 
@@ -181,6 +239,7 @@ object ShimLoader extends Logging {
   private def detectShimProvider(): String = {
     val sparkVersion = getSparkVersion
     logInfo(s"Loading shim for Spark version: $sparkVersion")
+    logInfo("Complete Spark build info: " + sparkBuildInfo.mkString(", "))
 
     val thisClassLoader = getClass.getClassLoader
 
@@ -245,13 +304,6 @@ object ShimLoader extends Logging {
     }
   }
 
-  // shimId corresponds to spark.version.classifier by convention
-  // e.g. com.nvidia.spark.rapids.shims.spark320.SparkShimServiceProvider implies
-  // shimId = "spark320"
-  private def shimIdFromPackageName(shimServiceProvider: SparkShimServiceProvider) = {
-    shimServiceProvider.getClass.getPackage.toString.split('.').last
-  }
-
   private def shimIdFromPackageName(shimServiceProviderStr: String) = {
     shimServiceProviderStr.split('.').takeRight(2).head
   }
@@ -280,10 +332,18 @@ object ShimLoader extends Logging {
     }
   }
 
+  private def sparkBuildInfo = Seq(
+    getSparkVersion,
+    SPARK_REPO_URL,
+    SPARK_BRANCH,
+    SPARK_REVISION,
+    SPARK_BUILD_DATE
+  )
+
   // TODO broken right now, check if this can be supported with parallel worlds
   // it implies the prerequisite of having such a class in the conventional root jar entry
   // - or the necessity of an additional parameter for specifying the shim subdirectory
-  // - or enforcing the convention the class file parent directory is the shimid that is also
+  // - or enforcing the convention the class file parent directory is the shimId that is also
   //   a top entry e.g. /spark301/com/nvidia/test/shim/spark301/Spark301Shims.class
   def setSparkShimProviderClass(classname: String): Unit = {
     shimProviderClass = classname

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -18,10 +18,11 @@ package org.apache.spark.sql.rapids.execution
 
 import org.json4s.JsonAST
 
-import org.apache.spark.{SparkContext, SparkEnv, SparkUpgradeException, TaskContext}
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv, SparkUpgradeException, TaskContext}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.InputMetrics
+import org.apache.spark.internal.config.EXECUTOR_ID
 import org.apache.spark.memory.TaskMemoryManager
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -59,6 +60,11 @@ object TrampolineUtil {
     } else {
       false
     }
+  }
+
+  def isDriver(sparkConf: SparkConf): Boolean = {
+    sparkConf.get(EXECUTOR_ID).map(_ == SparkContext.DRIVER_IDENTIFIER)
+      .getOrElse(isDriver(SparkEnv.get))
   }
 
   /**


### PR DESCRIPTION
- uprev spark320 breaking DiskManager changes
- use the Serializer instance to find mutable classloader
- make the the update logic oblivious to the executor/driver side
- add missing binary dedupes

Signed-off-by: Gera Shegalov <gera@apache.org>
