### PR TITLE
Temporarily disable integration test - test_hash_reduction_pivot_without_nans

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -533,20 +533,20 @@ def test_hash_pivot_reduction_nan_fallback(data_gen):
         "PivotFirst",
         conf=_nans_float_conf)
 
-# https://github.com/NVIDIA/spark-rapids/issues/4514
-# Disabling below test temporarily until we have a fix. Disabling fixes the CI pipeline failures.
-#@approximate_float
-#ignore_order(local=True)
-#@incompat
-#@pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
-#@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
-#def test_hash_reduction_pivot_without_nans(data_gen, conf):
-#    assert_gpu_and_cpu_are_equal_collect(
-#        lambda spark: gen_df(spark, data_gen, length=100)
-#            .groupby()
-#            .pivot('b')
-#            .agg(f.sum('c')),
-#        conf=conf)
+@pytest.mark.xfail(reason="Disabling below test temporarily until we have a fix for this issue "
+                          "https://github.com/NVIDIA/spark-rapids/issues/4514")
+@approximate_float
+ignore_order(local=True)
+@incompat
+@pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
+def test_hash_reduction_pivot_without_nans(data_gen, conf):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, data_gen, length=100)
+            .groupby()
+            .pivot('b')
+            .agg(f.sum('c')),
+        conf=conf)
 
 _repeat_agg_column_for_collect_op = [
     RepeatSeqGen(BooleanGen(), length=15),

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -533,18 +533,20 @@ def test_hash_pivot_reduction_nan_fallback(data_gen):
         "PivotFirst",
         conf=_nans_float_conf)
 
-@approximate_float
-@ignore_order(local=True)
-@incompat
-@pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
-@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
-def test_hash_reduction_pivot_without_nans(data_gen, conf):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: gen_df(spark, data_gen, length=100)
-            .groupby()
-            .pivot('b')
-            .agg(f.sum('c')),
-        conf=conf)
+# https://github.com/NVIDIA/spark-rapids/issues/4514
+# Disabling below test temporarily until we have a fix. Disabling fixes the CI pipeline failures.
+#@approximate_float
+#ignore_order(local=True)
+#@incompat
+#@pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
+#@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
+#def test_hash_reduction_pivot_without_nans(data_gen, conf):
+#    assert_gpu_and_cpu_are_equal_collect(
+#        lambda spark: gen_df(spark, data_gen, length=100)
+#            .groupby()
+#            .pivot('b')
+#            .agg(f.sum('c')),
+#        conf=conf)
 
 _repeat_agg_column_for_collect_op = [
     RepeatSeqGen(BooleanGen(), length=15),

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -536,7 +536,7 @@ def test_hash_pivot_reduction_nan_fallback(data_gen):
 @pytest.mark.xfail(reason="Disabling below test temporarily until we have a fix for this issue "
                           "https://github.com/NVIDIA/spark-rapids/issues/4514")
 @approximate_float
-ignore_order(local=True)
+@ignore_order(local=True)
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)


### PR DESCRIPTION
This PR is to temporarily disable test_hash_reduction_pivot_without_nans test until we have a proper fix for the issue 
https://github.com/NVIDIA/spark-rapids/issues/4514.
I am not able to repro the issue in YARN cluster so it might take sometime to reproduce and fix the bug.
This would help the CI pipelines to be green. 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
