### PR TITLE
Update approx percentile docs to link to issue 4060 [skip ci]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -817,6 +817,9 @@ distribution. Because the results are not bit-for-bit identical with the Apache 
 `approximate_percentile`, this feature is disabled by default and can be enabled by setting
 `spark.rapids.sql.expression.ApproximatePercentile=true`.
 
+There is also a known issue ([issue #4060](https://github.com/NVIDIA/spark-rapids/issues/4060)) where
+incorrect results are produced intermittently.
+
 ## Conditionals and operations with side effects (ANSI mode)
 
 In Apache Spark condition operations like `if`, `coalesce`, and `case/when` lazily evaluate


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Approx percentile is already disabled by default and this PR adds a note about issue 4060.