### PR TITLE
[BUG] Update nightly test script to dynamically set mem_fraction [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -221,7 +221,7 @@ if [[ $TEST_MODE == "ALL" || $TEST_MODE == "IT_ONLY" ]]; then
     # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
     #                      we can set it to "never" and print failed ones after finish running all tests if needed
     # --group: print stderr after test finished for better readability
-    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: $tests
+    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: hash_aggregate_test.py
   else
     run_test all
   fi

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -221,7 +221,7 @@ if [[ $TEST_MODE == "ALL" || $TEST_MODE == "IT_ONLY" ]]; then
     # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
     #                      we can set it to "never" and print failed ones after finish running all tests if needed
     # --group: print stderr after test finished for better readability
-    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: hash_aggregate_test.py
+    parallel -u --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: hash_aggregate_test.py test_hash_reduction_decimal_overflow_sum
   else
     run_test all
   fi

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -215,7 +215,7 @@ if [[ $TEST_MODE == "ALL" || $TEST_MODE == "IT_ONLY" ]]; then
   # integration tests
   if [[ $PARALLEL_TEST == "true" ]] && [ -x "$(command -v parallel)" ]; then
     # put most time-consuming tests at the head of queue
-    time_consuming_tests="join_test.py generate_expr_test.py parquet_write_test.py"
+    time_consuming_tests="join_test.py hash_aggregate_test.py parquet_write_test.py"
     tests_list=$(find "$SCRIPT_PATH"/src/main/python/ -name "*_test.py" -printf "%f ")
     tests=$(echo "$time_consuming_tests $tests_list" | tr ' ' '\n' | awk '!x[$0]++' | xargs)
     # --halt "now,fail=1": exit when the first job fail, and kill running jobs.

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -139,14 +139,16 @@ export SEQ_CONF="--executor-memory 16G \
 
 # currently we hardcode the parallelism and configs based on our CI node's hardware specs,
 # we can make it dynamically generated if this script is going to be used in other scenarios in the future
+PARALLELISM=${PARALLELISM:-'4'}
+MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 1))")
 export PARALLEL_CONF="--executor-memory 4G \
 --total-executor-cores 2 \
 --conf spark.executor.cores=2 \
 --conf spark.task.cpus=1 \
 --conf spark.rapids.sql.concurrentGpuTasks=2 \
---conf spark.rapids.memory.gpu.allocFraction=0.15 \
 --conf spark.rapids.memory.gpu.minAllocFraction=0 \
---conf spark.rapids.memory.gpu.maxAllocFraction=0.15"
+--conf spark.rapids.memory.gpu.allocFraction=${MEMORY_FRACTION} \
+--conf spark.rapids.memory.gpu.maxAllocFraction=${MEMORY_FRACTION}"
 
 export CUDF_UDF_TEST_ARGS="--conf spark.rapids.memory.gpu.allocFraction=0.1 \
 --conf spark.rapids.memory.gpu.minAllocFraction=0 \
@@ -219,7 +221,7 @@ if [[ $TEST_MODE == "ALL" || $TEST_MODE == "IT_ONLY" ]]; then
     # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
     #                      we can set it to "never" and print failed ones after finish running all tests if needed
     # --group: print stderr after test finished for better readability
-    parallel --group --halt "now,fail=1" -j5 run_test ::: $tests
+    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: $tests
   else
     run_test all
   fi

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -140,7 +140,7 @@ export SEQ_CONF="--executor-memory 16G \
 # currently we hardcode the parallelism and configs based on our CI node's hardware specs,
 # we can make it dynamically generated if this script is going to be used in other scenarios in the future
 PARALLELISM=${PARALLELISM:-'4'}
-MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 1))")
+MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 0.2))")
 export PARALLEL_CONF="--executor-memory 4G \
 --total-executor-cores 2 \
 --conf spark.executor.cores=2 \
@@ -221,7 +221,7 @@ if [[ $TEST_MODE == "ALL" || $TEST_MODE == "IT_ONLY" ]]; then
     # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
     #                      we can set it to "never" and print failed ones after finish running all tests if needed
     # --group: print stderr after test finished for better readability
-    parallel -u --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: hash_aggregate_test.py test_hash_reduction_decimal_overflow_sum
+    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test ::: $tests
   else
     run_test all
   fi


### PR DESCRIPTION
fix #4315 

Previously nightly test run w/ rmm `allocFraction=0.15` and `concurrentGpuTasks=2`, which failed new updated sum test

Verified internally, `[skip ci]` since no change for pre-merge