### PR TITLE
Remove the special reduction cast in hash aggregate

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -241,7 +241,7 @@ abstract case class CudfAggregate(ref: Expression) extends GpuUnevaluable with S
 
 class CudfCount(ref: Expression) extends CudfAggregate(ref) {
   override val updateReductionAggregateInternal: cudf.ColumnVector => cudf.Scalar =
-    (col: cudf.ColumnVector) => cudf.Scalar.fromLong(col.getRowCount - col.getNullCount)
+    (col: cudf.ColumnVector) => cudf.Scalar.fromInt((col.getRowCount - col.getNullCount).toInt)
   override val mergeReductionAggregateInternal: cudf.ColumnVector => cudf.Scalar =
     (col: cudf.ColumnVector) => col.sum
   override lazy val updateAggregate: GroupByAggregationOnColumn =


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes #3442
It's a step towards #3194

This PR changes the reduction aggregates such that they follow the pre/post update/merge steps that were added, to handle type and shape differences going into the cuDF aggregate and then coming out, to match Spark at the partial/final boundaries.