### PR TITLE
Minor: Clean up the tests of `concat_list`

### DIFF
--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -40,24 +40,14 @@ def test_concat_list(data_gen):
 
 @pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 def test_concat_list_with_lit(data_gen):
-    array_lit = gen_scalar(data_gen)
-    array_lit2 = gen_scalar(data_gen)
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: binary_op_df(spark, data_gen).select(
-            f.concat(f.col('a'),
-                     f.col('b'),
-                     f.lit(array_lit).cast(data_gen.data_type))))
+    lit_col1 = f.lit(gen_scalar(data_gen)).cast(data_gen.data_type)
+    lit_col2 = f.lit(gen_scalar(data_gen)).cast(data_gen.data_type)
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: binary_op_df(spark, data_gen).select(
-            f.concat(f.lit(array_lit).cast(data_gen.data_type),
-                     f.col('a'),
-                     f.lit(array_lit2).cast(data_gen.data_type))))
-
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: binary_op_df(spark, data_gen).select(
-            f.concat(f.lit(array_lit).cast(data_gen.data_type),
-                     f.lit(array_lit2).cast(data_gen.data_type))))
+            f.concat(f.col('a'), f.col('b'), lit_col1),
+            f.concat(lit_col1, f.col('a'), lit_col2),
+            f.concat(lit_col1, lit_col2)))
 
 def test_concat_string():
     gen = mk_str_gen('.{0,5}')

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -31,18 +31,12 @@ non_nested_array_gens = [ArrayGen(sub_gen, nullable=nullable)
 @pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 def test_concat_list(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: binary_op_df(spark, data_gen).selectExpr('concat(a)'))
-
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: binary_op_df(spark, data_gen).selectExpr('concat(a, b)'))
-
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: three_col_df(spark, data_gen, data_gen, data_gen
-                                   ).selectExpr('concat(a, b, c)'))
-
-def test_empty_concat_list():
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: binary_op_df(spark, ArrayGen(LongGen())).selectExpr('concat()'))
+        lambda spark: three_col_df(spark, data_gen, data_gen, data_gen).selectExpr(
+            'concat()',
+            'concat(a)',
+            'concat(a, b)',
+            'concat(a, b, c)')
+        )
 
 @pytest.mark.parametrize('data_gen', non_nested_array_gens, ids=idfn)
 def test_concat_list_with_lit(data_gen):


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?
None.

# What changes are included in this PR?
Just to merge some separate tests to save some runtime.

Run **bash run_pyspark_from_build.sh -k concat_list**
## Before:
```
=============== 57 passed, 14156 deselected in 125.44s (0:02:05) ===============
```
## After: 
(one less test becase `test_concat_list_empty` is merged in `test_concat_list`.)
```
==================== 56 passed, 14156 deselected in 59.20s =====================
```
We can save about 1 minute on testing!

# Are there any user-facing changes?
No.
