### PR TITLE
Add arguments support to 'databricks/run-tests.py' [databricks]

### DIFF
--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Parse input parameters."""
 
-import sys
 import getopt
+import sys
 
 workspace = 'https://dbc-9ff9942e-a9c4.cloud.databricks.com'
 token = ''
@@ -27,21 +28,24 @@ base_spark_version_to_install_databricks_jars = base_spark_pom_version
 clusterid = ''
 build_profiles = 'databricks,!snapshot-shims'
 jar_path = ''
-# `spark_conf` can take comma seperated mutiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
+# `spark_conf` can take comma seperated multiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
 spark_conf = ''
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:i:',
-                               ['workspace=', 'token=', 'clusterid=', 'private=', 'localscript=', 'dest=', 'sparktgz=', 'basesparkpomversion=', 'buildprofiles=', 'jarpath', 'sparkconf', 'sparkinstallver='])
+                               ['workspace=', 'token=', 'clusterid=', 'private=', 'localscript=', 'dest=', 'sparktgz=',
+                                'basesparkpomversion=', 'buildprofiles=', 'jarpath', 'sparkconf', 'sparkinstallver='])
 except getopt.GetoptError:
-    print(
-        'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -l <localscript> -d <scriptdestinatino> -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -j <jarpath> -f <sparkconf> -i <sparkinstallver>')
+    print('run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -l <localscript> '
+          '-d <scriptdestinatino> -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -j <jarpath> '
+          '-f <sparkconf> -i <sparkinstallver>')
     sys.exit(2)
 
 for opt, arg in opts:
     if opt == '-h':
-        print(
-            'run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -n <skipstartingcluster> -l <localscript> -d <scriptdestinatino>, -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -f <sparkconf> -i <sparkinstallver>')
+        print('run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -n <skipstartingcluster> '
+              '-l <localscript> -d <scriptdestinatino>, -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> '
+              '-f <sparkconf> -i <sparkinstallver>')
         sys.exit()
     elif opt in ('-w', '--workspace'):
         workspace = arg

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -21,6 +21,7 @@ token = ''
 private_key_file = "~/.ssh/id_rsa"
 local_script = 'build.sh'
 script_dest = '/home/ubuntu/build.sh'
+script_args = []
 source_tgz = 'spark-rapids-ci.tgz'
 tgz_dest = '/home/ubuntu/spark-rapids-ci.tgz'
 base_spark_pom_version = '3.0.1'
@@ -72,11 +73,15 @@ for opt, arg in opts:
     elif opt in ('-i', '--sparkinstallver'):
         base_spark_version_to_install_databricks_jars = arg
 
+if args:
+    script_args = args
+
 print('-w is ' + workspace)
 print('-c is ' + clusterid)
 print('-p is ' + private_key_file)
 print('-l is ' + local_script)
 print('-d is ' + script_dest)
+print('script_args is ' + ' '.join(script_args))
 print('-z is ' + source_tgz)
 print('-v is ' + base_spark_pom_version)
 print('-j is ' + jar_path)

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -21,7 +21,6 @@ token = ''
 private_key_file = "~/.ssh/id_rsa"
 local_script = 'build.sh'
 script_dest = '/home/ubuntu/build.sh'
-script_args = []
 source_tgz = 'spark-rapids-ci.tgz'
 tgz_dest = '/home/ubuntu/spark-rapids-ci.tgz'
 base_spark_pom_version = '3.0.1'
@@ -32,22 +31,47 @@ jar_path = ''
 # `spark_conf` can take comma seperated multiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
 spark_conf = ''
 
+
+def usage():
+    """Define usage."""
+    print('Usage: ' + sys.argv[0] +
+          ' -s <workspace>'
+          ' -t <token>'
+          ' -c <clusterid>'
+          ' -p <privatekeyfile>'
+          ' -l <localscript>'
+          ' -d <scriptdestination>'
+          ' -z <sparktgz>'
+          ' -v <basesparkpomversion>'
+          ' -b <buildprofiles>'
+          ' -j <jarpath>'
+          ' -n <skipstartingcluster>'
+          ' -f <sparkconf>'
+          ' -i <sparkinstallver>')
+
+
 try:
-    opts, args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:i:',
-                               ['workspace=', 'token=', 'clusterid=', 'private=', 'localscript=', 'dest=', 'sparktgz=',
-                                'basesparkpomversion=', 'buildprofiles=', 'jarpath', 'sparkconf', 'sparkinstallver='])
+    opts, script_args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:i:',
+                                      ['workspace=',
+                                       'token=',
+                                       'clusterid=',
+                                       'private=',
+                                       'localscript=',
+                                       'dest=',
+                                       'sparktgz=',
+                                       'basesparkpomversion=',
+                                       'buildprofiles=',
+                                       'jarpath',
+                                       'sparkconf',
+                                       'sparkinstallver='])
 except getopt.GetoptError:
-    print('run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -l <localscript> '
-          '-d <scriptdestinatino> -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> -j <jarpath> '
-          '-f <sparkconf> -i <sparkinstallver>')
+    usage()
     sys.exit(2)
 
 for opt, arg in opts:
     if opt == '-h':
-        print('run-tests.py -s <workspace> -t <token> -c <clusterid> -p <privatekeyfile> -n <skipstartingcluster> '
-              '-l <localscript> -d <scriptdestinatino>, -z <sparktgz> -v <basesparkpomversion> -b <buildprofiles> '
-              '-f <sparkconf> -i <sparkinstallver>')
-        sys.exit()
+        usage()
+        sys.exit(1)
     elif opt in ('-w', '--workspace'):
         workspace = arg
     elif opt in ('-t', '--token'):
@@ -72,9 +96,6 @@ for opt, arg in opts:
         spark_conf = arg
     elif opt in ('-i', '--sparkinstallver'):
         base_spark_version_to_install_databricks_jars = arg
-
-if args:
-    script_args = args
 
 print('-w is ' + workspace)
 print('-c is ' + clusterid)

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -11,33 +11,38 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
-import requests
-import sys
-import getopt
-import time
-import os
+"""Upload & run test script on Databricks cluster."""
+
 import subprocess
+import sys
+
 from clusterutils import ClusterUtils
+
 import params
 
 
 def main():
+    """Define main function."""
+    master_addr = ClusterUtils.cluster_get_master_addr(params.workspace, params.clusterid, params.token)
+    if master_addr is None:
+        print("Error, didn't get master address")
+        sys.exit(1)
+    print("Master node address is: %s" % master_addr)
 
-  master_addr = ClusterUtils.cluster_get_master_addr(params.workspace, params.clusterid, params.token)
-  if master_addr is None:
-      print("Error, didn't get master address")
-      sys.exit(1)
-  print("Master node address is: %s" % master_addr)
+    print("Copying script")
+    rsync_command = "rsync -I -Pave \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s\"" \
+        " %s ubuntu@%s:%s" % (params.private_key_file, params.local_script, master_addr, params.script_dest)
+    print("rsync command: %s" % rsync_command)
+    subprocess.check_call(rsync_command, shell=True)
 
-  print("Copying script")
-  rsync_command = "rsync -I -Pave \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s\" %s ubuntu@%s:%s" % (params.private_key_file, params.local_script, master_addr, params.script_dest)
-  print("rsync command: %s" % rsync_command)
-  subprocess.check_call(rsync_command, shell = True)
+    ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s " \
+        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VER=%s bash %s 2>&1 | tee testout; " \
+        "if [ ${PIPESTATUS[0]} -ne 0 ]; then false; else true; fi'" % \
+        (master_addr, params.private_key_file, params.jar_path, params.spark_conf, params.base_spark_pom_version,
+         params.script_dest)
+    print("ssh command: %s" % ssh_command)
+    subprocess.check_call(ssh_command, shell=True)
 
-  ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s 'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VER=%s bash %s 2>&1 | tee testout; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; else true; fi'" % (master_addr, params.private_key_file, params.jar_path, params.spark_conf, params.base_spark_pom_version, params.script_dest)
-  print("ssh command: %s" % ssh_command)
-  subprocess.check_call(ssh_command, shell = True)
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -36,10 +36,10 @@ def main():
     subprocess.check_call(rsync_command, shell=True)
 
     ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s " \
-        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VER=%s bash %s 2>&1 | tee testout; " \
+        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VER=%s bash %s %s 2>&1 | tee testout; " \
         "if [ ${PIPESTATUS[0]} -ne 0 ]; then false; else true; fi'" % \
         (master_addr, params.private_key_file, params.jar_path, params.spark_conf, params.base_spark_pom_version,
-         params.script_dest)
+         params.script_dest, ' '.join(params.script_args))
     print("ssh command: %s" % ssh_command)
     subprocess.check_call(ssh_command, shell=True)
 


### PR DESCRIPTION
in order to run other scripts with arguments, e.g, save event logs for rapids tools testing.
And fixed flake8 reported issues for related .py files.

Signed-off-by: Alex Zhang alex4zhang@gmail.com

Integration test passed on Databricks: http://nv/2nf (need vpn)