### PR TITLE
Hash aggregate fix empty resultExpressions [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -14,7 +14,8 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql,\
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal,\
+    assert_gpu_and_cpu_are_equal_sql,\
     assert_gpu_fallback_collect, assert_cpu_and_gpu_are_equal_sql_with_capture,\
     assert_cpu_and_gpu_are_equal_collect_with_capture, run_with_cpu, run_with_cpu_and_gpu
 from conftest import is_databricks_runtime
@@ -256,6 +257,17 @@ _grpkey_small_decimals = [
 
 _init_list_no_nans_with_decimal = _init_list_no_nans + [
     _grpkey_small_decimals]
+
+@pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
+def test_hash_grpby_sum_count_action(data_gen):
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b'))
+    )
+@pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
+def test_hash_reduction_sum_count_action(data_gen):
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark: gen_df(spark, data_gen, length=100).agg(f.sum('b'))
+    )
 
 @shuffle_test
 @approximate_float

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 
 import ai.rapids.cudf
-import ai.rapids.cudf.{GroupByAggregation, NvtxColor, Scalar, Table}
+import ai.rapids.cudf.{NvtxColor, Scalar, Table}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.v2.ShimUnaryExecNode
@@ -40,7 +40,7 @@ import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.{ExplainUtils, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
-import org.apache.spark.sql.rapids.{CpuToGpuAggregateBufferConverter, GpuAggregateExpression, GpuToCpuAggregateBufferConverter}
+import org.apache.spark.sql.rapids.{CpuToGpuAggregateBufferConverter, CudfAggregate, GpuAggregateExpression, GpuToCpuAggregateBufferConverter}
 import org.apache.spark.sql.rapids.execution.{GpuShuffleMeta, TrampolineUtil}
 import org.apache.spark.sql.types.{ArrayType, DataType, LongType, MapType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -520,15 +520,15 @@ class GpuHashAggregateIterator(
         batch
       }
 
+      // If `resultCvs` empty, it means we don't have any `resultExpressions` for this
+      // aggregate. In these cases, the row count is the only important piece of information
+      // that this aggregate exec needs to report up, so it will return batches that have no columns
+      // but that do have a row count. If `resultCvs` is non-empty, the row counts match
+      // `finalBatch.numRows` since `columnarEvalToColumn` cannot change the number of rows.
       val finalNumRows = finalBatch.numRows()
 
       // Perform the last project to get the correct shape that Spark expects. Note this may
       // add things like literals that were not part of the aggregate into the batch.
-      //
-      // If `resultCvs` empty, it means we don't have any `resultExpressions` for this
-      // aggregate. In these cases, the row count is the only important piece of information
-      // that this aggregate exec needs to report up, so it will return batches that have no columns
-      // but that do have a row count.
       val resultCvs = withResource(finalBatch) { _ =>
         boundExpressions.boundResultReferences.safeMap { ref =>
           // Result references can be virtually anything, we need to coerce
@@ -673,18 +673,15 @@ class GpuHashAggregateIterator(
    *                   as an optimization hint
    */
   class AggHelper(merge: Boolean, isSorted: Boolean = false) {
-    // `CudfAggregate` instances to apply for groupBy aggregates
-    private val groupByAggregates = new mutable.ArrayBuffer[GroupByAggregation]()
-
-    // Reduction function (outputs a cuDF scalar) for non-groupBy aggs
-    private val reductionAggregates = new mutable.ArrayBuffer[cudf.ColumnVector => cudf.Scalar]()
+    // `CudfAggregate` instances to apply, either update or merge aggregates
+    private val cudfAggregates = new mutable.ArrayBuffer[CudfAggregate]()
 
     // integers for each column the aggregate is operating on
     private val aggOrdinals = new mutable.ArrayBuffer[Int]
 
     // the resulting data type from the cuDF aggregate (from
     // the update or merge aggregate, be it reduction or group by)
-    private val aggDataType = new mutable.ArrayBuffer[DataType]()
+    private val postStepDataTypes = new mutable.ArrayBuffer[DataType]()
 
     private val groupingAttributes = groupingExpressions.map(_.toAttribute)
     private val aggBufferAttributes = groupingAttributes ++
@@ -702,7 +699,7 @@ class GpuHashAggregateIterator(
     postStep ++= GpuBindReferences.bindGpuReferences(
       groupingAttributes, groupingAttributes)
     postStepAttr ++= groupingAttributes
-    aggDataType ++=
+    postStepDataTypes ++=
       groupingExpressions.map(_.dataType)
 
     private var ix = groupingAttributes.length
@@ -713,9 +710,8 @@ class GpuHashAggregateIterator(
         aggOrdinals ++= ordinals
         ix += ordinals.length
         val updateAggs = aggFn.updateAggregates
-        aggDataType ++= updateAggs.map(_.dataType)
-        groupByAggregates ++= updateAggs.map(_.groupByAggregate)
-        reductionAggregates ++= updateAggs.map(_.reductionAggregate)
+        postStepDataTypes ++= updateAggs.map(_.dataType)
+        cudfAggregates ++= updateAggs
         preStep ++= aggFn.aggBufferAttributes
         postStep ++= aggFn.postUpdate
         postStepAttr ++= aggFn.postUpdateAttr
@@ -724,17 +720,12 @@ class GpuHashAggregateIterator(
         aggOrdinals ++= ordinals
         ix += ordinals.length
         val mergeAggs = aggFn.mergeAggregates
-        aggDataType ++= mergeAggs.map(_.dataType)
-        groupByAggregates ++= mergeAggs.map(_.groupByAggregate)
-        reductionAggregates ++= mergeAggs.map(_.reductionAggregate)
+        postStepDataTypes ++= mergeAggs.map(_.dataType)
+        cudfAggregates ++= mergeAggs
         preStep ++= aggFn.preMerge
         postStep ++= aggFn.postMerge
         postStepAttr ++= aggFn.postMergeAttr
       }
-    }
-
-    if (aggDataType.isEmpty) {
-      aggDataType.append(LongType)
     }
 
     // a bound expression that is applied before the cuDF aggregate
@@ -762,13 +753,13 @@ class GpuHashAggregateIterator(
      */
     def performReduction(preProcessed: ColumnarBatch): Table = {
       val cvs = mutable.ArrayBuffer[GpuColumnVector]()
-      reductionAggregates.zip(aggDataType)
-        .zipWithIndex.foreach { case ((aggFn, dataType), ix) =>
+      cudfAggregates.zipWithIndex.foreach { case (cudfAgg, ix) =>
+        val aggFn = cudfAgg.reductionAggregate
         val cols = GpuColumnVector.extractColumns(preProcessed)
         val reductionCol = cols(aggOrdinals(ix))
         withResource(aggFn(reductionCol.getBase)) { res =>
           cvs += GpuColumnVector.from(
-            cudf.ColumnVector.fromScalar(res, 1), dataType)
+            cudf.ColumnVector.fromScalar(res, 1), cudfAgg.dataType)
         }
       }
       if (cvs.isEmpty) {
@@ -781,6 +772,13 @@ class GpuHashAggregateIterator(
         withResource(Scalar.fromLong(0L)) { ZERO =>
           cvs += GpuColumnVector.from(cudf.ColumnVector.fromScalar(ZERO, 1), LongType)
         }
+        // a reduction has no grouping keys, and in this case we also have no aggregate functions
+        // this means that we have an empty dataType collection. We need to add the LongType
+        // to the types, since we are producing batches with a new Long column.
+        require(postStepDataTypes.isEmpty,
+          s"Invalid aggregate batch data types ($postStepDataTypes) for a reduction with " +
+            s"no aggregate functions")
+        postStepDataTypes.append(LongType)
       }
       withResource(cvs) { _ =>
         GpuColumnVector.from(new ColumnarBatch(cvs.toArray, 1))
@@ -799,8 +797,8 @@ class GpuHashAggregateIterator(
           .withKeysSorted(isSorted)
           .build()
 
-        val cudfAggsOnColumn = groupByAggregates.zip(aggOrdinals).map {
-          case (cudfAgg, ord) => cudfAgg.onColumn(ord)
+        val cudfAggsOnColumn = cudfAggregates.zip(aggOrdinals).map {
+          case (cudfAgg, ord) => cudfAgg.groupByAggregate.onColumn(ord)
         }
 
         // perform the aggregate
@@ -821,7 +819,7 @@ class GpuHashAggregateIterator(
      */
     def postProcess(resultTbl: cudf.Table): ColumnarBatch = {
       withResource(resultTbl) { result =>
-        withResource(GpuColumnVector.from(result, aggDataType.toArray)) { resultBatch =>
+        withResource(GpuColumnVector.from(result, postStepDataTypes.toArray)) { resultBatch =>
           GpuProjectExec.project(resultBatch, postStepBound)
         }
       }


### PR DESCRIPTION
Closes #4017

This fixes a case where the hash aggregate was not handling the case where `resultExpressions` was empty. We can see this case for the `count` action pretty consistently, where spark may perform an agg and not want an aggregation column, or any output, other than the number of rows.

I cleaned up a projection that we used to do for the reduction aggregate with no agg function case, where we added a column of zeros. This column gets removed right after and it is a waste of time. 