### PR TITLE
Reduce redundancy of decimal testing [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -25,7 +25,7 @@ from pyspark.sql.functions import array_contains, col, first, isnan, lit, elemen
 # negative indexes for all array gens. When that happens
 # test_nested_array_index should go away and this should test with
 # array_gens_sample instead
-@pytest.mark.parametrize('data_gen', single_level_array_gens + single_array_gens_sample_with_decimal128, ids=idfn)
+@pytest.mark.parametrize('data_gen', single_level_array_gens, ids=idfn)
 def test_array_item(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
@@ -48,10 +48,10 @@ def test_nested_array_item(data_gen):
                 'a[50]'))
 
 
-@pytest.mark.parametrize('data_gen', all_basic_gens +
-                         [decimal_gen_default, decimal_gen_scale_precision] + decimal_128_gens_no_neg
-                         + [StructGen([['child0', StructGen([['child01', IntegerGen()]])], ['child1', string_gen], ['child2', float_gen]], nullable=False),
-                            StructGen([['child0', byte_gen], ['child1', string_gen], ['child2', float_gen]], nullable=False)], ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + [
+                         decimal_gen_32bit, decimal_gen_64bit, decimal_gen_128bit,
+                         StructGen([['child0', StructGen([['child01', IntegerGen()]])], ['child1', string_gen], ['child2', float_gen]], nullable=False),
+                         StructGen([['child0', byte_gen], ['child1', string_gen], ['child2', float_gen]], nullable=False)], ids=idfn)
 def test_make_array(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     assert_gpu_and_cpu_are_equal_collect(
@@ -136,7 +136,7 @@ def test_get_array_item_ansi_not_fail(data_gen):
         spark, data_gen).select(col('a')[100]),
                                conf=ansi_enabled_conf)
 
-@pytest.mark.parametrize('data_gen', array_gens_sample_with_decimal128, ids=idfn)
+@pytest.mark.parametrize('data_gen', array_gens_sample, ids=idfn)
 def test_array_element_at(data_gen):
     assert_gpu_and_cpu_are_equal_collect(lambda spark: unary_op_df(
         spark, data_gen).select(element_at(col('a'), 1),
@@ -168,7 +168,7 @@ def test_array_element_at_all_null_ansi_not_fail(data_gen):
                                conf=ansi_enabled_conf)
 
 
-@pytest.mark.parametrize('data_gen', array_gens_sample_with_decimal128, ids=idfn)
+@pytest.mark.parametrize('data_gen', array_gens_sample, ids=idfn)
 def test_array_transform(data_gen):
     def do_it(spark):
         columns = ['a', 'b',
@@ -200,7 +200,7 @@ def test_array_transform(data_gen):
 
 # TODO add back in string_gen when https://github.com/rapidsai/cudf/issues/9156 is fixed
 array_min_max_gens_no_nan = [byte_gen, short_gen, int_gen, long_gen, FloatGen(no_nans=True), DoubleGen(no_nans=True),
-        string_gen, boolean_gen, date_gen, timestamp_gen, null_gen] + decimal_gens + decimal_128_gens
+        string_gen, boolean_gen, date_gen, timestamp_gen, null_gen] + decimal_gens
 
 @pytest.mark.parametrize('data_gen', array_min_max_gens_no_nan, ids=idfn)
 def test_array_min(data_gen):
@@ -210,7 +210,7 @@ def test_array_min(data_gen):
             conf=no_nans_conf)
 
 
-@pytest.mark.parametrize('data_gen', decimal_128_gens + decimal_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_array_concat_decimal(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : debug_df(unary_op_df(spark, ArrayGen(data_gen)).selectExpr(

--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -23,9 +23,6 @@ from marks import incompat, allow_non_gpu, ignore_order
 
 enable_vectorized_confs = [{"spark.sql.inMemoryColumnarStorage.enableVectorizedReader": "true"},
                            {"spark.sql.inMemoryColumnarStorage.enableVectorizedReader": "false"}]
-decimal_gens = [decimal_gen_default, decimal_gen_neg_scale, decimal_gen_scale_precision,
-                DecimalGen(precision=7, scale=-2),
-                decimal_gen_same_scale_precision, decimal_gen_64bit]
 decimal_struct_gen= StructGen([['child0', sub_gen] for ind, sub_gen in enumerate(decimal_gens)])
 
 @pytest.mark.parametrize('enable_vectorized_conf', enable_vectorized_confs, ids=idfn)
@@ -185,8 +182,8 @@ def test_cache_diff_req_order(spark_tmp_path):
                                                       StructGen([['child0', IntegerGen()]])]])),
                                      pytest.param(FloatGen(special_cases=[FLOAT_MIN, FLOAT_MAX, 0.0, 1.0, -1.0]), marks=[incompat]),
                                      pytest.param(DoubleGen(special_cases=double_special_cases), marks=[incompat]),
-                                     BooleanGen(), DateGen(), TimestampGen(), decimal_gen_default, decimal_gen_scale_precision,
-                                     decimal_gen_same_scale_precision, decimal_gen_64bit] + single_level_array_gens_no_null, ids=idfn)
+                                     BooleanGen(), DateGen(), TimestampGen(), decimal_gen_32bit, decimal_gen_64bit,
+                                     decimal_gen_128bit] + single_level_array_gens_no_null, ids=idfn)
 @pytest.mark.parametrize('ts_write', ['TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS'])
 @pytest.mark.parametrize('enable_vectorized', ['true', 'false'], ids=idfn)
 @ignore_order

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -20,7 +20,7 @@ from spark_session import with_cpu_session
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_eq(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -32,7 +32,7 @@ def test_eq(data_gen):
                 f.col('b') == f.lit(None).cast(data_type),
                 f.col('a') == f.col('b')))
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_eq_ns(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -44,7 +44,7 @@ def test_eq_ns(data_gen):
                 f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
                 f.col('a').eqNullSafe(f.col('b'))))
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_ne(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -56,7 +56,7 @@ def test_ne(data_gen):
                 f.col('b') != f.lit(None).cast(data_type),
                 f.col('a') != f.col('b')))
 
-@pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lt(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -68,7 +68,7 @@ def test_lt(data_gen):
                 f.col('b') < f.lit(None).cast(data_type),
                 f.col('a') < f.col('b')))
 
-@pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lte(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -80,7 +80,7 @@ def test_lte(data_gen):
                 f.col('b') <= f.lit(None).cast(data_type),
                 f.col('a') <= f.col('b')))
 
