### PR TITLE
Use correct column name in GpuIf test [databricks]

### DIFF
--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -186,28 +186,25 @@ def test_ifnull(data_gen):
                 'ifnull({}, b)'.format(null_lit),
                 'ifnull(a, {})'.format(null_lit)))
 
-@pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [IntegerGen().with_special_case(2147483647)], ids=idfn)
 def test_conditional_with_side_effects_col_col(data_gen):
-    gen = IntegerGen().with_special_case(2147483647)
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, data_gen, gen).selectExpr(
-                'IF(b < 2147483647, b + 1, b)'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'IF(a < 2147483647, a + 1, a)'),
             conf = {'spark.sql.ansi.enabled':True})
 
-@pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [IntegerGen().with_special_case(2147483647)], ids=idfn)
 def test_conditional_with_side_effects_col_scalar(data_gen):
-    gen = IntegerGen().with_special_case(2147483647)
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, data_gen, gen).selectExpr(
-                'IF(b < 2147483647, b + 1, 2147483647)',
-                'IF(b >= 2147483646, 2147483647, b + 1)'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'IF(a < 2147483647, a + 1, 2147483647)',
+                'IF(a >= 2147483646, 2147483647, a + 1)'),
             conf = {'spark.sql.ansi.enabled':True})
 
-@pytest.mark.parametrize('data_gen', int_n_long_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,20}')], ids=idfn)
 def test_conditional_with_side_effects_cast(data_gen):
-    gen = mk_str_gen('[0-9]{1,20}')
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, data_gen, gen).selectExpr(
-                'IF(b RLIKE "^[0-9]{1,5}$", CAST(b AS INT), 0)'),
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'IF(a RLIKE "^[0-9]{1,5}$", CAST(a AS INT), 0)'),
             conf = {'spark.sql.ansi.enabled':True,
                     'spark.rapids.sql.expression.RLike': True})

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -208,6 +208,6 @@ def test_conditional_with_side_effects_cast(data_gen):
     gen = mk_str_gen('[0-9]{1,20}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, data_gen, gen).selectExpr(
-                'IF(a RLIKE "^[0-9]{1,5}$", CAST(a AS INT), 0)'),
+                'IF(b RLIKE "^[0-9]{1,5}$", CAST(b AS INT), 0)'),
             conf = {'spark.sql.ansi.enabled':True,
                     'spark.rapids.sql.expression.RLike': True})


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/4386

The first commit updates the test `test_conditional_with_side_effects_cast` to fix an error where the test was referencing the wrong column. This worked fine in Apache Spark presumably due to implicit casts being added. The test failed in Databricks.

The second commit simplifies the side-effect tests to use `unary_op_df` instead of `two_col_df` since these tests only reference a single column.

