### PR TITLE
regexp_replace with back-references should fall back to CPU

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -480,6 +480,7 @@ Here are some examples of regular expression patterns that are not supported on 
 - Empty groups: `()`
 - Regular expressions containing null characters (unless the pattern is a simple literal string)
 - Hex and octal digits
+- `regexp_replace` does not support back-references
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.
 

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -370,7 +370,7 @@ def test_re_replace_escaped():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
-            'REGEXP_REPLACE(a, "[A-Z]+", "\\\\A\\A")'),
+            'REGEXP_REPLACE(a, "[A-Z]+", "\\\\A\\A\\\\t\\\\r\\\\n\\t\\r\\n")'),
         conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
 
 def test_re_replace_null():

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -347,6 +347,16 @@ def test_re_replace():
                 'REGEXP_REPLACE(a, "TEST", "%^[]\ud720")',
                 'REGEXP_REPLACE(a, "TEST", NULL)'),
             conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
+
+@allow_non_gpu('ProjectExec', 'RegExpReplace')
+def test_re_replace_backrefs():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    assert_gpu_fallback_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'REGEXP_REPLACE(a, "(TEST)", "[$0]")',
+            'REGEXP_REPLACE(a, "(TEST)", "[$1]")'),
+            'RegExpReplace',
+        conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
 
 def test_re_replace_null():
     gen = mk_str_gen('[\u0000 ]{0,2}TE[\u0000 ]{0,2}ST[\u0000 ]{0,2}')\

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -358,6 +358,21 @@ def test_re_replace_backrefs():
             'RegExpReplace',
         conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
 
+def test_re_replace_backrefs_escaped():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'REGEXP_REPLACE(a, "(TEST)", "[\\\\$0]")',
+            'REGEXP_REPLACE(a, "(TEST)", "[\\\\$1]")'),
+        conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
+
+def test_re_replace_escaped():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'REGEXP_REPLACE(a, "[A-Z]+", "\\\\A\\A")'),
+        conf={'spark.rapids.sql.expression.RegExpReplace': 'true'})
+
 def test_re_replace_null():
     gen = mk_str_gen('[\u0000 ]{0,2}TE[\u0000 ]{0,2}ST[\u0000 ]{0,2}')\
         .with_special_case("\u0000")\

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -15,12 +15,10 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.util.regex.Pattern
-
 import com.nvidia.spark.rapids.{CudfRegexTranspiler, DataFromReplacementRule, GpuExpression, GpuOverrides, RapidsConf, RapidsMeta, RegexUnsupportedException, TernaryExprMeta}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
