### PR TITLE
Enable forcePositionEvolution for 321cdh

### DIFF
--- a/sql-plugin/src/main/321cdh/scala/com/nvidia/spark/rapids/shims/OrcShims321CDHBase.scala
+++ b/sql-plugin/src/main/321cdh/scala/com/nvidia/spark/rapids/shims/OrcShims321CDHBase.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.nvidia.spark.rapids.OrcOutputStripe
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.common.io.DiskRangeList
-import org.apache.orc.{CompressionCodec, CompressionKind, DataReader, OrcFile, OrcProto, PhysicalWriter, Reader, StripeInformation, TypeDescription}
+import org.apache.orc.{CompressionCodec, CompressionKind, DataReader, OrcConf, OrcFile, OrcProto, PhysicalWriter, Reader, StripeInformation, TypeDescription}
 import org.apache.orc.impl.{DataReaderProperties, OutStream, SchemaEvolution}
 import org.apache.orc.impl.RecordReaderImpl.SargApplier
 
@@ -95,9 +95,9 @@ trait OrcShims321CDHBase {
     lhs.equals(rhs)
   }
 
-  // forcePositionalEvolution is available from Spark-3.2. So setting this as false.
+  // forcePositionalEvolution is available from Spark-3.2.
   def forcePositionalEvolution(conf:Configuration): Boolean = {
-    false
+    OrcConf.FORCE_POSITIONAL_EVOLUTION.getBoolean(conf)
   }
 
   // orcTypeDescriptionString is renamed to getOrcSchemaString from 3.3+


### PR DESCRIPTION
Get the value of `forcePositionEvolution` from the configuration instead of the hardcode `false` for 321cdh shim, since 321cdh also supports `forcePositionEvolution` and GPU should follow its behavior.

The test failed because when `forcePositionEvolution` is set to `true`, GPU still returns `false`, then CPU and GPU run into different pathes in method `requestedColumnIds`, producing different output.

fixes https://github.com/NVIDIA/spark-rapids/issues/5511

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
