### PR TITLE
Bump hadoop-client dependency to 3.1.4

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -32,7 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.1.4</hadoop.version>
         <spark.version>${spark311.version}</spark.version>
         <spark.test.version>${spark311.version}</spark.test.version>
         <spark.version.classifier>spark311</spark.version.classifier>


### PR DESCRIPTION
Moves the hadoop-client dependency of the tools project from 3.1.1 to 3.1.4.