### PR TITLE
Fix map_test ANSI failure in Spark 3.3.0

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect
 from data_gen import *
 from marks import incompat, allow_non_gpu
-from spark_session import is_before_spark_311
+from spark_session import is_before_spark_311, is_before_spark_330
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
 import pyspark.sql.functions as f
@@ -145,12 +145,13 @@ def test_map_scalar_project():
 @pytest.mark.skipif(is_before_spark_311(), reason="Only in Spark 3.1.1 + ANSI mode, map key throws on no such element")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_get_map_value_ansi_fail(data_gen):
+    message = "org.apache.spark.SparkNoSuchElementException" if not is_before_spark_330() else "java.util.NoSuchElementException"
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'a["NOT_FOUND"]').collect(),
                 conf={'spark.sql.ansi.enabled':True,
                       'spark.sql.legacy.allowNegativeScaleOfDecimal': True},
-                error_message='java.util.NoSuchElementException')
+                error_message=message)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
@@ -176,12 +177,13 @@ def test_simple_element_at_map(data_gen):
 @pytest.mark.skipif(is_before_spark_311(), reason="Only in Spark 3.1.1 + ANSI mode, map key throws on no such element")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_map_element_at_ansi_fail(data_gen):
+    message = "org.apache.spark.SparkNoSuchElementException" if not is_before_spark_330() else "java.util.NoSuchElementException"
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'element_at(a, "NOT_FOUND")').collect(),
                 conf={'spark.sql.ansi.enabled':True,
                       'spark.sql.legacy.allowNegativeScaleOfDecimal': True},
-                error_message='java.util.NoSuchElementException')
+                error_message=message)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)

--- a/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsErrorUtils.scala
@@ -23,4 +23,11 @@ object RapidsErrorUtils {
     throw new ArrayIndexOutOfBoundsException(s"index $index is beyond the max index allowed " +
         s"${numElements - 1}")
   }
+
+  def throwInvalidElementAtIndexError(
+      elementKey: String, isElementAtFunction: Boolean = false): ColumnVector = {
+    // For now, the default argument is false. The caller sets the correct value accordingly.
+    throw new NoSuchElementException(s"Key: ${elementKey} " +
+      s"does not exist in any one of the rows in the map column")
+  }
 }

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsErrorUtils.scala
@@ -24,4 +24,10 @@ object RapidsErrorUtils {
   def throwArrayIndexOutOfBoundsException(index: Int, numElements: Int): ColumnVector = {
     throw QueryExecutionErrors.invalidArrayIndexError(index, numElements)
   }
+
+  def throwInvalidElementAtIndexError(
+      elementKey: String, isElementAtFunction: Boolean = false): ColumnVector = {
+    // For now, the default argument is false. The caller sets the correct value accordingly.
+    throw QueryExecutionErrors.mapKeyNotExistError(elementKey, isElementAtFunction)
+  }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -172,7 +172,7 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
                 lhs.getBase.getMapValue(rhs.getBase)
               } else {
                 RapidsErrorUtils.throwInvalidElementAtIndexError(
-                  rhs.getValue.asInstanceOf[UTF8String].toString)
+                  rhs.getValue.asInstanceOf[UTF8String].toString, true)
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -171,9 +171,8 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
               if (!exist.isValid || exist.getBoolean) {
                 lhs.getBase.getMapValue(rhs.getBase)
               } else {
-                throw new NoSuchElementException(
-                  s"Key: ${rhs.getValue.asInstanceOf[UTF8String].toString} " +
-                    s"does not exist in one of the rows in the map column")
+                RapidsErrorUtils.throwInvalidElementAtIndexError(
+                  rhs.getValue.asInstanceOf[UTF8String].toString)
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -183,9 +183,8 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
       withResource(lhs.getBase.getMapKeyExistence(rhs.getBase)) { keyExistenceColumn =>
         withResource(keyExistenceColumn.all) { exist =>
           if (exist.isValid && !exist.getBoolean) {
-            throw new NoSuchElementException(
-              s"Key: ${rhs.getValue.asInstanceOf[UTF8String].toString} " +
-                s"does not exist in any one of the rows in the map column")
+            RapidsErrorUtils.throwInvalidElementAtIndexError(
+              rhs.getValue.asInstanceOf[UTF8String].toString)
           }
         }
       }


### PR DESCRIPTION
Fixes #4564

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Spark-330+ throws an `SparkNoSuchElementException` on failure for `map_get`.
The tests were failing because prior Spark releases were throwing `java.util.NoSuchElementException`.

Building on the changes in #4039, the fix is to add shims to specify the correct type of exception for the different releases.

This fix needs to be followed up by the feature request in #4668 
