### PR TITLE
Use the new ucx clientId apis

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -43,7 +43,7 @@ be installed on the host and inside Docker containers (if not baremetal). A host
 requirements, like the MLNX_OFED driver and `nv_peer_mem` kernel module.
 
 The minimum UCX requirement for the RAPIDS Shuffle Manager is
-[UCX 1.11.2](https://github.com/openucx/ucx/releases/tag/v1.11.2).
+[UCX 1.12.1](https://github.com/openucx/ucx/releases/tag/v1.12.1).
 
 #### Baremetal
 
@@ -73,47 +73,40 @@ The minimum UCX requirement for the RAPIDS Shuffle Manager is
    further.
 
 2. Fetch and install the UCX package for your OS from:
-   [UCX 1.11.2](https://github.com/openucx/ucx/releases/tag/v1.11.2).
-
-   NOTE: Please install the artifact with the newest CUDA 11.x version (for UCX 1.11.2 please
-   pick CUDA 11.2) as CUDA 11 introduced [CUDA Enhanced Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#enhanced-compat-minor-releases).
-   Starting with UCX 1.12, UCX will stop publishing individual artifacts for each minor version of CUDA.
-
-   Please refer to our [FAQ](../FAQ.md#what-hardware-is-supported) for caveats with
-   CUDA Enhanced Compatibility.
+   [UCX 1.12.1](https://github.com/openucx/ucx/releases/tag/v1.12.1).
 
    RDMA packages have extra requirements that should be satisfied by MLNX_OFED.
 
 ##### CentOS UCX RPM
-The UCX packages for CentOS 7 and 8 are divided into different RPMs. For example, UCX 1.11.2
+The UCX packages for CentOS 7 and 8 are divided into different RPMs. For example, UCX 1.12.1
 available at
-https://github.com/openucx/ucx/releases/download/v1.11.2/ucx-v1.11.2-centos7-mofed5.x-cuda11.2.tar.bz2
+https://github.com/openucx/ucx/releases/download/v1.12.1/ucx-v1.12.1-centos7-mofed5-cuda11.tar.bz2
 contains:
 
 ```
-ucx-devel-1.11.2-1.el7.x86_64.rpm
-ucx-debuginfo-1.11.2-1.el7.x86_64.rpm
-ucx-1.11.2-1.el7.x86_64.rpm
-ucx-cuda-1.11.2-1.el7.x86_64.rpm
-ucx-rdmacm-1.11.2-1.el7.x86_64.rpm
-ucx-cma-1.11.2-1.el7.x86_64.rpm
-ucx-ib-1.11.2-1.el7.x86_64.rpm
+ucx-devel-1.12.1-1.el7.x86_64.rpm
+ucx-debuginfo-1.12.1-1.el7.x86_64.rpm
+ucx-1.12.1-1.el7.x86_64.rpm
+ucx-cuda-1.12.1-1.el7.x86_64.rpm
+ucx-rdmacm-1.12.1-1.el7.x86_64.rpm
+ucx-cma-1.12.1-1.el7.x86_64.rpm
+ucx-ib-1.12.1-1.el7.x86_64.rpm
 ```
 
 For a setup without RoCE or Infiniband networking, the only packages required are:
 
 ```
-ucx-1.11.2-1.el7.x86_64.rpm
-ucx-cuda-1.11.2-1.el7.x86_64.rpm
+ucx-1.12.1-1.el7.x86_64.rpm
+ucx-cuda-1.12.1-1.el7.x86_64.rpm
 ```
 
 If accelerated networking is available, the package list is:
 
 ```
-ucx-1.11.2-1.el7.x86_64.rpm
-ucx-cuda-1.11.2-1.el7.x86_64.rpm
-ucx-rdmacm-1.11.2-1.el7.x86_64.rpm
-ucx-ib-1.11.2-1.el7.x86_64.rpm
+ucx-1.12.1-1.el7.x86_64.rpm
+ucx-cuda-1.12.1-1.el7.x86_64.rpm
+ucx-rdmacm-1.12.1-1.el7.x86_64.rpm
+ucx-ib-1.12.1-1.el7.x86_64.rpm
 ```
 
 ---
@@ -152,7 +145,7 @@ system if you have RDMA capable hardware.
 Within the Docker container we need to install UCX and its requirements. These are Dockerfile
 examples for Ubuntu 18.04:
 
-The following are examples of Docker containers with UCX 1.11.2 and cuda-11.2 support.
+The following are examples of Docker containers with UCX 1.12.1 and cuda-11.2 support.
 
 | OS Type | RDMA | Dockerfile |
 | ------- | ---- | ---------- |
@@ -296,7 +289,7 @@ In this section, we are using a docker container built using the sample dockerfi
    | Databricks 9.1  | com.nvidia.spark.rapids.spark312db.RapidsShuffleManager  |
    | Databricks 10.4 | com.nvidia.spark.rapids.spark321db.RapidsShuffleManager  |
 
-2. Settings for UCX 1.11.2+:
+2. Settings for UCX 1.12.1+:
 
     Minimum configuration:
 
@@ -345,9 +338,9 @@ guide for Databricks. The following are extra steps required to enable UCX.
 ```
 #!/bin/bash
 sudo apt install -y wget libnuma1 &&
-wget https://github.com/openucx/ucx/releases/download/v1.11.2/ucx-v1.11.2-ubuntu18.04-mofed5.x-cuda11.2.deb &&
-sudo dpkg -i ucx-v1.11.2-ubuntu18.04-mofed5.x-cuda11.2.deb &&
-rm ucx-v1.11.2-ubuntu18.04-mofed5.x-cuda11.2.deb
+wget https://github.com/openucx/ucx/releases/download/v1.12.1/ucx-v1.12.1-ubuntu18.04-mofed5-cuda11.deb &&
+sudo dpkg -i ucx-v1.12.1-ubuntu18.04-mofed5-cuda11.deb &&
+rm ucx-v1.12.1-ubuntu18.04-mofed5-cuda11.deb
 ```
 
 Save the script in DBFS and add it to the "Init Scripts" list:

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_no_rdma
@@ -22,15 +22,15 @@
 #                               See: https://github.com/openucx/ucx/releases/
 
 ARG CUDA_VER=11.2.2
-ARG UCX_VER=1.11.2
-ARG UCX_CUDA_VER=11.2
+ARG UCX_VER=1.12.1
+ARG UCX_CUDA_VER=11
 
 FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
 ARG UCX_VER
 ARG UCX_CUDA_VER
 
 RUN yum update -y && yum install -y wget bzip2
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5.x-cuda$UCX_CUDA_VER.tar.bz2
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5-cuda$UCX_CUDA_VER.tar.bz2
 RUN cd /tmp && tar -xvf *.bz2 && \
   yum install -y ucx-$UCX_VER-1.el7.x86_64.rpm && \
   yum install -y ucx-cuda-$UCX_VER-1.el7.x86_64.rpm && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_rdma
@@ -29,8 +29,8 @@
 
 ARG RDMA_CORE_VERSION=32.1
 ARG CUDA_VER=11.2.2
-ARG UCX_VER=1.11.2
-ARG UCX_CUDA_VER=11.2
+ARG UCX_VER=1.12.1
+ARG UCX_CUDA_VER=11
 
 # Throw away image to build rdma_core
 FROM centos:7 as rdma_core
@@ -59,7 +59,7 @@ COPY --from=rdma_core /tmp/*.rpm /tmp/
 
 RUN yum update -y
 RUN yum install -y wget bzip2
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5.x-cuda$UCX_CUDA_VER.tar.bz2
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5-cuda$UCX_CUDA_VER.tar.bz2
 RUN cd /tmp && \
   yum install -y *.rpm && \
   tar -xvf *.bz2 && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -22,8 +22,8 @@
 #                               See: https://github.com/openucx/ucx/releases/
 
 ARG CUDA_VER=11.2.2
-ARG UCX_VER=1.11.2
-ARG UCX_CUDA_VER=11.2
+ARG UCX_VER=1.12.1
+ARG UCX_CUDA_VER=11
 
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu18.04
 ARG UCX_VER
@@ -31,5 +31,5 @@ ARG UCX_CUDA_VER
 
 RUN apt update
 RUN apt-get install -y wget
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-ubuntu18.04-mofed5.x-cuda$UCX_CUDA_VER.deb
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-ubuntu18.04-mofed5-cuda$UCX_CUDA_VER.deb
 RUN apt install -y /tmp/*.deb && rm -rf /tmp/*.deb

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -29,8 +29,8 @@
 
 ARG RDMA_CORE_VERSION=32.1
 ARG CUDA_VER=11.2.2
-ARG UCX_VER=1.11.2
-ARG UCX_CUDA_VER=11.2
+ARG UCX_VER=1.12.1
+ARG UCX_CUDA_VER=11
 
 # Throw away image to build rdma_core
 FROM ubuntu:18.04 as rdma_core
@@ -50,5 +50,5 @@ COPY --from=rdma_core /*.deb /tmp/
 
 RUN apt update
 RUN apt-get install -y wget
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-ubuntu18.04-mofed5.x-cuda$UCX_CUDA_VER.deb
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-ubuntu18.04-mofed5-cuda$UCX_CUDA_VER.deb
 RUN apt install -y /tmp/*.deb && rm -rf /tmp/*.deb

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
           <groupId>org.openucx</groupId>
           <artifactId>jucx</artifactId>
-          <version>1.11</version>
+          <version>1.12.0</version>
           <scope>compile</scope>
         </dependency>
         <dependency>

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -136,6 +136,7 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
       }
 
       var workerParams = new UcpWorkerParams()
+        .setClientId(localExecutorId)
 
       if (rapidsConf.shuffleUcxUseWakeup) {
         workerParams = workerParams
@@ -775,6 +776,7 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
       // enables `onError` callback
       .setPeerErrorHandlingMode()
       .setErrorHandler(this)
+      .sendClientId()
 
     /**
      * Get a `ClientConnection` after optionally connecting to a peer given by `peerExecutorId`,
@@ -806,7 +808,8 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
       onWorkerThreadAsync(() => {
         endpoints.computeIfAbsent(peerExecutorId, _ => {
           val sockAddr = new InetSocketAddress(peerHost, peerPort)
-          val ep = worker.newEndpoint(epParams.setSocketAddress(sockAddr))
+          val ep = worker.newEndpoint(
+            epParams.setSocketAddress(sockAddr))
           logDebug(s"Initiator: created an endpoint $ep to $peerExecutorId")
           reverseLookupEndpoints.put(ep, peerExecutorId)
           ep
@@ -816,11 +819,19 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
 
     // UcpListenerConnectionHandler interface - called from progress thread
     // handles an incoming connection to our UCP Listener
-    // TODO: in the future, this function may reject `ConnectionRequest`s
-    //  given a peer id we already established a connection to:
-    //  https://github.com/openucx/ucx/pull/6859
     override def onConnectionRequest(connectionRequest: UcpConnectionRequest): Unit = {
       logInfo(s"Got UcpListener request from ${connectionRequest.getClientAddress}")
+
+      val clientId = connectionRequest.getClientId
+
+      if (endpoints.containsKey(clientId)) {
+        connectionRequest.reject()
+        logWarning(s"Rejected connection request from ${clientId}, we already had an " +
+          s"endpoint established: ${endpoints.get(clientId)}")
+        return
+      } else {
+        logWarning(s"Accepting connection request from ${clientId}!")
+      }
 
       // accept it
       val ep = worker.newEndpoint(epParams.setConnectionRequest(connectionRequest))

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -824,7 +824,10 @@ class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: 
 
       val clientId = connectionRequest.getClientId
 
-      if (endpoints.containsKey(clientId)) {
+      // We reject redundant connections iff the peer has an executor Id less
+      // than ours as a tie breaker when both executors in question start a connection
+      // to each other at the same time.
+      if (endpoints.containsKey(clientId) && clientId < localExecutorId) {
         connectionRequest.reject()
         logWarning(s"Rejected connection request from ${clientId}, we already had an " +
           s"endpoint established: ${endpoints.get(clientId)}")


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/3106.

This is a change to enable use of the new `clientId` in UCX 1.12.0. This also moves us to the new version of UCX. In a nutshell, this functionally prevents us from having redundant connections between peers. As the connection establishment is a race condition, since peers are connecting to each other when they receive a heartbeat or when they intend to fetch shuffle blocks, we now have enough information in the `UcpConnectionRequest` to reject it, if we already had initiated a connection to the peer that is trying to connect to us.

This is in draft. UCX 1.12 is not released yet so, I am posting to get some reviews from @petro-rudenko and to give a heads up this will go into branch-22.02 when UCX 1.12 is officially released.
