### PR TITLE
Use install for the base version build thread [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,13 +72,13 @@ You can also install some manually and build a combined jar. For instance to bui
 
 ```shell script
 mvn clean
-mvn -Dbuildver=301 package -DskipTests
-mvn -Dbuildver=302 package -Drat.skip=true -DskipTests
-mvn -Dbuildver=303 package -Drat.skip=true -DskipTests
-mvn -Dbuildver=311 package -Drat.skip=true -DskipTests
-mvn -Dbuildver=312 package -Drat.skip=true -DskipTests
-mvn -Dbuildver=320 package -Drat.skip=true -DskipTests
-mvn -Dbuildver=311cdh package -Drat.skip=true -DskipTests
+mvn -Dbuildver=301 install -DskipTests
+mvn -Dbuildver=302 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=303 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=311 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=312 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=320 install -Drat.skip=true -DskipTests
+mvn -Dbuildver=311cdh install -Drat.skip=true -DskipTests
 mvn -pl dist -PnoSnapshots package -DskipTests
 ```
 #### Building with buildall script

--- a/build/buildall
+++ b/build/buildall
@@ -151,6 +151,14 @@ build_single_shim() {
 
   if [[ "$BUILD_VER" == "$BASE_VER" ]]; then
     SKIP_CHECKS="false"
+    # WORKAROUND:
+    # maven build on L193 currently relies on aggregator dependency which
+    # will removed by
+    # https://github.com/NVIDIA/spark-rapids/issues/3932
+    #
+    # if it were a single maven invocation Maven would register and give
+    # precedence package-phase artifacts
+    #
     MVN_PHASE="install"
   else
     SKIP_CHECKS="true"

--- a/build/buildall
+++ b/build/buildall
@@ -148,10 +148,17 @@ build_single_shim() {
   mkdir -p "$MVN_BASE_DIR/target"
   (( BUILD_PARALLEL == 1 || NUM_SHIMS == 1 )) && LOG_FILE="/dev/tty" || \
     LOG_FILE="$MVN_BASE_DIR/target/mvn-build-$BUILD_VER.log"
-  SKIP_CHECKS=$( [[ "$BUILD_VER" == "$BASE_VER" ]] && echo false || echo true )
+
+  if [[ "$BUILD_VER" == "$BASE_VER" ]]; then
+    SKIP_CHECKS="false"
+    MVN_PHASE="install"
+  else
+    SKIP_CHECKS="true"
+    MVN_PHASE="package"
+  fi
 
   echo "#### REDIRECTING mvn output to $LOG_FILE ####"
-  mvn -U package \
+  mvn -U "$MVN_PHASE" \
       -DskipTests \
       -Dbuildver="$BUILD_VER" \
       -Drat.skip="$SKIP_CHECKS" \


### PR DESCRIPTION
Make sure that the minimum spark version classifier of the aggregator (typically 301) is `install`ed  

Closes #4053 

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
