### PR TITLE
Add support for regular expressions containing hexadecimal digits greater than `0x7f`

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -837,13 +837,16 @@ def test_regexp_extract_idx_0():
         conf=_regexp_conf)
 
 def test_regexp_hexadecimal_digits():
-    gen = mk_str_gen('[abcd]\\\\x00\\\\x7f\\\\x80\\\\xff[\\\\xa0-\\\\xb0][abcd]')
+    gen = mk_str_gen(
+        '[abcd]\\\\x00\\\\x7f\\\\x80\\\\xff\\\\x{10ffff}\\\\x{00eeee}[\\\\xa0-\\\\xb0][abcd]')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'rlike(a, "\\\\x7f")',
                 'rlike(a, "\\\\x80")',
+                'rlike(a, "\\\\x{00eeee}")',
                 'regexp_extract(a, "([a-d]+)\\\\xa0([a-d]+)", 1)',
                 'regexp_replace(a, "\\\\xff", "")',
+                'regexp_replace(a, "\\\\x{10ffff}", "")',
             ),
         conf=_regexp_conf)
 

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -836,6 +836,17 @@ def test_regexp_extract_idx_0():
                 'regexp_extract(a, "^([a-d]*)[0-9]*([a-d]*)\\z", 0)'),
         conf=_regexp_conf)
 
+def test_regexp_hexadecimal_digits():
+    gen = mk_str_gen('[abcd]\\\\x00\\\\x7f\\\\x80\\\\xff[\\\\xa0-\\\\xb0][abcd]')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'rlike(a, "\\\\x7f")',
+                'rlike(a, "\\\\x80")',
+                'regexp_extract(a, "([a-d]+)\\\\xa0([a-d]+)", 1)',
+                'regexp_replace(a, "\\\\xff", "")',
+            ),
+        conf=_regexp_conf)
+
 def test_regexp_whitespace():
     gen = mk_str_gen('\u001e[abcd]\t\n{1,3} [0-9]\n {1,3}\x0b\t[abcd]\r\f[0-9]{0,10}')
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -628,11 +628,11 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case RegexHexDigit(digits) =>
         val codePoint = Integer.parseInt(digits, 16)
         if (codePoint >= 128) {
-          // see https://github.com/NVIDIA/spark-rapids/issues/4866
-          throw new RegexUnsupportedException(
-            "cuDF does not support hex digits > 0x7F")
+          // cuDF only supports 0x00 to 0x7f hexidecimal chars
+          RegexChar(codePoint.toChar)
+        } else {
+          RegexHexDigit(String.format("%02x", Int.box(codePoint)))
         }
-        RegexHexDigit(String.format("%02x", Int.box(codePoint)))
 
       case RegexEscaped(ch) => ch match {
         case 'D' =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -150,14 +150,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         "cuDF does not support octal digits 0o177 < n <= 0o377"))
   }
 
-  test("cuDF does not support hex digits > 0x7F") {
-    // see https://github.com/NVIDIA/spark-rapids/issues/4866
-    val patterns = Seq(raw"\x80", raw"\xff", raw"\xFF", raw"\x{ABC}")
-    patterns.foreach(pattern =>
-      assertUnsupported(pattern, RegexFindMode,
-        "cuDF does not support hex digits > 0x7F"))
-  }
-
   test("cuDF does not support octal digits in character classes") {
     // see https://github.com/NVIDIA/spark-rapids/issues/4862
     val patterns = Seq(raw"[\02]", raw"[\012]", raw"[\0177]")
@@ -188,6 +180,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     val patterns = Seq(raw"\x07", raw"\x3f", raw"\x7F", raw"\x7f", raw"\x{7}", raw"\x{0007f}")
     assertCpuGpuMatchesRegexpFind(patterns, Seq("", "\u0007", "a\u0007b", 
         "\u0007\u003f\u007f", "\u007f", "\u007f2"))
+  }
+
+  test("hex digits >= 0x7F - find") {
+    val patterns = Seq(raw"\x7f", raw"\x80", raw"\xff", raw"\xfe", raw"\x{7f}", raw"\x{0008f}")
+    assertCpuGpuMatchesRegexpFind(patterns, Seq("", "\u007f", "a\u007fb", 
+        "\u007f\u003f\u007f", "\u0080", "a\u00fe\u00ffb", "\u007f2"))
   }
   
   test("string anchors - find") {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -176,16 +176,11 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         "\u0007\u003f\u007f", "\u007f", "\u007f2"))
   }
 
-  test("hex digits < 0x7F - find") {
-    val patterns = Seq(raw"\x07", raw"\x3f", raw"\x7F", raw"\x7f", raw"\x{7}", raw"\x{0007f}")
+  test("hex digits - find") {
+    val patterns = Seq(raw"\x07", raw"\x3f", raw"\x7F", raw"\x7f", raw"\x{7}", raw"\x{0007f}",
+      raw"\x80", raw"\xff", raw"\x{0008f}", raw"\x{10FFFF}", raw"\x{00eeee}")
     assertCpuGpuMatchesRegexpFind(patterns, Seq("", "\u0007", "a\u0007b", 
-        "\u0007\u003f\u007f", "\u007f", "\u007f2"))
-  }
-
-  test("hex digits >= 0x7F - find") {
-    val patterns = Seq(raw"\x7f", raw"\x80", raw"\xff", raw"\xfe", raw"\x{7f}", raw"\x{0008f}")
-    assertCpuGpuMatchesRegexpFind(patterns, Seq("", "\u007f", "a\u007fb", 
-        "\u007f\u003f\u007f", "\u0080", "a\u00fe\u00ffb", "\u007f2"))
+        "\u0007\u003f\u007f", "\u0080", "a\u00fe\u00ffb", "ab\ueeeecd"))
   }
   
   test("string anchors - find") {


### PR DESCRIPTION
Fixes #4866

cuDF only supports hexadecimal characters up to 0x7f, and we fallback to CPU for characters outside that range. This workaround converts hexadecimal digits directly to the Unicode character itself, allowing GPU support for the full range of hexadecimal digits.

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
