### PR TITLE
Case-insensitive PR title check [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -143,7 +143,7 @@ pipeline {
                         echo "failed to try abort duplicate builds: " + e.toString()
                     }
 
-                    def title = githubHelper.getIssue().title
+                    def title = githubHelper.getIssue().title.toLowerCase()
                     if (title ==~ /.*\[skip ci\].*/) {
                         githubHelper.updateCommitStatus("$BUILD_URL", "Skipped", GitHubCommitState.SUCCESS)
                         currentBuild.result == "SUCCESS"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Seeing some triggering w/o following case-sensitive pattern, like `[Databricks]` instead of [[databricks]](https://github.com/NVIDIA/spark-rapids/blob/branch-22.04/CONTRIBUTING.md#blossom-ci)
To avoid passing CI unintentionally, I decide to compromise (change the pattern matching to case insensitive)