### PR TITLE
Support ANSI mode for `ToUnixTimestamp, UnixTimestamp, GetTimestamp, DateAddInterval`

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -975,6 +975,7 @@ nested_gens_sample = array_gens_sample + struct_gens_sample_with_decimal128 + ma
 
 ansi_enabled_conf = {'spark.sql.ansi.enabled': 'true'}
 no_nans_conf = {'spark.rapids.sql.hasNans': 'false'}
+legacy_interval_enabled_conf = {'spark.sql.legacy.interval.enabled': 'true'}
 
 def copy_and_update(conf, *more_confs):
     local_conf = conf.copy()
@@ -1030,10 +1031,3 @@ def append_unique_int_col_to_df(spark, dataframe):
     new_rows = append_unique_to_rows(collected)
     new_schema = StructType(existing_schema.fields + [StructField("uniq_int", IntegerType(), False)])
     return spark.createDataFrame(new_rows, new_schema)
-
-# add multiple confs
-def add_conf(*confs):
-    all_items = []
-    for conf in confs:
-        all_items += list(conf.items())
-    return dict(all_items)

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -1030,3 +1030,10 @@ def append_unique_int_col_to_df(spark, dataframe):
     new_rows = append_unique_to_rows(collected)
     new_schema = StructType(existing_schema.fields + [StructField("uniq_int", IntegerType(), False)])
     return spark.createDataFrame(new_rows, new_schema)
+
+# add multiple confs
+def add_conf(*confs):
+    all_items = []
+    for conf in confs:
+        all_items += list(conf.items())
+    return dict(all_items)

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -279,7 +279,7 @@ def test_string_unix_timestamp_ansi_exception():
 
 @pytest.mark.parametrize('data_gen', [StringGen('200[0-9]-0[1-9]-[0-2][1-8]')], ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
-def test_gettimestamp_ansi(data_gen, ansi_enabled):
+def test_gettimestamp(data_gen, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).select(f.to_date(f.col("a"), "yyyy-MM-dd")),
         {'spark.sql.ansi.enabled': ansi_enabled})

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 
 import pytest
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_error
 from data_gen import *
 from datetime import date, datetime, timezone
 from marks import incompat, allow_non_gpu
 from pyspark.sql.types import *
 from spark_session import with_spark_session, is_before_spark_330
 import pyspark.sql.functions as f
+
+ANSI_ENABLE_CONF = {'spark.sql.ansi.enabled': 'true'}
+LEGACY_INTERVAL_CONF = {'spark.sql.legacy.interval.enabled': 'true'}
 
 # We only support literal intervals for TimeSub
 vals = [(-584, 1563), (1943, 1101), (2693, 2167), (2729, 0), (44, 1534), (2635, 3319),
@@ -51,13 +54,37 @@ def test_timeadd_daytime_column():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, gen_list).selectExpr("t + d", "t + INTERVAL '1 02:03:04' DAY TO SECOND"))
 
+# Should specify `spark.sql.legacy.interval.enabled` to test `DateAddInterval` after Spark 3.2.0,
+# refer to https://issues.apache.org/jira/browse/SPARK-34896
+# [SPARK-34896][SQL] Return day-time interval from dates subtraction
+# 1. Add the SQL config `spark.sql.legacy.interval.enabled` which will control when Spark SQL should use `CalendarIntervalType` instead of ANSI intervals.
 @pytest.mark.parametrize('data_gen', vals, ids=idfn)
 def test_dateaddinterval(data_gen):
     days, seconds = data_gen
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, DateGen(start=date(200, 1, 1), end=date(800, 1, 1)), seed=1)
             .selectExpr('a + (interval {} days {} seconds)'.format(days, seconds),
-            'a - (interval {} days {} seconds)'.format(days, seconds)))
+            'a - (interval {} days {} seconds)'.format(days, seconds)),
+        LEGACY_INTERVAL_CONF)
+
+# test add days(not specify hours, minutes, seconds, milliseconds, microseconds) in ANSI mode.
+@pytest.mark.parametrize('data_gen', vals, ids=idfn)
+def test_dateaddinterval_ansi(data_gen):
+    days, _ = data_gen
+    # only specify the `days`
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, DateGen(start=date(200, 1, 1), end=date(800, 1, 1)), seed=1)
+            .selectExpr('a + (interval {} days)'.format(days)),
+        conf=add_conf(ANSI_ENABLE_CONF, LEGACY_INTERVAL_CONF))
+
+# Throws if add hours, minutes or seconds, milliseconds, microseconds to a date in ANSI mode
+def test_dateaddinterval_ansi_exception():
+    assert_gpu_and_cpu_error(
+        # specify the `seconds`
+        lambda spark : unary_op_df(spark, DateGen(start=date(200, 1, 1), end=date(800, 1, 1)), seed=1)
+            .selectExpr('a + (interval {} days {} seconds)'.format(1, 5)).collect(),
+        conf=add_conf(ANSI_ENABLE_CONF, LEGACY_INTERVAL_CONF),
+        error_message="IllegalArgumentException")
 
 @pytest.mark.parametrize('data_gen', date_gens, ids=idfn)
 def test_datediff(data_gen):
