### PR TITLE
Disable approx percentile tests that intermittently fail

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1238,6 +1238,7 @@ def test_hash_groupby_approx_percentile_byte_scalar(aqe_enabled):
                                      ('v', ByteGen())], length=100),
         0.5, conf)
 
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/4060")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled):
     conf = copy_and_update(_approx_percentile_conf, {'spark.sql.adaptive.enabled': aqe_enabled})
@@ -1246,6 +1247,7 @@ def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled):
                                      ('v', LongRangeGen())], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/4060")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 def test_hash_groupby_approx_percentile_long(aqe_enabled):
     conf = copy_and_update(_approx_percentile_conf, {'spark.sql.adaptive.enabled': aqe_enabled})
@@ -1254,6 +1256,7 @@ def test_hash_groupby_approx_percentile_long(aqe_enabled):
                                      ('v', LongRangeGen())], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
+@pytest.mark.skip(reason="https://github.com/NVIDIA/spark-rapids/issues/4060")
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 def test_hash_groupby_approx_percentile_long_single(aqe_enabled):
     conf = copy_and_update(_approx_percentile_conf, {'spark.sql.adaptive.enabled': aqe_enabled})


### PR DESCRIPTION
relates to https://github.com/NVIDIA/spark-rapids/issues/4060

skip some of the tests that intermittently fail in 21.12 to make sure they don't affect CI and release.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
