### PR TITLE
Change the `catalystConverter` to be a Scala `val`.

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -120,7 +120,7 @@ abstract class GpuRowBasedScalaUDFBase(
    * converter for typed ScalaUDF only, since its the only case where we know the type tag
    * of the return data type of udf function.
    */
-  private[this] val catalystConverter: Any => Any = outputEncoder.map { enc =>
+  private[this] lazy val catalystConverter: Any => Any = outputEncoder.map { enc =>
     val toRow = enc.createSerializer().asInstanceOf[Any => Any]
     if (enc.isSerializedAsStructForTopLevel) {
       value: Any =>
@@ -145,7 +145,7 @@ abstract class GpuRowBasedScalaUDFBase(
   /**
    * Spark Scala UDF supports at most 22 parameters.
    */
-  private[this] val wrappedFunc: InternalRow => Any = {
+  private lazy val wrappedFunc: InternalRow => Any = {
     children.size match {
       case 0 =>
         val f = sparkFunc.asInstanceOf[() => Any]

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -120,7 +120,7 @@ abstract class GpuRowBasedScalaUDFBase(
    * converter for typed ScalaUDF only, since its the only case where we know the type tag
    * of the return data type of udf function.
    */
-  private def catalystConverter: Any => Any = outputEncoder.map { enc =>
+  private[this] val catalystConverter: Any => Any = outputEncoder.map { enc =>
     val toRow = enc.createSerializer().asInstanceOf[Any => Any]
     if (enc.isSerializedAsStructForTopLevel) {
       value: Any =>
@@ -145,7 +145,7 @@ abstract class GpuRowBasedScalaUDFBase(
   /**
    * Spark Scala UDF supports at most 22 parameters.
    */
-  private lazy val wrappedFunc: InternalRow => Any = {
+  private[this] val wrappedFunc: InternalRow => Any = {
     children.size match {
       case 0 =>
         val f = sparkFunc.asInstanceOf[() => Any]


### PR DESCRIPTION
Change the `catalystConverter` to be a Scala `val` to avoid evaluating a converter per row. 

This repeating evaluation for the converter is unnecessary, leading to really bad performance. 

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
