### PR TITLE
Increase premerge databricks IDLE_TIMEOUT to 4 hours [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -114,7 +114,7 @@ pipeline {
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CUDA_CLASSIFIER = 'cuda11'
         // DB related ENVs
-        IDLE_TIMEOUT = '180' // 3 hours
+        IDLE_TIMEOUT = '240' // 4 hours
         NUM_WORKERS = '0'
         DB_TYPE = getDbType()
         DATABRICKS_HOST = "${PARAM_MAP["$DB_TYPE"][ID_HOST]}"
@@ -395,7 +395,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            timeout(time: 4, unit: 'HOURS') {
+                            timeout(time: 5, unit: 'HOURS') {
                                 unstash "source_tree"
                                 databricksBuild()
                             }
@@ -430,7 +430,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            timeout(time: 4, unit: 'HOURS') {
+                            timeout(time: 5, unit: 'HOURS') {
                                 unstash "source_tree"
                                 databricksBuild()
                             }


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

the whole DB test (cluster init + test) cost more than 3 hours