### PR TITLE
Support GpuScalarSubquery on nested types

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -16736,12 +16736,12 @@ are limited.
 <td>S</td>
 <td>S</td>
 <td>S</td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
-<td> </td>
+<td><b>NS</b></td>
+<td>S</td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
+<td><b>NS</b></td>
 </tr>
 <tr>
 <td rowSpan="2">HiveGenericUDF</td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -16737,7 +16737,7 @@ are limited.
 <td>S</td>
 <td>S</td>
 <td><b>NS</b></td>
-<td>S</td>
+<td><b>NS</b></td>
 <td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
 <td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>
 <td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP;<br/>unsupported child types BINARY, CALENDAR, UDT</em></td>

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -17,18 +17,65 @@ from asserts import assert_gpu_and_cpu_are_equal_sql
 from data_gen import *
 from marks import *
 
-gens = [('l', LongGen()), ('i', IntegerGen()), ('f', FloatGen()), (
-    's', StringGen()), ('d', decimal_gen_128bit)]
-
-
-@ignore_order
-@pytest.mark.parametrize('data_gen', [gens], ids=idfn)
-def test_scalar_subquery(data_gen):
+@ignore_order(local=True)
+@pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
+def test_scalar_subquery_basics(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, data_gen, length=2048),
+        lambda spark: gen_df(spark, [('a', data_gen)], num_slices=1),
         'table',
-        '''
-        select l, i, f, (select count(s) from table) as c, (select max(d) from table) as dec
+        '''select a, (select last(a) from table)
         from table
-        where l > (select max(i) from table) or f < (select min(i) from table)
+        where a > (select first(a) from table)
+        ''')
+
+@ignore_order(local=True)
+def test_scalar_subquery_struct():
+    # single-level struct
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('ss', all_basic_struct_gen)], num_slices=1),
+        'table',
+        '''select ss, (select last(ss) from table)
+        from table
+        where (select first(ss) from table)['child2'] > ss['child2']
+        ''')
+    # nested struct
+    gen = [('ss', StructGen([['child', StructGen([['c0', int_gen]])]]))]
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, gen, num_slices=1),
+        'table',
+        '''select ss, (select last(ss) from table)
+        from table
+        where (select first(ss) from table)['child']['c0'] > ss['child']['c0']
+        ''')
+
+@ignore_order(local=True)
+def test_scalar_subquery_array():
+    # single-level array
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('arr', ArrayGen(int_gen))], num_slices=1),
+        'table',
+        '''select sort_array(arr),
+                  sort_array((select last(arr) from table))
+        from table
+        where (select first(arr) from table)[0] > arr[0]
+        ''')
+    # nested array
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('arr', ArrayGen(ArrayGen(int_gen)))], num_slices=1),
+        'table',
+        '''select sort_array(arr[10]),
+                  sort_array((select last(arr) from table)[10])
+        from table
+        where (select first(arr) from table)[0][1] > arr[0][1]
+        ''')
+
+@ignore_order(local=True)
+def test_scalar_subquery_map():
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('kv', map_string_string_gen[0])], num_slices=1),
+        'table',
+        '''select kv['key_0'],
+                  (select first(kv) from table)['key_1'],
+                  (select last(kv) from table)['key_2']
+        from table
         ''')

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -29,30 +29,42 @@ def test_scalar_subquery_basics(data_gen):
         ''')
 
 @ignore_order(local=True)
-def test_scalar_subquery_struct():
+@pytest.mark.parametrize('basic_gen', all_basic_gens, ids=idfn)
+def test_scalar_subquery_struct(basic_gen):
     # single-level struct
-    assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, [('ss', all_basic_struct_gen)], num_slices=1),
-        'table',
-        '''select ss, (select last(ss) from table)
-        from table
-        where (select first(ss) from table)['child2'] > ss['child2']
-        ''')
-    # nested struct
-    gen = [('ss', StructGen([['child', StructGen([['c0', int_gen]])]]))]
+    gen = [('ss', StructGen([['a', basic_gen], ['b', basic_gen]]))]
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: gen_df(spark, gen, num_slices=1),
         'table',
         '''select ss, (select last(ss) from table)
         from table
-        where (select first(ss) from table)['child']['c0'] > ss['child']['c0']
+        where (select first(ss) from table).b > ss.a
+        ''')
+    # nested struct
+    gen = [('ss', StructGen([['child', StructGen([['c0', basic_gen]])]]))]
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, gen, num_slices=1),
+        'table',
+        '''select ss, (select last(ss) from table)
+        from table
+        where (select first(ss) from table)['child']['c0'] > ss.child.c0
+        ''')
+    # struct of array
+    gen = [('ss', StructGen([['arr', ArrayGen(basic_gen)]]))]
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, gen, length=100, num_slices=1),
+        'table',
+        '''select sort_array(ss.arr), sort_array((select last(ss) from table)['arr'])
+        from table
+        where (select first(ss) from table).arr[0] > ss.arr[1]
         ''')
 
 @ignore_order(local=True)
