### PR TITLE
Set the task context in background reader threads

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -145,4 +145,10 @@ object TrampolineUtil {
 
   /** Throw a Spark analysis exception */
   def throwAnalysisException(msg: String) = throw new AnalysisException(msg)
+
+  /** Set the task context for the current thread */
+  def setTaskContext(tc: TaskContext): Unit = TaskContext.setTaskContext(tc)
+
+  /** Remove the task context for the current thread */
+  def unsetTaskContext(): Unit = TaskContext.unset()
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
@@ -22,6 +22,7 @@ import ai.rapids.cudf.HostMemoryBuffer
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.sources.Filter
@@ -49,6 +50,7 @@ class GpuMultiFileReaderSuite extends FunSuite with Arm {
       })
 
       override def getBatchRunner(
+          tc: TaskContext,
           file: PartitionedFile,
           conf: Configuration,
           filters: Array[Filter]): Callable[HostMemoryBuffersWithMetaDataBase] = {


### PR DESCRIPTION
Fixes #3872.

This changes the multi file reader code to pass the current task context to the batch runner instances, and those instances now ensure the task context is set on the thread while running the background task and cleared when the task completes.