### PR TITLE
Avoid using HostColumnarToGpu for nested types [databricks]

### DIFF
--- a/integration_tests/src/main/python/row_conversion_test.py
+++ b/integration_tests/src/main/python/row_conversion_test.py
@@ -51,6 +51,10 @@ def test_row_conversions_fixed_width():
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))
 
 # Test handling of transitions when the data is already columnar on the host
+# Note that Apache Spark will automatically convert a load of nested types to rows, so
+# the nested types will not test a host columnar transition in that case.
+# Databricks does support returning nested types as columnar data on the host, and that
+# is where we would expect any problems with handling nested types in host columnar form to appear.
 @pytest.mark.parametrize('data_gen', [
     int_gen,
     string_gen,

--- a/integration_tests/src/main/python/row_conversion_test.py
+++ b/integration_tests/src/main/python/row_conversion_test.py
@@ -57,7 +57,7 @@ def test_row_conversions_fixed_width():
     decimal_gen_default,
     ArrayGen(string_gen, max_length=10),
     StructGen([('a', string_gen)]) ] + map_string_string_gen, ids=idfn)
-@allow_non_gpu('FileSourceScanExec')
+@allow_non_gpu('ColumnarToRowExec', 'FileSourceScanExec')
 def test_host_columnar_transition(spark_tmp_path, data_gen):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(lambda spark : unary_op_df(spark, data_gen).write.parquet(data_path))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DataTypeUtils.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
+
+object DataTypeUtils {
+  def isNestedType(dataType: DataType): Boolean = dataType match {
+    case _: ArrayType | _: MapType | _: StructType => true
+    case _ => false
+  }
+
+  def hasNestedTypes(schema: StructType): Boolean =
+    schema.exists(f => isNestedType(f.dataType))
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -172,10 +172,10 @@ object GpuParquetScanBase {
       case _ => false
     }
     val schemaMightNeedNestedRebase = readSchema.exists { field =>
-      field.dataType match {
-        case MapType(_, _, _) | ArrayType(_, _) | StructType(_) =>
-          TrampolineUtil.dataTypeExistsRecursively(field.dataType, isTsOrDate)
-        case _ => false
+      if (DataTypeUtils.isNestedType(field.dataType)) {
+        TrampolineUtil.dataTypeExistsRecursively(field.dataType, isTsOrDate)
+      } else {
+        false
       }
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -25,7 +25,6 @@ import com.nvidia.spark.rapids.shims.v2.ShimUnaryExecNode
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, SortOrder}
-import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
@@ -36,6 +35,7 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, Exchange,
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
 import org.apache.spark.sql.rapids.{GpuDataSourceScanExec, GpuFileSourceScanExec, GpuInputFileBlockLength, GpuInputFileBlockStart, GpuInputFileName, GpuShuffleEnv}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastExchangeExec, GpuBroadcastToCpuExec, GpuCustomShuffleReaderExec, GpuHashJoin, GpuShuffleExchangeExecBase}
+import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -386,7 +386,22 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
   private def insertColumnarToGpu(plan: SparkPlan): SparkPlan = {
     val nonQueryStagePlan = GpuTransitionOverrides.getNonQueryStagePlan(plan)
     if (nonQueryStagePlan.supportsColumnar && !nonQueryStagePlan.isInstanceOf[GpuExec]) {
-      HostColumnarToGpu(insertColumnarFromGpu(plan), TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
+      val coalesceGoal = TargetSize(rapidsConf.gpuTargetBatchSizeBytes)
+      // There are no batch methods to access nested types in Spark's ColumnVector, and as such
+      // HostColumnarToGpu does not support nested types due to the performance problem. If there's
+      // nested types involved, use a CPU columnar to row transition followed by a GPU row to
+      // columnar transition which is a more optimized code path for these types.
+      val hasNestedTypes = nonQueryStagePlan.schema.exists {
+        _.dataType match {
+          case _: ArrayType | _: MapType | _: StructType => true
+          case _ => false
+        }
+      }
+      if (hasNestedTypes) {
+        GpuRowToColumnarExec(ColumnarToRowExec(plan), coalesceGoal)
+      } else {
+        HostColumnarToGpu(insertColumnarFromGpu(plan), coalesceGoal)
+      }
     } else {
       plan.withNewChildren(plan.children.map(insertColumnarToGpu))
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -203,16 +203,9 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
    * looking for HostColumnarToGpu when optimizing transitions.
    */
   def fixupHostColumnarTransitions(plan: SparkPlan): SparkPlan = plan match {
-    case HostColumnarToGpu(child, goal) if hasNestedTypes(child.schema) =>
+    case HostColumnarToGpu(child, goal) if DataTypeUtils.hasNestedTypes(child.schema) =>
       GpuRowToColumnarExec(ColumnarToRowExec(fixupHostColumnarTransitions(child)), goal)
     case p => p.withNewChildren(p.children.map(fixupHostColumnarTransitions))
-  }
-
-  private def hasNestedTypes(schema: StructType) = schema.exists {
-    _.dataType match {
-      case _: ArrayType | _: MapType | _: StructType => true
-      case _ => false
-    }
   }
 
   @tailrec


### PR DESCRIPTION
Fixes #1304.  Transition planning now avoids using `HostColumnarToGpu` when the schema contains nested types and instead inserts a host `ColumnarToRowExec` followed by a `GpuRowToColumnarExec` to handle nested type conversion from columnar host data.  Added an integration test that exercises this code path on platforms that support host columnar forms of nested types (e.g.: Databricks).