### PR TITLE
ORC encrypted write should fallback to CPU [databricks]

### DIFF
--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -15,6 +15,7 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write
+from spark_session import is_databricks104_or_later
 from datetime import date, datetime, timezone
 from data_gen import *
 from marks import *
@@ -172,6 +173,7 @@ def test_write_empty_orc_round_trip(spark_tmp_path, orc_gens):
 @pytest.mark.parametrize("provider", ["", "hadoop"])
 @pytest.mark.parametrize("encrypt", ["", "pii:a"])
 @pytest.mark.parametrize("mask", ["", "sha256:a"])
+@pytest.mark.skipif(is_databricks104_or_later(), reason="The test will fail on Databricks10.4 because `HadoopShimsPre2_3$NullKeyProvider` is loaded")
 def test_orc_write_encryption_fallback(spark_tmp_path, spark_tmp_table_factory, path, provider, encrypt, mask):
     def write_func(spark, write_path):
         writer = unary_op_df(spark, gen).coalesce(1).write

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -166,3 +166,29 @@ def test_write_empty_orc_round_trip(spark_tmp_path, orc_gens):
         lambda spark, path: spark.read.orc(path),
         data_path,
         conf={'spark.rapids.sql.format.orc.write.enabled': True})
+
+@allow_non_gpu('DataWritingCommandExec')
+@pytest.mark.parametrize("path", ["", "kms://http@localhost:9600/kms"])
+@pytest.mark.parametrize("provider", ["", "hadoop"])
+@pytest.mark.parametrize("encrypt", ["", "pii:a"])
+@pytest.mark.parametrize("mask", ["", "sha256:a"])
+def test_orc_write_encryption_fallback(spark_tmp_path, spark_tmp_table_factory, path, provider, encrypt, mask):
+    def write_func(spark, write_path):
+        writer = unary_op_df(spark, gen).coalesce(1).write
+        if path != "":
+            writer.option("hadoop.security.key.provider.path", path)
+        if provider != "":
+            writer.option("orc.key.provider", provider)
+        if encrypt != "":
+            writer.option("orc.encrypt", encrypt)
+        if mask != "":
+            writer.option("orc.mask", mask)
+        writer.format("orc").mode('overwrite').option("path", write_path).saveAsTable(spark_tmp_table_factory.get())
+    if path == "" and provider == "" and encrypt == "" and mask == "":
+        pytest.xfail("Expected to fail as non-encrypted write will not fallback to CPU")
+    gen = IntegerGen()
+    data_path = spark_tmp_path + '/ORC_DATA'
+    assert_gpu_fallback_write(write_func,
+        lambda spark, path: spark.read.orc(path),
+        data_path,
+        'DataWritingCommandExec')

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -185,7 +185,7 @@ def test_orc_write_encryption_fallback(spark_tmp_path, spark_tmp_table_factory, 
             writer.option("orc.mask", mask)
         writer.format("orc").mode('overwrite').option("path", write_path).saveAsTable(spark_tmp_table_factory.get())
     if path == "" and provider == "" and encrypt == "" and mask == "":
-        pytest.xfail("Expected to fail as non-encrypted write will not fallback to CPU")
+        pytest.skip("Skip this test when none of the encryption confs are set")
     gen = IntegerGen()
     data_path = spark_tmp_path + '/ORC_DATA'
     assert_gpu_fallback_write(write_func,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -58,7 +58,7 @@ object GpuOrcFileFormat extends Logging {
         s"${RapidsConf.ENABLE_ORC_WRITE} to true")
     }
 
-    val keyProviderPath= options.getOrElse("hadoop.security.key.provider.path", "")
+    val keyProviderPath = options.getOrElse("hadoop.security.key.provider.path", "")
     val keyProvider = options.getOrElse("orc.key.provider", "")
     val encrypt = options.getOrElse("orc.encrypt", "")
     val mask = options.getOrElse("orc.mask", "")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -58,6 +58,17 @@ object GpuOrcFileFormat extends Logging {
         s"${RapidsConf.ENABLE_ORC_WRITE} to true")
     }
 
+    val keyProviderPath= options.getOrElse("hadoop.security.key.provider.path", "")
+    val keyProvider = options.getOrElse("orc.key.provider", "")
+    val encrypt = options.getOrElse("orc.encrypt", "")
+    val mask = options.getOrElse("orc.mask", "")
+
+    if (!keyProvider.isEmpty || !keyProviderPath.isEmpty || !encrypt.isEmpty || !mask.isEmpty) {
+      meta.willNotWorkOnGpu("Encryption is not yet supported on GPU. If encrypted ORC " +
+          "writes are not required unset the \"hadoop.security.key.provider.path\" and " +
+          "\"orc.key.provider\" and \"orc.encrypt\" and \"orc.mask\"")
+    }
+
     FileFormatChecks.tag(meta, schema, OrcFormatType, WriteFileOp)
 
     val sqlConf = spark.sessionState.conf


### PR DESCRIPTION
This PR falls back to the CPU if any of the ORC encryption configurations are set. 

The configs that we are checking for are 
```
hadoop.security.key.provider.path
orc.key.provider
orc.encrypt
orc.mask
```

fixes #5463 

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
