### PR TITLE
Optionally return null if element not exists map/array

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -138,15 +138,35 @@ def test_map_scalar_project():
                 "map('a', named_struct('foo', 10, 'bar', 'bar')) as st"
                 "id"))
 
-@pytest.mark.skipif(is_before_spark_311(), reason="Only in Spark 3.1.1 + ANSI mode, map key throws on no such element")
+@pytest.mark.skipif(not is_before_spark_330() or is_before_spark_311(),
+                    reason="Only in Spark 3.1.1+ (< 3.3.0) + ANSI mode, map key throws on no such element")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_get_map_value_ansi_fail(data_gen):
-    message = "org.apache.spark.SparkNoSuchElementException" if not is_before_spark_330() else "java.util.NoSuchElementException"
+    message = "java.util.NoSuchElementException"
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'a["NOT_FOUND"]').collect(),
                 conf=ansi_enabled_conf,
                 error_message=message)
+
+@pytest.mark.skipif(is_before_spark_330(),
+                    reason="Only in Spark 3.3.0 + ANSI mode + Strict Index, map key throws on no such element")
+@pytest.mark.parametrize('strict_index', ['true', 'false'])
+@pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
+def test_simple_get_map_value_with_strict_index(strict_index, data_gen):
+    message = "org.apache.spark.SparkNoSuchElementException"
+    test_conf=copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': strict_index})
+    if strict_index == 'true':  
+        assert_gpu_and_cpu_error(
+                lambda spark: unary_op_df(spark, data_gen).selectExpr(
+                        'a["NOT_FOUND"]').collect(),
+                conf=test_conf,
+                error_message=message)
+    else:
+        assert_gpu_and_cpu_are_equal_collect(
+                lambda spark: unary_op_df(spark, data_gen).selectExpr(
+                        'a["NOT_FOUND"]'),
+                conf=test_conf)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
@@ -172,10 +192,12 @@ def test_simple_element_at_map(data_gen):
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_map_element_at_ansi_fail(data_gen):
     message = "org.apache.spark.SparkNoSuchElementException" if not is_before_spark_330() else "java.util.NoSuchElementException"
+    # For 3.3.0+ strictIndexOperator should not affect element_at
+    test_conf=copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': 'false'})
     assert_gpu_and_cpu_error(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'element_at(a, "NOT_FOUND")').collect(),
-                conf=ansi_enabled_conf,
+                conf=test_conf,
                 error_message=message)
 
 @pytest.mark.skipif(not is_before_spark_311(), reason="For Spark before 3.1.1 + ANSI mode, null will be returned instead of an exception if key is not found")

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShimsBase.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShimsBase.scala
@@ -129,5 +129,7 @@ trait Spark30XdbShimsBase extends SparkShims {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = false
 
+  override def shouldFailOnElementNotExists(): Boolean = false
+
   override def isCastingStringToNegDecimalScaleSupported: Boolean = true
 }

