### PR TITLE
Fix whitespace character class tests

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -853,7 +853,7 @@ def test_regexp_hexadecimal_digits():
 def test_regexp_whitespace():
     gen = mk_str_gen('\u001e[abcd]\t\n{1,3} [0-9]\n {1,3}\x0b\t[abcd]\r\f[0-9]{0,10}')
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr('a',
+            lambda spark: unary_op_df(spark, gen).selectExpr(
                 'rlike(a, "\\\\s")',
                 'rlike(a, "\\\\s{3}")',
                 'rlike(a, "[abcd]+\\\\s+[0-9]+")',

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -853,17 +853,17 @@ def test_regexp_hexadecimal_digits():
 def test_regexp_whitespace():
     gen = mk_str_gen('\u001e[abcd]\t\n{1,3} [0-9]\n {1,3}\x0b\t[abcd]\r\f[0-9]{0,10}')
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
-                'rlike(a, "\\s{2}")',
-                'rlike(a, "\\s{3}")',
-                'rlike(a, "[abcd]+\\s+[0-9]+")',
-                'rlike(a, "\\S{3}")',
-                'rlike(a, "[abcd]+\\s+\\S{2,3}")',
-                'regexp_extract(a, "([a-d]+)([0-9\\s]+)([a-d]+)", 2)',
-                'regexp_extract(a, "([a-d]+)(\\S+)([0-9]+)", 2)',
-                'regexp_extract(a, "([a-d]+)(\\S+)([0-9]+)", 3)',
-                'regexp_replace(a, "(\\s+)", "@")',
-                'regexp_replace(a, "(\\S+)", "#")',
+            lambda spark: unary_op_df(spark, gen).selectExpr('a',
+                'rlike(a, "\\\\s")',
+                'rlike(a, "\\\\s{3}")',
+                'rlike(a, "[abcd]+\\\\s+[0-9]+")',
+                'rlike(a, "\\\\S{3}")',
+                'rlike(a, "[abcd]+\\\\s+\\\\S{2,3}")',
+                'regexp_extract(a, "([a-d]+)(\\\\s[0-9]+)([a-d]+)", 2)',
+                'regexp_extract(a, "([a-d]+)(\\\\S+)([0-9]+)", 2)',
+                'regexp_extract(a, "([a-d]+)(\\\\S+)([0-9]+)", 3)',
+                'regexp_replace(a, "(\\\\s+)", "@")',
+                'regexp_replace(a, "(\\\\S+)", "#")',
             ),
         conf=_regexp_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -269,40 +269,7 @@ class RegexParser(pattern: String) {
             // string anchors
             consumeExpected(ch)
             RegexEscaped(ch)
-          case 'h' | 'H' =>
-            // horizontal whitespace
-            // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html 
-            // under "Predefined character classes"
-            val chars: ListBuffer[RegexCharacterClassComponent] = ListBuffer(
-              RegexChar(' '), RegexChar('\u00A0'), RegexChar('\u1680'), RegexChar('\u180e'), 
-              RegexChar('\u202f'), RegexChar('\u205f'), RegexChar('\u3000')
-            )
-            chars += RegexEscaped('t')
-            chars += RegexCharacterRange('\u2000', '\u200a')
-            consumeExpected(ch)
-            RegexCharacterClass(negated = ch.isUpper, characters = chars)
-          case 'v' | 'V' =>
-            // vertical whitespace
-            // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html 
-            // under "Predefined character classes"
-            val chars: ListBuffer[RegexCharacterClassComponent] = ListBuffer(
-              RegexChar('\u000B'), RegexChar('\u0085'), RegexChar('\u2028'), RegexChar('\u2029')
-            )
-            chars ++= Seq('n', 'f', 'r').map(RegexEscaped)
-            consumeExpected(ch)
-            RegexCharacterClass(negated = ch.isUpper, characters = chars)
-          case 'R' =>
-            // linebreak sequence
-            // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
-            // under "Linebreak matcher"
-            val l = RegexSequence(ListBuffer(RegexChar('\u000D'), RegexChar('\u000A')))
-            val r = RegexCharacterClass(false, ListBuffer[RegexCharacterClassComponent](
-              RegexChar('\u000A'), RegexChar('\u000B'), RegexChar('\u000C'), RegexChar('\u000D'), 
-              RegexChar('\u0085'), RegexChar('\u2028'), RegexChar('\u2029')
-            ))
-            consumeExpected(ch)
-            RegexGroup(true, RegexChoice(l, r))
-          case 's' | 'S' | 'd' | 'D' | 'w' | 'W' =>
+          case 's' | 'S' | 'd' | 'D' | 'w' | 'W' | 'v' | 'V' | 'h' | 'H' | 'R' =>
             // meta sequences
             consumeExpected(ch)
             RegexEscaped(ch)
@@ -548,7 +515,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
   private def isSupportedRepetitionBase(e: RegexAST): Boolean = {
     e match {
       case RegexEscaped(ch) => ch match {
-        case 'd' | 'w' | 'h' | 'H' | 'v' | 'V' => true
+        case 'd' | 'w' | 's' | 'S' | 'h' | 'H' | 'v' | 'V' => true
         case _ => false
       }
 
@@ -591,6 +558,46 @@ class CudfRegexTranspiler(mode: RegexMode) {
         RegexChoice(
           RegexCharacterClass(negated = false, characters = terminatorChars),
           RegexSequence(ListBuffer(RegexChar('\r'), RegexChar('\n')))))
+    }
+  }
+
+  private def negateCharacterClass(components: Seq[RegexCharacterClassComponent]): RegexAST = {
+    // There are differences between cuDF and Java handling of newlines
+    // for negative character matches. The expression `[^a]` will match
+    // `\r` and `\n` in Java but not in cuDF, so we replace `[^a]` with
+    // `(?:[\r\n]|[^a])`. We also have to take into account whether any
+    // newline characters are included in the character range.
+    //
+    // Examples:
+    //
+    // `[^a]`     => `(?:[\r\n]|[^a])`
+    // `[^a\r]`   => `(?:[\n]|[^a])`
+    // `[^a\n]`   => `(?:[\r]|[^a])`
+    // `[^a\r\n]` => `[^a]`
+    // `[^\r\n]`  => `[^\r\n]`
+
+    val linefeedCharsInPattern = components.flatMap {
+      case RegexChar(ch) if ch == '\n' || ch == '\r' => Seq(ch)
+      case RegexEscaped(ch) if ch == 'n' => Seq('\n')
+      case RegexEscaped(ch) if ch == 'r' => Seq('\r')
+      case _ => Seq.empty
+    }
+
+    val onlyLinefeedChars = components.length == linefeedCharsInPattern.length
+
+    val negatedNewlines = Seq('\r', '\n').diff(linefeedCharsInPattern.distinct)
+
+    if (onlyLinefeedChars && linefeedCharsInPattern.length == 2) {
+      // special case for `[^\r\n]` and `[^\\r\\n]`
+      RegexCharacterClass(negated = true, ListBuffer(components: _*))
+    } else if (negatedNewlines.isEmpty) {
+      RegexCharacterClass(negated = true, ListBuffer(components: _*))
+    } else {
+      RegexGroup(capture = false,
+        RegexChoice(
+          RegexCharacterClass(negated = false,
+            characters = ListBuffer(negatedNewlines.map(RegexChar): _*)),
+          RegexCharacterClass(negated = true, ListBuffer(components: _*))))
     }
   }
 
@@ -706,10 +713,53 @@ class CudfRegexTranspiler(mode: RegexMode) {
               rewrite(RegexChar('$'), previous)
           }
         case 's' | 'S' =>
+          // whitespace characters
           val chars: ListBuffer[RegexCharacterClassComponent] = ListBuffer(
             RegexChar(' '), RegexChar('\u000b'))
           chars ++= Seq('n', 't', 'r', 'f').map(RegexEscaped)
-          RegexCharacterClass(negated = ch.isUpper, characters = chars)
+          if (ch.isUpper) {
+            negateCharacterClass(chars) 
+          } else {
+            RegexCharacterClass(negated = false, characters = chars)
+          }
+        case 'h' | 'H' =>
+          // horizontal whitespace
+          // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html 
+          // under "Predefined character classes"
+          val chars: ListBuffer[RegexCharacterClassComponent] = ListBuffer(
+            RegexChar(' '), RegexChar('\u00A0'), RegexChar('\u1680'), RegexChar('\u180e'), 
+            RegexChar('\u202f'), RegexChar('\u205f'), RegexChar('\u3000')
+          )
+          chars += RegexEscaped('t')
+          chars += RegexCharacterRange('\u2000', '\u200a')
+          if (ch.isUpper) {
+            negateCharacterClass(chars) 
+          } else {
+            RegexCharacterClass(negated = false, characters = chars)
+          }
+        case 'v' | 'V' =>
+          // vertical whitespace
+          // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html 
+          // under "Predefined character classes"
+          val chars: ListBuffer[RegexCharacterClassComponent] = ListBuffer(
+            RegexChar('\u000B'), RegexChar('\u0085'), RegexChar('\u2028'), RegexChar('\u2029')
+          )
+          chars ++= Seq('n', 'f', 'r').map(RegexEscaped)
+          if (ch.isUpper) {
+            negateCharacterClass(chars) 
+          } else {
+            RegexCharacterClass(negated = false, characters = chars)
+          }
+        case 'R' =>
+          // linebreak sequence
+          // see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
+          // under "Linebreak matcher"
+          val l = RegexSequence(ListBuffer(RegexChar('\u000D'), RegexChar('\u000A')))
+          val r = RegexCharacterClass(false, ListBuffer[RegexCharacterClassComponent](
+            RegexChar('\u000A'), RegexChar('\u000B'), RegexChar('\u000C'), RegexChar('\u000D'), 
+            RegexChar('\u0085'), RegexChar('\u2028'), RegexChar('\u2029')
+          ))
+          RegexGroup(true, RegexChoice(l, r))
         case _ =>
           regex
       }
@@ -744,43 +794,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
           })
 
         if (negated) {
-          // There are differences between cuDF and Java handling of newlines
-          // for negative character matches. The expression `[^a]` will match
-          // `\r` and `\n` in Java but not in cuDF, so we replace `[^a]` with
-          // `(?:[\r\n]|[^a])`. We also have to take into account whether any
-          // newline characters are included in the character range.
-          //
-          // Examples:
-          //
-          // `[^a]`     => `(?:[\r\n]|[^a])`
-          // `[^a\r]`   => `(?:[\n]|[^a])`
-          // `[^a\n]`   => `(?:[\r]|[^a])`
-          // `[^a\r\n]` => `[^a]`
-          // `[^\r\n]`  => `[^\r\n]`
-
-          val linefeedCharsInPattern = components.flatMap {
-            case RegexChar(ch) if ch == '\n' || ch == '\r' => Seq(ch)
-            case RegexEscaped(ch) if ch == 'n' => Seq('\n')
-            case RegexEscaped(ch) if ch == 'r' => Seq('\r')
-            case _ => Seq.empty
-          }
-
-          val onlyLinefeedChars = components.length == linefeedCharsInPattern.length
-
-          val negatedNewlines = Seq('\r', '\n').diff(linefeedCharsInPattern.distinct)
-
-          if (onlyLinefeedChars && linefeedCharsInPattern.length == 2) {
-            // special case for `[^\r\n]` and `[^\\r\\n]`
-            RegexCharacterClass(negated = true, ListBuffer(components: _*))
-          } else if (negatedNewlines.isEmpty) {
-            RegexCharacterClass(negated = true, ListBuffer(components: _*))
-          } else {
-            RegexGroup(capture = false,
-              RegexChoice(
-                RegexCharacterClass(negated = false,
-                  characters = ListBuffer(negatedNewlines.map(RegexChar): _*)),
-                RegexCharacterClass(negated = true, ListBuffer(components: _*))))
-          }
+          negateCharacterClass(components)
         } else {
           RegexCharacterClass(negated, ListBuffer(components: _*))
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -335,6 +335,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     doTranspileTest("a\\Z+", "a(?:[\n\r\u0085\u2028\u2029]|\r\n)?$")
     doTranspileTest("a\\Z{1}", "a(?:[\n\r\u0085\u2028\u2029]|\r\n)?$")
     doTranspileTest("a\\Z{1,}", "a(?:[\n\r\u0085\u2028\u2029]|\r\n)?$")
+    doTranspileTest("a\\Z\\V", 
+      "a(?:[\n\r\u0085\u2028\u2029]|\r\n)?$[^\u000B\u0085\u2028\u2029\n\f\r]")
   }
 
   test("compare CPU and GPU: character range including unescaped + and -") {
@@ -740,6 +742,11 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       case '\r' => "\\r"
       case '\n' => "\\n"
       case '\t' => "\\t"
+      case '\f' => "\\f"
+      case '\u000b' => "\\u000b"
+      case '\u0085' => "\\u0085"
+      case '\u2028' => "\\u2028"
+      case '\u2029' => "\\u2029"
       case other => other
     }.mkString
   }


### PR DESCRIPTION
- Previously, the python tests for whitespace `\s` and `\S` were not testing the intended code path. This PR fixes it by using double backslashes
- The fuzz tests caught a case we were not handling when a predefined character class is used immediately after a string anchor (eg. the pattern `a\Z\V`) which caused the transpilation to be incorrect. To fix this, I moved the rewriting of character classes `\s, \S, \v, \V, \h, \H` to the `rewrite()` stage and factored out the logic handle negated character classes

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
