### PR TITLE
Add cudaStreamSynchronize when a new device buffer is added to the spill framework

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -138,8 +138,7 @@ abstract class RapidsBufferStore(
   def copyBuffer(buffer: RapidsBuffer, memoryBuffer: MemoryBuffer, stream: Cuda.Stream)
   : RapidsBufferBase = {
     freeOnExcept(createBuffer(buffer, memoryBuffer, stream)) { newBuffer =>
-      buffers.add(newBuffer)
-      catalog.registerNewBuffer(newBuffer)
+      addBuffer(newBuffer)
       newBuffer
     }
   }
@@ -208,6 +207,7 @@ abstract class RapidsBufferStore(
    * If the data transfer will be performed asynchronously, this method is responsible for
    * adding a reference to the existing buffer and later closing it when the transfer completes.
    * @note DO NOT close the buffer unless adding a reference!
+   * @note `createBuffer` impls should synchronize against `stream` before returning, if needed.
    * @param buffer data from another store
    * @param memoryBuffer memory buffer obtained from the specified Rapids buffer. The ownership
    *                     for `memoryBuffer` is transferred to this store. The store may close

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -430,7 +430,12 @@ class RapidsShuffleClient(
     logDebug(s"Adding buffer id ${id} to catalog")
     if (buffer != null) {
       // add the buffer to the catalog so it is available for spill
-      devStorage.addBuffer(id, buffer, meta, SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
+      devStorage.addBuffer(id, buffer, meta,
+        SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY,
+        // set needsSync to false because we already have stream synchronized after
+        // consuming the bounce buffer, so we know these buffers are synchronized
+        // w.r.t. the CPU
+        needsSync = false)
     } else {
       // no device data, just tracking metadata
       catalog.registerNewBuffer(new DegenerateRapidsBuffer(id, meta))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -127,7 +127,10 @@ class RapidsCachingWriter[K, V](
                 bufferId,
                 buffer,
                 tableMeta,
-                SpillPriorities.OUTPUT_FOR_SHUFFLE_INITIAL_PRIORITY)
+                SpillPriorities.OUTPUT_FOR_SHUFFLE_INITIAL_PRIORITY,
+                // we don't need to sync here, because we sync on the cuda
+                // stream after compression.
+                needsSync = false)
             case c => throw new IllegalStateException(s"Unexpected column type: ${c.getClass}")
           }
           bytesWritten += partSize


### PR DESCRIPTION
Closes #4818.

This is to fix the stream-ordered violation we could see currently in the spill framework: a buffer is allocated and acted on in stream A, and added to the store without any synchronization. Then stream B runs OOM and spills such buffer, not having waited on stream A.

The idea here is that if a device buffer is added to the store, we force in most cases a call to cudaStreamSynchronize, which should take care of the cases where we return from cuDF and have not stream synchronized there. There is a lot of stream synchronization in cuDF (via thrift usually) so it seems like this is an unlikely issue. That said, adding this synchronize, would be more robust as now the spill framework knows for a fact that the buffer can be freely copied (spilled).

Note that I added a flag to not synchronize in some cases, this is used for UCX since we synchronize on writes after compressing buffers, and also on reads after copying from the bounce buffer, so those two cases we can reliably say we have synchronized. I don't know of other cases where the synchronize in the spill framework can be skipped.

I have been measuring the impact of this in our benchmarks. I do not see any big differences so far in UCX or non-UCX runs. I am going to continue testing it today. Adding as WIP for comments.
