### PR TITLE
Restore test_computation_in_grpby_columns and test_struct_self_join

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -344,7 +344,6 @@ def test_hash_reduction_sum_count_action(data_gen):
 
 # Make sure that we can do computation in the group by columns
 @ignore_order
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/5286")
 def test_computation_in_grpby_columns():
     conf = {'spark.rapids.sql.batchSizeBytes' : '250'}
     data_gen = [

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -741,7 +741,6 @@ def test_sortmerge_join_struct_as_key_fallback(data_gen, join_type):
 
 # Regression test for https://github.com/NVIDIA/spark-rapids/issues/3775
 @ignore_order(local=True)
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/5286")
 def test_struct_self_join(spark_tmp_table_factory):
     def do_join(spark):
         data = [


### PR DESCRIPTION
Fixes #5286.

Now that rapidsai/cudf#10717 is fixed, we can re-enable the tests that were disabled in #5288.