### PR TITLE
Support multiple datatypes in `TypeSig.withPsNote()`

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -5069,7 +5069,7 @@ are limited.
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
-<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Supported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -5069,7 +5069,7 @@ are limited.
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
-<td><em>PS<br/>Supported as array index. Only Literals supported as map keys.</em></td>
+<td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>
 <td><em>PS<br/>Unsupported as array index. Only Literals supported as map keys.</em></td>

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1764,7 +1764,7 @@ object GpuOverrides extends Logging {
         Seq(ParamCheck(
           "pivotColumn",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
           TypeSig.all),
           ParamCheck("valueColumn",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
@@ -1805,7 +1805,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1813,7 +1813,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+                .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (max, conf, p, r) => new AggExprMeta[Max](max, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -1832,7 +1832,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1840,7 +1840,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+                .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (a, conf, p, r) => new AggExprMeta[Min](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2154,7 +2154,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
+            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2167,7 +2167,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
+            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2189,7 +2189,7 @@ object GpuOverrides extends Logging {
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes
             .withPsNote(
-              List(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
+              Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
               "NaN literals are not supported. Columnar input" +
               s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
             TypeSig.all)),
@@ -2828,7 +2828,7 @@ object GpuOverrides extends Logging {
           .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
               s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
           .withPsNote(
-            List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
             "Round-robin partitioning is not supported if " +
               s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true"),
         TypeSig.all),
@@ -2879,7 +2879,7 @@ object GpuOverrides extends Logging {
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
           TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT)
             .nested()
-            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            .withPsNote(Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
               "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1805,7 +1805,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1813,7 +1813,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (max, conf, p, r) => new AggExprMeta[Max](max, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -1832,7 +1832,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1840,7 +1840,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (a, conf, p, r) => new AggExprMeta[Min](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2154,7 +2154,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), GpuOverrides.nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2167,7 +2167,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), GpuOverrides.nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2189,7 +2189,7 @@ object GpuOverrides extends Logging {
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes
             .withPsNote(
-              List(TypeEnum.DOUBLE, TypeEnum.Float), 
+              List(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
               "NaN literals are not supported. Columnar input" +
               s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
             TypeSig.all)),

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1764,8 +1764,7 @@ object GpuOverrides extends Logging {
         Seq(ParamCheck(
           "pivotColumn",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
           TypeSig.all),
           ParamCheck("valueColumn",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
@@ -1806,8 +1805,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1815,8 +1813,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-                .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (max, conf, p, r) => new AggExprMeta[Max](max, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -1835,8 +1832,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -1844,8 +1840,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-                .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (a, conf, p, r) => new AggExprMeta[Min](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2159,8 +2154,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(TypeEnum.DOUBLE, GpuOverrides.nanAggPsNote)
-            .withPsNote(TypeEnum.FLOAT, GpuOverrides.nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2173,8 +2167,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(TypeEnum.DOUBLE, GpuOverrides.nanAggPsNote)
-            .withPsNote(TypeEnum.FLOAT, GpuOverrides.nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.Float), GpuOverrides.nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2195,10 +2188,10 @@ object GpuOverrides extends Logging {
         ("array", TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.NULL),
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes
-            .withPsNote(TypeEnum.DOUBLE, "NaN literals are not supported. Columnar input" +
-                s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false.")
-            .withPsNote(TypeEnum.FLOAT, "NaN literals are not supported. Columnar input" +
-                s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
+            .withPsNote(
+              List(TypeEnum.DOUBLE, TypeEnum.Float), 
+              "NaN literals are not supported. Columnar input" +
+              s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
             TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ArrayContains](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2834,9 +2827,9 @@ object GpuOverrides extends Logging {
           TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested()
           .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
               s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
-          .withPsNote(TypeEnum.ARRAY, "Round-robin partitioning is not supported if " +
-              s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
-          .withPsNote(TypeEnum.MAP, "Round-robin partitioning is not supported if " +
+          .withPsNote(
+            List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            "Round-robin partitioning is not supported if " +
               s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true"),
         TypeSig.all),
       (shuffle, conf, p, r) => new GpuShuffleMeta(shuffle, conf, p, r)),
@@ -2886,8 +2879,8 @@ object GpuOverrides extends Logging {
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
           TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT)
             .nested()
-            .withPsNote(TypeEnum.ARRAY, "not allowed for grouping expressions")
-            .withPsNote(TypeEnum.MAP, "not allowed for grouping expressions")
+            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+              "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
         TypeSig.all),

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -265,7 +265,7 @@ final class TypeSig private(
   def withPsNote(dataTypes: Seq[TypeEnum.Value], note: String): TypeSig =
     new TypeSig(
       dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
-      litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
+      litOnlyTypes, dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
 
 
   private def isSupportedType(dataType: TypeEnum.Value): Boolean =

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -256,6 +256,18 @@ final class TypeSig private(
     new TypeSig(initialTypes + dataType, maxAllowedDecimalPrecision, childTypes, litOnlyTypes,
       notes.+((dataType, note)))
 
+  /**
+   * Add a note about given types that marks them as partially supported.
+   * @param dataTypes the types this note is for.
+   * @param note the note itself
+   * @return the updated TypeSignature.
+   */
+  def withPsNote(dataTypes: List[TypeEnum.Value], note: String): TypeSig =
+    new TypeSig(
+      dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
+      litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
+
+
   private def isSupportedType(dataType: TypeEnum.Value): Boolean =
       initialTypes.contains(dataType)
 

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -262,7 +262,7 @@ final class TypeSig private(
    * @param note the note itself
    * @return the updated TypeSignature.
    */
-  def withPsNote(dataTypes: List[TypeEnum.Value], note: String): TypeSig =
+  def withPsNote(dataTypes: Seq[TypeEnum.Value], note: String): TypeSig =
     new TypeSig(
       dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
       litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2235,8 +2235,7 @@ object GpuOverrides extends Logging {
         Seq(ParamCheck(
           "pivotColumn",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
           TypeSig.all),
           ParamCheck("valueColumn",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
@@ -2284,8 +2283,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -2293,8 +2291,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-                .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (max, conf, p, r) => new AggExprMeta[Max](max, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2319,8 +2316,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-              .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -2328,8 +2324,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-                .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (a, conf, p, r) => new AggExprMeta[Min](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2631,28 +2626,11 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.MAP ,"If it's map, only primitive key types are supported."),
           TypeSig.ARRAY.nested(TypeSig.all) + TypeSig.MAP.nested(TypeSig.all)),
         ("index/key", (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128)
-          .withPsNote(TypeEnum.INT, "Supported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.BOOLEAN, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.BYTE, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.SHORT, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.LONG, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.FLOAT, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.DOUBLE, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.DATE, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.TIMESTAMP, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.STRING, "Unsupported as array index. " +
-            "Only Literals supported as map keys.")
-          .withPsNote(TypeEnum.DECIMAL, "Unsupported as array index. " +
-            "Only Literals supported as map keys."),
+          .withPsNote(
+            List(TypeEnum.INT, TypeEnum.BOOLEAN, TypeEnum.BYTE, TypeEnum.SHORT,
+              TypeEnum.LONG, TypeEnum.FLOAT, TypeEnum.DOUBLE, TypeEnum.DATE,
+              TypeEnum.TIMESTAMP, TypeEnum.STRING, TypeEnum.DECIMAL),
+            "Unsupported as array index. Only Literals supported as map keys."),
           TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ElementAt](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2740,8 +2718,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-            .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2757,8 +2734,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(TypeEnum.DOUBLE, nanAggPsNote)
-            .withPsNote(TypeEnum.FLOAT, nanAggPsNote),
+            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2783,10 +2759,10 @@ object GpuOverrides extends Logging {
         ("array", TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.NULL),
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes
-            .withPsNote(TypeEnum.DOUBLE, "NaN literals are not supported. Columnar input" +
-                s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false.")
-            .withPsNote(TypeEnum.FLOAT, "NaN literals are not supported. Columnar input" +
-                s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
+            .withPsNote(
+              List(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
+              "NaN literals are not supported. Columnar input" +
+              s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
             TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ArrayContains](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -3765,9 +3741,9 @@ object GpuOverrides extends Logging {
           GpuTypeShims.additionalArithmeticSupportedTypes).nested()
           .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
               s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
-          .withPsNote(TypeEnum.ARRAY, "Round-robin partitioning is not supported if " +
-              s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
-          .withPsNote(TypeEnum.MAP, "Round-robin partitioning is not supported if " +
+          .withPsNote(
+            List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            "Round-robin partitioning is not supported if " +
               s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true"),
         TypeSig.all),
       (shuffle, conf, p, r) => new GpuShuffleMeta(shuffle, conf, p, r)),
@@ -3830,8 +3806,8 @@ object GpuOverrides extends Logging {
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
           TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT)
             .nested()
-            .withPsNote(TypeEnum.ARRAY, "not allowed for grouping expressions")
-            .withPsNote(TypeEnum.MAP, "not allowed for grouping expressions")
+            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+              "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
         TypeSig.all),
@@ -3846,8 +3822,8 @@ object GpuOverrides extends Logging {
             .nested()
             .withPsNote(TypeEnum.BINARY, "only allowed when aggregate buffers can be " +
               "converted between CPU and GPU")
-            .withPsNote(TypeEnum.ARRAY, "not allowed for grouping expressions")
-            .withPsNote(TypeEnum.MAP, "not allowed for grouping expressions")
+            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+              "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
         TypeSig.all),
@@ -3864,8 +3840,8 @@ object GpuOverrides extends Logging {
             .nested()
             .withPsNote(TypeEnum.BINARY, "only allowed when aggregate buffers can be " +
               "converted between CPU and GPU")
-            .withPsNote(TypeEnum.ARRAY, "not allowed for grouping expressions")
-            .withPsNote(TypeEnum.MAP, "not allowed for grouping expressions")
+            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+              "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
         TypeSig.all),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2235,7 +2235,7 @@ object GpuOverrides extends Logging {
         Seq(ParamCheck(
           "pivotColumn",
           (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
           TypeSig.all),
           ParamCheck("valueColumn",
           TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128,
@@ -2283,7 +2283,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -2291,7 +2291,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+                .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (max, conf, p, r) => new AggExprMeta[Max](max, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2316,7 +2316,7 @@ object GpuOverrides extends Logging {
           Seq(ParamCheck("input",
             (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL + TypeSig.STRUCT)
               .nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-              .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+              .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
             TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts
           ++
           ExprChecks.windowOnly(
@@ -2324,7 +2324,7 @@ object GpuOverrides extends Logging {
             TypeSig.orderable,
             Seq(ParamCheck("input",
               (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-                .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+                .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
               TypeSig.orderable))).asInstanceOf[ExprChecksImpl].contexts),
       (a, conf, p, r) => new AggExprMeta[Min](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
@@ -2629,7 +2629,7 @@ object GpuOverrides extends Logging {
           .withPsNote(TypeEnum.INT, "Supported as array index. " +
             "Only Literals supported as map keys.")
           .withPsNote(
-            List(TypeEnum.BOOLEAN, TypeEnum.BYTE, TypeEnum.SHORT, TypeEnum.LONG,
+            Seq(TypeEnum.BOOLEAN, TypeEnum.BYTE, TypeEnum.SHORT, TypeEnum.LONG,
               TypeEnum.FLOAT, TypeEnum.DOUBLE, TypeEnum.DATE, TypeEnum.TIMESTAMP,
               TypeEnum.STRING, TypeEnum.DECIMAL),
             "Unsupported as array index. Only Literals supported as map keys."),
@@ -2720,7 +2720,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2736,7 +2736,7 @@ object GpuOverrides extends Logging {
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
         TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(List(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
@@ -2762,7 +2762,7 @@ object GpuOverrides extends Logging {
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes
             .withPsNote(
-              List(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
+              Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), 
               "NaN literals are not supported. Columnar input" +
               s" must not contain NaNs and ${RapidsConf.HAS_NANS} must be false."),
             TypeSig.all)),
@@ -3744,7 +3744,7 @@ object GpuOverrides extends Logging {
           .withPsNote(TypeEnum.STRUCT, "Round-robin partitioning is not supported for nested " +
               s"structs if ${SQLConf.SORT_BEFORE_REPARTITION.key} is true")
           .withPsNote(
-            List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
             "Round-robin partitioning is not supported if " +
               s"${SQLConf.SORT_BEFORE_REPARTITION.key} is true"),
         TypeSig.all),
@@ -3808,7 +3808,7 @@ object GpuOverrides extends Logging {
         (TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 +
           TypeSig.MAP + TypeSig.ARRAY + TypeSig.STRUCT)
             .nested()
-            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            .withPsNote(Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
               "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
@@ -3824,7 +3824,7 @@ object GpuOverrides extends Logging {
             .nested()
             .withPsNote(TypeEnum.BINARY, "only allowed when aggregate buffers can be " +
               "converted between CPU and GPU")
-            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            .withPsNote(Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
               "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),
@@ -3842,7 +3842,7 @@ object GpuOverrides extends Logging {
             .nested()
             .withPsNote(TypeEnum.BINARY, "only allowed when aggregate buffers can be " +
               "converted between CPU and GPU")
-            .withPsNote(List(TypeEnum.ARRAY, TypeEnum.MAP), 
+            .withPsNote(Seq(TypeEnum.ARRAY, TypeEnum.MAP), 
               "not allowed for grouping expressions")
             .withPsNote(TypeEnum.STRUCT,
               "not allowed for grouping expressions if containing Array or Map as child"),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2626,10 +2626,12 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.MAP ,"If it's map, only primitive key types are supported."),
           TypeSig.ARRAY.nested(TypeSig.all) + TypeSig.MAP.nested(TypeSig.all)),
         ("index/key", (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128)
+          .withPsNote(TypeEnum.INT, "Supported as array index. " +
+            "Only Literals supported as map keys.")
           .withPsNote(
-            List(TypeEnum.INT, TypeEnum.BOOLEAN, TypeEnum.BYTE, TypeEnum.SHORT,
-              TypeEnum.LONG, TypeEnum.FLOAT, TypeEnum.DOUBLE, TypeEnum.DATE,
-              TypeEnum.TIMESTAMP, TypeEnum.STRING, TypeEnum.DECIMAL),
+            List(TypeEnum.BOOLEAN, TypeEnum.BYTE, TypeEnum.SHORT, TypeEnum.LONG,
+              TypeEnum.FLOAT, TypeEnum.DOUBLE, TypeEnum.DATE, TypeEnum.TIMESTAMP,
+              TypeEnum.STRING, TypeEnum.DECIMAL),
             "Unsupported as array index. Only Literals supported as map keys."),
           TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ElementAt](in, conf, p, r) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -272,13 +272,13 @@ final class TypeSig private(
 
   /**
    * Add a note about given types that marks them as partially supported.
-   * @param dataType the types this note is for.
+   * @param dataTypes the types this note is for.
    * @param note the note itself
    * @return the updated TypeSignature.
    */
   def withPsNote(dataTypes: List[TypeEnum.Value], note: String): TypeSig =
     new TypeSig(
-      dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes, 
+      dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
       litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
 
   private def isSupportedType(dataType: TypeEnum.Value): Boolean =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -270,6 +270,17 @@ final class TypeSig private(
     new TypeSig(initialTypes + dataType, maxAllowedDecimalPrecision, childTypes, litOnlyTypes,
       notes.+((dataType, note)))
 
+  /**
+   * Add a note about given types that marks them as partially supported.
+   * @param dataType the types this note is for.
+   * @param note the note itself
+   * @return the updated TypeSignature.
+   */
+  def withPsNote(dataTypes: List[TypeEnum.Value], note: String): TypeSig =
+    new TypeSig(
+      dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes, 
+      litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
+
   private def isSupportedType(dataType: TypeEnum.Value): Boolean =
       initialTypes.contains(dataType)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -279,7 +279,7 @@ final class TypeSig private(
   def withPsNote(dataTypes: Seq[TypeEnum.Value], note: String): TypeSig =
     new TypeSig(
       dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
-      litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
+      litOnlyTypes, dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))
 
   private def isSupportedType(dataType: TypeEnum.Value): Boolean =
       initialTypes.contains(dataType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -276,7 +276,7 @@ final class TypeSig private(
    * @param note the note itself
    * @return the updated TypeSignature.
    */
-  def withPsNote(dataTypes: List[TypeEnum.Value], note: String): TypeSig =
+  def withPsNote(dataTypes: Seq[TypeEnum.Value], note: String): TypeSig =
     new TypeSig(
       dataTypes.foldLeft(initialTypes)(_+_), maxAllowedDecimalPrecision, childTypes,
       litOnlyTypes,dataTypes.foldLeft(notes)((notes, dataType) => notes.+((dataType, note))))


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

close #5203

Add a new API for `withPSNote` which can mark multi datatypes with same note.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
