### PR TITLE
Fix nightly scripts to deploy w/ classifier correctly [skip ci]

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -87,9 +87,9 @@ $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
 # Distribution jar is a shaded artifact so use the reduced dependency pom.
 $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             $SRC_DOC_JARS \
-            -Dfile=$FPATH.jar -Dtypes=jar -Dfiles=$FPATH.jar \
-            -DgroupId=com.nvidia -DartifactId=$ART_ID -Dversion=$ART_VER \
-            -DpomFile="$POM_FPATH" -Dclassifiers=$CUDA_CLASSIFIER
+            -Dfile=$FPATH.jar -DgroupId=com.nvidia -DartifactId=$ART_ID -Dversion=$ART_VER \
+            -Dfiles=$FPATH.jar -Dtypes=jar -Dclassifiers=$CUDA_CLASSIFIER \
+            -DpomFile="$POM_FPATH"
 
 ###### Deploy profiling tool jar(s) ######
 TOOL_PL=${TOOL_PL:-"tools"}

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -87,7 +87,8 @@ $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
 # Distribution jar is a shaded artifact so use the reduced dependency pom.
 $DEPLOY_CMD -Durl=$SERVER_URL -DrepositoryId=$SERVER_ID \
             $SRC_DOC_JARS \
-            -Dfile=$FPATH.jar -DgroupId=com.nvidia -DartifactId=$ART_ID -Dversion=$ART_VER \
+            -Dfile=$FPATH.jar -Dtypes=jar -Dfiles=$FPATH.jar \
+            -DgroupId=com.nvidia -DartifactId=$ART_ID -Dversion=$ART_VER \
             -DpomFile="$POM_FPATH" -Dclassifiers=$CUDA_CLASSIFIER
 
 ###### Deploy profiling tool jar(s) ######

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -31,7 +31,7 @@ ART_ID=$(mvnEval project.artifactId)
 ART_GROUP_ID=$(mvnEval project.groupId)
 ART_VER=$(mvnEval project.version)
 
-DIST_FPATH="$DIST_PL/target/$ART_ID-$ART_VER-$CUDA_CLASSIFIER"
+DIST_FPATH="$DIST_PL/target/$ART_ID-$ART_VER"
 DIST_POM_FPATH="$DIST_PL/target/extra-resources/META-INF/maven/$ART_GROUP_ID/$ART_ID/pom.xml"
 
 DIST_PROFILE_OPT=-Dincluded_buildvers=$(IFS=,; echo "${SPARK_SHIM_VERSIONS[*]}")
@@ -55,7 +55,7 @@ function distWithReducedPom {
 
         deploy)
             mvnCmd="deploy:deploy-file"
-            mvnExtaFlags="-Durl=${URM_URL}-local -DrepositoryId=snapshots"
+            mvnExtaFlags="-Durl=${URM_URL}-local -DrepositoryId=snapshots -Dtypes=jar -Dfiles=${DIST_FPATH}.jar -Dclassifiers=$CUDA_CLASSIFIER"
             ;;
 
         *)
@@ -71,7 +71,6 @@ function distWithReducedPom {
         -DgroupId="${ART_GROUP_ID}" \
         -DartifactId="${ART_ID}" \
         -Dversion="${ART_VER}" \
-        -Dclassifiers=$CUDA_CLASSIFIER \
         $mvnExtaFlags
 }
 
@@ -114,6 +113,7 @@ mvn -B clean install -pl '!tools' \
 distWithReducedPom "install"
 
 if [[ $SKIP_DEPLOY != 'true' ]]; then
+    DIST_FPATH="$DIST_FPATH-$CUDA_CLASSIFIER"
     distWithReducedPom "deploy"
 
     # this deploy includes 'tools' that is unconditionally built with Spark 3.1.1


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Its my fault to incorrectly update classifier deploy support in the common func of nightly script.
for each spark shim, it incorrectly includes (install shims dist artifacts w/ classifier) an independent libcu*.so instead of using the common one, so the final dist jar results in ~ 4 GB :(

deploy.sh change was trying to fix missing `-files` w/ -Dclassifiers, the real release fix is tracked at https://github.com/NVIDIA/spark-rapids/issues/5259

This fix has been verified internally