### PR TITLE
Parameter for the Databricks zone-id [skip ci]

### DIFF
--- a/jenkins/databricks/clusterutils.py
+++ b/jenkins/databricks/clusterutils.py
@@ -23,7 +23,7 @@ class ClusterUtils(object):
 
     @staticmethod
     def generate_create_templ(sshKey, cluster_name, runtime, idle_timeout,
-            num_workers, driver_node_type, worker_node_type, cloud_provider, init_scripts,
+            num_workers, driver_node_type, worker_node_type, cloud_provider, init_scripts, aws_zone,
             printLoc=sys.stdout):
         timeStr = str(int(time.time()))
         uniq_name = cluster_name + "-" + timeStr
@@ -33,7 +33,7 @@ class ClusterUtils(object):
         templ['spark_version'] = runtime
         if (cloud_provider == 'aws'):
             templ['aws_attributes'] = {
-                        "zone_id": "us-west-2c",
+                        "zone_id": aws_zone,
                         "first_on_demand": 1,
                         "availability": "SPOT_WITH_FALLBACK",
                         "spot_bid_price_percent": 100,

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -36,21 +36,22 @@ def main():
   cloud_provider = 'aws'
   # comma separated init scripts, e.g. dbfs:/foo,dbfs:/bar,...
   init_scripts = ''
+  aws_zone='us-west-2c'
 
 
   try:
-      opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:f:',
+      opts, args = getopt.getopt(sys.argv[1:], 'hw:t:k:n:i:r:o:d:e:s:f:z:',
                                  ['workspace=', 'token=', 'sshkey=', 'clustername=', 'idletime=',
-                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=', 'initscripts='])
+                                     'runtime=', 'workertype=', 'drivertype=', 'numworkers=', 'cloudprovider=', 'initscripts=', 'awszone='])
   except getopt.GetoptError:
       print(
-          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscripts>')
+          'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscripts> -z <awszone>')
       sys.exit(2)
 
   for opt, arg in opts:
       if opt == '-h':
           print(
-              'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider>')
+              'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider>  -f <initscripts> -z <awszone>')
           sys.exit()
       elif opt in ('-w', '--workspace'):
           workspace = arg
@@ -74,6 +75,8 @@ def main():
           cloud_provider = arg
       elif opt in ('-f', '--initscripts'):
           init_scripts = arg
+      elif opt in ('-z', '--awszone'):
+          aws_zone = arg
 
   print('-w is ' + workspace, file=sys.stderr)
   print('-k is ' + sshkey, file=sys.stderr)
@@ -85,6 +88,7 @@ def main():
   print('-e is ' + str(num_workers), file=sys.stderr)
   print('-s is ' + cloud_provider, file=sys.stderr)
   print('-f is ' + init_scripts, file=sys.stderr)
+  print('-z is ' + aws_zone, file=sys.stderr)
 
   if not sshkey:
       print("You must specify an sshkey!", file=sys.stderr)
@@ -95,7 +99,7 @@ def main():
       sys.exit(2)
 
   templ = ClusterUtils.generate_create_templ(sshkey, cluster_name, runtime, idletime,
-          num_workers, driver_type, worker_type, cloud_provider, init_scripts, printLoc=sys.stderr)
+          num_workers, driver_type, worker_type, cloud_provider, init_scripts, aws_zone,printLoc=sys.stderr)
   clusterid = ClusterUtils.create_cluster(workspace, templ, token, printLoc=sys.stderr)
   ClusterUtils.wait_for_cluster_start(workspace, clusterid, token, printLoc=sys.stderr)
 

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -51,7 +51,7 @@ def main():
   for opt, arg in opts:
       if opt == '-h':
           print(
-              'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider>  -f <initscripts> -z <awszone>')
+              'create.py -w <workspace> -t <token> -k <sshkey> -n <clustername> -i <idletime> -r <runtime> -o <workernodetype> -d <drivernodetype> -e <numworkers> -s <cloudprovider> -f <initscripts> -z <awszone>')
           sys.exit()
       elif opt in ('-w', '--workspace'):
           workspace = arg
@@ -99,7 +99,7 @@ def main():
       sys.exit(2)
 
   templ = ClusterUtils.generate_create_templ(sshkey, cluster_name, runtime, idletime,
-          num_workers, driver_type, worker_type, cloud_provider, init_scripts, aws_zone,printLoc=sys.stderr)
+          num_workers, driver_type, worker_type, cloud_provider, init_scripts, aws_zone, printLoc=sys.stderr)
   clusterid = ClusterUtils.create_cluster(workspace, templ, token, printLoc=sys.stderr)
   ClusterUtils.wait_for_cluster_start(workspace, clusterid, token, printLoc=sys.stderr)
 


### PR DESCRIPTION
Parameter 'aws_zone' to switch to other zones when not having sufficient gpu resources in the requested zone.

```
{"code":"AWS_INSUFFICIENT_INSTANCE_CAPACITY_FAILURE","parameters":{"aws_api_error_code":"InsufficientInstanceCapacity","aws_error_message":"We currently do not have sufficient g4dn.2xlarge capacity in the Availability Zone you requested (us-west-2c)
```

Signed-off-by: Tim Liu <timl@nvidia.com>
