### PR TITLE
Reenable test_hash_reduction_pivot_without_nans

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -533,8 +533,6 @@ def test_hash_pivot_reduction_nan_fallback(data_gen):
         "PivotFirst",
         conf=_nans_float_conf)
 
-@pytest.mark.xfail(reason="Disabling below test temporarily until we have a fix for this issue "
-                          "https://github.com/NVIDIA/spark-rapids/issues/4514")
 @approximate_float
 @ignore_order(local=True)
 @incompat


### PR DESCRIPTION
This reverts commit 7d8b6d4c77cd450e21b693ac3b6fb456f15004b5 to enable the disabled test.  The test has been passing (with XPASS) in the nightly builds where it used to fail.

Closes #4514.