### PR TITLE
Avoid fetching batch likely to exceed target size when coalescing batches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -345,8 +345,8 @@ abstract class AbstractGpuCoalesceIterator(
               // avoid fetching if next batch is likely to exceed the specified row or size limits
               // based on the stats of previous batches
               val rowLimit = if (batchRowLimit > 0) batchRowLimit else Int.MaxValue
-              numRows + largestInputBatchSize <= rowLimit &&
-                  numBytes + largestInputBatchRows <= g.targetSizeBytes
+              numRows + largestInputBatchRows <= rowLimit &&
+                  numBytes + largestInputBatchSize <= g.targetSizeBytes
             case _ => true
           }
         } else {
@@ -362,8 +362,8 @@ abstract class AbstractGpuCoalesceIterator(
           if (nextRows > 0) {
             numInputRows += nextRows
             val nextBytes = getBatchDataSize(cb)
-            largestInputBatchSize = largestInputBatchSize.max(nextRows)
-            largestInputBatchRows = largestInputBatchRows.max(nextBytes)
+            largestInputBatchRows = largestInputBatchRows.max(nextRows)
+            largestInputBatchSize = largestInputBatchSize.max(nextBytes)
 
             // calculate the new sizes based on this input batch being added to the current
             // output batch


### PR DESCRIPTION
Closes #3750.

Updates the batch coalesce logic to track the largest number of rows and size seen in a single input batch to guesstimate whether the next batch is likely to fit in the current set of batches being coalesced within the specified target size.  Avoiding pulling in a batch that is unlikely to fit should help reduce the number of times we need to call `contiguous_split` to make the batch splittable and reduce the memory pressure from caching the manifested batch that we cannot immediately process.