### PR TITLE
Fix spark-tests syntax issue [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -87,7 +87,7 @@ cat "$tmp_info" || true
 
 SKIP_REVISION_CHECK=${SKIP_REVISION_CHECK:-'false'}
 if [[ "$SKIP_REVISION_CHECK" != "true" && (-z "$c_ver" || -z "$p_ver"|| \
-      "$p_ver" != "$it_ver" || "$p_ver" != "$pt_ver" ]]; then
+      "$p_ver" != "$it_ver" || "$p_ver" != "$pt_ver") ]]; then
   echo "Artifacts revisions are inconsistent!"
   exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix nightly ` jenkins/spark-tests.sh: line 89: unexpected token `]]', expected `)'` which introduces in missed `)` in https://github.com/NVIDIA/spark-rapids/commit/7d1662efb24888d7ef490cacbd8968f7b62e1832#diff-6966e0988f278848f7f517087f3bad25135b36afc2529fbd2641bddce7c9bd56L95

