### PR TITLE
[auto-merge] branch-21.12 to branch-22.02 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-21.10
+    - branch-21.12
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-21.10 # force to fetch from latest upstream instead of PR ref
+          ref: branch-21.12 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-21.10
-          BASE: branch-21.12
+          HEAD: branch-21.12
+          BASE: branch-22.02
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-21.12` to create a PR keeping `branch-22.02` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.