### PR TITLE
Default integration test configs to allow negative decimal scale [databricks]

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -21,7 +21,6 @@ from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
 from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_311, is_before_spark_320, is_databricks91_or_later
 import pyspark.sql.functions as f
-from pyspark.sql.utils import IllegalArgumentException
 
 # No overflow gens here because we just focus on verifying the fallback to CPU when
 # enabling ANSI mode. But overflows will fail the tests because CPU runs raise
@@ -47,8 +46,7 @@ def test_addition(data_gen):
                 f.lit(-12).cast(data_type) + f.col('b'),
                 f.lit(None).cast(data_type) + f.col('a'),
                 f.col('b') + f.lit(None).cast(data_type),
-                f.col('a') + f.col('b')),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') + f.col('b')))
 
 # If it will not overflow for multiply it is good for add too
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
@@ -61,7 +59,7 @@ def test_addition_ansi_no_overflow(data_gen):
                 f.lit(None).cast(data_type) + f.col('a'),
                 f.col('b') + f.lit(None).cast(data_type),
                 f.col('a') + f.col('b')),
-            conf={'spark.sql.ansi.enabled': 'true'})
+            conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + decimal_128_gens, ids=idfn)
 def test_subtraction(data_gen):
@@ -72,8 +70,7 @@ def test_subtraction(data_gen):
                 f.lit(-12).cast(data_type) - f.col('b'),
                 f.lit(None).cast(data_type) - f.col('a'),
                 f.col('b') - f.lit(None).cast(data_type),
-                f.col('a') - f.col('b')),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') - f.col('b')))
 
 # If it will not overflow for multiply it is good for subtract too
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
@@ -86,7 +83,7 @@ def test_subtraction_ansi_no_overflow(data_gen):
                 f.lit(None).cast(data_type) - f.col('a'),
                 f.col('b') - f.lit(None).cast(data_type),
                 f.col('a') - f.col('b')),
-            conf={'spark.sql.ansi.enabled': 'true'})
+            conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', numeric_gens + [decimal_gen_neg_scale, 
     decimal_gen_scale_precision, decimal_gen_same_scale_precision,
@@ -99,8 +96,7 @@ def test_multiplication(data_gen):
                 f.lit(-12).cast(data_type) * f.col('b'),
                 f.lit(None).cast(data_type) * f.col('a'),
                 f.col('b') * f.lit(None).cast(data_type),
-                f.col('a') * f.col('b')),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') * f.col('b')))
 
 @allow_non_gpu('ProjectExec', 'Alias', 'Multiply', 'Cast')
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens, ids=idfn)
@@ -109,7 +105,7 @@ def test_multiplication_fallback_when_ansi_enabled(data_gen):
             lambda spark : binary_op_df(spark, data_gen).select(
                 f.col('a') * f.col('b')),
             'Multiply',
-            conf={'spark.sql.ansi.enabled': 'true'})
+            conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', [float_gen, double_gen,
     decimal_gen_scale_precision], ids=idfn)
@@ -119,15 +115,14 @@ def test_multiplication_ansi_enabled(data_gen):
             lambda spark : binary_op_df(spark, data_gen).select(
                 f.col('a') * f.lit(100).cast(data_type),
                 f.col('a') * f.col('b')),
-            conf={'spark.sql.ansi.enabled': 'true'})
+            conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('lhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 5), DecimalGen(6, 4), DecimalGen(5, 4), DecimalGen(5, 3), DecimalGen(4, 2), DecimalGen(3, -2), DecimalGen(16, 7)], ids=idfn)
 @pytest.mark.parametrize('rhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3), DecimalGen(10, -2), DecimalGen(15, 3)], ids=idfn)
 def test_multiplication_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).select(
-                f.col('a') * f.col('b')),
-            conf = allow_negative_scale_of_decimal_conf)
+                f.col('a') * f.col('b')))
 
 @approximate_float # we should get the perfectly correct answer for floats except when casting a decimal to a float in some corner cases.
 @pytest.mark.parametrize('lhs', [float_gen, double_gen], ids=idfn)
@@ -136,8 +131,7 @@ def test_float_multiplication_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).select(
                 f.col('a') * f.col('b')),
-            conf=copy_and_update(allow_negative_scale_of_decimal_conf,
-                {'spark.rapids.sql.castDecimalToFloat.enabled': 'true'}))
+            conf={'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
 
 @pytest.mark.parametrize('data_gen', [double_gen, decimal_gen_neg_scale, DecimalGen(6, 3),
  DecimalGen(5, 5), DecimalGen(6, 0), DecimalGen(7, 4), DecimalGen(15, 0), DecimalGen(18, 0), 
@@ -150,8 +144,7 @@ def test_division(data_gen):
                 f.lit(-12).cast(data_type) / f.col('b'),
                 f.lit(None).cast(data_type) / f.col('a'),
                 f.col('b') / f.lit(None).cast(data_type),
-                f.col('a') / f.col('b')),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') / f.col('b')))
 
 @allow_non_gpu('ProjectExec', 'Alias', 'Divide', 'Cast', 'PromotePrecision', 'CheckOverflow')
 @pytest.mark.parametrize('data_gen', [DecimalGen(38, 21), DecimalGen(21, 17)], ids=idfn)
@@ -166,8 +159,7 @@ def test_division_fallback_on_decimal(data_gen):
 def test_division_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).select(
-                f.col('a') / f.col('b')),
-            conf = allow_negative_scale_of_decimal_conf)
+                f.col('a') / f.col('b')))
 
 @approximate_float # we should get the perfectly correct answer for floats except when casting a decimal to a float in some corner cases.
 @pytest.mark.parametrize('rhs', [float_gen, double_gen], ids=idfn)
@@ -176,8 +168,7 @@ def test_float_division_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).select(
                 f.col('a') / f.col('b')),
-            conf=copy_and_update(allow_negative_scale_of_decimal_conf,
-                {'spark.rapids.sql.castDecimalToFloat.enabled': 'true'}))
+            conf={'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
 
 @ignore_order
 @pytest.mark.parametrize('rhs,rhs_type', [
@@ -187,15 +178,13 @@ def test_float_division_mixed(lhs, rhs):
     (DecimalGen(15, 3), DecimalType(27, 7)),
     (DecimalGen(3, -3), DecimalType(20, -3))], ids=idfn)
 def test_decimal_division_mixed_no_overflow_guarantees(lhs, lhs_type, rhs, rhs_type):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf,
-                {'spark.rapids.sql.decimalOverflowGuarantees': 'false'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs)\
                     .withColumn('lhs', f.col('a').cast(lhs_type))\
                     .withColumn('rhs', f.col('b').cast(rhs_type))\
                     .repartition(1)\
                     .select(f.col('lhs'), f.col('rhs'), f.col('lhs') / f.col('rhs')),
-            conf = conf)
+            conf={'spark.rapids.sql.decimalOverflowGuarantees': 'false'})
 
 @ignore_order
 @pytest.mark.parametrize('rhs,rhs_type', [
@@ -205,15 +194,13 @@ def test_decimal_division_mixed_no_overflow_guarantees(lhs, lhs_type, rhs, rhs_t
     (DecimalGen(10, 3), DecimalType(27, 7)),
     (DecimalGen(3, -3), DecimalType(20, -3))], ids=idfn)
 def test_decimal_multiplication_mixed_no_overflow_guarantees(lhs, lhs_type, rhs, rhs_type):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf,
-                {'spark.rapids.sql.decimalOverflowGuarantees': 'false'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs)\
                     .withColumn('lhs', f.col('a').cast(lhs_type))\
                     .withColumn('rhs', f.col('b').cast(rhs_type))\
                     .repartition(1)\
                     .select(f.col('lhs'), f.col('rhs'), f.col('lhs') * f.col('rhs')),
-            conf = conf)
+            conf={'spark.rapids.sql.decimalOverflowGuarantees': 'false'})
 
 @pytest.mark.parametrize('data_gen', integral_gens +  [decimal_gen_default, decimal_gen_scale_precision,
         decimal_gen_same_scale_precision, decimal_gen_64bit, decimal_gen_18_3, decimal_gen_30_2,
@@ -233,8 +220,7 @@ def test_int_division(data_gen):
 def test_int_division_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).selectExpr(
-                'a DIV b'),
-            conf=allow_negative_scale_of_decimal_conf)
+                'a DIV b'))
 
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_128_gens + [decimal_gen_scale_precision,
         decimal_gen_64bit], ids=idfn)
