### PR TITLE
[WIP] ShimLoader.updateSparkClassLoader fails with openjdk Java11

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -165,7 +165,7 @@ object RapidsShuffleTestHelper extends MockitoSugar with Arm {
   }
 
   def withMockContiguousTable[T](numRows: Long)(body: ContiguousTable => T): T = {
-    val rows: Seq[Integer] = (0 until numRows.toInt).map(new Integer(_))
+    val rows: Seq[Integer] = (0 until numRows.toInt).map(Integer.valueOf)
     withResource(ColumnVector.fromBoxedInts(rows:_*)) { cvBase =>
       cvBase.incRefCount()
       val gpuCv = GpuColumnVector.from(cvBase, IntegerType)


### PR DESCRIPTION
This PR is opened to fix one of the JDK11 support issue: https://github.com/NVIDIA/spark-rapids/issues/3851

java.lang.NoSuchMethodException: No such method: addURL() on object: jdk.internal.loader.ClassLoaders$AppClassLoader
        at org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:231)
        at org.apache.commons.lang3.reflect.MethodUtils.invokeMethod(MethodUtils.java:184)
        at com.nvidia.spark.rapids.ShimLoader$.$anonfun$updateSparkClassLoader$3(ShimLoader.scala:216)
        
Also, deprecated new Integer(_) was replaced.