### PR TITLE
Prevent deadlock between RapidsBufferStore and RapidsBufferBase on close

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.tests.mortgage
 
 import com.nvidia.spark.rapids.ShimLoader
 import org.scalatest.FunSuite
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
@@ -26,6 +27,11 @@ class MortgageSparkSuite extends FunSuite {
   /**
    * This is intentionally a def rather than a val so that scalatest uses the correct value (from
    * this class or the derived class) when registering tests.
+   *
+   * @note You are likely to see device/host leaks from this test when using the
+   *       RAPIDS Shuffle Manager. The reason for that is a race between cuDF's MemoryCleaner
+   *       and the SparkContext shutdown. Because of this, shuffle buffers cached may not get
+   *       cleaned (on shuffle unregister) when the MemoryCleaner exits.
    */
   def adaptiveQueryEnabled = false
 

--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@
 package com.nvidia.spark.rapids.tests.mortgage
 
 import com.nvidia.spark.rapids.ShimLoader
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
-
+import org.scalatest.FunSuite
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
-class MortgageSparkSuite extends FunSuite with BeforeAndAfterAll {
+class MortgageSparkSuite extends FunSuite {
 
   /**
    * This is intentionally a def rather than a val so that scalatest uses the correct value (from
@@ -61,11 +60,6 @@ class MortgageSparkSuite extends FunSuite with BeforeAndAfterAll {
       println("RAPIDS SHUFFLE MANAGER INACTIVE")
     }
     builder.getOrCreate()
-  }
-
-  // Close the session to avoid hanging after all cases are completed
-  override def afterAll() = {
-    session.close()
   }
 
   test("extract mortgage data") {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -149,6 +149,13 @@ class RapidsBufferCatalog extends Logging {
     }
   }
 
+  /** Remove all buffers. Only to be called on shutdown. */
+  def removeAllBuffersOnShutdown(): Unit = {
+    val existingBuffers = bufferMap.keySet()
+    logWarning(s"Removing all buffers (${existingBuffers.size()}) from catalog when shutting down.")
+    existingBuffers.forEach(removeBuffer(_))
+  }
+
   /** Return the number of buffers currently in the catalog. */
   def numBuffers: Int = bufferMap.size()
 }
@@ -232,6 +239,8 @@ object RapidsBufferCatalog extends Logging with Arm {
       gdsStorage.close()
       gdsStorage = null
     }
+
+    singleton.removeAllBuffersOnShutdown()
   }
 
   def getDeviceStorage: RapidsDeviceMemoryStore = deviceStorage

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -149,13 +149,6 @@ class RapidsBufferCatalog extends Logging {
     }
   }
 
-  /** Remove all buffers. Only to be called on shutdown. */
-  def removeAllBuffersOnShutdown(): Unit = {
-    val existingBuffers = bufferMap.keySet()
-    logDebug(s"Removing all buffers (${existingBuffers.size()}) from catalog when shutting down.")
-    existingBuffers.forEach(removeBuffer(_))
-  }
-
   /** Return the number of buffers currently in the catalog. */
   def numBuffers: Int = bufferMap.size()
 }
@@ -239,8 +232,6 @@ object RapidsBufferCatalog extends Logging with Arm {
       gdsStorage.close()
       gdsStorage = null
     }
-
-    singleton.removeAllBuffersOnShutdown()
   }
 
   def getDeviceStorage: RapidsDeviceMemoryStore = deviceStorage

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -152,7 +152,7 @@ class RapidsBufferCatalog extends Logging {
   /** Remove all buffers. Only to be called on shutdown. */
   def removeAllBuffersOnShutdown(): Unit = {
     val existingBuffers = bufferMap.keySet()
-    logWarning(s"Removing all buffers (${existingBuffers.size()}) from catalog when shutting down.")
+    logDebug(s"Removing all buffers (${existingBuffers.size()}) from catalog when shutting down.")
     existingBuffers.forEach(removeBuffer(_))
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -70,11 +70,17 @@ abstract class RapidsBufferStore(
       }
     }
 
-    def freeAll(): Unit = synchronized {
-      val values = buffers.values().toArray(new Array[RapidsBufferBase](0))
+    def freeAll(): Unit = {
+      val values = synchronized {
+        val buffs = buffers.values().toArray(new Array[RapidsBufferBase](0))
+        buffers.clear()
+        spillable.clear()
+        buffs
+      }
+      // We need to release the `RapidsBufferStore` lock to prevent a lock order inversion
+      // deadlock: (1) `RapidsBufferBase.free`     calls  (2) `RapidsBufferStore.remove` and
+      //           (1) `RapidsBufferStore.freeAll` calls  (2) `RapidsBufferBase.free`.
       values.foreach(_.free())
-      buffers.clear()
-      spillable.clear()
     }
 
     def nextSpillableBuffer(): RapidsBufferBase = synchronized {


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Targeting this to 22.04 but I can target to 22.02 if desired.

Closes https://github.com/NVIDIA/spark-rapids/issues/4664.

Prevents a deadlock between `RapidsBufferStore` and `RapidsBufferBase` on shutdown, removing code that was added before that was causing #4664 (this patch no longer stops the context -> no longer causes shuffle id conflicts on register)