@@ -246,8 +232,7 @@ def test_mod(data_gen):
                 f.lit(-12).cast(data_type) % f.col('b'),
                 f.lit(None).cast(data_type) % f.col('a'),
                 f.col('b') % f.lit(None).cast(data_type),
-                f.col('a') % f.col('b')),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') % f.col('b')))
 
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_128_gens_no_neg + [decimal_gen_scale_precision,
         decimal_gen_64bit], ids=idfn)
@@ -269,15 +254,13 @@ def test_signum(data_gen):
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + decimal_128_gens, ids=idfn)
 def test_unary_minus(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'))
 
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens + [float_gen, double_gen] + decimal_gens + decimal_128_gens, ids=idfn)
 def test_unary_minus_ansi_no_overflow(data_gen):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr('-a'),
-            conf=conf)
+            conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_type,value', [
     (LongType(), LONG_MIN),
@@ -285,10 +268,9 @@ def test_unary_minus_ansi_no_overflow(data_gen):
     (ShortType(), SHORT_MIN),
     (ByteType(), BYTE_MIN)], ids=idfn)
 def test_unary_minus_ansi_overflow(data_type, value):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_overflow_df(spark, [value], data_type, '-a').collect(),
-            conf=conf,
+            conf=ansi_enabled_conf,
             error_message='ArithmeticException')
 
 # This just ends up being a pass through.  There is no good way to force
@@ -297,22 +279,19 @@ def test_unary_minus_ansi_overflow(data_type, value):
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + decimal_128_gens, ids=idfn)
 def test_unary_positive(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('+a'),
-            conf=allow_negative_scale_of_decimal_conf)
+        lambda spark : unary_op_df(spark, data_gen).selectExpr('+a'))
 
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + decimal_128_gens, ids=idfn)
 def test_abs(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'))
 
 # ANSI is ignored for abs prior to 3.2.0, but still okay to test it a little more.
 @pytest.mark.parametrize('data_gen', _no_overflow_multiply_gens + [float_gen, double_gen] + decimal_gens + decimal_128_gens, ids=idfn)
 def test_abs_ansi_no_overflow(data_gen):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr('abs(a)'),
-            conf=conf)
+            conf=ansi_enabled_conf)
 
 # Only run this test for Spark v3.2.0 and later to verify abs will
 # throw exceptions for overflow when ANSI mode is enabled.
@@ -323,10 +302,9 @@ def test_abs_ansi_no_overflow(data_gen):
     (ShortType(), SHORT_MIN),
     (ByteType(), BYTE_MIN)], ids=idfn)
 def test_abs_ansi_overflow(data_type, value):
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.sql.ansi.enabled': 'true'})
     assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_overflow_df(spark, [value], data_type, 'abs(a)').collect(),
-            conf=conf,
+            conf=ansi_enabled_conf,
             error_message='ArithmeticException')
 
 @approximate_float
@@ -351,24 +329,22 @@ def test_hypot(data_gen):
 @pytest.mark.parametrize('data_gen', double_n_long_gens + decimal_gens + decimal_128_gens_no_neg, ids=idfn)
 def test_floor(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a)'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('floor(a)'))
 
 @pytest.mark.parametrize('data_gen', double_n_long_gens + decimal_gens + decimal_128_gens_no_neg, ids=idfn)
 def test_ceil(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr('ceil(a)'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).selectExpr('ceil(a)'))
 
 @pytest.mark.parametrize('data_gen', [decimal_gen_36_neg5, decimal_gen_38_neg10], ids=idfn)
 def test_floor_ceil_overflow(data_gen):
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('floor(a)').collect(),
-        conf=allow_negative_scale_of_decimal_conf,
+        conf={},
         error_message="ArithmeticException")
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('ceil(a)').collect(),
-        conf=allow_negative_scale_of_decimal_conf,
+        conf={},
         error_message="ArithmeticException")
 
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
@@ -425,8 +401,7 @@ def test_decimal_bround(data_gen):
                 'bround(a, -1)',
                 'bround(a, 1)',
                 'bround(a, 2)',
-                'bround(a, 10)'),
-                conf=allow_negative_scale_of_decimal_conf)
+                'bround(a, 10)'))
 
 @incompat
 @approximate_float
@@ -438,8 +413,7 @@ def test_decimal_round(data_gen):
                 'round(a, -1)',
                 'round(a, 1)',
                 'round(a, 2)',
-                'round(a, 10)'),
-               conf=allow_negative_scale_of_decimal_conf)
+                'round(a, 10)'))
 
 @incompat
 @approximate_float
@@ -712,7 +686,7 @@ def test_least(data_gen):
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gen).select(
-                f.least(*command_args)), conf=allow_negative_scale_of_decimal_conf)
+                f.least(*command_args)))
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens + decimal_128_gens, ids=idfn)
 def test_greatest(data_gen):
@@ -726,7 +700,7 @@ def test_greatest(data_gen):
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gen).select(
-                f.greatest(*command_args)), conf=allow_negative_scale_of_decimal_conf)
+                f.greatest(*command_args)))
 
 
 def _test_div_by_zero(ansi_mode, expr):
