### PR TITLE
Revert commonizing the int96ParquetRebase* functions 

### DIFF
--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -48,6 +48,16 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 abstract class Spark30XShims extends Spark301util320Shims with Logging {
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    parquetRebaseRead(conf)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    parquetRebaseWrite(conf)
+  override def int96ParquetRebaseReadKey: String =
+    parquetRebaseReadKey
+  override def int96ParquetRebaseWriteKey: String =
+    parquetRebaseWriteKey
+  override def hasSeparateINT96RebaseConf: Boolean = false
+
   override def getScalaUDFAsExpression(
       function: AnyRef,
       dataType: DataType,

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301util320Shims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301util320Shims.scala
@@ -72,15 +72,6 @@ trait Spark301util320Shims extends SparkShims {
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ)
   override def parquetRebaseWrite(conf: SQLConf): String =
     conf.getConf(SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_WRITE)
-  override def int96ParquetRebaseRead(conf: SQLConf): String =
-    parquetRebaseRead(conf)
-  override def int96ParquetRebaseWrite(conf: SQLConf): String =
-    parquetRebaseWrite(conf)
-  override def int96ParquetRebaseReadKey: String =
-    parquetRebaseReadKey
-  override def int96ParquetRebaseWriteKey: String =
-    parquetRebaseWriteKey
-  override def hasSeparateINT96RebaseConf: Boolean = false
 
   override def sessionFromPlan(plan: SparkPlan): SparkSession = {
     plan.sqlContext.sparkSession

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -52,6 +52,16 @@ import org.apache.spark.storage.{BlockId, BlockManagerId}
 // 31x nondb shims, used by 311cdh and 31x
 abstract class Spark31XShims extends Spark301util320Shims with Logging {
 
+  override def int96ParquetRebaseRead(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)
+  override def int96ParquetRebaseWrite(conf: SQLConf): String =
+    conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE)
+  override def int96ParquetRebaseReadKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ.key
+  override def int96ParquetRebaseWriteKey: String =
+    SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_WRITE.key
+  override def hasSeparateINT96RebaseConf: Boolean = true
+
   override def getScalaUDFAsExpression(
       function: AnyRef,
       dataType: DataType,


### PR DESCRIPTION
These functions are different between Spark 3.0.x and 3.1.x but they were commonized.

fixes https://github.com/NVIDIA/spark-rapids/issues/4294

I checked the other functions that were commonized and didn't see any other issues.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
