### PR TITLE
Fix tools depending on the common jar

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -41,11 +41,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-common_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <scope>compile</scope>
@@ -105,7 +100,6 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.rogach:scallop_${scala.binary.version}</include>
-                                    <include>com.nvidia:rapids-4-spark-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/ThreadFactoryBuilder.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/ThreadFactoryBuilder.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.tool
+
+import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.atomic.AtomicLong
+
+// This is similar to Guava ThreadFactoryBuilder
+// Avoid to use Guava as it is a messy dependency in practice.
+// This is copied from the common module
+class ThreadFactoryBuilder {
+  private var nameFormat = Option.empty[String]
+  private var daemon = Option.empty[Boolean]
+
+  def setNameFormat(nameFormat: String): ThreadFactoryBuilder = {
+    nameFormat.format(0)
+    this.nameFormat = Some(nameFormat)
+    this
+  }
+
+  def setDaemon(daemon: Boolean): ThreadFactoryBuilder = {
+    this.daemon = Some(daemon)
+    this
+  }
+
+  def build(): ThreadFactory = {
+    val count = nameFormat.map(_ => new AtomicLong(0))
+    new ThreadFactory() {
+      private val defaultThreadFactory = Executors.defaultThreadFactory
+
+      override def newThread(r: Runnable): Thread = {
+        val thread = defaultThreadFactory.newThread(r)
+        nameFormat.foreach(f => thread.setName(f.format(count.get.getAndIncrement())))
+        daemon.foreach(b => thread.setDaemon(b))
+        thread
+      }
+    }
+  }
+}

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -22,8 +22,8 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.util.control.NonFatal
 
-import com.nvidia.spark.rapids.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.tool.{EventLogInfo, EventLogPathProcessor}
+import com.nvidia.spark.rapids.tool.ThreadFactoryBuilder
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -20,8 +20,8 @@ import java.util.concurrent.{ConcurrentLinkedQueue, Executors, ThreadPoolExecuto
 
 import scala.collection.JavaConverters._
 
-import com.nvidia.spark.rapids.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.tool.EventLogInfo
+import com.nvidia.spark.rapids.tool.ThreadFactoryBuilder
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.internal.Logging

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
@@ -22,8 +22,8 @@ import java.util.regex.PatternSyntaxException
 
 import scala.collection.JavaConverters._
 
-import com.nvidia.spark.rapids.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.tool.EventLogInfo
+import com.nvidia.spark.rapids.tool.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.tool.qualification.QualificationArgs
 import org.apache.hadoop.conf.Configuration
 


### PR DESCRIPTION
fixes #5233 

This is the same as https://github.com/NVIDIA/spark-rapids/pull/5235/files but removed the include of the common jar in the shade plugin.  

Tools jar is a standalone jar, should not depend on common jar


Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