-@pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gt(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -92,7 +92,7 @@ def test_gt(data_gen):
                 f.col('b') > f.lit(None).cast(data_type),
                 f.col('a') > f.col('b')))
 
-@pytest.mark.parametrize('data_gen', orderable_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gte(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
@@ -104,7 +104,7 @@ def test_gte(data_gen):
                 f.col('b') >= f.lit(None).cast(data_type),
                 f.col('a') >= f.col('b')))
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_isnull(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(
@@ -116,24 +116,24 @@ def test_isnan(data_gen):
             lambda spark : unary_op_df(spark, data_gen).select(
                 f.isnan(f.col('a'))))
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_dropna_any(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).dropna())
 
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_dropna_all(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).dropna(how='all'))
 
 #dropna is really a filter along with a test for null, but lets do an explicit filter test too
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_filter(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : three_col_df(spark, BooleanGen(), data_gen, data_gen).filter(f.col('a')))
 
 # coalesce batch happens after a filter, but only if something else happens on the GPU after that
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_filter_with_project(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, BooleanGen(), data_gen).filter(f.col('a')).selectExpr('*', 'a as a2'))
@@ -145,7 +145,7 @@ def test_filter_with_lit(expr):
 
 # Spark supports two different versions of 'IN', and it depends on the spark.sql.optimizer.inSetConversionThreshold conf
 # This is to test entries under that value.
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_in(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) - 1
@@ -156,7 +156,7 @@ def test_in(data_gen):
 
 # Spark supports two different versions of 'IN', and it depends on the spark.sql.optimizer.inSetConversionThreshold conf
 # This is to test entries over that value.
-@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_in_set(data_gen):
     # nulls are not supported for in on the GPU yet
     num_entries = int(with_cpu_session(lambda spark: spark.conf.get('spark.sql.optimizer.inSetConversionThreshold'))) + 1

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -17,22 +17,18 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error
 from data_gen import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session
 from string_test import mk_str_gen
 import pyspark.sql.functions as f
 
-nested_gens = [ArrayGen(LongGen()), ArrayGen(decimal_gen_38_10),
-               StructGen([("a", LongGen()), ("b", decimal_gen_38_10)]),
+nested_gens = [ArrayGen(LongGen()), ArrayGen(decimal_gen_128bit),
+               StructGen([("a", LongGen()), ("b", decimal_gen_128bit)]),
                MapGen(StringGen(pattern='key_[0-9]', nullable=False), StringGen())]
 # additional test for NonNull Array because of https://github.com/rapidsai/cudf/pull/8181
 non_nested_array_gens = [ArrayGen(sub_gen, nullable=nullable)
                          for nullable in [True, False]
                          for sub_gen in all_gen + [null_gen]]
-non_nested_array_gens_dec128 = [ArrayGen(sub_gen, nullable=nullable)
-                                for nullable in [True, False]
-                                for sub_gen in all_gen + [null_gen] + decimal_128_gens_no_neg]
 
-@pytest.mark.parametrize('data_gen', non_nested_array_gens_dec128, ids=idfn)
+@pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 def test_concat_list(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: binary_op_df(spark, data_gen).selectExpr('concat(a)'))
@@ -48,7 +44,7 @@ def test_empty_concat_list():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: binary_op_df(spark, ArrayGen(LongGen())).selectExpr('concat()'))
 
-@pytest.mark.parametrize('data_gen', non_nested_array_gens_dec128, ids=idfn)
+@pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 def test_concat_list_with_lit(data_gen):
     array_lit = gen_scalar(data_gen)
     array_lit2 = gen_scalar(data_gen)
@@ -86,7 +82,7 @@ def test_concat_string():
                 f.concat(f.lit(''), f.col('b')),
                 f.concat(f.col('a'), f.lit(''))))
 
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens_no_neg + nested_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen + nested_gens, ids=idfn)
 @pytest.mark.parametrize('size_of_null', ['true', 'false'], ids=idfn)
 def test_size_of_array(data_gen, size_of_null):
     gen = ArrayGen(data_gen)
@@ -101,14 +97,14 @@ def test_size_of_map(data_gen, size_of_null):
             lambda spark: unary_op_df(spark, data_gen).selectExpr('size(a)'),
             conf={'spark.sql.legacy.sizeOfNull': size_of_null})
 
-@pytest.mark.parametrize('data_gen', non_nested_array_gens_dec128, ids=idfn)
+@pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 @pytest.mark.parametrize('is_ascending', [True, False], ids=idfn)
 def test_sort_array(data_gen, is_ascending):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen).select(
             f.sort_array(f.col('a'), is_ascending)))
 
-@pytest.mark.parametrize('data_gen', non_nested_array_gens_dec128, ids=idfn)
+@pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 @pytest.mark.parametrize('is_ascending', [True, False], ids=idfn)
 def test_sort_array_lit(data_gen, is_ascending):
     array_lit = gen_scalar(data_gen)

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -41,7 +41,7 @@ if_struct_gens_sample = [if_struct_gen,
         StructGen([['child0', ArrayGen(short_gen)], ['child1', double_gen]])]
 if_nested_gens = if_array_gens_sample + if_struct_gens_sample
 
-@pytest.mark.parametrize('data_gen', all_gens + if_nested_gens + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gens + if_nested_gens, ids=idfn)
 def test_if_else(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     null_lit = get_null_lit_string(data_gen.data_type)
@@ -67,7 +67,7 @@ def test_if_else_map(data_gen):
                 'IF(a, b, c)'))
 
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', all_gens + all_nested_gens + single_array_gens_sample_with_decimal128 + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gens + all_nested_gens, ids=idfn)
 def test_case_when(data_gen):
     num_cmps = 20
     s1 = gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -108,7 +108,7 @@ def test_nanvl(data_gen):
                 f.nanvl(f.lit(None).cast(data_type), f.col('b')),
                 f.nanvl(f.lit(float('nan')).cast(data_type), f.col('b'))))
 
