### PR TITLE
Fall back to CPU for regular expressions containing hex digits

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -474,6 +474,7 @@ Here are some examples of regular expression patterns that are not supported on 
 - Regular expressions containing null characters (unless the pattern is a simple literal string)
 - Beginning-of-line and end-of-line anchors (`^` and `$`) are not supported in some contexts, such as when combined 
 - with a choice (`^|a`).
+- Hex and octal digits
 
 In addition to these cases that can be detected, there are also known issues that can cause incorrect results:
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -456,13 +456,14 @@ class CudfRegexTranspiler(replace: Boolean) {
       }
 
       case RegexOctalChar(_) =>
-        // cuDF produced different results compared to Spark in some cases
-        // example: "a\141|.$"
+        // see https://github.com/NVIDIA/spark-rapids/issues/4288
         throw new RegexUnsupportedException(
           s"cuDF does not support octal digits consistently with Spark")
 
       case RegexHexDigit(_) =>
-        regex
+        // see https://github.com/NVIDIA/spark-rapids/issues/4486
+        throw new RegexUnsupportedException(
+          s"cuDF does not support hex digits consistently with Spark")
 
       case RegexEscaped(ch) => ch match {
         case 'b' | 'B' =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -148,6 +148,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   ignore("known issue - octal digit") {
+    // see https://github.com/NVIDIA/spark-rapids/issues/4288
     val pattern = "a\\141|.$" // using hex works fine e.g. "a\\x61|.$"
     assertCpuGpuMatchesRegexpFind(Seq(pattern), Seq("] b["))
   }
@@ -220,7 +221,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
   }
 
-  test("compare CPU and GPU: hex") {
+  ignore("compare CPU and GPU: hex") {
+    // see https://github.com/NVIDIA/spark-rapids/issues/4486
     val patterns = Seq(raw"\x61")
     val inputs = Seq("a", "b")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -146,6 +146,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       assertUnsupported(pattern, replace = false,
         "cuDF does not support octal digits consistently with Spark"))
   }
+  
   test("string anchors - find") {
     val patterns = Seq("\\Atest", "test\\z", "test\\Z")
     assertCpuGpuMatchesRegexpFind(patterns, Seq("", "test", "atest", "testa",


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

cuDF and Spark are not consistent in handling certain ranges of hex digits, so we fall back to the CPU for now.

Issue https://github.com/NVIDIA/spark-rapids/issues/4486 has been filed for fixing the hex digit support in the future.
