### PR TITLE
Fix query planning issue when Iceberg is used with DPP and AQE

### DIFF
--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from asserts import assert_gpu_and_cpu_are_equal_collect
-from marks import allow_non_gpu, iceberg
-from spark_session import with_cpu_session
+from data_gen import *
+from marks import allow_non_gpu, iceberg, ignore_order
+from spark_session import is_before_spark_320, is_databricks_runtime, with_cpu_session
 
 @allow_non_gpu('BatchScanExec')
 @iceberg
@@ -26,3 +29,21 @@ def test_iceberg_fallback_not_unsafe_row(spark_tmp_table_factory):
     with_cpu_session(setup_iceberg_table)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.sql("SELECT COUNT(DISTINCT id) from {}".format(table)))
+
+@allow_non_gpu('BatchScanExec')
+@iceberg
+@ignore_order(local=True)
+@pytest.mark.skipif(is_before_spark_320() or is_databricks_runtime(),
+                    reason="AQE+DPP not supported until Spark 3.2.0+ and AQE+DPP not supported on Databricks")
+def test_iceberg_aqe_dpp(spark_tmp_table_factory):
+    table = spark_tmp_table_factory.get()
+    def setup_iceberg_table(spark):
+        df = two_col_df(spark, int_gen, int_gen)
+        df.createOrReplaceTempView("df")
+        spark.sql("CREATE TABLE {} (a INT, b INT) USING ICEBERG PARTITIONED BY (a)".format(table))
+        spark.sql("INSERT INTO {} SELECT * FROM df".format(table))
+    with_cpu_session(setup_iceberg_table)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : spark.sql("SELECT * from {} as X JOIN {} as Y ON X.a = Y.a WHERE Y.a > 0".format(table, table)),
+        conf={"spark.sql.adaptive.enabled": "true",
+              "spark.sql.optimizer.dynamicPartitionPruning.enabled": "true"})


### PR DESCRIPTION
Fixes #5464.

#4630 added code to fixup the case where the subquery produces GPU-formatted data but we cannot replace the FileSourceScanExec.  Iceberg uses DataSource V2, so it appears as BatchScanExec rather than FileSourceScanExec.  Since we currently do not replace Iceberg reads, we end up with the same problem that the changes in #4630 was intended to solve, where the subquery is GPU-formatted but we don't replace the exec that is examining the subquery results.  Since the GPU data is columnar, Spark automatically inserts a ColumnarToRow between the AdaptiveSparkPlanExec and the BroadcastQueryStageExec which triggers the assert in Spark.

This adds similar handling for BatchScanExec as #4630 added for FileSourceScanExec.  In Spark 3.2+ BatchScanExec can have a dynamic runtimeFilter subquery which needs to be handled separately from the BatchScanExec in case we can translate one without translating the other.