-@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens, ids=idfn)
 def test_nvl(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     null_lit = get_null_lit_string(data_gen.data_type)
@@ -125,7 +125,7 @@ def test_nvl(data_gen):
 # in both cpu and gpu runs.
 #      E: java.lang.AssertionError: assertion failed: each serializer expression should contain\
 #         at least one `BoundReference`
-@pytest.mark.parametrize('data_gen', all_gens + all_nested_gens_nonempty_struct + decimal_128_gens + single_array_gens_sample_with_decimal128, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gens + all_nested_gens_nonempty_struct, ids=idfn)
 def test_coalesce(data_gen):
     num_cols = 20
     s1 = gen_scalar(data_gen, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -146,7 +146,7 @@ def test_coalesce_constant_output():
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.range(1, 100).selectExpr("4 + coalesce(5, id) as nine"))
 
-@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens, ids=idfn)
 def test_nvl2(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     null_lit = get_null_lit_string(data_gen.data_type)
@@ -158,7 +158,7 @@ def test_nvl2(data_gen):
                 'nvl2({}, b, c)'.format(null_lit),
                 'nvl2(a, {}, c)'.format(null_lit)))
 
-@pytest.mark.parametrize('data_gen', eq_gens + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_nullif(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     null_lit = get_null_lit_string(data_gen.data_type)
@@ -170,7 +170,7 @@ def test_nullif(data_gen):
                 'nullif({}, b)'.format(null_lit),
                 'nullif(a, {})'.format(null_lit)))
 
