### PR TITLE
Update for the public release [skip ci]

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -344,6 +344,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadoc</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doclint>none</doclint>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -56,3 +56,6 @@ RUN mkdir -p /tmp/ucx && \
     wget https://github.com/openucx/ucx/releases/download/v${UCX_VER}/ucx-v${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5.x-cuda${CUDA_VER}.deb && \
     dpkg -i *.deb && \
     rm -rf /tmp/ucx
+
+# export JAVA_HOME for mvn option 'source-javadoc'
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -24,7 +24,7 @@ export M2DIR="$WORKSPACE/.m2"
 
 DIST_PL="dist"
 function mvnEval {
-    mvn help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Prelease301 -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER -DforceStdout -Dexpression=$1
+    mvn help:evaluate -q -pl $DIST_PL $MVN_URM_MIRROR -Prelease311 -Dmaven.repo.local=$M2DIR -Dcuda.version=$CUDA_CLASSIFIER -DforceStdout -Dexpression=$1
 }
 
 ART_ID=$(mvnEval project.artifactId)

--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,7 @@
                         </executions>
                         <configuration>
                             <doclint>none</doclint>
+                            <detectOfflineLinks>false</detectOfflineLinks>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -793,7 +793,6 @@
                         </executions>
                         <configuration>
                             <doclint>none</doclint>
-                            <detectOfflineLinks>false</detectOfflineLinks>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
To fix issue #5050

1, Add JAVA_HOME for maven opt `-P source-javadoc`

2, Change to use maven opt `-P release311` instead of `-P release301`

3, Add configuration `<detectOfflineLinks>` for maven-javadoc-plugin:
   
     Not detecting the links for all modules defined in the project: https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-no-fork-mojo.html#detectOfflineLinks
    To fix: [ERROR] `The specified file '/home/jenkins/agent/workspace/jenkins-tim-rapids-release-11/dist/target/rapids-4-spark_2.12-22.04.0.jar' not exists`

Signed-off-by: Tim Liu <timl@nvidia.com>