--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XShims.scala
@@ -275,7 +275,7 @@ abstract class Spark31XShims extends Spark301until320Shims with Logging {
       ("ordinal", TypeSig.lit(TypeEnum.INT), TypeSig.INT)),
     (in, conf, p, r) => new GpuGetArrayItemMeta(in, conf, p, r){
       override def convertToGpu(arr: Expression, ordinal: Expression): GpuExpression =
-        GpuGetArrayItem(arr, ordinal, SQLConf.get.ansiEnabled)
+        GpuGetArrayItem(arr, ordinal, shouldFailOnElementNotExists)
     }),
     GpuOverrides.expr[GetMapValue](
       "Gets Value from a Map based on a key",
@@ -284,7 +284,7 @@ abstract class Spark31XShims extends Spark301until320Shims with Logging {
         ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all)),
       (in, conf, p, r) => new GpuGetMapValueMeta(in, conf, p, r){
         override def convertToGpu(map: Expression, key: Expression): GpuExpression =
-          GpuGetMapValue(map, key, SQLConf.get.ansiEnabled)
+          GpuGetMapValue(map, key, shouldFailOnElementNotExists)
       }),
     GpuOverrides.expr[ElementAt](
       "Returns element of array at given(1-based) index in value if column is array. " +
@@ -541,6 +541,8 @@ abstract class Spark31XShims extends Spark301until320Shims with Logging {
   }
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
+
+  override def shouldFailOnElementNotExists(): Boolean = SQLConf.get.ansiEnabled
 
   override def getAdaptiveInputPlan(adaptivePlan: AdaptiveSparkPlanExec): SparkPlan = {
     adaptivePlan.inputPlan

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
@@ -274,7 +274,7 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
       ("ordinal", TypeSig.lit(TypeEnum.INT), TypeSig.INT)),
     (in, conf, p, r) => new GpuGetArrayItemMeta(in, conf, p, r){
       override def convertToGpu(arr: Expression, ordinal: Expression): GpuExpression =
-        GpuGetArrayItem(arr, ordinal, SQLConf.get.ansiEnabled)
+        GpuGetArrayItem(arr, ordinal, shouldFailOnElementNotExists)
     }),
     GpuOverrides.expr[GetMapValue](
       "Gets Value from a Map based on a key",
@@ -283,7 +283,7 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
         ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all)),
       (in, conf, p, r) => new GpuGetMapValueMeta(in, conf, p, r){
         override def convertToGpu(map: Expression, key: Expression): GpuExpression =
-          GpuGetMapValue(map, key, SQLConf.get.ansiEnabled)
+          GpuGetMapValue(map, key, shouldFailOnElementNotExists)
       }),
     GpuOverrides.expr[ElementAt](
       "Returns element of array at given(1-based) index in value if column is array. " +
@@ -832,6 +832,8 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
   }
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
+
+  override def shouldFailOnElementNotExists(): Boolean = SQLConf.get.ansiEnabled
 
   override def getAdaptiveInputPlan(adaptivePlan: AdaptiveSparkPlanExec): SparkPlan = {
     adaptivePlan.inputPlan

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShimsBase.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShimsBase.scala
@@ -128,4 +128,6 @@ trait Spark31XdbShimsBase extends SparkShims {
   }
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = false
+
+  override def shouldFailOnElementNotExists(): Boolean = SQLConf.get.ansiEnabled
 }

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
@@ -153,6 +153,8 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
 
   override def shouldFallbackOnAnsiTimestamp(): Boolean = SQLConf.get.ansiEnabled
 
+  override def shouldFailOnElementNotExists(): Boolean = SQLConf.get.ansiEnabled
+
   override def getLegacyStatisticalAggregate(): Boolean =
     SQLConf.get.legacyStatisticalAggregate
 
@@ -377,7 +379,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
         ("ordinal", TypeSig.lit(TypeEnum.INT), TypeSig.INT)),
       (in, conf, p, r) => new GpuGetArrayItemMeta(in, conf, p, r) {
         override def convertToGpu(arr: Expression, ordinal: Expression): GpuExpression =
-          GpuGetArrayItem(arr, ordinal, SQLConf.get.ansiEnabled)
+          GpuGetArrayItem(arr, ordinal, shouldFailOnElementNotExists)
       }),
     GpuOverrides.expr[GetMapValue](
       "Gets Value from a Map based on a key",
@@ -386,7 +388,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
         ("key", TypeSig.lit(TypeEnum.STRING), TypeSig.all)),
       (in, conf, p, r) => new GpuGetMapValueMeta(in, conf, p, r) {
         override def convertToGpu(map: Expression, key: Expression): GpuExpression =
-          GpuGetMapValue(map, key, SQLConf.get.ansiEnabled)
+          GpuGetMapValue(map, key, shouldFailOnElementNotExists)
       }),
     GpuOverrides.expr[ElementAt](
       "Returns element of array at given(1-based) index in value if column is array. " +

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/Spark33XShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/Spark33XShims.scala
@@ -31,9 +31,17 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
+
 trait Spark33XShims extends Spark33XFileOptionsShims {
+
+  /**
+   * For spark3.3+ optionally return null if element not exists. 
+   */
+  override def shouldFailOnElementNotExists(): Boolean = SQLConf.get.strictIndexOperator
+
   override def neverReplaceShowCurrentNamespaceCommand: ExecRule[_ <: SparkPlan] = null
 
   override def getFileScanRDD(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -221,6 +221,12 @@ trait SparkShims {
    */
   def shouldFallbackOnAnsiTimestamp(): Boolean
 
+  /**
+   * This is to support ANSI mode: optionally return null result if element not exists
+   * in array/map.
+   */
+  def shouldFailOnElementNotExists(): Boolean = false
+
   def createTable(table: CatalogTable,
     sessionCatalog: SessionCatalog,
     tableLocation: Option[URI],


### PR DESCRIPTION
fixes #4668 

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Spark 330 Added a new configuration `spark.sql.ansi.failOnElementNotExists` which controls whether throwing exceptions or returning null results when element not exists in the `[]` operator in array/map type. [Spark-37750 ](https://issues.apache.org/jira/browse/SPARK-37750) 
The default value of the new configuration is true.

This PR adds support of the new flag for rapids.
