### PR TITLE
Fix missing GpuBatchScanExec metrics in SQL UI

### DIFF
--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -30,16 +30,16 @@ case class GpuBatchScanExec(
     @transient scan: Scan) extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
   @transient lazy val batch: Batch = scan.toBatch
 
-  scan match {
-    case s: ScanWithMetrics => s.metrics = allMetrics ++ additionalMetrics
-    case _ =>
-  }
-
   override lazy val partitions: Seq[InputPartition] = batch.planInputPartitions()
 
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
+    scan match {
+      case s: ScanWithMetrics => s.metrics = allMetrics
+      case _ =>
+    }
+
     new GpuDataSourceRDD(sparkContext, partitions, readerFactory)
   }
 

--- a/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/320until330-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -37,11 +37,6 @@ case class GpuBatchScanExec(
     extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
   @transient lazy val batch: Batch = scan.toBatch
 
-  scan match {
-    case s: ScanWithMetrics => s.metrics = allMetrics ++ additionalMetrics
-    case _ =>
-  }
-
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
   override def equals(other: Any): Boolean = other match {
     case other: GpuBatchScanExec =>
@@ -89,6 +84,11 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
+    scan match {
+      case s: ScanWithMetrics => s.metrics = allMetrics
+      case _ =>
+    }
+
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -39,11 +39,6 @@ case class GpuBatchScanExec(
     extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
   @transient lazy val batch: Batch = scan.toBatch
 
-  scan match {
-    case s: ScanWithMetrics => s.metrics = allMetrics ++ additionalMetrics
-    case _ =>
-  }
-
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
   override def equals(other: Any): Boolean = other match {
     case other: BatchScanExec =>
@@ -111,6 +106,11 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
+    scan match {
+      case s: ScanWithMetrics => s.metrics = allMetrics
+      case _ =>
+    }
+
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)


### PR DESCRIPTION
Fixes #5615.  SQLMetric instances were being created on the executor separately from the metrics on the driver, causing the metrics to get disconnected.  The eventlog would contain the metric data for the missing metrics, but the metric IDs would not match those predeclared in the SQL execution start event.  That explains why the SQL UI wouldn't show them, as it was looking for metric IDs that never received any updates in any of the task completion events.