### PR TITLE
Reduce usage of escaping in xargs

### DIFF
--- a/dist/scripts/binary-dedupe.sh
+++ b/dist/scripts/binary-dedupe.sh
@@ -24,7 +24,7 @@ set -ex
 }
 
 SPARK3XX_COMMON_TXT=$PWD/spark3xx-common.txt
-SPARK3XX_COMMON_DIR=$PWD/spark3xx-common
+export SPARK3XX_COMMON_DIR=$PWD/spark3xx-common
 
 # This script de-duplicates .class files at the binary level.
 # We could also diff classes using scalap / javap outputs.
@@ -47,16 +47,23 @@ find . -path './parallel-world/spark*' -type f -name '*class' | \
   sort -k3 -k2,2 -u | uniq -f 2 -c | grep '^\s\+1 .*' | \
   awk '{$1=""; $3=""; print $0 }' | tr -s ' ' | sed 's/\ /\//g' > "$SPARK3XX_COMMON_TXT"
 
+remove_duplicates() {
+  set -x
+  class_resource=$1
+  shim=$(<<< "$class_resource" cut -d'/' -f 2)
+  class_file=$(<<< "$class_resource" cut -d'/' -f 3-)
+  class_dir=$(dirname "$class_file")
+  dest_dir="$SPARK3XX_COMMON_DIR/$class_dir"
+  mkdir -p "$dest_dir"
+  cp "./parallel-world/$shim/$class_file" "$dest_dir/"
+  find ./parallel-world -path './parallel-world/spark3*/'"$class_file" | xargs rm || \
+    exit 255
+}
+export -f remove_duplicates
+
 echo "Deleting duplicates of spark3xx-common classes"
-xargs --arg-file="$SPARK3XX_COMMON_TXT" -P 6 -n 1 -I% bash -c "
-    shim=\$(echo '%' | cut -d'/' -f 2)
-    class_file=\$(echo '%' | cut -d'/' -f 3-)
-    class_dir=\$(dirname \$class_file)
-    dest_dir=$SPARK3XX_COMMON_DIR/\$class_dir
-    mkdir -p \$dest_dir && \
-      cp ./parallel-world/\$shim\/\$class_file \$dest_dir/ && \
-      find ./parallel-world -path './parallel-world/spark3*/'\$class_file -exec rm {} + || exit 255
-  "
+# https://stackoverflow.com/questions/11003418/calling-shell-functions-with-xargs
+xargs --arg-file="$SPARK3XX_COMMON_TXT" -P 6 -n 1 -I% bash -c 'remove_duplicates "$@"' _ %
 
 mv "$SPARK3XX_COMMON_DIR" parallel-world/
 
@@ -102,5 +109,6 @@ for classFile in $(< $UNSHIMMED_LIST_TXT); do
 done
 
 # Remove unshimmed classes from parallel worlds
+echo Removing duplicates of unshimmed classes
 xargs --arg-file="$UNSHIMMED_LIST_TXT" -P 6 -n 100 -I% \
-  find . -path './parallel-world/spark*/%' -exec rm {} +
+  find . -path './parallel-world/spark*/%' | xargs rm || exit 255


### PR DESCRIPTION
- use exported functions instead

potentially fixes #3769, #3783 

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
