### PR TITLE
Support `str_to_map`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2648,6 +2648,13 @@ object GpuOverrides extends Logging {
         override def convertToGpu(child: Expression): GpuExpression =
           GpuMapEntries(child)
       }),
+    expr[StringToMap](
+      "Creates a map after splitting the input into key-value pairs using delimiters",
+      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
+        Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
+          ParamCheck("pairDelim", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING),
+          ParamCheck("keyValueDelim", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
+      (in, conf, p, r) => new GpuStringToMapMeta(in, conf, p, r)),
     expr[ArrayMin](
       "Returns the minimum value in the array",
       ExprChecks.unaryProject(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2650,7 +2650,7 @@ object GpuOverrides extends Logging {
       }),
     expr[StringToMap](
       "Creates a map after splitting the input into key-value pairs using delimiters",
-      ExprChecks.projectOnly(TypeSig.STRING, TypeSig.STRING,
+      ExprChecks.projectOnly(TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.STRING),
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("pairDelim", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING),
           ParamCheck("keyValueDelim", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1392,9 +1392,14 @@ class GpuStringToMapMeta(
     extractLit(delimExpr).foreach { delim =>
       val str = delim.value.asInstanceOf[UTF8String]
       if (str != null){
-        if(!canRegexpBeTreatedLikeARegularString(str)) {
-          willNotWorkOnGpu("str_to_map does not support regular expression delimiter(s)")
-        }
+        //
+        // Currently, we don't support regex. However, we can't check for regex very accurately.
+        // As such, just treat the delimiter string as a literal string without regex.
+        // In the future, we can re-enable regex check when it is improved.
+        //
+        // if(!canRegexpBeTreatedLikeARegularString(str)) {
+        //   willNotWorkOnGpu("str_to_map does not support regular expression delimiter(s)")
+        // }
         if (str.numChars() == 0) {
           willNotWorkOnGpu("delimiter is empty")
         }
@@ -1405,6 +1410,7 @@ class GpuStringToMapMeta(
   }
 
   override def tagExprForGpu(): Unit = {
+    // Will this work with GpuLiteral?
     checkRegex(expr.pairDelim)
     checkRegex(expr.keyValueDelim)
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1391,8 +1391,15 @@ class GpuStringToMapMeta(
   private def checkRegex(delimExpr: Expression) : Unit = {
     extractLit(delimExpr).foreach { delim =>
       val str = delim.value.asInstanceOf[UTF8String]
-      if (str != null && !canRegexpBeTreatedLikeARegularString(str)) {
-        willNotWorkOnGpu("str_to_map does not support regular expression delimiter(s)")
+      if (str != null){
+        if(!canRegexpBeTreatedLikeARegularString(str)) {
+          willNotWorkOnGpu("str_to_map does not support regular expression delimiter(s)")
+        }
+        if (str.numChars() == 0) {
+          willNotWorkOnGpu("delimiter is empty")
+        }
+      } else {
+        willNotWorkOnGpu("delimiter is null")
       }
     }
   }


### PR DESCRIPTION
This adds supports for `str_to_map` SQL function.

Note that fully support for this function requires the ability to split string by regular expression delimiter. As such, this PR depends on https://github.com/NVIDIA/spark-rapids/issues/4003, which also depends on https://github.com/rapidsai/cudf/pull/10128 and https://github.com/rapidsai/cudf/pull/10139.

If the dependencies cannot be resolved upon releasing of 24.04, we will just merge this with basic support (i.e., string split with only literal delimiters).

 - [ ] Implementation for basic support
 - [ ] Implementation with regex support
 - [ ] Integration tests