### PR TITLE
[BUG] When ASYNC is enabled GDS needs to handle cudaMalloced bounce buffers

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -40,7 +40,7 @@ class RapidsGdsStore(
       stream: Cuda.Stream): RapidsBufferBase = {
     withResource(otherBuffer) { _ =>
       val deviceBuffer = otherBuffer match {
-        case d: DeviceMemoryBuffer => d
+        case d: BaseDeviceMemoryBuffer => d
         case _ => throw new IllegalStateException("copying from buffer without device memory")
       }
       if (deviceBuffer.getLength < batchWriteBufferSize) {
@@ -84,7 +84,7 @@ class RapidsGdsStore(
     override def copyToMemoryBuffer(srcOffset: Long, dst: MemoryBuffer, dstOffset: Long,
         length: Long, stream: Cuda.Stream): Unit = {
       dst match {
-        case dmOriginal: DeviceMemoryBuffer =>
+        case dmOriginal: BaseDeviceMemoryBuffer =>
           val dm = dmOriginal.slice(dstOffset, length)
           // TODO: switch to async API when it's released, using the passed in CUDA stream.
           stream.sync()
@@ -106,7 +106,7 @@ class RapidsGdsStore(
     }
   }
 
-  private def singleShotSpill(other: RapidsBuffer, deviceBuffer: DeviceMemoryBuffer)
+  private def singleShotSpill(other: RapidsBuffer, deviceBuffer: BaseDeviceMemoryBuffer)
   : RapidsBufferBase = {
     val id = other.id
     val path = id.getDiskPath(diskBlockManager)
@@ -139,7 +139,7 @@ class RapidsGdsStore(
       batchWriteBuffer.close()
     }
 
-    def spill(other: RapidsBuffer, deviceBuffer: DeviceMemoryBuffer): RapidsBufferBase =
+    def spill(other: RapidsBuffer, deviceBuffer: BaseDeviceMemoryBuffer): RapidsBufferBase =
       this.synchronized {
         if (deviceBuffer.getLength > batchWriteBufferSize - currentOffset) {
           val path = currentFile.getAbsolutePath
@@ -229,7 +229,7 @@ class RapidsGdsStore(
       override def copyToMemoryBuffer(srcOffset: Long, dst: MemoryBuffer, dstOffset: Long,
           length: Long, stream: Cuda.Stream): Unit = this.synchronized {
         dst match {
-          case dmOriginal: DeviceMemoryBuffer =>
+          case dmOriginal: BaseDeviceMemoryBuffer =>
             val dm = dmOriginal.slice(dstOffset, length)
             if (isPending) {
               copyToBuffer(dm, fileOffset + srcOffset, length, stream)


### PR DESCRIPTION
Given the ASYNC allocator is enabled, the UCX bounce buffers are allocated directly, bypassing the ASYNC pool (because memory from the async pool can't be mapped for purposes of GPUDirectRDMA).

This PR fixes GDS copies where it assumed the bounce buffer was a `DeviceMemoryBuffer` when it was really a `CudaMemoryBuffer` (e.g. straight from cudaMalloc). It also fixes a couple of leaks where `.slice` was used, but the sliced buffer was not closed in the stack.