### PR TITLE
Add profile release301 when mvn help:evaluate

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -24,7 +24,7 @@ export M2DIR="$WORKSPACE/.m2"
 
 DIST_PL="dist"
 function mvnEval {
-    mvn help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER -DforceStdout -Dexpression=$1
+    mvn help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Prelease301 -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER -DforceStdout -Dexpression=$1
 }
 
 ART_ID=$(mvnEval project.artifactId)


### PR DESCRIPTION
Fix #4631
Signed-off-by: Gary Shen <gashen@nvidia.com>

When running release build, the source-javadoc profile will disable the default profile of release301, which has the submodules definition.
Explicitly specify the release301 profile.