### PR TITLE
Enable support for escaping the right square bracket

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -277,7 +277,7 @@ class RegexParser(pattern: String) {
             // word boundaries
             consumeExpected(ch)
             RegexEscaped(ch)
-          case '[' | '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '{' | '}' =>
+          case '[' | ']' | '\\' | '^' | '$' | '.' | '|' | '?' | '*' | '+' | '(' | ')' | '{' | '}' =>
             // escaped metacharacter
             consumeExpected(ch)
             RegexEscaped(ch)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -125,7 +125,7 @@ class RegularExpressionParserSuite extends FunSuite {
             )
           ))
         ),
-        RegexEscaped(']'),
+        RegexEscaped(']')
       ))
     )
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -112,6 +112,24 @@ class RegularExpressionParserSuite extends FunSuite {
           ListBuffer(RegexChar('a'))), RegexChar(']'))))
   }
 
+  test("escaped brackets") {
+    assert(parse("\\[([A-Z]+)\\]") ===
+      RegexSequence(ListBuffer(
+        RegexEscaped('['),
+        RegexGroup(capture = true,
+          RegexSequence(ListBuffer(
+            RegexRepetition(
+              RegexCharacterClass(negated = false, ListBuffer(
+                RegexCharacterRange('A', 'Z'))),
+              SimpleQuantifier('+')
+            )
+          ))
+        ),
+        RegexEscaped(']'),
+      ))
+    )
+  }
+
   test("unclosed character class") {
     val e = intercept[RegexUnsupportedException] {
       parse("[ab")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -407,6 +407,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }
 
+  test("compare CPU and GPU: handle escaped brackets") {
+    val inputs = Seq("[", "]", "[]", "[asdf]", "[deadbeef]", "[a123b456c]")
+    val patterns = Seq("\\[", "\\]", "\\[\\]", "\\[([a-z]+)\\]", "\\[([a-z0-9]+)\\]")
+    assertCpuGpuMatchesRegexpFind(patterns, inputs)
+  }
+
   test("compare CPU and GPU: regexp replace fuzz test with limited chars") {
     // testing with this limited set of characters finds issues much
     // faster than using the full ASCII set

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -409,7 +409,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("compare CPU and GPU: handle escaped brackets") {
     val inputs = Seq("[", "]", "[]", "[asdf]", "[deadbeef]", "[a123b456c]")
-    val patterns = Seq("\\[", "\\]", "\\[\\]", "\\[([a-z]+)\\]", "\\[([a-z0-9]+)\\]")
+    val patterns = Seq("\\[", "\\]", "\\[]", "\\[\\]", "\\[([a-z]+)\\]", "\\[([a-z0-9]+)\\]")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
   }
 


### PR DESCRIPTION
Fixes #5275. 

This enables support for escaping the right square bracket in regular expressions that should run on the GPU. Previously, the right square bracket was not considered a valid escapable regular expression meta character (the left square bracket was). This allows it to be an escapable character in a regular expression used when running on the GPU. 

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
