### PR TITLE
Make the sync marker uniform for the Avro coalescing reader

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 
-from spark_session import with_cpu_session
+from spark_session import with_cpu_session, with_gpu_session
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
@@ -95,3 +95,25 @@ def test_avro_input_meta(spark_tmp_path, v1_enabled_list, reader_type):
                         'input_file_block_start()',
                         'input_file_block_length()'),
         conf=all_confs)
+
+
+# This is for https://github.com/NVIDIA/spark-rapids/issues/5312
+@pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
+def test_coalescing_uniform_sync(spark_tmp_path, v1_enabled_list):
+    # Generate the data files
+    data_path = spark_tmp_path + '/AVRO_DATA'
+    with_cpu_session(
+        lambda spark: unary_op_df(spark, long_gen).repartition(coalescingPartitionNum)\
+            .write.format("avro").save(data_path))
+    # dump the coalesced files
+    dump_path = spark_tmp_path + '/AVRO_DUMP/'
+    all_confs = copy_and_update(_enable_all_types_conf, {
+        'spark.rapids.sql.format.avro.reader.type': 'COALESCING',
+        'spark.rapids.sql.avro.debug.dumpPrefix': dump_path,
+        'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    with_gpu_session(
+        lambda spark: spark.read.format("avro").load(data_path).collect(),
+        conf=all_confs)
+    # read the coalesced files by CPU
+    with_cpu_session(
+        lambda spark: spark.read.format("avro").load(dump_path).collect())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -562,6 +562,17 @@ trait SingleDataBlockInfo {
 }
 
 /**
+ * A context lives during the whole process of reading partitioned files
+ * to a batch buffer (aka HostMemoryBuffer) to build a memory file.
+ * Children can extend this to add more necessary fields.
+ * @param origChunkedBlocks a map with file as the key, and its blocks as the value
+ * @param schema shema info
+ */
+class BatchContext(
+  val origChunkedBlocks: LinkedHashMap[Path, ArrayBuffer[DataBlockBase]],
+  val schema: SchemaBase) {}
+
+/**
  * The abstracted multi-file coalescing reading class, which tries to coalesce small
  * ColumnarBatch into a bigger ColumnarBatch according to maxReadBatchSizeRows,
  * maxReadBatchSizeBytes and the [[checkIfNeedToSplitDataBlock]].
@@ -632,12 +643,10 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    *
    * Please be note, the estimated size should be at least equal to size of HEAD + Blocks + FOOTER
    *
-   * @param blocks a map with file as the key, and its stripes as the value
-   * @param schema shema info
+   * @param batchContext the batch building context
    * @return Long, the estimated output size
    */
-  def calculateEstimatedBlocksOutputSize(blocks: LinkedHashMap[Path, ArrayBuffer[DataBlockBase]],
-    schema: SchemaBase): Long
+  def calculateEstimatedBlocksOutputSize(batchContext: BatchContext): Long
 
   /**
    * Calculate the final block output size which will be used to decide
@@ -652,11 +661,11 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    *
    * @param footerOffset  footer offset
    * @param blocks        blocks to be evaluated
-   * @param schema        schema info
+   * @param batchContext  the batch building context
    * @return the output size
    */
   def calculateFinalBlocksOutputSize(footerOffset: Long, blocks: Seq[DataBlockBase],
-    schema: SchemaBase): Long
+    batchContext: BatchContext): Long
 
   /**
    * Get ThreadPoolExecutor to run the Callable.
@@ -679,6 +688,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    *               is in charge of closing it in sub-class
    * @param blocks blocks meta info to specify which blocks to be read
    * @param offset used as the offset adjustment
+   * @param batchContext the batch building context
    * @return Callable[(Seq[DataBlockBase], Long)], which will be submitted to a
    *         ThreadPoolExecutor, and the Callable will return a tuple result and
    *         result._1 is block meta info with the offset adjusted
@@ -689,7 +699,8 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       file: Path,
       outhmb: HostMemoryBuffer,
       blocks: ArrayBuffer[DataBlockBase],
-      offset: Long): Callable[(Seq[DataBlockBase], Long)]
+      offset: Long,
+      batchContext: BatchContext): Callable[(Seq[DataBlockBase], Long)]
 
   /**
    * File format short name used for logging and other things to uniquely identity
@@ -715,11 +726,11 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    * Write a header for a specific file format. If there is no header for the file format,
    * just ignore it and return 0
    *
-   * @param paths the paths of files to be coalesced into a single batch
    * @param buffer where the header will be written
+   * @param batchContext the batch building context
    * @return how many bytes written
    */
