### PR TITLE
On task failure catch some CUDA exceptions and kill executor [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -280,15 +280,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     super.onTaskFailed(failureReason)
     failureReason match {
       case ef: ExceptionFailure =>
-        logWarning(" exception description: " + ef.description)
-        logWarning(" exception Failures: " + ef.toErrorString)
-
-        // parse the exception message
-        logWarning("full stack trace: " + ef.fullStackTrace)
-        logWarning("full exception: " + ef.exception.getOrElse(""))
-        ef.stackTrace.foreach { elem =>
-          logWarning(s"stacktrace elem is: $elem")
-        }
         val unrecoverableErrors = Seq("cudaErrorIllegalAddress", "cudaErrorLaunchTimeout",
           "cudaErrorHardwareStackError", "cudaErrorIllegalInstruction",
           "cudaErrorMisalignedAddress", "cudaErrorInvalidAddressSpace", "cudaErrorInvalidPc",
@@ -296,6 +287,8 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorECCUncorrectable")
         if (unrecoverableErrors.exists(ef.toErrorString.contains(_)) ||
           unrecoverableErrors.exists(ef.description.contains(_)) ) {
+          logError("Existing Executor based on exception having fata CUDA error: " +
+            s"${ef.toErrorString}")
           System.exit(2)
         }
       case other =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -286,7 +286,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorECCUncorrectable")
         // Could check the entire error string, but don't think its necessary
         // unrecoverableErrors.exists(ef.toErrorString.contains(_))
-        if (unrecoverableErrors.exists(ef.description.contains(_)) ) {
+        if (unrecoverableErrors.exists(ef.description.contains(_))) {
           logError("Stopping the Executor based on exception being a fatal CUDA error: " +
             s"${ef.toErrorString}")
           System.exit(20)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -285,8 +285,8 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorLaunchFailure", "cudaErrorExternalDevice", "cudaErrorUnknown",
           "cudaErrorECCUncorrectable")
         // Could check the entire error string, but don't think its necessary
-        // unrecoverableErrors.exists(ef.toErrorString.contains(_))
-        if (unrecoverableErrors.exists(ef.description.contains(_))) {
+        if (unrecoverableErrors.exists(ef.description.contains(_)) ||
+          unrecoverableErrors.exists(ef.toErrorString.contains(_))) {
           logError("Stopping the Executor based on exception being a fatal CUDA error: " +
             s"${ef.toErrorString}")
           System.exit(20)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -289,10 +289,10 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           unrecoverableErrors.exists(ef.description.contains(_)) ) {
           logError("Stopping the Executor based on exception being a fatal CUDA error: " +
             s"${ef.toErrorString}")
-          System.exit(2)
+          System.exit(20)
         }
       case other =>
-        logWarning(s"other type of task failure: ${other.toString}")
+        logDebug(s"Executor onTaskFailed not a CUDA fatal error: ${other.toString}")
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -284,8 +284,9 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorMisalignedAddress", "cudaErrorInvalidAddressSpace", "cudaErrorInvalidPc",
           "cudaErrorLaunchFailure", "cudaErrorExternalDevice", "cudaErrorUnknown",
           "cudaErrorECCUncorrectable")
-        if (unrecoverableErrors.exists(ef.toErrorString.contains(_)) ||
-          unrecoverableErrors.exists(ef.description.contains(_)) ) {
+        // Could check the entire error string, but don't think its necessary
+        // unrecoverableErrors.exists(ef.toErrorString.contains(_))
+        if (unrecoverableErrors.exists(ef.description.contains(_)) ) {
           logError("Stopping the Executor based on exception being a fatal CUDA error: " +
             s"${ef.toErrorString}")
           System.exit(20)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -284,7 +284,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorMisalignedAddress", "cudaErrorInvalidAddressSpace", "cudaErrorInvalidPc",
           "cudaErrorLaunchFailure", "cudaErrorExternalDevice", "cudaErrorUnknown",
           "cudaErrorECCUncorrectable")
-        // Could check the entire error string, but don't think its necessary
         if (unrecoverableErrors.exists(ef.description.contains(_)) ||
           unrecoverableErrors.exists(ef.toErrorString.contains(_))) {
           logError("Stopping the Executor based on exception being a fatal CUDA error: " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -287,7 +287,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
           "cudaErrorECCUncorrectable")
         if (unrecoverableErrors.exists(ef.toErrorString.contains(_)) ||
           unrecoverableErrors.exists(ef.description.contains(_)) ) {
-          logError("Existing Executor based on exception having fata CUDA error: " +
+          logError("Stopping the Executor based on exception being a fatal CUDA error: " +
             s"${ef.toErrorString}")
           System.exit(2)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -277,7 +277,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def onTaskFailed(failureReason: TaskFailedReason): Unit = {
-    super.onTaskFailed(failureReason)
     failureReason match {
       case ef: ExceptionFailure =>
         val unrecoverableErrors = Seq("cudaErrorIllegalAddress", "cudaErrorLaunchTimeout",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -289,12 +289,13 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
         ef.stackTrace.foreach { elem =>
           logWarning(s"stacktrace elem is: $elem")
         }
-        val errorText = "CUDA, the process must be terminated and relaunched."
-        val unknownErrorText = "cudaErrorUnknown"
-        val eccErrorText = "cudaErrorECCUncorrectable"
-        val allErrors = Seq(unknownErrorText, eccErrorText, errorText)
-        if (allErrors.exists(ef.toErrorString.contains(_)) ||
-          allErrors.exists(ef.description.contains(_)) ) {
+        val unrecoverableErrors = Seq("cudaErrorIllegalAddress", "cudaErrorLaunchTimeout",
+          "cudaErrorHardwareStackError", "cudaErrorIllegalInstruction",
+          "cudaErrorMisalignedAddress", "cudaErrorInvalidAddressSpace", "cudaErrorInvalidPc",
+          "cudaErrorLaunchFailure", "cudaErrorExternalDevice", "cudaErrorUnknown",
+          "cudaErrorECCUncorrectable")
+        if (unrecoverableErrors.exists(ef.toErrorString.contains(_)) ||
+          unrecoverableErrors.exists(ef.description.contains(_)) ) {
           System.exit(2)
         }
       case other =>


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/5029. This is shorter term solution to just parse the exception message to catch certain types of unrecoverable CUDA errors.  It may not be bullet proof as the messages could change.

Here if we find an exception that we think is unrecoverable we system.exit to kill the executor.  
Generally you would want to use this with the Spark excludeOnFailure functionality so it doesn't start the executor back up using the same GPU.

I've manually tested this by faking the exception occurring since we can't reproduce it.  It properly kills the executor when it sees the exception.

Sample code used to cause failures:
```
sc.range(0, 4, 1, 4).mapPartitions{x =>
  import org.apache.spark.TaskContext
  val tc = TaskContext.get()
  println("task id: " + tc.taskAttemptId)
  
  if (tc.taskAttemptId % 3 == 0) {
    try {
    throw new Exception("cudaErrorHardwareStackError")
    } catch {
      case e: Throwable =>
      throw new RuntimeException(s"CUDA error encountered: ${e.getMessage}", e)
    }
  }
  x.map(x => x)}.collect()
```

this generates exceptions like:
```
22/03/31 22:46:57 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
java.lang.RuntimeException: CUDA error encountered: cudaErrorHardwareStackError
```

This new executor plugin code catches and logs the following and then exits:

`22/03/31 22:46:57 ERROR RapidsExecutorPlugin: Stopping the Executor based on exception being a fatal CUDA error: java.lang.RuntimeException: CUDA error encountered: cudaErrorHardwareStackError`

In standalone mode with the excludeOnFailure spark configs set to 1 for the node exclusion, it when the task fails and this kills the executor, the node with be excluded and the worker will not be able to restart an executor on that node.  Also note keep in mind the spark config  spark.excludeOnFailure.timeout which will try spark to retry that node after the timeout value.
Without excludeonFailure, the executors just get restarted on the same nodes for standalone mode.  I tested on yarn as well and there it will restart executors but it could be on different nodes depending on the size of the cluster.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
