### PR TITLE
Qualification tool: Add support to json and avro formats

### DIFF
--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -168,7 +168,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val parquet = allExecInfo.filter(_.exec.contains("Scan parquet"))
     val text = allExecInfo.filter(_.exec.contains("Scan text"))
     val csv = allExecInfo.filter(_.exec.contains("Scan csv"))
-    assertSizeAndNotSupported(2, json.toSeq)
+    assertSizeAndSupported(2, json.toSeq)
     assertSizeAndNotSupported(1, text.toSeq)
     for (t <- Seq(parquet, csv)) {
       assertSizeAndSupported(1, t.toSeq)
@@ -190,7 +190,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val orc = allExecInfo.filter(_.exec.contains("BatchScan orc"))
     val parquet = allExecInfo.filter(_.exec.contains("BatchScan parquet"))
     val csv = allExecInfo.filter(_.exec.contains("BatchScan csv"))
-    assertSizeAndNotSupported(3, json.toSeq)
+    assertSizeAndSupported(3, json.toSeq)
     assertSizeAndSupported(1, csv.toSeq)
     for (t <- Seq(orc, parquet)) {
       assertSizeAndSupported(2, t.toSeq)


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids/issues/5305 .

JSON and AVRO file formats are mentioned as "Configured Off" by default in the qualification tool. At present, while calculating the speedup factor, it's always `0` as the file format's score is calculated as `0`. In this PR, we are assising the score so that speed up factor is non zero which in turn helps in improving the qualification of applications.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
