### PR TITLE
Fix ShimVectorizedColumnReader construction for recent Spark 3.3.0 changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,7 @@
                                         <source>${project.basedir}/src/main/320+-nondb/scala</source>
                                         <source>${project.basedir}/src/main/320until330-all/scala</source>
                                         <source>${project.basedir}/src/main/321+/scala</source>
+                                        <source>${project.basedir}/src/main/321until330-all/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
                                 </configuration>
@@ -524,8 +525,9 @@
                                         <source>${project.basedir}/src/main/311until330-nondb/scala</source>
                                         <source>${project.basedir}/src/main/320+/scala</source>
                                         <source>${project.basedir}/src/main/320+-nondb/scala</source>
-                                        <source>${project.basedir}/src/main/321+/scala</source>
                                         <source>${project.basedir}/src/main/320until330-all/scala</source>
+                                        <source>${project.basedir}/src/main/321+/scala</source>
+                                        <source>${project.basedir}/src/main/321until330-all/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
                                 </configuration>
@@ -597,8 +599,9 @@
                                         <source>${project.basedir}/src/main/311until330-all/scala</source>
                                         <source>${project.basedir}/src/main/311+-db/scala</source>
                                         <source>${project.basedir}/src/main/320+/scala</source>
-                                        <source>${project.basedir}/src/main/321+/scala</source>
                                         <source>${project.basedir}/src/main/320until330-all/scala</source>
+                                        <source>${project.basedir}/src/main/321+/scala</source>
+                                        <source>${project.basedir}/src/main/321until330-all/scala</source>
                                         <source>${project.basedir}/src/main/post320-treenode/scala</source>
                                     </sources>
                                 </configuration>

--- a/sql-plugin/src/main/311until320-noncdh/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/311until320-noncdh/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.parquet.rapids.shims
 
 import java.time.ZoneId
 
+import org.apache.parquet.VersionParser.ParsedVersion
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.column.page.PageReadStore
 import org.apache.parquet.schema.{GroupType, Type}
