### PR TITLE
Fix unfiltered partitions being used to create GpuBatchScanExec RDD

### DIFF
--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -93,7 +93,7 @@ case class GpuBatchScanExec(
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)
     } else {
-      new GpuDataSourceRDD(sparkContext, partitions, readerFactory)
+      new GpuDataSourceRDD(sparkContext, filteredPartitions, readerFactory)
     }
   }
 


### PR DESCRIPTION
Fixes a typo in the GpuBatchScanExec for Spark 3.2.x where the unfiltered partitions were used to create the RDD rather than the filtered partitions.  This had the effect of disabling runtime filtering for scans under GpuBatchScanExec.