### PR TITLE
Fix compiler warning in regex transpiler

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -530,6 +530,8 @@ class CudfRegexTranspiler {
           RegexGroup(rewrite(term))
       }
 
+      case other =>
+        throw new RegexUnsupportedException(s"Unhandled expression in transpiler: $other")
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

This is required to fix the pre-merge build for https://github.com/NVIDIA/spark-rapids/pull/4071 although that PR will likely need upmerging as well since `RegexParser::transpile` has been substantially refactored recently.