### PR TITLE
Enable approx_percentile by default

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -785,7 +785,7 @@ The GPU implementation of `approximate_percentile` uses
 [t-Digests](https://arxiv.org/abs/1902.04023) which have high accuracy, particularly near the tails of a
 distribution. Because the results are not bit-for-bit identical with the Apache Spark implementation of
 `approximate_percentile`, this feature is disabled by default and can be enabled by setting
-`spark.rapids.sql.expression.ApproximatePercentile=true`.
+`spark.rapids.sql.incompatibleOps.enabled=true`.
 
 There is also a known issue ([issue #4060](https://github.com/NVIDIA/spark-rapids/issues/4060)) where
 incorrect results are produced intermittently.

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -317,7 +317,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.WindowSpecDefinition"></a>spark.rapids.sql.expression.WindowSpecDefinition| |Specification of a window function, indicating the partitioning-expression, the row ordering, and the width of the window|true|None|
 <a name="sql.expression.Year"></a>spark.rapids.sql.expression.Year|`year`|Returns the year from a date or timestamp|true|None|
 <a name="sql.expression.AggregateExpression"></a>spark.rapids.sql.expression.AggregateExpression| |Aggregate expression|true|None|
-<a name="sql.expression.ApproximatePercentile"></a>spark.rapids.sql.expression.ApproximatePercentile|`percentile_approx`, `approx_percentile`|Approximate percentile|true|None|
+<a name="sql.expression.ApproximatePercentile"></a>spark.rapids.sql.expression.ApproximatePercentile|`percentile_approx`, `approx_percentile`|Approximate percentile|false|This is not 100% compatible with the Spark version because the GPU implementation of approx_percentile is not bit-for-bit compatible with Apache Spark. To enable it, set spark.rapids.sql.incompatibleOps.enabled|
 <a name="sql.expression.Average"></a>spark.rapids.sql.expression.Average|`avg`, `mean`|Average aggregate operator|true|None|
 <a name="sql.expression.CollectList"></a>spark.rapids.sql.expression.CollectList|`collect_list`|Collect a list of non-unique elements, not supported in reduction|true|None|
 <a name="sql.expression.CollectSet"></a>spark.rapids.sql.expression.CollectSet|`collect_set`|Collect a set of unique elements, not supported in reduction|true|None|

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -317,7 +317,7 @@ Name | SQL Function(s) | Description | Default Value | Notes
 <a name="sql.expression.WindowSpecDefinition"></a>spark.rapids.sql.expression.WindowSpecDefinition| |Specification of a window function, indicating the partitioning-expression, the row ordering, and the width of the window|true|None|
 <a name="sql.expression.Year"></a>spark.rapids.sql.expression.Year|`year`|Returns the year from a date or timestamp|true|None|
 <a name="sql.expression.AggregateExpression"></a>spark.rapids.sql.expression.AggregateExpression| |Aggregate expression|true|None|
-<a name="sql.expression.ApproximatePercentile"></a>spark.rapids.sql.expression.ApproximatePercentile|`percentile_approx`, `approx_percentile`|Approximate percentile|false|This is disabled by default because The GPU implementation of approx_percentile is not bit-for-bit compatible with Apache Spark. See the compatibility guide for more information.|
+<a name="sql.expression.ApproximatePercentile"></a>spark.rapids.sql.expression.ApproximatePercentile|`percentile_approx`, `approx_percentile`|Approximate percentile|true|None|
 <a name="sql.expression.Average"></a>spark.rapids.sql.expression.Average|`avg`, `mean`|Average aggregate operator|true|None|
 <a name="sql.expression.CollectList"></a>spark.rapids.sql.expression.CollectList|`collect_list`|Collect a list of non-unique elements, not supported in reduction|true|None|
 <a name="sql.expression.CollectSet"></a>spark.rapids.sql.expression.CollectSet|`collect_set`|Collect a set of unique elements, not supported in reduction|true|None|

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -14102,7 +14102,7 @@ are limited.
 <td rowSpan="12">ApproximatePercentile</td>
 <td rowSpan="12">`percentile_approx`, `approx_percentile`</td>
 <td rowSpan="12">Approximate percentile</td>
-<td rowSpan="12">None</td>
+<td rowSpan="12">This is not 100% compatible with the Spark version because the GPU implementation of approx_percentile is not bit-for-bit compatible with Apache Spark. To enable it, set spark.rapids.sql.incompatibleOps.enabled</td>
 <td rowSpan="4">reduction</td>
 <td>input</td>
 <td> </td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -14102,7 +14102,7 @@ are limited.
 <td rowSpan="12">ApproximatePercentile</td>
 <td rowSpan="12">`percentile_approx`, `approx_percentile`</td>
 <td rowSpan="12">Approximate percentile</td>
-<td rowSpan="12">This is disabled by default because The GPU implementation of approx_percentile is not bit-for-bit compatible with Apache Spark. See the compatibility guide for more information.</td>
+<td rowSpan="12">None</td>
 <td rowSpan="4">reduction</td>
 <td>input</td>
 <td> </td>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3249,11 +3249,6 @@ object GpuOverrides extends Logging {
       (c, conf, p, r) => new TypedImperativeAggExprMeta[ApproximatePercentile](c, conf, p, r) {
 
         override def tagAggForGpu(): Unit = {
-          if (!conf.isIncompatEnabled) {
-            willNotWorkOnGpu("The GPU implementation of approx_percentile is not bit-for-bit " +
-              s"compatible with Apache Spark. To enable it, set ${RapidsConf.INCOMPATIBLE_OPS}")
-          }
-
           // check if the percentile expression can be supported on GPU
           childExprs(1).wrapped match {
             case lit: Literal => lit.value match {
@@ -3286,7 +3281,8 @@ object GpuOverrides extends Logging {
           val aggBuffer = c.aggBufferAttributes.head
           aggBuffer.copy(dataType = CudfTDigest.dataType)(aggBuffer.exprId, aggBuffer.qualifier)
         }
-      }),
+      }).incompat("the GPU implementation of approx_percentile is not bit-for-bit " +
+          s"compatible with Apache Spark. To enable it, set ${RapidsConf.INCOMPATIBLE_OPS}"),
     expr[GetJsonObject](
       "Extracts a json object from path",
       ExprChecks.projectOnly(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class ApproximatePercentileSuite extends SparkQueryCompareTestSuite {
   def sqlFallbackTest(sql: String) {
 
     val conf = new SparkConf()
-      .set("spark.rapids.sql.expression.ApproximatePercentile", "true")
+      .set("spark.rapids.sql.incompatibleOps.enabled", "true")
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key,
         "ShuffleExchangeExec,ObjectHashAggregateExec,HashPartitioning," +
         "AggregateExpression,ApproximatePercentile,Literal,Alias")
@@ -134,7 +134,7 @@ class ApproximatePercentileSuite extends SparkQueryCompareTestSuite {
     }
 
     val conf = new SparkConf()
-      .set("spark.rapids.sql.expression.ApproximatePercentile", "true")
+      .set("spark.rapids.sql.incompatibleOps.enabled", "true")
 
     val approxPercentilesGpu = withGpuSparkSession(spark =>
       calcPercentiles(spark, func, percentileArg, delta, approx = true)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Enable approx_percentile by default.