### PR TITLE
Fallback to CPU when encoding is not supported for JSON reader

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.catalyst.json.rapids
 
+import java.nio.charset.StandardCharsets
+
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf
@@ -137,6 +139,11 @@ object GpuJsonScan {
     if (parsedOptions.lineSeparator.getOrElse("\n") != "\n") {
       meta.willNotWorkOnGpu("GpuJsonScan only supports \"\\n\" as a line separator")
     }
+
+    parsedOptions.encoding.foreach(enc =>
+      if (enc != StandardCharsets.UTF_8.name() && enc != StandardCharsets.US_ASCII.name()) {
+      meta.willNotWorkOnGpu("GpuJsonScan only supports UTF8 encoded data")
+    })
 
     if (readSchema.map(_.dataType).contains(DateType)) {
       ShimLoader.getSparkShims.dateFormatInRead(parsedOptions).foreach { dateFormat =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -142,7 +142,7 @@ object GpuJsonScan {
 
     parsedOptions.encoding.foreach(enc =>
       if (enc != StandardCharsets.UTF_8.name() && enc != StandardCharsets.US_ASCII.name()) {
-      meta.willNotWorkOnGpu("GpuJsonScan only supports UTF8 encoded data")
+      meta.willNotWorkOnGpu("GpuJsonScan only supports UTF8 or US-ASCII encoded data")
     })
 
     if (readSchema.map(_.dataType).contains(DateType)) {


### PR DESCRIPTION
Falllback to CPU when encoding is not UTF-8 or US-ASCII