### PR TITLE
Update Outdated GCP getting started guide[skip ci]

### DIFF
--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -24,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-#    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-    - uses: nvliyuan/github-action-markdown-link-check@fix-markdown-check-fail
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         max-depth: -1
         use-verbose-mode: 'yes'

--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+#    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: nvliyuan/github-action-markdown-link-check@fix-markdown-check-fail
       with:
         max-depth: -1
         use-verbose-mode: 'yes'

--- a/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
+++ b/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
@@ -126,12 +126,11 @@ function configure_gpu_isolation() {
   chmod a+rwx -R /sys/fs/cgroup/devices
 }
 
-readonly RAPIDS_VERSION="0.19"
-readonly DEFAULT_SPARK_RAPIDS_VERSION="0.5.0"
+readonly DEFAULT_SPARK_RAPIDS_VERSION="22.02.0"
 readonly DEFAULT_CUDA_VERSION="11.0"
-readonly DEFAULT_CUDF_VERSION="0.19.2"
-readonly DEFAULT_XGBOOST_VERSION="1.3.0"
-readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.1.0"
+readonly DEFAULT_CUDF_VERSION="22.02.0"
+readonly DEFAULT_XGBOOST_VERSION="1.4.2"
+readonly DEFAULT_XGBOOST_GPU_SUB_VERSION="0.2.0"
 readonly SPARK_VERSION="3.0"
 
 readonly CUDF_VERSION=${DEFAULT_CUDF_VERSION}
@@ -168,23 +167,10 @@ function configure_spark() {
 # query explain output won't show GPU operator, if user have doubt
 # they can uncomment the line before to see the GPU plan explan, but AQE on give user the best performance.
 # spark.sql.adaptive.enabled=false
-spark.rapids.sql.concurrentGpuTasks=2
 spark.executor.resource.gpu.amount=1
-spark.executor.cores=4
-spark.executor.memory=8G
-spark.task.cpus=1
-spark.task.resource.gpu.amount=0.25
-spark.rapids.memory.pinnedPool.size=2G
-spark.executor.memoryOverhead=2G
 spark.plugins=com.nvidia.spark.SQLPlugin
-spark.executor.extraJavaOptions='-Dai.rapids.cudf.prefer-pinned=true'
-spark.locality.wait=0s
 spark.executor.resource.gpu.discoveryScript=/usr/lib/spark/scripts/gpu/getGpusResources.sh
-spark.sql.shuffle.partitions=48
-spark.sql.files.maxPartitionBytes=512m
 spark.submit.pyFiles=/usr/lib/spark/jars/xgboost4j-spark_${SPARK_VERSION}-${XGBOOST_VERSION}-${XGBOOST_GPU_SUB_VERSION}.jar
-spark.dynamicAllocation.enabled=false
-spark.shuffle.service.enabled=false
 ###### END   : RAPIDS properties for Spark ${SPARK_VERSION} ######
 EOF
 }

--- a/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
+++ b/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
the plugin version is out of date in the GCP getting started guide,
update the plugin&xgboost jars versions and remove some configs
fix #5186