### PR TITLE
Add independent mvn verify check [skip ci]

### DIFF
--- a/.github/workflows/docgen-check.yml
+++ b/.github/workflows/docgen-check.yml
@@ -1,0 +1,45 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow to check if generated docs are up to date
+name: doc-gen check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docgen-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+
+      - name: Setup Java and Maven Env
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 8
+
+      - name: build deps
+        run: mvn install -pl 'aggregator' -am -DskipTests
+
+      - name: doc-gen
+        run: mvn antrun:run@update_config_docs -pl dist
+
+      - name: check if existing modified files
+        run: mvn exec:exec@if_modified_files -P pre-merge -pl dist

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A workflow to check if generated docs are up to date
-name: doc-gen check
+# A workflow to run mvn verify check
+name: mvn-verify check
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docgen-check:
+  mvn-verify-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
@@ -35,11 +35,6 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      - name: build deps
-        run: mvn install -pl 'aggregator' -am -DskipTests
-
-      - name: doc-gen
-        run: mvn antrun:run@update_config_docs -pl dist
-
-      - name: check if existing modified files
-        run: mvn exec:exec@if_modified_files -P pre-merge -pl dist
+      # this step includes style and doc-gen checks of default shim
+      - name: mvn verify check
+        run: mvn verify -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -37,4 +37,4 @@ jobs:
 
       # this step includes style and doc-gen checks of default shim
       - name: mvn verify check
-        run: mvn verify -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip
+        run: mvn verify -P pre-merge -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -35,6 +35,6 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      # this step includes style and doc-gen checks of default shim
+      # includes RAT, code style and doc-gen checks of default shim
       - name: mvn verify check
-        run: mvn verify -P pre-merge -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip
+        run: mvn verify -P 'individual,pre-merge' -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #4939 

The check is running in github runners, so the triggering does not require manual operation which is the same as signoff check (PR open, reopen, new commit)

Verified in forked repo, and working in this PR. the check would normally take 2-3 minutes. 
If this looks OK, I will merge and let it run for some days before mark it as a required check, thanks!

Success
![image](https://user-images.githubusercontent.com/8086184/159193616-99708919-336f-485e-9800-c7b6e488a5c1.png)
