### PR TITLE
Change `nullOnDivideByZero` from runtime parameter to aggregate expression for `stddev` and `variance` aggregations [databricks]

### DIFF
--- a/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
+++ b/shims/spark320/src/main/scala/com/nvidia/spark/rapids/shims/spark320/Spark320Shims.scala
@@ -1004,8 +1004,6 @@ class Spark320Shims extends Spark32XShims {
       new KryoJavaSerializer())
   }
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = {
-    val nullOnDivideByZero: Boolean = !SQLConf.get.legacyStatisticalAggregate
-    GpuLiteral(if (nullOnDivideByZero) null else Double.NaN, DoubleType)
-  }
+  override def getLegacyStatisticalAggregate(): Boolean =
+    SQLConf.get.legacyStatisticalAggregate
 }

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
@@ -688,5 +688,5 @@ abstract class SparkBaseShims extends Spark30XShims {
       new KryoJavaSerializer())
   }
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = GpuLiteral(Double.NaN)
+  override def getLegacyStatisticalAggregate(): Boolean = true
 }

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -142,5 +142,5 @@ trait Spark30XShims extends SparkShims {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = GpuLiteral(Double.NaN)
+  override def getLegacyStatisticalAggregate(): Boolean = true
 }

--- a/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
+++ b/sql-plugin/src/main/311db/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
@@ -874,8 +874,6 @@ abstract class SparkBaseShims extends Spark30XShims {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = {
-    val nullOnDivideByZero: Boolean = !SQLConf.get.legacyStatisticalAggregate
-    GpuLiteral(if (nullOnDivideByZero) null else Double.NaN, DoubleType)
-  }
+  override def getLegacyStatisticalAggregate(): Boolean =
+    SQLConf.get.legacyStatisticalAggregate
 }

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/SparkBaseShims.scala
@@ -845,8 +845,6 @@ abstract class SparkBaseShims extends Spark31XShims {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = {
-    val nullOnDivideByZero: Boolean = !SQLConf.get.legacyStatisticalAggregate
-    GpuLiteral(if (nullOnDivideByZero) null else Double.NaN, DoubleType)
-  }
+  override def getLegacyStatisticalAggregate(): Boolean =
+    SQLConf.get.legacyStatisticalAggregate
 }

--- a/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
+++ b/sql-plugin/src/main/320/scala/com/nvidia/spark/rapids/shims/v2/Spark32XShims.scala
@@ -155,8 +155,6 @@ trait Spark32XShims extends SparkShims {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 
-  override def getCentralMomentDivideByZeroEvalResult(): Expression = {
-    val nullOnDivideByZero: Boolean = !SQLConf.get.legacyStatisticalAggregate
-    GpuLiteral(if (nullOnDivideByZero) null else Double.NaN, DoubleType)
-  }
+  override def getLegacyStatisticalAggregate(): Boolean =
+    SQLConf.get.legacyStatisticalAggregate
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3113,8 +3113,10 @@ object GpuOverrides extends Logging {
         TypeSig.DOUBLE, TypeSig.DOUBLE,
         Seq(ParamCheck("input", TypeSig.DOUBLE, TypeSig.DOUBLE))),
       (a, conf, p, r) => new AggExprMeta[StddevPop](a, conf, p, r) {
-        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuStddevPop(childExprs.head)
+        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression = {
+          val legacyStatisticalAggregate = ShimLoader.getSparkShims.getLegacyStatisticalAggregate
+          GpuStddevPop(childExprs.head, !legacyStatisticalAggregate)
+        }
       }),
     expr[StddevSamp](
       "Aggregation computing sample standard deviation",
@@ -3122,8 +3124,10 @@ object GpuOverrides extends Logging {
         TypeSig.DOUBLE, TypeSig.DOUBLE,
         Seq(ParamCheck("input", TypeSig.DOUBLE, TypeSig.DOUBLE))),
       (a, conf, p, r) => new AggExprMeta[StddevSamp](a, conf, p, r) {
-        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuStddevSamp(childExprs.head)
+        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression = {
+          val legacyStatisticalAggregate = ShimLoader.getSparkShims.getLegacyStatisticalAggregate
+          GpuStddevSamp(childExprs.head, !legacyStatisticalAggregate)
+        }
       }),
     expr[VariancePop](
       "Aggregation computing population variance",
@@ -3131,8 +3135,10 @@ object GpuOverrides extends Logging {
         TypeSig.DOUBLE, TypeSig.DOUBLE,
         Seq(ParamCheck("input", TypeSig.DOUBLE, TypeSig.DOUBLE))),
       (a, conf, p, r) => new AggExprMeta[VariancePop](a, conf, p, r) {
-        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuVariancePop(childExprs.head)
+        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression = {
+          val legacyStatisticalAggregate = ShimLoader.getSparkShims.getLegacyStatisticalAggregate
+          GpuVariancePop(childExprs.head, !legacyStatisticalAggregate)
+        }
       }),
     expr[VarianceSamp](
       "Aggregation computing sample variance",
@@ -3140,8 +3146,10 @@ object GpuOverrides extends Logging {
         TypeSig.DOUBLE, TypeSig.DOUBLE,
         Seq(ParamCheck("input", TypeSig.DOUBLE, TypeSig.DOUBLE))),
       (a, conf, p, r) => new AggExprMeta[VarianceSamp](a, conf, p, r) {
-        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
-          GpuVarianceSamp(childExprs.head)
+        override def convertToGpu(childExprs: Seq[Expression]): GpuExpression = {
+          val legacyStatisticalAggregate = ShimLoader.getSparkShims.getLegacyStatisticalAggregate
+          GpuVarianceSamp(childExprs.head, !legacyStatisticalAggregate)
+        }
       }),
     expr[ApproximatePercentile](
       "Approximate percentile",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -281,7 +281,12 @@ trait SparkShims {
 
   def registerKryoClasses(kryo: Kryo): Unit
 
-  def getCentralMomentDivideByZeroEvalResult(): Expression
+  /**
+  * This Boolean variable set to `true` for Spark < 3.1.0, and set to 
+  * `SQLConf.get.legacyStatisticalAggregate` otherwise.
+  * This is because the `legacyStatisticalAggregate` config was introduced in Spark 3.1.0.
+  */
+  def getLegacyStatisticalAggregate(): Boolean
 }
 
 abstract class SparkCommonShims extends SparkShims {


### PR DESCRIPTION
Currently, `stddev` and `variance` aggregation families evaluate an expression `divideByZeroEvalResult` from shim loader instead of computing it from the input expression. As such, `divideByZeroEvalResult` may be evaluated differently at runtime, causing potential bugs as indicated in #3705.

This PR change that expression to be evaluated consistently from a boolean variable given as an input expression. That boolean input expression in turn is evaluated from the shim loader during GPU-overriding the entire aggregation.

This closes #3705.