### PR TITLE
Support predictors on ANSI day time interval type

### DIFF
--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -33,8 +33,8 @@ def test_eq(data_gen):
                 f.col('a') == f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_eq_for_interval(data_gen):
+def test_eq_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -45,7 +45,6 @@ def test_eq_for_interval(data_gen):
             f.col('b') == f.lit(None).cast(data_type),
             f.col('a') == f.col('b')))
 
-@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_eq_ns(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -59,8 +58,8 @@ def test_eq_ns(data_gen):
                 f.col('a').eqNullSafe(f.col('b'))))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_eq_ns_for_interval(data_gen):
+def test_eq_ns_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -84,8 +83,8 @@ def test_ne(data_gen):
                 f.col('a') != f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_ne_for_interval(data_gen):
+def test_ne_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -109,8 +108,8 @@ def test_lt(data_gen):
                 f.col('a') < f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_lt_for_interval(data_gen):
+def test_lt_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -134,8 +133,8 @@ def test_lte(data_gen):
                 f.col('a') <= f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_lte_for_interval(data_gen):
+def test_lte_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -160,8 +159,8 @@ def test_gt(data_gen):
                 f.col('a') > f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_gt_interval(data_gen):
+def test_gt_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -185,8 +184,8 @@ def test_gte(data_gen):
                 f.col('a') >= f.col('b')))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_gte_for_interval(data_gen):
+def test_gte_for_interval():
+    data_gen = DayTimeIntervalGen()
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -204,8 +203,8 @@ def test_isnull(data_gen):
                 f.isnull(f.col('a'))))
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
-@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
-def test_isnull_for_interval(data_gen):
+def test_isnull_for_interval():
+    data_gen = DayTimeIntervalGen()
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).select(
             f.isnull(f.col('a'))))

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from spark_session import with_cpu_session
+from spark_session import with_cpu_session, is_before_spark_330
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
@@ -32,6 +32,20 @@ def test_eq(data_gen):
                 f.col('b') == f.lit(None).cast(data_type),
                 f.col('a') == f.col('b')))
 
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_eq_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') == s1,
+            s2 == f.col('b'),
+            f.lit(None).cast(data_type) == f.col('a'),
+            f.col('b') == f.lit(None).cast(data_type),
+            f.col('a') == f.col('b')))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_eq_ns(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -43,6 +57,19 @@ def test_eq_ns(data_gen):
                 f.lit(None).cast(data_type).eqNullSafe(f.col('a')),
                 f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
                 f.col('a').eqNullSafe(f.col('b'))))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_eq_ns_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a').eqNullSafe(s1),
+            s2.eqNullSafe(f.col('b')),
+            f.lit(None).cast(data_type).eqNullSafe(f.col('a')),
+            f.col('b').eqNullSafe(f.lit(None).cast(data_type)),
+            f.col('a').eqNullSafe(f.col('b'))))
 
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen, ids=idfn)
 def test_ne(data_gen):
@@ -56,6 +83,19 @@ def test_ne(data_gen):
                 f.col('b') != f.lit(None).cast(data_type),
                 f.col('a') != f.col('b')))
 
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_ne_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') != s1,
+            s2 != f.col('b'),
+            f.lit(None).cast(data_type) != f.col('a'),
+            f.col('b') != f.lit(None).cast(data_type),
+            f.col('a') != f.col('b')))
+
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lt(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -67,6 +107,19 @@ def test_lt(data_gen):
                 f.lit(None).cast(data_type) < f.col('a'),
                 f.col('b') < f.lit(None).cast(data_type),
                 f.col('a') < f.col('b')))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_lt_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') < s1,
+            s2 < f.col('b'),
+            f.lit(None).cast(data_type) < f.col('a'),
+            f.col('b') < f.lit(None).cast(data_type),
+            f.col('a') < f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_lte(data_gen):
@@ -80,6 +133,20 @@ def test_lte(data_gen):
                 f.col('b') <= f.lit(None).cast(data_type),
                 f.col('a') <= f.col('b')))
 
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_lte_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') <= s1,
+            s2 <= f.col('b'),
+            f.lit(None).cast(data_type) <= f.col('a'),
+            f.col('b') <= f.lit(None).cast(data_type),
+            f.col('a') <= f.col('b')))
+
+
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gt(data_gen):
     (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
@@ -91,6 +158,19 @@ def test_gt(data_gen):
                 f.lit(None).cast(data_type) > f.col('a'),
                 f.col('b') > f.lit(None).cast(data_type),
                 f.col('a') > f.col('b')))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_gt_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') > s1,
