### PR TITLE
Fix build errors in udf-examples native build

### DIFF
--- a/udf-examples/Dockerfile
+++ b/udf-examples/Dockerfile
@@ -40,7 +40,7 @@ CUDA_VERSION_MINOR=$(echo $CUDA_VERSION | tr -d '.' | cut -c 3); \
 && add-apt-repository ppa:deadsnakes/ppa \
 && apt update -y \
 && apt install -y \
-   build-essential git wget \
+   build-essential git rsync wget \
    gcc-${GCC_VERSION} g++-${GCC_VERSION} \
    openjdk-8-jdk maven tzdata \
    # CMake dependencies

--- a/udf-examples/src/main/cpp/CMakeLists.txt
+++ b/udf-examples/src/main/cpp/CMakeLists.txt
@@ -20,7 +20,11 @@ file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 
+include(rapids-cmake)
+include(rapids-cpm)
 include(rapids-cuda)
+include(rapids-export)
+include(rapids-find)
 
 # Use GPU_ARCHS if it is defined
 if(DEFINED GPU_ARCHS)
@@ -32,19 +36,6 @@ project(UDFEXAMPLESJNI VERSION 21.12.0 LANGUAGES C CXX CUDA)
 
 option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
 option(BUILD_UDF_BENCHMARKS "Build the benchmarks" OFF)
-
-#################################################################################################
-# - CPM -----------------------------------------------------------------------------------------
-
-set(CPM_DOWNLOAD_VERSION 0.27.2)
-set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-    message(STATUS "Downloading CPM.cmake")
-    file(DOWNLOAD https://github.com/TheLartians/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
-endif()
-
-include(${CPM_DOWNLOAD_LOCATION})
 
 ###################################################################################################
 # - build type ------------------------------------------------------------------------------------
@@ -92,8 +83,9 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w --expt-extended-lambda --expt-relax
 # Ensure CUDA runtime is dynamic despite statically linking Arrow in libcudf
 set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 
-CPMAddPackage(NAME  cudf
-        VERSION         "21.12.00"
+rapids_cpm_init()
+rapids_cpm_find(cudf 21.12.00
+        CPM_ARGS
         GIT_REPOSITORY  https://github.com/rapidsai/cudf.git
         GIT_TAG         branch-21.12
         GIT_SHALLOW     TRUE

--- a/udf-examples/src/main/cpp/src/cosine_similarity.cu
+++ b/udf-examples/src/main/cpp/src/cosine_similarity.cu
@@ -135,10 +135,11 @@ std::unique_ptr<cudf::column> cosine_similarity(cudf::lists_column_view const& l
                     cosine_similarity_functor({lv1_data, lv2_data, lv1_offsets, lv2_offsets}));
 
   // the validity of the output is the bitwise-and of the two input validity masks
-  rmm::device_buffer null_mask = cudf::bitmask_and(cudf::table_view({lv1.parent(), lv2.parent()}));
+  auto [null_mask, null_count] = cudf::bitmask_and(cudf::table_view({lv1.parent(), lv2.parent()}));
 
   return std::make_unique<cudf::column>(cudf::data_type{cudf::type_id::FLOAT32},
                                         row_count,
                                         float_results.release(),
-                                        std::move(null_mask));
+                                        std::move(null_mask),
+                                        null_count);
 }


### PR DESCRIPTION
Fixes #4102.

Fixes a number of problems in the udf-examples native build:
- `rsync` is required by the RAPIDS Accelerator build but is not provided in the sample Docker container
- CPM was fixed at a specific version which conflicted with the version rapids-cmake wants to use.  Updated to use rapids-cpm to fetch cudf
- cudf::bitmask_and API recently changed to return a pair, and that broke the cosine similarity UDF code.