### PR TITLE
Fix an Intellij debug issue [databricks]

### DIFF
--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -28,7 +28,6 @@ object TypeSigUtil extends TypeSigUtilBase {
    *
    * @param check        the Supported Types
    * @param dataType     the data type to be checked
-   * @param allowDecimal whether decimal support is enabled or not
    * @return true if it is allowed else false.
    */
   override def isSupported(
@@ -48,7 +47,6 @@ object TypeSigUtil extends TypeSigUtilBase {
    *
    * @param check              the Supported Types
    * @param dataType           the data type to be checked
-   * @param allowDecimal       whether decimal support is enabled or not
    * @param notSupportedReason the reason for not supporting
    * @return the reason
    */

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -16,12 +16,12 @@
 
 package com.nvidia.spark.rapids.shims.v2
 
-import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilTrait}
+import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilBase}
 
 import org.apache.spark.sql.types.DataType
 
 /** TypeSig Support for [3.0.1, 3.2.0) */
-object TypeSigUtil extends TypeSigUtilTrait {
+object TypeSigUtil extends TypeSigUtilBase {
 
   /**
    * Check if this type of Spark-specific is supported by the plugin or not.

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -16,12 +16,12 @@
 
 package com.nvidia.spark.rapids.shims.v2
 
-import com.nvidia.spark.rapids.{TypeEnum, TypeSig}
+import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilTrait}
 
 import org.apache.spark.sql.types.DataType
 
 /** TypeSig Support for [3.0.1, 3.2.0) */
-object TypeSigUtil extends com.nvidia.spark.rapids.TypeSigUtil {
+object TypeSigUtil extends TypeSigUtilTrait {
 
   /**
    * Check if this type of Spark-specific is supported by the plugin or not.

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -16,14 +16,14 @@
 
 package com.nvidia.spark.rapids.shims.v2
 
-import com.nvidia.spark.rapids.{TypeEnum, TypeSig}
+import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilTrait}
 
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, YearMonthIntervalType}
 
 /**
  * Add DayTimeIntervalType and YearMonthIntervalType support
  */
-object TypeSigUtil extends com.nvidia.spark.rapids.TypeSigUtil {
+object TypeSigUtil extends TypeSigUtilTrait {
 
   override def isSupported(
     check: TypeEnum.ValueSet,

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/TypeSigUtil.scala
@@ -16,14 +16,14 @@
 
 package com.nvidia.spark.rapids.shims.v2
 
-import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilTrait}
+import com.nvidia.spark.rapids.{TypeEnum, TypeSig, TypeSigUtilBase}
 
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, YearMonthIntervalType}
 
 /**
  * Add DayTimeIntervalType and YearMonthIntervalType support
  */
-object TypeSigUtil extends TypeSigUtilTrait {
+object TypeSigUtil extends TypeSigUtilBase {
 
   override def isSupported(
     check: TypeEnum.ValueSet,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -25,8 +25,8 @@ import com.nvidia.spark.rapids.shims.v2.TypeSigUtil
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, WindowSpecDefinition}
 import org.apache.spark.sql.types._
 
-/** TypeSigUtil for different spark versions */
-trait TypeSigUtil {
+/** TypeSigUtilTrait for different spark versions */
+trait TypeSigUtilTrait {
 
   /**
    * Check if this type of Spark-specific is supported by the plugin or not.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryEx
 import org.apache.spark.sql.types._
 
 /** TypeSigUtilTrait for different spark versions */
-trait TypeSigUtilTrait {
+trait TypeSigUtilBase {
 
   /**
    * Check if this type of Spark-specific is supported by the plugin or not.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -25,7 +25,7 @@ import com.nvidia.spark.rapids.shims.v2.TypeSigUtil
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, WindowSpecDefinition}
 import org.apache.spark.sql.types._
 
-/** TypeSigUtilTrait for different spark versions */
+/** TypeSigUtilBase for different spark versions */
 trait TypeSigUtilBase {
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -25,7 +25,7 @@ import com.nvidia.spark.rapids.shims.v2.TypeSigUtil
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, WindowSpecDefinition}
 import org.apache.spark.sql.types._
 
-/** TypeSigUtilBase for different spark versions */
+/** Trait of TypeSigUtil for different spark versions */
 trait TypeSigUtilBase {
 
   /**


### PR DESCRIPTION
Intellij complains below error when debugging

```
imported `TypeSigUtil` is permanently hidden by definition of trait TypeSigUtil in package rapids
import com.nvidia.spark.rapids.shims.v2.TypeSigUtil
```

This PR just renames TypeSigUtil to TypeSigUtilTrait to avoid this.

Signed-off-by: Bobby Wang <wbo4958@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
