### PR TITLE
[WIP] Auto-detect single shim jar

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -215,26 +215,29 @@ object ShimLoader extends Logging {
       logInfo(s"Updating spark classloader $urlAddable with the URLs: " +
         urlsForSparkClassLoader.mkString(", "))
       urlsForSparkClassLoader.foreach { url =>
-        Try(MethodUtils.invokeMethod(urlAddable, true, "addURL", url))
-          .recoverWith {
-            case nsm: NoSuchMethodException =>
-              logWarning("JDK8+ detected,  if you are not using a single-Spark-shim jar consider" +
-                "spark.rapids.force.caller.classloader to false as a workaround")
-              logDebug(s"JDK8+ detected by catching ${nsm}", nsm)
-              Success(Unit)
-            case t => Failure(t)
-          }.get
-      }
-      logInfo(s"Spark classLoader $urlAddable updated successfully")
-      urlAddable match {
-        case urlCl: java.net.URLClassLoader =>
-          if (!urlCl.getURLs.contains(shimCommonURL)) {
-            // infeasible, defensive diagnostics
-            logWarning(s"Didn't find expected URL $shimCommonURL in the spark " +
-              s"classloader $urlCl although addURL succeeded, maybe pushed up to the " +
-              s"parent classloader ${urlCl.getParent}")
+        if (!conventionalSingleShimJarDetected) {
+          Try(MethodUtils.invokeMethod(urlAddable, true, "addURL", url))
+            .recoverWith {
+              case nsm: NoSuchMethodException =>
+                logWarning("JDK8+ detected, consider setting " +
+                  "spark.rapids.force.caller.classloader to false as a workaround")
+                logDebug(s"JDK8+ detected by catching ${nsm}", nsm)
+                Success(Unit)
+              case t => Failure(t)
+            }.get
+
+          logInfo(s"Spark classLoader $urlAddable updated successfully")
+          urlAddable match {
+            case urlCl: java.net.URLClassLoader =>
+              if (!urlCl.getURLs.contains(shimCommonURL)) {
+                // infeasible, defensive diagnostics
+                logWarning(s"Didn't find expected URL $shimCommonURL in the spark " +
+                  s"classloader $urlCl although addURL succeeded, maybe pushed up to the " +
+                  s"parent classloader ${urlCl.getParent}")
+              }
+            case _ => ()
           }
-        case _ => ()
+        }
       }
       pluginClassLoader = urlAddable
     }
@@ -295,18 +298,27 @@ object ShimLoader extends Logging {
         thisClassLoader.getResources(serviceProviderListPath)
           .asScala.map(scala.io.Source.fromURL)
           .flatMap(_.getLines())
+          .toSeq
       }
 
     assert(serviceProviderList.nonEmpty, "Classpath should contain the resource for " +
         serviceProviderListPath)
 
+    val numShimServiceProviders = serviceProviderList.size
     val shimServiceProviderOpt = serviceProviderList.flatMap { shimServiceProviderStr =>
       val mask = shimIdFromPackageName(shimServiceProviderStr)
       try {
         val shimURL = new java.net.URL(s"${shimRootURL.toString}$mask/")
         val shimClassLoader = new MutableURLClassLoader(Array(shimURL, shimCommonURL),
           thisClassLoader)
-        val shimClass = shimClassLoader.loadClass(shimServiceProviderStr)
+        val shimClass = Try[java.lang.Class[_]] {
+          val ret = thisClassLoader.loadClass(shimServiceProviderStr)
+          if (numShimServiceProviders == 1) {
+            conventionalSingleShimJarDetected = true
+            logInfo("Conventional shim jar layout for a single Spark verision detected")
+          }
+          ret
+        }.getOrElse(shimClassLoader.loadClass(shimServiceProviderStr))
         Option(
           (instantiateClass(shimClass).asInstanceOf[SparkShimServiceProvider], shimURL)
         )


### PR DESCRIPTION
This PR contributes to #3682.  Whenever the rapids-4-spark dist jar contains only one SparkShimServiceProvider, and it is loadable from the root jar path and not in a /spark3xx parallel world, parallel world classloading is disabled.

TODO: provide a build flag that would simply copy an aggregator jar as a dist jar instead of building parallel worlds.

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
