### PR TITLE
Fix warning when catching all throwables in GpuOverrides

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3818,7 +3818,7 @@ object GpuOverrideUtil extends Logging {
       case NonFatal(t) if !failOnError =>
         logWarning("Failed to apply GPU overrides, falling back on the original plan: " + t, t)
         planOriginal
-      case fatal =>
+      case fatal: Throwable =>
         logError("Encountered an exception applying GPU overrides " + fatal, fatal)
         throw fatal
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Related to: https://github.com/NVIDIA/spark-rapids/issues/3743. Not closing #3743 since I think @gerashegalov is looking into a plugin to add.

```
[WARNING] [Warn] /home/abellina/work/rapids-plugin-4-spark-latest/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:3821: This catches all Throwables. If this is really intended, use `case fatal : Throwable` to clear this warning.
```