### PR TITLE
PCBS and Parquet support ANSI year month interval type [databricks]

### DIFF
--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -18,9 +18,9 @@ package com.nvidia.spark.rapids.shims
 import ai.rapids.cudf
 import ai.rapids.cudf.{DType, Scalar}
 import com.nvidia.spark.rapids.ColumnarCopyHelper
-import com.nvidia.spark.rapids.GpuRowToColumnConverter.{LongConverter, NotNullLongConverter, TypeConverter}
+import com.nvidia.spark.rapids.GpuRowToColumnConverter.{IntConverter, LongConverter, NotNullIntConverter, NotNullLongConverter, TypeConverter}
 
-import org.apache.spark.sql.types.{DataType, DayTimeIntervalType}
+import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, YearMonthIntervalType}
 import org.apache.spark.sql.vectorized.ColumnVector
 
 /**
@@ -63,6 +63,7 @@ object GpuTypeShims {
   def hasConverterForType(otherType: DataType) : Boolean = {
     otherType match {
       case DayTimeIntervalType(_, _) => true
+      case YearMonthIntervalType(_, _) => true
       case _ => false
     }
   }
@@ -78,6 +79,8 @@ object GpuTypeShims {
     (t, nullable) match {
       case (DayTimeIntervalType(_, _), true) => LongConverter
       case (DayTimeIntervalType(_, _), false) => NotNullLongConverter
+      case (YearMonthIntervalType(_, _), true) => IntConverter
+      case (YearMonthIntervalType(_, _), false) => NotNullIntConverter
       case _ => throw new RuntimeException(s"No converter is found for type $t.")
     }
   }
@@ -92,6 +95,9 @@ object GpuTypeShims {
       case _: DayTimeIntervalType =>
         // use int64 as Spark does
         DType.INT64
+      case _: YearMonthIntervalType =>
+        // use int32 as Spark does
+        DType.INT32
       case _ =>
         null
     }
@@ -100,6 +106,7 @@ object GpuTypeShims {
   /** Whether the Shim supports columnar copy for the given type */
   def isColumnarCopySupportedForType(colType: DataType): Boolean = colType match {
     case DayTimeIntervalType(_, _) => true
+    case YearMonthIntervalType(_, _) => true
     case _ => false
   }
 
@@ -111,12 +118,15 @@ object GpuTypeShims {
       b: ai.rapids.cudf.HostColumnVector.ColumnBuilder, rows: Int): Unit = cv.dataType() match {
     case DayTimeIntervalType(_, _) =>
       ColumnarCopyHelper.longCopy(cv, b, rows)
+    case YearMonthIntervalType(_, _) =>
+      ColumnarCopyHelper.intCopy(cv, b, rows)
     case t =>
       throw new UnsupportedOperationException(s"Converting to GPU for $t is not supported yet")
   }
 
   def isParquetColumnarWriterSupportedForType(colType: DataType): Boolean = colType match {
     case DayTimeIntervalType(_, _) => true
+    case YearMonthIntervalType(_, _) => true
     case _ => false
   }
 

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/Spark33XShims.scala
@@ -91,11 +91,11 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
         sparkSig = TypeSig.cpuAtomics)),
       (ParquetFormatType, FileFormatChecks(
         cudfRead = (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.STRUCT +
-            TypeSig.ARRAY + TypeSig.MAP + TypeSig.DAYTIME).nested(),
+            TypeSig.ARRAY + TypeSig.MAP + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
         cudfWrite = (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.STRUCT +
-            TypeSig.ARRAY + TypeSig.MAP + TypeSig.DAYTIME).nested(),
+            TypeSig.ARRAY + TypeSig.MAP + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
         sparkSig = (TypeSig.cpuAtomics + TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP +
-            TypeSig.UDT + TypeSig.DAYTIME).nested())))
+            TypeSig.UDT + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested())))
   }
 
   // 330+ supports DAYTIME interval types
