### PR TITLE
GpuStringSplit now honors the`spark.rapids.sql.regexp.enabled` configuration option

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -184,6 +184,50 @@ def test_split_optimized_no_re_combined():
         )
     )
 
+def test_split_regexp_disabled_no_fallback():
+    conf = { 'spark.rapids.sql.regexp.enabled': 'false' }
+    data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|&_]{1,2}){1,7}') \
+        .with_special_case('boo.and.foo') \
+        .with_special_case('boo?and?foo') \
+        .with_special_case('boo+and+foo') \
+        .with_special_case('boo^and^foo') \
+        .with_special_case('boo$and$foo') \
+        .with_special_case('boo|and|foo') \
+        .with_special_case('boo&and&foo') \
+        .with_special_case('boo_and_foo')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'split(a, "\\\\.")',
+            'split(a, "\\\\?")',
+            'split(a, "\\\\+")',
+            'split(a, "\\\\^")',
+            'split(a, "\\\\$")',
+            'split(a, "\\\\|")',
+            'split(a, "&")',
+            'split(a, "_")',
+        ), conf
+    )
+
+@allow_non_gpu('ProjectExec', 'StringSplit')
+def test_split_regexp_disabled_fallback():
+    conf = { 'spark.rapids.sql.regexp.enabled': 'false' }
+    data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
+        .with_special_case('boo:and:foo')
+    assert_gpu_sql_fallback_collect(
+        lambda spark : unary_op_df(spark, data_gen),
+            'StringSplit',
+            'string_split_table',
+            'select ' +
+            'split(a, "[:]", 2), ' +
+            'split(a, "[o:]", 5), ' +
+            'split(a, "[^:]", 2), ' +
+            'split(a, "[^o]", 55), ' +
+            'split(a, "[o]{1,2}", 999), ' +
+            'split(a, "[bf]", 2), ' +
+            'split(a, "[o]", 5) from string_split_table',
+            conf)
+
+
 @pytest.mark.parametrize('data_gen,delim', [(mk_str_gen('([ABC]{0,3}_?){0,7}'), '_'),
     (mk_str_gen('([MNP_]{0,3}\\.?){0,5}'), '.'),
     (mk_str_gen('([123]{0,3}\\^?){0,5}'), '^')], ids=idfn)

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -35,7 +35,8 @@ def test_split_no_limit():
             lambda spark : unary_op_df(spark, data_gen).selectExpr(
                 'split(a, "AB")',
                 'split(a, "C")',
-                'split(a, "_")'))
+                'split(a, "_")'),
+                conf=_regexp_conf)
 
 def test_split_negative_limit():
     data_gen = mk_str_gen('([ABC]{0,3}_?){0,7}')
@@ -43,7 +44,8 @@ def test_split_negative_limit():
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             'split(a, "AB", -1)',
             'split(a, "C", -2)',
-            'split(a, "_", -999)'))
+            'split(a, "_", -999)'),
+            conf=_regexp_conf)
 
 # https://github.com/NVIDIA/spark-rapids/issues/4720
 @allow_non_gpu('ProjectExec', 'StringSplit')
@@ -52,6 +54,7 @@ def test_split_zero_limit_fallback():
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             'split(a, "AB", 0)'),
+        conf=_regexp_conf,
         exist_classes= "ProjectExec",
         non_exist_classes= "GpuProjectExec")
 
@@ -62,6 +65,7 @@ def test_split_one_limit_fallback():
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             'split(a, "AB", 1)'),
+        conf=_regexp_conf,
         exist_classes= "ProjectExec",
         non_exist_classes= "GpuProjectExec")
 
@@ -84,7 +88,8 @@ def test_split_re_negative_limit():
             'split(a, "[^o]", -1)',
             'split(a, "[o]{1,2}", -1)',
             'split(a, "[bf]", -1)',
-            'split(a, "[o]", -2)'))
+            'split(a, "[o]", -2)'),
+            conf=_regexp_conf)
 
 # https://github.com/NVIDIA/spark-rapids/issues/4720
 @allow_non_gpu('ProjectExec', 'StringSplit')
@@ -123,7 +128,8 @@ def test_split_re_positive_limit():
             'split(a, "[^o]", 55)',
             'split(a, "[o]{1,2}", 999)',
             'split(a, "[bf]", 2)',
