### PR TITLE
More integration tests with decimal128

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -937,8 +937,10 @@ nonempty_struct_gens_sample = [all_basic_struct_gen,
         StructGen([['child0', ArrayGen(short_gen)], ['child1', double_gen]])]
 
 struct_gens_sample = nonempty_struct_gens_sample + [StructGen([])]
+struct_gen_decimal128 = StructGen(
+    [['child' + str(ind), sub_gen] for ind, sub_gen in enumerate(decimal_128_gens)])
 struct_gens_sample_with_decimal128 = struct_gens_sample + [
-    StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(decimal_128_gens)])]
+    struct_gen_decimal128]
 
 simple_string_to_string_map_gen = MapGen(StringGen(pattern='key_[0-9]', nullable=False),
         StringGen(), max_length=10)

--- a/integration_tests/src/main/python/generate_expr_test.py
+++ b/integration_tests/src/main/python/generate_expr_test.py
@@ -63,7 +63,7 @@ def test_explode_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens, ids=idfn)
 def test_explode_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(
@@ -97,7 +97,7 @@ def test_explode_outer_array_data(spark_tmp_path, data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens, ids=idfn)
 def test_explode_outer_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(
@@ -149,7 +149,7 @@ def test_posexplode_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens, ids=idfn)
 def test_posexplode_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(
@@ -183,7 +183,7 @@ def test_posexplode_outer_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('map_gen', map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('map_gen', map_gens_sample + decimal_128_map_gens, ids=idfn)
 def test_posexplode_outer_map_data(map_gen):
     data_gen = [int_gen, map_gen]
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/project_lit_alias_test.py
+++ b/integration_tests/src/main/python/project_lit_alias_test.py
@@ -20,13 +20,14 @@ from marks import incompat, approximate_float
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
-@pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
 def test_project_alias(data_gen):
     dec = Decimal('123123123123123123123123123.456')
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : binary_op_df(spark, data_gen).select(
             f.col('a').alias('col1'),
             f.col('b').alias('col2'),
-            f.lit(dec)))
+            f.lit(dec)),
+        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
 
 

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -180,9 +180,10 @@ def test_coalesce_types(data_gen):
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
 def test_coalesce_df(num_parts, length):
     #This should change eventually to be more than just the basic gens
-    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens)]
+    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts))
+            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts),
+        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
 
 @pytest.mark.parametrize('data_gen', [
     pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]),

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -151,7 +151,9 @@ def test_single_sort_in_part(data_gen, order):
 
 @pytest.mark.parametrize('data_gen', [
     pytest.param(all_basic_struct_gen),
+    pytest.param(struct_gen_decimal128),
     pytest.param(StructGen([['child0', all_basic_struct_gen]])),
+    pytest.param(StructGen([['child0', struct_gen_decimal128]])),
 ], ids=idfn)
 @pytest.mark.parametrize('order', [
     pytest.param(f.col('a').asc()),


### PR DESCRIPTION
Part of ongoing work in #3890  for testing audit for decimal128. I understand and some of this and what follows might increase execution times so we can eliminate the ones we do not care about in favor of time during review.