### PR TITLE
Disable GPU accelerated row-column transpose for Pascal GPUs:

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -346,11 +346,11 @@ object GpuColumnarToRowExecParent {
   /**
    * Helper to check if GPU accelerated row-column transpose is supported
    */
-  private def isAcceleratedTransposeSupported: Boolean = {
+  private lazy val isAcceleratedTransposeSupported: Boolean = {
     // Check if the current CUDA device architecture exceeds Pascal.
     // i.e. CUDA compute capability > 6.x.
     // Reference:  https://developer.nvidia.com/cuda-gpus
-    Cuda.getCurrentComputeCapabilityMajor > 6
+    Cuda.getComputeCapabilityMajor > 6
   }
 
   def makeIteratorFunc(


### PR DESCRIPTION
Depends on rapidsai/cudf/pull/10568.
Works around the failures described in #4980. 

This commit bypasses GPU accelerated row-column conversion for Pascal GPUs. 
Other architectures should remain unaffected by this shunt.

Further investigation might be required to find the actual problem in
CUDF's `fixed_width_convert_to_rows()` implementation.

Signed-off-by: MithunR <mythrocks@gmail.com>
