### PR TITLE
Fall back to CPU for regular expressions containing \D or \W

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -470,6 +470,8 @@ Here are some examples of regular expression patterns that are not supported on 
 - Character classes that use union, intersection, or subtraction semantics, such as `[a-d[m-p]]`, `[a-z&&[def]]`, 
   or `[a-z&&[^bc]]`
 - Word and non-word boundaries, `\b` and `\B`
+- Non-digit character class `\D`
+- Non-word character class `\W`
 - Empty groups: `()`
 - Regular expressions containing null characters (unless the pattern is a simple literal string)
 - Beginning-of-line and end-of-line anchors (`^` and `$`) are not supported in some contexts, such as when combined 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -466,6 +466,12 @@ class CudfRegexTranspiler(replace: Boolean) {
           s"cuDF does not support hex digits consistently with Spark")
 
       case RegexEscaped(ch) => ch match {
+        case 'D' =>
+          // see https://github.com/NVIDIA/spark-rapids/issues/4475
+          throw new RegexUnsupportedException("non-digit class \\D is not supported")
+        case 'W' =>
+          // see https://github.com/NVIDIA/spark-rapids/issues/4475
+          throw new RegexUnsupportedException("non-word class \\W is not supported")
         case 'b' | 'B' =>
           // example: "a\Bb"
           // this needs further analysis to determine why words boundaries behave

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -266,16 +266,29 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   private val REGEXP_LIMITED_CHARS_REPLACE = REGEXP_LIMITED_CHARS_COMMON
 
   test("compare CPU and GPU: find digits") {
-    val patterns = Seq("\\d", "\\d+", "\\d*", "\\d?",
-      "\\D", "\\D+", "\\D*", "\\D?")
+    val patterns = Seq("\\d", "\\d+", "\\d*", "\\d?")
     val inputs = Seq("a", "1", "12", "a12z", "1az2")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
+  }
+
+  test("fall back to CPU for \\D") {
+    // see https://github.com/NVIDIA/spark-rapids/issues/4475
+    for (replace <- Seq(true, false)) {
+      assertUnsupported("\\D", replace, "non-digit class \\D is not supported")
+    }
+  }
+
+  test("fall back to CPU for \\W") {
+    // see https://github.com/NVIDIA/spark-rapids/issues/4475
+    for (replace <- Seq(true, false)) {
+      assertUnsupported("\\W", replace, "non-word class \\W is not supported")
+    }
   }
 
   test("compare CPU and GPU: replace digits") {
     // note that we do not test with quantifiers `?` or `*` due
     // to https://github.com/NVIDIA/spark-rapids/issues/4468
-    val patterns = Seq("\\d", "\\d+", "\\D", "\\D+")
+    val patterns = Seq("\\d", "\\d+")
     val inputs = Seq("a", "1", "12", "a12z", "1az2")
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Workaround until we fix https://github.com/NVIDIA/spark-rapids/issues/4475