### PR TITLE
Add limited support for captured vars and athrow

### DIFF
--- a/docs/additional-functionality/udf-to-catalyst-expressions.md
+++ b/docs/additional-functionality/udf-to-catalyst-expressions.md
@@ -109,6 +109,8 @@ When translating UDFs to Catalyst expressions, the supported UDF functions are l
 |                          | lhs += rhs                                               |
 |                          | lhs :+ rhs                                               |
 | Method call              | Only if the method being called 1. Consists of operations supported by the UDF compiler, and 2. is one of the folllowing: a final method, a method in a final class, or a method in a final object |
+| Captured variables       | Only primitive type variables captured from a method |
+| Throwing exception       | Only if the exception thrown is a SparkException.  The exception is then convered to a RuntimeException at runtime |
 
 All other expressions, including but not limited to `try` and `catch`, are unsupported and UDFs
 with such expressions cannot be compiled.

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
@@ -108,7 +108,7 @@ case class BB(instructionTable: SortedMap[Int, Instruction]) extends Logging {
         val defaultState = state.copy(cond = simplify(defaultCondition))
         newStates + (defaultSucc -> defaultState.merge(newStates.get(defaultSucc)))
       case Opcode.IRETURN | Opcode.LRETURN | Opcode.FRETURN | Opcode.DRETURN |
-           Opcode.ARETURN | Opcode.RETURN => states
+           Opcode.ARETURN | Opcode.RETURN | Opcode.ATHROW => states
       case _ =>
         val (0, successor) :: Nil = cfg.successor(this)
         // The condition, stack and locals from the current BB state need to be

--- a/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
+++ b/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
@@ -2384,7 +2384,7 @@ class OpcodeSuite extends FunSuite {
     try {
       run(20)
     } catch {
-      case e: Throwable =>
+      case e: RuntimeException =>
         assert(e.getMessage == "Fold number must be in range [0, 20), but got 20.")
     }
   }

--- a/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
+++ b/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
@@ -25,6 +25,7 @@ import com.nvidia.spark.rapids.RapidsConf
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.functions.{udf => makeUdf}
@@ -2348,6 +2349,44 @@ class OpcodeSuite extends FunSuite {
     val result = runner(dataset)
     val ref = dataset.withColumn("new", length(col("value")) + capturedArg)
     checkEquivNotCompiled(result, ref)
+  }
+
+  test("capture a primitive var in method") {
+    def run() = {
+      val capturedArg: Int = 4
+      val myudf: (String) => Int = str => {
+        str.length + capturedArg
+      }
+      val u = makeUdf(myudf)
+      val dataset = List("hello", "world").toDS()
+      val result = dataset.withColumn("new", u(col("value")))
+      val ref = dataset.withColumn("new", length(col("value")) + capturedArg)
+      checkEquiv(result, ref)
+    }
+    run
+  }
+
+  test("throw a SparkException object") {
+    def run(x: Int) = {
+      val myudf: (Int) => Boolean = i => {
+        if (i < 0 || i >= x) {
+          throw new SparkException(s"Fold number must be in range [0, $x), but got $i.")
+        }
+        true
+      }
+      val u = makeUdf(myudf)
+      val dataset = List(2, 20).toDS()
+      val result = dataset.withColumn("new", u('value))
+      val ref = dataset.withColumn("new", lit(true))
+      checkEquiv(result, ref)
+    }
+    run(30)
+    try {
+      run(20)
+    } catch {
+      case e: Throwable =>
+        assert(e.getMessage == "Fold number must be in range [0, 20), but got 20.")
+    }
   }
 
   test("Conditional array buffer processing") {


### PR DESCRIPTION
Only the primitive type variables captured from a method are supported.
athrow is supported only with SparkException and is converted to raise_error.

Following additional changes have also been made:
* A check to reject lambdas with void return type has been added.
* An operand stack bug fix for consturctor calls has been added.

This commit also simplifies the code that handles method calls.

Signed-off-by: Sean Lee <selee@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
