### PR TITLE
Fix infinite loop with Profiling tool compare mode and app with no sql ids

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CompareApplications.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CompareApplications.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CompareApplications.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CompareApplications.scala
@@ -51,7 +51,7 @@ class CompareApplications(apps: Seq[ApplicationInfo]) extends Logging {
       val sourceAppId = appIds.head
       val sourceSqlIdArr = appIdToSortedSqlIds(sourceAppId)
       if (sourceSqlIdArr.isEmpty) {
-        logWarning("empty sql id arr" )
+        appIdToSortedSqlIds.remove(sourceAppId)
       } else {
         val sourceSqlId = sourceSqlIdArr.head
 


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/4567

The profiling tool when run in compare mode and an application doesn't have sqlIds can end up in an infinite loop.
Here we fix that just by removing that appId so we continue on to the next one.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
