### PR TITLE
[Draft] Trying to support HiveTableScanExec

### DIFF
--- a/shims/spark312/pom.xml
+++ b/shims/spark312/pom.xml
@@ -81,5 +81,11 @@
             <version>${spark312.version}</version>
 	    <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>${spark312.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
+++ b/shims/spark312/src/main/scala/com/nvidia/spark/rapids/shims/spark312/Spark312Shims.scala
@@ -20,7 +20,9 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.v2._
 import org.apache.parquet.schema.MessageType
 
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
+import org.apache.spark.sql.hive.execution.HiveOverrides
 import org.apache.spark.sql.internal.SQLConf
 
 class Spark312Shims extends SparkBaseShims with Spark30Xuntil33XShims {
@@ -41,4 +43,7 @@ class Spark312Shims extends SparkBaseShims with Spark30Xuntil33XShims {
     new ParquetFilters(schema, pushDownDate, pushDownTimestamp, pushDownDecimal, pushDownStartWith,
       pushDownInFilterThreshold, caseSensitive)
   }
+
+  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
+    HiveOverrides.hiveExec ++ super.getExecs
 }

--- a/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveMetastoreCatalogUtils.scala
+++ b/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveMetastoreCatalogUtils.scala
@@ -16,6 +16,7 @@ import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.internal.SQLConf.HiveCaseSensitiveInferenceMode.{INFER_AND_SAVE, NEVER_INFER}
 import org.apache.spark.sql.types.StructType
 
+// This class mainly originates from [[HiveMetastoreCatalog]]
 class HiveMetastoreCatalogUtils(sparkSession: SparkSession) extends Logging {
   // these are def_s and not val/lazy val since the latter would introduce circular references
   private def sessionState = sparkSession.sessionState

--- a/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveMetastoreCatalogUtils.scala
+++ b/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveMetastoreCatalogUtils.scala
@@ -1,0 +1,263 @@
+package org.apache.spark.sql.hive.execution
+
+import java.util.Locale
+
+import scala.util.control.NonFatal
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.{QualifiedTableName, TableIdentifier}
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, HiveTableRelation}
+import org.apache.spark.sql.execution.datasources.{CatalogFileIndex, DataSource, FileFormat, FileIndex, HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
+import org.apache.spark.sql.hive.HiveUtils
+import org.apache.spark.sql.internal.SQLConf.HiveCaseSensitiveInferenceMode.{INFER_AND_SAVE, NEVER_INFER}
+import org.apache.spark.sql.types.StructType
+
+class HiveMetastoreCatalogUtils(sparkSession: SparkSession) extends Logging {
+  // these are def_s and not val/lazy val since the latter would introduce circular references
+  private def sessionState = sparkSession.sessionState
+  private def catalogProxy = sparkSession.sessionState.catalog
+  import org.apache.spark.sql.hive.HiveMetastoreCatalog._
+
+  /** These locks guard against multiple attempts to instantiate a table, which wastes memory. */
+//  private val tableCreationLocks = Striped.lazyWeakLock(100)
+
+  /** Acquires a lock on the table cache for the duration of `f`. */
+  private def withTableCreationLock[A](tableName: QualifiedTableName, f: => A): A = {
+//    val lock = tableCreationLocks.get(tableName)
+//    lock.lock()
+    try f finally {
+//      lock.unlock()
+    }
+  }
+
+  private def getCached(
+    tableIdentifier: QualifiedTableName,
+    pathsInMetastore: Seq[Path],
+    schemaInMetastore: StructType,
+    expectedFileFormat: Class[_ <: FileFormat],
+    partitionSchema: Option[StructType]): Option[LogicalRelation] = {
+
+    catalogProxy.getCachedTable(tableIdentifier) match {
+      case null => None // Cache miss
+      case logical @ LogicalRelation(relation: HadoopFsRelation, _, _, _) =>
+        val cachedRelationFileFormatClass = relation.fileFormat.getClass
+
+        expectedFileFormat match {
+          case `cachedRelationFileFormatClass` =>
+            // If we have the same paths, same schema, and same partition spec,
+            // we will use the cached relation.
+            val useCached =
+              relation.location.rootPaths.toSet == pathsInMetastore.toSet &&
+                logical.schema.sameType(schemaInMetastore) &&
+                // We don't support hive bucketed tables. This function `getCached` is only used for
+                // converting supported Hive tables to data source tables.
+                relation.bucketSpec.isEmpty &&
+                relation.partitionSchema == partitionSchema.getOrElse(StructType(Nil))
+
+            if (useCached) {
+              Some(logical)
+            } else {
+              // If the cached relation is not updated, we invalidate it right away.
+              catalogProxy.invalidateCachedTable(tableIdentifier)
+              None
+            }
+          case _ =>
+            logWarning(s"Table $tableIdentifier should be stored as $expectedFileFormat. " +
+              s"However, we are getting a ${relation.fileFormat} from the metastore cache. " +
+              "This cached entry will be invalidated.")
+            catalogProxy.invalidateCachedTable(tableIdentifier)
+            None
+        }
+      case other =>
+        logWarning(s"Table $tableIdentifier should be stored as $expectedFileFormat. " +
+          s"However, we are getting a $other from the metastore cache. " +
+          "This cached entry will be invalidated.")
+        catalogProxy.invalidateCachedTable(tableIdentifier)
+        None
+    }
+  }
+
+  def convert(relation: HiveTableRelation): LogicalRelation = {
+    val serde = relation.tableMeta.storage.serde.getOrElse("").toLowerCase(Locale.ROOT)
+
+    // Consider table and storage properties. For properties existing in both sides, storage
+    // properties will supersede table properties.
+    val options = relation.tableMeta.storage.properties
+    convertToLogicalRelation(relation, options, classOf[CSVFileFormat], "csv")
+  }
+
+  private def convertToLogicalRelation(
+    relation: HiveTableRelation,
+    options: Map[String, String],
+    fileFormatClass: Class[_ <: FileFormat],
+    fileType: String): LogicalRelation = {
+    val metastoreSchema = relation.tableMeta.schema
+    val tableIdentifier =
+      QualifiedTableName(relation.tableMeta.database, relation.tableMeta.identifier.table)
+
+    val lazyPruningEnabled = sparkSession.sqlContext.conf.manageFilesourcePartitions
+    val tablePath = new Path(relation.tableMeta.location)
+    val fileFormat = fileFormatClass.getConstructor().newInstance()
+
+    val result = if (relation.isPartitioned) {
+      val partitionSchema = relation.tableMeta.partitionSchema
+      val rootPaths: Seq[Path] = if (lazyPruningEnabled) {
+        Seq(tablePath)
+      } else {
+        // By convention (for example, see CatalogFileIndex), the definition of a
+        // partitioned table's paths depends on whether that table has any actual partitions.
+        // Partitioned tables without partitions use the location of the table's base path.
+        // Partitioned tables with partitions use the locations of those partitions' data
+        // locations,_omitting_ the table's base path.
+        val paths = sparkSession.sharedState.externalCatalog
+          .listPartitions(tableIdentifier.database, tableIdentifier.name)
+          .map(p => new Path(p.storage.locationUri.get))
+
+        if (paths.isEmpty) {
+          Seq(tablePath)
+        } else {
+          paths
+        }
+      }
+
+      withTableCreationLock(tableIdentifier, {
+        val cached = getCached(
+          tableIdentifier,
+          rootPaths,
+          metastoreSchema,
+          fileFormatClass,
+          Some(partitionSchema))
+
+        val logicalRelation = cached.getOrElse {
+          val sizeInBytes = relation.stats.sizeInBytes.toLong
+          val fileIndex = {
+            val index = new CatalogFileIndex(sparkSession, relation.tableMeta, sizeInBytes)
+            if (lazyPruningEnabled) {
+              index
+            } else {
+              index.filterPartitions(Nil)  // materialize all the partitions in memory
+            }
+          }
+
+          val updatedTable = inferIfNeeded(relation, options, fileFormat, Option(fileIndex))
+
+          // Spark SQL's data source table now support static and dynamic partition insert. Source
+          // table converted from Hive table should always use dynamic.
+          val enableDynamicPartition = options.updated("partitionOverwriteMode", "dynamic")
+          val fsRelation = HadoopFsRelation(
+            location = fileIndex,
+            partitionSchema = partitionSchema,
+            dataSchema = updatedTable.dataSchema,
+            bucketSpec = None,
+            fileFormat = fileFormat,
+            options = enableDynamicPartition)(sparkSession = sparkSession)
+          val created = LogicalRelation(fsRelation, updatedTable)
+          catalogProxy.cacheTable(tableIdentifier, created)
+          created
+        }
+
+        logicalRelation
+      })
+    } else {
+      val rootPath = tablePath
+      withTableCreationLock(tableIdentifier, {
+        val cached = getCached(
+          tableIdentifier,
+          Seq(rootPath),
+          metastoreSchema,
+          fileFormatClass,
+          None)
+        val logicalRelation = cached.getOrElse {
+          val updatedTable = inferIfNeeded(relation, options, fileFormat)
+          val created =
+            LogicalRelation(
+              DataSource(
+                sparkSession = sparkSession,
+                paths = rootPath.toString :: Nil,
+                userSpecifiedSchema = Option(updatedTable.dataSchema),
+                bucketSpec = None,
+                options = options,
+                className = fileType).resolveRelation(),
+              table = updatedTable)
+
+          catalogProxy.cacheTable(tableIdentifier, created)
+          created
+        }
+
+        logicalRelation
+      })
+    }
+    // The inferred schema may have different field names as the table schema, we should respect
+    // it, but also respect the exprId in table relation output.
+    if (result.output.length != relation.output.length) {
+      throw new AnalysisException(
+        s"Converted table has ${result.output.length} columns, " +
+          s"but source Hive table has ${relation.output.length} columns. " +
+          s"Set ${HiveUtils.CONVERT_METASTORE_PARQUET.key} to false, " +
+          s"or recreate table ${relation.tableMeta.identifier} to workaround.")
+    }
+    if (!result.output.zip(relation.output).forall {
+      case (a1, a2) => a1.dataType == a2.dataType }) {
+      throw new AnalysisException(
+        s"Column in converted table has different data type with source Hive table's. " +
+          s"Set ${HiveUtils.CONVERT_METASTORE_PARQUET.key} to false, " +
+          s"or recreate table ${relation.tableMeta.identifier} to workaround.")
+    }
+    val newOutput = result.output.zip(relation.output).map {
+      case (a1, a2) => a1.withExprId(a2.exprId)
+    }
+    result.copy(output = newOutput)
+  }
+
+  private def inferIfNeeded(
+    relation: HiveTableRelation,
+    options: Map[String, String],
+    fileFormat: FileFormat,
+    fileIndexOpt: Option[FileIndex] = None): CatalogTable = {
+    val inferenceMode = sparkSession.sessionState.conf.caseSensitiveInferenceMode
+    val shouldInfer = (inferenceMode != NEVER_INFER) && !relation.tableMeta.schemaPreservesCase
+    val tableName = relation.tableMeta.identifier.unquotedString
+    if (shouldInfer) {
+      logInfo(s"Inferring case-sensitive schema for table $tableName (inference mode: " +
+        s"$inferenceMode)")
+      val fileIndex = fileIndexOpt.getOrElse {
+        val rootPath = new Path(relation.tableMeta.location)
+        new InMemoryFileIndex(sparkSession, Seq(rootPath), options, None)
+      }
+
+      val inferredSchema = fileFormat
+        .inferSchema(
+          sparkSession,
+          options,
+          fileIndex.listFiles(Nil, Nil).flatMap(_.files))
+        .map(mergeWithMetastoreSchema(relation.tableMeta.dataSchema, _))
+
+      inferredSchema match {
+        case Some(dataSchema) =>
+          if (inferenceMode == INFER_AND_SAVE) {
+            updateDataSchema(relation.tableMeta.identifier, dataSchema)
+          }
+          val newSchema = StructType(dataSchema ++ relation.tableMeta.partitionSchema)
+          relation.tableMeta.copy(schema = newSchema)
+        case None =>
+          logWarning(s"Unable to infer schema for table $tableName from file format " +
+            s"$fileFormat (inference mode: $inferenceMode). Using metastore schema.")
+          relation.tableMeta
+      }
+    } else {
+      relation.tableMeta
+    }
+  }
+
+  private def updateDataSchema(identifier: TableIdentifier, newDataSchema: StructType): Unit = try {
+    logInfo(s"Saving case-sensitive schema for table ${identifier.unquotedString}")
+    sparkSession.sessionState.catalog.alterTableDataSchema(identifier, newDataSchema)
+  } catch {
+    case NonFatal(ex) =>
+      logWarning(s"Unable to save case-sensitive schema for table ${identifier.unquotedString}", ex)
+  }
+}

--- a/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveOverrides.scala
+++ b/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveOverrides.scala
@@ -1,0 +1,54 @@
+package org.apache.spark.sql.hive.execution
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+
+object HiveOverrides {
+  lazy val hiveExec: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
+    GpuOverrides.exec[HiveTableScanExec](
+      "Reading data from files, often from Hive tables",
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
+        TypeSig.ARRAY + TypeSig.DECIMAL_128_FULL).nested(), TypeSig.all),
+      (fsse, conf, p, r) => new SparkPlanMeta[HiveTableScanExec](fsse, conf, p, r) {
+        // partition filters and data filters are not run on the GPU
+        override val childExprs: Seq[ExprMeta[_]] = Seq.empty
+
+        override def tagPlanForGpu(): Unit = {
+          val x = this.wrapped.relation
+          val y = this.wrapped.relation.tableMeta
+        }
+
+        override def convertToGpu(): GpuExec = {
+
+          val logicalRelation = new HiveMetastoreCatalogUtils(this.wrapped.sqlContext.sparkSession)
+            .convert(this.wrapped.relation)
+
+          val relation = logicalRelation.relation match {
+            case fs: HadoopFsRelation =>
+              HadoopFsRelation(
+                fs.location,
+                fs.partitionSchema,
+                fs.dataSchema,
+                fs.bucketSpec,
+                GpuFileSourceScanExec.convertFileFormat(fs.fileFormat),
+                fs.options)(this.wrapped.sqlContext.sparkSession)
+            case _ => throw new RuntimeException("Wrong relation")
+          }
+
+          GpuFileSourceScanExec(
+            relation,
+            wrapped.output,
+            wrapped.relation.schema,
+            wrapped.partitionPruningPred,
+            None,
+            None,
+            Seq(),
+            None)(conf)
+        }
+      })
+  ).collect { case r if r != null => (r.getClassFor.asSubclass(classOf[SparkPlan]), r) }.toMap
+
+}

