### PR TITLE
Update approximate percentile documentation

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -567,7 +567,7 @@ The GPU implementation of `approximate_percentile` uses
 [t-Digests](https://arxiv.org/abs/1902.04023) which have high accuracy, particularly near the tails of a
 distribution. Because the results are not bit-for-bit identical with the Apache Spark implementation of
 `approximate_percentile`, this feature is disabled by default and can be enabled by setting
-`spark.rapids.approxPercentileEnabled=true`.
+`spark.rapids.sql.expression.ApproximatePercentile=true`.
 
 There are known issues with the approximate percentile implementation
 ([#3706](https://github.com/NVIDIA/spark-rapids/issues/3706),


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

The compatibility guide was out of date and had an incorrect setting for enabling ApproximatePercentile on the GPU.