### PR TITLE
[auto-merge] branch-22.02 to branch-22.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-21.12
+    - branch-22.02
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: branch-21.12 # force to fetch from latest upstream instead of PR ref
+          ref: branch-22.02 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-21.12
-          BASE: branch-22.02
+          HEAD: branch-22.02
+          BASE: branch-22.04
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-22.02` to create a PR keeping `branch-22.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.