### PR TITLE
Support for hexadecimal digits in regular expressions on the GPU

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -550,7 +550,8 @@ Here are some examples of regular expression patterns that are not supported on 
 - Regular expressions containing null characters (unless the pattern is a simple literal string)
 - Octal digits in the range `\0200` to `\0377`
 - Character classes with octal digits, such as `[\02]` or `[\024]`
-- Hex digits
+- Character classes with hex digits, such as `[\x02]` or `[\x24]`
+- Hex digits in the range `\x80` to `Character.MAX_CODE_POINT`
 - `regexp_replace` does not support back-references
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -539,7 +539,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
         if (codePoint >= 128) {
           // see https://github.com/NVIDIA/spark-rapids/issues/4866
           throw new RegexUnsupportedException(
-            "cuDF does not support hex digits > 0x80")
+            "cuDF does not support hex digits > 0x7F")
         }
         RegexHexDigit(String.format("%02x", Int.box(codePoint)))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -302,13 +302,18 @@ class RegexParser(pattern: String) {
     // \x{h...h} The character with hexadecimal value 0xh...h
     //           (Character.MIN_CODE_POINT  <= 0xh...h <=  Character.MAX_CODE_POINT)
 
+    val varHex = pattern.charAt(pos) == '{'
+    if (varHex) {
+      consumeExpected('{')
+    }
     val start = pos
     while (!eof() && isHexDigit(pattern.charAt(pos))) {
       pos += 1
     }
     val hexDigit = pattern.substring(start, pos)
-
-    if (hexDigit.length < 2) {
+    if (varHex) {
+      consumeExpected('}')
+    } else if (hexDigit.length != 2) {
       throw new RegexUnsupportedException(s"Invalid hex digit: $hexDigit")
     }
 
@@ -523,15 +528,20 @@ class CudfRegexTranspiler(mode: RegexMode) {
           digits
         }
         if (Integer.parseInt(octal, 8) >= 128) {
+          // see https://github.com/NVIDIA/spark-rapids/issues/4746
           throw new RegexUnsupportedException(
             "cuDF does not support octal digits 0o177 < n <= 0o377")
         }
         RegexOctalChar(octal)
 
-      case RegexHexDigit(_) =>
-        // see https://github.com/NVIDIA/spark-rapids/issues/4486
-        throw new RegexUnsupportedException(
-          s"cuDF does not support hex digits consistently with Spark")
+      case RegexHexDigit(digits) =>
+        val codePoint = Integer.parseInt(digits, 16)
+        if (codePoint >= 128) {
+          // see https://github.com/NVIDIA/spark-rapids/issues/4866
+          throw new RegexUnsupportedException(
+            "cuDF does not support hex digits > 0x80")
+        }
+        RegexHexDigit(String.format("%02x", Int.box(codePoint)))
 
       case RegexEscaped(ch) => ch match {
         case 'D' =>
@@ -578,10 +588,16 @@ class CudfRegexTranspiler(mode: RegexMode) {
             // - "[a-b[c-d]]" is supported by Java but not cuDF
             throw new RegexUnsupportedException("nested character classes are not supported")
           case RegexEscaped(ch) if ch == '0' =>
+            // see https://github.com/NVIDIA/spark-rapids/issues/4862
             // examples
             // - "[\02] should match the character with code point 2"
             throw new RegexUnsupportedException(
               "cuDF does not support octal digits in character classes")
+          case RegexEscaped(ch) if ch == 'x' =>
+            // examples
+            // - "[\x02] should match the character with code point 2"
+            throw new RegexUnsupportedException(
+              "cuDF does not support hex digits in character classes")
           case _ =>
         }
         val components: Seq[RegexCharacterClassComponent] = characters
@@ -797,7 +813,13 @@ sealed trait RegexCharacterClassComponent extends RegexAST
 
 sealed case class RegexHexDigit(a: String) extends RegexCharacterClassComponent {
   override def children(): Seq[RegexAST] = Seq.empty
-  override def toRegexString: String = s"\\x$a"
+  override def toRegexString: String = {
+    if (a.length == 2) {
+      s"\\x$a"
+    } else {
+      s"\\x{$a}"
+    }
+  }
 }
 
 sealed case class RegexOctalChar(a: String) extends RegexCharacterClassComponent {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -124,6 +124,11 @@ class RegularExpressionParserSuite extends FunSuite {
       RegexSequence(ListBuffer(RegexHexDigit("FF"))))
   }
 
+  test("variable length hex digit") {
+    assert(parse(raw"\x{ABC}") ===
+      RegexSequence(ListBuffer(RegexHexDigit("ABC"))))
+  }
+
   test("octal digit") {
     val digits = Seq("0", "01", "076", "077", "0123", "0177", "0377")
     for (digit <- digits) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -151,12 +151,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         "cuDF does not support octal digits 0o177 < n <= 0o377"))
   }
 
-  test("cuDF does not support hex digits > 0x80") {
+  test("cuDF does not support hex digits > 0x7F") {
     // see https://github.com/NVIDIA/spark-rapids/issues/4866
     val patterns = Seq(raw"\x80", raw"\xff", raw"\xFF", raw"\x{ABC}")
     patterns.foreach(pattern =>
       assertUnsupported(pattern, RegexFindMode,
-        "cuDF does not support hex digits > 0x80"))
+        "cuDF does not support hex digits > 0x7F"))
   }
 
   test("cuDF does not support octal digits in character classes") {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -730,8 +730,8 @@ class FuzzRegExp(suggestedChars: String, skipKnownIssues: Boolean = true) {
     } else {
       baseGenerators ++ Seq(
         () => escapedChar, // https://github.com/NVIDIA/spark-rapids/issues/4505
-        () => hexDigit, // https://github.com/NVIDIA/spark-rapids/issues/4486
-        () => octalDigit) // https://github.com/NVIDIA/spark-rapids/issues/4409
+        () => hexDigit, // https://github.com/NVIDIA/spark-rapids/issues/4865
+        () => octalDigit) // https://github.com/NVIDIA/spark-rapids/issues/4862
     }
     generators(rr.nextInt(generators.length))()
   }


### PR DESCRIPTION
Fixes #4486.

This code enables partial support for hexadecimal digits in regular expressions on the GPU. A couple of limitations that currently will fall back to CPU:

* Hex digits greater >= `0x80` are not supported
* Hex digits in character classes, e.g. `[\x20]`

Also, this code will transpile the variable length hex digits format from Java's `Pattern` into the 2 digit format that is supported by CUDF.

For example `\x{007f}` will transpile to `\x7f`, and `\x{f}` will transpile to `\x0f`.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
