### PR TITLE
Test case insensitive reading for Parquet and CSV

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -826,9 +826,8 @@ def test_parquet_read_case_insensitivity(spark_tmp_path):
     data_path = spark_tmp_path + '/PARQUET_DATA'
 
     with_cpu_session(lambda spark: gen_df(spark, gen_list).write.parquet(data_path))
-    read_fn = lambda spark: spark.read.parquet(data_path).select('one', 'two', 'three')
 
     assert_gpu_and_cpu_are_equal_collect(
-        read_fn,
+        lambda spark: spark.read.parquet(data_path).select('one', 'two', 'three'),
         {'spark.sql.caseSensitive': 'false'}
     )

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from webbrowser import get
 import pytest
 
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -15,7 +15,7 @@
 from webbrowser import get
 import pytest
 
-from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql
+from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *


### PR DESCRIPTION
Close #5262.

# Changes
Add 2 tests to confirm that when `spark.sql.caseSensitive = False`, GPU can normalize column names to lower case when reading the data frame.

No API changes.
