### PR TITLE
Make InternalExclusiveModeGpuDiscoveryPlugin and ExplainPlanImpl as protected class.

### DIFF
--- a/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/ParquetCachedBatchSerializer.scala
@@ -257,8 +257,9 @@ private case class CloseableColumnBatchIterator(iter: Iterator[ColumnarBatch]) e
 }
 
 /**
- * This class assumes, the data is Columnar and the plugin is on. This is meant to be loaded
- * by reflection only.
+ * This class assumes, the data is Columnar and the plugin is on.
+ * Note, this class should not be referenced directly in source code.
+ * It should be loaded by reflection using ShimLoader.newInstanceOf, see ./docs/dev/shims.md
  */
 protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer with Arm {
 

--- a/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/311+-all/scala/com/nvidia/spark/rapids/shims/v2/ParquetCachedBatchSerializer.scala
@@ -257,7 +257,8 @@ private case class CloseableColumnBatchIterator(iter: Iterator[ColumnarBatch]) e
 }
 
 /**
- * This class assumes, the data is Columnar and the plugin is on
+ * This class assumes, the data is Columnar and the plugin is on. This is meant to be loaded
+ * by reflection only.
  */
 protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer with Arm {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3991,7 +3991,8 @@ object GpuOverrides extends Logging {
 }
 
 /**
- * This class is meant to be loaded by reflection only.
+ * Note, this class should not be referenced directly in source code.
+ * It should be loaded by reflection using ShimLoader.newInstanceOf, see ./docs/dev/shims.md
  */
 protected class ExplainPlanImpl extends ExplainPlanBase {
   override def explainPotentialGpuPlan(df: DataFrame, explain: String): String = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3990,7 +3990,10 @@ object GpuOverrides extends Logging {
   }
 }
 
-class ExplainPlanImpl extends ExplainPlanBase {
+/**
+ * This class is meant to be loaded by reflection only.
+ */
+protected class ExplainPlanImpl extends ExplainPlanBase {
   override def explainPotentialGpuPlan(df: DataFrame, explain: String): String = {
     GpuOverrides.explainPotentialGpuPlan(df, explain)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InternalExclusiveModeGpuDiscoveryPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InternalExclusiveModeGpuDiscoveryPlugin.scala
@@ -28,7 +28,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.resource.{ResourceInformation, ResourceRequest}
 
 /**
- * This class is meant to be loaded by reflection only.
+ * Note, this class should not be referenced directly in source code.
+ * It should be loaded by reflection using ShimLoader.newInstanceOf, see ./docs/dev/shims.md
  */
 protected class InternalExclusiveModeGpuDiscoveryPlugin
   extends ResourceDiscoveryPlugin with Logging {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InternalExclusiveModeGpuDiscoveryPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/InternalExclusiveModeGpuDiscoveryPlugin.scala
@@ -27,7 +27,11 @@ import org.apache.spark.api.resource.ResourceDiscoveryPlugin
 import org.apache.spark.internal.Logging
 import org.apache.spark.resource.{ResourceInformation, ResourceRequest}
 
-class InternalExclusiveModeGpuDiscoveryPlugin extends ResourceDiscoveryPlugin with Logging {
+/**
+ * This class is meant to be loaded by reflection only.
+ */
+protected class InternalExclusiveModeGpuDiscoveryPlugin
+  extends ResourceDiscoveryPlugin with Logging {
   override def discoverResource(
     request: ResourceRequest,
     sparkconf: SparkConf


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/4022.  
Went through the docs and checked all the public classes which can be set. In this PR, we are making InternalExclusiveModeGpuDiscoveryPlugin as protected as it should be loaded only through reflection. 
Updated the comments for  ParquetCachedBatchSerializer as well. 
Rest of the public classes - GpuKryoRegistrator and RapidsShuffleManager doesn't require any changes.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
