### PR TITLE
Use data type to create an inspector for a foldable GPU expression.

### DIFF
--- a/integration_tests/src/main/python/row-based_udf_test.py
+++ b/integration_tests/src/main/python/row-based_udf_test.py
@@ -28,7 +28,7 @@ def test_hive_empty_simple_udf():
     assert_gpu_and_cpu_are_equal_sql(
         evalfn,
         "hive_simple_udf_test_table",
-        "SELECT i, emptysimple(s) FROM hive_simple_udf_test_table",
+        "SELECT i, emptysimple(s, 'const_string') FROM hive_simple_udf_test_table",
         conf={'spark.rapids.sql.rowBasedUDF.enabled': 'true'})
 
 def test_hive_empty_generic_udf():

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/rowBasedHiveUDFs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/rowBasedHiveUDFs.scala
@@ -59,7 +59,7 @@ trait GpuRowBasedHiveUDFBase extends GpuRowBasedUserDefinedFunction with HiveIns
   protected def gpuToInspector(expr: Expression): ObjectInspector = expr match {
     case GpuLiteral(value, dataType) =>
       // Convert to CPU literal as possible as we can before going into `toInspector(Expression)`.
-      // Because inspectors for literals of primitive types are likely to get better performance.
+      // Because some optimization will be made for Literal expressions of primitive types.
       value match {
         case scalar: ai.rapids.cudf.Scalar =>
           if (scalar.getType.isNestedType) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/rowBasedHiveUDFs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/rowBasedHiveUDFs.scala
@@ -63,7 +63,7 @@ trait GpuRowBasedHiveUDFBase extends GpuRowBasedUserDefinedFunction with HiveIns
       // Because the `toInspector(Expression)` method will take care of the CPU Literal
       // especially, converting it to a ConstantObjectInspector when it is primitive type. A
       // `ConstantObjectInspector` can accelerate the row data reading by caching the actual
-      // value and bypassing the unnecessary null check.
+      // value and skipping the null check which becomes unnecessary.
       value match {
         case scalar: ai.rapids.cudf.Scalar =>
           if (scalar.getType.isNestedType) {

--- a/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveSimpleUDF.java
+++ b/udf-examples/src/main/java/com/nvidia/spark/rapids/udf/hive/EmptyHiveSimpleUDF.java
@@ -18,9 +18,9 @@ package com.nvidia.spark.rapids.udf.hive;
 
 import org.apache.hadoop.hive.ql.exec.UDF;
 
-/** An empty Hive simple UDF returning the input directly for row-based UDF test only. */
+/** An empty Hive simple UDF returning the first input directly for row-based UDF test only. */
 public class EmptyHiveSimpleUDF extends UDF {
-  public String evaluate(String in) {
+  public String evaluate(String in, String in2) {
     return in;
   }
 }


### PR DESCRIPTION
Take care of the `GpuLiteral` and foldable GPU expressions specially when creating an inspector from an expression.

This fixes https://github.com/NVIDIA/spark-rapids/issues/4275

- [x] Add tests


Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