-@pytest.mark.parametrize('data_gen', eq_gens + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_ifnull(data_gen):
     (s1, s2) = gen_scalars_for_sql(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     null_lit = get_null_lit_string(data_gen.data_type)

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -844,22 +844,6 @@ string_gen = StringGen()
 boolean_gen = BooleanGen()
 date_gen = DateGen()
 timestamp_gen = TimestampGen()
-decimal_gen_default = DecimalGen()
-decimal_gen_neg_scale = DecimalGen(precision=7, scale=-3)
-decimal_gen_scale_precision = DecimalGen(precision=7, scale=3)
-decimal_gen_same_scale_precision = DecimalGen(precision=7, scale=7)
-decimal_gen_64bit = DecimalGen(precision=12, scale=2)
-decimal_gen_12_2 = DecimalGen(precision=12, scale=2)
-decimal_gen_18_3 = DecimalGen(precision=18, scale=3)
-decimal_gen_128bit = DecimalGen(precision=20, scale=2)
-decimal_gen_20_2 = DecimalGen(precision=20, scale=2)
-decimal_gen_30_2 = DecimalGen(precision=30, scale=2)
-decimal_gen_36_5 = DecimalGen(precision=36, scale=5)
-decimal_gen_36_neg5 = DecimalGen(precision=36, scale=-5)
-decimal_gen_38_0 = DecimalGen(precision=38, scale=0)
-decimal_gen_38_10 = DecimalGen(precision=38, scale=10)
-decimal_gen_38_neg10 = DecimalGen(precision=38, scale=-10)
-
 null_gen = NullGen()
 
 numeric_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen]
@@ -870,15 +854,13 @@ integral_gens = [byte_gen, short_gen, int_gen, long_gen]
 double_gens = [double_gen]
 double_n_long_gens = [double_gen, long_gen]
 int_n_long_gens = [int_gen, long_gen]
-decimal_gens_no_neg = [decimal_gen_default, decimal_gen_scale_precision,
-        decimal_gen_same_scale_precision, decimal_gen_64bit]
 
-decimal_gens = [decimal_gen_neg_scale] + decimal_gens_no_neg
+decimal_gen_32bit = DecimalGen(precision=7, scale=3)
+decimal_gen_32bit_neg_scale = DecimalGen(precision=7, scale=-3)
+decimal_gen_64bit = DecimalGen(precision=12, scale=2)
+decimal_gen_128bit = DecimalGen(precision=20, scale=2)
 
-decimal_128_gens_no_neg = [decimal_gen_20_2, decimal_gen_30_2, decimal_gen_36_5,
-        decimal_gen_38_0, decimal_gen_38_10]
-
-decimal_128_gens = decimal_128_gens_no_neg + [decimal_gen_36_neg5, decimal_gen_38_neg10]
+decimal_gens = [decimal_gen_32bit, decimal_gen_64bit, decimal_gen_128bit]
 
 # all of the basic gens
 all_basic_gens_no_null = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
@@ -907,9 +889,8 @@ date_n_time_gens = [date_gen, timestamp_gen]
 boolean_gens = [boolean_gen]
 
 single_level_array_gens = [ArrayGen(sub_gen) for sub_gen in all_basic_gens + decimal_gens]
-single_array_gens_sample_with_decimal128 = [ArrayGen(sub_gen) for sub_gen in decimal_128_gens]
 
-single_level_array_gens_no_null = [ArrayGen(sub_gen) for sub_gen in all_basic_gens_no_null + decimal_gens_no_neg]
+single_level_array_gens_no_null = [ArrayGen(sub_gen) for sub_gen in all_basic_gens_no_null + decimal_gens]
 
 single_level_array_gens_no_nan = [ArrayGen(sub_gen) for sub_gen in all_basic_gens_no_nan + decimal_gens]
 
@@ -925,7 +906,6 @@ nested_array_gens_sample = [ArrayGen(ArrayGen(short_gen, max_length=10), max_len
 
 # Some array gens, but not all because of nesting
 array_gens_sample = single_level_array_gens + nested_array_gens_sample
-array_gens_sample_with_decimal128 = single_level_array_gens + nested_array_gens_sample + single_array_gens_sample_with_decimal128
 
 # all of the basic types in a single struct
 all_basic_struct_gen = StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(all_basic_gens)])
@@ -937,18 +917,15 @@ nonempty_struct_gens_sample = [all_basic_struct_gen,
 
 struct_gens_sample = nonempty_struct_gens_sample + [StructGen([])]
 struct_gen_decimal128 = StructGen(
-    [['child' + str(ind), sub_gen] for ind, sub_gen in enumerate(decimal_128_gens)])
-struct_gens_sample_with_decimal128 = struct_gens_sample + [
-    struct_gen_decimal128]
+    [['child' + str(ind), sub_gen] for ind, sub_gen in enumerate([decimal_gen_128bit])])
+struct_gens_sample_with_decimal128 = struct_gens_sample + [struct_gen_decimal128]
 
 simple_string_to_string_map_gen = MapGen(StringGen(pattern='key_[0-9]', nullable=False),
         StringGen(), max_length=10)
 
 all_basic_map_gens = [MapGen(f(nullable=False), f()) for f in [BooleanGen, ByteGen, ShortGen, IntegerGen, LongGen, FloatGen, DoubleGen, DateGen, TimestampGen]] + [simple_string_to_string_map_gen]
-decimal_64_map_gens = [MapGen(key_gen=gen, value_gen=gen, nullable=False) for gen in [DecimalGen(7, 3, nullable=False), DecimalGen(12, 2, nullable=False), DecimalGen(18, -3, nullable=False)]]
-decimal_128_map_gens = [MapGen(key_gen=gen, value_gen=gen, nullable=False) for gen in [DecimalGen(20, 2, nullable=False), DecimalGen(36, 5, nullable=False), DecimalGen(38, 38, nullable=False),
-                                                                                       DecimalGen(36, -5, nullable=False)]]
-decimal_128_no_neg_map_gens = [MapGen(key_gen=gen, value_gen=gen, nullable=False) for gen in [DecimalGen(20, 2, nullable=False), DecimalGen(36, 5, nullable=False), DecimalGen(38, 38, nullable=False)]]
+decimal_64_map_gens = [MapGen(key_gen=gen, value_gen=gen, nullable=False) for gen in [DecimalGen(7, 3, nullable=False), DecimalGen(12, 2, nullable=False)]]
+decimal_128_map_gens = [MapGen(key_gen=gen, value_gen=gen, nullable=False) for gen in [DecimalGen(20, 2, nullable=False)]]
 
 # Some map gens, but not all because of nesting
 map_gens_sample = all_basic_map_gens + [MapGen(StringGen(pattern='key_[0-9]', nullable=False), ArrayGen(string_gen), max_length=10),
@@ -966,8 +943,7 @@ def copy_and_update(conf, *more_confs):
 
 all_gen = [StringGen(), ByteGen(), ShortGen(), IntegerGen(), LongGen(),
            FloatGen(), DoubleGen(), BooleanGen(), DateGen(), TimestampGen(),
-           decimal_gen_default, decimal_gen_scale_precision, decimal_gen_same_scale_precision,
-           decimal_gen_64bit, decimal_gen_128bit, decimal_gen_36_5, decimal_gen_38_10]
+           decimal_gen_32bit, decimal_gen_64bit, decimal_gen_128bit]
 
 # Pyarrow will complain the error as below if the timestamp is out of range for both CPU and GPU,
 # so narrow down the time range to avoid exceptions causing test failures.

--- a/integration_tests/src/main/python/generate_expr_test.py
+++ b/integration_tests/src/main/python/generate_expr_test.py
@@ -32,7 +32,7 @@ def four_op_df(spark, gen, length=2048, seed=0):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_explode_makearray(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : four_op_df(spark, data_gen).selectExpr('a', 'explode(array(b, c, d))'))
@@ -40,7 +40,7 @@ def test_explode_makearray(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_explode_litarray(data_gen):
     array_lit = gen_scalar(ArrayGen(data_gen, min_length=3, max_length=3, nullable=False))
     assert_gpu_and_cpu_are_equal_collect(
@@ -52,8 +52,8 @@ conf_to_enforce_split_input = {'spark.rapids.sql.batchSizeBytes': '8192'}
 
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens +
-                         struct_gens_sample_with_decimal128 + array_gens_sample_with_decimal128 + map_gens_sample,
+@pytest.mark.parametrize('data_gen', all_gen + struct_gens_sample_with_decimal128 +
+                         array_gens_sample + map_gens_sample,
                          ids=idfn)
 def test_explode_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
@@ -74,7 +74,7 @@ def test_explode_map_data(map_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_explode_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
     assert_gpu_and_cpu_are_equal_collect(
@@ -86,8 +86,8 @@ def test_explode_nested_array_data(data_gen):
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens +
-                         struct_gens_sample_with_decimal128 + array_gens_sample_with_decimal128 + map_gens_sample,
+@pytest.mark.parametrize('data_gen', all_gen + struct_gens_sample_with_decimal128 +
+                         array_gens_sample + map_gens_sample,
                          ids=idfn)
 def test_explode_outer_array_data(spark_tmp_path, data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
@@ -108,7 +108,7 @@ def test_explode_outer_map_data(map_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_explode_outer_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
     assert_gpu_and_cpu_are_equal_collect(
@@ -119,7 +119,7 @@ def test_explode_outer_nested_array_data(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_posexplode_makearray(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : four_op_df(spark, data_gen).selectExpr('posexplode(array(b, c, d))', 'a'))
@@ -127,7 +127,7 @@ def test_posexplode_makearray(data_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens_no_neg, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_posexplode_litarray(data_gen):
     array_lit = gen_scalar(ArrayGen(data_gen, min_length=3, max_length=3, nullable=False))
     assert_gpu_and_cpu_are_equal_collect(
@@ -138,8 +138,8 @@ def test_posexplode_litarray(data_gen):
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens +
-                         struct_gens_sample_with_decimal128 + array_gens_sample_with_decimal128 + map_gens_sample,
+@pytest.mark.parametrize('data_gen', all_gen + struct_gens_sample_with_decimal128 +
+                         array_gens_sample + map_gens_sample,
                          ids=idfn)
 def test_posexplode_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
@@ -160,7 +160,7 @@ def test_posexplode_map_data(map_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_posexplode_nested_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
     assert_gpu_and_cpu_are_equal_collect(
@@ -172,8 +172,8 @@ def test_posexplode_nested_array_data(data_gen):
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens +
-                         struct_gens_sample_with_decimal128 + array_gens_sample_with_decimal128 + map_gens_sample,
+@pytest.mark.parametrize('data_gen', all_gen + struct_gens_sample_with_decimal128 +
+                         array_gens_sample + map_gens_sample,
                          ids=idfn)
 def test_posexplode_outer_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(data_gen)]
@@ -194,7 +194,7 @@ def test_posexplode_outer_map_data(map_gen):
 #sort locally because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 def test_posexplode_nested_outer_array_data(data_gen):
     data_gen = [int_gen, ArrayGen(ArrayGen(data_gen))]
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/limit_test.py
+++ b/integration_tests/src/main/python/limit_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 
 
-@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_128_gens + array_gens_sample + map_gens_sample + struct_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens + array_gens_sample + map_gens_sample + struct_gens_sample, ids=idfn)
 def test_simple_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             # We need some processing after the limit to avoid a CollectLimitExec

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.premerge_ci_1
 basic_struct_gen = StructGen([
     ['child' + str(ind), sub_gen]
     for ind, sub_gen in enumerate([StringGen(), ByteGen(), ShortGen(), IntegerGen(), LongGen(),
-                                   BooleanGen(), DateGen(), TimestampGen(), null_gen, decimal_gen_default] + decimal_128_gens_no_neg)],
+                                   BooleanGen(), DateGen(), TimestampGen(), null_gen] + decimal_gens)],
     nullable=False)
 
 @pytest.mark.parametrize('data_gen', map_gens_sample + decimal_64_map_gens + decimal_128_map_gens, ids=idfn)

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -60,7 +60,7 @@ def test_basic_read(std_input_path, name, read_func, v1_enabled_list, orc_impl, 
 orc_basic_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
     string_gen, boolean_gen, DateGen(start=date(1590, 1, 1)),
     TimestampGen(start=datetime(1590, 1, 1, tzinfo=timezone.utc))
-                  ] + decimal_gens_no_neg + decimal_128_gens_no_neg
+                  ] + decimal_gens
 
 orc_basic_struct_gen = StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(orc_basic_gens)])
 
@@ -68,7 +68,7 @@ orc_basic_struct_gen = StructGen([['child'+str(ind), sub_gen] for ind, sub_gen i
 orc_array_gens_sample = [ArrayGen(sub_gen) for sub_gen in orc_basic_gens] + [
     ArrayGen(ArrayGen(short_gen, max_length=10), max_length=10),
     ArrayGen(ArrayGen(string_gen, max_length=10), max_length=10),
-    ArrayGen(ArrayGen(decimal_gen_default, max_length=10), max_length=10),
+    ArrayGen(ArrayGen(decimal_gen_64bit, max_length=10), max_length=10),
     ArrayGen(StructGen([['child0', byte_gen], ['child1', string_gen], ['child2', float_gen]]))]
 
 # Some struct gens, but not all because of nesting.
@@ -92,9 +92,9 @@ orc_basic_map_gens = [simple_string_to_string_map_gen] + [MapGen(f(nullable=Fals
 # Some map gens, but not all because of nesting
 orc_map_gens_sample = orc_basic_map_gens + [
     MapGen(StringGen(pattern='key_[0-9]', nullable=False), ArrayGen(string_gen), max_length=10),
-    MapGen(StringGen(pattern='key_[0-9]', nullable=False), ArrayGen(decimal_gen_36_5), max_length=10),
+    MapGen(StringGen(pattern='key_[0-9]', nullable=False), ArrayGen(decimal_gen_128bit), max_length=10),
     MapGen(StringGen(pattern='key_[0-9]', nullable=False),
-           ArrayGen(StructGen([["c0", decimal_gen_18_3], ["c1", decimal_gen_20_2]])), max_length=10),
+           ArrayGen(StructGen([["c0", decimal_gen_64bit], ["c1", decimal_gen_128bit]])), max_length=10),
     MapGen(RepeatSeqGen(IntegerGen(nullable=False), 10), long_gen, max_length=10),
     MapGen(StringGen(pattern='key_[0-9]', nullable=False), simple_string_to_string_map_gen),
     MapGen(StructGen([['child0', byte_gen], ['child1', long_gen]], nullable=False),

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.nightly_resource_consuming_test
 orc_write_basic_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
         string_gen, boolean_gen, DateGen(start=date(1590, 1, 1)),
         TimestampGen(start=datetime(1970, 1, 1, tzinfo=timezone.utc)) ] + \
-        decimal_gens_no_neg + decimal_128_gens_no_neg
+        decimal_gens
 
 orc_write_basic_struct_gen = StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(orc_write_basic_gens)])
 

--- a/integration_tests/src/main/python/project_lit_alias_test.py
+++ b/integration_tests/src/main/python/project_lit_alias_test.py
@@ -19,7 +19,7 @@ from data_gen import *
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
-@pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
 def test_project_alias(data_gen):
     dec = Decimal('123123123123123123123123123.456')
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/repart_test.py
+++ b/integration_tests/src/main/python/repart_test.py
@@ -84,7 +84,7 @@ def test_union_struct_missing_children(data_gen):
         lambda spark : binary_op_df(spark, left_gen).unionByName(binary_op_df(
             spark, right_gen), True))
 
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
+@pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
                                       StructGen([['child0', DecimalGen(7, 2)]]),
                                       nested_struct,
@@ -94,7 +94,7 @@ def test_union(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).union(binary_op_df(spark, data_gen)))
 
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
+@pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
                                       StructGen([['child0', DecimalGen(7, 2)]]),
                                       nested_struct,
@@ -104,7 +104,7 @@ def test_unionAll(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).unionAll(binary_op_df(spark, data_gen)))
 
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
+@pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
                                       pytest.param(all_basic_struct_gen),
                                       pytest.param(StructGen([[ 'child0', DecimalGen(7, 2)]])),
@@ -151,7 +151,7 @@ def test_union_by_missing_field_name_in_arrays_structs(gen_pair):
 
 
 
-@pytest.mark.parametrize('data_gen', all_gen + decimal_128_gens + map_gens + array_gens_sample_with_decimal128 +
+@pytest.mark.parametrize('data_gen', all_gen + map_gens + array_gens_sample +
                                      [all_basic_struct_gen,
                                       StructGen([['child0', DecimalGen(7, 2)]]),
                                       nested_struct,
@@ -162,7 +162,7 @@ def test_union_by_name(data_gen):
 
 
 @pytest.mark.parametrize('data_gen', [
-    pytest.param([('basic' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]),
+    pytest.param([('basic' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens)]),
     pytest.param([('struct' + str(i), gen) for i, gen in enumerate(struct_gens_sample)]),
     pytest.param([('array' + str(i), gen) for i, gen in enumerate(array_gens_sample)]),
     pytest.param([('map' + str(i), gen) for i, gen in enumerate(map_gens_sample)]),
@@ -175,12 +175,12 @@ def test_coalesce_types(data_gen):
 @pytest.mark.parametrize('length', [0, 2048, 4096], ids=idfn)
 def test_coalesce_df(num_parts, length):
     #This should change eventually to be more than just the basic gens
-    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]
+    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens)]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gen_list, length=length).coalesce(num_parts))
 
 @pytest.mark.parametrize('data_gen', [
-    pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens + decimal_128_gens)]),
+    pytest.param([('_c' + str(i), gen) for i, gen in enumerate(all_basic_gens + decimal_gens)]),
     pytest.param([('s', StructGen([['child0', all_basic_struct_gen]]))]),
     pytest.param([('a', ArrayGen(string_gen))]),
     pytest.param([('m', simple_string_to_string_map_gen)]),
@@ -228,19 +228,9 @@ def test_round_robin_sort_fallback(data_gen):
     ([('a', double_gen)], ['a']),
     ([('a', timestamp_gen)], ['a']),
     ([('a', date_gen)], ['a']),
-    ([('a', decimal_gen_default)], ['a']),
-    ([('a', decimal_gen_neg_scale)], ['a']),
-    ([('a', decimal_gen_scale_precision)], ['a']),
-    ([('a', decimal_gen_same_scale_precision)], ['a']),
-    ([('a', decimal_gen_64bit)], ['a']),
+    ([('a', decimal_gen_32bit)], ['a']),
     ([('a', decimal_gen_64bit)], ['a']),
     ([('a', decimal_gen_128bit)], ['a']),
-    ([('a', decimal_gen_30_2)], ['a']),
-    ([('a', decimal_gen_36_5)], ['a']),
-    ([('a', decimal_gen_36_neg5)], ['a']),
-    ([('a', decimal_gen_38_0)], ['a']),
-    ([('a', decimal_gen_38_10)], ['a']),
-    ([('a', decimal_gen_38_neg10)], ['a']),
     ([('a', string_gen)], ['a']),
     ([('a', null_gen)], ['a']),
     ([('a', StructGen([('c0', boolean_gen), ('c1', StructGen([('c1_0', byte_gen), ('c1_1', string_gen), ('c1_2', boolean_gen)]))]))], ['a']), 
@@ -256,8 +246,8 @@ def test_round_robin_sort_fallback(data_gen):
     ([('a', float_gen), ('b', double_gen), ('c', short_gen)], ['a', 'b', 'c']),
     ([('a', timestamp_gen), ('b', date_gen), ('c', int_gen)], ['a', 'b', 'c']),
     ([('a', short_gen), ('b', string_gen), ('c', int_gen)], ['a', 'b', 'c']),
-    ([('a', decimal_gen_default), ('b', decimal_gen_64bit), ('c', decimal_gen_scale_precision)], ['a', 'b', 'c']),
-    ([('a', decimal_gen_128bit), ('b', decimal_gen_38_neg10), ('c', decimal_gen_36_5)], ['a', 'b', 'c']),
+    ([('a', decimal_gen_64bit), ('b', decimal_gen_64bit), ('c', decimal_gen_64bit)], ['a', 'b', 'c']),
+    ([('a', decimal_gen_128bit), ('b', decimal_gen_128bit), ('c', decimal_gen_128bit)], ['a', 'b', 'c']),
     ], ids=idfn)
 def test_hash_repartition_exact(gen, num_parts):
     data_gen = gen[0]

--- a/integration_tests/src/main/python/row_conversion_test.py
+++ b/integration_tests/src/main/python/row_conversion_test.py
@@ -18,7 +18,6 @@ from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from marks import allow_non_gpu, approximate_float, incompat
 from pyspark.sql.types import *
-import pyspark.sql.functions as f
 from spark_session import with_cpu_session
 
 
@@ -38,8 +37,8 @@ def test_row_conversions():
             ["p", StructGen([["c0", byte_gen], ["c1", ArrayGen(byte_gen)]])],
             ["q", simple_string_to_string_map_gen],
             ["r", MapGen(BooleanGen(nullable=False), ArrayGen(boolean_gen), max_length=2)],
-            ["s", null_gen], ["t", decimal_gen_64bit], ["u", decimal_gen_scale_precision],
-            ["v", decimal_gen_36_5]]
+            ["s", null_gen], ["t", decimal_gen_64bit], ["u", decimal_gen_32bit],
+            ["v", decimal_gen_128bit]]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))
 
