### PR TITLE
Disable failing CastOpSuite test

### DIFF
--- a/tests/cufile.log
+++ b/tests/cufile.log
@@ -1,4 +1,0 @@
- 30-11-2021 20:29:25:208 [pid=3983535 tid=3983538] NOTICE  cufio-drv:636 running in compatible mode
- 30-11-2021 20:36:48:776 [pid=4006731 tid=4006734] NOTICE  cufio-drv:636 running in compatible mode
- 30-11-2021 21:12:05:424 [pid=4082806 tid=4082809] NOTICE  cufio-drv:636 running in compatible mode
- 30-11-2021 21:19:04:846 [pid=4105043 tid=4105046] NOTICE  cufio-drv:636 running in compatible mode

--- a/tests/cufile.log
+++ b/tests/cufile.log
@@ -1,0 +1,4 @@
+ 30-11-2021 20:29:25:208 [pid=3983535 tid=3983538] NOTICE  cufio-drv:636 running in compatible mode
+ 30-11-2021 20:36:48:776 [pid=4006731 tid=4006734] NOTICE  cufio-drv:636 running in compatible mode
+ 30-11-2021 21:12:05:424 [pid=4082806 tid=4082809] NOTICE  cufio-drv:636 running in compatible mode
+ 30-11-2021 21:19:04:846 [pid=4105043 tid=4105046] NOTICE  cufio-drv:636 running in compatible mode

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -126,7 +126,8 @@ class CastOpSuite extends GpuExpressionTestSuite {
     testCastStringTo(DataTypes.FloatType, generateRandomStrings(Some(NUMERIC_CHARS)))
   }
 
-  test("Cast from string to float using hand-picked values") {
+  // https://github.com/NVIDIA/spark-rapids/issues/4246
+  ignore("Cast from string to float using hand-picked values") {
     testCastStringTo(DataTypes.FloatType, Seq(".", "e", "Infinity", "+Infinity", "-Infinity",
       "+nAn", "-naN", "Nan", "5f", "1.2f", "\riNf", null))
   }


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Fixes build by disabling failing test (caused by cuDF commit https://github.com/rapidsai/cudf/commit/69d576543b5414372f36d02a189a7217d3bb8006)

Follow on issue to reinstate test: https://github.com/NVIDIA/spark-rapids/issues/4246