### PR TITLE
Move ShimServiceProvider file re-init/truncate

### DIFF
--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -15,6 +15,7 @@
   limitations under the License.
 -->
 <project name="maven-antrun" xmlns:ac="antlib:net.sf.antcontrib" xmlns:if="ant:if">
+    <record name="/tmp/ant-build.log" loglevel="verbose" action="start" />
     <!--
         - Generates shim service discovery META-INF entries for ShimLoader
 
@@ -61,7 +62,6 @@
         <property name="shimServiceRsrc" value="META-INF/services/com.nvidia.spark.rapids.SparkShimServiceProvider"/>
         <property name="shimServiceFile" value="${project.build.directory}/extra-resources/${shimServiceRsrc}"/>
         <property name="aggregatorPrefix" value="${project.build.directory}/deps/${aggregatorArtifact}-${project.version}"/>
-        <truncate file="${shimServiceFile}" create="true" mkdirs="true"/>
         <property name="aggregatorBuildDir" value="${project.basedir}/../aggregator/target"/>
 
         <condition property="should.build.conventional.jar">
@@ -148,6 +148,7 @@
             </sequential>
         </ac:for>
 
+        <truncate file="${shimServiceFile}" create="true" mkdirs="true"/>
         <concat destfile="${shimServiceFile}">
             <fileset dir="${project.build.directory}/parallel-world" includes="spark*/${shimServiceRsrc}"/>
         </concat>

--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -15,7 +15,6 @@
   limitations under the License.
 -->
 <project name="maven-antrun" xmlns:ac="antlib:net.sf.antcontrib" xmlns:if="ant:if">
-    <record name="/tmp/ant-build.log" loglevel="verbose" action="start" />
     <!--
         - Generates shim service discovery META-INF entries for ShimLoader
 


### PR DESCRIPTION
This PR closes #5596 by moving truncate close to when shim service file
concatentation is about to generate a new list. 

The empty file for ShimServiceProvider created during init-properties is not populated via
concat in the conventional jar path, later overwriting the original file
from the aggregator jar. it's also bad practice to have side effects
while still initializing properties. This PR corrects these issues.

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