@@ -47,7 +46,7 @@ def test_row_conversions_fixed_width():
     gens = [["a", byte_gen], ["b", short_gen], ["c", int_gen], ["d", long_gen],
             ["e", float_gen], ["f", double_gen], ["h", boolean_gen],
             ["i", timestamp_gen], ["j", date_gen], ["k", decimal_gen_64bit],
-            ["l", decimal_gen_scale_precision]]
+            ["l", decimal_gen_32bit]]
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : gen_df(spark, gens).selectExpr("*", "a as a_again"))
 
@@ -77,10 +76,10 @@ def test_row_conversions_fixed_width_wide():
 @pytest.mark.parametrize('data_gen', [
     int_gen,
     string_gen,
-    decimal_gen_default,
-    decimal_gen_36_5,
+    decimal_gen_64bit,
+    decimal_gen_128bit,
     ArrayGen(string_gen, max_length=10),
-    ArrayGen(decimal_gen_36_5, max_length=10),
+    ArrayGen(decimal_gen_128bit, max_length=10),
     StructGen([('a', string_gen)]) ] + map_string_string_gen, ids=idfn)
 @allow_non_gpu('ColumnarToRowExec', 'FileSourceScanExec')
 def test_host_columnar_transition(spark_tmp_path, data_gen):

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -23,9 +23,9 @@ from spark_session import is_before_spark_311
 
 orderable_not_null_gen = [ByteGen(nullable=False), ShortGen(nullable=False), IntegerGen(nullable=False),
         LongGen(nullable=False), FloatGen(nullable=False), DoubleGen(nullable=False), BooleanGen(nullable=False),
-        TimestampGen(nullable=False), DateGen(nullable=False), StringGen(nullable=False), DecimalGen(nullable=False),
-        DecimalGen(precision=7, scale=-3, nullable=False), DecimalGen(precision=7, scale=3, nullable=False),
-        DecimalGen(precision=7, scale=7, nullable=False), DecimalGen(precision=12, scale=2, nullable=False)]
+        TimestampGen(nullable=False), DateGen(nullable=False), StringGen(nullable=False),
+        DecimalGen(precision=7, scale=3, nullable=False), DecimalGen(precision=12, scale=2, nullable=False),
+        DecimalGen(precision=20, scale=2, nullable=False)]
 
 @allow_non_gpu('SortExec', 'ShuffleExchangeExec', 'RangePartitioning', 'SortOrder')
 @pytest.mark.parametrize('data_gen', [StringGen(nullable=False)], ids=idfn)
