### PR TITLE
Allow GpuWindowExec to partition on structs

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1202,7 +1202,7 @@ Accelerator supports are described below.
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><b>NS</b></td>
+<td><em>PS<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/integration_tests/src/main/python/time_window_test.py
+++ b/integration_tests/src/main/python/time_window_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/time_window_test.py
+++ b/integration_tests/src/main/python/time_window_test.py
@@ -27,9 +27,6 @@ _restricted_start = datetime(2020, 1, 1, tzinfo=timezone.utc)
 _restricted_end = datetime(2020, 1, 2, tzinfo=timezone.utc)
 _restricted_ts_gen = TimestampGen(start=_restricted_start, end=_restricted_end)
 
-# Once we support grouping by a struct (even single level) this should go away
-# https://github.com/NVIDIA/spark-rapids/issues/2877
-# Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_tumbling_window(data_gen):
@@ -41,9 +38,6 @@ def test_grouped_tumbling_window(data_gen):
 # have some real problems and even crash some times when trying to JIT it. This problem only happens on the CPU
 # so be careful.
 
-# Once we support grouping by a struct (even single level) this should go away
-# https://github.com/NVIDIA/spark-rapids/issues/2877
-# Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_sliding_window(data_gen):
@@ -51,10 +45,6 @@ def test_grouped_sliding_window(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, row_gen).groupBy(f.window('ts', '5 hour', '1 hour')).agg(f.max("data").alias("max_data")))
 
-# Having arrays allows us to verify that expand exec in this case works with arrays too
-# Once we support grouping by a struct (even single level) this should go away
-# https://github.com/NVIDIA/spark-rapids/issues/2877
-# Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_sliding_window_array(data_gen):

--- a/integration_tests/src/main/python/time_window_test.py
+++ b/integration_tests/src/main/python/time_window_test.py
@@ -30,7 +30,6 @@ _restricted_ts_gen = TimestampGen(start=_restricted_start, end=_restricted_end)
 # Once we support grouping by a struct (even single level) this should go away
 # https://github.com/NVIDIA/spark-rapids/issues/2877
 # Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
-@allow_non_gpu('HashAggregateExec', 'SortAggregateExec', 'AggregateExpression', 'Max', 'Alias', 'ShuffleExchangeExec', 'HashPartitioning')
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_tumbling_window(data_gen):
@@ -45,7 +44,6 @@ def test_grouped_tumbling_window(data_gen):
 # Once we support grouping by a struct (even single level) this should go away
 # https://github.com/NVIDIA/spark-rapids/issues/2877
 # Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
-@allow_non_gpu('HashAggregateExec', 'SortAggregateExec', 'AggregateExpression', 'Max', 'Alias', 'ShuffleExchangeExec', 'HashPartitioning')
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_sliding_window(data_gen):
@@ -57,7 +55,6 @@ def test_grouped_sliding_window(data_gen):
 # Once we support grouping by a struct (even single level) this should go away
 # https://github.com/NVIDIA/spark-rapids/issues/2877
 # Shuffle falls back to CPU because it is in between two CPU hash/sort aggregates
-@allow_non_gpu('HashAggregateExec', 'SortAggregateExec', 'AggregateExpression', 'GetArrayItem', 'Literal', 'Max', 'Alias', 'ShuffleExchangeExec', 'HashPartitioning')
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
 @ignore_order
 def test_grouped_sliding_window_array(data_gen):

--- a/integration_tests/src/main/python/time_window_test.py
+++ b/integration_tests/src/main/python/time_window_test.py
@@ -66,7 +66,6 @@ def test_grouped_sliding_window_array(data_gen):
             lambda spark : gen_df(spark, row_gen).groupBy(f.window('ts', '5 hour', '1 hour')).agg(f.max(f.col("data")[3]).alias("max_data")))
 
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
-@allow_non_gpu('WindowExec', 'WindowExpression', 'WindowSpecDefinition', 'SpecifiedWindowFrame', 'UnboundedPreceding$', 'UnboundedFollowing$', 'AggregateExpression', 'Max', 'Alias')
 @ignore_order
 def test_tumbling_window(data_gen):
     row_gen = StructGen([['ts', _restricted_ts_gen],['data', data_gen]], nullable=False)