+            s2 > f.col('b'),
+            f.lit(None).cast(data_type) > f.col('a'),
+            f.col('b') > f.lit(None).cast(data_type),
+            f.col('a') > f.col('b')))
 
 @pytest.mark.parametrize('data_gen', orderable_gens, ids=idfn)
 def test_gte(data_gen):
@@ -104,11 +184,31 @@ def test_gte(data_gen):
                 f.col('b') >= f.lit(None).cast(data_type),
                 f.col('a') >= f.col('b')))
 
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_gte_for_interval(data_gen):
+    (s1, s2) = gen_scalars(data_gen, 2, force_no_nulls=not isinstance(data_gen, NullGen))
+    data_type = data_gen.data_type
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : binary_op_df(spark, data_gen).select(
+            f.col('a') >= s1,
+            s2 >= f.col('b'),
+            f.lit(None).cast(data_type) >= f.col('a'),
+            f.col('b') >= f.lit(None).cast(data_type),
+            f.col('a') >= f.col('b')))
+
 @pytest.mark.parametrize('data_gen', eq_gens_with_decimal_gen + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_isnull(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(
                 f.isnull(f.col('a'))))
+
+@pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
+@pytest.mark.parametrize('data_gen', [DayTimeIntervalGen()], ids=idfn)
+def test_isnull_for_interval(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).select(
+            f.isnull(f.col('a'))))
 
 @pytest.mark.parametrize('data_gen', [FloatGen(), DoubleGen()], ids=idfn)
 def test_isnan(data_gen):

--- a/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -64,11 +64,13 @@ object GpuTypeShims {
   def isParquetColumnarWriterSupportedForType(colType: DataType): Boolean = false
 
   /**
-   * Whether this Shim supports convert this type to GPU Scalar
-   * @param t
+   * Whether the Shim supports converting the given type to GPU Scalar
    */
   def supportToScalarForType(t: DataType): Boolean = false
 
+  /**
+   * Convert the given value to Scalar
+   */
   def toScalarForType(t: DataType, v: Any) = {
     throw new RuntimeException(s"Can not convert $v to scalar for type $t.")
   }

--- a/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/301until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -46,4 +46,14 @@ object GpuTypeShims {
    * @return the cuDF type if the Shim supports
    */
   def toRapidsOrNull(t: DataType): DType = null
+
+  /**
+   * Whether this Shim supports convert this type to GPU Scalar
+   * @param t
+   */
+  def supportToScalarForType(t: DataType): Boolean = false
+
+  def toScalarForType(t: DataType, v: Any) = {
+    throw new RuntimeException(s"Can not convert $v to scalar for type $t.")
+  }
 }

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -120,8 +120,7 @@ object GpuTypeShims {
   }
 
   /**
-   * Whether this Shim supports convert this type to GPU Scalar
-   * @param t
+   * Whether the Shim supports converting the given type to GPU Scalar
    */
   def supportToScalarForType(t: DataType): Boolean = {
     t match {
@@ -130,6 +129,9 @@ object GpuTypeShims {
     }
   }
 
+  /**
+   * Convert the given value to Scalar
+   */
   def toScalarForType(t: DataType, v: Any) = {
     t match {
       case _: DayTimeIntervalType => v match {

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -15,7 +15,7 @@
  */
 package com.nvidia.spark.rapids.shims
 
-import ai.rapids.cudf.DType
+import ai.rapids.cudf.{DType, Scalar}
 import com.nvidia.spark.rapids.GpuRowToColumnConverter.{LongConverter, NotNullLongConverter, TypeConverter}
 
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType}
@@ -91,6 +91,29 @@ object GpuTypeShims {
         DType.INT64
       case _ =>
         null
+    }
+  }
+
+  /**
+   * Whether this Shim supports convert this type to GPU Scalar
+   * @param t
+   */
+  def supportToScalarForType(t: DataType): Boolean = {
+    t match {
+      case _: DayTimeIntervalType => true
+      case _ => false
+    }
+  }
+
+  def toScalarForType(t: DataType, v: Any) = {
+    t match {
+      case _: DayTimeIntervalType => v match {
+        case l: Long => Scalar.fromLong(l)
+        case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
+            s" for LongType, expecting Long")
+      }
+      case _ =>
+        throw new RuntimeException(s"Can not convert $v to scalar for type $t.")
     }
   }
 }

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
@@ -367,11 +367,11 @@ trait Spark33XShims extends Spark33XFileOptionsShims {
       GpuOverrides.exec[FilterExec](
         "The backend for most filter statements",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
-            TypeSig.ARRAY + TypeSig.DECIMAL_128).nested(), TypeSig.all),
+            TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(), TypeSig.all),
         (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {
           override def convertToGpu(): GpuExec =
             GpuFilterExec(childExprs.head.convertToGpu(), childPlans.head.convertIfNeeded())
-        }),
+        })
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
     super.getExecs ++ map
   }

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
@@ -17,19 +17,20 @@
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.GpuOverrides
 import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Coalesce, DynamicPruningExpression, Expression, MetadataAttribute, TimeAdd}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.json.rapids.shims.Spark33XFileOptionsShims
