### PR TITLE
Add PCA example to ml-integration page [skip ci]

### DIFF
--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -39,8 +39,6 @@ access to any of the memory that RMM is holding.
 
 ## Spark ML Algorithms Supported by RAPIDS Accelerator
 
-[PCA(Principal Component Analysis)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca) has been supported by the plugin directly. (only transform part now)
-
-The implementation leverages the technique of [RapidsUDF](https://github.com/NVIDIA/spark-rapids/blob/branch-21.12/docs/additional-functionality/rapids-udfs.md#rapids-accelerated-user-defined-functions).
+The plugin implements the `transform` API for [Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca) as an [accelerated UDF](https://github.com/NVIDIA/spark-rapids/blob/branch-21.12/docs/additional-functionality/rapids-udfs.md#rapids-accelerated-user-defined-functions).
 
 You may find the details in [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) and the use case in [spark-rapids-example's pca subfolder](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca).

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -39,6 +39,10 @@ access to any of the memory that RMM is holding.
 
 ## Spark ML Algorithms Supported by RAPIDS Accelerator
 
-The plugin implements the `transform` API for [Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca) as an [accelerated UDF](https://github.com/NVIDIA/spark-rapids/blob/branch-21.12/docs/additional-functionality/rapids-udfs.md#rapids-accelerated-user-defined-functions).
-
-You can find the details in [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) and the use case in [spark-rapids-example's pca subfolder](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca).
+The [spark-rapids-examples repository](https://github.com/NVIDIA/spark-rapids-examples) provides a
+[working example](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca)
+of accelerating the `transform` API for
+[Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca).
+The example leverages the [RAPIDS accelerated UDF interface](rapids-udfs.md) to provide a native
+implementation of the algorithm. The details of the UDF implementation can be found in the
+[spark-rapids-ml repository](https://github.com/NVIDIA/spark-rapids-ml).

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -36,3 +36,11 @@ val maxValue = rdd.map(table => {
 You may need to disable RMM caching when exporting data to an ML library as that library
 will likely want to use all of the GPU's memory and if it is not aware of RMM it will not have
 access to any of the memory that RMM is holding.
+
+## Spark ML Algorithms Supported by RAPIDS Accelerator
+
+[PCA(Principal Component Analysis)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca) has been supported by the plugin directly. (only transform part now)
+
+The implementation leverages the technique of [RapidsUDF](https://github.com/NVIDIA/spark-rapids/blob/branch-21.12/docs/additional-functionality/rapids-udfs.md#rapids-accelerated-user-defined-functions).
+
+You may find the details in [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) and the use case in [spark-rapids-example's pca subfolder](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca).

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -41,4 +41,4 @@ access to any of the memory that RMM is holding.
 
 The plugin implements the `transform` API for [Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca) as an [accelerated UDF](https://github.com/NVIDIA/spark-rapids/blob/branch-21.12/docs/additional-functionality/rapids-udfs.md#rapids-accelerated-user-defined-functions).
 
-You may find the details in [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) and the use case in [spark-rapids-example's pca subfolder](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca).
+You can find the details in [spark-rapids-ml](https://github.com/NVIDIA/spark-rapids-ml) and the use case in [spark-rapids-example's pca subfolder](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-21.10/examples/pca).


### PR DESCRIPTION
- link implementation repo and use case to ml-integration page.

skip ci since just docs update.

Signed-off-by: Allen Xu <allxu@nvidia.com>