### PR TITLE
Add ignoreCorruptFiles feature for Parquet reader [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -20,7 +20,7 @@ from marks import *
 from pyspark.sql.types import *
 from pyspark.sql.functions import *
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330
-from src.main.python.conftest import is_databricks_runtime
+from conftest import is_databricks_runtime
 
 
 def read_parquet_df(data_path):

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -20,6 +20,8 @@ from marks import *
 from pyspark.sql.types import *
 from pyspark.sql.functions import *
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330
+from src.main.python.conftest import is_databricks_runtime
+
 
 def read_parquet_df(data_path):
     return lambda spark : spark.read.parquet(data_path)
@@ -755,6 +757,7 @@ def test_parquet_scan_with_hidden_metadata_fallback(spark_tmp_path, metadata_col
 @ignore_order
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+@pytest.mark.skipif(is_databricks_runtime(), reason="Databricks does not support ignoreCorruptFiles")
 def test_parquet_read_with_corrupt_files(spark_tmp_path, reader_confs, v1_enabled_list):
     first_data_path = spark_tmp_path + '/PARQUET_DATA/first'
     with_cpu_session(lambda spark : spark.range(1).toDF("a").write.parquet(first_data_path))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import java.io.File
+import java.io.{File, IOException}
 import java.net.{URI, URISyntaxException}
 import java.util.concurrent.{Callable, ConcurrentLinkedQueue, Future, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 
@@ -296,6 +296,7 @@ abstract class FilePartitionReaderBase(conf: Configuration, execMetrics: Map[Str
  *                            submitted to threadpool
  * @param filters push down filters
  * @param execMetrics the metrics
+ * @param ignoreCorruptFiles Whether to ignore corrupt files when GPU failed to decode the files
  */
 abstract class MultiFileCloudPartitionReaderBase(
     conf: Configuration,
@@ -303,7 +304,8 @@ abstract class MultiFileCloudPartitionReaderBase(
     numThreads: Int,
     maxNumFileProcessed: Int,
     filters: Array[Filter],
-    execMetrics: Map[String, GpuMetric]) extends FilePartitionReaderBase(conf, execMetrics) {
+    execMetrics: Map[String, GpuMetric],
+    ignoreCorruptFiles: Boolean = false) extends FilePartitionReaderBase(conf, execMetrics) {
 
   private var filesToRead = 0
   protected var currentFileHostBuffers: Option[HostMemoryBuffersWithMetaDataBase] = None
@@ -389,7 +391,15 @@ abstract class MultiFileCloudPartitionReaderBase(
           closeCurrentFileHostBuffers()
           next()
         } else {
-          batch = readBatch(currentFileHostBuffers.get)
+          val file = currentFileHostBuffers.get.partitionedFile.filePath
+          batch = try {
+            readBatch(currentFileHostBuffers.get)
+          } catch {
+            case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+              logWarning(
+                s"Skipped the corrupted file: ${file}", e)
+              None
+          }
         }
       } else {
         if (filesToRead > 0 && !isDone) {
@@ -408,7 +418,16 @@ abstract class MultiFileCloudPartitionReaderBase(
             addNextTaskIfNeeded()
             next()
           } else {
-            batch = readBatch(fileBufsAndMeta)
+            val file = fileBufsAndMeta.partitionedFile.filePath
+            batch = try {
+              readBatch(fileBufsAndMeta)
+            } catch {
+              case e @ (_: RuntimeException | _: IOException) if ignoreCorruptFiles =>
+                logWarning(
+                  s"Skipped the corrupted file: ${file}", e)
+                None
+            }
+
             // the data is copied to GPU so submit another task if we were limited
             addNextTaskIfNeeded()
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -1244,7 +1244,7 @@ class MultiFileCloudParquetPartitionReader(
     ignoreMissingFiles: Boolean,
     ignoreCorruptFiles: Boolean)
   extends MultiFileCloudPartitionReaderBase(conf, files, numThreads, maxNumFileProcessed, filters,
-    execMetrics) with ParquetPartitionReaderBase {
+    execMetrics, ignoreCorruptFiles) with ParquetPartitionReaderBase {
 
   case class HostMemoryBuffersWithMetaData(
       override val partitionedFile: PartitionedFile,


### PR DESCRIPTION
To close https://github.com/NVIDIA/spark-rapids/issues/4727.

GPU parquet reader will throw an exception when reading some corrupt parquet files even if the user has set `"spark.sql.files.ignoreCorruptFiles"` to true for `coalescing` or `multi-threaded` reading. While `PERFILE` reading is ok since it is in the wrapper of `FilePartitionReader` which has handled the exceptions. see https://github.com/apache/spark/blob/branch-3.2/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FilePartitionReader.scala#L39-L59

For multi-threaded reading, when detecting the `wrong footer` or `failing to copy the files` into the HostMemoryBuffer, it will totally ignore the whole file. For example, assuming there are 3 row groups,  the multi-threaded reader has successfully copied the first 2 row groups into the HostMemoryBuffer, and it failed to copy the 3rd row group caused by IOException. The multi-threaded reader will ignore the first loaded 2 row groups,  return empty HostMemoryBuffer. But for CPU, it may have returned the first 2 row groups to users. 

For coalescing reading, we have first calculated the offset and size for each file and launched multi-threads to copy the row groups into the `fixed location` of the HostMemoryBuffer. Assuming we're coalescing 1.parquet, 2.parquet and 3.parquet files. First, we have allocated a total HostMemoryBuffer for 1.parquet, 2.parquet and 3.parquet and launched 3 threads to copy 1.parquet, 2.parquet and 3.parquet into the total HostMemoryBuffer separately. Asssuming the 2.parquet is failed to copying or something. Then the re-generated parquet file will only contain 1.parquet, empty hole (for 2.parquet, but failed to copy, we just left the empty hole), 3.parquet

This PR only considers the exceptions that happened in reading footer and copying row groups. It didn't catch the exception when decoding in GPU. So, even if ignoreCorruptFiles is enabled, it will throw an exception when cudf failed to decode the host buffer.