### PR TITLE
Fix overflow checking on optimized decimal sum

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2974,6 +2974,7 @@ object GpuOverrides extends Logging {
       ExprChecks.unaryProject(TypeSig.LONG, TypeSig.LONG,
         TypeSig.DECIMAL_64, TypeSig.DECIMAL_128_FULL),
       (a, conf, p, r) => new UnaryExprMeta[UnscaledValue](a, conf, p, r) {
+        override val isFoldableNonLitAllowed: Boolean = true
         override def convertToGpu(child: Expression): GpuExpression = GpuUnscaledValue(child)
       }),
     expr[MakeDecimal](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -976,8 +976,10 @@ abstract class BaseExprMeta[INPUT <: Expression](
     case _ => ExpressionContext.getRegularOperatorContext(this)
   }
 
+  val isFoldableNonLitAllowed: Boolean = false
+
   final override def tagSelfForGpu(): Unit = {
-    if (wrapped.foldable && !GpuOverrides.isLit(wrapped)) {
+    if (wrapped.foldable && !GpuOverrides.isLit(wrapped) && !isFoldableNonLitAllowed) {
       willNotWorkOnGpu(s"Cannot run on GPU. Is ConstantFolding excluded? Expression " +
         s"$wrapped is foldable and operates on non literals")
     }


### PR DESCRIPTION
I found this yesterday while trying to check a few things with overflow on the decimal 128 branch. It turns out the underflow, and wrapped overflow were not being checked properly. I have fixed it, but the test would take a very long time to run and I am not sure we want to put into into our regular integration tests

```
spark.range(174467442481L).selectExpr("SUM(CAST(99999999 as Decimal(8, 0)))")
```

The changes for `GpuUnscaledValue` are there mostly to get the test to work. It turns out that UnscaledValue is applied after constant folding so if you have a Decimal constant value with precision 8 or lower that you are doing a SUM on  it will not run on the GPU.  It is a bit of a corner case. The changes for `GpuUnscaledValue` were already applied to the decimal128 support branch.
