### PR TITLE
Update doc for CSV reading interval

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -358,19 +358,30 @@ They are within round-off errors except when they are close enough to overflow t
 then results in a number being returned when the CPU would have returned null.
 
 ### CSV ANSI day time interval
-Apache Spark has an overflow issue when reading ANSI day time interval, the plugin fixed it on GPU.
-The issue is https://issues.apache.org/jira/browse/SPARK-38520.   
-e.g.:   
+This type was added in as a part of Spark 3.3.0, and it's not supported on Spark versions before 3.3.0.
+Apache Spark can [overflow](https://issues.apache.org/jira/browse/SPARK-38520) when reading ANSI day time interval values.
+The RAPIDS Accelerator does not overflow and as such is not bug for bug compatible with Spark in this case.
 
-interval string in csv | Spark reads to | Plugin reads to | comments
------|---------------------------|-----------------|-----------
-interval '106751992' day| INTERVAL '-106751990' DAY | NULL| Spark issue
-interval '2562047789' hour| INTERVAL '-2562047787' HOUR | NULL| Spark issue
+Interval string in csv|Spark reads to|The RAPIDS Accelerator reads to|Comments|
+-----|-------------------------|-----------------|-----------|
+interval '106751992' day| INTERVAL '-106751990' DAY | NULL| Spark issue|
+interval '2562047789' hour| INTERVAL '-2562047787' HOUR | NULL| Spark issue|
 
-There are two valid textual representations in CSV, take DAY TO SECOND interval for example:   
-INTERVAL '100 10:30:40.999999' DAY TO SECOND   
-100 10:30:40.999999  
-Currently only supports the first one which is the default when Apache Spark writing.
+There are two valid textual representations in CSV: the ANSI style and the HIVE style, e.g:
+
+SQL Type|An instance of ANSI style|An instance of HIVE style|
+-----|-------------------------------------------|-----------------|
+INTERVAL DAY | INTERVAL '100' DAY TO SECOND              | 100|
+INTERVAL DAY TO HOUR | INTERVAL '100 10' DAY TO HOUR             | 100 10|
+INTERVAL DAY TO MINUTE | INTERVAL '100 10:30' DAY TO MINUTE        | 100 10:30|
+INTERVAL DAY TO SECOND | INTERVAL '100 10:30:40.999999' DAY TO SECOND | 100 10:30:40.999999|
+INTERVAL HOUR | INTERVAL '10' HOUR                        | 10|
+INTERVAL HOUR TO MINUTE | INTERVAL '10:30' HOUR TO MINUTE           | 10:30|
+INTERVAL HOUR TO SECOND | INTERVAL '10:30:40.999999' HOUR TO SECOND | 10:30:40.999999|
+INTERVAL MINUTE | INTERVAL '30' MINUTE                      | 30|
+INTERVAL MINUTE TO SECOND | INTERVAL '30:40.999999' MINUTE TO SECOND  | 30:40.999999|
+INTERVAL SECOND | INTERVAL '40.999999' SECOND               | 40.999999|
+Currently, the RAPIDS Accelerator only supports the ANSI style.
 
 ## ORC
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -357,6 +357,21 @@ Also parsing of some values will not produce bit for bit identical results to wh
 They are within round-off errors except when they are close enough to overflow to Inf or -Inf which
 then results in a number being returned when the CPU would have returned null.
 
+### CSV ANSI day time interval
+Apache Spark has an overflow issue when reading ANSI day time interval, the plugin fixed it on GPU.
+The issue is https://issues.apache.org/jira/browse/SPARK-38520.   
+e.g.:   
+
+interval string in csv | Spark reads to | Plugin reads to | comments
+-----|---------------------------|-----------------|-----------
+interval '106751992' day| INTERVAL '-106751990' DAY | NULL            | Spark issue
+interval '2562047789' hour| INTERVAL '-2562047787' HOUR | NULL            | Spark issue
+
+There are two valid textual representations in CSV, take DAY TO SECOND interval for example:   
+INTERVAL '100 10:30:40.999999' DAY TO SECOND   
+100 10:30:40.999999  
+Currently only supports the first one which is the default when Apache Spark writing.
+
 ## ORC
 
 The ORC format has fairly complete support for both reads and writes. There are only a few known

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -364,8 +364,8 @@ e.g.:
 
 interval string in csv | Spark reads to | Plugin reads to | comments
 -----|---------------------------|-----------------|-----------
-interval '106751992' day| INTERVAL '-106751990' DAY | NULL            | Spark issue
-interval '2562047789' hour| INTERVAL '-2562047787' HOUR | NULL            | Spark issue
+interval '106751992' day| INTERVAL '-106751990' DAY | NULL| Spark issue
+interval '2562047789' hour| INTERVAL '-2562047787' HOUR | NULL| Spark issue
 
 There are two valid textual representations in CSV, take DAY TO SECOND interval for example:   
 INTERVAL '100 10:30:40.999999' DAY TO SECOND   


### PR DESCRIPTION
Contributes #4146

This is a followup for PR https://github.com/NVIDIA/spark-rapids/pull/4927 to update doc.
This PR describes the compatibility for CSV ANSI day time interval.

Signed-off-by: Chong Gao <res_life@163.com>