### PR TITLE
[DB31x] Pick the correct Python runner for flatmap-group Pandas UDF[databricks]

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -213,8 +213,7 @@ def test_window_aggregate_udf_array_from_python(data_gen, window):
 
 
 # ======= Test flat map group in Pandas =======
-@pytest.mark.skipif(is_databricks91_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/4599")
-@ignore_order
+@ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [LongGen()], ids=idfn)
 def test_group_apply_udf(data_gen):
     def pandas_add(data):
@@ -228,8 +227,7 @@ def test_group_apply_udf(data_gen):
             conf=arrow_udf_conf)
 
 
-@pytest.mark.skipif(is_databricks91_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/4599")
-@ignore_order
+@ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', arrow_common_gen, ids=idfn)
 def test_group_apply_udf_more_types(data_gen):
     def group_size_udf(key, pdf):

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -225,7 +225,8 @@ def test_group_apply_udf_zero_conf(data_gen, zero_enabled):
         data.sum = data.b + data.a
         return data
 
-    conf_with_zero = arrow_udf_conf.update({
+    conf_with_zero = arrow_udf_conf.copy()
+    conf_with_zero.update({
         'spark.databricks.execution.pandasZeroConfConversion.groupbyApply.enabled': zero_enabled
     })
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -214,7 +214,7 @@ def test_window_aggregate_udf_array_from_python(data_gen, window):
 
 # ======= Test flat map group in Pandas =======
 
-# seperate the tests into before and after db 91. To verify
+# separate the tests into before and after db 91. To verify
 # the new "zero-conf-conversion" feature introduced from db 9.1.
 @pytest.mark.skipif(not is_databricks91_or_later(), reason="zero-conf is supported only from db9.1")
 @ignore_order(local=True)


### PR DESCRIPTION
This PR follows the change introduced in Databricks 9.1 to choose the correct Python runner (`GpuGroupUDFArrowPythonRunner` or `GpuArrowPythonRunner`) for the `GpuFlatMapGroupsInPandasExec` according to two Databricks specific configs.

These two Python runners use different protocols to communicate with the Python side. And the protocol choice is made by the two related configs.

Fixes https://github.com/NVIDIA/spark-rapids/issues/4599

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
