### PR TITLE
Update test_floor_ceil_overflow to be more lenient on exception type

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -354,11 +354,11 @@ def test_floor_ceil_overflow(data_gen):
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('floor(a)').collect(),
         conf=allow_negative_scale_of_decimal_conf,
-        error_message="java.lang.ArithmeticException")
+        error_message="ArithmeticException")
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('ceil(a)').collect(),
         conf=allow_negative_scale_of_decimal_conf,
-        error_message="java.lang.ArithmeticException")
+        error_message="ArithmeticException")
 
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
 def test_rint(data_gen):


### PR DESCRIPTION
Fixes #4207.  Changes `test_floor_ceil_overflow` to check for just `ArithmeticException` in the error message which is consistent with other arithmetic exception checks.  Filed #4210 to track making the exception types consistent with Apache Spark..