### PR TITLE
Fix typo in shim class name

### DIFF
--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.storage.{BlockId, BlockManagerId}
 import org.apache.spark.unsafe.types.CalendarInterval
 
-abstract class Spark30XShims extends Spark301util320Shims with Logging {
+abstract class Spark30XShims extends Spark301until320Shims with Logging {
   override def int96ParquetRebaseRead(conf: SQLConf): String =
     parquetRebaseRead(conf)
   override def int96ParquetRebaseWrite(conf: SQLConf): String =

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301until320Shims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301until320Shims.scala
@@ -59,7 +59,7 @@ import org.apache.spark.sql.types._
 /**
 * Shim base class that can be compiled with from 301 until 320
 */
-trait Spark301util320Shims extends SparkShims {
+trait Spark301until320Shims extends SparkShims {
   override def parquetRebaseReadKey: String =
     SQLConf.LEGACY_PARQUET_REBASE_MODE_IN_READ.key
   override def parquetRebaseWriteKey: String =

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -50,7 +50,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.storage.{BlockId, BlockManagerId}
 
 // 31x nondb shims, used by 311cdh and 31x
-abstract class Spark31XShims extends Spark301util320Shims with Logging {
+abstract class Spark31XShims extends Spark301until320Shims with Logging {
 
   override def int96ParquetRebaseRead(conf: SQLConf): String =
     conf.getConf(SQLConf.LEGACY_PARQUET_INT96_REBASE_MODE_IN_READ)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Replace `util` with `until` in class name