### PR TITLE
Fix whitespace `\s` and `\S` tests

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -880,16 +880,16 @@ def test_regexp_whitespace():
     gen = mk_str_gen('\u001e[abcd]\t\n{1,3} [0-9]\n {1,3}\x0b\t[abcd]\r\f[0-9]{0,10}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
-                'rlike(a, "\\s{2}")',
-                'rlike(a, "\\s{3}")',
-                'rlike(a, "[abcd]+\\s+[0-9]+")',
-                'rlike(a, "\\S{3}")',
-                'rlike(a, "[abcd]+\\s+\\S{2,3}")',
-                'regexp_extract(a, "([a-d]+)([0-9\\s]+)([a-d]+)", 2)',
-                'regexp_extract(a, "([a-d]+)(\\S+)([0-9]+)", 2)',
-                'regexp_extract(a, "([a-d]+)(\\S+)([0-9]+)", 3)',
-                'regexp_replace(a, "(\\s+)", "@")',
-                'regexp_replace(a, "(\\S+)", "#")',
+                'rlike(a, "\\\\s")',
+                'rlike(a, "\\\\s{3}")',
+                'rlike(a, "[abcd]+\\\\s+[0-9]+")',
+                'rlike(a, "\\\\S{3}")',
+                'rlike(a, "[abcd]+\\\\s+\\\\S{2,3}")',
+                'regexp_extract(a, "([a-d]+)(\\\\s[0-9]+)([a-d]+)", 2)',
+                'regexp_extract(a, "([a-d]+)(\\\\S+)([0-9]+)", 2)',
+                'regexp_extract(a, "([a-d]+)(\\\\S+)([0-9]+)", 3)',
+                'regexp_replace(a, "(\\\\s+)", "@")',
+                'regexp_replace(a, "(\\\\S+)", "#")',
             ),
         conf=_regexp_conf)
 


### PR DESCRIPTION
Previously, the python tests for whitespace `\s` and `\S` were not testing the intended code path. This PR fixes it by using double backslashes

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
