### PR TITLE
Avoid output cast by using unsigned type output for GpuExtractChunk32 [databricks]

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -152,7 +152,11 @@ public class GpuColumnVector extends GpuColumnVectorBase {
             || DType.TIMESTAMP_SECONDS.equals(type)
             || DType.TIMESTAMP_MICROSECONDS.equals(type)
             || DType.TIMESTAMP_MILLISECONDS.equals(type)
-            || DType.TIMESTAMP_NANOSECONDS.equals(type)) {
+            || DType.TIMESTAMP_NANOSECONDS.equals(type)
+            || DType.UINT8.equals(type)
+            || DType.UINT16.equals(type)
+            || DType.UINT32.equals(type)
+            || DType.UINT64.equals(type)) {
       debugInteger(hostCol, type);
    } else if (DType.BOOL8.equals(type)) {
       for (int i = 0; i < hostCol.getRowCount(); i++) {
@@ -486,6 +490,10 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       // So, we don't have to handle decimal-supportable problem at here.
       DecimalType dt = (DecimalType) type;
       return DecimalUtil.createCudfDecimal(dt.precision(), dt.scale());
+    } else if (type instanceof GpuUnsignedIntegerType) {
+      return DType.UINT32;
+    } else if (type instanceof GpuUnsignedLongType) {
+      return DType.UINT64;
     }
     return null;
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataTypes.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataTypes.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.types.DataType
+
+/**
+ * An unsigned, 32-bit integer type that maps to DType.UINT32 in cudf.
+ * @note This type should NOT be used in Catalyst plan nodes that could be exposed to
+ *       CPU expressions.
+ */
+class GpuUnsignedIntegerType private() extends DataType {
+  // The companion object and this class are separated so the companion object also subclasses
+  // this type. Otherwise the companion object would be of type "UnsignedIntegerType$" in
+  // byte code.
+  // Defined with a private constructor so the companion object is the only possible instantiation.
+  override def defaultSize: Int = 4
+
+  override def simpleString: String = "uint"
+
+  override def asNullable: DataType = this
+}
+
+case object GpuUnsignedIntegerType extends GpuUnsignedIntegerType
+
+
+/**
+ * An unsigned, 64-bit integer type that maps to DType.UINT64 in cudf.
+ * @note This type should NOT be used in Catalyst plan nodes that could be exposed to
+ *       CPU expressions.
+ */
+class GpuUnsignedLongType private() extends DataType {
+  // The companion object and this class are separated so the companion object also subclasses
+  // this type. Otherwise the companion object would be of type "UnsignedIntegerType$" in
+  // byte code.
+  // Defined with a private constructor so the companion object is the only possible instantiation.
+  override def defaultSize: Int = 8
+
+  override def simpleString: String = "ulong"
+
+  override def asNullable: DataType = this
+}
+
+case object GpuUnsignedLongType extends GpuUnsignedLongType


### PR DESCRIPTION
Fixes #4777.

Now that rapidsai/cudf#10246 is fixed, we can avoid upcasting the outputs of `GpuExtractChunk32` by directly using the unsigned types generated during the chunk extraction.  This also adds GPU unsigned types for integer and long for use in Catalyst expressions which are needed for this change.