### PR TITLE
[DOC] Add rebase mode notes for databricks doc [skip ci]

### DIFF
--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -49,7 +49,7 @@ when using the plugin. Queries may still see significant speedups even with AQE 
 
 5. Parquet rebase mode is set to "LEGACY" by default.
 
-   Below 2 rebase mode related Spark configurations are set to `LEGACY` by default on Databricks:
+   The following Spark configurations are set to `LEGACY` by default on Databricks:
    
    ```
    spark.sql.legacy.parquet.datetimeRebaseModeInWrite

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -56,8 +56,9 @@ when using the plugin. Queries may still see significant speedups even with AQE 
    spark.sql.legacy.parquet.int96RebaseModeInWrite
    ```
    
-   It will cause CPU fallback when writing parquet files. If you do not need "LEGACY" mode, please 
-   set them back to "EXCEPTION" which is the default value in Apache Spark.
+   These settings will cause a CPU fallback for Parquet writes involving dates and timestamps.
+   If you do not need `LEGACY` write semantics, set these configs to `EXCEPTION` which is
+   the default value in Apache Spark.
 
 6. Databricks makes changes to the runtime without notification.
 

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -47,7 +47,19 @@ when using the plugin. Queries may still see significant speedups even with AQE 
    (where N is the number of GPUs per node). This will result in failed executors when starting the
    cluster.
 
-5. Databricks makes changes to the runtime without notification.
+5. Parquet rebase mode is set to "LEGACY" by default.
+
+   Below 2 rebase mode related Spark configurations are set to `LEGACY` by default on Databricks:
+   
+   ```
+   spark.sql.legacy.parquet.datetimeRebaseModeInWrite
+   spark.sql.legacy.parquet.int96RebaseModeInWrite
+   ```
+   
+   It will cause CPU fallback when writing parquet files. If you do not need "LEGACY" mode, please 
+   set them back to "EXCEPTION" which is the default value in Apache Spark.
+
+6. Databricks makes changes to the runtime without notification.
 
     Databricks makes changes to existing runtimes, applying patches, without notification.
 	[Issue-3098](https://github.com/NVIDIA/spark-rapids/issues/3098) is one example of this.  We run

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -58,7 +58,7 @@ when using the plugin. Queries may still see significant speedups even with AQE 
    
    These settings will cause a CPU fallback for Parquet writes involving dates and timestamps.
    If you do not need `LEGACY` write semantics, set these configs to `EXCEPTION` which is
-   the default value in Apache Spark.
+   the default value in Apache Spark 3.0 and higher.
 
 6. Databricks makes changes to the runtime without notification.
 


### PR DESCRIPTION
Add rebase mode notes for databricks doc.

By default, those 2 parameters are LEGACY in Databricks(at least 9.1ML and 10.4ML).
```
 spark.sql.legacy.parquet.datetimeRebaseModeInWrite
 spark.sql.legacy.parquet.int96RebaseModeInWrite
```

If we are writing a parquet file with date/timestamp/int96, below fallback will happen:
```
!Output <InsertIntoHadoopFsRelationCommand> cannot run on GPU because LEGACY rebase mode for dates and timestamps is not supported; LEGACY rebase mode for int96 timestamps is not supported
```

Minimum repro is:
```
import scala.collection.Seq
import java.sql.Date
Seq(java.sql.Timestamp.valueOf("1500-01-01 00:00:00")).toDF("ts").write.format("parquet").mode("overwrite").save("/tmp/testparquet_legacy")
```

We need to manually set them back to "EXCEPTION" which is default value in Apache Spark.