### PR TITLE
Remove an unused method with its outdated comment

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -355,15 +355,6 @@ object ShimLoader extends Logging {
     SPARK_BUILD_DATE
   )
 
-  // TODO broken right now, check if this can be supported with parallel worlds
-  // it implies the prerequisite of having such a class in the conventional root jar entry
-  // - or the necessity of an additional parameter for specifying the shim subdirectory
-  // - or enforcing the convention the class file parent directory is the shimId that is also
-  //   a top entry e.g. /spark301/com/nvidia/test/shim/spark301/Spark301Shims.class
-  def setSparkShimProviderClass(classname: String): Unit = {
-    shimProviderClass = classname
-  }
-
   def loadClass(className: String): Class[_] = {
     val loader = getShimClassLoader()
     logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
@@ -428,6 +419,6 @@ object ShimLoader extends Logging {
   }
 
   def newExplainPlan(): ExplainPlanBase = {
-    ShimLoader.newInstanceOf[ExplainPlanBase]("com.nvidia.spark.rapids.ExplainPlanImpl")
+    newInstanceOf[ExplainPlanBase]("com.nvidia.spark.rapids.ExplainPlanImpl")
   }
 }


### PR DESCRIPTION
Minor cleanup in ShimLoader.scala
- unused method `setSparkShimProviderClass` that used to power the shim override option
- unnecessary self-reference in `newExplainPlan`

Fixes #4213 

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