@@ -813,21 +787,20 @@ _data_type_expr_for_add_overflow = [
 
 @pytest.mark.parametrize('data,tp,expr', _data_type_expr_for_add_overflow, ids=idfn)
 def test_add_overflow_with_ansi_enabled(data, tp, expr):
-    ansi_conf = {'spark.sql.ansi.enabled': 'true'}
     if isinstance(tp, IntegralType):
         assert_gpu_and_cpu_error(
             lambda spark: _get_overflow_df(spark, data, tp, expr).collect(),
-            conf=ansi_conf,
+            conf=ansi_enabled_conf,
             error_message='overflow')
     elif isinstance(tp, DecimalType):
         assert_gpu_and_cpu_error(
             lambda spark: _get_overflow_df(spark, data, tp, expr).collect(),
-            conf=ansi_conf,
+            conf=ansi_enabled_conf,
             error_message='')
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: _get_overflow_df(spark, data, tp, expr),
-            conf=ansi_conf)
+            conf=ansi_enabled_conf)
 
 
 _data_type_expr_for_sub_overflow = [
@@ -843,18 +816,17 @@ _data_type_expr_for_sub_overflow = [
 
 @pytest.mark.parametrize('data,tp,expr', _data_type_expr_for_sub_overflow, ids=idfn)
 def test_subtraction_overflow_with_ansi_enabled(data, tp, expr):
-    ansi_conf = {'spark.sql.ansi.enabled': 'true'}
     if isinstance(tp, IntegralType):
         assert_gpu_and_cpu_error(
             lambda spark: _get_overflow_df(spark, data, tp, expr).collect(),
-            conf=ansi_conf,
+            conf=ansi_enabled_conf,
             error_message='overflow')
     elif isinstance(tp, DecimalType):
         assert_gpu_and_cpu_error(
             lambda spark: _get_overflow_df(spark, data, tp, expr).collect(),
-            conf=ansi_conf,
+            conf=ansi_enabled_conf,
             error_message='')
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: _get_overflow_df(spark, data, tp, expr),
-            conf=ansi_conf)
+            conf=ansi_enabled_conf)

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -95,8 +95,7 @@ def test_cast_string_timestamp_fallback():
 def test_cast_decimal_to(data_gen, to_type):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.col('a').cast(to_type), f.col('a')),
-            conf = copy_and_update(allow_negative_scale_of_decimal_conf, 
-                {'spark.rapids.sql.castDecimalToFloat.enabled': 'true'}))
+            conf = {'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
 
 @pytest.mark.parametrize('data_gen', [
     DecimalGen(7, 1),
@@ -115,8 +114,7 @@ def test_cast_decimal_to(data_gen, to_type):
     DecimalType(1, -1)], ids=meta_idfn('to:'))
 def test_cast_decimal_to_decimal(data_gen, to_type):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').cast(to_type), f.col('a')),
-            conf = allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').cast(to_type), f.col('a')))
 
 @pytest.mark.parametrize('data_gen', [byte_gen, short_gen, int_gen, long_gen], ids=idfn)
 @pytest.mark.parametrize('to_type', [
@@ -136,26 +134,22 @@ def test_cast_integral_to_decimal(data_gen, to_type):
 def test_cast_byte_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, byte_gen).select(
-            f.col('a').cast(DecimalType(2, -1))),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+            f.col('a').cast(DecimalType(2, -1))))
 
 def test_cast_short_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, short_gen).select(
-            f.col('a').cast(DecimalType(4, -1))),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+            f.col('a').cast(DecimalType(4, -1))))
 
 def test_cast_int_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, int_gen).select(
-            f.col('a').cast(DecimalType(9, -1))),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+            f.col('a').cast(DecimalType(9, -1))))
 
 def test_cast_long_to_decimal_overflow():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, long_gen).select(
-            f.col('a').cast(DecimalType(18, -1))),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+            f.col('a').cast(DecimalType(18, -1))))
 
 # casting these types to string should be passed
 basic_gens_for_cast_to_string = [ByteGen, ShortGen, IntegerGen, LongGen, StringGen, BooleanGen, DateGen, TimestampGen] 
@@ -204,8 +198,7 @@ def test_cast_array_to_string(data_gen, legacy):
 def test_cast_array_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen,
-        {"spark.sql.legacy.allowNegativeScaleOfDecimal"     : "true",
-         "spark.rapids.sql.castDecimalToString.enabled"    : 'true',
+        {"spark.rapids.sql.castDecimalToString.enabled"     : 'true',
          "spark.rapids.sql.castFloatToString.enabled"       : "true", 
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
@@ -216,7 +209,7 @@ def test_cast_array_with_unmatched_element_to_string(data_gen, legacy):
 def test_cast_map_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen, 
-        {"spark.rapids.sql.castDecimalToString.enabled"    : 'true', 
+        {"spark.rapids.sql.castDecimalToString.enabled"    : 'true',
         "spark.sql.legacy.castComplexTypesToString.enabled": legacy})
 
 
@@ -226,9 +219,8 @@ def test_cast_map_to_string(data_gen, legacy):
 def test_cast_map_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen,
-        {"spark.sql.legacy.allowNegativeScaleOfDecimal"     : "true",
-         "spark.rapids.sql.castDecimalToString.enabled"    : 'true',
-         "spark.rapids.sql.castFloatToString.enabled"       : "true", 
+        {"spark.rapids.sql.castDecimalToString.enabled"     : 'true',
+         "spark.rapids.sql.castFloatToString.enabled"       : "true",
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
 
@@ -282,8 +274,7 @@ def test_two_col_struct_legacy_cast(cast_conf):
 def test_cast_struct_with_unmatched_element_to_string(data_gen, legacy):
     _assert_cast_to_string_equal(
         data_gen, 
-        {"spark.sql.legacy.allowNegativeScaleOfDecimal"     : "true",
-          "spark.rapids.sql.castDecimalToString.enabled"    : 'true',
+        {"spark.rapids.sql.castDecimalToString.enabled"     : 'true',
          "spark.rapids.sql.castFloatToString.enabled"       : "true", 
          "spark.sql.legacy.castComplexTypesToString.enabled": legacy}
     )
@@ -297,4 +288,4 @@ def is_neg_dec_scale_bug_version():
 def test_cast_string_to_negative_scale_decimal():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, StringGen("[0-9]{9}")).select(
-            f.col('a').cast(DecimalType(8, -3))), conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+            f.col('a').cast(DecimalType(8, -3))))

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from marks import incompat, approximate_float
 from spark_session import with_cpu_session
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
@@ -31,7 +30,7 @@ def test_eq(data_gen):
                 s2 == f.col('b'),
                 f.lit(None).cast(data_type) == f.col('a'),
                 f.col('b') == f.lit(None).cast(data_type),
-                f.col('a') == f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') == f.col('b')))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
 def test_eq_ns(data_gen):
@@ -43,7 +42,7 @@ def test_eq_ns(data_gen):
                 s2.eqNullSafe(f.col('b')),
                 f.lit(None).cast(data_type).eqNullSafe(f.col('a')),
                 f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
-                f.col('a').eqNullSafe(f.col('b'))), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a').eqNullSafe(f.col('b'))))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
 def test_ne(data_gen):
@@ -55,7 +54,7 @@ def test_ne(data_gen):
                 s2 != f.col('b'),
                 f.lit(None).cast(data_type) != f.col('a'),
                 f.col('b') != f.lit(None).cast(data_type),
-                f.col('a') != f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') != f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
 def test_lt(data_gen):
@@ -67,7 +66,7 @@ def test_lt(data_gen):
                 s2 < f.col('b'),
                 f.lit(None).cast(data_type) < f.col('a'),
                 f.col('b') < f.lit(None).cast(data_type),
-                f.col('a') < f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') < f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
 def test_lte(data_gen):
@@ -79,7 +78,7 @@ def test_lte(data_gen):
                 s2 <= f.col('b'),
                 f.lit(None).cast(data_type) <= f.col('a'),
                 f.col('b') <= f.lit(None).cast(data_type),
-                f.col('a') <= f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') <= f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
 def test_gt(data_gen):
@@ -91,7 +90,7 @@ def test_gt(data_gen):
                 s2 > f.col('b'),
                 f.lit(None).cast(data_type) > f.col('a'),
                 f.col('b') > f.lit(None).cast(data_type),
-                f.col('a') > f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') > f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
 def test_gte(data_gen):
@@ -103,14 +102,13 @@ def test_gte(data_gen):
                 s2 >= f.col('b'),
                 f.lit(None).cast(data_type) >= f.col('a'),
                 f.col('b') >= f.lit(None).cast(data_type),
-                f.col('a') >= f.col('b')), conf=allow_negative_scale_of_decimal_conf)
+                f.col('a') >= f.col('b')))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_isnull(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(
-                f.isnull(f.col('a'))),
-            conf=allow_negative_scale_of_decimal_conf)
+                f.isnull(f.col('a'))))
 
 @pytest.mark.parametrize('data_gen', [FloatGen(), DoubleGen()], ids=idfn)
 def test_isnan(data_gen):
