### PR TITLE
Remove unused scallop dependency from integration_tests

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>scala-library</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.rogach</groupId>
-            <artifactId>scallop_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
While reviewing #4374 I noticed the integration tests have a dependency on scallop that is no longer used.  This cleans up the unused dependency.