### PR TITLE
Also check cuda runtime version when using the ASYNC allocator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1492,8 +1492,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val rmmPool: String = {
     val pool = get(RMM_POOL)
-    if ("ASYNC".equalsIgnoreCase(pool) && Cuda.getDriverVersion < 11020) {
-      logWarning("CUDA driver does not support the ASYNC allocator, falling back to ARENA")
+    if ("ASYNC".equalsIgnoreCase(pool) &&
+        (Cuda.getRuntimeVersion < 11020 || Cuda.getDriverVersion < 11020)) {
+      logWarning("CUDA runtime/driver does not support the ASYNC allocator, falling back to ARENA")
       "ARENA"
     } else {
       pool


### PR DESCRIPTION
It's possible to use the newest driver with a runtime < 11.2, in which case ASYNC would break.

Signed-off-by: Rong Ou <rong.ou@gmail.com>
