### PR TITLE
Make bloopInstall version configurable in buildall

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -19,7 +19,6 @@ set -e
 
 shopt -s extglob
 
-# actually bloopInstall mojo version but it's just a nuance at the moment.
 BLOOP_VERSION=${BLOOP_VERSION:-"1.4.12"}
 BLOOP_SCALA_VERSION=${BLOOP_SCALA_VERSION:-"2.13"}
 SKIP_CLEAN=1

--- a/build/buildall
+++ b/build/buildall
@@ -15,15 +15,22 @@
 # limitations under the License.
 #
 
-set -ex
+set -e
 
 shopt -s extglob
+
+# actually bloopInstall mojo version but it's just a nuance at the moment.
+BLOOP_VERSION=${BLOOP_VERSION:-"1.4.12"}
+BLOOP_SCALA_VERSION=${BLOOP_SCALA_VERSION:-"2.13"}
+SKIP_CLEAN=1
 
 function print_usage() {
   echo "Usage: buildall [OPTION]"
   echo "Options:"
   echo "   -h, --help"
   echo "        print this help message"
+  echo "   --clean"
+  echo "        include Maven clean phase"
   echo "   -gb, --generate-bloop"
   echo "        generate projects for Bloop clients: IDE (Scala Metals, IntelliJ) or Bloop CLI"
   echo "   -p=DIST_PROFILE, --profile=DIST_PROFILE"
@@ -50,7 +57,7 @@ function bloopInstall() {
       mkdir -p "$bloop_config_dir"
       rm -f "$bloop_config_dir"/*
 
-      mvn install ch.epfl.scala:maven-bloop_2.13:1.4.9:bloopInstall -pl dist -am \
+      mvn install ch.epfl.scala:maven-bloop_${BLOOP_SCALA_VERSION}:${BLOOP_VERSION}:bloopInstall -pl dist -am \
         -Dbloop.configDirectory="$bloop_config_dir" \
         -DdownloadSources=true \
         -Dbuildver="$bv" \
@@ -100,6 +107,14 @@ case "$1" in
 
 -P=*|--parallel=*)
   BUILD_PARALLEL="${1#*=}"
+  ;;
+
+--debug)
+  set -x
+  ;;
+
+--clean)
+  SKIP_CLEAN="0"
   ;;
 
 *)
@@ -183,8 +198,10 @@ export BASE_VER=${SPARK_SHIM_VERSIONS[0]}
 export NUM_SHIMS=${#SPARK_SHIM_VERSIONS[@]}
 export BUILD_PARALLEL=${BUILD_PARALLEL:-4}
 
-echo Clean once across all modules
-mvn -q clean
+if [[ "$SKIP_CLEAN" != "1" ]]; then
+  echo Clean once across all modules
+  mvn -q clean
+fi
 
 echo "Building a combined dist jar with Shims for ${SPARK_SHIM_VERSIONS[@]} ..."
 
@@ -219,7 +236,7 @@ function build_single_shim() {
       -Dbuildver="$BUILD_VER" \
       -Drat.skip="$SKIP_CHECKS" \
       -Dmaven.javadoc.skip="$SKIP_CHECKS" \
-      -Dskip="$SKIP_CHECKS" \
+      -Dskip \
       -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
       -pl aggregator -am > "$LOG_FILE" 2>&1 || {
         [[ "$LOG_FILE" != "/dev/tty" ]] && tail -20 "$LOG_FILE" || true

--- a/build/buildall
+++ b/build/buildall
@@ -19,7 +19,7 @@ set -e
 
 shopt -s extglob
 
-BLOOP_VERSION=${BLOOP_VERSION:-"1.4.12"}
+BLOOP_VERSION=${BLOOP_VERSION:-"1.4.13"}
 BLOOP_SCALA_VERSION=${BLOOP_SCALA_VERSION:-"2.13"}
 SKIP_CLEAN=1
 
@@ -28,6 +28,8 @@ function print_usage() {
   echo "Options:"
   echo "   -h, --help"
   echo "        print this help message"
+  echo "   --debug"
+  echo "        enable bash -x tracing right after this option is parsed"
   echo "   --clean"
   echo "        include Maven clean phase"
   echo "   -gb, --generate-bloop"


### PR DESCRIPTION
1. BLOOP_VERSION env variable to configure bloopInstall
2. Make clean phase opt-in via --clean
3. Make `set -x` opt-in via --debug
4. Skip lengthy scaladoc build

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