@@ -121,28 +119,24 @@ def test_isnan(data_gen):
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_dropna_any(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).dropna(),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : binary_op_df(spark, data_gen).dropna())
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_dropna_all(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).dropna(how='all'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : binary_op_df(spark, data_gen).dropna(how='all'))
 
 #dropna is really a filter along with a test for null, but lets do an explicit filter test too
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_filter(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : three_col_df(spark, BooleanGen(), data_gen, data_gen).filter(f.col('a')),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : three_col_df(spark, BooleanGen(), data_gen, data_gen).filter(f.col('a')))
 
 # coalesce batch happens after a filter, but only if something else happens on the GPU after that
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_filter_with_project(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, BooleanGen(), data_gen).filter(f.col('a')).selectExpr('*', 'a as a2'),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : two_col_df(spark, BooleanGen(), data_gen).filter(f.col('a')).selectExpr('*', 'a as a2'))
 
 @pytest.mark.parametrize('expr', [f.lit(True), f.lit(False), f.lit(None).cast('boolean')], ids=idfn)
 def test_filter_with_lit(expr):
@@ -156,11 +150,9 @@ def test_in(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) - 1
     # we have to make the scalars in a session so negative scales in decimals are supported
-    scalars = with_cpu_session(lambda spark: list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen))),
-            conf=allow_negative_scale_of_decimal_conf)
+    scalars = with_cpu_session(lambda spark: list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen))))
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)))
 
 # Spark supports two different versions of 'IN', and it depends on the spark.sql.optimizer.inSetConversionThreshold conf
 # This is to test entries over that value.
@@ -169,9 +161,6 @@ def test_in_set(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) + 1
     # we have to make the scalars in a session so negative scales in decimals are supported
-    scalars = with_cpu_session(lambda spark: list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen))),
-            conf=allow_negative_scale_of_decimal_conf)
+    scalars = with_cpu_session(lambda spark: list(gen_scalars(data_gen, num_entries, force_no_nulls=not isinstance(data_gen, NullGen))))
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)),
-            conf=allow_negative_scale_of_decimal_conf)
-
+            lambda spark : unary_op_df(spark, data_gen).select(f.col('a').isin(scalars)))

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -20,7 +20,6 @@ from pyspark.context import SparkContext
 from pyspark.sql import Row
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
-import pytest
 import random
 from spark_session import is_tz_utc
 import sre_yield
@@ -956,8 +955,7 @@ map_gens_sample = all_basic_map_gens + [MapGen(StringGen(pattern='key_[0-9]', nu
         MapGen(RepeatSeqGen(IntegerGen(nullable=False), 10), long_gen, max_length=10),
         MapGen(StringGen(pattern='key_[0-9]', nullable=False), simple_string_to_string_map_gen)]
 
-allow_negative_scale_of_decimal_conf = {'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'}
-
+ansi_enabled_conf = {'spark.sql.ansi.enabled': 'true'}
 no_nans_conf = {'spark.rapids.sql.hasNans': 'false'}
 
 def copy_and_update(conf, *more_confs):

--- a/integration_tests/src/main/python/explain_mode_test.py
+++ b/integration_tests/src/main/python/explain_mode_test.py
@@ -22,7 +22,6 @@ from marks import ignore_order
 _explain_mode_conf = {'spark.rapids.sql.mode': 'explainOnly',
                       'spark.sql.join.preferSortMergeJoin': 'True',
                       'spark.sql.shuffle.partitions': '2',
-                      'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
                       }
 
 def create_df(spark, data_gen, left_length, right_length):

--- a/integration_tests/src/main/python/generate_expr_test.py
+++ b/integration_tests/src/main/python/generate_expr_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,8 +48,7 @@ def test_explode_litarray(data_gen):
                 f.explode(array_lit)))
 
 # use a small `spark.rapids.sql.batchSizeBytes` to enforce input batches splitting up during explode
-conf_to_enforce_split_input = {'spark.rapids.sql.batchSizeBytes': '8192',
-        'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'}
+conf_to_enforce_split_input = {'spark.rapids.sql.batchSizeBytes': '8192'}
 
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -356,7 +356,7 @@ def test_computation_in_grpby_columns():
 def test_hash_grpby_sum(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, conf))
+        conf = conf)
 
 @pytest.mark.skipif(is_before_spark_311(), reason="SUM overflows for CPU were fixed in Spark 3.1.1")
 @shuffle_test
@@ -368,7 +368,7 @@ def test_hash_grpby_sum(data_gen, conf):
 def test_hash_grpby_sum_full_decimal(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, conf))
+        conf = conf)
 
 @approximate_float
 @ignore_order
@@ -378,7 +378,7 @@ def test_hash_grpby_sum_full_decimal(data_gen, conf):
 def test_hash_reduction_sum(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, length=100).selectExpr("SUM(a)"),
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, conf))
+        conf = conf)
 
 @pytest.mark.skipif(is_before_spark_311(), reason="SUM overflows for CPU were fixed in Spark 3.1.1")
 @approximate_float
@@ -389,7 +389,7 @@ def test_hash_reduction_sum(data_gen, conf):
 def test_hash_reduction_sum_full_decimal(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, length=100).selectExpr("SUM(a)"),
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, conf))
+        conf = conf)
 
 @approximate_float
 @ignore_order
@@ -426,8 +426,7 @@ def test_hash_avg_nulls_partial_only(data_gen):
 @pytest.mark.parametrize('data_gen', _init_list_no_nans_with_decimalbig, ids=idfn)
 def test_intersectAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : gen_df(spark, data_gen, length=100).intersectAll(gen_df(spark, data_gen, length=100)),
-        conf=allow_negative_scale_of_decimal_conf)
+        lambda spark : gen_df(spark, data_gen, length=100).intersectAll(gen_df(spark, data_gen, length=100)))
 
 @approximate_float
 @ignore_order
@@ -435,8 +434,7 @@ def test_intersectAll(data_gen):
 @pytest.mark.parametrize('data_gen', _init_list_no_nans_with_decimalbig, ids=idfn)
 def test_exceptAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : gen_df(spark, data_gen, length=100).exceptAll(gen_df(spark, data_gen, length=100).filter('a != b')),
-        conf=allow_negative_scale_of_decimal_conf)
+        lambda spark : gen_df(spark, data_gen, length=100).exceptAll(gen_df(spark, data_gen, length=100).filter('a != b')))
 
 @approximate_float
 @ignore_order(local=True)
