### PR TITLE
Update GpuFileFormatWriter to stay in sync with recent Spark changes, but still not support writing Hive bucketed table on GPU.

### DIFF
--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -23,7 +23,7 @@ from pyspark.sql.types import *
 @pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
 def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory, fileFormat):
     """
-    parquet with Hive hash, not supportted yet
+    fallback because GPU does not support Hive hash partition
     """
     table = spark_tmp_table_factory.get()
 

--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -18,7 +18,7 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 
-
+@ignore_order
 @allow_non_gpu('DataWritingCommandExec')
 @pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
 def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory, fileFormat):
@@ -38,7 +38,7 @@ def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_fact
         
         data = map(lambda i: (i % 13, str(i), i % 5), range(50))
         df = spark.createDataFrame(data, ["i", "j", "k"])
-        df.write.mode("overwrite").insertInto(table)
+        df.write.mode("append").saveAsTable(table)
     
     data_path = spark_tmp_path + '/HIVE_DATA'
 

--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from asserts import assert_gpu_fallback_write
+from data_gen import *
+from marks import *
+from pyspark.sql.types import *
+
+
+@allow_non_gpu('DataWritingCommandExec')
+@pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
+def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory, fileFormat):
+    """
+    parquet with Hive hash, not supportted yet
+    """
+    table = spark_tmp_table_factory.get()
+
+    def write_hive_table(spark, path):
+        spark.sql("""
+            CREATE TABLE IF NOT EXISTS {0} (i int, j string) 
+            PARTITIONED BY (k string) 
+            CLUSTERED BY (i, j) SORTED BY (i) INTO 8 BUCKETS 
+            STORED AS {1}
+            LOCATION \"{2}\" 
+            """.format(table, fileFormat, path))
+        
+        data = map(lambda i: (i % 13, str(i), i % 5), range(50))
+        df = spark.createDataFrame(data, ["i", "j", "k"])
+        df.write.mode("overwrite").insertInto(table)
+    
+    data_path = spark_tmp_path + '/HIVE_DATA'
+
+    assert_gpu_fallback_write(
+            lambda spark, path: write_hive_table(spark, path),
+            lambda spark, _: spark.sql("SELECT * FROM {}".format(table)),
+            data_path,
+            'DataWritingCommandExec')

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -325,15 +325,6 @@ def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_fallback_write(
             lambda spark, path: spark.range(10e4).write.bucketBy(4, "id").sortBy("id").format('parquet').mode('overwrite').option("path", path).saveAsTable(spark_tmp_table_factory.get()),
-            lambda spark, path: spark.read.parquet(path),
-            data_path,
-            'DataWritingCommandExec')
-
-
-def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory):
-    data_path = spark_tmp_path + '/HIVE_DATA'
-    assert_gpu_fallback_write(
-            lambda spark, path: spark.range(10e4).write.bucketBy(4, "id").sortBy("id").format('hive').mode('overwrite').option("path", path).saveAsTable(spark_tmp_table_factory.get()),
             lambda spark, path: spark.read.parquet(path),
             data_path,
             'DataWritingCommandExec')

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -329,8 +329,14 @@ def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
             data_path,
             'DataWritingCommandExec')
 
-def test_write_hive_bucketed_table_fallback():
-    assert False
+
+def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory):
+    data_path = spark_tmp_path + '/HIVE_DATA'
+    assert_gpu_fallback_write(
+            lambda spark, path: spark.range(10e4).write.bucketBy(4, "id").sortBy("id").format('hive').mode('overwrite').option("path", path).saveAsTable(spark_tmp_table_factory.get()),
+            lambda spark, path: spark.read.parquet(path),
+            data_path,
+            'DataWritingCommandExec')
 
 # This test is testing how the parquet_writer will behave if column has a validity mask without having any nulls.
 # There is no straight forward to do it besides creating a vector with nulls and then dropping nulls

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -329,6 +329,9 @@ def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
             data_path,
             'DataWritingCommandExec')
 