--- a/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveOverrides.scala
+++ b/shims/spark312/src/main/scala/org/apache/spark/sql/hive/execution/HiveOverrides.scala
@@ -17,8 +17,7 @@ object HiveOverrides {
         override val childExprs: Seq[ExprMeta[_]] = Seq.empty
 
         override def tagPlanForGpu(): Unit = {
-          val x = this.wrapped.relation
-          val y = this.wrapped.relation.tableMeta
+          // should add more checks for not running on GPU
         }
 
         override def convertToGpu(): GpuExec = {


### PR DESCRIPTION
This PR is trying to support HiveTableScanExec running on GPU.

HiveTableScanExec will be planned if there is HiveTableRelation, pls refer to [the code]( https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala#L254-L270)

But if the Hive table is backend by **Parquet** or **Orc** file format, then the  [HiveMetastoreCatalog](https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala#L133-L157) will convert HiveTableRelation to HadoopFsRelation by default (there are some confs to control if need to convert).  Finally, HadoopFsRelation will be planed into FileSourceScanExec which will be replaced by GpuFileSourceScanExec.

So if the Hive table is backend by "CSV", then we will get HiveTableScanExec which will not run on GPU. Since rapids plugin has supported to read CSV by GPU, it will be better if we can support HiveTableScanExec backed by CSV running on GPU.

For now, This PR tries to convert HiveTableRelation to HadoopFsRelation and then replace HiveTableScanExec with GpuFileSourceScanExec.

For now, I can't get the correct result with this PR since some exceptions happened

``` console
java.lang.NullPointerException
	at ai.rapids.cudf.HostColumnVectorCore.getStartListOffset(HostColumnVectorCore.java:275)
	at ai.rapids.cudf.HostColumnVectorCore.getUTF8(HostColumnVectorCore.java:365)
	at com.nvidia.spark.rapids.RapidsHostColumnVectorCore.getUTF8String(RapidsHostColumnVectorCore.java:183)
	at org.apache.spark.sql.vectorized.ColumnarBatchRow.getUTF8String(ColumnarBatch.java:220)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.writeFields_0_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at scala.collection.Iterator$$anon$10.next(Iterator.scala:459)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:346)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:898)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2$adapted(RDD.scala:898)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
```

## Do we really need to support HiveTableScanExec?
Spark decide to convert parquet or orc backend hive table according to the Hive SerDe. But for CSV, there is no explicit keyword to match, since there are many SerDe for Csv file.

So I don't know if I need to continue to do this. @revans2 @jlowe Could you provide some advice on this?

