### PR TITLE
remove hadoop version requirement[skip ci]

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -33,8 +33,6 @@ Software Requirements:
 
 	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 9.1 ML LTS Runtime and GCP Dataproc 2.0
 
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-
 	Python 3.6+, Scala 2.12, Java 8
 
 *Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
@@ -99,8 +97,6 @@ Software Requirements:
 
 	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, GCP Dataproc 2.0, and Azure Synapse
 
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-
 	Python 3.6+, Scala 2.12, Java 8
 
 *Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
@@ -157,8 +153,6 @@ Software Requirements:
 
 	Apache Spark 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, Cloudera CDP 7.1.6, 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, and GCP Dataproc 2.0
 
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-
 	Python 3.6+, Scala 2.12, Java 8
 
 *Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
@@ -212,8 +206,6 @@ Software Requirements:
 
 	Apache Spark 3.0.1, 3.0.2, 3.1.1, 3.1.2, Cloudera CDP 7.1.7, Databricks 7.3 ML LTS or 8.2 ML Runtime, and GCP Dataproc 2.0
 
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-
 	Python 3.6+, Scala 2.12, Java 8
 
 *Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
@@ -253,8 +245,6 @@ Software Requirements:
 	CUDA & NVIDIA Drivers*: 11.0 or 11.2 & v450.80.02+
 
 	Apache Spark 3.0.1, 3.0.2, 3.1.1, 3.1.2, Cloudera CDP 7.1.7, and GCP Dataproc 2.0
-
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
 
 	Python 3.6+, Scala 2.12, Java 8
 
@@ -299,9 +289,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers*: 11.0 or 11.2 & v450.80.02+
 	
 	Apache Spark 3.0.1, 3.0.2, 3.1.1, 3.1.2, Cloudera CDP 7.1.7, Databricks 8.2 ML Runtime, and GCP Dataproc 2.0
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.6+, Scala 2.12, Java 8 
 
 *Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet 
@@ -365,9 +353,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
 	
 	Apache Spark 3.0.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS Runtime, or GCP Dataproc 2.0 
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.6+, Scala 2.12, Java 8 
 
 ### Download v0.5.0
@@ -413,9 +399,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
 	
 	Apache Spark 3.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS Runtime, or GCP Dataproc 2.0 
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.6+, Scala 2.12, Java 8 
 
 ### Release Notes
@@ -455,9 +439,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
 	
 	Apache Spark 3.0, 3.0.1, 3.0.2, 3.1.1, Databricks 7.3 ML LTS Runtime, or GCP Dataproc 2.0 
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.6+, Scala 2.12, Java 8 
 
 ### Release Notes
@@ -509,9 +491,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
 	
 	Apache Spark 3.0, 3.0.1, Databricks 7.3 ML LTS Runtime, or GCP Dataproc 2.0 
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.6+, Scala 2.12, Java 8 
 
 ### Release Notes
@@ -560,9 +540,7 @@ Software Requirements:
 	CUDA & NVIDIA Drivers: 10.1.2 & v418.87+, 10.2 & v440.33+ or 11.0 & v450.36+
 	
 	Apache Spark 3.0, 3.0.1
-	
-	Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
-	
+		
 	Python 3.x, Scala 2.12, Java 8 
 	
 ### Release Notes
@@ -614,7 +592,5 @@ Software Requirements:
     CUDA & NVIDIA Drivers: 10.1.2 & v418.87+ or 10.2 & v440.33+
     
     Apache Spark 3.0
-  
-    Apache Hadoop 2.10+ or 3.1.1+ (3.1.1 for nvidia-docker version 2)
 
     Python 3.x, Scala 2.12, Java 8


### PR DESCRIPTION
remove hadoop version requirement.

This is due to discussion in https://github.com/NVIDIA/spark-rapids/issues/4319 with @tgravescs  and since we already have the hadoop version requirement in the on-prem getting started guide, we can remove this hadoop requirement in download page.


Signed-off-by: Hao Zhu <hazhu@nvidia.com>