-import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuStringReplace}
+import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuRegExpUtils, GpuStringReplace}
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -32,6 +30,7 @@ class GpuRegExpReplaceMeta(
   extends TernaryExprMeta[RegExpReplace](expr, conf, parent, rule) {
 
   private var pattern: Option[String] = None
+  private var replacement: Option[String] = None
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
@@ -53,10 +52,11 @@ class GpuRegExpReplaceMeta(
 
     expr.rep match {
       case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
-        val backrefPattern = Pattern.compile("\\$[0-9]")
-        if (backrefPattern.matcher(s.toString).find()) {
+        if (GpuRegExpUtils.containsBackrefs(s.toString)) {
           willNotWorkOnGpu("regexp_replace with back-references is not supported")
         }
+        replacement = Some(GpuRegExpUtils.unescapeReplaceString(s.toString))
+      case _ =>
     }
   }
 
@@ -67,8 +67,12 @@ class GpuRegExpReplaceMeta(
     if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
       GpuStringReplace(lhs, regexp, rep)
     } else {
-      GpuRegExpReplace(lhs, regexp, rep, pattern.getOrElse(
-        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
+      (pattern, replacement) match {
+        case (Some(cudfPattern), Some(cudfReplacement)) =>
+          GpuRegExpReplace(lhs, regexp, rep, cudfPattern, cudfReplacement)
+        case _ =>
+          throw new IllegalStateException("Expression has not been tagged correctly")
+      }
     }
   }
 }

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.nvidia.spark.rapids.shims.v2
+
+import java.util.regex.Pattern
 
 import com.nvidia.spark.rapids.{CudfRegexTranspiler, DataFromReplacementRule, GpuExpression, GpuOverrides, RapidsConf, RapidsMeta, RegexUnsupportedException, TernaryExprMeta}
 
@@ -47,6 +49,14 @@ class GpuRegExpReplaceMeta(
 
       case _ =>
         willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
+    }
+
+    expr.rep match {
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
+        val backrefPattern = Pattern.compile("\\$[0-9]")
+        if (backrefPattern.matcher(s.toString).find()) {
+          willNotWorkOnGpu("regexp_replace with back-references is not supported")
+        }
     }
   }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package com.nvidia.spark.rapids.shims.v2
+
+import java.util.regex.Pattern
 
 import com.nvidia.spark.rapids._
 
@@ -47,6 +49,14 @@ class GpuRegExpReplaceMeta(
 
       case _ =>
         willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
+    }
+
+    expr.rep match {
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
+        val backrefPattern = Pattern.compile("\\$[0-9]")
+        if (backrefPattern.matcher(s.toString).find()) {
+          willNotWorkOnGpu("regexp_replace with back-references is not supported")
+        }
     }
   }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/GpuRegExpReplaceMeta.scala
@@ -15,12 +15,10 @@
  */
 package com.nvidia.spark.rapids.shims.v2
 
-import java.util.regex.Pattern
-
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, RegExpReplace}
-import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuStringReplace}
+import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuRegExpUtils, GpuStringReplace}
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -32,6 +30,7 @@ class GpuRegExpReplaceMeta(
   extends TernaryExprMeta[RegExpReplace](expr, conf, parent, rule) {
 
   private var pattern: Option[String] = None
+  private var replacement: Option[String] = None
 
   override def tagExprForGpu(): Unit = {
     expr.regexp match {
@@ -53,10 +52,11 @@ class GpuRegExpReplaceMeta(
 
     expr.rep match {
       case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
-        val backrefPattern = Pattern.compile("\\$[0-9]")
-        if (backrefPattern.matcher(s.toString).find()) {
+        if (GpuRegExpUtils.containsBackrefs(s.toString)) {
           willNotWorkOnGpu("regexp_replace with back-references is not supported")
         }
+        replacement = Some(GpuRegExpUtils.unescapeReplaceString(s.toString))
+      case _ =>
     }
   }
 
@@ -67,8 +67,12 @@ class GpuRegExpReplaceMeta(
     if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
       GpuStringReplace(lhs, regexp, rep)
     } else {
-      GpuRegExpReplace(lhs, regexp, rep, pattern.getOrElse(
-        throw new IllegalStateException("Expression has not been tagged with cuDF regex pattern")))
+      (pattern, replacement) match {
+        case (Some(cudfPattern), Some(cudfReplacement)) =>
+          GpuRegExpReplace(lhs, regexp, rep, cudfPattern, cudfReplacement)
+        case _ =>
+          throw new IllegalStateException("Expression has not been tagged correctly")
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -915,7 +915,9 @@ case class GpuRegExpReplace(
       strExpr: GpuColumnVector,
       searchExpr: GpuScalar,
       replaceExpr: GpuScalar): ColumnVector = {
-    strExpr.getBase.replaceRegex(cudfRegexPattern, Scalar.fromString(cudfReplacementString))
+    withResource(Scalar.fromString(cudfReplacementString)) { rep =>
+      strExpr.getBase.replaceRegex(cudfRegexPattern, rep)
+    }
   }
 
 }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/4503 and https://github.com/NVIDIA/spark-rapids/issues/4559

Follow-on issue to support back-references on the GPU: https://github.com/NVIDIA/spark-rapids/issues/4557