@@ -43,7 +43,7 @@ def test_sort_nonbinary_carry_binary(data_gen):
                 .withColumn("binary_string", f.col("a").cast(BinaryType()))
                 .orderBy(f.col('a')))
 
-@pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_orderby(data_gen, order):
     assert_gpu_and_cpu_are_equal_collect(
@@ -56,7 +56,7 @@ def test_single_orderby(data_gen, order):
 @pytest.mark.parametrize('stable_sort', ['STABLE', 'OUTOFCORE'])
 @pytest.mark.parametrize('data_gen', [
     pytest.param(all_basic_struct_gen),
-    pytest.param(StructGen([['child0', decimal_gen_38_10]])),
+    pytest.param(StructGen([['child0', decimal_gen_128bit]])),
     pytest.param(StructGen([['child0', all_basic_struct_gen]])),
     pytest.param(ArrayGen(string_gen),
         marks=pytest.mark.xfail(reason="arrays are not supported")),
@@ -97,7 +97,7 @@ def test_single_nested_orderby_fallback_for_nullorder(data_gen, order):
             "SortExec")
 
 # SPARK CPU itself has issue with negative scale for take ordered and project
-orderable_without_neg_decimal = [n for n in (orderable_gens + orderable_not_null_gen + decimal_128_gens) if not (isinstance(n, DecimalGen) and n.scale < 0)]
+orderable_without_neg_decimal = [n for n in (orderable_gens + orderable_not_null_gen) if not (isinstance(n, DecimalGen) and n.scale < 0)]
 @pytest.mark.parametrize('data_gen', orderable_without_neg_decimal, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_orderby_with_limit(data_gen, order):
@@ -134,7 +134,7 @@ def test_single_nested_orderby_with_limit_fallback(data_gen, order):
             'spark.rapids.allowCpuRangePartitioning': False
         })
 
-@pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', orderable_gens + orderable_not_null_gen, ids=idfn)
 @pytest.mark.parametrize('order', [f.col('a').asc(), f.col('a').asc_nulls_last(), f.col('a').desc(), f.col('a').desc_nulls_first()], ids=idfn)
 def test_single_sort_in_part(data_gen, order):
     # We set `num_slices` to handle https://github.com/NVIDIA/spark-rapids/issues/2477
@@ -169,14 +169,14 @@ orderable_gens_sort = [byte_gen, short_gen, int_gen, long_gen,
             reason='Spark has -0.0 < 0.0 before Spark 3.1')),
         pytest.param(double_gen, marks=pytest.mark.xfail(condition=is_before_spark_311(),
             reason='Spark has -0.0 < 0.0 before Spark 3.1')),
