### PR TITLE
Support spark.sql.mapKeyDedupPolicy=LAST_WIN for TransformKeys

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -442,6 +442,12 @@ def test_transform_keys_last_win(data_gen):
             lambda spark: unary_op_df(spark, data_gen).selectExpr('transform_keys(a, (key, value) -> 1)'),
             conf={'spark.sql.mapKeyDedupPolicy': 'LAST_WIN'})
 
+@pytest.mark.parametrize('data_gen', [MapGen(IntegerGen(nullable=False), long_gen)], ids=idfn)
+def test_transform_keys_last_win2(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, data_gen).selectExpr('transform_keys(a, (key, value) -> key % 2)'),
+        conf={'spark.sql.mapKeyDedupPolicy': 'LAST_WIN'})
+
 # We add in several types of processing for foldable functions because the output
 # can be different types.
 @pytest.mark.parametrize('query', [

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -436,12 +436,10 @@ def test_transform_keys_duplicate_fail(data_gen):
             error_message='Duplicate map key')
 
 
-@allow_non_gpu('ProjectExec,Alias,TransformKeys,Literal,LambdaFunction,NamedLambdaVariable')
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
-def test_transform_keys_last_win_fallback(data_gen):
-    assert_gpu_fallback_collect(
+def test_transform_keys_last_win(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr('transform_keys(a, (key, value) -> 1)'),
-            'TransformKeys',
             conf={'spark.sql.mapKeyDedupPolicy': 'LAST_WIN'})
 
 # We add in several types of processing for foldable functions because the output

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2928,7 +2928,7 @@ object GpuOverrides extends Logging {
       (in, conf, p, r) => new ExprMeta[TransformKeys](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
           SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).toUpperCase match {
-            case "EXCEPTION" => // Good we can support this
+            case "EXCEPTION"| "LAST_WIN" => // Good we can support this
             case other =>
               willNotWorkOnGpu(s"$other is not supported for config setting" +
                   s" ${SQLConf.MAP_KEY_DEDUP_POLICY.key}")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -508,7 +508,7 @@ case class GpuTransformKeys(
                   }
                 }
               }
-              GpuColumnVector.from(updatedMapView.copyToColumnVector(), dataType)
+              GpuColumnVector.from(deduped.incRefCount(), dataType)
             }
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -474,7 +474,7 @@ case class GpuTransformKeys(
 
   override def prettyName: String = "transform_keys"
 
-  private val exceptionOnDupKeys = SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY) ==
+  private def exceptionOnDupKeys = SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY) ==
     SQLConf.MapKeyDedupPolicy.EXCEPTION.toString
 
   override lazy val hasSideEffects: Boolean =


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/5325

Adds support for `spark.sql.mapKeyDedupPolicy=LAST_WIN` for `TransformKeys`.