-            'split(a, "[o]", 5)'))
+            'split(a, "[o]", 5)'),
+            conf=_regexp_conf)
 
 def test_split_re_no_limit():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
@@ -136,7 +142,8 @@ def test_split_re_no_limit():
             'split(a, "[^o]")',
             'split(a, "[o]{1,2}")',
             'split(a, "[bf]")',
-            'split(a, "[o]")'))
+            'split(a, "[o]")'),
+            conf=_regexp_conf)
 
 def test_split_optimized_no_re():
     data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|{}]{1,2}){1,7}') \
@@ -158,9 +165,8 @@ def test_split_optimized_no_re():
             'split(a, "\\\\|")',
             'split(a, "\\\\{")',
             'split(a, "\\\\}")',
-            'split(a, "\\\\$\\\\|")',
-        )
-    )
+            'split(a, "\\\\$\\\\|")'),
+            conf=_regexp_conf)
 
 def test_split_optimized_no_re_combined():
     data_gen = mk_str_gen('([bf]o{0,2}[AZ.?+\\^$|{}]{1,2}){1,7}') \
@@ -180,9 +186,8 @@ def test_split_optimized_no_re_combined():
             'split(a, "A\\\\$Z")',
             'split(a, "A\\\\|Z")',
             'split(a, "\\\\{Z")',
-            'split(a, "\\\\}Z")',
-        )
-    )
+            'split(a, "\\\\}Z")'),
+            conf=_regexp_conf)
 
 def test_split_regexp_disabled_no_fallback():
     conf = { 'spark.rapids.sql.regexp.enabled': 'false' }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1419,7 +1419,9 @@ class GpuStringSplitMeta(
 
   override def tagExprForGpu(): Unit = {
     checkRegExp(expr.regex) match {
-      case Some((p, isRe)) => pattern = p; isRegExp = isRe
+      case Some((p, isRe)) =>
+        pattern = p
+        isRegExp = isRe
       case _ => throwUncheckedDelimiterException()
     }
     


### PR DESCRIPTION
Fixes #5130.

This allows GpuStringSplit to honor the `spark.rapids.sql.regexp.enabled` configuration flag. Desired behavior is to fallback to CPU when using a valid regular expression, but still use the GPU when using a simple string or when the pattern can be converted into a simple string.  This is done by using the existing `checkRegExp` method that already handles the logic when the transpilation to a simple string will still work, and also when the parameter is not an actual regular expression.  

Here's some PySpark code to test this branch:

```
from pyspark.sql.functions import expr
from pyspark.sql.types import StructType,StructField, StringType, IntegerType

spark = SparkSession.builder \
      .master("local[*]") \
      .appName("regex_bracket") \
      .config("spark.rapids.sql.explain","ALL") \
      .config("spark.rapids.sql.regexp.enabled", "false") \
      .config("spark.rapids.sql.castStringToTimestamp.enabled","true") \
      .config("spark.rapids.sql.exec.CollectLimitExec", "true") \
      .config("spark.rapids.sql.castFloatToString.enabled", "true") \
      .config("spark.rapids.sql.hasExtendedYearValues", "false") \
      .getOrCreate()  


data2 = [("abc|123abc|123",""),
    ("xyz|123xyz|123","Rose")
  ]

schema = StructType([ \
    StructField("firstname",StringType(),True), \
    StructField("middlename",StringType(),True) \
  ])
 
df = spark.createDataFrame(data=data2,schema=schema)
df.printSchema()
df.show(truncate=False)

regex = r"[a-z]\\|[0-9]"

# This code will fallback to the CPU
df2 = df.withColumn('newcol1', expr(f"""   split(firstname, "{regex}", 2)    """))
df2.explain()
df2.show(truncate=False)

transpilable = r"\\|"

# This code will continue to run on the GPU (Note that | is an escaped regular expression meta character but here is used as a simple delimeter)
df3 = df.withColumn('newcol2', expr(f"""   split(firstname, "{transpilable}", 3)    """))
df3.explain()
df3.show(truncate=False)


simple = "1"

# This code will continue to run on the GPU (this is a simple string)
df4 = df.withColumn('newcol2', expr(f"""   split(firstname, "{simple}", 3)    """))
df4.explain()
df4.show(truncate=False)
```


Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
