### PR TITLE
Update centos 8 dockerfile to handle EOL issue [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -26,10 +26,16 @@
 ARG CUDA_VER=11.0
 ARG CENTOS_VER=7
 FROM nvidia/cuda:${CUDA_VER}-runtime-centos${CENTOS_VER}
+ARG CENTOS_VER
 ARG CUDA_VER
 ARG CUDF_VER
 ARG URM_URL
 
+# centOS 8 went EOL, use vault.centos.org to avoid "No URLs in mirrorlist"
+RUN if [ "$CENTOS_VER" == "8" ]; then\
+      sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* &&\
+      sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*;\
+    fi
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
     yum install epel-release -y && \


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

centos8 went EOL Dec. 2021, retarget image repo to vault URL.

for internal nightly test only, skip ci. verified locally