### PR TITLE
Modify docs for 22.02 to address issue-4319[skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -290,15 +290,10 @@ In this section, we are using a docker container built using the sample dockerfi
     | 3.0.1         | com.nvidia.spark.rapids.spark301.RapidsShuffleManager    |
     | 3.0.2         | com.nvidia.spark.rapids.spark302.RapidsShuffleManager    |
     | 3.0.3         | com.nvidia.spark.rapids.spark303.RapidsShuffleManager    |
-    | 3.0.4         | com.nvidia.spark.rapids.spark304.RapidsShuffleManager    |
     | 3.1.1         | com.nvidia.spark.rapids.spark311.RapidsShuffleManager    |
     | 3.1.1 CDH     | com.nvidia.spark.rapids.spark311cdh.RapidsShuffleManager |
     | 3.1.2         | com.nvidia.spark.rapids.spark312.RapidsShuffleManager    |
-    | 3.1.3         | com.nvidia.spark.rapids.spark313.RapidsShuffleManager    |
     | 3.2.0         | com.nvidia.spark.rapids.spark320.RapidsShuffleManager    |
-    | 3.2.1         | com.nvidia.spark.rapids.spark321.RapidsShuffleManager    |
-    | 3.2.2         | com.nvidia.spark.rapids.spark322.RapidsShuffleManager    |
-    | 3.3.0         | com.nvidia.spark.rapids.spark330.RapidsShuffleManager    |
     | Databricks 7.3| com.nvidia.spark.rapids.spark301db.RapidsShuffleManager  |
     | Databricks 9.1| com.nvidia.spark.rapids.spark312db.RapidsShuffleManager  |
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -23,7 +23,7 @@ Hardware Requirements:
 
 The plugin is tested on the following architectures:
 
-	GPU Architecture: NVIDIA V100, T4 and A2/A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 and A2/A10/A30/A100 GPUs
 
 Software Requirements:
 
@@ -89,7 +89,7 @@ Hardware Requirements:
 
 The plugin is tested on the following architectures:
 
-	GPU Architecture: NVIDIA V100, T4 and A2/A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 and A2/A10/A30/A100 GPUs
 
 Software Requirements:
 
@@ -147,7 +147,7 @@ Hardware Requirements:
 
 The plugin is tested on the following architectures:
 
-	GPU Architecture: NVIDIA V100, T4 and A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 and A10/A30/A100 GPUs
 
 Software Requirements:
 
@@ -202,7 +202,7 @@ This is a patch release to address an issue with the plugin in the Databricks 8.
 
 Hardware Requirements:
 
-	GPU Architecture: NVIDIA V100, T4 or A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 or A10/A30/A100 GPUs
 
 Software Requirements:
 
@@ -244,7 +244,7 @@ This is a patch release to address an issue with the plugin in the Databricks 7.
 
 Hardware Requirements:
 
-	GPU Architecture: NVIDIA V100, T4 or A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 or A10/A30/A100 GPUs
 
 Software Requirements:
 
@@ -290,7 +290,7 @@ Hardware Requirements:
 
 The plugin is tested on the following architectures: 
 
-	GPU Architecture: NVIDIA V100, T4 and A10/A30/A100 GPUs
+	GPU Models: NVIDIA V100, T4 and A10/A30/A100 GPUs
 
 Software Requirements:
 


### PR DESCRIPTION
Modify docs for 22.02 to address issues in 4319. contributes to #4319 

Signed-off-by: Hao Zhu <hazhu@nvidia.com>

1. remove not-released RapidsShuffleManager manager.
2. Change some “GPU Architecture” to "GPU Models"