### PR TITLE
Aggregate (Min/Max/Count) push down for ORC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,7 @@
                                         <source>${project.basedir}/src/main/311until330-all/scala</source>
                                         <source>${project.basedir}/src/main/320/scala</source>
                                         <source>${project.basedir}/src/main/320+/scala</source>
+                                        <source>${project.basedir}/src/main/320until330-all/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
                                 </configuration>
@@ -694,6 +695,7 @@
                                         <source>${project.basedir}/src/main/311+-nondb/scala</source>
                                         <source>${project.basedir}/src/main/311until330-all/scala</source>
                                         <source>${project.basedir}/src/main/320+/scala</source>
+                                        <source>${project.basedir}/src/main/320until330-all/scala</source>
                                         <source>${project.basedir}/src/main/321+/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
@@ -758,6 +760,7 @@
                                         <source>${project.basedir}/src/main/311until330-all/scala</source>
                                         <source>${project.basedir}/src/main/320+/scala</source>
                                         <source>${project.basedir}/src/main/321+/scala</source>
+                                        <source>${project.basedir}/src/main/320until330-all/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
                                 </configuration>

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/v2/Spark30XdbShims.scala
@@ -388,42 +388,10 @@ abstract class Spark30XdbShims extends Spark30XdbShimsBase with Logging {
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan = {
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-        }
-      }),
+      (a, conf, p, r) => new RapidsParquetScanMeta(a, conf, p, r)),
     GpuOverrides.scan[OrcScan](
       "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit =
-          GpuOrcScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      })
+      (a, conf, p, r) => new RapidsOrcScanMeta(a, conf, p, r))
   ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def getPartitionFileNames(

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.Scan
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+
+class RapidsOrcScanMeta(
+    oScan: OrcScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[OrcScan](oScan, conf, parent, rule) {
+  
+  override def tagSelfForGpu(): Unit = {
+    GpuOrcScanBase.tagSupport(this)
+  }
+
+  override def convertToGpu(): Scan =
+    GpuOrcScan(oScan.sparkSession,
+      oScan.hadoopConf,
+      oScan.fileIndex,
+      oScan.dataSchema,
+      oScan.readDataSchema,
+      oScan.readPartitionSchema,
+      oScan.options,
+      oScan.pushedFilters,
+      oScan.partitionFilters,
+      oScan.dataFilters,
+      conf)
+}

--- a/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/301until320-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.Scan
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+
+class RapidsParquetScanMeta(
+    pScan: ParquetScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[ParquetScan](pScan, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    GpuParquetScanBase.tagSupport(this)
+  }
+
+  override def convertToGpu(): Scan = {
+    GpuParquetScan(pScan.sparkSession,
+      pScan.hadoopConf,
+      pScan.fileIndex,
+      pScan.dataSchema,
+      pScan.readDataSchema,
+      pScan.readPartitionSchema,
+      pScan.pushedFilters,
+      pScan.options,
+      pScan.partitionFilters,
+      pScan.dataFilters,
+      conf)
+  }
+}

--- a/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301until320Shims.scala
+++ b/sql-plugin/src/main/301until320-nondb/scala/com/nvidia/spark/rapids/shims/v2/Spark301until320Shims.scala
@@ -161,42 +161,10 @@ trait Spark301until320Shims extends SparkShims {
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan = {
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-        }
-      }),
+      (a, conf, p, r) => new RapidsParquetScanMeta(a, conf, p, r)),
     GpuOverrides.scan[OrcScan](
       "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit =
-          GpuOrcScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      })
+      (a, conf, p, r) => new RapidsOrcScanMeta(a, conf, p, r))
   ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def getPartitionFileNames(

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/v2/Spark31XdbShims.scala
@@ -507,42 +507,10 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = GpuParquetScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan = {
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-        }
-      }),
+      (a, conf, p, r) => new RapidsParquetScanMeta(a, conf, p, r)),
     GpuOverrides.scan[OrcScan](
       "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit =
-          GpuOrcScanBase.tagSupport(this)
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      })
+      (a, conf, p, r) => new RapidsOrcScanMeta(a, conf, p, r))
   ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def getPartitionFileNames(

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/RapidsCsvScanMeta.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuCSVScan, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
+
+class RapidsCsvScanMeta(
+    cScan: CSVScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[CSVScan](cScan, conf, parent, rule) {
+  
+  override def tagSelfForGpu(): Unit = {
+    GpuCSVScan.tagSupport(this)
+    // we are being overly cautious and that Csv does not support this yet
+    if (cScan.isInstanceOf[SupportsRuntimeFiltering]) {
+      willNotWorkOnGpu("Csv does not support Runtime filtering (DPP)" +
+        " on datasource V2 yet.")
+    }
+  }
+
+  override def convertToGpu(): Scan =
+    GpuCSVScan(cScan.sparkSession,
+      cScan.fileIndex,
+      cScan.dataSchema,
+      cScan.readDataSchema,
+      cScan.readPartitionSchema,
+      cScan.options,
+      cScan.partitionFilters,
+      cScan.dataFilters,
+      conf.maxReadBatchSizeRows,
+      conf.maxReadBatchSizeBytes)
+}

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/v2/Spark320PlusShims.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.Average
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, Partitioning}
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.catalyst.util.DateFormatter
-import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{BaseSubqueryExec, CommandResultExec, FileSourceScanExec, InSubqueryExec, PartitionedFileUtil, ReusedSubqueryExec, SparkPlan, SubqueryBroadcastExec}
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
@@ -671,79 +671,13 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
     GpuOverrides.scan[ParquetScan](
       "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuParquetScanBase.tagSupport(this)
-          // we are being overly cautious and that Parquet does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Parquet does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-        }
-
-        override def convertToGpu(): Scan = {
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-        }
-      }),
+      (a, conf, p, r) => new RapidsParquetScanMeta(a, conf, p, r)),
     GpuOverrides.scan[OrcScan](
       "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuOrcScanBase.tagSupport(this)
-          // we are being overly cautious and that Orc does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Orc does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-        }
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      }),
+      (a, conf, p, r) => new RapidsOrcScanMeta(a, conf, p, r)),
     GpuOverrides.scan[CSVScan](
       "CSV parsing",
-      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuCSVScan.tagSupport(this)
-          // we are being overly cautious and that Csv does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Csv does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-        }
-
-        override def convertToGpu(): Scan =
-          GpuCSVScan(a.sparkSession,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
-      })
+      (a, conf, p, r) => new RapidsCsvScanMeta(a, conf, p, r))
   ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def getPartitionFileNames(

--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+
+class RapidsOrcScanMeta(
+    oScan: OrcScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[OrcScan](oScan, conf, parent, rule) {
+  
+  override def tagSelfForGpu(): Unit = {
+    GpuOrcScanBase.tagSupport(this)
+    // we are being overly cautious and that Orc does not support this yet
+    if (oScan.isInstanceOf[SupportsRuntimeFiltering]) {
+      willNotWorkOnGpu("Orc does not support Runtime filtering (DPP)" +
+        " on datasource V2 yet.")
+    }
+  }
+
+  override def convertToGpu(): Scan =
+    GpuOrcScan(oScan.sparkSession,
+      oScan.hadoopConf,
+      oScan.fileIndex,
+      oScan.dataSchema,
+      oScan.readDataSchema,
+      oScan.readPartitionSchema,
+      oScan.options,
+      oScan.pushedFilters,
+      oScan.partitionFilters,
+      oScan.dataFilters,
+      conf)
+}

--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+
+class RapidsParquetScanMeta(
+    pScan: ParquetScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[ParquetScan](pScan, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    GpuParquetScanBase.tagSupport(this)
+    // we are being overly cautious and that Parquet does not support this yet
+    if (pScan.isInstanceOf[SupportsRuntimeFiltering]) {
+      willNotWorkOnGpu("Parquet does not support Runtime filtering (DPP)" +
+        " on datasource V2 yet.")
+    }
+  }
+
+  override def convertToGpu(): Scan = {
+    GpuParquetScan(pScan.sparkSession,
+      pScan.hadoopConf,
+      pScan.fileIndex,
+      pScan.dataSchema,
+      pScan.readDataSchema,
+      pScan.readPartitionSchema,
+      pScan.pushedFilters,
+      pScan.options,
+      pScan.partitionFilters,
+      pScan.dataFilters,
+      conf)
+  }
+}

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsOrcScanMeta.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
+
+class RapidsOrcScanMeta(
+    oScan: OrcScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[OrcScan](oScan, conf, parent, rule) {
+  
+  override def tagSelfForGpu(): Unit = {
+    GpuOrcScanBase.tagSupport(this)
+    // we are being overly cautious and that Orc does not support this yet
+    if (oScan.isInstanceOf[SupportsRuntimeFiltering]) {
+      willNotWorkOnGpu("Orc does not support Runtime filtering (DPP)" +
+        " on datasource V2 yet.")
+    }
+    // Spark[330,_] allows aggregates to be pushed down to ORC
+    if (oScan.pushedAggregate.nonEmpty) {
+      willNotWorkOnGpu("aggregates pushed into ORC read, which is a metadata only operation")
+    }
+  }
+
+  override def convertToGpu(): Scan =
+    GpuOrcScan(oScan.sparkSession,
+      oScan.hadoopConf,
+      oScan.fileIndex,
+      oScan.dataSchema,
+      oScan.readDataSchema,
+      oScan.readPartitionSchema,
+      oScan.options,
+      oScan.pushedFilters,
+      oScan.partitionFilters,
+      oScan.dataFilters,
+      conf)
+}

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/RapidsParquetScanMeta.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.v2
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScanBase, RapidsConf, RapidsMeta, ScanMeta}
+
+import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+
+class RapidsParquetScanMeta(
+    pScan: ParquetScan,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends ScanMeta[ParquetScan](pScan, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    GpuParquetScanBase.tagSupport(this)
+    // we are being overly cautious and that Parquet does not support this yet
+    if (pScan.isInstanceOf[SupportsRuntimeFiltering]) {
+      willNotWorkOnGpu("Parquet does not support Runtime filtering (DPP)" +
+        " on datasource V2 yet.")
+    }
+    // Spark[330,_] allows aggregates to be pushed down to parquet
+    if (pScan.pushedAggregate.nonEmpty) {
+      willNotWorkOnGpu(
+        "aggregates pushed into Parquet read, which is a metadata only operation")
+    }
+  }
+
+  override def convertToGpu(): Scan = {
+    GpuParquetScan(pScan.sparkSession,
+      pScan.hadoopConf,
+      pScan.fileIndex,
+      pScan.dataSchema,
+      pScan.readDataSchema,
+      pScan.readPartitionSchema,
+      pScan.pushedFilters,
+      pScan.options,
+      pScan.partitionFilters,
+      pScan.dataFilters,
+      conf)
+  }
+}

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/Spark33XShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/v2/Spark33XShims.scala
@@ -24,13 +24,9 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, MetadataAttribute}
 import org.apache.spark.sql.catalyst.json.rapids.shims.v2.Spark33XFileOptionsShims
-import org.apache.spark.sql.connector.read.{Scan, SupportsRuntimeFiltering}
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{DataSourceUtils, FilePartition, FileScanRDD, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
-import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
-import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
-import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -68,89 +64,6 @@ trait Spark33XShims extends Spark33XFileOptionsShims {
     new ParquetFilters(schema, pushDownDate, pushDownTimestamp, pushDownDecimal, pushDownStartWith,
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
   }
-
-  override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Seq(
-    GpuOverrides.scan[ParquetScan](
-      "Parquet parsing",
-      (a, conf, p, r) => new ScanMeta[ParquetScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuParquetScanBase.tagSupport(this)
-          // we are being overly cautious and that Parquet does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Parquet does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-          if (a.pushedAggregate.nonEmpty) {
-            willNotWorkOnGpu(
-              "aggregates pushed into Parquet read, which is a metadata only operation"
-            )
-          }
-        }
-
-        override def convertToGpu(): Scan = {
-          GpuParquetScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.pushedFilters,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-        }
-      }),
-    GpuOverrides.scan[OrcScan](
-      "ORC parsing",
-      (a, conf, p, r) => new ScanMeta[OrcScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuOrcScanBase.tagSupport(this)
-          // we are being overly cautious and that Orc does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Orc does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-        }
-
-        override def convertToGpu(): Scan =
-          GpuOrcScan(a.sparkSession,
-            a.hadoopConf,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.pushedFilters,
-            a.partitionFilters,
-            a.dataFilters,
-            conf)
-      }),
-    GpuOverrides.scan[CSVScan](
-      "CSV parsing",
-      (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
-        override def tagSelfForGpu(): Unit = {
-          GpuCSVScan.tagSupport(this)
-          // we are being overly cautious and that Csv does not support this yet
-          if (a.isInstanceOf[SupportsRuntimeFiltering]) {
-            willNotWorkOnGpu("Csv does not support Runtime filtering (DPP)" +
-              " on datasource V2 yet.")
-          }
-        }
-
-        override def convertToGpu(): Scan =
-          GpuCSVScan(a.sparkSession,
-            a.fileIndex,
-            a.dataSchema,
-            a.readDataSchema,
-            a.readPartitionSchema,
-            a.options,
-            a.partitionFilters,
-            a.dataFilters,
-            conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
-      })
-  ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     if (meta.wrapped.expressions.exists(expr => expr match {


### PR DESCRIPTION
Fixes #4638 

Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

[SPARK-34960](https://issues.apache.org/jira/browse/SPARK-34960) allows push down certain aggregations into ORC. ORC exposes column statistics in interface `org.apache.orc.Reader`.
This PR makes the following changes:

- fall back to the CPU when aggregates are pushed down.
- created new ScanMeta classes for each file format and placed them in the shims. This way, we won't have to copy paste the entire `getScans` implementation just to support a new feature.
