### PR TITLE
Set conda/mamba default to Python version to 3.8 [skip ci]

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -27,7 +27,7 @@ base=$(conda info --base)
 # Create and activate 'cudf-udf' conda env for cudf-udf tests
 conda create -y -n cudf-udf && source activate && conda activate cudf-udf
 # Use mamba to install cudf-udf packages to speed up conda resolve time
-conda install -c conda-forge mamba
+conda install -c conda-forge mamba python=3.8
 ${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas
-${base}/envs/cudf-udf/bin/mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=$CUDF_VER cudatoolkit=11.0 python=3.8
+${base}/envs/cudf-udf/bin/mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=$CUDF_VER cudatoolkit=11.0
 conda deactivate


### PR DESCRIPTION
To fix issue: https://github.com/NVIDIA/spark-rapids/issues/4876

Set python version to 3.8 with conda/mamba installation, conda will install pip-python 3.8, instead of the default python 3.10 along with pip-python 3.10. 



Signed-off-by: Tim Liu <timl@nvidia.com>