### PR TITLE
Fix regression from 21.12 where udfs defined in repl no longer worked

### DIFF
--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
@@ -151,6 +151,14 @@ object LambdaReflection {
   }
 
   def getClass(name: String): Class[_] = {
+    // Don't use ShimLoader.loadClass because in the REPL use case the classes
+    // compiled by REPL are accessible via the thread's context classloader,
+    // but not by the parent classloader detected by the plugin.
+    //
+    // This code is executed after the Plugin and ShimLoader has already been initialized.
+    // REPL classes are able to interact with the Plugin classes because the the REPL
+    // Thread context classloader is a descendant of the Plugin classloader.
+
     // scalastyle:off classforname
     Class.forName(name, true, Thread.currentThread().getContextClassLoader)
     // scalastyle:on classforname

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
@@ -18,7 +18,6 @@ package com.nvidia.spark.udf
 
 import java.lang.invoke.SerializedLambda
 
-import com.nvidia.spark.rapids.ShimLoader
 import javassist.{ClassClassPath, ClassPool, CtBehavior, CtClass, CtField, CtMethod}
 import javassist.bytecode.{CodeIterator, ConstPool, Descriptor}
 
@@ -152,7 +151,9 @@ object LambdaReflection {
   }
 
   def getClass(name: String): Class[_] = {
-    ShimLoader.loadClass(name)
+    // scalastyle:off classforname
+    Class.forName(name, true, Thread.currentThread().getContextClassLoader)
+    // scalastyle:on classforname
   }
 
   def parseTypeSig(sig: String): Option[DataType] = {

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/LambdaReflection.scala
@@ -156,7 +156,7 @@ object LambdaReflection {
     // but not by the parent classloader detected by the plugin.
     //
     // This code is executed after the Plugin and ShimLoader has already been initialized.
-    // REPL classes are able to interact with the Plugin classes because the the REPL
+    // REPL classes are able to interact with the Plugin classes because the REPL
     // Thread context classloader is a descendant of the Plugin classloader.
 
     // scalastyle:off classforname


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/5019.

Reverts a localized change to the udf-compiler introduced with this PR (https://github.com/NVIDIA/spark-rapids/pull/3726).

With `ShimLoader.loadClass`, we couldn't resolve a UDF defined in the repl, as documented here: https://github.com/NVIDIA/spark-rapids/issues/5019.