### PR TITLE
Fix failing bool agg test in Spark 3.3

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -295,7 +295,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       _.getMessage.startsWith("cannot resolve"),
       longsFromCSVDf,
       conf = floatAggConf) {
-    frame => frame.agg(avg(lit(true)),avg(lit(false)))
+    frame => frame.agg(avg(lit(true)).alias("t"), avg(lit(false)).alias("f"))
   }
 
   testSparkResultsAreEqual(


### PR DESCRIPTION
This fixes #5496

Spark started to do things differently and was returning a different error without a few tweaks to the test.