### PR TITLE
Change resume-from to aggregator in buildall [skip ci]

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -243,8 +243,14 @@ time (
   printf "%s\n" "${SPARK_SHIM_VERSIONS[@]}" | \
     xargs -t -I% -P "$BUILD_PARALLEL" -n 1 \
     bash -c 'build_single_shim "$@"' _ %
-  echo "Resuming from dist build only using $BASE_VER"
-  mvn package --resume-from dist $MODULE_OPT $MVN_PROFILE_OPT $INCLUDED_BUILDVERS_OPT \
+  # This used to resume from dist. However, without including aggregator in the build
+  # the build does not properly initialize spark.version proprty via buildver profiles
+  # in the root pom, and we get a missing spark301 dependency even if for --profile=312,321
+  # where the build does not require it. Moving it to aggregator resolves this issue with
+  # a negligible increase of the build time by ~2 seconds.
+  joinShimBuildFrom="aggregator"
+  echo "Resuming from $joinShimBuildFrom build only using $BASE_VER"
+  mvn package -rf $joinShimBuildFrom $MODULE_OPT $MVN_PROFILE_OPT $INCLUDED_BUILDVERS_OPT \
     -Dbuildver="$BASE_VER" \
     -DskipTests -Dskip -Dmaven.javadoc.skip
 )

--- a/build/buildall
+++ b/build/buildall
@@ -244,8 +244,8 @@ time (
     xargs -t -I% -P "$BUILD_PARALLEL" -n 1 \
     bash -c 'build_single_shim "$@"' _ %
   # This used to resume from dist. However, without including aggregator in the build
-  # the build does not properly initialize spark.version proprty via buildver profiles
-  # in the root pom, and we get a missing spark301 dependency even if for --profile=312,321
+  # the build does not properly initialize spark.version property via buildver profiles
+  # in the root pom, and we get a missing spark301 dependency even for --profile=312,321
   # where the build does not require it. Moving it to aggregator resolves this issue with
   # a negligible increase of the build time by ~2 seconds.
   joinShimBuildFrom="aggregator"


### PR DESCRIPTION
Ensure proper spark version classifier profile activation by making aggregator the start of resume-from in the second single-threaded part of the build. 

Note that  this is a quick fix without much investigation if this is "the right" fix but it works, and should be acceptable for a non-production script. The impact on the build time is negligible   

Closes #4736

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
