### PR TITLE
Fix DIST_JAR PATH in coverage-report [skip ci]

### DIFF
--- a/build/coverage-report
+++ b/build/coverage-report
@@ -22,9 +22,9 @@ JDEST=${JACOCO_DEST:-"./target/jacococli.jar"}
 TMP_CLASS=${TEMP_CLASS_LOC:-"./target/jacoco_classes/"}
 HTML_LOC=${HTML_LOCATION:="./target/jacoco-report/"}
 XML_LOC=${XML_LOCATION:="${HTML_LOC}"}
-DIST_JAR=${RAPIDS_DIST_JAR:-$(ls ./dist/target/rapids-4-spark_2.12-*.jar | grep -v test | xargs readlink -f)}
+DIST_JAR=${RAPIDS_DIST_JAR:-$(ls ./dist/target/rapids-4-spark_2.12-*cuda*.jar | grep -v test | head -1 | xargs readlink -f)}
 SPK_VER=${JACOCO_SPARK_VER:-"311"}
-UDF_JAR=${RAPIDS_UDF_JAR:-$(ls ./udf-compiler/target/spark${SPK_VER}/rapids-4-spark-udf_2.12-*-SNAPSHOT-spark${SPK_VER}.jar | grep -v test | xargs readlink -f)}
+UDF_JAR=${RAPIDS_UDF_JAR:-$(ls ./udf-compiler/target/spark${SPK_VER}/rapids-4-spark-udf_2.12-*-SNAPSHOT-spark${SPK_VER}.jar | grep -v test | head -1 | xargs readlink -f)}
 SOURCE_DIRS=${SOURCE_DIRS:-"./sql-plugin/src/main/scala/:./sql-plugin/src/main/java/:./shuffle-plugin/src/main/scala/:./udf-compiler/src/main/scala/"}
 
 SOURCE_WITH_ARGS="--sourcefiles "$(echo $SOURCE_DIRS | sed -e 's/:/ --sourcefiles /g')


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

coverage-report failed working after plugin jar w/ classifier,
```
10:33:40  + bash ./build/coverage-report
10:33:40  /home/jenkins/agent/workspace/rapids_codecov-github/target/jacoco_classes /home/jenkins/agent/workspace/rapids_codecov-github
10:33:40  java.io.FileNotFoundException: /home/jenkins/agent/workspace/rapids_codecov-github/dist/target/rapids-4-spark_2.12-22.06.0-SNAPSHOT-cuda11.jar
10:33:40  /home/jenkins/agent/workspace/rapids_codecov-github/dist/target/rapids-4-spark_2.12-22.06.0-SNAPSHOT.jar (No such file or directory)
10:33:40  	at java.util.zip.ZipFile.open(Native Method)
10:33:40  	at java.util.zip.ZipFile.<init>(ZipFile.java:228)
10:33:40  	at java.util.zip.ZipFile.<init>(ZipFile.java:157)
10:33:40  	at java.util.zip.ZipFile.<init>(ZipFile.java:128)
10:33:40  	at sun.tools.jar.Main.extract(Main.java:1004)
10:33:40  	at sun.tools.jar.Main.run(Main.java:305)
10:33:40  	at sun.tools.jar.Main.main(Main.java:1288)
```

Update and verified locally