### PR TITLE
Enable integration test results report on Jenkins [skip ci]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -154,6 +154,7 @@ else
           $TEST_TYPE_PARAM
           "$TEST_ARGS"
           $RUN_TEST_PARAMS
+          --junitxml=TEST-pytest-`date +%s%N`.xml
           "$@")
 
     NUM_LOCAL_EXECS=${NUM_LOCAL_EXECS:-0}

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -41,6 +41,8 @@ def PROJECT_VER // project version retrieved from 'version-def.sh' to determine 
 def major_ver // major version extracted from project version
 def minor_ver // minor version extracted from project version
 def PREMERGE_CI_2_ARGUMENT // argument for 'spark-premerge-build.sh' running from stage of Premerge CI 2
+def TestResult1 // keep ci_1 pytest result files that's in JUnit-XML style
+def TestResult2 // keep ci_2 pytest result files that's in JUnit-XML style
 
 // constant parameters for aws and azure databricks cluster
 // CSP params
@@ -314,19 +316,24 @@ pipeline {
                         script {
                             container('gpu') {
                                 timeout(time: 4, unit: 'HOURS') { // step only timeout for test run
-                                    sh "$PREMERGE_SCRIPT mvn_verify"
-                                    step([$class                : 'JacocoPublisher',
-                                          execPattern           : '**/target/jacoco.exec',
-                                          classPattern          : 'target/jacoco_classes/',
-                                          sourceInclusionPattern: '**/*.java,**/*.scala',
-                                          sourcePattern         : 'shuffle-plugin/src/main/scala/,' +
-                                                  'udf-compiler/src/main/scala/,sql-plugin/src/main/java/,' +
-                                                  'sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,' +
-                                                  'shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,' +
-                                                  'shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,' +
-                                                  'shims/spark304/src/main/scala/,shims/spark312/src/main/scala/,' +
-                                                  'shims/spark313/src/main/scala/'
-                                    ])
+                                    try {
+                                        sh "$PREMERGE_SCRIPT mvn_verify"
+                                        step([$class                : 'JacocoPublisher',
+                                              execPattern           : '**/target/jacoco.exec',
+                                              classPattern          : 'target/jacoco_classes/',
+                                              sourceInclusionPattern: '**/*.java,**/*.scala',
+                                              sourcePattern         : 'shuffle-plugin/src/main/scala/,' +
+                                                                      'udf-compiler/src/main/scala/,sql-plugin/src/main/java/,' +
+                                                                      'sql-plugin/src/main/scala/,shims/spark311/src/main/scala/,' +
+                                                                      'shims/spark301db/src/main/scala/,shims/spark301/src/main/scala/,' +
+                                                                      'shims/spark302/src/main/scala/,shims/spark303/src/main/scala/,' +
+                                                                      'shims/spark304/src/main/scala/,shims/spark312/src/main/scala/,' +
+                                                                      'shims/spark313/src/main/scala/'
+                                        ])
+                                    } finally {
+                                        // Save pytest result and publish to Jenkins at last
+                                        TestResult1 = stashPytestResult("testResult1")
+                                    }
                                 }
                             }
                         }
@@ -362,7 +369,12 @@ pipeline {
 
                             container('gpu') {
                                 timeout(time: 4, unit: 'HOURS') {
-                                    sh "$PREMERGE_SCRIPT $PREMERGE_CI_2_ARGUMENT"
+                                    try {
+                                        sh "$PREMERGE_SCRIPT $PREMERGE_CI_2_ARGUMENT"
+                                    } finally {
+                                        // Save pytest result and publish to Jenkins at last
+                                        TestResult2 = stashPytestResult("testResult2")
+                                    }
                                 }
                             }
                         }
@@ -477,6 +489,21 @@ pipeline {
                         deleteDockerTempTag("${PREMERGE_TAG}") // clean premerge temp image
                     }
                 }
+
+                // Collect test results
+                if (TestResult1) {
+                    unstash "testResult1"
+                }
+                if (TestResult2) {
+                    unstash "testResult2"
+                }
+
+                // Record test results to Jenkins
+                if (TestResult1 || TestResult2) {
+                    junit skipPublishingChecks: true, testResults: '**/TEST-pytest*.xml'
+                } else {
+                    echo 'Skip recording test results'
+                }
             }
         }
     }
@@ -586,4 +613,15 @@ void abortDupBuilds() {
         }
         prevBuild = prevBuild.getPreviousBuildInProgress()
     }
+}
+
+String stashPytestResult(String name) {
+    def result = sh(returnStdout: true, script: "find . -name 'TEST-pytest*.xml' -exec ls -l {} \\;")
+    echo result
+
+    if (result) {
+        stash(name: name, includes: "**/TEST-pytest*.xml")
+    }
+
+    return result
 }


### PR DESCRIPTION
Signed-off-by: Alex Zhang <alex4zhang@gmail.com>

The test result would be collected by using [JUnit plugin](https://plugins.jenkins.io/junit) on Jenkins for helping evaluate individual test case duration, e.g, https://github.com/NVIDIA/spark-rapids/issues/4538#issuecomment-1017154557

In case of any test case was failed, the error message or stacktrace would be collected for further troubleshooting, e.g, http://nv/2sU (need vpn)

![image](https://user-images.githubusercontent.com/13271672/150948101-4dbcb7b6-83ac-43c4-b7ab-7c7ba757b1e5.png)
