### PR TITLE
Profile tool: fix printing of task failed reason

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
@@ -93,7 +93,6 @@ class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: 
 object ProfileOutputWriter {
   val CSVDelimiter = ","
 
-
   /**
    * Regular expression matching full width characters.
    *

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileOutputWriter.scala
@@ -21,8 +21,6 @@ import org.apache.commons.lang3.StringUtils
 class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: Int,
     outputCSV: Boolean = false) {
 
-  private val CSVDelimiter = ","
-
   private val textFileWriter = new ToolTextFileWriter(outputDir,
     s"$filePrefix.log", "Profile summary")
 
@@ -64,13 +62,14 @@ class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: 
         val csvWriter = new ToolTextFileWriter(outputDir,
           s"${suffix}.csv", s"$header CSV:")
         try {
-          val headerString = outRows.head.outputHeaders.mkString(CSVDelimiter)
+          val headerString = outRows.head.outputHeaders.mkString(ProfileOutputWriter.CSVDelimiter)
           csvWriter.write(headerString + "\n")
           val rows = outRows.map(_.convertToSeq)
           rows.foreach { row =>
-            val delimiterHandledRow = row.map(ProfileUtils.replaceDelimiter(_, CSVDelimiter))
+            val delimiterHandledRow =
+              row.map(ProfileUtils.replaceDelimiter(_, ProfileOutputWriter.CSVDelimiter))
             val formattedRow = delimiterHandledRow.map(stringIfempty(_))
-            val outStr = formattedRow.mkString(CSVDelimiter)
+            val outStr = formattedRow.mkString(ProfileOutputWriter.CSVDelimiter)
             csvWriter.write(outStr + "\n")
           }
         } finally {
@@ -92,6 +91,8 @@ class ProfileOutputWriter(outputDir: String, filePrefix: String, numOutputRows: 
 }
 
 object ProfileOutputWriter {
+  val CSVDelimiter = ","
+
 
   /**
    * Regular expression matching full width characters.

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.tool.profiling._
 
+import org.apache.spark.TaskFailedReason
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui.{SparkListenerDriverAccumUpdates, SparkListenerSQLAdaptiveExecutionUpdate, SparkListenerSQLAdaptiveSQLMetricUpdates, SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
@@ -209,12 +210,18 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
             + res.name + ",value=" + res.value + ",update=" + res.update)
       }
     }
+    val reason = event.reason match {
+      case failed: TaskFailedReason =>
+        failed.toErrorString
+      case _ =>
+        event.reason.toString
+    }
 
     val thisTask = TaskCase(
       event.stageId,
       event.stageAttemptId,
       event.taskType,
-      event.reason.toString,
+      reason,
       event.taskInfo.taskId,
       event.taskInfo.attemptNumber,
       event.taskInfo.launchTime,

--- a/tools/src/test/resources/ProfilingExpectations/tasks_failure_eventlog_expectation.csv
+++ b/tools/src/test/resources/ProfilingExpectations/tasks_failure_eventlog_expectation.csv
@@ -1,4 +1,4 @@
 appIndex,stageId,stageAttemptId,taskId,attempt,failureReason
-1,238,0,8519,0,"ExecutorLostFailure(2,true,Some(Executor Process Lost))"
-1,238,0,8560,1,"FetchFailed(BlockManagerId(1, hostname-08.domain.com, 46008, None),54,8347,9,72,org.apache.spark.shu"
-1,238,0,8574,1,"FetchFailed(BlockManagerId(1, hostname-08.domain.com, 46008, None),54,8339,1,138,org.apache.spark.sh"
+1,238,0,8519,0,ExecutorLostFailure (executor 2 exited caused by one of the running tasks) Reason: Executor Process 
+1,238,0,8560,1,FetchFailed(BlockManagerId(1; hostname-08.domain.com; 46008; None); shuffleId=54; mapIndex=9; mapId=
+1,238,0,8574,1,FetchFailed(BlockManagerId(1; hostname-08.domain.com; 46008; None); shuffleId=54; mapIndex=1; mapId=

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
@@ -58,7 +58,7 @@ class HealthCheckSuite extends FunSuite {
     val healthCheck = new HealthCheck(apps)
     for (app <- apps) {
       val failedTasks = healthCheck.getFailedTasks
-      // the end reason gets the delimtier changed when writing to CSV so to compare properly
+      // the end reason gets the delimiter changed when writing to CSV so to compare properly
       // change it to be the same here
       val failedWithDelimiter = failedTasks.map { t =>
         val delimited = ProfileUtils.replaceDelimiter(t.endReason, ProfileOutputWriter.CSVDelimiter)

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/HealthCheckSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,14 @@ class HealthCheckSuite extends FunSuite {
     val healthCheck = new HealthCheck(apps)
     for (app <- apps) {
       val failedTasks = healthCheck.getFailedTasks
+      // the end reason gets the delimtier changed when writing to CSV so to compare properly
+      // change it to be the same here
+      val failedWithDelimiter = failedTasks.map { t =>
+        val delimited = ProfileUtils.replaceDelimiter(t.endReason, ProfileOutputWriter.CSVDelimiter)
+        t.copy(endReason = delimited)
+      }
       import sparkSession.implicits._
-      val taskAccums = failedTasks.toDF
+      val taskAccums = failedWithDelimiter.toDF
       val tasksResultExpectation =
         new File(expRoot, "tasks_failure_eventlog_expectation.csv")
       val tasksDfExpect =


### PR DESCRIPTION
In the profiling tool task failed table, we were just doing a toString on the task end reason. This caused it to some times have an address in the output and that address could change between runs.  Fix it so we use the toErrorString to get the nicely formatted string. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
