### PR TITLE
Enable some union of structs tests that were marked xfail

### DIFF
--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -20,8 +20,6 @@ from data_gen import *
 from marks import ignore_order, allow_non_gpu
 import pyspark.sql.functions as f
 
-nested_scalar_mark = pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/1459")
-
 # 4 level nested struct
 # each level has a different number of children to avoid a bug in spark < 3.1
 nested_struct = StructGen([
@@ -59,7 +57,7 @@ struct_of_maps = StructGen([['child0', BooleanGen()]] + [
     ['child%d' % (i + 1), gen] for i, gen in enumerate(map_gens)])
 
 @pytest.mark.parametrize('data_gen', [pytest.param((StructGen([['child0', DecimalGen(7, 2)]]),
-                                                    StructGen([['child1', IntegerGen()]])), marks=nested_scalar_mark),
+                                                    StructGen([['child1', IntegerGen()]]))),
                                       # left_struct(child0 = 4 level nested struct, child1 = Int)
                                       # right_struct(child0 = 4 level nested struct, child1 = missing)
                                       (StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
@@ -110,8 +108,8 @@ def test_unionAll(data_gen):
 
 @pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
-                                      pytest.param(all_basic_struct_gen, marks=nested_scalar_mark),
-                                      pytest.param(StructGen([[ 'child0', DecimalGen(7, 2)]]), marks=nested_scalar_mark),
+                                      pytest.param(all_basic_struct_gen),
+                                      pytest.param(StructGen([[ 'child0', DecimalGen(7, 2)]])),
                                       nested_struct,
                                       StructGen([['child0', StructGen([['child0', StructGen([['child0', StructGen([['child0',
                                                             StructGen([['child0', DecimalGen(7, 2)]])]])]])]])], ['child1', IntegerGen()]]),


### PR DESCRIPTION
This PR just removes the mark to xfail some tests


Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
