### PR TITLE
Enable 330 unit tests for nightly

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -89,12 +89,9 @@ mvn -B $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR -Dbuildver=24X clean install -D
 # Deploy jars unless SKIP_DEPLOY is 'true'
 
 for buildver in "${SPARK_SHIM_VERSIONS[@]:1}"; do
-    # temporarily skip tests on Spark 3.3.0 - https://github.com/NVIDIA/spark-rapids/issues/4031
-    [[ $buildver == "330" ]] && skipTestsFor330=true || skipTestsFor330=false
     mvn -U -B clean install -pl '!tools' $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR \
         -Dcuda.version=$CUDA_CLASSIFIER \
-        -Dbuildver="${buildver}" \
-        -DskipTests="${skipTestsFor330}"
+        -Dbuildver="${buildver}"
     distWithReducedPom "install"
     [[ $SKIP_DEPLOY != 'true' ]] && \
         mvn -B deploy -pl '!tools,!dist' $MVN_URM_MIRROR \

--- a/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
+++ b/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
@@ -18,8 +18,6 @@ package com.nvidia.spark.rapids
 import java.io.File
 import java.time.{Duration, Period}
 
-import org.apache.spark
-
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -71,7 +69,7 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
 
   test("test GPU cache interval when reading/writing parquet") {
     // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
-    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
+    assumePriorToSpark330
     setPCBS()
 
     val tempFile = File.createTempFile("pcbs", ".parquet")
@@ -94,7 +92,7 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
   // CPU write a parquet, then test the reading between CPU and GPU
   test("test ANSI interval read") {
     // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
-    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
+    assumePriorToSpark330
     val tmpFile = File.createTempFile("interval", ".parquet")
     try {
       withCpuSparkSession(spark => getDF(spark).coalesce(1)
@@ -112,7 +110,7 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
   // GPU write a parquet, then test the reading between CPU and GPU
   test("test ANSI interval write") {
     // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
-    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
+    assumePriorToSpark330
     val tmpFile = File.createTempFile("interval", ".parquet")
     try {
       withGpuSparkSession(spark => getDF(spark).coalesce(1)

--- a/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
+++ b/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
@@ -19,6 +19,7 @@ import java.io.File
 import java.time.{Duration, Period}
 
 import org.apache.spark
+
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**

--- a/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
+++ b/tests/src/test/330/scala/com/nvidia/spark/rapids/IntervalSuite.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 import java.io.File
 import java.time.{Duration, Period}
 
+import org.apache.spark
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -68,6 +69,8 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
   }
 
   test("test GPU cache interval when reading/writing parquet") {
+    // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
+    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
     setPCBS()
 
     val tempFile = File.createTempFile("pcbs", ".parquet")
@@ -89,6 +92,8 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
 
   // CPU write a parquet, then test the reading between CPU and GPU
   test("test ANSI interval read") {
+    // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
+    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
     val tmpFile = File.createTempFile("interval", ".parquet")
     try {
       withCpuSparkSession(spark => getDF(spark).coalesce(1)
@@ -105,6 +110,8 @@ class IntervalSuite extends SparkQueryCompareTestSuite {
 
   // GPU write a parquet, then test the reading between CPU and GPU
   test("test ANSI interval write") {
+    // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5497
+    assume(spark.SPARK_VERSION_SHORT < "3.3.0")
     val tmpFile = File.createTempFile("interval", ".parquet")
     try {
       withGpuSparkSession(spark => getDF(spark).coalesce(1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -290,12 +290,15 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     frame => frame.agg(avg(lit("abc")),avg(lit("pqr")))
   }
 
-  testExpectedException[AnalysisException](
-      "avg literals bools fail",
-      _.getMessage.startsWith("cannot resolve"),
-      longsFromCSVDf,
-      conf = floatAggConf) {
-    frame => frame.agg(avg(lit(true)),avg(lit(false)))
+  // temporarily skip the test on Spark 3.3.0-https://github.com/NVIDIA/spark-rapids/issues/5496
+  if (spark.SPARK_VERSION_SHORT < "3.3.0") {
+    testExpectedException[AnalysisException](
+        "avg literals bools fail",
+        _.getMessage.startsWith("cannot resolve"),
+        longsFromCSVDf,
+        conf = floatAggConf) {
+      frame => frame.agg(avg(lit(true)),avg(lit(false)))
+    }
   }
 
   testSparkResultsAreEqual(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1953,6 +1953,9 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   def assumeSpark320orLater: Assertion =
     assume(VersionUtils.isSpark320OrLater, "Spark version not 3.2.0+")
 
+  def assumePriorToSpark330: Assertion =
+    assume(cmpSparkVersion(3,3,0) < 0, "Spark version not before 3.3.0")
+
   def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
     val sparkShimVersion = SparkShimImpl.getSparkShimVersion
     val (sparkMajor, sparkMinor, sparkBugfix) = sparkShimVersion match {


### PR DESCRIPTION
Enable 330 unit tests for nightly, since the issue in the comment has been fixed. 

It skips the 4 failing tests, and tracks them by separate issues.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
