### PR TITLE
Exhaustively iterate ColumnarToRow iterator to avoid leaks

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuColumnarToRowSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuColumnarToRowSuite.scala
@@ -66,6 +66,7 @@ class GpuColumnarToRowSuite extends SparkQueryCompareTestSuite {
           }
           assert(input.getBinary(1) sameElements output.getBinary(1))
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
@@ -57,6 +57,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           }
           assert(input.getSeq[Byte](1) sameElements output.getBinary(1))
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -118,6 +119,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
             }
           }
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -143,6 +145,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           }
           assert(input.getString(1) == output.getString(1))
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -169,6 +172,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           }
           assert(input.getByte(1) == output.getByte(1))
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -194,6 +198,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           }
           assert(input.getSeq(1) sameElements output.getArray(1).toDoubleArray())
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -221,6 +226,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           }
           compareMapAndMapDate(input.getMap(1), output.getMap(1))
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }
@@ -269,6 +275,7 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
             }
           }
         }
+        assert(!c2rIterator.hasNext)
       }
     }
   }


### PR DESCRIPTION
Fixes #4422.  ColumnarToRowIterator will close its current batch via a task completion listener, but during unit tests there is no task context to leverage and thus the test must ensure the iterator is exhausted to ensure the batch is closed.  In each of these cases the iterator was _almost_ exhausted, but it was lacking a final `hasNext` to trigger the batch closing.  Arguably this was a missed check in each of these tests anyway.