### PR TITLE
Fix the issue of parquet reading with case insensitive schema

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -477,14 +477,20 @@ _nested_pruning_schemas = [
         ([["a", StructGen([["c_1", StringGen()], ["c_2", LongGen()], ["c_3", ShortGen()]])]],
             [["a", StructGen([["c_3", ShortGen()], ["c_2", LongGen()], ["c_1", StringGen()]])]]),
         ([["ar", ArrayGen(StructGen([["str_1", StringGen()],["str_2", StringGen()]]))]],
-            [["ar", ArrayGen(StructGen([["str_2", StringGen()]]))]])
+            [["ar", ArrayGen(StructGen([["str_2", StringGen()]]))]]),
+        ([["struct", StructGen([["c_1", StringGen()], ["case_insensitive", LongGen()], ["c_3", ShortGen()]])]],
+            [["STRUCT", StructGen([["case_INSENsitive", LongGen()]])]]),
+        ([["struct", StructGen([["c_1", StringGen()], ["case_insensitive", LongGen()], ["c_3", ShortGen()]])]],
+            [["struct", StructGen([["CASE_INSENSITIVE", LongGen()]])]]),
+        ([["struct", StructGen([["c_1", StringGen()], ["case_insensitive", LongGen()], ["c_3", ShortGen()]])]],
+            [["stRUct", StructGen([["CASE_INSENSITIVE", LongGen()]])]]),
         ]
 
 @pytest.mark.parametrize('data_gen,read_schema', _nested_pruning_schemas, ids=idfn)
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 @pytest.mark.parametrize('nested_enabled', ["true", "false"])
-def test_nested_pruning(spark_tmp_path, data_gen, read_schema, reader_confs, v1_enabled_list, nested_enabled):
+def test_nested_pruning_and_case_insensitive(spark_tmp_path, data_gen, read_schema, reader_confs, v1_enabled_list, nested_enabled):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     with_cpu_session(
             lambda spark : gen_df(spark, data_gen).write.parquet(data_path),

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -681,32 +681,3 @@ def test_reading_from_unaligned_pages_basic_filters_with_nulls(spark_tmp_path, r
         assert_gpu_and_cpu_are_equal_collect(
                 lambda spark : spark.read.parquet(data_path).filter(filter_str),
                 all_confs)
-
-
-@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
-@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
-def test_user_defined_schema_with_case_insensitive(spark_tmp_path, reader_confs, v1_enabled_list):
-    all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
-
-    data_gens = [string_gen, int_gen, long_gen]
-    gen_list = [('c_' + str(i), gen) for i, gen in enumerate(data_gens)]
-    gen = StructGen([['struct', StructGen(gen_list, nullable=False)]], nullable=False)
-    data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_cpu_session(
-            lambda spark : gen_df(spark, gen).write.parquet(data_path))
-
-    schema = StructType([StructField('struct', StructType([StructField('c_1', IntegerType())]))])
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(schema).parquet(data_path), all_confs)
-
-    schema = StructType([StructField('STRUCT', StructType([StructField('c_1', IntegerType())]))])
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(schema).parquet(data_path), all_confs)
-
-    schema = StructType([StructField('struct', StructType([StructField('C_1', IntegerType())]))])
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(schema).parquet(data_path), all_confs)
-
-    schema = StructType([StructField('stRUCt', StructType([StructField('C_1', IntegerType())]))])
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(schema).parquet(data_path), all_confs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -889,7 +889,9 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
 
     if (!isCaseSensitive) {
       val m = CaseInsensitiveMap(fields.zip(fields).toMap)
-      readDataSchema.fieldNames.map(m(_))
+      // The schemas may be different among parquet files, so some column names may not be existing
+      // in the CaseInsensitiveMap. In that case, we just use the field name of readDataSchema
+      readDataSchema.fieldNames.map { name => m.get(name).getOrElse(name) }
     } else {
       readDataSchema.fieldNames.toSeq
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -874,9 +874,9 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
 
   /**
    * Take case-sensitive into consideration when getting the data reading column names
-   * before sending parquet-format buffer to cudf.
+   * before sending parquet-formatted buffer to cudf.
    *
-   * @param readDataSchema spark schema to read
+   * @param readDataSchema Spark schema to read
    * @param fileSchema  the schema of the dumped parquet-format buffer
    * @param isCaseSensitive if it is case sensitive
    * @return a sequence of column names following the order of readDataSchema
@@ -885,9 +885,9 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
       readDataSchema: StructType,
       fileSchema: MessageType,
       isCaseSensitive: Boolean): Seq[String] = {
-    val fields = fileSchema.getFields.asScala.map(_.getName).toSet
 
     if (!isCaseSensitive) {
+      val fields = fileSchema.asGroupType().getFields.asScala.map(_.getName).toSet
       val m = CaseInsensitiveMap(fields.zip(fields).toMap)
       // The schemas may be different among parquet files, so some column names may not be existing
       // in the CaseInsensitiveMap. In that case, we just use the field name of readDataSchema
@@ -1072,12 +1072,12 @@ class MultiFileParquetPartitionReader(
     // Dump parquet data into a file
     dumpDataToFile(dataBuffer, dataSize, splits, Option(debugDumpPrefix), Some("parquet"))
 
-    val includeColumn = toCudfColumnNames(readDataSchema, clippedSchema,
+    val includeColumns = toCudfColumnNames(readDataSchema, clippedSchema,
       isSchemaCaseSensitive)
     val parseOpts = ParquetOptions.builder()
       .withTimeUnit(DType.TIMESTAMP_MICROSECONDS)
       .enableStrictDecimalType(true)
-      .includeColumn(includeColumn: _*).build()
+      .includeColumn(includeColumns: _*).build()
 
     // About to start using the GPU
     GpuSemaphore.acquireIfNecessary(TaskContext.get(), metrics(SEMAPHORE_WAIT_TIME))
@@ -1331,12 +1331,12 @@ class MultiFileCloudParquetPartitionReader(
       // Dump parquet data into a file
       dumpDataToFile(hostBuffer, dataSize, files, Option(debugDumpPrefix), Some("parquet"))
 
-      val includeColumn = toCudfColumnNames(readDataSchema, clippedSchema,
+      val includeColumns = toCudfColumnNames(readDataSchema, clippedSchema,
         isSchemaCaseSensitive)
       val parseOpts = ParquetOptions.builder()
         .withTimeUnit(DType.TIMESTAMP_MICROSECONDS)
         .enableStrictDecimalType(true)
-        .includeColumn(includeColumn: _*).build()
+        .includeColumn(includeColumns: _*).build()
 
       // about to start using the GPU
       GpuSemaphore.acquireIfNecessary(TaskContext.get(), metrics(SEMAPHORE_WAIT_TIME))
@@ -1472,12 +1472,12 @@ class ParquetPartitionReader(
         // Dump parquet data into a file
         dumpDataToFile(dataBuffer, dataSize, Array(split), Option(debugDumpPrefix), Some("parquet"))
 
-        val includeColumn = toCudfColumnNames(readDataSchema, clippedParquetSchema,
+        val includeColumns = toCudfColumnNames(readDataSchema, clippedParquetSchema,
           isSchemaCaseSensitive)
         val parseOpts = ParquetOptions.builder()
           .withTimeUnit(DType.TIMESTAMP_MICROSECONDS)
           .enableStrictDecimalType(true)
-          .includeColumn(includeColumn: _*).build()
+          .includeColumn(includeColumns: _*).build()
 
         // about to start using the GPU
         GpuSemaphore.acquireIfNecessary(TaskContext.get(), metrics(SEMAPHORE_WAIT_TIME))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -877,7 +877,7 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
    * before sending parquet-formatted buffer to cudf.
    *
    * @param readDataSchema Spark schema to read
-   * @param fileSchema  the schema of the dumped parquet-formatted buffer
+   * @param fileSchema the schema of the dumped parquet-formatted buffer
    * @param isCaseSensitive if it is case sensitive
    * @return a sequence of column names following the order of readDataSchema
    */
@@ -891,6 +891,10 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
       val m = CaseInsensitiveMap(fields.zip(fields).toMap)
       // The schemas may be different among parquet files, so some column names may not be existing
       // in the CaseInsensitiveMap. In that case, we just use the field name of readDataSchema
+      //
+      // For hive special case, the readDataSchema is lower case, we need to do
+      // the case insensitive conversion
+      // See https://github.com/NVIDIA/spark-rapids/pull/3982#issue-770410779
       readDataSchema.fieldNames.map { name => m.get(name).getOrElse(name) }
     } else {
       readDataSchema.fieldNames.toSeq

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -877,7 +877,7 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
    * before sending parquet-formatted buffer to cudf.
    *
    * @param readDataSchema Spark schema to read
-   * @param fileSchema  the schema of the dumped parquet-format buffer
+   * @param fileSchema  the schema of the dumped parquet-formatted buffer
    * @param isCaseSensitive if it is case sensitive
    * @return a sequence of column names following the order of readDataSchema
    */


### PR DESCRIPTION
## How to reproduce

1.  generate a parquet file

``` scala
import org.apache.spark.sql.Row
import org.apache.spark.sql.types._

val data = Seq(
    Row("1"),
    Row("2"),
    Row("3")
)

val schema = (new StructType().add("ID",StringType))

val df = spark.createDataFrame(spark.sparkContext.parallelize(data),schema)
df.write.format("parquet").mode("overwrite").save("/tmp/testparquet")
```

2. create hive table

``` mysql
CREATE EXTERNAL TABLE `testorder`(
  `ID` string
)
ROW FORMAT SERDE                                                                                                                                          
  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'                                                                                           
STORED AS INPUTFORMAT                                                                                                                                     
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'                                                                                         
OUTPUTFORMAT                                                                                                                                              
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'                                                                                        
LOCATION                                                                                                                                                  
  '/tmp/testparquet';
```

3. reading the hive table by GPU

``` scala
spark.sql("REFRESH TABLE testorder")
spark.sql("select * from testorder limit 1 ").show
```

## Exception

``` console
Exception in thread "main" org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (spark-bobby executor driver): java.lang.ArrayIndexOutOfBoundsException: 0
	at ai.rapids.cudf.Table.<init>(Table.java:94)
	at ai.rapids.cudf.Table.readParquet(Table.java:862)
	at com.nvidia.spark.rapids.ParquetPartitionReader.$anonfun$readToTable$1(GpuParquetScanBase.scala:1485)
	at com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
	at com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
	at com.nvidia.spark.rapids.FilePartitionReaderBase.withResource(GpuMultiFileReader.scala:236)
	at com.nvidia.spark.rapids.ParquetPartitionReader.readToTable(GpuParquetScanBase.scala:1484)
	at com.nvidia.spark.rapids.ParquetPartitionReader.$anonfun$readBatch$1(GpuParquetScanBase.scala:1445)
	at com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
	at com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
	at com.nvidia.spark.rapids.FilePartitionReaderBase.withResource(GpuMultiFileReader.scala:236)
	at com.nvidia.spark.rapids.ParquetPartitionReader.readBatch(GpuParquetScanBase.scala:1433)
	at com.nvidia.spark.rapids.ParquetPartitionReader.next(GpuParquetScanBase.scala:1418)
	at com.nvidia.spark.rapids.PartitionReaderWithBytesRead.next(GpuDataSourceRDD.scala:94)
	at com.nvidia.spark.rapids.ColumnarPartitionReaderWithPartitionValues.next(ColumnarPartitionReaderWithPartitionValues.scala:36)
	at com.nvidia.spark.rapids.PartitionReaderIterator.hasNext(PartitionReaderIterator.scala:37)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:93)
```

## Root cause

``` console
== Physical Plan ==
GpuColumnarToRow false
+- GpuFileGpuScan parquet default.testorder[id#0] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[file:/home/bobwang/tmp/hive/testparquet], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<id:string>
```

The spark reading data schema is "id", while the schema of parquet file is "ID". 

The original code specifies the spark reading data column name, but it does not exist in the schema of parquet file. So This PR takes the case sensitive into consideration when specify the column names.