-        boolean_gen, timestamp_gen, date_gen, string_gen, null_gen, StructGen([('child0', long_gen)])] + decimal_gens + decimal_128_gens
+        boolean_gen, timestamp_gen, date_gen, string_gen, null_gen, StructGen([('child0', long_gen)])] + decimal_gens
 @pytest.mark.parametrize('data_gen', orderable_gens_sort, ids=idfn)
 def test_multi_orderby(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : binary_op_df(spark, data_gen).orderBy(f.col('a'), f.col('b').desc()))
 
 # SPARK CPU itself has issue with negative scale for take ordered and project
-orderable_gens_sort_without_neg_decimal = [n for n in orderable_gens_sort + decimal_128_gens if not (isinstance(n, DecimalGen) and n.scale < 0)]
+orderable_gens_sort_without_neg_decimal = [n for n in orderable_gens_sort if not (isinstance(n, DecimalGen) and n.scale < 0)]
 @pytest.mark.parametrize('data_gen', orderable_gens_sort_without_neg_decimal, ids=idfn)
 def test_multi_orderby_with_limit(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
@@ -266,8 +266,8 @@ def test_large_orderby(data_gen, stable_sort):
     float_gen,
     date_gen,
     timestamp_gen,
-    decimal_gen_default,
-    decimal_gen_38_10,
+    decimal_gen_64bit,
+    decimal_gen_128bit,
     StructGen([('child1', byte_gen)]),
     simple_string_to_string_map_gen,
     ArrayGen(byte_gen, max_length=5)], ids=idfn)
@@ -285,11 +285,12 @@ def test_large_orderby_nested_ridealong(data_gen):
     float_gen,
     date_gen,
     timestamp_gen,
-    decimal_gen_default,
-    decimal_gen_38_10,
+    decimal_gen_64bit,
+    decimal_gen_128bit,
     StructGen([('child1', byte_gen)]),
     simple_string_to_string_map_gen,
-    ArrayGen(byte_gen, max_length=5)] + decimal_128_gens_no_neg + single_array_gens_sample_with_decimal128, ids=idfn)
+    ArrayGen(byte_gen, max_length=5),
+    ArrayGen(decimal_gen_128bit, max_length=5)], ids=idfn)
 @pytest.mark.order(2)
 def test_orderby_nested_ridealong_limit(data_gen):
     # We use a LongRangeGen to avoid duplicate keys that can cause ambiguity in the sort

--- a/integration_tests/src/main/python/struct_test.py
+++ b/integration_tests/src/main/python/struct_test.py
@@ -30,9 +30,8 @@ def test_struct_scalar_project():
     StructGen([["first", short_gen], ["second", int_gen], ["third", long_gen]]),
     StructGen([["first", double_gen], ["second", date_gen], ["third", timestamp_gen]]),
     StructGen([["first", string_gen], ["second", ArrayGen(byte_gen)], ["third", simple_string_to_string_map_gen]]),
-    StructGen([["first", decimal_gen_default], ["second", decimal_gen_scale_precision], ["third", decimal_gen_same_scale_precision]]),
-    StructGen([["first", decimal_gen_20_2], ["second", decimal_gen_30_2], ["third", decimal_gen_36_5]]),
-    StructGen([["first", decimal_gen_20_2], ["second", decimal_gen_30_2], ["third", decimal_gen_36_neg5]])], ids=idfn)
+    StructGen([["first", decimal_gen_64bit], ["second", decimal_gen_32bit], ["third", decimal_gen_32bit]]),
+    StructGen([["first", decimal_gen_128bit], ["second", decimal_gen_128bit], ["third", decimal_gen_128bit]])], ids=idfn)
 def test_struct_get_item(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
@@ -41,8 +40,8 @@ def test_struct_get_item(data_gen):
                 'a.third'))
 
 