@@ -449,7 +447,7 @@ def test_hash_grpby_pivot(data_gen, conf):
             .groupby('a')
             .pivot('b')
             .agg(f.sum('c')),
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, conf))
+        conf = conf)
 
 @approximate_float
 @ignore_order(local=True)
@@ -599,8 +597,7 @@ _gen_data_for_collect_set_op = [[
 @pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
 def test_decimal128_count_reduction(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, data_gen).selectExpr('count(a)'),
-            conf = allow_negative_scale_of_decimal_conf)
+        lambda spark: unary_op_df(spark, data_gen).selectExpr('count(a)'))
 
 # very simple test for just a count on decimals 128 values until we can support more with them
 @ignore_order(local=True)
@@ -609,16 +606,14 @@ def test_decimal128_count_group_by(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
-            .agg(f.count('b')),
-            conf = allow_negative_scale_of_decimal_conf)
+            .agg(f.count('b')))
 
 # very simple test for just a min/max on decimals 128 values until we can support more with them
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
 def test_decimal128_min_max_reduction(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: unary_op_df(spark, data_gen).selectExpr('min(a)', 'max(a)'),
-            conf = allow_negative_scale_of_decimal_conf)
+        lambda spark: unary_op_df(spark, data_gen).selectExpr('min(a)', 'max(a)'))
 
 # very simple test for just a min/max on decimals 128 values until we can support more with them
 @ignore_order(local=True)
@@ -627,8 +622,7 @@ def test_decimal128_min_max_group_by(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: two_col_df(spark, byte_gen, data_gen)
             .groupby('a')
-            .agg(f.min('b'), f.max('b')),
-            conf = allow_negative_scale_of_decimal_conf)
+            .agg(f.min('b'), f.max('b')))
 
 # to avoid ordering issues with collect_list we do it all in a single task
 @ignore_order(local=True)
@@ -640,7 +634,7 @@ def test_hash_groupby_collect_list(data_gen, use_obj_hash_agg):
             .groupby('a')
             .agg(f.collect_list('b')),
         conf={'spark.sql.execution.useObjectHashAggregateExec': str(use_obj_hash_agg).lower(),
-            'spark.sql.shuffle.partitons': '1'})
+            'spark.sql.shuffle.partitions': '1'})
 
 @approximate_float
 @ignore_order(local=True)
@@ -1048,8 +1042,7 @@ def test_first_last_reductions_decimal_types(data_gen):
         # Coalesce and sort are to make sure that first and last, which are non-deterministic
         # become deterministic
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).selectExpr(
-            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'),
-        conf=allow_negative_scale_of_decimal_conf)
+            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'))
 
 @pytest.mark.parametrize('data_gen', _nested_gens, ids=idfn)
 def test_first_last_reductions_nested_types(data_gen):
