### PR TITLE
Change the explanation of why the operator will not work on GPU

### DIFF
--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -124,7 +124,7 @@ the driver logs with `spark.rapids.sql.explain=all`.
    this version:
    
    ```
-   !Unsupported operator: <RowDataSourceScanExec> cannot run on GPU because no GPU enabled version of operator class org.apache.spark.sql.execution.RowDataSourceScanExec could be found
+   !Not supported by GPU: <RowDataSourceScanExec> cannot run on GPU because GPU does not support the operator class org.apache.spark.sql.execution.RowDataSourceScanExec
    ```
 
 This log can show you which operators (on what data type) can not run on GPU and the reason.
@@ -152,7 +152,7 @@ analysis.
 For example, the log lines starting with `!` is the so-called not-supported messages:
 ```
 !Exec <GenerateExec> cannot run on GPU because not all expressions can be replaced
-  !Unsupported operator:  <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because no GPU enabled version of expression class 
+  !Not supported by GPU:  <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because GPU does not support the operator ReplicateRows
 ```
 The indentation indicates the parent and child relationship for those expressions.
 If not all of the children expressions can run on GPU, the parent can not run on GPU either.

--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -124,7 +124,7 @@ the driver logs with `spark.rapids.sql.explain=all`.
    this version:
    
    ```
-   !NOT_FOUND <RowDataSourceScanExec> cannot run on GPU because no GPU enabled version of operator class org.apache.spark.sql.execution.RowDataSourceScanExec could be found
+   !Unsupported operator: <RowDataSourceScanExec> cannot run on GPU because no GPU enabled version of operator class org.apache.spark.sql.execution.RowDataSourceScanExec could be found
    ```
 
 This log can show you which operators (on what data type) can not run on GPU and the reason.
@@ -152,7 +152,7 @@ analysis.
 For example, the log lines starting with `!` is the so-called not-supported messages:
 ```
 !Exec <GenerateExec> cannot run on GPU because not all expressions can be replaced
-  !NOT_FOUND <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because no GPU enabled version of expression class 
+  !Unsupported operator:  <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because no GPU enabled version of expression class 
 ```
 The indentation indicates the parent and child relationship for those expressions.
 If not all of the children expressions can run on GPU, the parent can not run on GPU either.

--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -124,7 +124,7 @@ the driver logs with `spark.rapids.sql.explain=all`.
    this version:
    
    ```
-   !Not supported by GPU: <RowDataSourceScanExec> cannot run on GPU because GPU does not support the operator class org.apache.spark.sql.execution.RowDataSourceScanExec
+   ! <RowDataSourceScanExec> cannot run on GPU because GPU does not currently support the operator class org.apache.spark.sql.execution.RowDataSourceScanExec
    ```
 
 This log can show you which operators (on what data type) can not run on GPU and the reason.
@@ -152,7 +152,7 @@ analysis.
 For example, the log lines starting with `!` is the so-called not-supported messages:
 ```
 !Exec <GenerateExec> cannot run on GPU because not all expressions can be replaced
-  !Not supported by GPU:  <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because GPU does not support the operator ReplicateRows
+  ! <ReplicateRows> replicaterows(sum#99L, gender#76) cannot run on GPU because GPU does not currently support the operator ReplicateRows
 ```
 The indentation indicates the parent and child relationship for those expressions.
 If not all of the children expressions can run on GPU, the parent can not run on GPU either.

--- a/integration_tests/src/main/python/explain_test.py
+++ b/integration_tests/src/main/python/explain_test.py
@@ -83,7 +83,7 @@ def test_explain_udf():
         df2 = df.select(slen("name").alias("slen(name)"), to_upper("name"), add_one("age"))
         explain_str = spark.sparkContext._jvm.com.nvidia.spark.rapids.ExplainPlan.explainPotentialGpuPlan(df2._jdf, "ALL")
         # udf shouldn't be on GPU
-        udf_str_not = 'cannot run on GPU because GPU does not support the operator class org.apache.spark.sql.execution.python.BatchEvalPythonExec'
+        udf_str_not = 'cannot run on GPU because GPU does not currently support the operator class org.apache.spark.sql.execution.python.BatchEvalPythonExec'
         assert udf_str_not in explain_str
         not_on_gpu_str = spark.sparkContext._jvm.com.nvidia.spark.rapids.ExplainPlan.explainPotentialGpuPlan(df2._jdf, "NOT")
         assert udf_str_not in not_on_gpu_str

--- a/integration_tests/src/main/python/explain_test.py
+++ b/integration_tests/src/main/python/explain_test.py
@@ -83,7 +83,7 @@ def test_explain_udf():
         df2 = df.select(slen("name").alias("slen(name)"), to_upper("name"), add_one("age"))
         explain_str = spark.sparkContext._jvm.com.nvidia.spark.rapids.ExplainPlan.explainPotentialGpuPlan(df2._jdf, "ALL")
         # udf shouldn't be on GPU