-@pytest.mark.parametrize('data_gen', all_basic_gens + [null_gen, decimal_gen_default,
-                                                       decimal_gen_scale_precision] + decimal_128_gens + single_level_array_gens + struct_gens_sample + map_gens_sample, ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + decimal_gens + [
+    null_gen] + single_level_array_gens + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_make_struct(data_gen):
     # Spark has no good way to create a map literal without the map function
     # so we are inserting one.

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ from data_gen import *
 from marks import *
 
 gens = [('l', LongGen()), ('i', IntegerGen()), ('f', FloatGen()), (
-    's', StringGen()), ('d', decimal_gen_38_10)]
+    's', StringGen()), ('d', decimal_gen_128bit)]
 
 
 @ignore_order

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -138,7 +138,7 @@ all_basic_gens_no_nans = [byte_gen, short_gen, int_gen, long_gen,
         string_gen, boolean_gen, date_gen, timestamp_gen, null_gen]
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
 def test_decimal128_count_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
@@ -150,7 +150,7 @@ def test_decimal128_count_window(data_gen):
         'from window_agg_table')
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
 def test_decimal128_count_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
@@ -162,7 +162,7 @@ def test_decimal128_count_window_no_part(data_gen):
         'from window_agg_table')
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_sum_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
@@ -174,7 +174,7 @@ def test_decimal_sum_window(data_gen):
         'from window_agg_table')
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_sum_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
@@ -187,7 +187,7 @@ def test_decimal_sum_window_no_part(data_gen):
 
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_running_sum_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
@@ -200,7 +200,7 @@ def test_decimal_running_sum_window(data_gen):
         conf = {'spark.rapids.sql.batchSizeBytes': '100'})
 
 @ignore_order
-@pytest.mark.parametrize('data_gen', decimal_gens + decimal_128_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_running_sum_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
@@ -367,7 +367,7 @@ def test_window_aggs_for_rows(data_gen, batch_size):
 # specially, but it only works if all of the aggregations can support this.
 # the order returned should be consistent because the data ends up in a single task (no partitioning)
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches 
-@pytest.mark.parametrize('b_gen', all_basic_gens_no_nans + [decimal_gen_scale_precision], ids=meta_idfn('data:'))
+@pytest.mark.parametrize('b_gen', all_basic_gens_no_nans + [decimal_gen_32bit], ids=meta_idfn('data:'))
 def test_window_running_no_part(b_gen, batch_size):
     conf = {'spark.rapids.sql.batchSizeBytes': batch_size,
             'spark.rapids.sql.hasNans': False,
@@ -423,7 +423,7 @@ def test_running_float_sum_no_part(batch_size):
 # to allow for duplication in the ordering, because there will be no other columns. This means that if you swtich
 # rows it does not matter because the only time rows are switched is when the rows are exactly the same.
 @pytest.mark.parametrize('data_gen',
-                         all_basic_gens_no_nans + [decimal_gen_scale_precision, decimal_gen_38_10],
+                         all_basic_gens_no_nans + [decimal_gen_32bit, decimal_gen_128bit],
                          ids=meta_idfn('data:'))
 def test_window_running_rank_no_part(data_gen):
     # Keep the batch size small. We have tested these with operators with exact inputs already, this is mostly
@@ -452,7 +452,7 @@ def test_window_running_rank_no_part(data_gen):
 # but small batch sizes can make sort very slow, so do the final order by locally
 # TODO: add test data on DECIMAL_128 after we support DECIMAL_128 as PartitionSpec
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_basic_gens + [decimal_gen_scale_precision], ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + [decimal_gen_32bit], ids=idfn)
 def test_window_running_rank(data_gen):
     # Keep the batch size small. We have tested these with operators with exact inputs already, this is mostly
     # testing the fixup operation.
@@ -478,7 +478,7 @@ def test_window_running_rank(data_gen):
 @ignore_order(local=True)
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize('b_gen, c_gen', [(long_gen, x) for x in running_part_and_order_gens] +
-        [(x, long_gen) for x in all_basic_gens_no_nans + [decimal_gen_scale_precision]], ids=idfn)
+        [(x, long_gen) for x in all_basic_gens_no_nans + [decimal_gen_32bit]], ids=idfn)
 def test_window_running(b_gen, c_gen, batch_size):
     conf = {'spark.rapids.sql.batchSizeBytes': batch_size,
             'spark.rapids.sql.hasNans': False,
@@ -797,15 +797,15 @@ _gen_data_for_collect_list = [
     ('c_float', FloatGen()),
     ('c_double', DoubleGen()),
     ('c_decimal_32', DecimalGen(precision=8, scale=3)),
-    ('c_decimal_64', decimal_gen_12_2),
-    ('c_decimal_128', decimal_gen_36_5),
+    ('c_decimal_64', decimal_gen_64bit),
+    ('c_decimal_128', decimal_gen_128bit),
     ('c_struct', StructGen(children=[
         ['child_int', IntegerGen()],
         ['child_time', DateGen()],
         ['child_string', StringGen()],
         ['child_decimal_32', DecimalGen(precision=8, scale=3)],
-        ['child_decimal_64', decimal_gen_12_2],
-        ['child_decimal_128', decimal_gen_36_5]])),
+        ['child_decimal_64', decimal_gen_64bit],
+        ['child_decimal_128', decimal_gen_128bit]])),
     ('c_array', ArrayGen(int_gen)),
     ('c_map', simple_string_to_string_map_gen)]
 
@@ -909,8 +909,8 @@ _gen_data_for_collect_set = [
     ('c_float', RepeatSeqGen(FloatGen(), length=15)),
     ('c_double', RepeatSeqGen(DoubleGen(), length=15)),
     ('c_decimal_32', RepeatSeqGen(DecimalGen(precision=8, scale=3), length=15)),
-    ('c_decimal_64', RepeatSeqGen(decimal_gen_12_2, length=15)),
-    ('c_decimal_128', RepeatSeqGen(decimal_gen_36_5, length=15)),
+    ('c_decimal_64', RepeatSeqGen(decimal_gen_64bit, length=15)),
+    ('c_decimal_128', RepeatSeqGen(decimal_gen_128bit, length=15)),
     # case to verify the NAN_UNEQUAL strategy
     ('c_fp_nan', RepeatSeqGen(FloatGen().with_special_case(math.nan, 200.0), length=5)),
 ]


### PR DESCRIPTION
Relates to #4538 

Reduces the number of decimal types being tested for most tests that aren't really focused on decimal semantics.  Now most tests that test across types will test only three decimal combinations, a 32-bit decimal, a 64-bit decimal, and a 128-bit decimal.  In addition the following notable changes were made:
- `decimal_gens` now includes 128-bit decimals.
- `all_gen` now includes 128-bit decimals
