### PR TITLE
Ensure GpuM2 merge aggregation does not produce a null mean or m2

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -1785,11 +1785,13 @@ abstract class GpuM2(child: Expression, nullOnDivideByZero: Boolean)
   // The postMerge step needs to extract 3 columns (n, avg, m2) from the structs column
   // output from the merge step. Note that the first one is casted to Double to match with Spark.
   //
-  // In the future, when rewriting CudfMergeM2, we will need to ouput it in Double type.
+  // In the future, when rewriting CudfMergeM2, we will need to output it in Double type.
   override lazy val postMerge: Seq[Expression] = Seq(
     GpuCast(GpuGetStructField(mergeM2.attr, 0), DoubleType),
-    GpuCast(GpuGetStructField(mergeM2.attr, 1), DoubleType),
-    GpuCast(GpuGetStructField(mergeM2.attr, 2), DoubleType))
+    GpuCoalesce(Seq(GpuCast(GpuGetStructField(mergeM2.attr, 1), DoubleType),
+      GpuLiteral(0.0, DoubleType))),
+    GpuCoalesce(Seq(GpuCast(GpuGetStructField(mergeM2.attr, 2), DoubleType),
+      GpuLiteral(0.0, DoubleType))))
 }
 
 case class GpuStddevPop(child: Expression, nullOnDivideByZero: Boolean)


### PR DESCRIPTION
Fixes #4744.

When placing only the partial stddev aggregation on the GPU, it is possible that the merge aggregation could be invoked to merge multiple partial batches before shuffling to the CPU stage to perform the final aggregation.  Spark's CPU implementation is not tolerant of nulls, and `GpuM2` has post-processing for partial aggregations to ensure it does not generate a null.  However it was possible to generate a null during a merge aggregation as well, but the coalesce operations were not present on the corresponding merge aggregation post-processing.  This updates `GpuM2` to ensure there are no nulls generated for the mean and m2 values during a merge.