### PR TITLE
Fix test failure caused by change in Spark 3.3 exception

### DIFF
--- a/integration_tests/src/main/python/logic_test.py
+++ b/integration_tests/src/main/python/logic_test.py
@@ -78,7 +78,7 @@ def test_logical_with_side_effect(ansi_enabled, lhs_arg, int_arg, logic_op):
         assert_gpu_and_cpu_error(
             df_fun=lambda spark: do_it(spark, lhs_arg, int_arg, logic_op).collect(),
             conf=ansi_conf,
-            error_message="java.lang.ArithmeticException")
+            error_message="ArithmeticException")
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: do_it(spark, lhs_arg, int_arg, logic_op),


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Temporary fix for https://github.com/NVIDIA/spark-rapids/issues/5244 to work around Spark 3.3 now throwing `org.apache.spark.SparkArithmeticException` instead of `java.lang.ArithmeticException` for overflows in Add operations.

The real fix will be to implement https://github.com/NVIDIA/spark-rapids/issues/5196