### PR TITLE
Change Scala style continuation indentation to be 2 spaces to match guide [skip ci]

### DIFF
--- a/docs/dev/idea-code-style-settings.xml
+++ b/docs/dev/idea-code-style-settings.xml
@@ -31,8 +31,5 @@
   </codeStyleSettings>
   <codeStyleSettings language="Scala">
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-    </indentOptions>
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/4986

The scala style guide calls for 2 spaces of indentation at each level (https://docs.scala-lang.org/style/indentation.html).
Only exception to this that I know of is method declaration (https://github.com/databricks/scala-style-guide#indent).  So here change our code style template to use the default 2 spaces for continuation identation.  We can just remove the explicit 4 spaces and it goes back to default to 2.   

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