@@ -52,7 +53,8 @@ class ShimVectorizedColumnReader(
     convertTz: ZoneId,
     datetimeRebaseMode: String,
     int96RebaseMode: String,
-    int96CDPHive3Compatibility: Boolean
+    int96CDPHive3Compatibility: Boolean,
+    writerVersion: ParsedVersion
 ) extends VectorizedColumnReader(
       columns.get(index),
       types.get(index).getOriginalType,

--- a/sql-plugin/src/main/311until330-nondb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/311until330-nondb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.catalyst.trees.Origin
+
 object RapidsErrorUtils {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
@@ -23,7 +25,10 @@ object RapidsErrorUtils {
     new ArrayIndexOutOfBoundsException(s"Invalid index: $index, numElements: $numElements")
   }
 
-  def mapKeyNotExistError(key: String, isElementAtF: Boolean = false): NoSuchElementException = {
+  def mapKeyNotExistError(
+      key: String,
+      isElementAtFunction: Boolean = false,
+      origin: Origin): NoSuchElementException = {
     // Follow the Spark string format before 3.3.0
     new NoSuchElementException(s"Key $key does not exist.")
   }

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.catalyst.trees.Origin
+
 object RapidsErrorUtils {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
@@ -23,7 +25,10 @@ object RapidsErrorUtils {
     new ArrayIndexOutOfBoundsException(s"Invalid index: $index, numElements: $numElements")
   }
 
-  def mapKeyNotExistError(key: String, isElementAtF: Boolean = false): NoSuchElementException = {
+  def mapKeyNotExistError(
+      key: String,
+      isElementAtFunction: Boolean,
+      origin: Origin): NoSuchElementException = {
     // Follow the Spark string format before 3.3.0
     new NoSuchElementException(s"Key $key does not exist.")
   }

--- a/sql-plugin/src/main/320/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.parquet.rapids.shims
 
 import java.time.ZoneId
 
+import org.apache.parquet.VersionParser.ParsedVersion
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.column.page.PageReadStore
 import org.apache.parquet.schema.{GroupType, Type}
@@ -52,7 +53,8 @@ class ShimVectorizedColumnReader(
     convertTz: ZoneId,
     datetimeRebaseMode: String,
     int96RebaseMode: String,
-    int96CDPHive3Compatibility: Boolean
+    int96CDPHive3Compatibility: Boolean,
+    writerVersion: ParsedVersion
 ) extends VectorizedColumnReader(
       columns.get(index),
       types.get(index).getLogicalTypeAnnotation,

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
 
 object RapidsErrorUtils {
@@ -28,7 +29,10 @@ object RapidsErrorUtils {
     }
   }
 
-  def mapKeyNotExistError(key: String, isElementAtF: Boolean = false): NoSuchElementException = {
+  def mapKeyNotExistError(
+      key: String,
+      isElementAtFunction: Boolean,
+      origin: Origin): NoSuchElementException = {
     // For now, the default argument is false. The caller sets the correct value accordingly.
     QueryExecutionErrors.mapKeyNotExistError(key)
   }

--- a/sql-plugin/src/main/321until330-all/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/321until330-all/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet.rapids.shims
 import java.time.ZoneId
 import java.util.TimeZone
 
+import org.apache.parquet.VersionParser.ParsedVersion
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.column.page.PageReadStore
 import org.apache.parquet.schema.{GroupType, Type}
@@ -54,7 +55,8 @@ class ShimVectorizedColumnReader(
     convertTz: ZoneId,
     datetimeRebaseMode: String, // always LegacyBehaviorPolicy.CORRECTED
     int96RebaseMode: String, // always LegacyBehaviorPolicy.EXCEPTION
-    int96CDPHive3Compatibility: Boolean
+    int96CDPHive3Compatibility: Boolean,
+    writerVersion: ParsedVersion
 ) extends VectorizedColumnReader(
       columns.get(index),
       types.get(index).getLogicalTypeAnnotation,

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
 
 object RapidsErrorUtils {
@@ -28,9 +29,12 @@ object RapidsErrorUtils {
     }
   }
 
-  def mapKeyNotExistError(key: String, isElementAtF: Boolean = false): NoSuchElementException = {
+  def mapKeyNotExistError(
+      key: String,
+      isElementAtFunction: Boolean,
+      origin: Origin): NoSuchElementException = {
     // For now, the default argument is false. The caller sets the correct value accordingly.
-    QueryExecutionErrors.mapKeyNotExistError(key, isElementAtF)
+    QueryExecutionErrors.mapKeyNotExistError(key, isElementAtFunction, origin.context)
   }
 
   def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -59,9 +59,8 @@ class ShimVectorizedColumnReader(
     writerVersion: ParsedVersion
 ) extends VectorizedColumnReader(
       columns.get(index),
-      types.get(index).getLogicalTypeAnnotation,
-      pageReadStore.getPageReader(columns.get(index)),
-      pageReadStore.getRowIndexes().orElse(null),
+      true,
+      pageReadStore,
       convertTz,
       datetimeRebaseMode,
       TimeZone.getDefault.getID, // use default zone because of no rebase

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -17,12 +17,14 @@
 package org.apache.spark.sql.execution.datasources.parquet.rapids.shims
 
 import java.time.ZoneId
+import java.util.TimeZone
 
 import org.apache.parquet.VersionParser.ParsedVersion
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.column.page.PageReadStore
 import org.apache.parquet.schema.{GroupType, Type}
 
+import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.execution.datasources.parquet.{ParentContainerUpdater, ParquetRowConverter, ParquetToSparkSchemaConverter, VectorizedColumnReader}
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.types.StructType
@@ -32,8 +34,8 @@ class ShimParquetRowConverter(
     parquetType: GroupType,
     catalystType: StructType,
     convertTz: Option[ZoneId],
-    datetimeRebaseMode: LegacyBehaviorPolicy.Value,
-    int96RebaseMode: LegacyBehaviorPolicy.Value,
+    datetimeRebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.CORRECTED
+    int96RebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.EXCEPTION
     int96CDPHive3Compatibility: Boolean,
     updater: ParentContainerUpdater
 ) extends ParquetRowConverter(
@@ -41,9 +43,8 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      datetimeRebaseMode,
-      int96RebaseMode,
-      int96CDPHive3Compatibility,
+      RebaseSpec(datetimeRebaseMode), // no need to rebase, so set originTimeZone as default
+      RebaseSpec(int96RebaseMode), // no need to rebase, so set originTimeZone as default
       updater)
 
 class ShimVectorizedColumnReader(
@@ -52,15 +53,18 @@ class ShimVectorizedColumnReader(
     types: java.util.List[Type],
     pageReadStore: PageReadStore,
     convertTz: ZoneId,
-    datetimeRebaseMode: String,
-    int96RebaseMode: String,
+    datetimeRebaseMode: String, // always LegacyBehaviorPolicy.CORRECTED
+    int96RebaseMode: String, // always LegacyBehaviorPolicy.EXCEPTION
     int96CDPHive3Compatibility: Boolean,
     writerVersion: ParsedVersion
 ) extends VectorizedColumnReader(
       columns.get(index),
-      types.get(index).getOriginalType,
+      types.get(index).getLogicalTypeAnnotation,
       pageReadStore.getPageReader(columns.get(index)),
+      pageReadStore.getRowIndexes().orElse(null),
       convertTz,
       datetimeRebaseMode,
+      TimeZone.getDefault.getID, // use default zone because of no rebase
       int96RebaseMode,
-      int96CDPHive3Compatibility)
+      TimeZone.getDefault.getID, // use default zone because of will throw exception if rebase
+      writerVersion)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -231,7 +231,8 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
                 if (!exist.isValid || exist.getBoolean) {
                   map.getMapValue(key)
                 } else {
-                  throw RapidsErrorUtils.mapKeyNotExistError(keyS.getValue.toString, true)
+                  throw RapidsErrorUtils.mapKeyNotExistError(keyS.getValue.toString,
+                    isElementAtFunction = true, origin)
                 }
               }
             }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -212,7 +212,8 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
       withResource(lhs.getBase.getMapKeyExistence(rhs.getBase)) { keyExistenceColumn =>
         withResource(keyExistenceColumn.all) { exist =>
           if (exist.isValid && !exist.getBoolean) {
-            throw RapidsErrorUtils.mapKeyNotExistError(rhs.getValue.toString)
+            throw RapidsErrorUtils.mapKeyNotExistError(rhs.getValue.toString,
+              isElementAtFunction = false, origin)
           }
         }
       }


### PR DESCRIPTION
Fixes #5123.
Fixes #5133.

Adds in a `ParsedVersion` parameter which is new in the Spark 3.3.0 constructor for `VectorizedColumnReader`.  Creation of the parameter mirrors the same logic implemented in [SPARK-37974](https://issues.apache.org/jira/browse/SPARK-37974) and [SPARK-34863](https://issues.apache.org/jira/browse/SPARK-34863).

In addition this contains a build fix for the `QueryExecutionErrors` changes in [SPARK-38716](https://issues.apache.org/jira/browse/SPARK-38716).