### PR TITLE
Bring back AST support for BNLJ inner joins

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -92,13 +92,7 @@ class GpuBroadcastNestedLoopJoinMeta(
     verifyBuildSideWasReplaced(buildSide)
 
     val condition = conditionMeta.map(_.convertToGpu())
-    val isAstCondition = join.joinType match {
-      case _: InnerLike =>
-        // It appears to be faster to manifest the full cross join and post-filter than
-        // evaluate the AST during the join.
-        false
-      case _ => conditionMeta.forall(_.canThisBeAst)
-    }
+    val isAstCondition = conditionMeta.forall(_.canThisBeAst)
     join.joinType match {
       case _: InnerLike =>
       case LeftOuter | LeftSemi | LeftAnti if gpuBuildSide == GpuBuildLeft =>


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Now that https://github.com/rapidsai/cudf/pull/9523 has been merged, this PR brings back the request for AST for the BroadcastNestedLoopJoin InnerJoin case (which had been rolled back for 21.10 https://github.com/NVIDIA/spark-rapids/pull/3746)

This is marked as draft until we get a cuDF nightly pushed.