-def test_scalar_subquery_array():
+@pytest.mark.parametrize('basic_gen', all_basic_gens, ids=idfn)
+def test_scalar_subquery_array(basic_gen):
     # single-level array
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, [('arr', ArrayGen(int_gen))], num_slices=1),
+        lambda spark: gen_df(spark, [('arr', ArrayGen(basic_gen))], num_slices=1),
         'table',
         '''select sort_array(arr),
                   sort_array((select last(arr) from table))
@@ -61,21 +73,52 @@ def test_scalar_subquery_array():
         ''')
     # nested array
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, [('arr', ArrayGen(ArrayGen(int_gen)))], num_slices=1),
+        lambda spark: gen_df(spark, [('arr', ArrayGen(ArrayGen(basic_gen)))]
+                             , length=100
+                             , num_slices=1),
         'table',
         '''select sort_array(arr[10]),
                   sort_array((select last(arr) from table)[10])
         from table
         where (select first(arr) from table)[0][1] > arr[0][1]
         ''')
+    # array of struct
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('arr', ArrayGen(StructGen([['a', basic_gen]])))]
+                             , length=100
+                             , num_slices=1),
+        'table',
+        '''select arr[10].a, (select last(arr) from table)[10].a
+        from table
+        where (select first(arr) from table)[0].a > arr[0].a
+        ''')
 
 @ignore_order(local=True)
 def test_scalar_subquery_map():
+    map_gen = map_string_string_gen[0]
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: gen_df(spark, [('kv', map_string_string_gen[0])], num_slices=1),
+        lambda spark: gen_df(spark, [('kv', map_gen)], length=100, num_slices=1),
         'table',
         '''select kv['key_0'],
                   (select first(kv) from table)['key_1'],
                   (select last(kv) from table)['key_2']
+        from table
+        ''')
+    # array of map
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('arr', ArrayGen(map_gen))], length=100, num_slices=1),
+        'table',
+        '''select arr[0]['key_0'],
+                  (select first(arr) from table)[0]['key_1'],
+                  (select last(arr[0]) from table)['key_2']
+        from table
+        ''')
+    # struct of map
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark: gen_df(spark, [('ss', StructGen([['kv', map_gen]]))], length=100, num_slices=1),
+        'table',
+        '''select ss['kv']['key_0'],
+                  (select first(ss) from table)['kv']['key_1'],
+                  (select last(ss.kv) from table)['key_2']
         from table
         ''')

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -20,6 +20,7 @@ from marks import *
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', all_basic_gens, ids=idfn)
 def test_scalar_subquery_basics(data_gen):
+    # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark: gen_df(spark, [('a', data_gen)], num_slices=1),
         'table',
@@ -34,6 +35,7 @@ def test_scalar_subquery_struct(basic_gen):
     # single-level struct
     gen = [('ss', StructGen([['a', basic_gen], ['b', basic_gen]]))]
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, gen, num_slices=1),
         'table',
         '''select ss, (select last(ss) from table)
@@ -43,6 +45,7 @@ def test_scalar_subquery_struct(basic_gen):
     # nested struct
     gen = [('ss', StructGen([['child', StructGen([['c0', basic_gen]])]]))]
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, gen, num_slices=1),
         'table',
         '''select ss, (select last(ss) from table)
@@ -52,6 +55,7 @@ def test_scalar_subquery_struct(basic_gen):
     # struct of array
     gen = [('ss', StructGen([['arr', ArrayGen(basic_gen)]]))]
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, gen, length=100, num_slices=1),
         'table',
         '''select sort_array(ss.arr), sort_array((select last(ss) from table)['arr'])
@@ -64,6 +68,7 @@ def test_scalar_subquery_struct(basic_gen):
 def test_scalar_subquery_array(basic_gen):
     # single-level array
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('arr', ArrayGen(basic_gen))], num_slices=1),
         'table',
         '''select sort_array(arr),
