### PR TITLE
Add GpuEqualToNoNans and update GpuPivotFirst to use to handle PivotFirst with NaN support enabled on GPU

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -309,6 +309,11 @@ _init_list_no_nans_with_decimalbig = _init_list_no_nans + [
     _grpkey_short_big_decimals, _grpkey_short_very_big_decimals, 
     _grpkey_short_very_big_neg_scale_decimals]
 
+_init_list_with_nans_and_no_nans_with_decimalbig = _init_list_with_nans_and_no_nans + [
+    _grpkey_small_decimals, _grpkey_big_decimals, _grpkey_short_mid_decimals,
+    _grpkey_short_big_decimals, _grpkey_short_very_big_decimals, 
+    _grpkey_short_very_big_neg_scale_decimals]
+
 
 _init_list_full_decimal = [_grpkey_short_full_decimals, 
     _grpkey_short_full_neg_scale_decimals]
@@ -445,8 +450,8 @@ def test_exceptAll(data_gen):
 @approximate_float
 @ignore_order(local=True)
 @incompat
-@pytest.mark.parametrize('data_gen', _init_list_no_nans_with_decimalbig, ids=idfn)
-@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+@pytest.mark.parametrize('data_gen', _init_list_with_nans_and_no_nans_with_decimalbig, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
 def test_hash_grpby_pivot(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -454,32 +459,6 @@ def test_hash_grpby_pivot(data_gen, conf):
             .pivot('b')
             .agg(f.sum('c')),
         conf = conf)
-
-@approximate_float
-@ignore_order(local=True)
-@allow_non_gpu('HashAggregateExec', 'PivotFirst', 'AggregateExpression', 'Alias', 'GetArrayItem',
-        'Literal', 'ShuffleExchangeExec', 'HashPartitioning', 'KnownFloatingPointNormalized',
-        'NormalizeNaNAndZero')
-@incompat
-@pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nulls_and_nans], ids=idfn)
-def test_hash_pivot_groupby_nan_fallback(data_gen):
-    # collect values to pivot in previous, to avoid this preparation job being captured
-    def fetch_pivot_values(spark):
-        max_values = spark._jsparkSession.sessionState().conf().dataFramePivotMaxValues()
-        df = gen_df(spark, data_gen, length=100)
-        df = df.select('b').distinct().limit(max_values + 1).sort('b')
-        return [row[0] for row in df.collect()]
-
-    pivot_values = with_cpu_session(fetch_pivot_values)
-
-    assert_gpu_fallback_collect(
-        lambda spark: gen_df(spark, data_gen, length=100)
-            .groupby('a')
-            .pivot('b', pivot_values)
-            .agg(f.sum('c')),
-        "PivotFirst",
-        conf=_nans_float_conf)
-
 
 @approximate_float
 @ignore_order(local=True)
@@ -494,12 +473,11 @@ def test_hash_grpby_pivot_without_nans(data_gen, conf):
             .agg(f.sum('c')),
         conf=conf)
 
-
 @approximate_float
 @ignore_order(local=True)
 @incompat
-@pytest.mark.parametrize('data_gen', _init_list_no_nans, ids=idfn)
-@pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
+@pytest.mark.parametrize('data_gen', _init_list_with_nans_and_no_nans, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
 def test_hash_multiple_grpby_pivot(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: gen_df(spark, data_gen, length=100)
@@ -507,30 +485,6 @@ def test_hash_multiple_grpby_pivot(data_gen, conf):
             .pivot('b')
             .agg(f.sum('c'), f.max('c')),
         conf=conf)
-
-@approximate_float
-@ignore_order(local=True)
-@allow_non_gpu('HashAggregateExec', 'PivotFirst', 'AggregateExpression', 'Alias', 'GetArrayItem',
-        'Literal', 'ShuffleExchangeExec')
-@incompat
-@pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nulls_and_nans], ids=idfn)
-def test_hash_pivot_reduction_nan_fallback(data_gen):
-    # collect values to pivot in previous, to avoid this preparation job being captured
-    def fetch_pivot_values(spark):
-        max_values = spark._jsparkSession.sessionState().conf().dataFramePivotMaxValues()
-        df = gen_df(spark, data_gen, length=100)
-        df = df.select('b').distinct().limit(max_values + 1).sort('b')
-        return [row[0] for row in df.collect()]
-
-    pivot_values = with_cpu_session(fetch_pivot_values)
-
-    assert_gpu_fallback_collect(
-        lambda spark: gen_df(spark, data_gen, length=100)
-            .groupby()
-            .pivot('b', pivot_values)
-            .agg(f.sum('c')),
-        "PivotFirst",
-        conf=_nans_float_conf)
 
 @approximate_float
 @ignore_order(local=True)
@@ -544,6 +498,36 @@ def test_hash_reduction_pivot_without_nans(data_gen, conf):
             .pivot('b')
             .agg(f.sum('c')),
         conf=conf)
