### PR TITLE
Support env var INTEGRATION_TEST_VERSION to override shim version

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -37,19 +37,18 @@ else
 
     echo "Detected Spark version $VERSION_STRING (shim version: $SPARK_SHIM_VER)"
 
+    INTEGRATION_TEST_VERSION=$SPARK_SHIM_VER
+
+    if [[ ! -z $INTEGRATION_TEST_VERSION_OVERRIDE ]]; then
+        # Override auto detected shim version in case of non-standard version string, e.g. `spark3113172702000-53`
+        INTEGRATION_TEST_VERSION=$INTEGRATION_TEST_VERSION_OVERRIDE
+    fi
+
     # support alternate local jars NOT building from the source code
     if [ -d "$LOCAL_JAR_PATH" ]; then
         CUDF_JARS=$(echo "$LOCAL_JAR_PATH"/cudf-*.jar)
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
         PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
-
-        INTEGRATION_TEST_VERSION=$SPARK_SHIM_VER
-
-        if [[ ! -z $INTEGRATION_TEST_VERSION_OVERRIDE ]]; then
-            # Override auto detected shim version in case of non-standard version string, e.g. `spark3113172702000-53`
-            INTEGRATION_TEST_VERSION=$INTEGRATION_TEST_VERSION_OVERRIDE
-        fi
-
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     else

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -42,8 +42,16 @@ else
         CUDF_JARS=$(echo "$LOCAL_JAR_PATH"/cudf-*.jar)
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
         PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
+
+        INTEGRATION_TEST_VERSION=$SPARK_SHIM_VER
+
+        if [[ ! -z $INTEGRATION_TEST_VERSION_OVERRIDE ]]; then
+            # Override auto detected shim version in case of non-standard version string, e.g. `spark3113172702000-53`
+            INTEGRATION_TEST_VERSION=$INTEGRATION_TEST_VERSION_OVERRIDE
+        fi
+
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
-        TEST_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark-integration-tests*-$SPARK_SHIM_VER.jar)
+        TEST_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     else
         CUDF_JARS=$(echo "$SCRIPTPATH"/target/dependency/cudf-*.jar)
         AVRO_JARS=$(echo "$SCRIPTPATH"/target/dependency/spark-avro*.jar)

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -56,7 +56,7 @@ else
         AVRO_JARS=$(echo "$SCRIPTPATH"/target/dependency/spark-avro*.jar)
         PLUGIN_JARS=$(echo "$SCRIPTPATH"/../dist/target/rapids-4-spark_*.jar)
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
-        TEST_JARS=$(echo "$SCRIPTPATH"/target/rapids-4-spark-integration-tests*-$SPARK_SHIM_VER.jar)
+        TEST_JARS=$(echo "$SCRIPTPATH"/target/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     fi
 
     # `./run_pyspark_from_build.sh` runs all tests including avro_test.py with spark-avro.jar


### PR DESCRIPTION
to load specified integration test jar file

Signed-off-by: Alex Zhang <alex4zhang@gmail.com>
