### PR TITLE
Minor cleanup: do not set cuda stream to null

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -143,7 +143,8 @@ abstract class RapidsBufferStore(
    * @param targetTotalSize maximum total size of this store after spilling completes
    * @return number of bytes that were spilled
    */
-  def synchronousSpill(targetTotalSize: Long): Long = synchronousSpill(targetTotalSize, null)
+  def synchronousSpill(targetTotalSize: Long): Long =
+    synchronousSpill(targetTotalSize, Cuda.DEFAULT_STREAM)
 
   /**
    * Free memory in this store by spilling buffers to the spill store synchronously.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -78,12 +78,7 @@ class RapidsHostMemoryStore(
       val (hostBuffer, isPinned) = allocateHostBuffer(other.size)
       try {
         otherBuffer match {
-          case devBuffer: DeviceMemoryBuffer =>
-            if (stream != null) {
-              hostBuffer.copyFromDeviceBuffer(devBuffer, stream)
-            } else {
-              hostBuffer.copyFromDeviceBuffer(devBuffer)
-            }
+          case devBuffer: DeviceMemoryBuffer => hostBuffer.copyFromDeviceBuffer(devBuffer, stream)
           case _ => throw new IllegalStateException("copying from buffer without device memory")
         }
       } catch {


### PR DESCRIPTION
Use `Cuda.DEFAULT_STREAM` instead of `null`.

Signed-off-by: Rong Ou <rong.ou@gmail.com>
