### PR TITLE
Add missing 314 to buildall script

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -146,6 +146,7 @@ case $DIST_PROFILE in
       311cdh
       312
       313
+      314
       320
       321
       322


### PR DESCRIPTION
Fixes the `buildall` script when building with the `snapshots` profile, since it was not building for Spark 3.1.4 but the snapshot profile expected the aggregator artifacts to have been locally installed.