### PR TITLE
Fix unconditional nested loop joins on empty tables

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -98,6 +98,36 @@ def create_ridealong_df(spark, key_data_gen, data_gen, left_length, right_length
             .withColumnRenamed("b", "r_b")
     return left, right
 
+@ignore_order(local=True)
+@pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn)
+def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, batch_size):
+    def do_join(spark):
+        left, right = create_df(spark, long_gen, 50, 0)
+        return left.join(broadcast(right), how=join_type)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+@ignore_order(local=True)
+@pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn)
+def test_left_broadcast_nested_loop_join_without_condition_empty(join_type, batch_size):
+    def do_join(spark):
+        left, right = create_df(spark, long_gen, 0, 50)
+        return left.join(broadcast(right), how=join_type)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+@ignore_order(local=True)
+@pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
+@pytest.mark.parametrize('batch_size', ['100', '1g'], ids=idfn)
+def test_broadcast_nested_loop_join_without_condition_empty(join_type, batch_size):
+    def do_join(spark):
+        left, right = create_df(spark, long_gen, 0, 0)
+        return left.join(broadcast(right), how=join_type)
+    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -94,6 +94,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
       withResource(new NvtxRange("broadcast manifest batch", NvtxColor.PURPLE)) { _ =>
         if (headers.isEmpty) {
           batchInternal = GpuColumnVector.emptyBatchFromTypes(dataTypes)
+          GpuColumnVector.extractBases(batchInternal).foreach(_.noWarnLeakExpected())
         } else {
           withResource(JCudfSerialization.readTableFrom(headers.head, buffers.head)) { tableInfo =>
             val table = tableInfo.getContiguousTable
@@ -103,6 +104,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
             } else {
               batchInternal = GpuColumnVectorFromBuffer.from(table, dataTypes)
               GpuColumnVector.extractBases(batchInternal).foreach(_.noWarnLeakExpected())
+              table.getBuffer.noWarnLeakExpected()
             }
           }
         }


### PR DESCRIPTION
Fixes #4188.  Unconditional nested loop joins can be treated like a cross join as long as both tables are non-empty, but there needs to be special handling when one of the tables is empty based on the join type.