### PR TITLE
Throw again after logging that RMM could not intialize

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -296,15 +296,9 @@ object GpuDeviceManager extends Logging {
         logInfo("Using legacy default stream")
       }
 
-      try {
-        Cuda.setDevice(gpuId)
-        Rmm.initialize(init, logConf, poolAllocation)
-        RapidsBufferCatalog.init(conf)
-      } catch {
-        case e: CudfException =>
-          logError("Could not initialize RMM, exiting!", e)
-          throw e
-      }
+      Cuda.setDevice(gpuId)
+      Rmm.initialize(init, logConf, poolAllocation)
+      RapidsBufferCatalog.init(conf)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -301,7 +301,9 @@ object GpuDeviceManager extends Logging {
         Rmm.initialize(init, logConf, poolAllocation)
         RapidsBufferCatalog.init(conf)
       } catch {
-        case e: Exception => logError("Could not initialize RMM", e)
+        case e: CudfException =>
+          logError("Could not initialize RMM, exiting!", e)
+          throw e
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -238,7 +238,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
         // Exceptions in executor plugin can cause a single thread to die but the executor process
         // sticks around without any useful info until it hearbeat times out. Print what happened
         // and exit immediately.
-        logError("Exception in the executor plugin", e)
+        logError("Exception in the executor plugin, shutting down!", e)
         System.exit(1)
     }
   }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes: https://github.com/NVIDIA/spark-rapids/issues/5242.

This is a (small) proposed diff to make failure to initialize RMM (which throws a `CudfException`) fatal, instead of silently continuing with a default initialized raw cuda memory resource.

The executor logs will look like this:

```
22/04/13 14:56:06 ERROR GpuDeviceManager: Could not initialize RMM, exiting!
 ai.rapids.cudf.CudfException: RMM failure at: /home/jenkins/agent/workspace/jenkins-cudf-for-dev-32-cuda11/cpp/build/_deps/rmm-src/include/rmm/mr/device/    cuda_async_memory_resource.hpp:67: cudaMallocAsync not supported with this CUDA driver/runtime version
  at ai.rapids.cudf.Rmm.initializeInternal(Native Method)
```