### PR TITLE
Not publishing integration_tests jar to Maven Central [skip ci]

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -64,6 +64,14 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- use aggregator jar because accessing internal classes -->
+        <dependency>
+            <groupId>com.nvidia</groupId>
+            <artifactId>rapids-4-spark-aggregator_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <classifier>${spark.version.classifier}</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-udf-examples_${scala.binary.version}</artifactId>

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -64,14 +64,6 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- use aggregator jar because accessing internal classes -->
-        <dependency>
-            <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-aggregator_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-            <classifier>${spark.version.classifier}</classifier>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-udf-examples_${scala.binary.version}</artifactId>

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -87,26 +87,6 @@ $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             -Dfile=$FPATH.jar -DgroupId=com.nvidia -DartifactId=$ART_ID -Dversion=$ART_VER \
             -DpomFile="$POM_FPATH"
 
-###### Deploy integration tests jar(s) ######
-TESTS_ART_ID=`mvn help:evaluate -q -pl $TESTS_PL -Dexpression=project.artifactId -DforceStdout`
-TESTS_ART_VER=`mvn help:evaluate -q -pl $TESTS_PL -Dexpression=project.version -DforceStdout`
-TESTS_DOC_JARS="-Dsources=deployjars/$TESTS_ART_ID-$TESTS_ART_VER-sources.jar -Djavadoc=deployjars/$TESTS_ART_ID-$TESTS_ART_VER-javadoc.jar"
-# Copy the final aggregation jar as the default integration-tests jar
-TESTS_FPATH="deployjars/$TESTS_ART_ID-$TESTS_ART_VER"
-cp $TESTS_FPATH-spark${FINAL_AGG_VERSION_TOBUILD}.jar $TESTS_FPATH.jar
-$DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
-        $TESTS_DOC_JARS \
-        -Dfile=$TESTS_FPATH.jar -DpomFile=${TESTS_PL}/pom.xml
-
-# Deploy integration tests jars with classifier 'spark301/spark302/...'
-VERSIONS_LIST=${VERSIONS_BUILT//','/' '}
-for VER in ${VERSIONS_LIST}; do
-    TESTS_FPATH="deployjars/$TESTS_ART_ID-$TESTS_ART_VER-spark$VER"
-    $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
-            $TESTS_DOC_JARS \
-            -Dfile=$TESTS_FPATH.jar -DpomFile=${TESTS_PL}/pom.xml -Dclassifier=spark$VER
-done
-
 ###### Deploy profiling tool jar(s) ######
 TOOL_PL=${TOOL_PL:-"tools"}
 TOOL_ART_ID=`mvn help:evaluate -q -pl $TOOL_PL -Dexpression=project.artifactId -DforceStdout -Prelease311`


### PR DESCRIPTION
Fix issue: https://github.com/NVIDIA/spark-rapids/issues/3934

Stop publishing the integration tests jar to Maven Central.

Remove the aggregator dependency in the integration_tests module pom.xml.

Signed-off-by: Tim Liu <timl@nvidia.com>