### PR TITLE
Fix the incomplete capture of SubqueryBroadcast 

### DIFF
--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -100,6 +100,25 @@ _statements = [
     WHERE dim.filter = {2}
     GROUP BY fact.key, fact.skey, fact.ex_key
     ''',
+    # This query checks the pattern of reused broadcast subquery: ReusedSubquery(SubqueryBroadcast(...))
+    # https://github.com/NVIDIA/spark-rapids/issues/4625
+    """
+    SELECT key, max(value)
+    FROM (
+        SELECT fact.key as key, fact.value as value
+        FROM {0} fact
+        JOIN {1} dim
+        ON fact.key = dim.key
+        WHERE dim.filter = {2}
+    UNION ALL
+        SELECT fact.key as key, fact.value as value
+        FROM {0} fact
+        JOIN {1} dim
+        ON fact.key = dim.key
+        WHERE dim.filter = {2}
+    )
+    GROUP BY key
+    """
 ]
 
 

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
@@ -151,15 +151,24 @@ abstract class Spark30XdbShims extends Spark30XdbShimsBase with Logging {
           // FileSourceScan is independent from the replacement of the partitionFilters. It is
           // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
           // are on the GPU. And vice versa.
-          private lazy val partitionFilters = wrapped.partitionFilters.map { filter =>
-            filter.transformDown {
-              case dpe @ DynamicPruningExpression(inSub: InSubqueryExec)
-                if inSub.plan.isInstanceOf[SubqueryBroadcastExec] =>
-
-                val subBcMeta = GpuOverrides.wrapAndTagPlan(inSub.plan, conf)
-                subBcMeta.tagForExplain()
-                val gpuSubBroadcast = subBcMeta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
-                dpe.copy(inSub.copy(plan = gpuSubBroadcast))
+          private lazy val partitionFilters = {
+            val convertBroadcast = (bc: SubqueryBroadcastExec) => {
+              val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
+              meta.tagForExplain()
+              meta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
+            }
+            wrapped.partitionFilters.map { filter =>
+              filter.transformDown {
+                case dpe @ DynamicPruningExpression(inSub: InSubqueryExec) =>
+                  inSub.plan match {
+                    case bc: SubqueryBroadcastExec =>
+                      dpe.copy(inSub.copy(plan = convertBroadcast(bc)))
+                    case reuse @ ReusedSubqueryExec(bc: SubqueryBroadcastExec) =>
+                      dpe.copy(inSub.copy(plan = reuse.copy(convertBroadcast(bc))))
+                    case _ =>
+                      dpe
+                  }
+              }
             }
           }
 

--- a/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
+++ b/sql-plugin/src/main/301until310-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark30XShims.scala
@@ -130,15 +130,24 @@ abstract class Spark30XShims extends Spark301until320Shims with Logging {
           // FileSourceScan is independent from the replacement of the partitionFilters. It is
           // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
           // are on the GPU. And vice versa.
-          private lazy val partitionFilters = wrapped.partitionFilters.map { filter =>
-            filter.transformDown {
-              case dpe @ DynamicPruningExpression(inSub: InSubqueryExec)
-                if inSub.plan.isInstanceOf[SubqueryBroadcastExec] =>
-
-                val subBcMeta = GpuOverrides.wrapAndTagPlan(inSub.plan, conf)
-                subBcMeta.tagForExplain()
-                val gpuSubBroadcast = subBcMeta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
-                dpe.copy(inSub.copy(plan = gpuSubBroadcast))
+          private lazy val partitionFilters = {
+            val convertBroadcast = (bc: SubqueryBroadcastExec) => {
+              val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
+              meta.tagForExplain()
+              meta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
+            }
+            wrapped.partitionFilters.map { filter =>
+              filter.transformDown {
+                case dpe @ DynamicPruningExpression(inSub: InSubqueryExec) =>
+                  inSub.plan match {
+                    case bc: SubqueryBroadcastExec =>
+                      dpe.copy(inSub.copy(plan = convertBroadcast(bc)))
+                    case reuse @ ReusedSubqueryExec(bc: SubqueryBroadcastExec) =>
+                      dpe.copy(inSub.copy(plan = reuse.copy(convertBroadcast(bc))))
+                    case _ =>
+                      dpe
+                  }
+              }
             }
           }
 

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -370,15 +370,24 @@ abstract class Spark31XShims extends Spark301until320Shims with Logging {
           // FileSourceScan is independent from the replacement of the partitionFilters. It is
           // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
           // are on the GPU. And vice versa.
-          private lazy val partitionFilters = wrapped.partitionFilters.map { filter =>
-            filter.transformDown {
-              case dpe @ DynamicPruningExpression(inSub: InSubqueryExec)
-                if inSub.plan.isInstanceOf[SubqueryBroadcastExec] =>
-
-                val subBcMeta = GpuOverrides.wrapAndTagPlan(inSub.plan, conf)
-                subBcMeta.tagForExplain()
-                val gpuSubBroadcast = subBcMeta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
-                dpe.copy(inSub.copy(plan = gpuSubBroadcast))
+          private lazy val partitionFilters = {
+            val convertBroadcast = (bc: SubqueryBroadcastExec) => {
+              val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
+              meta.tagForExplain()
+              meta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
+            }
+            wrapped.partitionFilters.map { filter =>
+              filter.transformDown {
+                case dpe @ DynamicPruningExpression(inSub: InSubqueryExec) =>
+                  inSub.plan match {
+                    case bc: SubqueryBroadcastExec =>
+                      dpe.copy(inSub.copy(plan = convertBroadcast(bc)))
+                    case reuse @ ReusedSubqueryExec(bc: SubqueryBroadcastExec) =>
+                      dpe.copy(inSub.copy(plan = reuse.copy(convertBroadcast(bc))))
+                    case _ =>
+                      dpe
+                  }
+              }
             }
           }
 

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
@@ -382,15 +382,24 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
           // FileSourceScan is independent from the replacement of the partitionFilters. It is
           // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
           // are on the GPU. And vice versa.
-          private lazy val partitionFilters = wrapped.partitionFilters.map { filter =>
-            filter.transformDown {
-              case dpe @ DynamicPruningExpression(inSub: InSubqueryExec)
-                if inSub.plan.isInstanceOf[SubqueryBroadcastExec] =>
-
-                val subBcMeta = GpuOverrides.wrapAndTagPlan(inSub.plan, conf)
-                subBcMeta.tagForExplain()
-                val gpuSubBroadcast = subBcMeta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
-                dpe.copy(inSub.copy(plan = gpuSubBroadcast))
+          private lazy val partitionFilters = {
+            val convertBroadcast = (bc: SubqueryBroadcastExec) => {
+              val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
+              meta.tagForExplain()
+              meta.convertIfNeeded().asInstanceOf[BaseSubqueryExec]
+            }
+            wrapped.partitionFilters.map { filter =>
+              filter.transformDown {
+                case dpe @ DynamicPruningExpression(inSub: InSubqueryExec) =>
+                  inSub.plan match {
+                    case bc: SubqueryBroadcastExec =>
+                      dpe.copy(inSub.copy(plan = convertBroadcast(bc)))
+                    case reuse @ ReusedSubqueryExec(bc: SubqueryBroadcastExec) =>
+                      dpe.copy(inSub.copy(plan = reuse.copy(convertBroadcast(bc))))
+                    case _ =>
+                      dpe
+                  }
+              }
             }
           }
 

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
@@ -29,8 +29,8 @@ import com.nvidia.spark.rapids.GpuOverrides.exec
 import org.apache.arrow.memory.ReferenceManager
 import org.apache.arrow.vector.ValueVector
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.spark.SparkEnv
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.rapids.shims.v2.GpuShuffleExchangeExec
 import org.apache.spark.sql.SparkSession


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Fixes #4625 

This PR is to fix the logic on searching/matching  potential `SubqueryBroadcastExec` from partition filters of scans. In previous, we missed a possible condition: As a subquery, `SubqueryBroadcastExec` may be reused.  And this missing will lead to a crash when AQE is on. 