### PR TITLE
Fix profiling tool reading collectionAccumulator

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 import com.nvidia.spark.rapids.tool.profiling._
 
@@ -201,7 +202,7 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
         app.accumIdToStageId.put(res.id, event.stageId)
         arrBuf += thisMetric
       } catch {
-        case e: Exception =>
+        case NonFatal(e) =>
           logWarning("Exception when parsing accumulables for task "
             + "stageID=" + event.stageId + ",taskId=" + event.taskInfo.taskId
             + ": ")
@@ -404,7 +405,7 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
         app.accumIdToStageId.put(res._2.id, event.stageInfo.stageId)
         arrBuf += thisMetric
       } catch {
-        case e: Exception =>
+        case NonFatal(e) =>
           logWarning("Exception when parsing accumulables for task " +
               "stageID=" + event.stageInfo.stageId + ": ")
           logWarning(e.toString)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/EventsProcessor.scala
@@ -201,8 +201,8 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
         app.accumIdToStageId.put(res.id, event.stageId)
         arrBuf += thisMetric
       } catch {
-        case e: ClassCastException =>
-          logWarning("ClassCastException when parsing accumulables for task "
+        case e: Exception =>
+          logWarning("Exception when parsing accumulables for task "
             + "stageID=" + event.stageId + ",taskId=" + event.taskInfo.taskId
             + ": ")
           logWarning(e.toString)
@@ -404,8 +404,8 @@ class EventsProcessor(app: ApplicationInfo) extends EventProcessorBase[Applicati
         app.accumIdToStageId.put(res._2.id, event.stageInfo.stageId)
         arrBuf += thisMetric
       } catch {
-        case e: ClassCastException =>
-          logWarning("ClassCastException when parsing accumulables for task " +
+        case e: Exception =>
+          logWarning("Exception when parsing accumulables for task " +
               "stageID=" + event.stageInfo.stageId + ": ")
           logWarning(e.toString)
           logWarning("The problematic accumulable is: name="


### PR DESCRIPTION

The profiling tool can fail to process an event log if it has custom task accumulables of type CollectionAccumulator, this just changes it to catch the exception and ignore those accumulables.

This is a minimal fix for https://github.com/NVIDIA/spark-rapids/issues/5091 but I want to leave that open and handle these better.


Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