-import org.apache.spark.sql.execution.{BaseSubqueryExec, CoalesceExec, FileSourceScanExec, InSubqueryExec, ProjectExec, ReusedSubqueryExec, SparkPlan, SubqueryBroadcastExec}
+import org.apache.spark.sql.execution.{BaseSubqueryExec, CoalesceExec, FileSourceScanExec, FilterExec, InSubqueryExec, ProjectExec, ReusedSubqueryExec, SparkPlan, SubqueryBroadcastExec}
 import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources.{DataSourceUtils, FilePartition, FileScanRDD, HadoopFsRelation, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+import org.apache.spark.sql.rapids._
 import org.apache.spark.sql.rapids.shims.GpuTimeAdd
 import org.apache.spark.sql.types.{CalendarIntervalType, DayTimeIntervalType, StructType}
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -152,6 +153,101 @@ trait Spark33XShims extends Spark33XFileOptionsShims {
 
           override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
             GpuTimeAdd(lhs, rhs)
+        }),
+      GpuOverrides.expr[IsNull](
+        "Checks if a value is null",
+        ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
+              TypeSig.STRUCT + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
+          TypeSig.all),
+        (a, conf, p, r) => new UnaryExprMeta[IsNull](a, conf, p, r) {
+          override def convertToGpu(child: Expression): GpuExpression = GpuIsNull(child)
+        }),
+      GpuOverrides.expr[IsNotNull](
+        "Checks if a value is not null",
+        ExprChecks.unaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
+              TypeSig.STRUCT + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
+          TypeSig.all),
+        (a, conf, p, r) => new UnaryExprMeta[IsNotNull](a, conf, p, r) {
+          override def convertToGpu(child: Expression): GpuExpression = GpuIsNotNull(child)
+        }),
+      GpuOverrides.expr[EqualNullSafe](
+        "Check if the values are equal including nulls <=>",
+        ExprChecks.binaryProject(
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.comparable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.comparable)),
+        (a, conf, p, r) => new BinaryExprMeta[EqualNullSafe](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuEqualNullSafe(lhs, rhs)
+        }),
+      GpuOverrides.expr[EqualTo](
+        "Check if the values are equal",
+        ExprChecks.binaryProjectAndAst(
+          TypeSig.comparisonAstTypes,
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.comparable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.comparable)),
+        (a, conf, p, r) => new BinaryAstExprMeta[EqualTo](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuEqualTo(lhs, rhs)
+        }),
+      GpuOverrides.expr[GreaterThan](
+        "> operator",
+        ExprChecks.binaryProjectAndAst(
+          TypeSig.comparisonAstTypes,
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable)),
+        (a, conf, p, r) => new BinaryAstExprMeta[GreaterThan](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuGreaterThan(lhs, rhs)
+        }),
+      GpuOverrides.expr[GreaterThanOrEqual](
+        ">= operator",
+        ExprChecks.binaryProjectAndAst(
+          TypeSig.comparisonAstTypes,
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable)),
+        (a, conf, p, r) => new BinaryAstExprMeta[GreaterThanOrEqual](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuGreaterThanOrEqual(lhs, rhs)
+        }),
+      GpuOverrides.expr[LessThan](
+        "< operator",
+        ExprChecks.binaryProjectAndAst(
+          TypeSig.comparisonAstTypes,
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable)),
+        (a, conf, p, r) => new BinaryAstExprMeta[LessThan](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuLessThan(lhs, rhs)
+        }),
+      GpuOverrides.expr[LessThanOrEqual](
+        "<= operator",
+        ExprChecks.binaryProjectAndAst(
+          TypeSig.comparisonAstTypes,
+          TypeSig.BOOLEAN, TypeSig.BOOLEAN,
+          ("lhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable),
+          ("rhs", TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.DAYTIME,
+              TypeSig.orderable)),
+        (a, conf, p, r) => new BinaryAstExprMeta[LessThanOrEqual](a, conf, p, r) {
+          override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
+            GpuLessThanOrEqual(lhs, rhs)
         })
     ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
     super.getExprs ++ map
@@ -267,7 +363,15 @@ trait Spark33XShims extends Spark33XFileOptionsShims {
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
               TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
           TypeSig.all),
-        (proj, conf, p, r) => new GpuProjectExecMeta(proj, conf, p, r))
+        (proj, conf, p, r) => new GpuProjectExecMeta(proj, conf, p, r)),
+      GpuOverrides.exec[FilterExec](
+        "The backend for most filter statements",
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
+            TypeSig.ARRAY + TypeSig.DECIMAL_128).nested(), TypeSig.all),
+        (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {
+          override def convertToGpu(): GpuExec =
+            GpuFilterExec(childExprs.head.convertToGpu(), childPlans.head.convertIfNeeded())
+        }),
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
     super.getExecs ++ map
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -372,6 +372,11 @@ object GpuScalar extends Arm with Logging {
       case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
           s" for LongType, expecting Long, or Int.")
     }
