### PR TITLE
[DOC]update links for 2206 release[skip ci]

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -376,7 +376,7 @@ There are multiple reasons why this a problematic configuration:
 
 Yes, but it requires support from the underlying cluster manager to isolate the MIG GPU instance
 for each executor (e.g.: by setting `CUDA_VISIBLE_DEVICES`, 
-[YARN with docker isolation](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.04/examples/MIG-Support) 
+[YARN with docker isolation](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/MIG-Support) 
 or other means).
 
 Note that MIG is not recommended for use with the RAPIDS Accelerator since it significantly

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -40,7 +40,7 @@ access to any of the memory that RMM is holding.
 ## Spark ML Algorithms Supported by RAPIDS Accelerator
 
 The [spark-rapids-examples repository](https://github.com/NVIDIA/spark-rapids-examples) provides a
-[working example](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.04/examples/Spark-cuML/pca)
+[working example](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/ML+DL-Examples/Spark-cuML/pca)
 of accelerating the `transform` API for
 [Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca).
 The example leverages the [RAPIDS accelerated UDF interface](rapids-udfs.md) to provide a native

--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -135,7 +135,7 @@ type `DECIMAL64(scale=-2)`.
 ## RAPIDS Accelerated UDF Examples
 
 <!-- Note: should update the branch name to tag when releasing-->
-Source code for examples of RAPIDS accelerated UDFs is provided in the [udf-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.04/examples/RAPIDS-accelerated-UDFs) project.
+Source code for examples of RAPIDS accelerated UDFs is provided in the [udf-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/UDF-Examples/RAPIDS-accelerated-UDFs) project.
 
 ## GPU Support for Pandas UDF
 

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -139,9 +139,9 @@ val (xgbClassificationModel, _) = benchmark("train") {
 ## Submit Spark jobs to a Dataproc Cluster Accelerated by GPUs
 Similar to spark-submit for on-prem clusters, Dataproc supports a Spark application job to be
 submitted as a Dataproc job.  The mortgage examples we use above are also available as a [spark
-application](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/Spark-ETL+XGBoost).
+application](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/XGBoost-Examples).
 After [building the jar
-files](https://github.com/NVIDIA/spark-rapids-examples/tree/main/docs/get-started/xgboost-examples/building-sample-apps/scala.md)
+files](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.06/docs/get-started/xgboost-examples/building-sample-apps/scala.md)
 .
 
 Place the jar file `sample_xgboost_apps-<version>-jar-with-dependencies.jar` under the

--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -304,7 +304,7 @@ are using.
 #### YARN version 3.3.0+
 YARN version 3.3.0 and newer support a pluggable device framework which allows adding support for
 MIG devices via a plugin. See
-[NVIDIA GPU Plugin for YARN with MIG support for YARN 3.3.0+](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.04/examples/MIG-Support/device-plugins/gpu-mig).
+[NVIDIA GPU Plugin for YARN with MIG support for YARN 3.3.0+](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/MIG-Support/device-plugins/gpu-mig).
 If you are using that plugin with a Spark version older than 3.2.1 and/or specifying the resource
 as `nvidia/miggpu` you will also need to specify the config:
 
@@ -321,7 +321,7 @@ required.
 If you are using YARN version from 3.1.2 up until 3.3.0, it requires making modifications to YARN
 and deploying a version that adds support for MIG to the built-in YARN GPU resource plugin.
 
-See [NVIDIA Support for GPU for YARN with MIG support for YARN 3.1.2 until YARN 3.3.0](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.04/examples/MIG-Support/resource-types/gpu-mig)
+See [NVIDIA Support for GPU for YARN with MIG support for YARN 3.1.2 until YARN 3.3.0](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.06/examples/MIG-Support/resource-types/gpu-mig)
 for details.
 
 ## Running on Kubernetes


### PR DESCRIPTION
Signed-off-by: liyuan <yuali@nvidia.com>

Normally we first release spark-rapids and then release(not really, just merge dev to main) spark-rapids-examples. Since we revamp the spark-rapids-example repo and update the directories in v22.06, so there is a time gap that we either have broken links in spark-rapids repo or spark-rapids-example repo. Refer to dev-branch links would be a workaround to fix this issue. (The con is that we need to update the links for each release. Maybe we could re-refer to the main branch next release because I believe there will be no big directory changes in the future. )