### PR TITLE
Exclude all unicode line terminator characters from matching dot

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -565,7 +565,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case RegexChar(ch) => ch match {
         case '.' =>
           // workaround for https://github.com/rapidsai/cudf/issues/9619
-          RegexCharacterClass(negated = true, ListBuffer(RegexChar('\r'), RegexChar('\n')))
+          val terminatorChars = ListBuffer('\r', '\n', '\u0085', '\u2028', '\u2029')
+          RegexCharacterClass(negated = true, terminatorChars.map(RegexChar))
         case '$' if mode == RegexSplitMode || mode == RegexReplaceMode =>
           // see https://github.com/NVIDIA/spark-rapids/issues/4533
           throw new RegexUnsupportedException("line anchor $ is not supported in split or replace")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -565,8 +565,9 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case RegexChar(ch) => ch match {
         case '.' =>
           // workaround for https://github.com/rapidsai/cudf/issues/9619
-          val terminatorChars = ListBuffer('\r', '\n', '\u0085', '\u2028', '\u2029')
-          RegexCharacterClass(negated = true, terminatorChars.map(RegexChar))
+          val terminatorChars = new ListBuffer[RegexCharacterClassComponent]()
+          terminatorChars ++= lineTerminatorChars.map(RegexChar)
+          RegexCharacterClass(negated = true, terminatorChars)
         case '$' if mode == RegexSplitMode || mode == RegexReplaceMode =>
           // see https://github.com/NVIDIA/spark-rapids/issues/4533
           throw new RegexUnsupportedException("line anchor $ is not supported in split or replace")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -306,11 +306,11 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       "[0-9]{2}:[0-9]{2}:[0-9]{2})" +
       "(.[1-9]*(?:0)?[1-9]+)?(.0*[1-9]+)?(?:.0*)?\\z"
 
-    // input and output should be identical except for `.` being replaced with `[^\r\n]` and
-    // `\z` being replaced with `$`
+    // input and output should be identical except for `.` being replaced 
+    // with `[^\r\n\u0085\u2028\u2029]` and `\z` being replaced with `$`
     doTranspileTest(TIMESTAMP_TRUNCATE_REGEX,
       TIMESTAMP_TRUNCATE_REGEX
-        .replaceAll("\\.", "[^\r\n]")
+        .replaceAll("\\.", "[^\r\n\u0085\u2028\u2029]")
         .replaceAll("\\\\z", "\\$"))
   }
 


### PR DESCRIPTION
Signed-off-by: Anthony Chang <antchang@nvidia.com>

Fixes #5415

The wildcard `. ` matching should exclude all line terminators [defined in Java](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lt) (Line terminator section). This PR adds exclusions for next-line (\u0085), line-separator (\u2028), and paragraph-separator (\u2029) characters.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