+    case _: DayTimeIntervalType => v match {
+      case l: Long => Scalar.fromLong(l)
+      case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
+          s" for LongType, expecting Long")
+    }
     case _ => throw new UnsupportedOperationException(s"${v.getClass} '$v' is not supported" +
         s" as a Scalar yet")
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -28,7 +28,7 @@ import scala.reflect.runtime.universe.TypeTag
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Scalar}
 import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
-import com.nvidia.spark.rapids.shims.SparkShimImpl
+import com.nvidia.spark.rapids.shims.{GpuTypeShims, SparkShimImpl}
 import org.json4s.JsonAST.{JField, JNull, JString}
 
 import org.apache.spark.internal.Logging
@@ -372,11 +372,8 @@ object GpuScalar extends Arm with Logging {
       case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
           s" for LongType, expecting Long, or Int.")
     }
-    case _: DayTimeIntervalType => v match {
-      case l: Long => Scalar.fromLong(l)
-      case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
-          s" for LongType, expecting Long")
-    }
+    case other if GpuTypeShims.supportToScalarForType(other) =>
+      GpuTypeShims.toScalarForType(other, v)
     case _ => throw new UnsupportedOperationException(s"${v.getClass} '$v' is not supported" +
         s" as a Scalar yet")
   }


### PR DESCRIPTION
Fixes #4945
Closes #4149

1. Support predictors on ANSI day time interval type
IsNull, IsNotNull, EqualNullSafe, EqualTo, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual, FilterExec

2. Add test for pushdown ANSI interval type.
No need to change code, only need to add a test case.
Parquet stores day-time interval as long and the statistics on day-time interval are values of max(long) and min(long).
ParquetFilters.createFilter already converts filters on day-time to filters on long.

3. Add converter from ANSI day time literal to scalar

Signed-off-by: Chong Gao <res_life@163.com>
