### PR TITLE
Replace Scala document with Scala comment for inner functions

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -657,11 +657,11 @@ object GpuCast extends Arm {
    *
    * when `legacyCastToString = false`, step 2, 5 are skipped
    */
-  private def castArrayToString(input:                    ColumnView,
-                                 elementType:                DataType,
-                                 ansiMode:                    Boolean,
-                                 legacyCastToString:          Boolean,
-                                 stringToDateAnsiModeEnabled: Boolean): ColumnVector = {
+  private def castArrayToString(input: ColumnView,
+      elementType: DataType,
+      ansiMode: Boolean,
+      legacyCastToString: Boolean,
+      stringToDateAnsiModeEnabled: Boolean): ColumnVector = {
 
     val (leftStr, rightStr) =  ("[", "]")
     val emptyStr = ""
@@ -677,7 +677,7 @@ object GpuCast extends Arm {
       /* -------------------------------- helper functions -----------------------*/
 
       /*
-       * cast all not-null elements in a child column to string type <p>
+       * Cast all not-null elements in a child column to string type
        * add `' '` to all elements when `legacyCastToString = true`
        */
       def castChildToStr(child: ColumnView): ColumnView = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -679,8 +679,6 @@ object GpuCast extends Arm {
       /*
        * cast all not-null elements in a child column to string type <p>
        * add `' '` to all elements when `legacyCastToString = true`
-       * @param child child column of an array column
-       * @return a string type child column
        */
       def castChildToStr(child: ColumnView): ColumnView = {
         withResource(
@@ -704,7 +702,6 @@ object GpuCast extends Arm {
 
       /*
        * If the first char of a string is ' ', remove it (only for legacyCastToString = true)
-       * @param strVec a string type column vector
        */
       def removeFirstSpace(strVec: ColumnVector): ColumnVector = {
         if (legacyCastToString){
@@ -719,7 +716,6 @@ object GpuCast extends Arm {
 
       /*
        * Add brackets to each string. Ex: ["1, 2, 3", "4, 5"] => ["[1, 2, 3]", "[4, 5]"]
-       * @param strVec a string vector
        */
       def addBrackets(strVec: ColumnVector): ColumnVector = {
         withResource(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -657,7 +657,7 @@ object GpuCast extends Arm {
    *
    * when `legacyCastToString = false`, step 2, 5 are skipped
    */
-  private  def castArrayToString(input:                    ColumnView,
+  private def castArrayToString(input:                    ColumnView,
                                  elementType:                DataType,
                                  ansiMode:                    Boolean,
                                  legacyCastToString:          Boolean,
@@ -676,7 +676,7 @@ object GpuCast extends Arm {
 
       /* -------------------------------- helper functions -----------------------*/
 
-      /**
+      /*
        * cast all not-null elements in a child column to string type <p>
        * add `' '` to all elements when `legacyCastToString = true`
        * @param child child column of an array column
@@ -702,7 +702,7 @@ object GpuCast extends Arm {
         }
       }
 
-      /**
+      /*
        * If the first char of a string is ' ', remove it (only for legacyCastToString = true)
        * @param strVec a string type column vector
        */
@@ -717,7 +717,7 @@ object GpuCast extends Arm {
         else {strVec.incRefCount}
       }
 
-      /**
+      /*
        * Add brackets to each string. Ex: ["1, 2, 3", "4, 5"] => ["[1, 2, 3]", "[4, 5]"]
        * @param strVec a string vector
        */


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
close #4341 

When doing `mvn verify`, a warning "discarding unmoored doc comment" is thrown.
What causes the warning is that adding Scala document to an inner function is useless.
We fix this bug by replacing Scala document with Scala comment.