### PR TITLE
Fallback parquet reading with merged schema and native footer reader

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -394,6 +394,7 @@ def test_parquet_read_merge_schema_from_conf(spark_tmp_path, v1_enabled_list, re
 
 @pytest.mark.parametrize('reader_confs', reader_opt_confs_native)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+@allow_non_gpu('ColumnarToRowExec')
 def test_parquet_read_merge_schema_native_fallback(spark_tmp_path, v1_enabled_list, reader_confs):
     # Once https://github.com/NVIDIA/spark-rapids/issues/133 and https://github.com/NVIDIA/spark-rapids/issues/132 are fixed
     # we should go with a more standard set of generators
@@ -414,6 +415,7 @@ def test_parquet_read_merge_schema_native_fallback(spark_tmp_path, v1_enabled_li
     all_confs = copy_and_update(reader_confs, {'spark.sql.sources.useV1SourceList': v1_enabled_list})
     assert_gpu_fallback_collect(
         lambda spark: spark.read.option('mergeSchema', 'true').parquet(data_path),
+        cpu_fallback_class_name='FileSourceScanExec' if v1_enabled_list == 'parquet' else 'BatchScanExec',
         conf=all_confs)
 
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -30,6 +30,12 @@ class RapidsParquetScanMeta(
 
   override def tagSelfForGpu(): Unit = {
     GpuParquetScan.tagSupport(this)
+
+    if (pScan.options.getBoolean("mergeSchema", true) &&
+      conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
+      willNotWorkOnGpu("Native footer reader for parquet does not work when" +
+        " mergeSchema is enabled")
+    }
   }
 
   override def convertToGpu(): Scan = {

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -31,7 +31,7 @@ class RapidsParquetScanMeta(
   override def tagSelfForGpu(): Unit = {
     GpuParquetScan.tagSupport(this)
 
-    if (pScan.options.getBoolean("mergeSchema", true) &&
+    if (pScan.options.getBoolean("mergeSchema", false) &&
       conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
       willNotWorkOnGpu("Native footer reader for parquet does not work when" +
         " mergeSchema is enabled")

--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -36,7 +36,7 @@ class RapidsParquetScanMeta(
         " on datasource V2 yet.")
     }
 
-    if (pScan.options.getBoolean("mergeSchema", true) &&
+    if (pScan.options.getBoolean("mergeSchema", false) &&
       conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
       willNotWorkOnGpu("Native footer reader for parquet does not work when" +
         " mergeSchema is enabled")

--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -35,6 +35,12 @@ class RapidsParquetScanMeta(
       willNotWorkOnGpu("Parquet does not support Runtime filtering (DPP)" +
         " on datasource V2 yet.")
     }
+
+    if (pScan.options.getBoolean("mergeSchema", true) &&
+      conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
+      willNotWorkOnGpu("Native footer reader for parquet does not work when" +
+        " mergeSchema is enabled")
+    }
   }
 
   override def convertToGpu(): Scan = {

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -41,7 +41,7 @@ class RapidsParquetScanMeta(
         "aggregates pushed into Parquet read, which is a metadata only operation")
     }
 
-    if (pScan.options.getBoolean("mergeSchema", true) &&
+    if (pScan.options.getBoolean("mergeSchema", false) &&
       conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
       willNotWorkOnGpu("Native footer reader for parquet does not work when" +
         " mergeSchema is enabled")

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -40,6 +40,12 @@ class RapidsParquetScanMeta(
       willNotWorkOnGpu(
         "aggregates pushed into Parquet read, which is a metadata only operation")
     }
+
+    if (pScan.options.getBoolean("mergeSchema", true) &&
+      conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
+      willNotWorkOnGpu("Native footer reader for parquet does not work when" +
+        " mergeSchema is enabled")
+    }
   }
 
   override def convertToGpu(): Scan = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadParquetFileFormat.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.PartitionedFile
-import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -60,10 +60,15 @@ class GpuReadParquetFileFormat extends ParquetFileFormat with GpuReadFileFormatW
 object GpuReadParquetFileFormat {
   def tagSupport(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val fsse = meta.wrapped
-    GpuParquetScan.tagSupport(
-      SparkShimImpl.sessionFromPlan(fsse),
-      fsse.requiredSchema,
-      meta
-    )
+    val session = SparkShimImpl.sessionFromPlan(fsse)
+    GpuParquetScan.tagSupport(session, fsse.requiredSchema, meta)
+
+    if (meta.conf.parquetReaderFooterType == RapidsConf.ParquetFooterReaderType.NATIVE) {
+      val options = new ParquetOptions(fsse.relation.options, session.sessionState.conf)
+      if (options.mergeSchema) {
+        meta.willNotWorkOnGpu("Native footer reader for parquet does not work when" +
+          " mergeSchema is enabled")
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes the test to not fail for #5493

Native footer reader for parquet fetches data fields totally based on read schema, which may lead to overflow if merge schema is enabled. When merge schema is enabled, the file schema of each file partition may not contain the complete (read) schema. In this situation, native footer reader will come up with incorrect footers.

To prevent this situation, we fallback the parquet reading to CPU if merge schema and native footer reader are both enabled.