### PR TITLE
Qualification tool: Enable UDF reporting in potential problems

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -420,6 +420,7 @@ object QualOutputWriter {
       stringIfempty(replaceDelimiter(appInfo.readFileFormatAndTypesNotSupported, delimiter))
     val dataWriteFormat = stringIfempty(replaceDelimiter(appInfo.writeDataFormat, delimiter))
     val potentialProbs = stringIfempty(replaceDelimiter(appInfo.potentialProblems, delimiter))
+    val failedSQLIds =  stringIfempty(replaceDelimiter(appInfo.failedSQLIds, delimiter))
     val data = ListBuffer[(String, Int)](
       stringIfempty(appInfo.appName) -> headersAndSizes(APP_NAME_STR),
       stringIfempty(appInfo.appId) -> headersAndSizes(APP_ID_STR),
@@ -428,7 +429,7 @@ object QualOutputWriter {
       appInfo.estimatedInfo.appDur.toString -> headersAndSizes(APP_DUR_STR),
       appInfo.estimatedInfo.gpuOpportunity.toString -> GPU_OPPORTUNITY_STR_SIZE,
       appInfo.executorCpuTimePercent.toString -> headersAndSizes(EXEC_CPU_PERCENT_STR),
-      stringIfempty(appInfo.failedSQLIds) -> headersAndSizes(SQL_IDS_FAILURES_STR),
+      failedSQLIds -> headersAndSizes(SQL_IDS_FAILURES_STR),
       readFileFormatsNotSupported -> headersAndSizes(READ_FILE_FORMAT_TYPES_STR),
       dataWriteFormat -> headersAndSizes(WRITE_DATA_FORMAT_STR),
       complexTypes -> headersAndSizes(COMPLEX_TYPES_STR),

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -408,6 +408,14 @@ class QualificationAppInfo(
     val allnodes = planGraph.allNodes
     for (node <- allnodes) {
       checkGraphNodeForReads(sqlID, node)
+      if (isDataSetOrRDDPlan(node.desc)) {
+        sqlIDToDataSetOrRDDCase += sqlID
+      }
+      val issues = findPotentialIssues(node.desc)
+      if (issues.nonEmpty) {
+        val existingIssues = sqlIDtoProblematic.getOrElse(sqlID, Set.empty[String])
+        sqlIDtoProblematic(sqlID) = existingIssues ++ issues
+      }
       // Get the write data format
       if (node.name.contains("InsertIntoHadoopFsRelationCommand")) {
         val writeFormat = node.desc.split(",")(2)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -408,9 +408,6 @@ class QualificationAppInfo(
     val allnodes = planGraph.allNodes
     for (node <- allnodes) {
       checkGraphNodeForReads(sqlID, node)
-      if (isDataSetOrRDDPlan(node.desc)) {
-        sqlIDToDataSetOrRDDCase += sqlID
-      }
       val issues = findPotentialIssues(node.desc)
       if (issues.nonEmpty) {
         val existingIssues = sqlIDtoProblematic.getOrElse(sqlID, Set.empty[String])

--- a/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
@@ -1,5 +1,5 @@
 App Name,App ID,SQL DF Duration,SQL Dataframe Task Duration,App Duration,GPU Opportunity,Executor CPU Time Percent,SQL Ids with Failures,Unsupported Read File Formats and Types,Unsupported Write Data Format,Complex Types,Nested Complex Types,Potential Problems,Longest SQL Duration,NONSQL Task Duration Plus Overhead,Unsupported Task Duration,Supported SQL DF Task Duration,Task Speedup Factor,App Duration Estimated
 Rapids Spark Profiling Tool Unit Tests,local-1622043423018,12434,132257,16319,10589,37.7,"","",JSON,"","","",7143,4717,19616,112641,2.79,false
 Spark shell,local-1651187225439,760,180,355637,350,87.88,"",JSON[string:bigint:int],"","","","",498,343411,97,83,1.37,false
-Spark shell,local-1651188809790,911,283,166215,45,81.18,"",JSON[string:bigint:int],"","","","",715,133608,269,14,1.50,false
-Rapids Spark Profiling Tool Unit Tests,local-1623281204390,2032,4666,6240,0,46.27,"",JSON[string:bigint:int],JSON,"","","",1209,5793,4664,2,1.25,false
+Spark shell,local-1651188809790,911,283,166215,45,81.18,"",JSON[string:bigint:int],"","","",UDF,715,133608,269,14,1.50,false
+Rapids Spark Profiling Tool Unit Tests,local-1623281204390,2032,4666,6240,0,46.27,"",JSON[string:bigint:int],JSON,"","",UDF,1209,5793,4664,2,1.25,false

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -23,14 +23,12 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.io.Source
 
 import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
-//import com.nvidia.spark.rapids.tool.ToolTestUtils
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted, SparkListenerTaskEnd}
 import org.apache.spark.sql.{DataFrame, SparkSession, TrampolineUtil}
 import org.apache.spark.sql.functions.{desc,udf}
-//import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.rapids.tool.{AppBase, AppFilterImpl, ToolUtils}
 import org.apache.spark.sql.rapids.tool.qualification.QualificationSummaryInfo
 import org.apache.spark.sql.types._


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/5565 .
In this PR, 
1. We are reporting UDF as potential problem in the output csv file.
Uncommented the test and updated it to reflect new changes(time taken in UDF operations  is added in  unSupportedSQLTaskDuration) 
2. There was minor bug in reporting "SQL Ids with Failures". If there are multiple SQL ids, those would overflow in subsequent columns of the csv output file as the delimiter is `,`.  Fixed that issue.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
