### PR TITLE
remove GDS alignment code

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -290,19 +290,9 @@ object GpuDeviceManager extends Logging {
         logInfo("Using legacy default stream")
       }
 
-      val (allocationAlignment, alignmentThreshold) =
-        if (conf.isGdsSpillEnabled && conf.isGdsSpillAlignedIO) {
-          logInfo(s"Using allocation alignment = ${toKB(RapidsGdsStore.AllocationAlignment)} KB, " +
-              s"alignment threshold = ${toKB(conf.gdsSpillAlignmentThreshold)} KB")
-          (RapidsGdsStore.AllocationAlignment, conf.gdsSpillAlignmentThreshold)
-        } else {
-          (0L, 0L)
-        }
-
       try {
         Cuda.setDevice(gpuId)
-        Rmm.initialize(
-          init, logConf, initialAllocation, maxAllocation, allocationAlignment, alignmentThreshold)
+        Rmm.initialize(init, logConf, initialAllocation, maxAllocation)
         RapidsBufferCatalog.init(conf)
       } catch {
         case e: Exception => logError("Could not initialize RMM", e)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -181,8 +181,7 @@ object RapidsBufferCatalog extends Logging with Arm {
     deviceStorage = new RapidsDeviceMemoryStore()
     val diskBlockManager = new RapidsDiskBlockManager(conf)
     if (rapidsConf.isGdsSpillEnabled) {
-      gdsStorage = new RapidsGdsStore(diskBlockManager, rapidsConf.gdsSpillBatchWriteBufferSize,
-        rapidsConf.isGdsSpillAlignedIO, rapidsConf.gdsSpillAlignmentThreshold)
+      gdsStorage = new RapidsGdsStore(diskBlockManager, rapidsConf.gdsSpillBatchWriteBufferSize)
       deviceStorage.setSpillStore(gdsStorage)
     } else {
       hostStorage = new RapidsHostMemoryStore(rapidsConf.hostSpillStorageSize)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -385,24 +385,6 @@ object RapidsConf {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefault(ByteUnit.MiB.toBytes(8))
 
-  val GDS_SPILL_ALIGNED_IO =
-    conf("spark.rapids.memory.gpu.direct.storage.spill.alignedIO")
-    .doc("When GDS spill is enabled, should I/O be 4 KiB aligned. GDS is more efficient when " +
-        "reads and writes are 4 KiB aligned, but aligning has some additional memory overhead " +
-        "with the padding.")
-    .internal()
-    .booleanConf
-    .createWithDefault(true)
-
-  val GDS_SPILL_ALIGNMENT_THRESHOLD =
-    conf("spark.rapids.memory.gpu.direct.storage.spill.alignmentThreshold")
-    .doc("GPU memory buffers with size above this threshold will be aligned to 4 KiB. Setting " +
-        "this value to 0 means every allocation will be 4 KiB aligned. A low threshold may " +
-        "cause more memory consumption because of padding.")
-    .internal()
-    .bytesConf(ByteUnit.BYTE)
-    .createWithDefault(ByteUnit.KiB.toBytes(64))
-
   val POOLED_MEM = conf("spark.rapids.memory.gpu.pooling.enabled")
     .doc("Should RMM act as a pooling allocator for GPU memory, or should it just pass " +
       "through to CUDA memory allocation directly. DEPRECATED: please use " +
@@ -1487,10 +1469,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isGdsSpillEnabled: Boolean = get(GDS_SPILL)
 
   lazy val gdsSpillBatchWriteBufferSize: Long = get(GDS_SPILL_BATCH_WRITE_BUFFER_SIZE)
-
-  lazy val isGdsSpillAlignedIO: Boolean = get(GDS_SPILL_ALIGNED_IO)
-
-  lazy val gdsSpillAlignmentThreshold: Long = get(GDS_SPILL_ALIGNMENT_THRESHOLD)
 
   lazy val hasNans: Boolean = get(HAS_NANS)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -28,30 +28,10 @@ import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.sql.rapids.{RapidsDiskBlockManager, TempSpillBufferId}
 
-/**
- * A buffer store using GPUDirect Storage (GDS).
- *
- * GDS is more efficient when IO is aligned.
- *
- * An IO is unaligned if one of the following conditions is true:
- * - The file_offset that was issued in cuFileRead/cuFileWrite is not 4K aligned.
- * - The size that was issued in cuFileRead/cuFileWrite is not 4K aligned.
- * - The devPtr_base that was issued in cuFileRead/cuFileWrite is not 4K aligned.
- * - The devPtr_offset that was issued in cuFileRead/cuFileWrite is not 4K aligned.
- *
- * To avoid unaligned IO, when GDS spilling is enabled, the RMM `aligned_resource_adapter` is used
- * so that large buffers above certain size threshold are allocated with 4K aligned base pointer
- * and size.
- *
- * When reading and writing these large buffers through GDS, the size is aligned up to the next 4K
- * boundary. Although the aligned size appears to be out of bound, the extra space needed is held
- * in reserve by the RMM `aligned_resource_adapter`.
- */
+/** A buffer store using GPUDirect Storage (GDS). */
 class RapidsGdsStore(
     diskBlockManager: RapidsDiskBlockManager,
     batchWriteBufferSize: Long,
-    alignedIO: Boolean,
-    alignmentThreshold: Long,
     catalog: RapidsBufferCatalog = RapidsBufferCatalog.singleton)
     extends RapidsBufferStore(StorageTier.GDS, catalog) with Arm {
   private[this] val batchSpiller = new BatchSpiller()
@@ -68,23 +48,6 @@ class RapidsGdsStore(
       } else {
         singleShotSpill(other, deviceBuffer)
       }
-    }
-  }
-
-  private def alignBufferSize(buffer: DeviceMemoryBuffer): Long = {
-    if (alignedIO) {
-      RapidsGdsStore.alignUp(buffer.getLength)
-    } else {
-      buffer.getLength
-    }
-  }
-
-  private def alignLargeBufferSize(buffer: DeviceMemoryBuffer): Long = {
-    val length = buffer.getLength
-    if (alignedIO && length >= alignmentThreshold) {
-      RapidsGdsStore.alignUp(length)
-    } else {
-      length
     }
   }
 
@@ -107,8 +70,7 @@ class RapidsGdsStore(
 
     override def materializeMemoryBuffer: MemoryBuffer = {
       closeOnExcept(DeviceMemoryBuffer.allocate(size)) { buffer =>
-        CuFile.readFileToDeviceMemory(
-          buffer.getAddress, alignLargeBufferSize(buffer), path, fileOffset)
+        CuFile.readFileToDeviceBuffer(buffer, path, fileOffset)
         logDebug(s"Created device buffer for $path $fileOffset:$size via GDS")
         buffer
       }
@@ -121,8 +83,6 @@ class RapidsGdsStore(
           val dm = dmOriginal.slice(dstOffset, length)
           // TODO: switch to async API when it's released, using the passed in CUDA stream.
           stream.sync()
-          // TODO: align the reads once https://github.com/NVIDIA/spark-rapids/issues/2492 is
-          //  resolved.
           CuFile.readFileToDeviceBuffer(dm, path, fileOffset + srcOffset)
           logDebug(s"Created device buffer for $path ${fileOffset + srcOffset}:$length via GDS")
         case _ => throw new IllegalStateException(
@@ -145,15 +105,14 @@ class RapidsGdsStore(
   : RapidsBufferBase = {
     val id = other.id
     val path = id.getDiskPath(diskBlockManager)
-    val alignedSize = alignLargeBufferSize(deviceBuffer)
     // When sharing files, append to the file; otherwise, write from the beginning.
     val fileOffset = if (id.canShareDiskPaths) {
       // only one writer at a time for now when using shared files
       path.synchronized {
-        CuFile.appendDeviceMemoryToFile(path, deviceBuffer.getAddress, alignedSize)
+        CuFile.appendDeviceBufferToFile(path, deviceBuffer)
       }
     } else {
-      CuFile.writeDeviceMemoryToFile(path, 0, deviceBuffer.getAddress, alignedSize)
+      CuFile.writeDeviceBufferToFile(path, 0, deviceBuffer)
       0
     }
     logDebug(s"Spilled to $path $fileOffset:${other.size} via GDS")
@@ -162,6 +121,7 @@ class RapidsGdsStore(
   }
 
   class BatchSpiller() {
+    private val blockSize = 4096
     private[this] val spilledBuffers = new ConcurrentHashMap[File, Set[RapidsBufferId]]
     private[this] val pendingBuffers = ArrayBuffer.empty[RapidsGdsBatchedBuffer]
     private[this] val batchWriteBuffer = CuFileBuffer.allocate(batchWriteBufferSize, true)
@@ -170,8 +130,7 @@ class RapidsGdsStore(
 
     def spill(other: RapidsBuffer, deviceBuffer: DeviceMemoryBuffer): RapidsBufferBase =
       this.synchronized {
-        val alignedSize = alignBufferSize(deviceBuffer)
-        if (alignedSize > batchWriteBufferSize - currentOffset) {
+        if (deviceBuffer.getLength > batchWriteBufferSize - currentOffset) {
           val path = currentFile.getAbsolutePath
           withResource(new CuFileWriteHandle(path)) { handle =>
             handle.write(batchWriteBuffer, batchWriteBufferSize, 0)
@@ -190,10 +149,14 @@ class RapidsGdsStore(
         addBuffer(currentFile, id)
         val gdsBuffer = new RapidsGdsBatchedBuffer(id, currentFile, currentOffset,
           other.size, other.meta, other.getSpillPriority, other.spillCallback)
-        currentOffset += alignedSize
+        currentOffset += alignUp(deviceBuffer.getLength)
         pendingBuffers += gdsBuffer
         gdsBuffer
       }
+
+    private def alignUp(length: Long): Long = {
+      (length + blockSize - 1) & ~(blockSize - 1)
+    }
 
     private def copyToBuffer(
         buffer: MemoryBuffer, offset: Long, size: Long, stream: Cuda.Stream): Unit = {
@@ -245,8 +208,7 @@ class RapidsGdsStore(
             Cuda.DEFAULT_STREAM.sync()
             logDebug(s"Created device buffer $size from batch write buffer")
           } else {
-            CuFile.readFileToDeviceMemory(
-              buffer.getAddress, alignLargeBufferSize(buffer), path, fileOffset)
+            CuFile.readFileToDeviceBuffer(buffer, path, fileOffset)
             logDebug(s"Created device buffer for $path $fileOffset:$size via GDS")
           }
           buffer
@@ -265,8 +227,6 @@ class RapidsGdsStore(
             } else {
               // TODO: switch to async API when it's released, using the passed in CUDA stream.
               stream.sync()
-              // TODO: align the reads once https://github.com/NVIDIA/spark-rapids/issues/2492 is
-              //  resolved.
               CuFile.readFileToDeviceBuffer(dm, path, fileOffset + srcOffset)
               logDebug(s"Created device buffer for $path ${fileOffset + srcOffset}:$length via GDS")
             }
@@ -291,13 +251,5 @@ class RapidsGdsStore(
         }
       }
     }
-  }
-}
-
-object RapidsGdsStore {
-  val AllocationAlignment = 4096L
-
-  def alignUp(length: Long): Long = {
-    (length + AllocationAlignment - 1) & ~(AllocationAlignment - 1)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
@@ -66,7 +66,7 @@ class RapidsGdsStoreSuite extends FunSuite with BeforeAndAfterEach with Arm with
     val batchWriteBufferSize = 16384 // Holds 2 buffers.
     withResource(new RapidsDeviceMemoryStore(catalog)) { devStore =>
       withResource(new RapidsGdsStore(
-        diskBlockManager, batchWriteBufferSize, false, 65536, catalog)) { gdsStore =>
+        diskBlockManager, batchWriteBufferSize, catalog)) { gdsStore =>
 
         devStore.setSpillStore(gdsStore)
         assertResult(0)(gdsStore.currentSize)
@@ -111,7 +111,7 @@ class RapidsGdsStoreSuite extends FunSuite with BeforeAndAfterEach with Arm with
     val spillPriority = -7
     val catalog = spy(new RapidsBufferCatalog)
     withResource(new RapidsDeviceMemoryStore(catalog)) { devStore =>
-      withResource(new RapidsGdsStore(mock[RapidsDiskBlockManager], 4096, false, 65536, catalog)) {
+      withResource(new RapidsGdsStore(mock[RapidsDiskBlockManager], 4096, catalog)) {
         gdsStore =>
         devStore.setSpillStore(gdsStore)
         assertResult(0)(gdsStore.currentSize)


### PR DESCRIPTION
GDS IO alignment turns out to be not very useful. Removed in preparation for further cleanup of the RMM initialization code.

Signed-off-by: Rong Ou <rong.ou@gmail.com>
