### PR TITLE
Avoid regexp_cost with stringSplit on the GPU using transpilation

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -488,8 +488,14 @@ class CudfRegexTranspiler(mode: RegexMode) {
   }
 
   def transpileToSplittableString(pattern: String): Option[String] = {
-    val regex = new RegexParser(pattern).parse()
-    transpileToSplittableString(regex)
+    try {
+      val regex = new RegexParser(pattern).parse()
+      transpileToSplittableString(regex)
+    } catch {
+      // treat as regex if we can't parse it
+      case _: RegexUnsupportedException =>
+        None
+    }
   }
 
   private def isRepetition(e: RegexAST): Boolean = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1358,17 +1358,7 @@ abstract class StringSplitRegExpMeta[INPUT <: TernaryExpression](expr: INPUT,
               }
           }
         } else {
-          val str = utf8Str.toString
-          isRegExp = RegexParser.isRegExpString(str)
-          if (isRegExp) {
-            try {
-              pattern = new CudfRegexTranspiler(RegexSplitMode).transpile(str)
-            } catch {
-              case e: RegexUnsupportedException => willNotWorkOnGpu(e.getMessage)
-            }
-          } else {
-            pattern = str
-          }
+          pattern = utf8Str.toString
         }
       }
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1341,6 +1341,22 @@ abstract class StringSplitRegExpMeta[INPUT <: TernaryExpression](expr: INPUT,
       } else {
         if (utf8Str.numChars() == 0) {
           willNotWorkOnGpu("An empty delimiter pattern is not supported")
+        }
+        isRegExp = RegexParser.isRegExpString(utf8Str.toString)
+        if (isRegExp) {
+          val transpiler = new CudfRegexTranspiler(RegexSplitMode)
+          transpiler.transpileToSplittableString(utf8Str.toString) match {
+            case Some(simplified) =>
+              pattern = simplified
+              isRegExp = false
+            case None =>
+              try {
+                pattern = transpiler.transpile(utf8Str.toString)
+              } catch {
+                case e: RegexUnsupportedException =>
+                  willNotWorkOnGpu(e.getMessage)
+              }
+          }
         } else {
           val str = utf8Str.toString
           isRegExp = RegexParser.isRegExpString(str)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1342,23 +1342,18 @@ abstract class StringSplitRegExpMeta[INPUT <: TernaryExpression](expr: INPUT,
         if (utf8Str.numChars() == 0) {
           willNotWorkOnGpu("An empty delimiter pattern is not supported")
         }
-        isRegExp = RegexParser.isRegExpString(utf8Str.toString)
-        if (isRegExp) {
-          val transpiler = new CudfRegexTranspiler(RegexSplitMode)
-          transpiler.transpileToSplittableString(utf8Str.toString) match {
-            case Some(simplified) =>
-              pattern = simplified
-              isRegExp = false
-            case None =>
-              try {
-                pattern = transpiler.transpile(utf8Str.toString)
-              } catch {
-                case e: RegexUnsupportedException =>
-                  willNotWorkOnGpu(e.getMessage)
-              }
-          }
-        } else {
-          pattern = utf8Str.toString
+        val transpiler = new CudfRegexTranspiler(RegexSplitMode)
+        transpiler.transpileToSplittableString(utf8Str.toString) match {
+          case Some(simplified) =>
+            pattern = simplified
+          case None =>
+            try {
+              pattern = transpiler.transpile(utf8Str.toString)
+              isRegExp = true
+            } catch {
+              case e: RegexUnsupportedException =>
+                willNotWorkOnGpu(e.getMessage)
+            }
         }
       }
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -437,9 +437,9 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split - optimized") {
-    val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", "c\\|d")
+    val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", ",", ";", "cd", "c\\|d")
     val data = Seq("abc.def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
-        "abc|def")
+        "abc,def", "abc;def", "abcdef", "abc|def")
     for (limit <- Seq(Integer.MIN_VALUE, -2, -1)) {
       assertTranspileToSplittableString(patterns)
       doStringSplitTest(patterns, data, limit)
@@ -666,8 +666,11 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     input.map(s => s.split(pattern, limit))
   }
 
-  private def gpuSplit(pattern: String, input: Seq[String],
-                       limit: Int, isRegex: Boolean): Seq[Array[String]] = {
+  private def gpuSplit(
+      pattern: String,
+      input: Seq[String],
+      limit: Int,
+      isRegex: Boolean): Seq[Array[String]] = {
     withResource(ColumnVector.fromStrings(input: _*)) { cv =>
       withResource(cv.stringSplitRecord(pattern, limit, isRegex)) { x =>
         withResource(x.copyToHost()) { hcv =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -436,6 +436,26 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     doAstFuzzTest(Some(REGEXP_LIMITED_CHARS_REPLACE), RegexReplaceMode)
   }
 
+  test("string split - optimized") {
+    val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", "c\\|d")
+    val data = Seq("abc.def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
+        "abc|def")
+    for (limit <- Seq(Integer.MIN_VALUE, -2, -1)) {
+      assertTranspileToSplittableString(patterns)
+      doStringSplitTest(patterns, data, limit)
+    }
+  }
+
+  test("string split - not optimized") {
+    val patterns = Set(".\\$", "\\[.", "\\(.", ".\\}", "\\+.", "c.\\|d")
+    val data = Seq("abc.$def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
+        "abc#|def")
+    for (limit <- Seq(Integer.MIN_VALUE, -2, -1)) {
+      assertNoTranspileToSplittableString(patterns)
+      doStringSplitTest(patterns, data, limit)
+    }
+  }
+
   test("string split - limit < 0") {
     val patterns = Set("[^A-Z]+", "[0-9]+", ":", "o", "[:o]")
     val data = Seq("abc", "123", "1\n2\n3\n", "boo:and:foo")
@@ -460,17 +480,53 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     }
   }
 
+  def assertTranspileToSplittableString(patterns: Set[String]) {
+    for (pattern <- patterns) {
+      val transpiler = new CudfRegexTranspiler(RegexSplitMode)
+      transpiler.transpileToSplittableString(pattern) match {
+        case None =>
+          fail(s"string_split pattern=${toReadableString(pattern)} " +
+            "does not produce a simplified string to split on"
+          )
+        case _ =>
+      }
+    }
+  }
+
+  def assertNoTranspileToSplittableString(patterns: Set[String]) {
+    for (pattern <- patterns) {
+      val transpiler = new CudfRegexTranspiler(RegexSplitMode)
+      transpiler.transpileToSplittableString(pattern) match {
+        case Some(_) =>
+          fail(s"string_split pattern=${toReadableString(pattern)} " +
+            "is trying to produce a simplified string to split on when " +
+            "it can't"
+          )
+        case _ =>
+      }
+    }
+  }
+
   def doStringSplitTest(patterns: Set[String], data: Seq[String], limit: Int) {
     for (pattern <- patterns) {
       val cpu = cpuSplit(pattern, data, limit)
-      val cudfPattern = new CudfRegexTranspiler(RegexSplitMode).transpile(pattern)
-      val gpu = gpuSplit(cudfPattern, data, limit)
+      val transpiler = new CudfRegexTranspiler(RegexSplitMode)
+      val (isRegex, cudfPattern) = if (RegexParser.isRegExpString(pattern)) {
+        transpiler.transpileToSplittableString(pattern) match {
+          case Some(simplified) => (false, simplified)
+          case _ => (true, transpiler.transpile(pattern))
+        }
+      } else {
+        (false, pattern)
+      }
+      val gpu = gpuSplit(cudfPattern, data, limit, isRegex)
       assert(cpu.length == gpu.length)
       for (i <- cpu.indices) {
         val cpuArray = cpu(i)
         val gpuArray = gpu(i)
         if (!cpuArray.sameElements(gpuArray)) {
           fail(s"string_split pattern=${toReadableString(pattern)} " +
+            s"isRegex=$isRegex " +
             s"data=${toReadableString(data(i))} limit=$limit " +
             s"\nCPU [${cpuArray.length}]: ${toReadableString(cpuArray.mkString(", "))} " +
             s"\nGPU [${gpuArray.length}]: ${toReadableString(gpuArray.mkString(", "))}")
@@ -610,8 +666,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     input.map(s => s.split(pattern, limit))
   }
 
-  private def gpuSplit(pattern: String, input: Seq[String], limit: Int): Seq[Array[String]] = {
-    val isRegex = RegexParser.isRegExpString(pattern)
+  private def gpuSplit(pattern: String, input: Seq[String],
+                       limit: Int, isRegex: Boolean): Seq[Array[String]] = {
     withResource(ColumnVector.fromStrings(input: _*)) { cv =>
       withResource(cv.stringSplitRecord(pattern, limit, isRegex)) { x =>
         withResource(x.copyToHost()) { hcv =>


### PR DESCRIPTION
Fixes #4685.

This avoids the RegExp cost on the GPU by transpiling simple patterns that only contain a combination of non-special characters and escaped meta characters to simplified strings that can be passed to string split with RegExp disabled.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
