### PR TITLE
fallback to cpu when detecting column pruning in json reader

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -440,39 +440,9 @@ The JSON format read is a very experimental feature which is expected to have so
 it by default. If you would like to test it, you need to enable `spark.rapids.sql.format.json.enabled` and 
 `spark.rapids.sql.format.json.read.enabled`.
 
-Currently, the GPU accelerated JSON reader doesn't support column pruning, which will likely make 
-this difficult to use or even test. The user must specify the full schema or just let Spark infer 
-the schema from the JSON file. eg,
-
-We have a `people.json` file with below content
-
-``` console
-{"name":"Michael"}
-{"name":"Andy", "age":30}
-{"name":"Justin", "age":19}
-```
-
-Both below ways will work
-
-- Inferring the schema
-
-  ``` scala
-  val df = spark.read.json("people.json")
-  ```
-
-- Specifying the full schema
-
-  ``` scala
-  val schema = StructType(Seq(StructField("name", StringType), StructField("age", IntegerType)))
-  val df = spark.read.schema(schema).json("people.json")
-  ```
-
-While the below code will not work in the current version,
-
-``` scala
-val schema = StructType(Seq(StructField("name", StringType)))
-val df = spark.read.schema(schema).json("people.json")
-```
+Currently, the GPU accelerated JSON reader doesn't support column pruning. So, everytime, we infer the 
+json data schema and to check if there is column pruning happening. If yes, we will fallback the json reader 
+to CPU.
 
 ### JSON supporting types
 

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from src.main.python.marks import approximate_float, allow_non_gpu
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -32,8 +32,8 @@ import org.apache.spark.sql.catalyst.json.{JSONOptions, JSONOptionsInRead}
 import org.apache.spark.sql.catalyst.util.PermissiveMode
 import org.apache.spark.sql.connector.read.{PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.execution.datasources.json.JsonDataSource
 import org.apache.spark.sql.execution.datasources.{PartitionedFile, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.json.JsonDataSource
 import org.apache.spark.sql.execution.datasources.v2.{FilePartitionReaderFactory, FileScan, TextBasedFileScan}
 import org.apache.spark.sql.execution.datasources.v2.json.JsonScan
 import org.apache.spark.sql.internal.SQLConf

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.catalyst.json.rapids
 
+import java.nio.charset.StandardCharsets
+
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf
@@ -156,6 +158,11 @@ object GpuJsonScan {
     if (parsedOptions.lineSeparator.getOrElse("\n") != "\n") {
       meta.willNotWorkOnGpu("GpuJsonScan only supports \"\\n\" as a line separator")
     }
+
+    parsedOptions.encoding.foreach(enc =>
+      if (enc != StandardCharsets.UTF_8.name() && enc != StandardCharsets.US_ASCII.name()) {
+      meta.willNotWorkOnGpu("GpuJsonScan only supports UTF8 encoded data")
+    })
 
     if (readSchema.map(_.dataType).contains(DateType)) {
       ShimLoader.getSparkShims.dateFormatInRead(parsedOptions).foreach { dateFormat =>


### PR DESCRIPTION
It's really a bad user experience when a user tries to read JSON files with partial data schema (AKA column pruning), since the CUDF will throw exception.

So as an improvement, this PR added inferring JSON schema when tagging. If the data schema is not the same with the schema inferred, we will fallback the JSON reader to run on GPU instead of throwing an exception. But the extra inferring schema may have caused performance issues.