### PR TITLE
Close SpillableBatch to avoid leaks

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -210,9 +210,9 @@ else
         # when running tests in parallel, we allocate less than the default minAllocFraction per test
         # so we need to override this setting here
         export PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0
-        python "${RUN_TESTS_COMMAND[@]}" "${TEST_PARALLEL_OPTS[@]}" "${TEST_COMMON_OPTS[@]}"
+        exec python "${RUN_TESTS_COMMAND[@]}" "${TEST_PARALLEL_OPTS[@]}" "${TEST_COMMON_OPTS[@]}"
     else
-        "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
+        exec "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
             --driver-java-options "$PYSP_TEST_spark_driver_extraJavaOptions" \
             $SPARK_SUBMIT_FLAGS "${RUN_TESTS_COMMAND[@]}" "${TEST_COMMON_OPTS[@]}"
     fi

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,9 @@ class GroupingIterator(
 
   override def next(): ColumnarBatch = {
     if (groupBatches.nonEmpty) {
-      groupBatches.dequeue().getColumnarBatch()
+      withResource(groupBatches.dequeue()) { gb =>
+        gb.getColumnarBatch()
+      }
     } else {
       val batch = wrapped.next()
       inputBatches += 1
@@ -145,8 +147,9 @@ class GroupingIterator(
             withResource(GpuColumnVector.from(cb)) { table =>
               withResource(table.contiguousSplit(splitIndices:_*)) { tables =>
                 // Return the first one and enqueue others
-                val splitBatches = tables.safeMap(table =>
-                  GpuColumnVectorFromBuffer.from(table, GpuColumnVector.extractTypes(batch)))
+                val splitBatches = tables.safeMap { table =>
+                  GpuColumnVectorFromBuffer.from(table, GpuColumnVector.extractTypes(batch))
+                }
                 groupBatches.enqueue(splitBatches.tail.map(sb =>
                   SpillableColumnarBatch(sb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY,
                     spillCallback)): _*)


### PR DESCRIPTION
this fixes #4730 
I did a bit of cleanup for some of the code, but the leaks really were that the SpillableColumnBatch instances that were inserted into the queue were never closed when they were dequeued.
