### PR TITLE
Fix test failure with Spark 3.3 by looking for less specific error message

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -19,8 +19,7 @@ from data_gen import *
 from marks import ignore_order, incompat, approximate_float, allow_non_gpu
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
-from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_320, \
-    is_before_spark_330, is_databricks91_or_later, is_spark_330_or_later
+from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_320, is_before_spark_330, is_databricks91_or_later
 import pyspark.sql.functions as f
 from datetime import timedelta
 
@@ -781,7 +780,6 @@ div_overflow_exprs = [
 # Only run this test for Spark v3.2.0 and later to verify IntegralDivide will
 # throw exceptions for overflow when ANSI mode is enabled.
 @pytest.mark.skipif(is_before_spark_320(), reason='https://github.com/apache/spark/pull/32260')
-@pytest.mark.skipif(is_spark_330_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/5182')
 @pytest.mark.parametrize('expr', div_overflow_exprs)
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
 def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
@@ -790,7 +788,7 @@ def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
         assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_div_overflow_df(spark, expr).collect(),
             conf=ansi_conf,
-            error_message='java.lang.ArithmeticException: Overflow in integral divide')
+            error_message='ArithmeticException: Overflow in integral divide')
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: _get_div_overflow_df(spark, expr),

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -19,7 +19,8 @@ from data_gen import *
 from marks import ignore_order, incompat, approximate_float, allow_non_gpu
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
-from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_320, is_before_spark_330, is_databricks91_or_later
+from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_320, \
+    is_before_spark_330, is_databricks91_or_later, is_spark_330_or_later
 import pyspark.sql.functions as f
 from datetime import timedelta
 
@@ -780,6 +781,7 @@ div_overflow_exprs = [
 # Only run this test for Spark v3.2.0 and later to verify IntegralDivide will
 # throw exceptions for overflow when ANSI mode is enabled.
 @pytest.mark.skipif(is_before_spark_320(), reason='https://github.com/apache/spark/pull/32260')
+@pytest.mark.skipif(is_spark_330_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/5182')
 @pytest.mark.parametrize('expr', div_overflow_exprs)
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
 def test_div_overflow_exception_when_ansi(expr, ansi_enabled):


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/5182

Spark 3.3 changed which exception they throw for a divide that causes an overflow in https://github.com/apache/spark/commit/c2ed15de94f611972c463ff8bba9268c1e93fd30, causing our tests to fail.

This PR changes the affected test to just look for `ArithmeticException` rather than specifically `java.lang.ArithmeticException`. This is the same approach used in the other tests.
