### PR TITLE
Revert "skip failing tests for Spark 3.3.0 (#5313)"

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -288,9 +288,6 @@ def test_simple_get_map_value_ansi_fail(data_gen):
 
 @pytest.mark.skipif(is_before_spark_330(),
                     reason="Only in Spark 3.3.0 + ANSI mode + Strict Index, map key throws on no such element")
-@pytest.mark.xfail(not is_before_spark_330(),
-                    reason="There was a bug introduced in Spark 3.3.0 which is being tracked by " \
-                           "https://issues.apache.org/jira/browse/SPARK-39015")
 @pytest.mark.parametrize('strict_index', ['true', 'false'])
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_get_map_value_with_strict_index(strict_index, data_gen):
@@ -362,9 +359,6 @@ def test_element_at_map_timestamp_keys(data_gen):
 
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
-@pytest.mark.xfail(not is_before_spark_330(),
-                    reason="There was a bug introduced in Spark 3.3.0 which is being tracked by " \
-                           "https://issues.apache.org/jira/browse/SPARK-39015")
 def test_map_element_at_ansi_fail(data_gen):
     message = "org.apache.spark.SparkNoSuchElementException" if (not is_before_spark_330() or is_databricks104_or_later()) else "java.util.NoSuchElementException"
     # For 3.3.0+ strictIndexOperator should not affect element_at


### PR DESCRIPTION
This reverts commit fa7840bfc3f7f1b8fe48cd87383ed6f9e0cde727.

Now that the Spark [issue](https://issues.apache.org/jira/browse/SPARK-39015) is resolved. We can revert the change for skipping `map_test::test_simple_get_map_value_with_strict_index` and `map_test::test_map_element_at_ansi_fail`

fixes #5318 

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
