### PR TITLE
Don't acquire the semaphore for empty input while scanning

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -428,8 +428,9 @@ abstract class MultiFileCloudPartitionReaderBase(
     // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
     // We are not acquiring the semaphore here since this next() is getting called from
     // the `PartitionReaderIterator` which implements a standard iterator pattern, and
-    // advertises `hasNext` as false when we return false here (no downstream tasks should
-    // consume this empty batch)
+    // advertises `hasNext` as false when we return false here. No downstream tasks should
+    // try to call next after `hasNext` returns false, and any task that produces some kind of
+    // data when `hasNext` is false is responsible to get the semaphore themselves.
     batch.isDefined
   }
 
@@ -706,8 +707,9 @@ abstract class MultiFileCoalescingPartitionReaderBase(
     // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
     // We are not acquiring the semaphore here since this next() is getting called from
     // the `PartitionReaderIterator` which implements a standard iterator pattern, and
-    // advertises `hasNext` as false when we return false here (no downstream tasks should
-    // consume this empty batch)
+    // advertises `hasNext` as false when we return false here. No downstream tasks should
+    // try to call next after `hasNext` returns false, and any task that produces some kind of
+    // data when `hasNext` is false is responsible to get the semaphore themselves.
     batch.isDefined
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScanBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScanBase.scala
@@ -624,8 +624,9 @@ class GpuOrcPartitionReader(
     // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
     // We are not acquiring the semaphore here since this next() is getting called from
     // the `PartitionReaderIterator` which implements a standard iterator pattern, and
-    // advertises `hasNext` as false when we return false here (no downstream tasks should
-    // consume this empty batch)
+    // advertises `hasNext` as false when we return false here. No downstream tasks should
+    // try to call next after `hasNext` returns false, and any task that produces some kind of
+    // data when `hasNext` is false is responsible to get the semaphore themselves.
     batch.isDefined
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -1474,8 +1474,9 @@ class ParquetPartitionReader(
     // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
     // We are not acquiring the semaphore here since this next() is getting called from
     // the `PartitionReaderIterator` which implements a standard iterator pattern, and
-    // advertises `hasNext` as false when we return false here (no downstream tasks should
-    // consume this empty batch)
+    // advertises `hasNext` as false when we return false here. No downstream tasks should
+    // try to call next after `hasNext` returns false, and any task that produces some kind of
+    // data when `hasNext` is false is responsible to get the semaphore themselves.
     batch.isDefined
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -1458,7 +1458,6 @@ class ParquetPartitionReader(
   with ParquetPartitionReaderBase {
 
   private val blockIterator:  BufferedIterator[BlockMetaData] = clippedBlocks.iterator.buffered
-  private var isFirstBatch = true
 
   override def next(): Boolean = {
     batch.foreach(_.close())
@@ -1471,14 +1470,12 @@ class ParquetPartitionReader(
         batch = readBatch()
       }
     }
-    if (isFirstBatch) {
-      if (batch.isEmpty) {
-        // This is odd, but some operators return data even when there is no input so we need to
-        // be sure that we grab the GPU if there were no batches.
-        GpuSemaphore.acquireIfNecessary(TaskContext.get(), metrics(SEMAPHORE_WAIT_TIME))
-      }
-      isFirstBatch = false
-    }
+
+    // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
+    // We are not acquiring the semaphore here since this next() is getting called from
+    // the `PartitionReaderIterator` which implements a standard iterator pattern, and
+    // advertises `hasNext` as false when we return false here (no downstream tasks should
+    // consume this empty batch)
     batch.isDefined
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
@@ -223,8 +223,9 @@ abstract class GpuTextBasedPartitionReader(
     // NOTE: At this point, the task may not have yet acquired the semaphore if `batch` is `None`.
     // We are not acquiring the semaphore here since this next() is getting called from
     // the `PartitionReaderIterator` which implements a standard iterator pattern, and
-    // advertises `hasNext` as false when we return false here (no downstream tasks should
-    // consume this empty batch)
+    // advertises `hasNext` as false when we return false here. No downstream tasks should
+    // try to call next after `hasNext` returns false, and any task that produces some kind of
+    // data when `hasNext` is false is responsible to get the semaphore themselves.
     batch.isDefined
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -130,6 +130,7 @@ case class GpuHashAggregateMetrics(
     computeAggTime: GpuMetric,
     concatTime: GpuMetric,
     sortTime: GpuMetric,
+    semWaitTime: GpuMetric,
     spillCallback: SpillCallback)
 
 /** Utility class to convey information on the aggregation modes being used */
@@ -484,6 +485,11 @@ class GpuHashAggregateIterator(
     val aggregateFunctions = aggregateExpressions.map(_.aggregateFunction)
     val defaultValues =
       aggregateFunctions.flatMap(_.initialValues)
+    // We have to grab the semaphore in this scenario, since this is a reduction that produces
+    // rows on the GPU out of empty input, meaning that if a batch has 0 rows, a new single
+    // row is getting created with 0 as the count (if count is the operation), and other default
+    // values.
+    GpuSemaphore.acquireIfNecessary(TaskContext.get(), metrics.semWaitTime)
     val vecs = defaultValues.safeMap { ref =>
       withResource(GpuScalar.from(ref.asInstanceOf[GpuLiteral].value, ref.dataType)) {
         scalar => GpuColumnVector.from(scalar, 1, ref.dataType)
@@ -1392,6 +1398,7 @@ case class GpuHashAggregateExec(
       computeAggTime = gpuLongMetric(AGG_TIME),
       concatTime = gpuLongMetric(CONCAT_TIME),
       sortTime = gpuLongMetric(SORT_TIME),
+      semWaitTime = gpuLongMetric(SEMAPHORE_WAIT_TIME),
       makeSpillCallback(allMetrics))
 
     // cache in a local variable to avoid serializing the full child plan


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This PR removes instances where we acquired the GpuSemaphore within the scan code, specifically those scans that are `PartitionReader`s. The change is to stop acquiring the semaphore here, because these cases will not be consumed downstream, given how the `PartitionReader` is used. 

`PartitionReader` provides a `next()` method that returns false when there isn't work left. The `PartitionReaderIterator` wraps these readers, as far as I can tell, and it exposes the iterator interface (`hasNext()` returns false if the `PartitionReader` returned a false in `next()`). This allows us to stop requiring us to acquire the semaphore in the `next()` method, when there isn't any work left in the reader.

The PR also adds an acquire in the aggregate where we are producing rows out of nothing. This should be a noop, and likely just a miss that it wasn't there before (protected by upstream nodes doing the acquire for the agg).

The change has modest gains in NDS so far. I want to run a few more times, but so far I see: 10 queries that are 1.20x+ faster, 39 queries that are 1.10x+, and most queries (92) are above 1. I don't see a lot of regression here, except for q94 with 2 seconds, but q94 is falling back to the CPU and can be unpredictable. In other words, it seems to be mostly good, but I want to run a few more tests. 

@revans2 wanted comments explaining why we are not acquiring the semaphore. I wasn't sure where to put them, and they are the same each time. I could see us moving them to the `PartitionReaderIterator` or somewhere else more appropriate. 