-  def writeFileHeader(paths: Seq[Path], buffer: HostMemoryBuffer): Long
+  def writeFileHeader(buffer: HostMemoryBuffer, batchContext: BatchContext): Long
 
   /**
    * Writer a footer for a specific file format. If there is no footer for the file format,
@@ -733,11 +744,30 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    * @param bufferSize     The total buffer size which equals to size of (header + blocks + footer)
    * @param footerOffset   Where begin to write the footer
    * @param blocks         The data block meta info
-   * @param clippedSchema  The clipped schema info
+   * @param batchContext   The batch building context
    * @return the buffer and the buffer size
    */
   def writeFileFooter(buffer: HostMemoryBuffer, bufferSize: Long, footerOffset: Long,
-    blocks: Seq[DataBlockBase], clippedSchema: SchemaBase): (HostMemoryBuffer, Long)
+    blocks: Seq[DataBlockBase], batchContext: BatchContext): (HostMemoryBuffer, Long)
+
+  /**
+   * Return a batch context which will be shared during the process of building a memory file,
+   * aka with the following APIs.
+   *   - calculateEstimatedBlocksOutputSize
+   *   - writeFileHeader
+   *   - getBatchRunner
+   *   - calculateFinalBlocksOutputSize
+   *   - writeFileFooter
+   * It is useful when something is needed by some or all of the above APIs.
+   * Children can override this to return a customized batch context.
+   * @param chunkedBlocks a map with file as the key, and its stripes as the value
+   * @param clippedSchema shema info
+   */
+  protected def createBatchContext(
+      chunkedBlocks: LinkedHashMap[Path, ArrayBuffer[DataBlockBase]],
+      clippedSchema: SchemaBase): BatchContext = {
+    new BatchContext(chunkedBlocks, clippedSchema)
+  }
 
   override def next(): Boolean = {
     batch.foreach(_.close())
@@ -840,14 +870,15 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       }
       val tasks = new java.util.ArrayList[Future[(Seq[DataBlockBase], Long)]]()
 
+      val batchContext = createBatchContext(filesAndBlocks, clippedSchema)
       // First, estimate the output file size for the initial allocating.
       //   the estimated size should be >= size of HEAD + Blocks + FOOTER
-      val initTotalSize = calculateEstimatedBlocksOutputSize(filesAndBlocks, clippedSchema)
+      val initTotalSize = calculateEstimatedBlocksOutputSize(batchContext)
 
       val (buffer, bufferSize, footerOffset, outBlocks) =
         closeOnExcept(HostMemoryBuffer.allocate(initTotalSize)) { hmb =>
           // Second, write header
-          var offset = writeFileHeader(filesAndBlocks.keys.toSeq, hmb)
+          var offset = writeFileHeader(hmb, batchContext)
 
           val allOutputBlocks = scala.collection.mutable.ArrayBuffer[DataBlockBase]()
           val tc = TaskContext.get
@@ -857,7 +888,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
             val outLocal = hmb.slice(offset, fileBlockSize)
             // Third, copy the blocks for each file in parallel using background threads
             tasks.add(getThreadPool(numThreads).submit(
-              getBatchRunner(tc, file, outLocal, blocks, offset)))
+              getBatchRunner(tc, file, outLocal, blocks, offset, batchContext)))
             offset += fileBlockSize
           }
 
@@ -869,7 +900,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
 
           // Fourth, calculate the final buffer size
           val finalBufferSize = calculateFinalBlocksOutputSize(offset, allOutputBlocks,
-            clippedSchema)
+            batchContext)
 
           (hmb, finalBufferSize, offset, allOutputBlocks)
       }
@@ -908,7 +939,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
       // reason to do that.
       // If you have to do this, please think about to add other abstract methods first.
       val (finalBuffer, finalBufferSize) = writeFileFooter(buf, totalBufferSize, footerOffset,
-        outBlocks, clippedSchema)
+        outBlocks, batchContext)
 
       closeOnExcept(finalBuffer) { _ =>
         // triple check we didn't go over memory

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -565,8 +565,8 @@ trait SingleDataBlockInfo {
  * A context lives during the whole process of reading partitioned files
  * to a batch buffer (aka HostMemoryBuffer) to build a memory file.
  * Children can extend this to add more necessary fields.
- * @param origChunkedBlocks a map with file as the key, and its blocks as the value
- * @param schema shema info
+ * @param origChunkedBlocks mapping of file path to data blocks
+ * @param schema schema info
  */
 class BatchContext(
   val origChunkedBlocks: LinkedHashMap[Path, ArrayBuffer[DataBlockBase]],
@@ -760,8 +760,8 @@ abstract class MultiFileCoalescingPartitionReaderBase(
    *   - writeFileFooter
    * It is useful when something is needed by some or all of the above APIs.
    * Children can override this to return a customized batch context.
-   * @param chunkedBlocks a map with file as the key, and its stripes as the value
-   * @param clippedSchema shema info
+   * @param chunkedBlocks mapping of file path to data blocks
+   * @param clippedSchema schema info
    */
   protected def createBatchContext(
       chunkedBlocks: LinkedHashMap[Path, ArrayBuffer[DataBlockBase]],


### PR DESCRIPTION
This PR is to fix the issue https://github.com/NVIDIA/spark-rapids/issues/5312 by appending the same sync marker to every block that being coalesced into a single Avro file.

It has mainly

- introduced a new class named `BatchContext`, and a new method `createBatchContext` in the parent class of the coalescing reader. This new method returns a `BatchContext` who lives during the whole stage of building a coalesced memory file. By this design, the merged Avro header can be shared with the steps of estimating the output size, writing file header and building the block data for creating a batch. 
- updated the `copyBlocksData` and GPU Avro coalescing reader to support writing a given sync marker.
- added the related tests.

### Performance on Local
 - CPU 12 cores, and one GPU (Titan V, with 12GB memory)
- Non-partitioned 2000 avro files, 4.4GB in total in **LOCAL** storage

  ||CPU|PERFILE|COALESCING (non-uniform-sync)|COALESCING (uniform-sync)|
  |--|--|--|--|--|
  |time(sec)|27.844|24.758|16.005|15.713|

The numbers above show this change will not lead to any perf regression for the coalescing reader.

closes https://github.com/NVIDIA/spark-rapids/issues/5312

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
