### PR TITLE
Sets the GPU device id in the UCX early start thread

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
@@ -191,10 +191,11 @@ class RapidsShuffleHeartbeatEndpoint(pluginContext: PluginContext, conf: RapidsC
     conf.shuffleTransportEarlyStartHeartbeatInterval
 
   private[this] val executorService: ScheduledExecutorService =
-    Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-      .setNameFormat("rapids-shuffle-hb")
-      .setDaemon(true)
-      .build())
+    Executors.newSingleThreadScheduledExecutor(
+      GpuDeviceManager.wrapThreadFactory(new ThreadFactoryBuilder()
+        .setNameFormat("rapids-shuffle-hb")
+        .setDaemon(true)
+        .build()))
 
   private class InitializeShuffleManager(ctx: PluginContext,
       shuffleManager: RapidsShuffleInternalManagerBase) extends Runnable {


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This sets the GPU device in the thread that initializes UCX. The UCX team found that not setting the device ID here could affect the topology calculations when trying to find the "closest NIC" in a multi-NIC machine.

I need to run NDS with UCX fully, but I did run a few queries with this and I am not finding issues.