### PR TITLE
Added a getting started guide for Synapse[skip ci]

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,6 +22,7 @@ The RAPIDS Accelerator for Apache Spark officially supports:
 - [AWS EMR 6.2+](get-started/getting-started-aws-emr.md)
 - [Databricks Runtime 7.3, 9.1](get-started/getting-started-databricks.md)
 - [Google Cloud Dataproc 2.0](get-started/getting-started-gcp.md)
+- [Azure Synapse](get-started/getting-started-azure-synapse-analytics)
 
 Most distributions based on a supported Apache Spark version should work, but because the plugin
 replaces parts of the physical plan that Apache Spark considers to be internal the code for those

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,7 +22,7 @@ The RAPIDS Accelerator for Apache Spark officially supports:
 - [AWS EMR 6.2+](get-started/getting-started-aws-emr.md)
 - [Databricks Runtime 7.3, 9.1](get-started/getting-started-databricks.md)
 - [Google Cloud Dataproc 2.0](get-started/getting-started-gcp.md)
-- [Azure Synapse](get-started/getting-started-azure-synapse-analytics)
+- [Azure Synapse](get-started/getting-started-azure-synapse-analytics.md)
 
 Most distributions based on a supported Apache Spark version should work, but because the plugin
 replaces parts of the physical plan that Apache Spark considers to be internal the code for those

--- a/docs/download.md
+++ b/docs/download.md
@@ -31,7 +31,7 @@ Software Requirements:
 
 	CUDA & NVIDIA Drivers*: 11.0-11.4 & v450.80.02+
 
-	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, GCP Dataproc 2.0 and Azure Synapse
+	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, GCP Dataproc 2.0, and Azure Synapse
 
 	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -31,7 +31,7 @@ Software Requirements:
 
 	CUDA & NVIDIA Drivers*: 11.0-11.4 & v450.80.02+
 
-	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, and GCP Dataproc 2.0
+	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, GCP Dataproc 2.0 and Azure Synapse
 
 	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
 

--- a/docs/get-started/getting-started-alluxio.md
+++ b/docs/get-started/getting-started-alluxio.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Alluxio
-nav_order: 6
+nav_order: 7
 parent: Getting-Started
 ---
 # Getting Started with RAPIDS and Alluxio

--- a/docs/get-started/getting-started-azure-synapse-analytics.md
+++ b/docs/get-started/getting-started-azure-synapse-analytics.md
@@ -5,7 +5,7 @@ nav_order: 5
 parent: Getting-Started
 ---
 # Getting started with RAPIDS Accelerator on Azure Synapse Analytics
- [Azure Synapse](https://docs.microsoft.com/en-us/azure/synapse-analytics/) is a limitless analytics service that brings
+ [Azure Synapse](https://docs.microsoft.com/en-us/azure/synapse-analytics/) is an analytics service that brings
  together enterprise data warehousing and Big Data analytics.
 
 Synapse now offers the ability to create Apache Spark pools that use GPUs on the backend to run your Spark workloads on 

--- a/docs/get-started/getting-started-azure-synapse-analytics.md
+++ b/docs/get-started/getting-started-azure-synapse-analytics.md
@@ -11,7 +11,7 @@ parent: Getting-Started
 Synapse now offers the ability to create Apache Spark pools that use GPUs on the backend to run your Spark workloads on 
 GPUs for accelerated processing. This is called as 
 [GPU-accelerated Apache Spark pools](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-gpu-concept).
-Currently it ships with the RAPIDS Accelerator for Apache Spark version 21.10 jars.
+Currently it ships with the RAPIDS Accelerator for Apache Spark version 21.10.
 
 Please follow below 2 quickstart guides:
 1. [Quickstart: Create an Apache Spark GPU-enabled Pool in Azure Synapse Analytics using the Azure portal](https://docs.microsoft.com/en-us/azure/synapse-analytics/quickstart-create-apache-gpu-pool-portal)

--- a/docs/get-started/getting-started-azure-synapse-analytics.md
+++ b/docs/get-started/getting-started-azure-synapse-analytics.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Azure Synapse Analytics
+nav_order: 5
+parent: Getting-Started
+---
+# Getting started with RAPIDS Accelerator on Azure Synapse Analytics
+ [Azure Synapse](https://docs.microsoft.com/en-us/azure/synapse-analytics/) is a limitless analytics service that brings
+ together enterprise data warehousing and Big Data analytics.
+
+Synapse now offers the ability to create Apache Spark pools that use GPUs on the backend to run your Spark workloads on 
+GPUs for accelerated processing. This is called as 
+[GPU-accelerated Apache Spark pools](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-gpu-concept).
+Currently it ships with the RAPIDS Accelerator for Apache Spark version 21.10 jars.
+
+Please follow below 2 quickstart guides:
+1. [Quickstart: Create an Apache Spark GPU-enabled Pool in Azure Synapse Analytics using the Azure portal](https://docs.microsoft.com/en-us/azure/synapse-analytics/quickstart-create-apache-gpu-pool-portal)
+2. [Quickstart: Create an Apache Spark notebook to run on a GPU pool](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-rapids-gpu)
+

--- a/docs/get-started/getting-started-kubernetes.md
+++ b/docs/get-started/getting-started-kubernetes.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Kubernetes
-nav_order: 5
+nav_order: 6
 parent: Getting-Started
 ---
 

--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Workload Qualification
-nav_order: 7
+nav_order: 8
 parent: Getting-Started
 ---
 # Getting Started on Spark workload qualification


### PR DESCRIPTION
Added a getting started guide for Synapse.

Basically I plan to link to Azure Synapse Docs which has pretty detailed quickstart guide docs.
In the future, we only need to update the rapids spark jar version here.