### PR TITLE
Fix failure to generate worker_id when xdist is not present

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -234,11 +234,17 @@ def std_input_path(request):
         yield path
 
 @pytest.fixture
-def spark_tmp_path(request, worker_id):
+def spark_tmp_path(request):
     debug = request.config.getoption('debug_tmp_path')
     ret = request.config.getoption('tmp_path')
     if ret is None:
         ret = '/tmp/pyspark_tests/'
+    worker_id = 'main'
+    try:
+        import xdist
+        worker_id = xdist.plugin.get_xdist_worker_id(request)
+    except ImportError:
+        pass
     pid = os.getpid()
     hostname = os.uname()[1]
     ret = f'{ret}/{hostname}-{worker_id}-{pid}-{random.randrange(0, 1<<31)}/'


### PR DESCRIPTION
Fixes #4798.

xdist is optional, so we cannot rely on the typical `worker_id` fixture to identify the worker ID.  This uses a try-to-import approach to leverage an xdist API to retrieve the worker_id from the pytest config, using a static string for the worker ID if xdist fails to import.