### PR TITLE
Update regular expression tests related to `$` and strings ending with `\n`

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -508,8 +508,8 @@ Here are some examples of regular expression patterns that are not supported on 
 
 In addition to these cases that can be detected, there is also one known issue that can cause incorrect results:
 
-- `$` does not match the end of a string if the string ends with a line-terminator 
-  ([cuDF issue #9620](https://github.com/rapidsai/cudf/issues/9620))
+- `$` does not match the end of a string if the string ends with a carriage return (`\r`) 
+  ([issue #4170](https://github.com/NVIDIA/spark-rapids/issues/4170))
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.
 

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -530,7 +530,7 @@ def test_rlike_escape():
             conf={'spark.rapids.sql.expression.RLike': 'true'})
 
 def test_rlike_multi_line():
-    gen = mk_str_gen('[abc]\n[def]')
+    gen = mk_str_gen('[abc]\n[def][\n]?')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'a rlike "^a"',

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -252,13 +252,11 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("compare CPU and GPU: fuzz test ASCII chars") {
-    val chars = (0x00 to 0x7F)
-      .map(_.toChar)
+    val chars = (0x00 to 0x7F).map(_.toChar)
     doFuzzTest(Some(chars.mkString), replace = true)
   }
 
-  ignore("compare CPU and GPU: regexp find fuzz test all chars") {
-    // this test cannot be enabled until we support CR and LF
+  test("compare CPU and GPU: regexp find fuzz test all chars") {
     doFuzzTest(None, replace = false)
   }
 


### PR DESCRIPTION
Update tests and documentation now that https://github.com/rapidsai/cudf/issues/9620 is resolved.

The cuDF fix means that `$` now correctly matches strings that end with `\n` but unfortunately, we still have an issue with strings that end with `\r` so the documentation is updated to refer to a new issue for that.