-        udf_str_not = 'cannot run on GPU because no GPU enabled version of operator class org.apache.spark.sql.execution.python.BatchEvalPythonExec'
+        udf_str_not = 'cannot run on GPU because GPU does not support the operator class org.apache.spark.sql.execution.python.BatchEvalPythonExec'
         assert udf_str_not in explain_str
         not_on_gpu_str = spark.sparkContext._jvm.com.nvidia.spark.rapids.ExplainPlan.explainPotentialGpuPlan(df2._jdf, "NOT")
         assert udf_str_not in not_on_gpu_str

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -46,7 +46,7 @@ trait DataFromReplacementRule {
  * A version of DataFromReplacementRule that is used when no replacement rule can be found.
  */
 final class NoRuleDataFromReplacementRule extends DataFromReplacementRule {
-  override val operationName: String = "Unsupported operator: "
+  override val operationName: String = "Not supported by GPU: "
 
   override def confKey = "NOT_FOUND"
 
@@ -463,7 +463,7 @@ final class RuleNotFoundPartMeta[INPUT <: Partitioning](
   extends PartMeta[INPUT](part, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagPartForGpu(): Unit = {
-    willNotWorkOnGpu(s"no GPU enabled version of partitioning ${part.getClass} could be found")
+    willNotWorkOnGpu(s"GPU does not support the operator ${part.getClass}")
   }
 
   override def convertToGpu(): GpuPartitioning =
@@ -498,7 +498,7 @@ final class RuleNotFoundScanMeta[INPUT <: Scan](
   extends ScanMeta[INPUT](scan, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagSelfForGpu(): Unit = {
-    willNotWorkOnGpu(s"no GPU enabled version of scan ${scan.getClass} could be found")
+    willNotWorkOnGpu(s"GPU does not support the operator ${scan.getClass}")
   }
 
   override def convertToGpu(): Scan =
@@ -534,7 +534,7 @@ final class RuleNotFoundDataWritingCommandMeta[INPUT <: DataWritingCommand](
     extends DataWritingCommandMeta[INPUT](cmd, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagSelfForGpu(): Unit = {
-    willNotWorkOnGpu(s"no GPU accelerated version of command ${cmd.getClass} could be found")
+    willNotWorkOnGpu(s"GPU does not support the operator ${cmd.getClass}")
   }
 
   override def convertToGpu(): GpuDataWritingCommand =
@@ -795,7 +795,7 @@ final class RuleNotFoundSparkPlanMeta[INPUT <: SparkPlan](
   extends SparkPlanMeta[INPUT](plan, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagPlanForGpu(): Unit =
-    willNotWorkOnGpu(s"no GPU enabled version of operator ${plan.getClass} could be found")
+    willNotWorkOnGpu(s"GPU does not support the operator ${plan.getClass}")
 
   override def convertToGpu(): GpuExec =
     throw new IllegalStateException("Cannot be converted to GPU")
@@ -1307,7 +1307,7 @@ final class RuleNotFoundExprMeta[INPUT <: Expression](
   extends ExprMeta[INPUT](expr, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagExprForGpu(): Unit =
-    willNotWorkOnGpu(s"no GPU enabled version of expression ${expr.getClass} could be found")
+    willNotWorkOnGpu(s"GPU does not currently support the operator ${expr.getClass}")
 
   override def convertToGpu(): GpuExpression =
     throw new IllegalStateException("Cannot be converted to GPU")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -46,7 +46,7 @@ trait DataFromReplacementRule {
  * A version of DataFromReplacementRule that is used when no replacement rule can be found.
  */
 final class NoRuleDataFromReplacementRule extends DataFromReplacementRule {
-  override val operationName: String = "Not supported by GPU: "
+  override val operationName: String = ""
 
   override def confKey = "NOT_FOUND"
 
@@ -463,7 +463,7 @@ final class RuleNotFoundPartMeta[INPUT <: Partitioning](
   extends PartMeta[INPUT](part, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagPartForGpu(): Unit = {
-    willNotWorkOnGpu(s"GPU does not support the operator ${part.getClass}")
+    willNotWorkOnGpu(s"GPU does not currently support the operator ${part.getClass}")
   }
 
   override def convertToGpu(): GpuPartitioning =
@@ -498,7 +498,7 @@ final class RuleNotFoundScanMeta[INPUT <: Scan](
   extends ScanMeta[INPUT](scan, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagSelfForGpu(): Unit = {
-    willNotWorkOnGpu(s"GPU does not support the operator ${scan.getClass}")
+    willNotWorkOnGpu(s"GPU does not currently support the operator ${scan.getClass}")
   }
 
   override def convertToGpu(): Scan =
@@ -534,7 +534,7 @@ final class RuleNotFoundDataWritingCommandMeta[INPUT <: DataWritingCommand](
     extends DataWritingCommandMeta[INPUT](cmd, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagSelfForGpu(): Unit = {
-    willNotWorkOnGpu(s"GPU does not support the operator ${cmd.getClass}")
+    willNotWorkOnGpu(s"GPU does not currently support the operator ${cmd.getClass}")
   }
 
   override def convertToGpu(): GpuDataWritingCommand =
@@ -795,7 +795,7 @@ final class RuleNotFoundSparkPlanMeta[INPUT <: SparkPlan](
   extends SparkPlanMeta[INPUT](plan, conf, parent, new NoRuleDataFromReplacementRule) {
 
   override def tagPlanForGpu(): Unit =
-    willNotWorkOnGpu(s"GPU does not support the operator ${plan.getClass}")
+    willNotWorkOnGpu(s"GPU does not currently support the operator ${plan.getClass}")
 
   override def convertToGpu(): GpuExec =
     throw new IllegalStateException("Cannot be converted to GPU")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -46,7 +46,7 @@ trait DataFromReplacementRule {
  * A version of DataFromReplacementRule that is used when no replacement rule can be found.
  */
 final class NoRuleDataFromReplacementRule extends DataFromReplacementRule {
-  override val operationName: String = "NOT_FOUND"
+  override val operationName: String = "Unsupported operator: "
 
   override def confKey = "NOT_FOUND"
 


### PR DESCRIPTION
Signed-off-by: HaoYang670 13716567376yh@gmail.com
close #4088 
* Change explanation in log messages for unsupported operators. Instead of printing “NOT_FOUND”, we tell users that the GPU does not support the operator.
