### PR TITLE
Revert "Ignore failing string to timestamp tests temporarily (#4197)"

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -58,12 +58,10 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
   }
 
 
-  ignore("to_date yyyy-MM-dd fails - https://github.com/NVIDIA/spark-rapids/issues/4176") {
-    testSparkResultsAreEqual("to_date yyyy-MM-dd",
-        datesAsStrings,
-        conf = CORRECTED_TIME_PARSER_POLICY) {
-      df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
-    }
+  testSparkResultsAreEqual("to_date yyyy-MM-dd",
+      datesAsStrings,
+      conf = CORRECTED_TIME_PARSER_POLICY) {
+    df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd LEGACY",
@@ -102,12 +100,10 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
-  ignore("to_timestamp yyyy-MM-dd fails - https://github.com/NVIDIA/spark-rapids/issues/4176") {
-    testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
-        timestampsAsStrings,
-        conf = CORRECTED_TIME_PARSER_POLICY) {
-      df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
-    }
+  testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
+      timestampsAsStrings,
+      conf = CORRECTED_TIME_PARSER_POLICY) {
+    df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("to_timestamp dd/MM/yyyy",
@@ -124,12 +120,10 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0")))
   }
 
-  ignore("unix_timestamp parse date fails - https://github.com/NVIDIA/spark-rapids/issues/4176") {
-    testSparkResultsAreEqual("unix_timestamp parse date",
-        timestampsAsStrings,
-        CORRECTED_TIME_PARSER_POLICY) {
-      df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
-    }
+  testSparkResultsAreEqual("unix_timestamp parse date",
+      timestampsAsStrings,
+      CORRECTED_TIME_PARSER_POLICY) {
+    df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
   }
 
   testSparkResultsAreEqual("unix_timestamp parse yyyy/MM",


### PR DESCRIPTION
This reverts commit 24d93884d288b373dc8e2a2ae33df5c9bfaac4e2.

Closes https://github.com/NVIDIA/spark-rapids/issues/4176