### PR TITLE
Change Databricks image from 8.2 to 9.1 [skip ci]

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -57,7 +57,7 @@
         </snapshot.buildvers>
         <databricks.buildvers>
             301db,
-            311db
+            312db
         </databricks.buildvers>
     </properties>
     <profiles>

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -76,12 +76,12 @@ RUNTIME_MAP = [
                 'databricks301,!snapshot-shims',
                 '3.0.1'
         ],
-        '8.2': [
-                '8.2.x-gpu-ml-scala2.12',
-                '3.1.1',
+        '9.1': [
+                '9.1.x-gpu-ml-scala2.12',
+                '3.1.2',
                 'init_cudf_udf.sh',
-                'databricks311,!snapshot-shims',
-                '3.1.1'
+                'databricks312,!snapshot-shims',
+                '3.1.2'
         ]
 ]
 
@@ -390,7 +390,7 @@ pipeline {
                     }
                 } // end of DB runtime 7.3
 
-                stage('DB runtime 8.2') {
+                stage('DB runtime 9.1') {
                     when {
                         beforeAgent true
                         expression {
@@ -400,13 +400,13 @@ pipeline {
 
                     agent {
                         kubernetes {
-                            label "premerge-ci-db-8.2-${BUILD_NUMBER}"
+                            label "premerge-ci-db-9.1-${BUILD_NUMBER}"
                             cloud 'sc-ipp-blossom-prod'
                             yaml "${IMAGE_DB}"
                         }
                     }
                     environment {
-                        DB_RUNTIME = '8.2'
+                        DB_RUNTIME = '9.1'
                         DATABRICKS_RUNTIME = "${RUNTIME_MAP["$DB_RUNTIME"][ID_RUNTIME]}"
                         BASE_SPARK_VERSION = "${RUNTIME_MAP["$DB_RUNTIME"][ID_SPARK]}"
                         BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = "${RUNTIME_MAP["$DB_RUNTIME"][ID_INSTALL]}"
@@ -422,7 +422,7 @@ pipeline {
                             }
                         }
                     }
-                } // end of DB runtime 8.2
+                } // end of DB runtime 9.1
 
                 stage('Dummy stage: blue ocean log view') {
                     steps {

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -394,7 +394,7 @@ pipeline {
                     when {
                         beforeAgent true
                         expression {
-                            db_build && major_ver >= 21 && minor_ver >= 6
+                            db_build && major_ver >= 21 && minor_ver >= 12
                         }
                     }
 

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -22,8 +22,8 @@ SPARKSRCTGZ=$1
 BASE_SPARK_VERSION=$2
 BUILD_PROFILES=$3
 BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS=$4
-BUILD_PROFILES=${BUILD_PROFILES:-'databricks311,!snapshot-shims'}
-BASE_SPARK_VERSION=${BASE_SPARK_VERSION:-'3.1.1'}
+BUILD_PROFILES=${BUILD_PROFILES:-'databricks312,!snapshot-shims'}
+BASE_SPARK_VERSION=${BASE_SPARK_VERSION:-'3.1.2'}
 BUILDVER=$(echo ${BASE_SPARK_VERSION} | sed 's/\.//g')db
 # the version of Spark used when we install the Databricks jars in .m2
 # 3.1.0-databricks is add because its actually based on Spark 3.1.1

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -20,6 +20,12 @@
 
 CUDF_VER=${CUDF_VER:-21.12}
 
+# Need to explictly add conda into PATH environment if it is not set.
+if [ -z $(command -v conda) ]; then
+    export PATH=/databricks/conda/bin:$PATH
+    conda --version
+fi
+
 # Use mamba to install cudf-udf packages to speed up conda resolve time
 base=$(conda info --base)
 conda create -y -n mamba -c conda-forge mamba

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -20,17 +20,14 @@
 
 CUDF_VER=${CUDF_VER:-21.12}
 
-# Need to explictly add conda into PATH environment if it is not set.
-if [ -z $(command -v conda) ]; then
-    export PATH=/databricks/conda/bin:$PATH
-    conda --version
-fi
+# Need to explictly add conda into PATH environment, to activate conda environment.
+export PATH=/databricks/conda/bin:$PATH
 
-# Use mamba to install cudf-udf packages to speed up conda resolve time
 base=$(conda info --base)
-conda create -y -n mamba -c conda-forge mamba
-pip uninstall -y pyarrow
-${base}/envs/mamba/bin/mamba remove -y c-ares zstd libprotobuf pandas
-${base}/envs/mamba/bin/mamba install -y pyarrow=1.0.1 -c conda-forge
-${base}/envs/mamba/bin/mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=$CUDF_VER cudatoolkit=11.0
-conda env remove -n mamba
+# Create and activate 'cudf-udf' conda env for cudf-udf tests
+conda create -y -n cudf-udf && source activate && conda activate cudf-udf
+# Use mamba to install cudf-udf packages to speed up conda resolve time
+conda install -c conda-forge mamba
+${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas
+${base}/envs/cudf-udf/bin/mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=$CUDF_VER cudatoolkit=11.0 python=3.8
+conda deactivate

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -22,8 +22,12 @@ SPARK_CONF=${SPARK_CONF:-''}
 BASE_SPARK_VER=${BASE_SPARK_VER:-'3.1.2'}
 [[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VER//.}db
 
+# Try to use "cudf-udf" conda environment for the python cudf-udf tests.
+if [ -d "/databricks/conda/envs/cudf-udf" ]; then
+    export PATH=/databricks/conda/envs/cudf-udf/bin:/databricks/conda/bin:$PATH
+    export PYSPARK_PYTHON=/databricks/conda/envs/cudf-udf/bin/python
+fi
 # Try to use the pip from the conda environment if it is available
-export PATH=/databricks/conda/envs/databricks-ml-gpu/bin:/databricks/conda/condabin:$PATH
 sudo "$(which pip)" install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pytest-ordering
 
 export SPARK_HOME=/databricks/spark

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -19,7 +19,7 @@ set -ex
 
 LOCAL_JAR_PATH=${LOCAL_JAR_PATH:-''}
 SPARK_CONF=${SPARK_CONF:-''}
-BASE_SPARK_VER=${BASE_SPARK_VER:-'3.1.1'}
+BASE_SPARK_VER=${BASE_SPARK_VER:-'3.1.2'}
 [[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VER//.}db
 
 # Try to use the pip from the conda environment if it is available


### PR DESCRIPTION
Databricks 8.2 has been deprecated, change to Databricks 9.1 LTS.

Signed-off-by: Tim Liu <timl@nvidia.com>
