### PR TITLE
Address feedback in "string anchors regexp replace" PR

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -47,7 +47,7 @@ class GpuRegExpReplaceMeta(
           try {
             val (pat, repl) = 
                 new CudfRegexTranspiler(RegexReplaceMode).transpile(s.toString, replacement)
-            pattern = pat
+            pattern = Some(pat)
             repl.map(GpuRegExpUtils.backrefConversion).foreach {
                 case (hasBackref, convertedRep) =>
                   containsBackref = hasBackref

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -853,7 +853,7 @@ class GpuRLikeMeta(
         case Literal(str: UTF8String, DataTypes.StringType) if str != null =>
           try {
             // verify that we support this regex and can transpile it to cuDF format
-            pattern = (new CudfRegexTranspiler(RegexFindMode).transpile(str.toString, None))._1
+            pattern = Some(new CudfRegexTranspiler(RegexFindMode).transpile(str.toString, None)._1)
           } catch {
             case e: RegexUnsupportedException =>
               willNotWorkOnGpu(e.getMessage)
@@ -1023,8 +1023,8 @@ class GpuRegExpExtractMeta(
         try {
           val javaRegexpPattern = str.toString
           // verify that we support this regex and can transpile it to cuDF format
-          pattern = new CudfRegexTranspiler(RegexFindMode)
-            .transpile(javaRegexpPattern, None)._1
+          pattern = Some(new CudfRegexTranspiler(RegexFindMode)
+            .transpile(javaRegexpPattern, None)._1)
           numGroups = countGroups(new RegexParser(javaRegexpPattern).parse())
         } catch {
           case e: RegexUnsupportedException =>
@@ -1388,7 +1388,7 @@ abstract class StringSplitRegExpMeta[INPUT <: TernaryExpression](expr: INPUT,
             pattern = simplified
           case None =>
             try {
-              pattern = transpiler.transpile(utf8Str.toString, None)._1.get
+              pattern = transpiler.transpile(utf8Str.toString, None)._1
               isRegExp = true
             } catch {
               case e: RegexUnsupportedException =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -714,7 +714,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       for (i <- input.indices) {
         if (cpu(i) != gpu(i)) {
           fail(s"javaPattern=${toReadableString(javaPattern)}, " +
-            s"cudfPattern=${toReadableString(cudfPattern.get)}, " +
+            s"cudfPattern=${toReadableString(cudfPattern)}, " +
             s"input='${toReadableString(input(i))}', " +
             s"cpu=${toReadableString(cpu(i))}, " +
             s"gpu=${toReadableString(gpu(i))}")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -15,7 +15,6 @@
  */
 package com.nvidia.spark.rapids
 
-
 import java.util.regex.Pattern
 
 import scala.collection.mutable.{HashSet, ListBuffer}
@@ -97,6 +96,15 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     assertThrows[CudfException] {
       gpuContains("c+|d+", Seq("cat", "dog"))
     }
+  }
+
+  test("newline before $ in replace mode") {
+    val patterns = Seq("\r$", "\n$", "\r\n$", "\u0085$", "\u2028$", "\u2029$")
+    patterns.foreach(pattern =>
+      assertUnsupported(pattern, RegexReplaceMode,
+        "Regex sequences with a line terminator character followed by " +
+          "'$' are not supported in replace mode")
+    )
   }
 
   test("cuDF does not support possessive quantifier") {
@@ -296,7 +304,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     val patterns = Seq("a[-b]", "a[+-]", "a[-+]", "a[-]", "a[^-]")
     val expected = Seq(raw"a[\-b]", raw"a[+\-]", raw"a[\-+]", raw"a[\-]", "a(?:[\r\n]|[^\\-])")
     val transpiler = new CudfRegexTranspiler(RegexFindMode)
-    val transpiled = patterns.map(transpiler.transpile(_, None)._1.get)
+    val transpiled = patterns.map(transpiler.transpile(_, None)._1)
     assert(transpiled === expected)
   }
 
@@ -612,7 +620,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       val (isRegex, cudfPattern) = if (RegexParser.isRegExpString(pattern)) {
         transpiler.transpileToSplittableString(pattern) match {
           case Some(simplified) => (false, simplified)
-          case _ => (true, transpiler.transpile(pattern, None)._1.get)
+          case _ => (true, transpiler.transpile(pattern, None)._1)
         }
       } else {
         (false, pattern)
@@ -668,8 +676,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   private def assertCpuGpuMatchesRegexpFind(javaPatterns: Seq[String], input: Seq[String]) = {
     for (javaPattern <- javaPatterns) {
       val cpu = cpuContains(javaPattern, input)
-      val cudfPattern =
-          (new CudfRegexTranspiler(RegexFindMode)).transpile(javaPattern, None)._1.get
+      val (cudfPattern, _) =
+          new CudfRegexTranspiler(RegexFindMode).transpile(javaPattern, None)
       val gpu = try {
         gpuContains(cudfPattern, input)
       } catch {
@@ -696,10 +704,10 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
           (new CudfRegexTranspiler(RegexReplaceMode)).transpile(javaPattern,
               Some(REPLACE_STRING))
       val gpu = try {
-        gpuReplace(cudfPattern.get, replaceString.get, input)
+        gpuReplace(cudfPattern, replaceString.get, input)
       } catch {
         case e: CudfException =>
-          fail(s"cuDF failed to compile pattern: ${toReadableString(cudfPattern.get)}, " +
+          fail(s"cuDF failed to compile pattern: ${toReadableString(cudfPattern)}, " +
               s"original: ${toReadableString(javaPattern)}, " +
               s"replacement: ${toReadableString(replaceString.get)}", e)
       }
@@ -804,13 +812,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   private def transpile(pattern: String, mode: RegexMode): String = {
-    mode match {
-      case RegexReplaceMode =>
-        new CudfRegexTranspiler(mode).transpile(pattern, Some(REPLACE_STRING))._1.get
-      case _ =>
-        new CudfRegexTranspiler(mode).transpile(pattern, None)._1.get
-      
+    val replace = mode match {
+      case RegexReplaceMode => Some(REPLACE_STRING)
+      case _ => None
     }
+    val (cudfPattern, _) = new CudfRegexTranspiler(mode).transpile(pattern, replace)
+    cudfPattern
   }
 
   private def assertUnsupported(pattern: String, mode: RegexMode, message: String): Unit = {


### PR DESCRIPTION
This is a follow-on PR to https://github.com/NVIDIA/spark-rapids/pull/5491 to address some review feedback items.

Changes in this PR:

- Change `transpile` return type so that first item in tuple is no longer an option
- Replace many but not all uses of `._1` when processing result of calling `transpile`
- Add an additional test