### PR TITLE
Speed up copying decimal column from parquet buffer to GPU buffer

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
@@ -18,10 +18,6 @@ package com.nvidia.spark.rapids;
 
 import ai.rapids.cudf.HostColumnVector.ColumnBuilder;
 
-import ai.rapids.cudf.HostColumnVectorCore;
-import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
-import org.apache.spark.sql.execution.datasources.orc.OrcAtomicColumnVector;
-import org.apache.spark.sql.execution.datasources.orc.OrcColumnVector;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/ColumnarCopyHelper.java
@@ -167,18 +167,15 @@ public class ColumnarCopyHelper {
     }
   }
 
-  public static void decimal32CopyFromParquet(WritableColumnVector cv,
-      ColumnBuilder b, int rows) {
+  public static void decimal32Copy(WritableColumnVector cv, ColumnBuilder b, int rows) {
     intCopy(cv, b, rows);
   }
 
-  public static void decimal64CopyFromParquet(WritableColumnVector cv,
-      ColumnBuilder b, int rows) {
+  public static void decimal64Copy(WritableColumnVector cv, ColumnBuilder b, int rows) {
     longCopy(cv, b, rows);
   }
 
-  public static void decimal128CopyFromParquet(WritableColumnVector cv,
-      ColumnBuilder b, int rows) {
+  public static void decimal128Copy(WritableColumnVector cv, ColumnBuilder b, int rows) {
     if (!cv.hasNull()) {
       for (int i = 0; i < rows; i++) {
         b.appendDecimal128(cv.getBinary(i));

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -133,11 +133,11 @@ object HostColumnarToGpu extends Logging {
         cv match {
           case wcv: WritableColumnVector =>
             if (DecimalType.is32BitDecimalType(dt)) {
-              ColumnarCopyHelper.decimal32CopyFromParquet(wcv, b, rows)
+              ColumnarCopyHelper.decimal32Copy(wcv, b, rows)
             } else if (DecimalType.is64BitDecimalType(dt)) {
-              ColumnarCopyHelper.decimal64CopyFromParquet(wcv, b, rows)
+              ColumnarCopyHelper.decimal64Copy(wcv, b, rows)
             } else {
-              ColumnarCopyHelper.decimal128CopyFromParquet(wcv, b, rows)
+              ColumnarCopyHelper.decimal128Copy(wcv, b, rows)
             }
           case _ =>
             if (DecimalType.is32BitDecimalType(dt)) {


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Closes #4784

Adds specialized support for the columnar copy of  `WritableColumnVector` on decimal type. The new implementation copies the unscaled values directly to avoid the round trip of Decimal encoding/decoding.