### PR TITLE
Regexp: Only transpile once per expression rather than once per batch

### DIFF
--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -31,8 +31,6 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(null, _) =>
-        willNotWorkOnGpu(s"null pattern is not supported on GPU")
       case Literal(s: UTF8String, DataTypes.StringType) =>
         val pattern = s.toString
         if (pattern.isEmpty) {

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -32,16 +32,11 @@ class GpuRegExpReplaceMeta(
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) =>
-        val pattern = s.toString
-        if (pattern.isEmpty) {
-          willNotWorkOnGpu(s"empty pattern is not supported on GPU")
-        }
-
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
           try {
-            new CudfRegexTranspiler(replace = true).transpile(pattern)
+            new CudfRegexTranspiler(replace = true).transpile(s.toString)
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -15,8 +15,6 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.sql.SQLException
-
 import com.nvidia.spark.rapids.{CudfRegexTranspiler, DataFromReplacementRule, GpuExpression, GpuOverrides, RapidsConf, RapidsMeta, RegexUnsupportedException, TernaryExprMeta}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
@@ -60,7 +58,7 @@ class GpuRegExpReplaceMeta(
       GpuStringReplace(lhs, regexp, rep)
     } else {
       GpuRegExpReplace(lhs, regexp, rep, pattern.getOrElse(
-        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
+        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
     }
   }
 }

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -35,7 +35,7 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(s: UTF8String, DataTypes.StringType) =>
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
@@ -48,7 +48,7 @@ class GpuRegExpReplaceMeta(
         }
 
       case _ =>
-        willNotWorkOnGpu(s"non-literal pattern is not supported on GPU")
+        willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
     }
   }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -31,8 +31,6 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(null, _) =>
