### PR TITLE
Suppress newTaskTempFile method warnings for Spark 3.3.0 build

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -120,6 +120,9 @@ class GpuSingleDirectoryDataWriter(
   // Initialize currentWriter and statsTrackers
   newOutputWriter()
 
+  @scala.annotation.nowarn(
+    "msg=method newTaskTempFile in class FileCommitProtocol is deprecated"
+  )
   private def newOutputWriter(): Unit = {
     recordsInFile = 0
     releaseResources()
@@ -245,6 +248,9 @@ class GpuDynamicPartitionDataWriter(
     row => proj(row).getString(0)
   }
 
+  @scala.annotation.nowarn(
+    "msg=method newTaskTempFile.* in class FileCommitProtocol is deprecated"
+  )
   private def newOutputWriter(partDir: String): Unit = {
     recordsInFile = 0
     releaseResources()


### PR DESCRIPTION
Fixes #4632.  Suppressing the deprecation warnings caused by [SPARK-38015](https://issues.apache.org/jira/browse/SPARK-38015).  I don't think it's worth shimming these until we move to a Spark version that has removed these methods.