### PR TITLE
Don't distinguish between types of `ArithmeticException` for Spark 3.2.x

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -42,10 +42,12 @@ _decimal_gen_38_0 = DecimalGen(precision=38, scale=0)
 _decimal_gen_38_10 = DecimalGen(precision=38, scale=10)
 _decimal_gen_38_neg10 = DecimalGen(precision=38, scale=-10)
 
-_arith_decimal_gens_no_neg_scale = [
-    decimal_gen_32bit, _decimal_gen_7_7, decimal_gen_64bit, _decimal_gen_18_0, decimal_gen_128bit,
+_arith_data_gens_diff_precision_scale_and_no_neg_scale = [
+    decimal_gen_32bit, decimal_gen_64bit, _decimal_gen_18_0, decimal_gen_128bit,
     _decimal_gen_30_2, _decimal_gen_36_5, _decimal_gen_38_0, _decimal_gen_38_10
 ]
+
+_arith_decimal_gens_no_neg_scale = _arith_data_gens_diff_precision_scale_and_no_neg_scale + [_decimal_gen_7_7]
 
 _arith_decimal_gens = _arith_decimal_gens_no_neg_scale + [
     decimal_gen_32bit_neg_scale, _decimal_gen_36_neg5, _decimal_gen_38_neg10
@@ -275,7 +277,7 @@ def test_mod_pmod_long_min_value():
             'a % -1L'),
         ansi_enabled_conf)
 
-@pytest.mark.parametrize('data_gen', _arith_data_gens_no_neg_scale, ids=idfn)
+@pytest.mark.parametrize('data_gen', _arith_data_gens_diff_precision_scale_and_no_neg_scale, ids=idfn)
 @pytest.mark.parametrize('overflow_exp', [
     'pmod(a, cast(0 as {}))',
     'pmod(cast(-12 as {}), cast(0 as {}))',
@@ -283,15 +285,25 @@ def test_mod_pmod_long_min_value():
     'cast(-12 as {}) % cast(0 as {})'], ids=idfn)
 def test_mod_pmod_by_zero(data_gen, overflow_exp):
     string_type = to_cast_string(data_gen.data_type)
-    # spark 31X: throws java.lang.ArithmeticException
-    # spark 32X: throws either java.lang.ArithmeticException or org.apache.spark.SparkArithmeticException
-    # spark 33X: throws org.apache.spark.SparkArithmeticException
-    exception_str = "java.lang.ArithmeticException" if is_before_spark_320() else \
-        "org.apache.spark.SparkArithmeticException" if is_spark_330_or_later() else \
-        "ArithmeticException"
+    exception_str = "java.lang.ArithmeticException: divide by zero" if is_before_spark_320() else \
+        "org.apache.spark.SparkArithmeticException: divide by zero" 
+        
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             overflow_exp.format(string_type, string_type)).collect(),
+        ansi_enabled_conf,
+        exception_str)
+
+def test_cast_neg_to_decimal_err():
+    # -12 cannot be represented as decimal(7,7)
+    data_gen = _decimal_gen_7_7
+    exception_content = "Decimal(compact,-120000000,20,0}) cannot be represented as Decimal(7, 7)"
+    exception_str = "java.lang.ArithmeticException: " + exception_content if is_before_spark_330() else \
+        "org.apache.spark.SparkArithmeticException: " + exception_content
+
+    assert_gpu_and_cpu_error(
+        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'cast(-12 as {})'.format(to_cast_string(data_gen.data_type))).collect(),
         ansi_enabled_conf,
         exception_str)
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

Close #5474

In the test `test_mod_pmod_by_zero`, Spark 31X always throws `java.lang.ArithmeticException`, Spark 33X always throws `SparkArithmeticException`, but Spark 32X will throw either of them. So we don't distinguish the two for Spark 32X.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
