### PR TITLE
Update udf-examples dependencies to use dist jar

### DIFF
--- a/udf-examples/pom.xml
+++ b/udf-examples/pom.xml
@@ -58,9 +58,8 @@
     </dependency>
     <dependency>
         <groupId>com.nvidia</groupId>
-        <artifactId>rapids-4-spark-sql_${scala.binary.version}</artifactId>
+        <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
         <version>${project.version}</version>
-        <classifier>${spark.version.classifier}</classifier>
         <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Relates to #3931.

Updates the udf-examples dependencies to use the distribution jar rather than the unpublished sql jar.