### PR TITLE
Fix merge conflict from branch-22.04

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -5066,17 +5066,17 @@ are limited.
 </tr>
 <tr>
 <td>index/key</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>Only ints are supported as array indexes</em></td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
-<td><em>PS<br/>max DECIMAL precision of 18;<br/>Literal value only</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Supported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.;<br/>UTC is only supported TZ for TIMESTAMP</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>
@@ -6005,16 +6005,16 @@ are limited.
 </tr>
 <tr>
 <td>key</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td>S</td>
-<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP</em></td>
-<td>S</td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
+<td><em>PS<br/>UTC is only supported TZ for TIMESTAMP;<br/>Literal value only</em></td>
+<td><em>PS<br/>Literal value only</em></td>
 <td><em>PS<br/>max DECIMAL precision of 18;<br/>Literal value only</em></td>
 <td><b>NS</b></td>
 <td><b>NS</b></td>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2617,8 +2617,29 @@ object GpuOverrides extends Logging {
             TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.MAP)
             .withPsNote(TypeEnum.MAP ,"If it's map, only primitive key types are supported."),
           TypeSig.ARRAY.nested(TypeSig.all) + TypeSig.MAP.nested(TypeSig.all)),
-        ("index/key", (TypeSig.INT + TypeSig.commonCudfTypesLit() + TypeSig.lit(TypeEnum.DECIMAL))
-          .withPsNote(TypeEnum.INT, "Only ints are supported as array indexes"),
+        ("index/key", (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128)
+          .withPsNote(TypeEnum.INT, "Supported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.BOOLEAN, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.BYTE, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.SHORT, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.LONG, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.FLOAT, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.DOUBLE, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.DATE, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.TIMESTAMP, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.STRING, "Unsupported as array index. " +
+            "Only Literals supported as map keys.")
+          .withPsNote(TypeEnum.DECIMAL, "Unsupported as array index. " +
+            "Only Literals supported as map keys."),
           TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ElementAt](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -185,6 +185,17 @@ final class TypeSig private(
   }
 
   /**
+   * Add a literal restriction to the signature
+   * @param dataTypes the types that have to be literal. Will be added if they do not already exist.
+   * @return the new signature.
+   */
+  def withLit(dataTypes: TypeEnum.ValueSet): TypeSig = {
+    val it = initialTypes ++ dataTypes
+    val lt = litOnlyTypes ++ dataTypes
+    new TypeSig(it, maxAllowedDecimalPrecision, childTypes, lt, notes)
+  }
+
+  /**
    * All currently supported types can only be literal values.
    * @return the new signature.
    */
@@ -534,7 +545,7 @@ object TypeSig {
    * Create a TypeSig that only supports literals of certain given types.
    */
   def lit(dataTypes: TypeEnum.ValueSet): TypeSig =
-    new TypeSig(dataTypes)
+    TypeSig.none.withLit(dataTypes)
 
   /**
    * Create a TypeSig that supports only literals of common primitive CUDF types.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -228,10 +228,10 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
   }
 
   override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector =
-    throw new IllegalStateException("This is not supported yet")
+    throw new IllegalStateException("Map lookup keys must be scalar values")
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector =
-    throw new IllegalStateException("This is not supported yet")
+    throw new IllegalStateException("Map lookup keys must be scalar values")
 
   override def left: Expression = child
 


### PR DESCRIPTION
Fixes the merge conflict noted in #5198.  `ElementAt` was unshimmed in branch-22.06 which caused the merge conflict, and this was resolved by ignoring the changes to the shim-specific files and only taking the common changes to GpuOverrides.

**NOTE: This must be merged with a merge commit, not squashed!**