@@ -1057,8 +1050,7 @@ def test_first_last_reductions_nested_types(data_gen):
         # Coalesce and sort are to make sure that first and last, which are non-deterministic
         # become deterministic
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).selectExpr(
-            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'),
-        conf=allow_negative_scale_of_decimal_conf)
+            'first(a)', 'last(a)', 'first(a, true)', 'last(a, true)'))
 
 @pytest.mark.parametrize('data_gen', non_nan_all_basic_gens, ids=idfn)
 @pytest.mark.parametrize('parameterless', ['true', pytest.param('false', marks=pytest.mark.xfail(
@@ -1124,8 +1116,7 @@ def test_groupby_first_last(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         # First and last are not deterministic when they are run in a real distributed setup.
         # We set parallelism 1 to prevent nondeterministic results because of distributed setup.
-        lambda spark: agg_fn(gen_df(spark, gen_fn, num_slices=1)),
-        conf=allow_negative_scale_of_decimal_conf)
+        lambda spark: agg_fn(gen_df(spark, gen_fn, num_slices=1)))
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -80,7 +80,6 @@ cartesian_join_small_batch_gens = join_small_batch_gens + [basic_struct_gen, Arr
 _sortmerge_join_conf = {'spark.sql.autoBroadcastJoinThreshold': '-1',
                         'spark.sql.join.preferSortMergeJoin': 'True',
                         'spark.sql.shuffle.partitions': '2',
-                        'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
                         }
 
 # For spark to insert a shuffled hash join it has to be enabled with
@@ -93,7 +92,6 @@ _sortmerge_join_conf = {'spark.sql.autoBroadcastJoinThreshold': '-1',
 _hash_join_conf = {'spark.sql.autoBroadcastJoinThreshold': '160',
                    'spark.sql.join.preferSortMergeJoin': 'false',
                    'spark.sql.shuffle.partitions': '2',
-                   'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'
                   }
 
 def create_df(spark, data_gen, left_length, right_length):
@@ -128,7 +126,7 @@ def test_right_broadcast_nested_loop_join_without_condition_empty(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(broadcast(right), how=join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
@@ -136,7 +134,7 @@ def test_left_broadcast_nested_loop_join_without_condition_empty(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 50)
         return left.join(broadcast(right), how=join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
@@ -144,7 +142,7 @@ def test_broadcast_nested_loop_join_without_condition_empty(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 0, 0)
         return left.join(broadcast(right), how=join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(),
@@ -155,9 +153,7 @@ def test_right_broadcast_nested_loop_join_without_condition_empty_small_batch(jo
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(broadcast(right), how=join_type)
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf,
-            {'spark.sql.adaptive.enabled': 'true'})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.adaptive.enabled': 'true'})
 
 @ignore_order(local=True)
 @pytest.mark.skipif(is_databricks_runtime(),
@@ -168,9 +164,7 @@ def test_empty_broadcast_hash_join(join_type):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(right.hint("broadcast"), left.a == right.r_a, join_type)
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf,
-            {'spark.sql.adaptive.enabled': 'true'})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf = conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.adaptive.enabled': 'true'})
 
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
@@ -238,7 +232,7 @@ def test_broadcast_join_right_table(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', basic_nested_gens + decimal_128_gens + single_array_gens_sample_with_decimal128, ids=idfn)
@@ -249,7 +243,7 @@ def test_broadcast_join_right_table_ridealong(data_gen, join_type):
     def do_join(spark):
         left, right = create_ridealong_df(spark, short_gen, data_gen, 500, 500)
         return left.join(broadcast(right), left.key == right.r_key, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -263,7 +257,7 @@ def test_broadcast_join_right_table_with_job_group(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -276,8 +270,7 @@ def test_cartesian_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(right)
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -290,8 +283,7 @@ def test_cartesian_join_special_case_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(right).selectExpr('COUNT(*)')
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -304,8 +296,7 @@ def test_cartesian_join_special_case_group_by_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(right).groupBy('a').count()
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -335,8 +326,7 @@ def test_broadcast_nested_loop_join(data_gen, batch_size):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.crossJoin(broadcast(right))
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -346,8 +336,7 @@ def test_broadcast_nested_loop_join_special_case_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(broadcast(right)).selectExpr('COUNT(*)')
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -359,8 +348,7 @@ def test_broadcast_nested_loop_join_special_case_group_by_count(batch_size):
     def do_join(spark):
         left, right = create_df(spark, int_gen, 50, 25)
         return left.crossJoin(broadcast(right)).groupBy('a').count()
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -377,8 +365,7 @@ def test_right_broadcast_nested_loop_join_with_ast_condition(data_gen, join_type
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
-    conf = copy_and_update(allow_negative_scale_of_decimal_conf, {'spark.rapids.sql.batchSizeBytes': batch_size})
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.rapids.sql.batchSizeBytes': batch_size})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -392,7 +379,7 @@ def test_left_broadcast_nested_loop_join_with_ast_condition(data_gen):
         # but these take a long time to verify so we run with smaller numbers by default
         # that do not expose the error
         return broadcast(left).join(right, (left.b >= right.r_b), 'Right')
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -408,7 +395,7 @@ def test_broadcast_nested_loop_join_with_condition_post_filter(data_gen, join_ty
         # that do not expose the error
         # AST does not support cast or logarithm yet, so this must be implemented as a post-filter
         return left.join(broadcast(right), left.a > f.log(right.r_a), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'Cast', 'GreaterThan', 'Log')
 @ignore_order(local=True)
@@ -419,8 +406,7 @@ def test_broadcast_nested_loop_join_with_condition_fallback(data_gen, join_type)
         left, right = create_df(spark, data_gen, 50, 25)
         # AST does not support cast or logarithm yet
         return broadcast(left).join(right, left.a > f.log(right.r_a), join_type)
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec', conf=conf)
+    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec')
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
@@ -435,8 +421,7 @@ def test_right_broadcast_nested_loop_join_condition_missing(data_gen, join_type)
         # Compute the distinct of the join result to verify the join produces a proper dataframe
         # for downstream processing.
         return left.join(broadcast(right), how=join_type).distinct()
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
@@ -451,8 +436,7 @@ def test_left_broadcast_nested_loop_join_condition_missing(data_gen, join_type):
         # Compute the distinct of the join result to verify the join produces a proper dataframe
         # for downstream processing.
         return broadcast(left).join(right, how=join_type).distinct()
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + single_array_gens_sample_with_decimal128, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Left', 'LeftSemi', 'LeftAnti'], ids=idfn)
@@ -460,8 +444,7 @@ def test_right_broadcast_nested_loop_join_condition_missing_count(data_gen, join
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.join(broadcast(right), how=join_type).selectExpr('COUNT(*)')
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @pytest.mark.parametrize('data_gen', all_gen + single_level_array_gens + single_array_gens_sample_with_decimal128, ids=idfn)
 @pytest.mark.parametrize('join_type', ['Right'], ids=idfn)
@@ -469,8 +452,7 @@ def test_left_broadcast_nested_loop_join_condition_missing_count(data_gen, join_
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return broadcast(left).join(right, how=join_type).selectExpr('COUNT(*)')
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'GreaterThanOrEqual')
 @ignore_order(local=True)
@@ -480,8 +462,7 @@ def test_broadcast_nested_loop_join_with_conditionals_build_left_fallback(data_g
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return broadcast(left).join(right, (left.b >= right.r_b), join_type)
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec', conf=conf)
+    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec')
 
 @allow_non_gpu('BroadcastExchangeExec', 'BroadcastNestedLoopJoinExec', 'GreaterThanOrEqual')
 @ignore_order(local=True)
@@ -491,8 +472,7 @@ def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, 
     def do_join(spark):
         left, right = create_df(spark, data_gen, 50, 25)
         return left.join(broadcast(right), (left.b >= right.r_b), join_type)
-    conf = allow_negative_scale_of_decimal_conf
-    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec', conf=conf)
+    assert_gpu_fallback_collect(do_join, 'BroadcastNestedLoopJoinExec')
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -505,7 +485,7 @@ def test_broadcast_join_left_table(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -517,7 +497,7 @@ def test_broadcast_join_with_conditionals(data_gen, join_type):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right),
                    (left.a == right.r_a) & (left.b >= right.r_b), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -531,9 +511,8 @@ def test_broadcast_join_with_condition_ast_op_fallback(data_gen, join_type):
         # AST does not support cast or logarithm yet
         return left.join(broadcast(right),
                          (left.a == right.r_a) & (left.b > f.log(right.r_b)), join_type)
-    conf = allow_negative_scale_of_decimal_conf
     exec = 'SortMergeJoinExec' if join_type in ['Right', 'FullOuter'] else 'BroadcastHashJoinExec'
-    assert_gpu_fallback_collect(do_join, exec, conf=conf)
+    assert_gpu_fallback_collect(do_join, exec)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -547,9 +526,8 @@ def test_broadcast_join_with_condition_ast_type_fallback(data_gen, join_type):
         # AST does not support cast or logarithm yet
         return left.join(broadcast(right),
                          (left.a == right.r_a) & (left.b > right.r_b), join_type)
-    conf = allow_negative_scale_of_decimal_conf
     exec = 'SortMergeJoinExec' if join_type in ['Right', 'FullOuter'] else 'BroadcastHashJoinExec'
-    assert_gpu_fallback_collect(do_join, exec, conf=conf)
+    assert_gpu_fallback_collect(do_join, exec)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -561,7 +539,7 @@ def test_broadcast_join_with_condition_post_filter(data_gen, join_type):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right),
                          (left.a == right.r_a) & (left.b > right.r_b), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -614,7 +592,7 @@ def test_broadcast_join_mixed(join_type):
         right = gen_df(spark, _mixed_df2_with_nulls, length=500).withColumnRenamed("a", "r_a")\
                 .withColumnRenamed("b", "r_b").withColumnRenamed("c", "r_c")
         return left.join(broadcast(right), left.a.eqNullSafe(right.r_a), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order
 @allow_non_gpu('DataWritingCommandExec')
@@ -725,7 +703,7 @@ def test_broadcast_join_right_struct_as_key(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 500, 250)
         return left.join(broadcast(right), left.a == right.r_a, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
@@ -737,7 +715,7 @@ def test_broadcast_join_right_struct_mixed_key(data_gen, join_type):
         left = two_col_df(spark, data_gen, int_gen, length=500)
         right = two_col_df(spark, data_gen, int_gen, length=250)
         return left.join(broadcast(right), (left.a == right.a) & (left.b == right.b), join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_join)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this

--- a/integration_tests/src/main/python/limit_test.py
+++ b/integration_tests/src/main/python/limit_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
-from spark_session import is_before_spark_311
+from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from marks import ignore_order, allow_non_gpu
-import pyspark.sql.functions as f
 
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + decimal_128_gens + array_gens_sample + map_gens_sample + struct_gens_sample, ids=idfn)
@@ -26,5 +23,4 @@ def test_simple_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             # We need some processing after the limit to avoid a CollectLimitExec
             lambda spark : unary_op_df(spark, data_gen, num_slices=1).limit(10).repartition(1),
-            conf = copy_and_update(allow_negative_scale_of_decimal_conf, 
-                {'spark.sql.execution.sortBeforeRepartition': 'false'}))
+            conf = {'spark.sql.execution.sortBeforeRepartition': 'false'})

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -20,7 +20,6 @@ from marks import incompat, allow_non_gpu
 from spark_session import is_before_spark_311, is_before_spark_330
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
-import pyspark.sql.functions as f
 
 # Mark all tests in current file as premerge_ci_1 in order to be run in first k8s pod for parallel build premerge job
 pytestmark = pytest.mark.premerge_ci_1
@@ -39,8 +38,7 @@ def test_map_keys(data_gen):
                 # but it works this way for now so lets see if we can maintain it.
                 # Good thing too, because we cannot support sorting all of the types that could be
                 # in here yet, and would need some special case code for checking equality
-                'map_keys(a)'),
-        conf=allow_negative_scale_of_decimal_conf)
+                'map_keys(a)'))
 
 @pytest.mark.parametrize('data_gen', map_gens_sample + decimal_64_map_gens + decimal_128_map_gens, ids=idfn)
 def test_map_values(data_gen):
@@ -50,8 +48,7 @@ def test_map_values(data_gen):
                 # but it works this way for now so lets see if we can maintain it.
                 # Good thing too, because we cannot support sorting all of the types that could be
                 # in here yet, and would need some special case code for checking equality
-                'map_values(a)'),
-        conf=allow_negative_scale_of_decimal_conf)
+                'map_values(a)'))
 
 @pytest.mark.parametrize('data_gen', map_gens_sample  + decimal_64_map_gens + decimal_128_map_gens, ids=idfn)
 def test_map_entries(data_gen):
@@ -61,8 +58,7 @@ def test_map_entries(data_gen):
                 # but it works this way for now so lets see if we can maintain it.
                 # Good thing too, because we cannot support sorting all of the types that could be
                 # in here yet, and would need some special case code for checking equality
-                'map_entries(a)'),
-        conf=allow_negative_scale_of_decimal_conf)
+                'map_entries(a)'))
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_get_map_value(data_gen):
@@ -149,8 +145,7 @@ def test_simple_get_map_value_ansi_fail(data_gen):
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'a["NOT_FOUND"]').collect(),
-                conf={'spark.sql.ansi.enabled':True,
-                      'spark.sql.legacy.allowNegativeScaleOfDecimal': True},
+                conf=ansi_enabled_conf,
                 error_message=message)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")
