### PR TITLE
[Doc] Update the getting started guide for databricks: Change from 8.2 to 9.1 runtime [skip ci]

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,7 +20,7 @@ process, we try to stay on top of these changes and release updates as quickly a
 The RAPIDS Accelerator for Apache Spark officially supports:
 - [Apache Spark](get-started/getting-started-on-prem.md)
 - [AWS EMR 6.2+](get-started/getting-started-aws-emr.md)
-- [Databricks Runtime 7.3, 8.2](get-started/getting-started-databricks.md)
+- [Databricks Runtime 7.3, 9.1](get-started/getting-started-databricks.md)
 - [Google Cloud Dataproc 2.0](get-started/getting-started-gcp.md)
 
 Most distributions based on a supported Apache Spark version should work, but because the plugin

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -298,7 +298,6 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.2.0         | com.nvidia.spark.rapids.spark320.RapidsShuffleManager    |
     | 3.2.1         | com.nvidia.spark.rapids.spark321.RapidsShuffleManager    |
     | Databricks 7.3| com.nvidia.spark.rapids.spark301db.RapidsShuffleManager  |
-    | Databricks 8.2| com.nvidia.spark.rapids.spark311db.RapidsShuffleManager  |
     | Databricks 9.1| com.nvidia.spark.rapids.spark312db.RapidsShuffleManager  |
 
 2. Settings for UCX 1.11.2+:

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -11,9 +11,9 @@ At the end of this guide, the reader will be able to run a sample Apache Spark a
 on NVIDIA GPUs on Databricks.
 
 ## Prerequisites
-    * Apache Spark 3.x running in Databricks Runtime 7.3 ML or 8.2 ML with GPU
-    * AWS: 7.3 LTS ML (GPU, Scala 2.12, Spark 3.0.1) or 8.2 ML (GPU, Scala 2.12, Spark 3.1.1)
-    * Azure: 7.3 LTS ML (GPU, Scala 2.12, Spark 3.0.1) or 8.2 ML (GPU, Scala 2.12, Spark 3.1.1)
+    * Apache Spark 3.x running in Databricks Runtime 7.3 ML or 9.1 ML with GPU
+    * AWS: 7.3 LTS ML (GPU, Scala 2.12, Spark 3.0.1) or 9.1 LTS ML (GPU, Scala 2.12, Spark 3.1.2)
+    * Azure: 7.3 LTS ML (GPU, Scala 2.12, Spark 3.0.1) or 9.1 LTS ML (GPU, Scala 2.12, Spark 3.1.2)
 
 Databricks may do [maintenance
 releases](https://docs.databricks.com/release-notes/runtime/maintenance-updates.html) for their
@@ -85,9 +85,9 @@ Update 2. Users wishing to try 21.06.1 or later on Databricks 7.3 LTS ML will ne
 CUDA 11.0 toolkit on the cluster.  This can be done with the [generate-init-script-cuda11.ipynb
 ](../demo/Databricks/generate-init-script-cuda11.ipynb) init script, which installs both the RAPIDS
 Spark plugin and the CUDA 11 toolkit. 
-    - [Databricks 8.2
-    ML](https://docs.databricks.com/release-notes/runtime/8.2ml.html#system-environment) has CUDA 11
-    installed.  Users will need to use 21.06.2 or later on Databricks 8.2 ML. In this case use
+    - [Databricks 9.1 LTS
+    ML](https://docs.databricks.com/release-notes/runtime/9.1ml.html#system-environment) has CUDA 11
+    installed.  Users will need to use 21.12.0 or later on Databricks 9.1 LTS ML. In this case use
     [generate-init-script.ipynb](../demo/Databricks/generate-init-script.ipynb) which will install
     the RAPIDS Spark plugin.
 2. Once you are in the notebook, click the “Run All” button.


### PR DESCRIPTION
Update the getting started guide for databricks: Change from 8.2 to 9.1 runtime.