### PR TITLE
Fix printing of split information when dumping debug data

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -301,7 +301,7 @@ abstract class FilePartitionReaderBase(conf: Configuration, execMetrics: Map[Str
 
       withResource(out) { _ =>
         withResource(new HostMemoryInputStream(hmb, dataLength)) { in =>
-          logInfo(s"Writing split data for $splits to $path")
+          logInfo(s"Writing split data for ${splits.mkString(", ")} to $path")
           IOUtils.copy(in, out)
         }
       }


### PR DESCRIPTION
When debug dumping files the log message was not showing the useful partition information and instead was logging something like `Writing split data for [Lorg.apache.spark.sql.execution.datasources.PartitionedFile;@301af261`.  The problem is that the log message was trying to write an array of partition info objects directly which does not produce a very useful message.  This updates the logging code to use `mkString` to build a more useful message.