### PR TITLE
Check for a null compression codec when creating ORC OutStream

### DIFF
--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/OrcShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/OrcShims.scala
@@ -72,7 +72,10 @@ object OrcShims {
   // create ORC out stream
   def newOrcOutStream(name: String, bufferSize: Int, codec: CompressionCodec,
       receiver: PhysicalWriter.OutputReceiver): OutStream = {
-    val options = new StreamOptions(bufferSize).withCodec(codec, codec.getDefaultOptions)
+    val options = new StreamOptions(bufferSize)
+    if (codec != null) {
+      options.withCodec(codec, codec.getDefaultOptions)
+    }
     new OutStream(name, options, receiver)
   }
 


### PR DESCRIPTION
Fixes #4728.

Fetching the compression codec can return null when no compression codec is being used, so we need to check for this before trying to use the resulting codec.