@@ -183,39 +210,36 @@ def test_unix_timestamp(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col('a'))))
 
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-def test_to_unix_timestamp(data_gen):
+def test_to_unix_timestamp(data_gen, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr("to_unix_timestamp(a)"))
+        lambda spark : unary_op_df(spark, data_gen).selectExpr("to_unix_timestamp(a)"),
+        {'spark.sql.ansi.enabled': ansi_enabled})
 
-@allow_non_gpu('ProjectExec,Alias,ToUnixTimestamp,Literal')
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-def test_to_unix_timestamp_fallback(data_gen):
-    assert_gpu_fallback_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr("to_unix_timestamp(a)"),
-            'ToUnixTimestamp',
-            conf={'spark.sql.ansi.enabled': 'true'})
-
-@pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-def test_unix_timestamp_improved(data_gen):
+def test_unix_timestamp_improved(data_gen, ansi_enabled):
     conf = {"spark.rapids.sql.improvedTimeOps.enabled": "true",
             "spark.sql.legacy.timeParserPolicy": "CORRECTED"}
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col('a'))), conf)
+        lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col('a'))),
+        add_conf({'spark.sql.ansi.enabled': ansi_enabled}, conf))
 
-@allow_non_gpu('ProjectExec,Alias,UnixTimestamp,Literal')
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-def test_unix_timestamp_fallback(data_gen):
-    assert_gpu_fallback_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col("a"))),
-            'UnixTimestamp',
-            conf={'spark.sql.ansi.enabled': 'true'})
+def test_unix_timestamp(data_gen, ansi_enabled):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col("a"))),
+        {'spark.sql.ansi.enabled': ansi_enabled})
 
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-def test_to_unix_timestamp_improved(data_gen):
+def test_to_unix_timestamp_improved(data_gen, ansi_enabled):
     conf = {"spark.rapids.sql.improvedTimeOps.enabled": "true"}
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen).selectExpr("to_unix_timestamp(a)"), conf)
+        lambda spark : unary_op_df(spark, data_gen).selectExpr("to_unix_timestamp(a)"),
+        add_conf({'spark.sql.ansi.enabled': ansi_enabled}, conf))
 
 str_date_and_format_gen = [pytest.param(StringGen('[0-9]{4}/[01][0-9]'),'yyyy/MM', marks=pytest.mark.xfail(reason="cudf does no checks")),
         (StringGen('[0-9]{4}/[01][12]/[0-2][1-8]'),'yyyy/MM/dd'),
@@ -223,23 +247,48 @@ str_date_and_format_gen = [pytest.param(StringGen('[0-9]{4}/[01][0-9]'),'yyyy/MM
         (StringGen('[0-2][1-8]/[01][12]'), 'dd/MM'),
         (ConvertGen(DateGen(nullable=False), lambda d: d.strftime('%Y/%m').zfill(7), data_type=StringType()), 'yyyy/MM')]
 
-@pytest.mark.parametrize('data_gen,date_form', str_date_and_format_gen, ids=idfn)
-def test_string_to_unix_timestamp(data_gen, date_form):
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen, seed=1).selectExpr("to_unix_timestamp(a, '{}')".format(date_form)))
+# get invalid date string df
+def invalid_date_string_df(spark):
+    return spark.createDataFrame([['invalid_date_string']], "a string")
 
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen,date_form', str_date_and_format_gen, ids=idfn)
-def test_string_unix_timestamp(data_gen, date_form):
+def test_string_to_unix_timestamp(data_gen, date_form, ansi_enabled):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : unary_op_df(spark, data_gen, seed=1).select(f.unix_timestamp(f.col('a'), date_form)))
+        lambda spark : unary_op_df(spark, data_gen, seed=1).selectExpr("to_unix_timestamp(a, '{}')".format(date_form)),
+        {'spark.sql.ansi.enabled': ansi_enabled})
 