+def test_write_hive_bucketed_table_fallback():
+    assert False
+
 # This test is testing how the parquet_writer will behave if column has a validity mask without having any nulls.
 # There is no straight forward to do it besides creating a vector with nulls and then dropping nulls
 # cudf will create a vector with a null_mask even though we have just filtered them

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -178,7 +178,7 @@ class GpuDynamicPartitionDataWriter(
   private val isPartitioned = description.partitionColumns.nonEmpty
 
   /** Flag saying whether or not the data to be written out is bucketed. */
-  private val isBucketed = description.bucketIdExpression.isDefined
+  private val isBucketed = description.bucketSpec.isDefined
 
   if (isBucketed) {
     throw new UnsupportedOperationException("Bucketing is not supported on the GPU yet.")
@@ -396,6 +396,16 @@ class GpuDynamicPartitionDataWriter(
 }
 
 /**
+ * Bucketing specification for all the write tasks.
+ * This is the GPU version of `org.apache.spark.sql.execution.datasources.WriterBucketSpec`
+ * @param bucketIdExpression Expression to calculate bucket id based on bucket column(s).
+ * @param bucketFileNamePrefix Prefix of output file name based on bucket id.
+ */
+case class GpuWriterBucketSpec(
+  bucketIdExpression: Expression,
+  bucketFileNamePrefix: Int => String)
+
+/**
  * A shared job description for all the GPU write tasks.
  * This is the GPU version of `org.apache.spark.sql.execution.datasources.WriteJobDescription`.
  */
@@ -406,7 +416,7 @@ class GpuWriteJobDescription(
     val allColumns: Seq[Attribute],
     val dataColumns: Seq[Attribute],
     val partitionColumns: Seq[Attribute],
-    val bucketIdExpression: Option[Expression],
+    val bucketSpec: Option[GpuWriterBucketSpec],
     val path: String,
     val customPartitionLocations: Map[TablePartitionSpec, String],
     val maxRecordsPerFile: Long,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.rapids
 
 import java.util.{Date, UUID}
-
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
@@ -26,7 +25,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
-
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
@@ -128,19 +126,17 @@ object GpuFileFormatWriter extends Logging {
 
     val empty2NullPlan = if (needConvert) GpuProjectExec(projectList, plan) else plan
 
-    val bucketIdExpression = bucketSpec.map { _ =>
-      // Use `HashPartitioning.partitionIdExpression` as our bucket id expression, so that we can
-      // guarantee the data distribution is same between shuffle and bucketed data source, which
-      // enables us to only shuffle one side when join a bucketed table and a normal one.
-      //HashPartitioning(bucketColumns, spec.numBuckets).partitionIdExpression
-      //
-      // TODO: Cannot support this until we either:
-      // Guarantee join and bucketing are both on the GPU and disable GPU-writing if join not on GPU
-      //   OR
-      // Guarantee GPU hash partitioning is 100% compatible with CPU hashing
+    val writerBucketSpec = bucketSpec.map { spec =>
+      // TODO: Cannot support this until we:
+      // support Hive hash partitioning on the GPU
       throw new UnsupportedOperationException("GPU hash partitioning for bucketed data is not "
-          + "compatible with the CPU version")
+        + "compatible with the CPU version")
+
+      // add this to let the compiler infer
+      // the type of writerBucketSpec as `Option[GpuWriterBucketSpec]`
+      GpuWriterBucketSpec(null, null)
     }
+
     val sortColumns = bucketSpec.toSeq.flatMap {
       spec => spec.sortColumnNames.map(c => dataColumns.find(_.name == c).get)
     }
@@ -161,7 +157,7 @@ object GpuFileFormatWriter extends Logging {
       allColumns = outputSpec.outputColumns,
       dataColumns = dataColumns,
       partitionColumns = partitionColumns,
-      bucketIdExpression = bucketIdExpression,
+      bucketSpec = writerBucketSpec,
       path = outputSpec.outputPath,
       customPartitionLocations = outputSpec.customPartitionLocations,
       maxRecordsPerFile = caseInsensitiveOptions.get("maxRecordsPerFile").map(_.toLong)
@@ -172,7 +168,8 @@ object GpuFileFormatWriter extends Logging {
     )
 
     // We should first sort by partition columns, then bucket id, and finally sorting columns.
-    val requiredOrdering = partitionColumns ++ bucketIdExpression ++ sortColumns
+    val requiredOrdering =
+      partitionColumns ++ writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
     // the sort order doesn't matter
     val actualOrdering = empty2NullPlan.outputOrdering.map(_.child)
     val orderingMatched = if (requiredOrdering.length > actualOrdering.length) {
@@ -298,7 +295,7 @@ object GpuFileFormatWriter extends Logging {
       if (sparkPartitionId != 0 && !iterator.hasNext) {
         // In case of empty job, leave first partition to save meta for file format like parquet.
         new GpuEmptyDirectoryDataWriter(description, taskAttemptContext, committer)
-      } else if (description.partitionColumns.isEmpty && description.bucketIdExpression.isEmpty) {
+      } else if (description.partitionColumns.isEmpty && description.bucketSpec.isEmpty) {
         new GpuSingleDirectoryDataWriter(description, taskAttemptContext, committer)
       } else {
         new GpuDynamicPartitionDataWriter(description, taskAttemptContext, committer)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.rapids
 
 import java.util.{Date, UUID}
+
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
@@ -25,6 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce._
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+
 import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.{FileCommitProtocol, SparkHadoopWriterUtils}
@@ -126,15 +128,11 @@ object GpuFileFormatWriter extends Logging {
 
     val empty2NullPlan = if (needConvert) GpuProjectExec(projectList, plan) else plan
 
-    val writerBucketSpec = bucketSpec.map { spec =>
+    val writerBucketSpec: Option[GpuWriterBucketSpec] = bucketSpec.map { spec =>
       // TODO: Cannot support this until we:
       // support Hive hash partitioning on the GPU
       throw new UnsupportedOperationException("GPU hash partitioning for bucketed data is not "
-        + "compatible with the CPU version")
-
-      // add this to let the compiler infer
-      // the type of writerBucketSpec as `Option[GpuWriterBucketSpec]`
-      GpuWriterBucketSpec(null, null)
+          + "compatible with the CPU version")
     }
 
     val sortColumns = bucketSpec.toSeq.flatMap {


### PR DESCRIPTION
Signed-off-by: remzi 13716567376yh@gmail.com
close #3949

In this PR, we:
1. Copy some code from  apache/spark@4a34db9 which supports Hive bucketed writing. However, as we do not support Hive hash partition on GPU, we throw an exception in Rapids.
2. Create a new file, datasourcev2_write_test.py and add a test here to make sure we are falling back to CPU when someone tries to do a Hive bucketed write.