### PR TITLE
Fix merge from 22.04 to 22.06

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_co
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, is_before_spark_330
+from spark_session import with_cpu_session, is_before_spark_320, is_before_spark_330
 from parquet_test import _nested_pruning_schemas
 from conftest import is_databricks_runtime
 
@@ -231,6 +231,30 @@ def test_simple_partitioned_read(spark_tmp_path, v1_enabled_list, reader_confs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.orc(data_path),
             conf=all_confs)
+
+# Setup external table by altering column names
+def setup_external_table_with_forced_positions(spark, table_name, data_path):
+    rename_cols_query = "CREATE EXTERNAL TABLE `{}` (`col10` INT, `_c1` STRING, `col30` DOUBLE) STORED AS orc LOCATION '{}'".format(table_name, data_path)
+    spark.sql(rename_cols_query).collect
+
+@pytest.mark.skipif(is_before_spark_320(), reason='ORC forced positional evolution support is added in Spark-3.2')
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+@pytest.mark.parametrize('forced_position', ["true", "false"])
+@pytest.mark.parametrize('orc_impl', ["native", "hive"])
+def test_orc_forced_position(spark_tmp_path, spark_tmp_table_factory, reader_confs, forced_position, orc_impl):
+    orc_gens = [int_gen, string_gen, double_gen]
+    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(orc_gens)]
+    data_path = spark_tmp_path + 'ORC_DATA'
+    with_cpu_session(lambda spark : gen_df(spark, gen_list).write.orc(data_path))
+    table_name = spark_tmp_table_factory.get()
+    with_cpu_session(lambda spark : setup_external_table_with_forced_positions(spark, table_name, data_path))
+
+    all_confs = copy_and_update(reader_confs, {
+        'orc.force.positional.evolution': forced_position,
+        'spark.sql.orc.impl': orc_impl})
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : spark.sql("SELECT * FROM {}".format(table_name)),
+        conf=all_confs)
 
 # In this we are reading the data, but only reading the key the data was partitioned by
 @pytest.mark.parametrize('v1_enabled_list', ["", "orc"])

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/OrcShims311until320Base.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/OrcShims311until320Base.scala
@@ -91,4 +91,9 @@ trait OrcShims311until320Base {
   def typeDescriptionEqual(lhs: TypeDescription, rhs: TypeDescription): Boolean = {
     lhs.equals(rhs)
   }
+
+  // forcePositionalEvolution is available from Spark-3.2. So setting this as false.
+  def forcePositionalEvolution(conf:Configuration): Boolean = {
+    false
+  }
 }

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/OrcShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/OrcShims.scala
@@ -127,4 +127,9 @@ object OrcShims {
   def typeDescriptionEqual(lhs: TypeDescription, rhs: TypeDescription): Boolean = {
     lhs.equals(rhs, false)
   }
+
+  // forcePositionalEvolution is available from Spark-3.2.
+  def forcePositionalEvolution(conf: Configuration): Boolean = {
+    OrcConf.FORCE_POSITIONAL_EVOLUTION.getBoolean(conf)
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -43,7 +43,6 @@ import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetInputFormat}
 import org.apache.parquet.hadoop.metadata._
-import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.schema.{GroupType, MessageType, OriginalType, PrimitiveType, Type, Types}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
@@ -370,8 +369,8 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
 
     val filePath = new Path(new URI(file.filePath))
     //noinspection ScalaDeprecation
-    val inputFile = HadoopInputFile.fromPath(filePath, conf)
-    val footer = withResource(ParquetFileReader.open(inputFile))(_.getFooter)
+    val footer = ParquetFileReader.readFooter(conf, filePath,
+      ParquetMetadataConverter.range(file.start, file.start + file.length))
     val fileSchema = footer.getFileMetaData.getSchema
     val pushedFilters = if (enableParquetFilterPushDown) {
       val parquetFilters = SparkShimImpl.getParquetFilters(fileSchema, pushDownDate,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -226,12 +226,6 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.parquet</groupId>
-                    <artifactId>parquet-common</artifactId>
-                    <version>${spark.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-column</artifactId>
                     <version>${spark.version}</version>
                     <scope>provided</scope>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -16,15 +16,13 @@
 
 package com.nvidia.spark.rapids
 
-import java.io.{File, FilenameFilter}
+import java.io.File
 import java.nio.charset.StandardCharsets
 
 import com.nvidia.spark.rapids.shims.SparkShimImpl
-import org.apache.commons.io.filefilter.WildcardFileFilter
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 import org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.parquet.hadoop.util.HadoopInputFile
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -34,6 +32,9 @@ import org.apache.spark.sql.rapids.BasicColumnarWriteJobStatsTracker
 /**
  * Tests for writing Parquet files with the GPU.
  */
+@scala.annotation.nowarn(
+  "msg=method readFooters in class ParquetFileReader is deprecated"
+)
 class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   test("file metadata") {
     val tempFile = File.createTempFile("stats", ".parquet")
@@ -41,13 +42,12 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
       withGpuSparkSession(spark => {
         val df = mixedDfWithNulls(spark)
         df.write.mode("overwrite").parquet(tempFile.getAbsolutePath)
-        val filter: FilenameFilter = new WildcardFileFilter("*.parquet")
-        val inputFile = HadoopInputFile.fromPath(
-          new Path(tempFile.listFiles(filter)(0).getAbsolutePath),
-          spark.sparkContext.hadoopConfiguration)
-        val parquetMeta = withResource(ParquetFileReader.open(inputFile))(_.getFooter)
 
-        val fileMeta = parquetMeta.getFileMetaData
+        val footer = ParquetFileReader.readFooters(spark.sparkContext.hadoopConfiguration,
+          new Path(tempFile.getAbsolutePath)).get(0)
+
+        val parquetMeta = footer.getParquetMetadata
+        val fileMeta = footer.getParquetMetadata.getFileMetaData
         val extra = fileMeta.getKeyValueMetaData
         assert(extra.containsKey("org.apache.spark.version"))
         assert(extra.containsKey("org.apache.spark.sql.parquet.row.metadata"))


### PR DESCRIPTION
Fixes the merge conflict reported by #5057.  The merge was automatically performed by git, so not sure why it was flagged as a merge conflict unless the auto-merge bot somehow was tripped up by the GpuOrcScanBase -> GpuOrcScan rename.  The git CLI was able to resolve it automatically for me.

**NOTE: This must be committed with a merge commit, not squashed!**