@@ -159,8 +154,7 @@ def test_map_get_map_value_ansi_not_fail(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'a["NOT_FOUND"]'),
-                conf={'spark.sql.ansi.enabled':True,
-                      'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+                conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_element_at_map(data_gen):
@@ -181,8 +175,7 @@ def test_map_element_at_ansi_fail(data_gen):
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'element_at(a, "NOT_FOUND")').collect(),
-                conf={'spark.sql.ansi.enabled':True,
-                      'spark.sql.legacy.allowNegativeScaleOfDecimal': True},
+                conf=ansi_enabled_conf,
                 error_message=message)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")
@@ -191,8 +184,7 @@ def test_map_element_at_ansi_not_fail(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'element_at(a, "NOT_FOUND")'),
-                conf={'spark.sql.ansi.enabled':True,
-                      'spark.sql.legacy.allowNegativeScaleOfDecimal': True})
+                conf=ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)
 def test_transform_values(data_gen):
@@ -226,8 +218,7 @@ def test_transform_values(data_gen):
 
         return two_col_df(spark, data_gen, byte_gen).selectExpr(columns)
 
-    assert_gpu_and_cpu_are_equal_collect(do_it, 
-            conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 
 @pytest.mark.parametrize('data_gen', map_gens_sample + decimal_128_map_gens + decimal_64_map_gens, ids=idfn)
@@ -244,8 +235,7 @@ def test_transform_keys(data_gen):
 
         return unary_op_df(spark, data_gen).selectExpr(columns)
 
-    assert_gpu_and_cpu_are_equal_collect(do_it, 
-            conf=allow_negative_scale_of_decimal_conf)
+    assert_gpu_and_cpu_are_equal_collect(do_it)
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_transform_keys_null_fail(data_gen):
@@ -280,5 +270,4 @@ def test_transform_keys_last_win_fallback(data_gen):
     'map(1, sequence(1, 5)) as m'], ids=idfn)
 def test_sql_map_scalars(query):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : spark.sql('SELECT {}'.format(query)),
-            conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
+            lambda spark : spark.sql('SELECT {}'.format(query)))

--- a/integration_tests/src/main/python/project_lit_alias_test.py
+++ b/integration_tests/src/main/python/project_lit_alias_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from marks import incompat, approximate_float
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
@@ -27,7 +26,6 @@ def test_project_alias(data_gen):
         lambda spark : binary_op_df(spark, data_gen).select(
             f.col('a').alias('col1'),
             f.col('b').alias('col2'),
-            f.lit(dec)),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
+            f.lit(dec)))
 
 

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -92,8 +92,7 @@ def test_union_struct_missing_children(data_gen):
 # This tests union of two DFs of two cols each. The types of the left col and right col is the same
 def test_union(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).union(binary_op_df(spark, data_gen)),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : binary_op_df(spark, data_gen).union(binary_op_df(spark, data_gen)))
 
 @pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
                                      [all_basic_struct_gen,
@@ -103,8 +102,7 @@ def test_union(data_gen):
 # This tests union of two DFs of two cols each. The types of the left col and right col is the same
 def test_unionAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).unionAll(binary_op_df(spark, data_gen)),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : binary_op_df(spark, data_gen).unionAll(binary_op_df(spark, data_gen)))
 
 @pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
                                      [all_basic_struct_gen,
@@ -120,8 +118,7 @@ def test_unionAll(data_gen):
 def test_union_by_missing_col_name(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : binary_op_df(spark, data_gen).withColumnRenamed("a", "x")
-                                .unionByName(binary_op_df(spark, data_gen).withColumnRenamed("a", "y"), True),
-        conf=allow_negative_scale_of_decimal_conf)
+                                .unionByName(binary_op_df(spark, data_gen).withColumnRenamed("a", "y"), True))
 
 
 # the first number ('1' and '2') is the nest level
@@ -161,8 +158,7 @@ def test_union_by_missing_field_name_in_arrays_structs(gen_pair):
                                       struct_of_maps], ids=idfn)
 def test_union_by_name(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : binary_op_df(spark, data_gen).unionByName(binary_op_df(spark, data_gen)),
-            conf=allow_negative_scale_of_decimal_conf)
+            lambda spark : binary_op_df(spark, data_gen).unionByName(binary_op_df(spark, data_gen)))
 
 
 @pytest.mark.parametrize('data_gen', [
@@ -173,8 +169,7 @@ def test_union_by_name(data_gen):
 ], ids=idfn)
 def test_coalesce_types(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: gen_df(spark, data_gen).coalesce(2),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
+        lambda spark: gen_df(spark, data_gen).coalesce(2))
 
 @pytest.mark.parametrize('num_parts', [1, 10, 100, 1000, 2000], ids=idfn)
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
@@ -182,8 +177,7 @@ def test_coalesce_df(num_parts, length):
     #This should change eventually to be more than just the basic gens
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
+            lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts))
 
 @pytest.mark.parametrize('data_gen', [
     pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]),
@@ -200,8 +194,7 @@ def test_repartition_df(data_gen, num_parts, length):
             # Add a computed column to avoid shuffle being optimized back to a CPU shuffle
             lambda spark : gen_df(spark, data_gen, length=length).withColumn('x', lit(1)).repartition(num_parts),
             # disable sort before shuffle so round robin works for arrays
