### PR TITLE
Support WindowExec partitioning by Decimal 128 on the GPU

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -1194,13 +1194,13 @@ Accelerator supports are described below.
 <td>S</td>
 <td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
 <td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18</em></td>
+<td>S</td>
 <td>S</td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
-<td><em>PS<br/>max child DECIMAL precision of 18;<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, ARRAY, MAP, STRUCT, UDT</em></td>
 <td><b>NS</b></td>
 </tr>
 <tr>

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -996,7 +996,7 @@ def test_nested_part_fallback(part_gen):
 
 @ignore_order(local=True)
 # single-level structs (no nested structs) are now supported by the plugin
-@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]]), StructGen([["a", decimal_gen_36_5]])], ids=meta_idfn('partBy:'))
+@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]])], ids=meta_idfn('partBy:'))
 def test_nested_part_struct(part_gen):
     data_gen = [
             ('a', RepeatSeqGen(part_gen, length=20)),

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -119,14 +119,16 @@ _grpkey_long_with_nulls_with_overflow = [
     ('b', LongGen(nullable=True))]
 
 part_and_order_gens = [long_gen, DoubleGen(no_nans=True, special_cases=[]),
-        string_gen, boolean_gen, timestamp_gen, DecimalGen(precision=18, scale=1)]
+        string_gen, boolean_gen, timestamp_gen, DecimalGen(precision=18, scale=1),
+        DecimalGen(precision=38, scale=1)]
 
 running_part_and_order_gens = [long_gen, DoubleGen(no_nans=True, special_cases=[]),
-        string_gen, byte_gen, timestamp_gen, DecimalGen(precision=18, scale=1)]
+        string_gen, byte_gen, timestamp_gen, DecimalGen(precision=18, scale=1),
+        DecimalGen(precision=38, scale=1)]
 
 lead_lag_data_gens = [long_gen, DoubleGen(no_nans=True, special_cases=[]),
         boolean_gen, timestamp_gen, string_gen, DecimalGen(precision=18, scale=3),
-        DecimalGen(38, 4),
+        DecimalGen(precision=38, scale=4),
         StructGen(children=[
             ['child_int', IntegerGen()],
             ['child_time', DateGen()],
@@ -994,7 +996,7 @@ def test_nested_part_fallback(part_gen):
 
 @ignore_order(local=True)
 # single-level structs (no nested structs) are now supported by the plugin
-@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]])], ids=meta_idfn('partBy:'))
+@pytest.mark.parametrize('part_gen', [StructGen([["a", long_gen]]), StructGen([["a", decimal_gen_36_5]])], ids=meta_idfn('partBy:'))
 def test_nested_part_struct(part_gen):
     data_gen = [
             ('a', RepeatSeqGen(part_gen, length=20)),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3769,8 +3769,8 @@ object GpuOverrides extends Logging {
         TypeSig.all,
         Map("partitionSpec" ->
             InputCheck(
-                TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64 +
-                TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64),
+                TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
+                TypeSig.STRUCT.nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128),
             TypeSig.all))),
       (windowOp, conf, p, r) =>
         new GpuWindowExecMeta(windowOp, conf, p, r)


### PR DESCRIPTION
Fixes #4712.

This updates the WindowExec type check to allow Decimal 128 as a valid type in the partitionSpec. Also, integration tests for window functions have been updated to support higher precision decimals to test Decimal 128 support.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
