### PR TITLE
Support building from sub directory

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -214,7 +214,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>generate-build-info</id>
@@ -225,7 +224,7 @@
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <mkdir dir="${project.build.directory}/tmp"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/rapids4spark-version-info.properties">
-                                    <arg value="${user.dir}/build/build-info"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/build-info"/>
                                     <arg value="${project.version}"/>
                                     <arg value="${cudf.version}"/>
                                 </exec>

--- a/pom.xml
+++ b/pom.xml
@@ -1022,7 +1022,7 @@
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <mkdir dir="${project.build.directory}/tmp"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/rapids4spark-version-info.properties">
-                                    <arg value="${user.dir}/build/build-info"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/build-info"/>
                                     <arg value="${project.version}"/>
                                     <arg value="${cudf.version}"/>
                                 </exec>
@@ -1225,6 +1225,26 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <!--use this plugin to configure "spark.rapids.source.basedir" property-->
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>0.1</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>highest-basedir</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>spark.rapids.source.basedir</property>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <!--
                 This is an alternative implementation of the scalastyle check invocation,

--- a/shims/spark301/pom.xml
+++ b/shims/spark301/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark301.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark301.version}"/>

--- a/shims/spark301db/pom.xml
+++ b/shims/spark301db/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark301db.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark301db.version}"/>

--- a/shims/spark302/pom.xml
+++ b/shims/spark302/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark302.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark302.version}"/>

--- a/shims/spark303/pom.xml
+++ b/shims/spark303/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark303.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark303.version}"/>

--- a/shims/spark304/pom.xml
+++ b/shims/spark304/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark304.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark304.version}"/>

--- a/shims/spark311/pom.xml
+++ b/shims/spark311/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark311.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark311.version}"/>

--- a/shims/spark311cdh/pom.xml
+++ b/shims/spark311cdh/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark311cdh.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark311cdh.version}"/>

--- a/shims/spark311db/pom.xml
+++ b/shims/spark311db/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark311db.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark311db.version}"/>

--- a/shims/spark312/pom.xml
+++ b/shims/spark312/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark312.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark312.version}"/>

--- a/shims/spark312db/pom.xml
+++ b/shims/spark312db/pom.xml
@@ -49,7 +49,7 @@
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true"
                                       output="${project.build.directory}/extra-resources/spark-${spark312db.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark312db.version}"/>

--- a/shims/spark313/pom.xml
+++ b/shims/spark313/pom.xml
@@ -48,7 +48,7 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/extra-resources"/>
                                 <exec executable="bash" failonerror="true" output="${project.build.directory}/extra-resources/spark-${spark313.version}-info.properties">
-                                    <arg value="${user.dir}/build/dependency-info.sh"/>
+                                    <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                                     <arg value="${cudf.version}"/>
                                     <arg value="${cuda.version}"/>
                                     <arg value="${spark313.version}"/>

--- a/shims/spark320/pom.xml
+++ b/shims/spark320/pom.xml
@@ -49,7 +49,7 @@
                 <mkdir dir="${project.build.directory}/extra-resources"/>
                 <exec executable="bash" failonerror="true"
                       output="${project.build.directory}/extra-resources/spark-${spark320.version}-info.properties">
-                  <arg value="${user.dir}/build/dependency-info.sh"/>
+                  <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                   <arg value="${cudf.version}"/>
                   <arg value="${cuda.version}"/>
                   <arg value="${spark320.version}"/>

--- a/shims/spark321/pom.xml
+++ b/shims/spark321/pom.xml
@@ -49,7 +49,7 @@
                 <mkdir dir="${project.build.directory}/extra-resources"/>
                 <exec executable="bash" failonerror="true"
                       output="${project.build.directory}/extra-resources/spark-${spark321.version}-info.properties">
-                  <arg value="${user.dir}/build/dependency-info.sh"/>
+                  <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                   <arg value="${cudf.version}"/>
                   <arg value="${cuda.version}"/>
                   <arg value="${spark321.version}"/>

--- a/shims/spark330/pom.xml
+++ b/shims/spark330/pom.xml
@@ -49,7 +49,7 @@
                 <mkdir dir="${project.build.directory}/extra-resources"/>
                 <exec executable="bash" failonerror="true"
                       output="${project.build.directory}/extra-resources/spark-${spark330.version}-info.properties">
-                  <arg value="${user.dir}/build/dependency-info.sh"/>
+                  <arg value="${spark.rapids.source.basedir}/build/dependency-info.sh"/>
                   <arg value="${cudf.version}"/>
                   <arg value="${cuda.version}"/>
                   <arg value="${spark330.version}"/>


### PR DESCRIPTION
Use directory-maven-plugin to get spark-rapids root path instead of user.dir which is a relative path.
Fixes #3461 

Signed-off-by: Chong Gao <res_life@163.com>