### PR TITLE
Revert "Replace ParquetFileReader.readFooter with open() and getFooter [databricks]" [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScanBase.scala
@@ -43,7 +43,6 @@ import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
 import org.apache.parquet.hadoop.metadata._
-import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.schema.{GroupType, MessageType, OriginalType, PrimitiveType, Type, Types}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
@@ -341,8 +340,8 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
 
     val filePath = new Path(new URI(file.filePath))
     //noinspection ScalaDeprecation
-    val inputFile = HadoopInputFile.fromPath(filePath, conf)
-    val footer = withResource(ParquetFileReader.open(inputFile))(_.getFooter)
+    val footer = ParquetFileReader.readFooter(conf, filePath,
+      ParquetMetadataConverter.range(file.start, file.start + file.length))
     val fileSchema = footer.getFileMetaData.getSchema
     val pushedFilters = if (enableParquetFilterPushDown) {
       val parquetFilters = SparkShimImpl.getParquetFilters(fileSchema, pushDownDate,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -226,12 +226,6 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.parquet</groupId>
-                    <artifactId>parquet-common</artifactId>
-                    <version>${spark.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-column</artifactId>
                     <version>${spark.version}</version>
                     <scope>provided</scope>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -16,15 +16,13 @@
 
 package com.nvidia.spark.rapids
 
-import java.io.{File, FilenameFilter}
+import java.io.File
 import java.nio.charset.StandardCharsets
 
 import com.nvidia.spark.rapids.shims.SparkShimImpl
-import org.apache.commons.io.filefilter.WildcardFileFilter
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -34,6 +32,9 @@ import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 /**
  * Tests for writing Parquet files with the GPU.
  */
+@scala.annotation.nowarn(
+  "msg=method readFooters in class ParquetFileReader is deprecated"
+)
 class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   test("file metadata") {
     val tempFile = File.createTempFile("stats", ".parquet")
@@ -41,13 +42,12 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
       withGpuSparkSession(spark => {
         val df = mixedDfWithNulls(spark)
         df.write.mode("overwrite").parquet(tempFile.getAbsolutePath)
-        val filter: FilenameFilter = new WildcardFileFilter("*.parquet")
-        val inputFile = HadoopInputFile.fromPath(
-          new Path(tempFile.listFiles(filter)(0).getAbsolutePath),
-          spark.sparkContext.hadoopConfiguration)
-        val parquetMeta = withResource(ParquetFileReader.open(inputFile))(_.getFooter)
 
-        val fileMeta = parquetMeta.getFileMetaData
+        val footer = ParquetFileReader.readFooters(spark.sparkContext.hadoopConfiguration,
+          new Path(tempFile.getAbsolutePath)).get(0)
+
+        val parquetMeta = footer.getParquetMetadata
+        val fileMeta = footer.getParquetMetadata.getFileMetaData
         val extra = fileMeta.getKeyValueMetaData
         assert(extra.containsKey("org.apache.spark.version"))
         assert(extra.containsKey("org.apache.spark.sql.parquet.row.metadata"))


### PR DESCRIPTION
Reverts NVIDIA/spark-rapids#4976
Closes https://github.com/NVIDIA/spark-rapids/issues/5048.

This PR #4976 looks to be causing us to read a lot more data from parquet than it used to (https://github.com/NVIDIA/spark-rapids/issues/5048). This reverts this, since as far as I know, this was introduced to fix a warning in databricks.