-@allow_non_gpu('ProjectExec,Alias,GetTimestamp,Literal,Cast')
+def test_string_to_unix_timestamp_ansi_exception():
+    assert_gpu_and_cpu_error(
+        lambda spark : invalid_date_string_df(spark).selectExpr("to_unix_timestamp(a, '{}')".format('yyyy/MM/dd')).collect(),
+        error_message="Exception",
+        conf=ANSI_ENABLE_CONF)
+
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
+@pytest.mark.parametrize('data_gen,date_form', str_date_and_format_gen, ids=idfn)
+def test_string_unix_timestamp(data_gen, date_form, ansi_enabled):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen, seed=1).select(f.unix_timestamp(f.col('a'), date_form)),
+        {'spark.sql.ansi.enabled': ansi_enabled})
+
+def test_string_unix_timestamp_ansi_exception():
+    assert_gpu_and_cpu_error(
+        lambda spark : invalid_date_string_df(spark).select(f.unix_timestamp(f.col('a'), 'yyyy/MM/dd')).collect(),
+        error_message="Exception",
+        conf=ANSI_ENABLE_CONF)
+
 @pytest.mark.parametrize('data_gen', [StringGen('200[0-9]-0[1-9]-[0-2][1-8]')], ids=idfn)
-def test_gettimestamp_fallback(data_gen):
-    assert_gpu_fallback_collect(
-            lambda spark : unary_op_df(spark, data_gen).select(f.to_date(f.col("a"), "yyyy-MM-dd")),
-            'GetTimestamp',
-            conf={'spark.sql.ansi.enabled': 'true'})
+@pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
+def test_gettimestamp_ansi(data_gen, ansi_enabled):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).select(f.to_date(f.col("a"), "yyyy-MM-dd")),
+        {'spark.sql.ansi.enabled': ansi_enabled})
+
+def test_gettimestamp_ansi_exception():
+    assert_gpu_and_cpu_error(
+        lambda spark : invalid_date_string_df(spark).select(f.to_date(f.col("a"), "yyyy-MM-dd")).collect(),
+        error_message="Exception",
+        conf=ANSI_ENABLE_CONF)
 
 supported_date_formats = ['yyyy-MM-dd', 'yyyy-MM', 'yyyy/MM/dd', 'yyyy/MM', 'dd/MM/yyyy',
                           'MM-dd', 'MM/dd', 'dd-MM', 'dd/MM']

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1732,8 +1732,6 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[DateFormatClass](a, conf, p, r) {
-        override def shouldFallbackOnAnsiTimestamp: Boolean = false
-
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuDateFormatClass(lhs, rhs, strfFormat)
       }
@@ -1748,8 +1746,6 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[ToUnixTimestamp](a, conf, p, r) {
-        override def shouldFallbackOnAnsiTimestamp: Boolean = SQLConf.get.ansiEnabled
-
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
           if (conf.isImprovedTimestampOpsEnabled) {
             // passing the already converted strf string for a little optimization
@@ -1769,8 +1765,6 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[UnixTimestamp](a, conf, p, r) {
-        override def shouldFallbackOnAnsiTimestamp: Boolean = SQLConf.get.ansiEnabled
-
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
           if (conf.isImprovedTimestampOpsEnabled) {
             // passing the already converted strf string for a little optimization
@@ -1846,8 +1840,6 @@ object GpuOverrides extends Logging {
             .withPsNote(TypeEnum.STRING, "Only a limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[FromUnixTime](a, conf, p, r) {
-        override def shouldFallbackOnAnsiTimestamp: Boolean = false
-
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           // passing the already converted strf string for a little optimization
           GpuFromUnixTime(lhs, rhs, strfFormat)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/expressions/rapids/Timestamp.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.expressions.rapids
 import com.nvidia.spark.rapids.{ExprChecks, ExprRule, GpuExpression, GpuOverrides, TypeEnum, TypeSig}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, GetTimestamp}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.{GpuGetTimestamp, UnixTimeExprMeta}
 
 /**
@@ -39,8 +38,6 @@ object TimeStamp {
             .withPsNote(TypeEnum.STRING, "A limited number of formats are supported"),
             TypeSig.STRING)),
       (a, conf, p, r) => new UnixTimeExprMeta[GetTimestamp](a, conf, p, r) {
-        override def shouldFallbackOnAnsiTimestamp: Boolean = SQLConf.get.ansiEnabled
-
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
           GpuGetTimestamp(lhs, rhs, sparkFormat, strfFormat)
         }


### PR DESCRIPTION
Contributes to #5119 

Supports ANSI mode for:
- ToUnixTimestamp
- UnixTimestamp
- GetTimestamp
- DateAddInterval

Signed-off-by: Chong Gao <res_life@163.com>