-            conf = {'spark.sql.execution.sortBeforeRepartition': 'false',
-                'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true'})
+            conf = {'spark.sql.execution.sortBeforeRepartition': 'false'})
 
 @allow_non_gpu('ShuffleExchangeExec', 'RoundRobinPartitioning')
 @pytest.mark.parametrize('data_gen', [[('ag', ArrayGen(string_gen))],
@@ -274,8 +267,7 @@ def test_hash_repartition_exact(gen, num_parts):
                     .repartition(num_parts, *part_on)\
                     .withColumn('id', f.spark_partition_id())\
                     .withColumn('hashed', f.hash(*part_on))\
-                    .selectExpr('*', 'pmod(hashed, {})'.format(num_parts)),
-            conf = allow_negative_scale_of_decimal_conf)
+                    .selectExpr('*', 'pmod(hashed, {})'.format(num_parts)))
 
 # Test a query that should cause Spark to leverage getShuffleRDD
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/sample_test.py
+++ b/integration_tests/src/main/python/sample_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,14 +40,12 @@ nested_gens = array_gens_sample + struct_gens_sample + map_gens_sample
 def test_sample(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, num_slices = 10)
-            .sample(fraction = 0.9, seed = 1),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True}
+            .sample(fraction = 0.9, seed = 1)
     )
 
 @pytest.mark.parametrize('data_gen', basic_gens + nested_gens, ids=idfn)
 def test_sample_with_replacement(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, num_slices = 10).sample(
-            withReplacement =True, fraction = 0.5, seed = 1),
-        conf={'spark.sql.legacy.allowNegativeScaleOfDecimal': True}
+            withReplacement =True, fraction = 0.5, seed = 1)
     )

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -31,6 +31,10 @@ _spark = get_spark_i_know_what_i_am_doing()
 _orig_conf = _from_scala_map(_spark.conf._jconf.getAll())
 _orig_conf_keys = _orig_conf.keys()
 
+# Default settings that should apply to CPU and GPU sessions.
+# These settings can be overridden by specific tests if necessary.
+_default_conf = { 'spark.sql.legacy.allowNegativeScaleOfDecimal': 'true' }
+
 def is_tz_utc(spark=_spark):
     """
     true if the tz is UTC else false
@@ -42,7 +46,9 @@ def is_tz_utc(spark=_spark):
     return utc == sys_tz
 
 def _set_all_confs(conf):
-    for key, value in conf.items():
+    newconf = _default_conf.copy()
+    newconf.update(conf)
+    for key, value in newconf.items():
         if _spark.conf.get(key, None) != value:
             _spark.conf.set(key, value)
 

--- a/integration_tests/src/main/python/struct_test.py
+++ b/integration_tests/src/main/python/struct_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql
-from conftest import is_dataproc_runtime
 from data_gen import *
 from pyspark.sql.types import *
 
@@ -39,7 +38,7 @@ def test_struct_get_item(data_gen):
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
                 'a.first',
                 'a.second',
-                'a.third'), conf=allow_negative_scale_of_decimal_conf)
+                'a.third'))
 
 
 @pytest.mark.parametrize('data_gen', all_basic_gens + [null_gen, decimal_gen_default,
@@ -50,8 +49,7 @@ def test_make_struct(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).selectExpr(
                 'struct(a, b)',
-                'named_struct("foo", b, "m", map("a", "b"), "n", null, "bar", 5, "other", named_struct("z", "z"),"end", a)'),
-            conf = allow_negative_scale_of_decimal_conf)
+                'named_struct("foo", b, "m", map("a", "b"), "n", null, "bar", 5, "other", named_struct("z", "z"),"end", a)'))
 
 
 @pytest.mark.parametrize('data_gen', [StructGen([["first", boolean_gen], ["second", byte_gen], ["third", float_gen]]),

--- a/integration_tests/src/main/python/time_window_test.py
+++ b/integration_tests/src/main/python/time_window_test.py
@@ -75,7 +75,6 @@ def test_sliding_window(data_gen):
 def test_just_window(data_gen):
     row_gen = StructGen([['ts', timestamp_gen],['data', data_gen]], nullable=False)
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : gen_df(spark, row_gen).withColumn('time_bucket', f.window('ts', '5 hour', '1 hour')),
-            conf = allow_negative_scale_of_decimal_conf)
+            lambda spark : gen_df(spark, row_gen).withColumn('time_bucket', f.window('ts', '5 hour', '1 hour')))
 
 

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -147,8 +147,7 @@ def test_decimal128_count_window(data_gen):
         ' count(c) over '
         '   (partition by a order by b asc '
         '      rows between 2 preceding and 10 following) as count_c_asc '
-        'from window_agg_table',
-        conf = allow_negative_scale_of_decimal_conf)
+        'from window_agg_table')
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
@@ -160,8 +159,7 @@ def test_decimal128_count_window_no_part(data_gen):
         ' count(b) over '
         '   (order by a asc '
         '      rows between 2 preceding and 10 following) as count_b_asc '
-        'from window_agg_table',
-        conf = allow_negative_scale_of_decimal_conf)
+        'from window_agg_table')
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
@@ -173,8 +171,7 @@ def test_decimal_sum_window(data_gen):
         ' sum(c) over '
         '   (partition by a order by b asc '
         '      rows between 2 preceding and 10 following) as sum_c_asc '
-        'from window_agg_table',
-        conf = allow_negative_scale_of_decimal_conf)
+        'from window_agg_table')
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
@@ -186,8 +183,7 @@ def test_decimal_sum_window_no_part(data_gen):
         ' sum(b) over '
         '   (order by a asc '
         '      rows between 2 preceding and 10 following) as sum_b_asc '
-        'from window_agg_table',
-        conf = allow_negative_scale_of_decimal_conf)
+        'from window_agg_table')
 
 
 @ignore_order
@@ -201,8 +197,7 @@ def test_decimal_running_sum_window(data_gen):
         '   (partition by a order by b asc '
         '      rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_c_asc '
         'from window_agg_table',
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, 
-            {'spark.rapids.sql.batchSizeBytes': '100'}))
+        conf = {'spark.rapids.sql.batchSizeBytes': '100'})
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
@@ -215,8 +210,7 @@ def test_decimal_running_sum_window_no_part(data_gen):
         '   (order by a asc '
         '      rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_b_asc '
         'from window_agg_table',
-        conf = copy_and_update(allow_negative_scale_of_decimal_conf, 
-            {'spark.rapids.sql.batchSizeBytes': '100'}))
+        conf = {'spark.rapids.sql.batchSizeBytes': '100'})
 
 @pytest.mark.xfail(reason="[UNSUPPORTED] Ranges over order by byte column overflow "
                           "(https://github.com/NVIDIA/spark-rapids/pull/2020#issuecomment-838127070)")
@@ -1024,8 +1018,7 @@ def test_window_ride_along(ride_along):
             "window_agg_table",
             'select *,'
             ' row_number() over (order by a) as row_num '
-            'from window_agg_table ',
-            conf = allow_negative_scale_of_decimal_conf)
+            'from window_agg_table ')
 
 @approximate_float
 @ignore_order


### PR DESCRIPTION
This changes the integration test setup to always request support for negative decimal scales by default.  If desired, tests could still override this by specifying a conf that explicitly sets the config to disallow it.  This reduces a lot of boilerplate on tests that have been copied throughout.

A reusable conf for enabling ANSI was also added to reduce the test boilerplate for this conf which appears in a number of places.