@@ -73,6 +78,7 @@ def test_scalar_subquery_array(basic_gen):
         ''')
     # nested array
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('arr', ArrayGen(ArrayGen(basic_gen)))]
                              , length=100
                              , num_slices=1),
@@ -84,6 +90,7 @@ def test_scalar_subquery_array(basic_gen):
         ''')
     # array of struct
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('arr', ArrayGen(StructGen([['a', basic_gen]])))]
                              , length=100
                              , num_slices=1),
@@ -97,6 +104,7 @@ def test_scalar_subquery_array(basic_gen):
 def test_scalar_subquery_map():
     map_gen = map_string_string_gen[0]
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('kv', map_gen)], length=100, num_slices=1),
         'table',
         '''select kv['key_0'],
@@ -106,6 +114,7 @@ def test_scalar_subquery_map():
         ''')
     # array of map
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('arr', ArrayGen(map_gen))], length=100, num_slices=1),
         'table',
         '''select arr[0]['key_0'],
@@ -115,6 +124,7 @@ def test_scalar_subquery_map():
         ''')
     # struct of map
     assert_gpu_and_cpu_are_equal_sql(
+        # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('ss', StructGen([['kv', map_gen]]))], length=100, num_slices=1),
         'table',
         '''select ss['kv']['key_0'],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3325,7 +3325,7 @@ object GpuOverrides extends Logging {
     expr[org.apache.spark.sql.execution.ScalarSubquery](
       "Subquery that will return only one row and one column",
       ExprChecks.projectOnly(
-        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.CALENDAR
+        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128
             + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT)
             .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
                         TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3325,8 +3325,11 @@ object GpuOverrides extends Logging {
     expr[org.apache.spark.sql.execution.ScalarSubquery](
       "Subquery that will return only one row and one column",
       ExprChecks.projectOnly(
-        TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
-        TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
+        (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.CALENDAR
+            + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT)
+            .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
+                        TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT),
+        TypeSig.all,
         Nil, None),
       (a, conf, p, r) =>
         new ExprMeta[org.apache.spark.sql.execution.ScalarSubquery](a, conf, p, r) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3326,9 +3326,7 @@ object GpuOverrides extends Logging {
       "Subquery that will return only one row and one column",
       ExprChecks.projectOnly(
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128
-            + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT)
-            .nested(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
-                        TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT),
+            + TypeSig.ARRAY + TypeSig.MAP + TypeSig.STRUCT).nested(),
         TypeSig.all,
         Nil, None),
       (a, conf, p, r) =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -56,8 +56,9 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
           }
         case null =>
           GpuColumnVector.fromNull(batch.numRows(), dt)
-        case ir: InternalRow =>
-          // Literal struct values are not currently supported, but just in case...
+        // Literal struct values are wrapped in GpuScalar
+        case s: GpuScalar =>
+          val ir = s.getValue.asInstanceOf[InternalRow]
           val tmp = ir.get(ordinal, dt)
           withResource(GpuScalar.from(tmp, dt)) { scalar =>
             GpuColumnVector.from(scalar, batch.numRows(), dt)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -58,10 +58,14 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
           GpuColumnVector.fromNull(batch.numRows(), dt)
         // Literal struct values are wrapped in GpuScalar
         case s: GpuScalar =>
-          val ir = s.getValue.asInstanceOf[InternalRow]
-          val tmp = ir.get(ordinal, dt)
-          withResource(GpuScalar.from(tmp, dt)) { scalar =>
-            GpuColumnVector.from(scalar, batch.numRows(), dt)
+          s.getValue match {
+            case null =>
+              GpuColumnVector.fromNull(batch.numRows(), dt)
+            case ir: InternalRow =>
+              val tmp = ir.get(ordinal, dt)
+              withResource(GpuScalar.from(tmp, dt)) { scalar =>
+                GpuColumnVector.from(scalar, batch.numRows(), dt)
+              }
           }
       }
     }


### PR DESCRIPTION
Signed-off-by: sperlingxx <lovedreamf@gmail.com>

Closes #4895

Current PR is to enable GpuScalarSubquery with output of nested types, so as to adapt the Spark patch https://github.com/apache/spark/pull/32298 which is under development.