### PR TITLE
Install locales and generate en_US.UTF-8

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -60,3 +60,7 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     conda clean -ay
 
 RUN apt install -y inetutils-ping expect
+
+# install locale and generate UTF-8, but don't set it as default, the test cases should specify it somehow
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -66,3 +66,8 @@ RUN mkdir -p /tmp/ucx && \
 
 # export JAVA_HOME for mvn option 'source-javadoc'
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+# install locale and use UTF-8
+RUN apt-get install -y locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -67,7 +67,6 @@ RUN mkdir -p /tmp/ucx && \
 # export JAVA_HOME for mvn option 'source-javadoc'
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-# install locale and use UTF-8
+# install locale and generate UTF-8, but don't set it as default, the test cases should specify it somehow
 RUN apt-get install -y locales
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/5549, but not close it.
Install locales and generate en_US.UTF-8 in ubuntu docker image.
No need to update centos one because there's already en_US.UTF-8.

Signed-off-by: gashen <gashen@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
