### PR TITLE
RAPIDS Shuffle Manager fallback if security is enabled

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -89,6 +89,22 @@ object GpuShuffleEnv extends Logging {
     SparkEnv.get.blockManager.externalShuffleServiceEnabled
   }
 
+  // Returns true if authentication is requested, which is not supported
+  // by the RAPIDS Shuffle Manager
+  def isSparkAuthenticateEnabled: Boolean = {
+    val conf = SparkEnv.get.conf
+    conf.getBoolean("spark.authenticate", false)
+  }
+
+  // Returns true if network encryption is enabled in Spark, which
+  // is not handled currently by the RAPIDS Shuffle Manager. Note that
+  // in order to enable network encryption, spark.authenticate must be
+  // already enabled presently.
+  def isNetworkEncryptionEnabled: Boolean = {
+    val conf = SparkEnv.get.conf
+    conf.getBoolean("spark.network.crypto.enabled", false)
+  }
+
   //
   // The actual instantiation of the RAPIDS Shuffle Manager is lazy, and
   // this forces the initialization when we know we are ready in the driver and executor.
@@ -112,7 +128,10 @@ object GpuShuffleEnv extends Logging {
     // executors have `env` defined when this is checked
     // in tests
     val isConfiguredInEnv = Option(env).map(_.isRapidsShuffleConfigured).getOrElse(false)
-    (isConfiguredInEnv || isRapidsManager) && !isExternalShuffleEnabled
+    (isConfiguredInEnv || isRapidsManager) &&
+      !isExternalShuffleEnabled &&
+      !isNetworkEncryptionEnabled &&
+      !isSparkAuthenticateEnabled
   }
 
   def shouldUseRapidsShuffle(conf: RapidsConf): Boolean = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -96,15 +96,6 @@ object GpuShuffleEnv extends Logging {
     conf.getBoolean("spark.authenticate", false)
   }
 
-  // Returns true if network encryption is enabled in Spark, which
-  // is not handled currently by the RAPIDS Shuffle Manager. Note that
-  // in order to enable network encryption, spark.authenticate must be
-  // already enabled presently.
-  def isNetworkEncryptionEnabled: Boolean = {
-    val conf = SparkEnv.get.conf
-    conf.getBoolean("spark.network.crypto.enabled", false)
-  }
-
   //
   // The actual instantiation of the RAPIDS Shuffle Manager is lazy, and
   // this forces the initialization when we know we are ready in the driver and executor.
@@ -130,7 +121,6 @@ object GpuShuffleEnv extends Logging {
     val isConfiguredInEnv = Option(env).map(_.isRapidsShuffleConfigured).getOrElse(false)
     (isConfiguredInEnv || isRapidsManager) &&
       !isExternalShuffleEnabled &&
-      !isNetworkEncryptionEnabled &&
       !isSparkAuthenticateEnabled
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -251,6 +251,12 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
     if (GpuShuffleEnv.isExternalShuffleEnabled) {
       fallThroughReasons += "External Shuffle Service is enabled"
     }
+    if (GpuShuffleEnv.isSparkAuthenticateEnabled) {
+      fallThroughReasons += "Spark authentication is enabled"
+    }
+    if (GpuShuffleEnv.isNetworkEncryptionEnabled) {
+      fallThroughReasons += "Network encryption is enabled"
+    }
     if (fallThroughReasons.nonEmpty) {
       logWarning(s"Rapids Shuffle Plugin is falling back to SortShuffleManager " +
           s"because: ${fallThroughReasons.mkString(", ")}")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -254,9 +254,6 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
     if (GpuShuffleEnv.isSparkAuthenticateEnabled) {
       fallThroughReasons += "Spark authentication is enabled"
     }
-    if (GpuShuffleEnv.isNetworkEncryptionEnabled) {
-      fallThroughReasons += "Network encryption is enabled"
-    }
     if (fallThroughReasons.nonEmpty) {
       logWarning(s"Rapids Shuffle Plugin is falling back to SortShuffleManager " +
           s"because: ${fallThroughReasons.mkString(", ")}")


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/4227.

This falls back the RAPIDS Shuffle Manager if RPC authentication or network encryption are requested.