### PR TITLE
Reimplement check for non-regexp strings using RegexParser

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -492,11 +492,6 @@ object GpuOverrides extends Logging {
     listeners.clear()
   }
 
-  def canRegexpBeTreatedLikeARegularString(strLit: UTF8String): Boolean = {
-    val s = strLit.toString
-    !regexList.exists(pattern => s.contains(pattern))
-  }
-
   private def convertPartToGpuIfPossible(part: Partitioning, conf: RapidsConf): Partitioning = {
     part match {
       case _: GpuPartitioning => part

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -409,23 +409,23 @@ object RegexParser {
   private val regexpEscapedChars = Seq('\\', 'b', 'B', 's', 'S', 'w', 'W', 'd', 'D', 'Q', 'E',
     'h', 'H', 'v', 'V', 'A', 'a', 'z', 'Z', 'x', 'e', 'c', 'p', 'G', 'R', 'k')
 
-  def isNonRegExpString(s: String): Boolean = {
+  def isRegExpString(s: String): Boolean = {
 
-    def isSimpleString(ast: RegexAST): Boolean = ast match {
-      case RegexChar(ch) => !regexpChars.contains(ch)
-      case RegexEscaped(ch) => !regexpEscapedChars.contains(ch)
-      case RegexSequence(parts) => parts.forall(isSimpleString)
-      case _ => false
+    def isRegExpString(ast: RegexAST): Boolean = ast match {
+      case RegexChar(ch) => regexpChars.contains(ch)
+      case RegexEscaped(ch) => regexpEscapedChars.contains(ch)
+      case RegexSequence(parts) => parts.exists(isRegExpString)
+      case _ => true
     }
 
     try {
       val parser = new RegexParser(s)
       val ast = parser.parse()
-      isSimpleString(ast)
+      isRegExpString(ast)
     } catch {
       case _: RegexUnsupportedException =>
         // if we cannot parse it then assume that it might be valid regexp
-        false
+        true
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -405,15 +405,13 @@ class RegexParser(pattern: String) {
 }
 
 object RegexParser {
-  private val regexpChars = Seq('\u0000', '\\', '.', '^', '$', '\f')
-  private val regexpEscapedChars = Seq('\\', 'b', 'B', 's', 'S', 'w', 'W', 'd', 'D', 'Q', 'E',
-    'h', 'H', 'v', 'V', 'A', 'a', 'z', 'Z', 'x', 'e', 'c', 'p', 'G', 'R', 'k')
+  private val regexpChars = Set('\u0000', '\\', '.', '^', '$', '\f')
 
   def isRegExpString(s: String): Boolean = {
 
     def isRegExpString(ast: RegexAST): Boolean = ast match {
       case RegexChar(ch) => regexpChars.contains(ch)
-      case RegexEscaped(ch) => regexpEscapedChars.contains(ch)
+      case RegexEscaped(_) => true
       case RegexSequence(parts) => parts.exists(isRegExpString)
       case _ => true
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1296,7 +1296,7 @@ class GpuStringSplitMeta(
     } else {
       val str = regexp.get.value.asInstanceOf[UTF8String]
       if (str != null) {
-        if (!RegexParser.isNonRegExpString(str.toString)) {
+        if (RegexParser.isRegExpString(str.toString)) {
           willNotWorkOnGpu("regular expressions are not supported yet")
         }
         if (str.numChars() == 0) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1296,7 +1296,7 @@ class GpuStringSplitMeta(
     } else {
       val str = regexp.get.value.asInstanceOf[UTF8String]
       if (str != null) {
-        if (!canRegexpBeTreatedLikeARegularString(str)) {
+        if (!RegexParser.isNonRegExpString(str.toString)) {
           willNotWorkOnGpu("regular expressions are not supported yet")
         }
         if (str.numChars() == 0) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,24 @@ import scala.collection.mutable.ListBuffer
 import org.scalatest.FunSuite
 
 class RegularExpressionParserSuite extends FunSuite {
+
+  test("detect regexp strings") {
+    // Based on https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+    val strings: Seq[String] = Seq("\\", "\u0000", "\\x00",
+      "\f", "\\a", "\\e", "\\cx", "[abc]", "^", "[a-z&&[def]]", ".", "*", "\\d", "\\D",
+      "\\h", "\\H", "\\s", "\\S", "\\v", "\\V", "\\w", "\\w", "\\p", "$", "\\b", "\\B",
+      "\\A", "\\G", "\\Z", "\\z", "\\R", "?", "|", "(abc)", "a{1,}", "\\k", "\\Q", "\\E")
+    for (string <- strings) {
+      assert(!RegexParser.isNonRegExpString(string))
+    }
+  }
+
+  test("detect non-regexp strings") {
+    val strings = Seq("\\.", "A", ",", "\t")
+    for (string <- strings) {
+      assert(RegexParser.isNonRegExpString(string))
+    }
+  }
 
   test("empty pattern") {
     assert(parse("") === RegexSequence(ListBuffer()))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -28,14 +28,14 @@ class RegularExpressionParserSuite extends FunSuite {
       "\\h", "\\H", "\\s", "\\S", "\\v", "\\V", "\\w", "\\w", "\\p", "$", "\\b", "\\B",
       "\\A", "\\G", "\\Z", "\\z", "\\R", "?", "|", "(abc)", "a{1,}", "\\k", "\\Q", "\\E")
     for (string <- strings) {
-      assert(!RegexParser.isNonRegExpString(string))
+      assert(RegexParser.isRegExpString(string))
     }
   }
 
   test("detect non-regexp strings") {
     val strings = Seq("\\.", "A", ",", "\t")
     for (string <- strings) {
-      assert(RegexParser.isNonRegExpString(string))
+      assert(!RegexParser.isRegExpString(string))
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -23,7 +23,7 @@ class RegularExpressionParserSuite extends FunSuite {
 
   test("detect regexp strings") {
     // Based on https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
-    val strings: Seq[String] = Seq("\\", "\u0000", "\\x00",
+    val strings: Seq[String] = Seq("\\", "\u0000", "\\x00", "\\.",
       "\f", "\\a", "\\e", "\\cx", "[abc]", "^", "[a-z&&[def]]", ".", "*", "\\d", "\\D",
       "\\h", "\\H", "\\s", "\\S", "\\v", "\\V", "\\w", "\\w", "\\p", "$", "\\b", "\\B",
       "\\A", "\\G", "\\Z", "\\z", "\\R", "?", "|", "(abc)", "a{1,}", "\\k", "\\Q", "\\E")
@@ -33,7 +33,7 @@ class RegularExpressionParserSuite extends FunSuite {
   }
 
   test("detect non-regexp strings") {
-    val strings = Seq("\\.", "A", ",", "\t", ":", "")
+    val strings = Seq("A", ",", "\t", ":", "")
     for (string <- strings) {
       assert(!RegexParser.isRegExpString(string))
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -33,7 +33,7 @@ class RegularExpressionParserSuite extends FunSuite {
   }
 
   test("detect non-regexp strings") {
-    val strings = Seq("\\.", "A", ",", "\t", ":")
+    val strings = Seq("\\.", "A", ",", "\t", ":", "")
     for (string <- strings) {
       assert(!RegexParser.isRegExpString(string))
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -33,7 +33,7 @@ class RegularExpressionParserSuite extends FunSuite {
   }
 
   test("detect non-regexp strings") {
-    val strings = Seq("\\.", "A", ",", "\t")
+    val strings = Seq("\\.", "A", ",", "\t", ":")
     for (string <- strings) {
       assert(!RegexParser.isRegExpString(string))
     }


### PR DESCRIPTION
This PR reimplements the check used in GpuStringSplit to determine if a string is a regular expression or not. The previous approach had limitations and now that we have a regular expression parser we can improve the check so that there are fewer false positives.

This change is needed to support the work for https://github.com/NVIDIA/spark-rapids/issues/3542