### PR TITLE
Add Decimal 128 as a supported type in partition by for [databricks] running window

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -455,7 +455,7 @@ def test_window_running_rank_no_part(data_gen):
 # In a distributed setup the order of the partitions returned might be different, so we must ignore the order
 # but small batch sizes can make sort very slow, so do the final order by locally
 @ignore_order(local=True)
-@pytest.mark.parametrize('data_gen', all_basic_gens + [decimal_gen_32bit, decimal_gen_128bit], ids=idfn)
+@pytest.mark.parametrize('data_gen', all_basic_gens + [decimal_gen_32bit], ids=idfn)
 def test_window_running_rank(data_gen):
     # Keep the batch size small. We have tested these with operators with exact inputs already, this is mostly
     # testing the fixup operation.
@@ -481,7 +481,7 @@ def test_window_running_rank(data_gen):
 @ignore_order(local=True)
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn) # set the batch size so we can test multiple stream batches
 @pytest.mark.parametrize('b_gen, c_gen', [(long_gen, x) for x in running_part_and_order_gens] +
-        [(x, long_gen) for x in all_basic_gens_no_nans + [decimal_gen_32bit, decimal_gen_128bit]], ids=idfn)
+        [(x, long_gen) for x in all_basic_gens_no_nans + [decimal_gen_32bit]], ids=idfn)
 def test_window_running(b_gen, c_gen, batch_size):
     conf = {'spark.rapids.sql.batchSizeBytes': batch_size,
             'spark.rapids.sql.hasNans': False,

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -465,11 +465,6 @@ def test_window_running_rank(data_gen):
             'rank() over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as rank_val',
             'dense_rank() over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as dense_rank_val']
 
-
-    if is_databricks_runtime() and data_gen == decimal_gen_128bit:
-      # See https://github.com/NVIDIA/spark-rapids/issues/4936
-      pytest.xfail("Decimal 128 for rank aggregations in running window is not supported on Databricks")
-
     # When generating the ordering try really hard to have duplicate values
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : two_col_df(spark, RepeatSeqGen(data_gen, length=500), RepeatSeqGen(data_gen, length=100), length=1024 * 14),
@@ -503,10 +498,6 @@ def test_window_running(b_gen, c_gen, batch_size):
     # Decimal precision can grow too large. Float and Double can get odd results for Inf/-Inf because of ordering
     if isinstance(c_gen.data_type, NumericType) and (not isinstance(c_gen, FloatGen)) and (not isinstance(c_gen, DoubleGen)) and (not isinstance(c_gen, DecimalGen)):
         query_parts.append('sum(c) over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_col')
-
-    if is_databricks_runtime() and b_gen == decimal_gen_128bit:
-      # See https://github.com/NVIDIA/spark-rapids/issues/4936
-      pytest.xfail("Decimal 128 for rank aggregations in running window is not supported on Databricks")
 
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : three_col_df(spark, LongRangeGen(), RepeatSeqGen(b_gen, length=100), c_gen, length=1024 * 14),

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -467,7 +467,8 @@ def test_window_running_rank(data_gen):
 
 
     if is_databricks_runtime() and data_gen == decimal_gen_128bit:
-      pytest.xfail("Decimal 128 in running window is not supported on Databricks")
+      # See https://github.com/NVIDIA/spark-rapids/issues/4936
+      pytest.xfail("Decimal 128 for rank aggregations in running window is not supported on Databricks")
 
     # When generating the ordering try really hard to have duplicate values
     assert_gpu_and_cpu_are_equal_sql(
@@ -504,7 +505,8 @@ def test_window_running(b_gen, c_gen, batch_size):
         query_parts.append('sum(c) over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_col')
 
     if is_databricks_runtime() and b_gen == decimal_gen_128bit:
-      pytest.xfail("Decimal 128 in running window is not supported on Databricks")
+      # See https://github.com/NVIDIA/spark-rapids/issues/4936
+      pytest.xfail("Decimal 128 for rank aggregations in running window is not supported on Databricks")
 
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : three_col_df(spark, LongRangeGen(), RepeatSeqGen(b_gen, length=100), c_gen, length=1024 * 14),

--- a/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/Spark30XdbShims.scala
+++ b/sql-plugin/src/main/301db/scala/com/nvidia/spark/rapids/shims/Spark30XdbShims.scala
@@ -134,7 +134,7 @@ abstract class Spark30XdbShims extends Spark30XdbShimsBase with Logging {
             TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
           TypeSig.all,
           Map("partitionSpec" ->
-              InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64,
+              InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
                 TypeSig.all))),
         (runningWindowFunctionExec, conf, p, r) =>
           new GpuRunningWindowExecMeta(runningWindowFunctionExec, conf, p, r)

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/Spark31XdbShims.scala
@@ -363,7 +363,7 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
             TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
           TypeSig.all,
           Map("partitionSpec" ->
-              InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64,
+              InputCheck(TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
                 TypeSig.all))),
           (runningWindowFunctionExec, conf, p, r) =>
             new GpuRunningWindowExecMeta(runningWindowFunctionExec, conf, p, r)


### PR DESCRIPTION
Fixes #4936.

This resolves the issue with Decimal 128 and Databricks by updating the type check to support Decimal 128 in the Databricks class for running window computation.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