-        willNotWorkOnGpu(s"null pattern is not supported on GPU")
       case Literal(s: UTF8String, DataTypes.StringType) =>
         val pattern = s.toString
         if (pattern.isEmpty) {

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -32,16 +32,11 @@ class GpuRegExpReplaceMeta(
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) =>
-        val pattern = s.toString
-        if (pattern.isEmpty) {
-          willNotWorkOnGpu(s"empty pattern is not supported on GPU")
-        }
-
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
           try {
-            new CudfRegexTranspiler(replace = true).transpile(pattern)
+            new CudfRegexTranspiler(replace = true).transpile(s.toString)
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -15,8 +15,9 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import com.nvidia.spark.rapids._
+import java.sql.SQLException
 
+import com.nvidia.spark.rapids._
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
 import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuStringReplace}
 import org.apache.spark.sql.types.DataTypes
@@ -29,6 +30,8 @@ class GpuRegExpReplaceMeta(
     rule: DataFromReplacementRule)
   extends TernaryExprMeta[RegExpReplace](expr, conf, parent, rule) {
 
+  private var pattern: Option[String] = None
+
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) =>
@@ -36,7 +39,7 @@ class GpuRegExpReplaceMeta(
           // use GpuStringReplace
         } else {
           try {
-            new CudfRegexTranspiler(replace = true).transpile(s.toString)
+            pattern = Some(new CudfRegexTranspiler(replace = true).transpile(s.toString))
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)
@@ -55,7 +58,8 @@ class GpuRegExpReplaceMeta(
     if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
       GpuStringReplace(lhs, regexp, rep)
     } else {
-      GpuRegExpReplace(lhs, regexp, rep)
+      GpuRegExpReplace(lhs, regexp, rep, pattern.getOrElse(
+        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
     }
   }
 }

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -15,8 +15,6 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.sql.SQLException
-
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
@@ -60,7 +58,7 @@ class GpuRegExpReplaceMeta(
       GpuStringReplace(lhs, regexp, rep)
     } else {
       GpuRegExpReplace(lhs, regexp, rep, pattern.getOrElse(
-        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
+        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
     }
   }
 }

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.shims.v2
 import java.sql.SQLException
 
 import com.nvidia.spark.rapids._
+
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
 import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuStringReplace}
 import org.apache.spark.sql.types.DataTypes
@@ -34,7 +35,7 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(s: UTF8String, DataTypes.StringType) =>
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
@@ -47,7 +48,7 @@ class GpuRegExpReplaceMeta(
         }
 
       case _ =>
-        willNotWorkOnGpu(s"non-literal pattern is not supported on GPU")
+        willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
     }
   }
 

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -31,8 +31,6 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(null, _) =>
-        willNotWorkOnGpu(s"null pattern is not supported on GPU")
       case Literal(s: UTF8String, DataTypes.StringType) =>
         val pattern = s.toString
         if (pattern.isEmpty) {

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -32,16 +32,11 @@ class GpuRegExpReplaceMeta(
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) =>
-        val pattern = s.toString
-        if (pattern.isEmpty) {
-          willNotWorkOnGpu(s"empty pattern is not supported on GPU")
-        }
-
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
           try {
-            new CudfRegexTranspiler(replace = true).transpile(pattern)
+            new CudfRegexTranspiler(replace = true).transpile(s.toString)
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -15,8 +15,6 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.sql.SQLException
-
 import com.nvidia.spark.rapids.{CudfRegexTranspiler, DataFromReplacementRule, GpuExpression, GpuOverrides, QuaternaryExprMeta, RapidsConf, RapidsMeta, RegexUnsupportedException}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
@@ -71,7 +69,7 @@ class GpuRegExpReplaceMeta(
       GpuStringReplace(subject, regexp, rep)
     } else {
       GpuRegExpReplace(subject, regexp, rep, pattern.getOrElse(
-        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
+        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
     }
   }
 }

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -35,7 +35,7 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(s: UTF8String, DataTypes.StringType) =>
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
@@ -48,7 +48,7 @@ class GpuRegExpReplaceMeta(
         }
 
       case _ =>
-        willNotWorkOnGpu(s"non-literal pattern is not supported on GPU")
+        willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
     }
 
     GpuOverrides.extractLit(expr.pos).foreach { lit =>

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -31,8 +31,6 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(null, _) =>
-        willNotWorkOnGpu(s"null pattern is not supported on GPU")
       case Literal(s: UTF8String, DataTypes.StringType) =>
         val pattern = s.toString
         if (pattern.isEmpty) {

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -32,16 +32,11 @@ class GpuRegExpReplaceMeta(
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) =>
-        val pattern = s.toString
-        if (pattern.isEmpty) {
-          willNotWorkOnGpu(s"empty pattern is not supported on GPU")
-        }
-
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
           try {
-            new CudfRegexTranspiler(replace = true).transpile(pattern)
+            new CudfRegexTranspiler(replace = true).transpile(s.toString)
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -15,8 +15,6 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.sql.SQLException
-
 import com.nvidia.spark.rapids.{CudfRegexTranspiler, DataFromReplacementRule, GpuExpression, GpuOverrides, QuaternaryExprMeta, RapidsConf, RapidsMeta, RegexUnsupportedException}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
@@ -71,7 +69,7 @@ class GpuRegExpReplaceMeta(
       GpuStringReplace(subject, regexp, rep)
     } else {
       GpuRegExpReplace(subject, regexp, rep, pattern.getOrElse(
-        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
+        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
     }
   }
 }

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -35,7 +35,7 @@ class GpuRegExpReplaceMeta(
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
-      case Literal(s: UTF8String, DataTypes.StringType) =>
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
         if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
           // use GpuStringReplace
         } else {
@@ -48,7 +48,7 @@ class GpuRegExpReplaceMeta(
         }
 
       case _ =>
-        willNotWorkOnGpu(s"non-literal pattern is not supported on GPU")
+        willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
     }
 
     GpuOverrides.extractLit(expr.pos).foreach { lit =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -44,6 +44,9 @@ class RegexParser(pattern: String) {
   private var pos = 0
 
   def parse(): RegexAST = {
+    if (pattern == null) {
+      return null
+    }
     val ast = parseUntil(() => eof())
     if (!eof()) {
       throw new RegexUnsupportedException("failed to parse full regex")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -44,9 +44,6 @@ class RegexParser(pattern: String) {
   private var pos = 0
 
   def parse(): RegexAST = {
-    if (pattern == null) {
-      return null
-    }
     val ast = parseUntil(() => eof())
     if (!eof()) {
       throw new RegexUnsupportedException("failed to parse full regex")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -810,17 +810,6 @@ case class GpuRLike(left: Expression, right: Expression)
   override def dataType: DataType = BooleanType
 }
 
-object GpuRegExpReplaceMeta {
-  def isSupportedRegExpReplacePattern(pattern: String): Boolean = {
-    try {
-      new CudfRegexTranspiler(replace = true).transpile(pattern)
-      true
-    } catch {
-      case _: RegexUnsupportedException => false
-    }
-  }
-}
-
 case class GpuRegExpReplace(
     srcExpr: Expression,
     searchExpr: Expression,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.rapids
 
-import java.sql.SQLException
-
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType, PadSide, Scalar, Table}
@@ -771,7 +769,7 @@ class GpuRLikeMeta(
 
     override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
       GpuRLike(lhs, rhs, pattern.getOrElse(
-        throw new SQLException("Expression has not been tagged with cuDF regex pattern")))
+        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
     }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -752,11 +752,11 @@ class GpuRLikeMeta(
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule) extends BinaryExprMeta[RLike](expr, conf, parent, rule) {
 
-    var pattern: Option[String] = None
+    private var pattern: Option[String] = None
 
     override def tagExprForGpu(): Unit = {
       expr.right match {
-        case Literal(str: UTF8String, _) =>
+        case Literal(str: UTF8String, DataTypes.StringType) if str != null =>
           try {
             // verify that we support this regex and can transpile it to cuDF format
             pattern = Some(new CudfRegexTranspiler(replace = false).transpile(str.toString))
@@ -765,7 +765,7 @@ class GpuRLikeMeta(
               willNotWorkOnGpu(e.getMessage)
           }
         case _ =>
-          willNotWorkOnGpu(s"RLike with non-literal pattern is not supported on GPU")
+          willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
       }
     }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -21,10 +21,6 @@ import org.scalatest.FunSuite
 
 class RegularExpressionParserSuite extends FunSuite {
 
-  test("null pattern") {
-    assert(parse(null) === null)
-  }
-
   test("empty pattern") {
     assert(parse("") === RegexSequence(ListBuffer()))
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -21,6 +21,14 @@ import org.scalatest.FunSuite
 
 class RegularExpressionParserSuite extends FunSuite {
 
+  test("null pattern") {
+    assert(parse(null) === null)
+  }
+
+  test("empty pattern") {
+    assert(parse("") === RegexSequence(ListBuffer()))
+  }
+
   test("simple quantifier") {
     assert(parse("a{1}") ===
       RegexSequence(ListBuffer(


### PR DESCRIPTION
The main motivation for this PR was to implement a performance optimization so that regular expressions get transpiled just once per expression (twice if you count the tagging) rather than being transpiled for each invocation (per batch).

While refactoring, I found some inconsistencies and unreachable code paths related to null patterns and empty patterns which are also fixed in this PR along with additional tests.