### PR TITLE
Make regexp pattern `[^a]` consistent with Spark for multiline strings

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -494,6 +494,21 @@ def test_regexp_replace_null_pattern_fallback():
             'RegExpReplace',
             conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
 
+def test_regexp_replace_character_set_negated():
+    gen = mk_str_gen('[abcd]{0,3}[\r\n]{0,2}[abcd]{0,3}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'regexp_replace(a, "([^a])|([^b])", "1")',
+                'regexp_replace(a, "[^a]", "1")',
+                'regexp_replace(a, "([^a]|[\r\n])", "1")',
+                'regexp_replace(a, "[^a\r\n]", "1")',
+                'regexp_replace(a, "[^a\r]", "1")',
+                'regexp_replace(a, "[^a\n]", "1")',
+                'regexp_replace(a, "[^\r\n]", "1")',
+                'regexp_replace(a, "[^\r]", "1")',
+                'regexp_replace(a, "[^\n]", "1")'),
+            conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
+
 def test_rlike():
     gen = mk_str_gen('[abcd]{1,3}')
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -150,9 +150,11 @@ class RegexParser(pattern: String) {
         case '[' =>
           // treat as a literal character and add to the character class
           characterClass.append(ch)
-        case ']' if pos > start + 1 =>
+        case ']' if (!characterClass.negated && pos > start + 1) ||
+            (characterClass.negated && pos > start + 2) =>
           // "[]" is not a valid character class
           // "[]a]" is a valid character class containing the characters "]" and "a"
+          // "[^]a]" is a valid negated character class containing the characters "]" and "a"
           characterClassComplete = true
         case '^' if pos == start + 1 =>
           // Negates the character class, causing it to match a single character not listed in
@@ -492,7 +494,40 @@ class CudfRegexTranspiler(replace: Boolean) {
         }
         val components: Seq[RegexCharacterClassComponent] = characters
           .map(x => rewrite(x).asInstanceOf[RegexCharacterClassComponent])
-        RegexCharacterClass(negated, ListBuffer(components: _*))
+
+        if (negated) {
+          // There are differences between cuDF and Java handling of newlines
+          // for negative character matches. The expression `[^a]` will match
+          // `\r` and `\n` in Java but not in cuDF, so we replace `[^a]` with
+          // `(?:[\r\n]|[^a])`. We also have to take into account whether any
+          // newline characters are included in the character range.
+          //
+          // Examples:
+          //
+          // `[^a]`     => `(?:[\r\n]|[^a])`
+          // `[^a\r]`   => `(?:[\n]|[^a])`
+          // `[^a\n]`   => `(?:[\r]|[^a])`
+          // `[^a\r\n]` => `[^a]`
+
+          val newlineCharsInClass = characters.flatMap {
+            case RegexChar(ch) if ch == '\n' || ch == '\r' =>
+              Seq(ch)
+            case _ =>
+              Seq.empty
+          }
+          val negatedNewlines = Seq('\r', '\n').diff(newlineCharsInClass)
+          if (negatedNewlines.isEmpty) {
+            RegexCharacterClass(negated, ListBuffer(components: _*))
+          } else {
+            RegexGroup(capture = false,
+              RegexChoice(
+                RegexCharacterClass(negated = false,
+                  characters = ListBuffer(negatedNewlines.map(RegexChar): _*)),
+                RegexCharacterClass(negated, ListBuffer(components: _*))))
+          }
+        } else {
+          RegexCharacterClass(negated, ListBuffer(components: _*))
+        }
 
       case RegexSequence(parts) =>
         if (parts.isEmpty) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -68,11 +68,24 @@ class RegularExpressionParserSuite extends FunSuite {
             RegexCharacterRange('A', 'Z'))))))
   }
 
+  test("foo") {
+    assert(parse("[^]+d]+") === RegexSequence(ListBuffer(
+      RegexRepetition(
+        RegexCharacterClass(negated = true,
+          ListBuffer(RegexChar(']'), RegexChar('+'), RegexChar('d'))),
+        SimpleQuantifier('+')))))
+  }
+
   test("character classes containing ']'") {
     // "[]a]" is a valid character class containing ']' and 'a'
     assert(parse("[]a]") ===
       RegexSequence(ListBuffer(
         RegexCharacterClass(negated = false,
+          ListBuffer(RegexChar(']'), RegexChar('a'))))))
+    // "[^]a]" is a valid negated character class containing ']' and 'a'
+    assert(parse("[^]a]") ===
+      RegexSequence(ListBuffer(
+        RegexCharacterClass(negated = true,
           ListBuffer(RegexChar(']'), RegexChar('a'))))))
     // "[a]]" is a valid character class "[a]" followed by character ']'
     assert(parse("[a]]") ===

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -68,7 +68,7 @@ class RegularExpressionParserSuite extends FunSuite {
             RegexCharacterRange('A', 'Z'))))))
   }
 
-  test("foo") {
+  test("character class complex example") {
     assert(parse("[^]+d]+") === RegexSequence(ListBuffer(
       RegexRepetition(
         RegexCharacterClass(negated = true,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -165,7 +165,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("transpile character class unescaped range symbol") {
     val patterns = Seq("a[-b]", "a[+-]", "a[-+]", "a[-]", "a[^-]")
-    val expected = Seq(raw"a[\-b]", raw"a[+\-]", raw"a[\-+]", raw"a[\-]", raw"a[^\-]")
+    val expected = Seq(raw"a[\-b]", raw"a[+\-]", raw"a[\-+]", raw"a[\-]", "a(?:[\r\n]|[^\\-])")
     val transpiler = new CudfRegexTranspiler(replace=false)
     val transpiled = patterns.map(transpiler.transpile)
     assert(transpiled === expected)
@@ -245,6 +245,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   test("compare CPU and GPU: regexp replace simple regular expressions") {
     val inputs = Seq("a", "b", "c")
     val patterns = Seq("a|b")
+    assertCpuGpuMatchesRegexpReplace(patterns, inputs)
+  }
+
+  test("compare CPU and GPU: regexp replace negated character class") {
+    val inputs = Seq("a", "b", "a\nb")
+    val patterns = Seq("[^z]")
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -249,8 +249,9 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("compare CPU and GPU: regexp replace negated character class") {
-    val inputs = Seq("a", "b", "a\nb")
-    val patterns = Seq("[^z]")
+    val inputs = Seq("a", "b", "a\nb", "a\r\nb\n\rc\rd")
+    val patterns = Seq("[^z]", "[^\r]", "[^\n]", "[^\r]", "[^\r\n]",
+      "[^a\n]", "[^b\r]", "[^bc\r\n]", "[^\\r\\n]")
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/4229

The following documentation from this PR explains the transpiler change that makes us consistent with CPU for patterns such as `[^a]`.

```
// There are differences between cuDF and Java handling of newlines
// for negative character matches. The expression `[^a]` will match
// `\r` and `\n` in Java but not in cuDF, so we replace `[^a]` with
// `(?:[\r\n]|[^a])`. We also have to take into account whether any
// newline characters are included in the character range.
//
// Examples:
//
// `[^a]`     => `(?:[\r\n]|[^a])`
// `[^a\r]`   => `(?:[\n]|[^a])`
// `[^a\n]`   => `(?:[\r]|[^a])`
// `[^a\r\n]` => `[^a]`
```