@@ -75,7 +74,6 @@ def test_tumbling_window(data_gen):
             lambda spark : gen_df(spark, row_gen).withColumn('rolling_max', f.max("data").over(w)))
 
 @pytest.mark.parametrize('data_gen', integral_gens + [string_gen], ids=idfn)
-@allow_non_gpu('WindowExec', 'WindowExpression', 'WindowSpecDefinition', 'SpecifiedWindowFrame', 'UnboundedPreceding$', 'UnboundedFollowing$', 'AggregateExpression', 'Max', 'Alias')
 @ignore_order
 def test_sliding_window(data_gen):
     row_gen = StructGen([['ts', _restricted_ts_gen],['data', data_gen]], nullable=False)

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -981,7 +981,8 @@ def test_window_aggs_for_rows_collect_set():
 # In a distributed setup the order of the partitions returned might be different, so we must ignore the order
 # but small batch sizes can make sort very slow, so do the final order by locally
 @ignore_order(local=True)
-@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]]), ArrayGen(long_gen)], ids=meta_idfn('partBy:'))
+# Arrays and struct of struct (more than single level nesting) are not supported
+@pytest.mark.parametrize('part_gen', [ArrayGen(long_gen), StructGen([["a", StructGen([["a1", long_gen]])]])], ids=meta_idfn('partBy:'))
 # For arrays the sort and hash partition are also not supported
 @allow_non_gpu('WindowExec', 'Alias', 'WindowExpression', 'AggregateExpression', 'Count', 'WindowSpecDefinition', 'SpecifiedWindowFrame', 'Literal', 'SortExec', 'SortOrder', 'ShuffleExchangeExec', 'HashPartitioning')
 def test_nested_part_fallback(part_gen):
@@ -996,6 +997,22 @@ def test_nested_part_fallback(part_gen):
             .withColumn('rn', f.count('c').over(window_spec))
 
     assert_gpu_fallback_collect(do_it, 'WindowExec')
+
+@ignore_order(local=True)
+# single-level structs (no nested structs) are now supported by the plugin
+@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]])], ids=meta_idfn('partBy:'))
+def test_nested_part_struct(part_gen):
+    data_gen = [
+            ('a', RepeatSeqGen(part_gen, length=20)),
+            ('b', LongRangeGen()),
+            ('c', int_gen)]
+    window_spec = Window.partitionBy('a').orderBy('b').rowsBetween(-5, 5)
+
+    def do_it(spark):
+        return gen_df(spark, data_gen, length=2048) \
+            .withColumn('rn', f.count('c').over(window_spec))
+
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 # In a distributed setup the order of the partitions returend might be different, so we must ignore the order
 # but small batch sizes can make sort very slow, so do the final order by locally

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3762,8 +3762,9 @@ object GpuOverrides extends Logging {
           TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all,
         Map("partitionSpec" ->
-            InputCheck((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(), TypeSig.all))),
+            InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+            TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64), 
+            TypeSig.all))),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)
     ),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3762,8 +3762,9 @@ object GpuOverrides extends Logging {
           TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all,
         Map("partitionSpec" ->
-            InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-            TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64), 
+            InputCheck(
+                TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+                TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
             TypeSig.all))),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3762,7 +3762,8 @@ object GpuOverrides extends Logging {
           TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all,
         Map("partitionSpec" ->
-            InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64, TypeSig.all))),
+            InputCheck((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
+            TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(), TypeSig.all))),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)
     ),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -1097,7 +1097,7 @@ object CaseWhenCheck extends ExprChecks {
 }
 
 /**
- * This is specific to WidowSpec, because it does not follow the typical parameter convention.
+ * This is specific to WindowSpec, because it does not follow the typical parameter convention.
  */
 object WindowSpecCheck extends ExprChecks {
   val check: TypeSig =


### PR DESCRIPTION
Fixes #4626.

This updates the type check for WindowExec's partitionBy parameter to ensure that the code will run on the GPU. The underlying requirements for these queries to run on the GPU has already been implemented previously (See https://github.com/NVIDIA/spark-rapids/issues/2877), so this code just unblocks the check.  Also, the allow_non_gpu mark has been removed from the relevant time window tests, since these are no longer blocked from running on the GPU.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
