### PR TITLE
Fix spark330 build due to removal of isElementAt parameter from mapKeyNotExistError

### DIFF
--- a/sql-plugin/src/main/311until330-nondb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/311until330-nondb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -27,7 +27,6 @@ object RapidsErrorUtils {
 
   def mapKeyNotExistError(
       key: String,
-      isElementAtFunction: Boolean = false,
       origin: Origin): NoSuchElementException = {
     // Follow the Spark string format before 3.3.0
     new NoSuchElementException(s"Key $key does not exist.")

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -27,7 +27,6 @@ object RapidsErrorUtils {
 
   def mapKeyNotExistError(
       key: String,
-      isElementAtFunction: Boolean,
       origin: Origin): NoSuchElementException = {
     // Follow the Spark string format before 3.3.0
     new NoSuchElementException(s"Key $key does not exist.")

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -31,7 +31,6 @@ object RapidsErrorUtils {
 
   def mapKeyNotExistError(
       key: String,
-      isElementAtFunction: Boolean,
       origin: Origin): NoSuchElementException = {
     // For now, the default argument is false. The caller sets the correct value accordingly.
     QueryExecutionErrors.mapKeyNotExistError(key)

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsErrorUtils.scala
@@ -31,10 +31,8 @@ object RapidsErrorUtils {
 
   def mapKeyNotExistError(
       key: String,
-      isElementAtFunction: Boolean,
       origin: Origin): NoSuchElementException = {
-    // For now, the default argument is false. The caller sets the correct value accordingly.
-    QueryExecutionErrors.mapKeyNotExistError(key, isElementAtFunction, origin.context)
+    QueryExecutionErrors.mapKeyNotExistError(key, origin.context)
   }
 
   def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -231,8 +231,7 @@ case class GpuElementAt(left: Expression, right: Expression, failOnError: Boolea
                 if (!exist.isValid || exist.getBoolean) {
                   map.getMapValue(key)
                 } else {
-                  throw RapidsErrorUtils.mapKeyNotExistError(keyS.getValue.toString,
-                    isElementAtFunction = true, origin)
+                  throw RapidsErrorUtils.mapKeyNotExistError(keyS.getValue.toString, origin)
                 }
               }
             }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -212,8 +212,7 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
       withResource(lhs.getBase.getMapKeyExistence(rhs.getBase)) { keyExistenceColumn =>
         withResource(keyExistenceColumn.all) { exist =>
           if (exist.isValid && !exist.getBoolean) {
-            throw RapidsErrorUtils.mapKeyNotExistError(rhs.getValue.toString,
-              isElementAtFunction = false, origin)
+            throw RapidsErrorUtils.mapKeyNotExistError(rhs.getValue.toString, origin)
           }
         }
       }


### PR DESCRIPTION
Fixes #5295.

Updates the code for the changes in [SPARK-38967](https://issues.apache.org/jira/browse/SPARK-38967) which removed the isElementAtFunction parameter from the `mapKeyNotExistError` method.  This parameter is no longer necessary in the corresponding RapidsErrorUtils method, so I removed it.