### PR TITLE
Implement hasSideEffects for GpuSequence

### DIFF
--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -217,3 +217,12 @@ def test_conditional_with_side_effects_case_when(data_gen):
                 WHEN a RLIKE "^[0-9]{4,6}\\z" THEN CAST(a AS INT) + 123 \
                 ELSE -1 END'),
                 conf = test_conf)
+
+@pytest.mark.parametrize('data_gen', [mk_str_gen('[a-z]{0,3}')], ids=idfn)
+def test_conditional_with_side_effects_sequence(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'CASE \
+            WHEN length(a) > 0 THEN sequence(1, length(a), 1) \
+            ELSE null END'),
+        conf = ansi_enabled_conf)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -667,6 +667,9 @@ case class GpuSequence(start: Expression, stop: Expression, stepOpt: Option[Expr
 
   override def foldable: Boolean = children.forall(_.foldable)
 
+  // can throw exceptions such as "Illegal sequence boundaries: step > 0 but start > stop"
+  override def hasSideEffects: Boolean = true
+
   override def columnarEval(batch: ColumnarBatch): Any = {
     withResource(columnarEvalToColumn(start, batch)) { startGpuCol =>
       withResource(stepOpt.map(columnarEvalToColumn(_, batch))) { stepGpuColOpt =>


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/5023

This PR implements `hasSideEffects` for `GpuSequence` to fix a bug where a conditional expression such as `CASE .. WHEN` could result in `GpuSequence` throwing an exception because we were evaluating for all rows and not just the rows that met the condition.

I filed a follow on issue https://github.com/NVIDIA/spark-rapids/issues/5041 to do the same for all other expressions that could potentially have side-effects.