+
+@approximate_float
+@ignore_order(local=True)
+@incompat
+@pytest.mark.parametrize('data_gen', _init_list_with_nans_and_no_nans, ids=idfn)
+@pytest.mark.parametrize('conf', get_params(_confs_with_nans, params_markers_for_confs_nans), ids=idfn)
+def test_hash_reduction_pivot_with_nans(data_gen, conf):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: gen_df(spark, data_gen, length=100)
+            .groupby()
+            .pivot('b')
+            .agg(f.sum('c')),
+        conf=conf)
+
+@approximate_float
+@ignore_order(local=True)
+@allow_non_gpu('HashAggregateExec', 'PivotFirst', 'AggregateExpression', 'Alias', 'GetArrayItem',
+        'Literal', 'ShuffleExchangeExec', 'HashPartitioning', 'KnownFloatingPointNormalized',
+        'NormalizeNaNAndZero')
+@incompat
+@pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nulls_and_nans], ids=idfn)
+def test_hash_pivot_groupby_duplicates_fallback(data_gen):
+    # PivotFirst will not work on the GPU when pivot_values has duplicates
+    assert_gpu_fallback_collect(
+        lambda spark: gen_df(spark, data_gen, length=100)
+            .groupby('a')
+            .pivot('b', ['10.0', '10.0'])
+            .agg(f.sum('c')),
+        "PivotFirst",
+        conf=_nans_float_conf)
 
 _repeat_agg_column_for_collect_op = [
     RepeatSeqGen(BooleanGen(), length=15),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2234,7 +2234,6 @@ object GpuOverrides extends Logging {
           TypeSig.all))),
       (pivot, conf, p, r) => new ImperativeAggExprMeta[PivotFirst](pivot, conf, p, r) {
         override def tagAggForGpu(): Unit = {
-          checkAndTagFloatNanAgg("Pivot", pivot.pivotColumn.dataType, conf, this)
           // If pivotColumnValues doesn't have distinct values, fall back to CPU
           if (pivot.pivotColumnValues.distinct.lengthCompare(pivot.pivotColumnValues.length) != 0) {
             willNotWorkOnGpu("PivotFirst does not work on the GPU when there are duplicate" +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -1174,7 +1174,9 @@ case class GpuPivotFirst(
       if (pivotColumnValue == null) {
         GpuIf(GpuIsNull(pivotColumn), valueColumn, GpuLiteral(null, valueDataType))
       } else {
-        GpuIf(GpuEqualTo(pivotColumn, GpuLiteral(pivotColumnValue, pivotColumn.dataType)),
+        // Need to use an equal to comparison that is != when both values are NaN to be consistent
+        // with Spark's inconsistency with regards to PivotFirst
+        GpuIf(GpuEqualToNoNans(pivotColumn, GpuLiteral(pivotColumnValue, pivotColumn.dataType)),
           valueColumn, GpuLiteral(null, valueDataType))
       }
     })

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -316,6 +316,79 @@ case class GpuEqualNullSafe(left: Expression, right: Expression) extends CudfBin
   }
 }
 
+case class GpuEqualToNoNans(left: Expression, right: Expression) extends CudfBinaryComparison
+    with NullIntolerant {
+  override def symbol: String = "="
+  override def outputTypeOverride: DType = DType.BOOL8
+  override def binaryOp: BinaryOp = BinaryOp.EQUAL
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+    val result = super.doColumnar(lhs, rhs)
+    if (hasFloatingPointInputs) {
+      withResource(result) { result =>
+        withResource(lhs.getBase.isNan) { lhsNan =>
+          withResource(rhs.getBase.isNan) { rhsNan =>
+            withResource(lhsNan.or(rhsNan)) { lhsNanOrRhsNan =>
+              withResource(lhsNanOrRhsNan.not) { neitherNan =>
+                neitherNan.and(result)
+              }
+            }
+          }
+        }
+      }
+    } else {
+      result
+    }
+  }
+
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    val result = super.doColumnar(lhs, rhs)
+    if (hasFloatingPointInputs) {
+      withResource(result) { result =>
+        withResource(Scalar.fromBool(lhs.isNan)) { lhsNan =>
+          withResource(rhs.getBase.isNan) { rhsNan =>
+            withResource(lhsNan.or(rhsNan)) { lhsNanOrRhsNan =>
+              withResource(lhsNanOrRhsNan.not) { neitherNan =>
+                neitherNan.and(result)
+              }
+            }
+          }
+        }
+      }
+    } else {
+      result
+    }
+  }
+
+  override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
+    val result = super.doColumnar(lhs, rhs)
+    if (hasFloatingPointInputs) {
+      withResource(result) { result =>
+        withResource(lhs.getBase.isNan) { lhsNan =>
+          withResource(Scalar.fromBool(rhs.isNan)) { rhsNan =>
+            withResource(lhsNan.or(rhsNan)) { lhsNanOrRhsNan =>
+              withResource(lhsNanOrRhsNan.not) { neitherNan =>
+                neitherNan.and(result)
+              }
+            }
+          }
+        }
+      }
+    } else {
+      result
+    }
+  }
+
+  override def convertToAst(numFirstTableColumns: Int): ast.AstExpression = {
+    // Currently AST computeColumn assumes nulls compare true for EQUAL, but NOT_EQUAL will
+    // return null for null input.
+    new ast.UnaryOperation(ast.UnaryOperator.NOT,
+      new ast.BinaryOperation(ast.BinaryOperator.NOT_EQUAL,
+        left.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns),
+        right.asInstanceOf[GpuExpression].convertToAst(numFirstTableColumns)))
+  }
+}
+
 /**
  * The table below shows how the result is calculated for greater-than. To make calculation easier
  * we are leveraging the fact that the cudf-result(r) always returns false. So that result is used


### PR DESCRIPTION
Fixes #5322.

This adds the GpuEqualToNoNans operation to support EqualTo where NaN != NaN. This is then used in GpuPivotFirst to allow GPU and CPU behavior to be consistent when the plugin knows that floats can be NaN. The check for the hasNans configuration is now removed so the operation will continue to run on the GPU even if the input data has NaN values.  The integration tests have also been updated to account for `hasNans` and support NaN float inputs in `pivot(...)` on the GPU.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