@@ -106,11 +106,11 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
         "Returns the first non-null argument if exists. Otherwise, null",
         ExprChecks.projectOnly(
           (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT +
-              TypeSig.DAYTIME).nested(),
+              TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all,
           repeatingParamCheck = Some(RepeatingParamCheck("param",
             (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT +
-                TypeSig.DAYTIME).nested(),
+                TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
             TypeSig.all))),
         (a, conf, p, r) => new ExprMeta[Coalesce](a, conf, p, r) {
           override def convertToGpu():
@@ -121,7 +121,7 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
         ExprChecks.projectAndAst(
           TypeSig.astTypes,
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.MAP + TypeSig.ARRAY +
-              TypeSig.STRUCT + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
+              TypeSig.STRUCT + TypeSig.DECIMAL_128 + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all),
         (att, conf, p, r) => new BaseExprMeta[AttributeReference](att, conf, p, r) {
           // This is the only NOOP operator.  It goes away when things are bound
@@ -266,8 +266,8 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
     val map: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
       GpuOverrides.exec[ShuffleExchangeExec](
         "The backend for most data being exchanged between processes",
-        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
-            TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP + TypeSig.DAYTIME).nested()
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.ARRAY +
+            TypeSig.STRUCT + TypeSig.MAP + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested()
             .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
                 s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
             .withPsNote(TypeEnum.ARRAY, "Round-robin partitioning is not supported if " +
@@ -280,7 +280,7 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
         "The backend for most file input",
         ExecChecks(
           (TypeSig.commonCudfTypes + TypeSig.STRUCT + TypeSig.MAP + TypeSig.ARRAY +
-              TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
+              TypeSig.DECIMAL_128 + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all),
         (p, conf, parent, r) => new SparkPlanMeta[BatchScanExec](p, conf, parent, r) {
           override val childScans: scala.Seq[ScanMeta[_]] =
@@ -292,7 +292,7 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
       GpuOverrides.exec[CoalesceExec](
         "The backend for the dataframe coalesce method",
         ExecChecks((_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.STRUCT + TypeSig.ARRAY +
-            TypeSig.MAP + TypeSig.DAYTIME).nested(),
+            TypeSig.MAP + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all),
         (coalesce, conf, parent, r) => new SparkPlanMeta[CoalesceExec](coalesce, conf, parent, r) {
           override def convertToGpu(): GpuExec =
@@ -305,7 +305,7 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
             TypeSig.STRUCT.withPsNote(TypeEnum.STRUCT, "Only supported for Parquet") +
             TypeSig.MAP.withPsNote(TypeEnum.MAP, "Only supported for Parquet") +
             TypeSig.ARRAY.withPsNote(TypeEnum.ARRAY, "Only supported for Parquet") +
-            TypeSig.DAYTIME).nested(),
+            TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all),
         (p, conf, parent, r) => new SparkPlanMeta[DataWritingCommandExec](p, conf, parent, r) {
           override val childDataWriteCmds: scala.Seq[DataWritingCommandMeta[_]] =
@@ -315,11 +315,11 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
             GpuDataWritingCommandExec(childDataWriteCmds.head.convertToGpu(),
               childPlans.head.convertIfNeeded())
         }),
-      // this is copied, only added TypeSig.DAYTIME check
+      // this is copied, only added TypeSig.DAYTIME and TypeSig.YEARMONTH check
       GpuOverrides.exec[FileSourceScanExec](
         "Reading data from files, often from Hive tables",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
-            TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.DAYTIME).nested(),
+            TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.DAYTIME + TypeSig.YEARMONTH).nested(),
           TypeSig.all),
         (fsse, conf, p, r) => new SparkPlanMeta[FileSourceScanExec](fsse, conf, p, r) {
 
@@ -392,7 +392,8 @@ trait Spark33XShims extends Spark321PlusShims with Spark320PlusNonDBShims {
       GpuOverrides.exec[InMemoryTableScanExec](
         "Implementation of InMemoryTableScanExec to use GPU accelerated Caching",
         // NullType is actually supported
-        ExecChecks(TypeSig.commonCudfTypesWithNested + TypeSig.DAYTIME, TypeSig.all),
+        ExecChecks(TypeSig.commonCudfTypesWithNested + TypeSig.DAYTIME + TypeSig.YEARMONTH,
+          TypeSig.all),
         (scan, conf, p, r) => new InMemoryTableScanMeta(scan, conf, p, r)),
       GpuOverrides.exec[ProjectExec](
         "The backend for most select, withColumn and dropColumn statements",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -235,7 +235,7 @@ private[rapids] object GpuRowToColumnConverter {
     override def getNullSize: Double = 2 + VALIDITY
   }
 
-  private object IntConverter extends TypeConverter {
+  private[rapids] object IntConverter extends TypeConverter {
     override def append(row: SpecializedGetters,
       column: Int,
       builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {
@@ -250,7 +250,7 @@ private[rapids] object GpuRowToColumnConverter {
     override def getNullSize: Double = 4 + VALIDITY
   }
 
-  private object NotNullIntConverter extends TypeConverter {
+  private[rapids] object NotNullIntConverter extends TypeConverter {
     override def append(row: SpecializedGetters,
       column: Int,
       builder: ai.rapids.cudf.HostColumnVector.ColumnBuilder): Double = {

--- a/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
+++ b/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids
+
+import java.io.File
+import java.time.{Duration, Period}
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+/**
+ * Can not put this suite to cache_test.py because of currently Pyspark not have year-month type.
+ * See: https://github.com/apache/spark/blob/branch-3.3/python/pyspark/sql/types.py
+ */
+class IntervalSuite extends SparkQueryCompareTestSuite {
+
+  /**
+   * Set environment variable: "spark.sql.cache.serializer"
+   * "spark.sql.cache.serializer" is a static SQL configuration, can NOT set/unset it.
+   * Should specify it as environment variable when running the MVN, e.g:
+   * SPARK_CONF="spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer" mvn test
+   * This method is a hack code to set environment variable in the test code. it's a workaround.
+   * Should move this test suite to cache_test.py after Pyspark supports year-month type
+   */
+  private def setPCBS() = {
+    val env = System.getenv
+    // use reflect to set environment variable
+    val field = System.getenv.getClass.getDeclaredField("m")
+    field.setAccessible(true)
+    val envMap = field.get(env).asInstanceOf[java.util.Map[String, String]]
+    envMap.put("SPARK_CONF",
+      "spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer")
+  }
+
+  private def getDF(spark: SparkSession): DataFrame = {
+    import spark.implicits._
+    // Period is the external type of year-month type
+    // Duration is the external type of day-time type
+    Seq((1, Period.ofYears(1).plusMonths(1), Duration.ofDays(1).plusSeconds(1)),
+      (2, Period.ofYears(2).plusMonths(2), Duration.ofDays(2).plusSeconds(2)))
+        .toDF("c_interval", "c_year_month", "c_day_type")
+  }
+
+  test("test CPU cache interval by PCBS") {
+    setPCBS()
+    withCpuSparkSession(spark => {
+      getDF(spark).cache().count()
+    })
+  }
+
+  test("test GPU cache interval by PCBS") {
+    setPCBS()
+    withGpuSparkSession(spark => {
+      getDF(spark).cache().count()
+    })
+  }
+
+  test("test GPU cache interval when reading/writing parquet") {
+    setPCBS()
+
+    val tempFile = File.createTempFile("stats", ".parquet")
+    try {
+      withGpuSparkSession(spark => {
+        // invoke convertInternalRowToCachedBatch
+        getDF(spark).coalesce(1).write.mode("overwrite").parquet(tempFile.getAbsolutePath)
+      })
+
+      withGpuSparkSession(spark => {
+        val df = spark.read.parquet(tempFile.getAbsolutePath)
+        // invoke convertColumnarBatchToCachedBatch
+        df.cache().count()
+      })
+    } finally {
+      tempFile.delete()
+    }
+  }
+}

--- a/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
+++ b/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
@@ -122,6 +122,6 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
     "test ANSI interval read/write",
     getDF,
     (df, path) => df.coalesce(1).write.mode("overwrite").parquet(path),
-    (spark, path) => spark.read.parquet(path),
+    (spark, path) => spark.read.parquet(path)
   )
 }


### PR DESCRIPTION
Closes #2814 

1. Parquet support ANSI year month interval type
2. PCBS support ANSI year month interval type

Signed-off-by: Chong Gao <res_life@163.com>

