### PR TITLE
Update the error messages for the failing arithmetic tests.

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -798,25 +798,19 @@ def _test_div_by_zero(ansi_mode, expr):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_mode == 'ansi'}
     data_gen = lambda spark: two_col_df(spark, IntegerGen(), IntegerGen(min_val=0, max_val=0), length=1)
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
-    err_exp = 'java.lang.ArithmeticException' if is_before_spark_320() else \
-        'SparkArithmeticException'
-    # 3.3.0
-    #      org.apache.spark.SparkArithmeticException: divide by zero. XXXX
-    # 3.3.1
-    #      org.apache.spark.SparkArithmeticException: Division by zero. XXXX
-    # 3.4.0
-    #      org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero. XXXX
+    if is_before_spark_320():
+        err_message = 'java.lang.ArithmeticException: divide by zero'
     if is_before_spark_331():
-        err_mess = ': divide by zero'
-    elif not is_before_spark_331() and is_before_spark_340():
-        err_mess = ': Division by zero'
+        err_message = 'SparkArithmeticException: divide by zero'
+    elif is_before_spark_340():
+        err_message = 'SparkArithmeticException: Division by zero'
     else:
-        err_mess = ': [DIVIDE_BY_ZERO] Division by zero'
+        err_message = 'SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero'
 
     if ansi_mode == 'ansi':
         assert_gpu_and_cpu_error(df_fun=lambda spark: div_by_zero_func(spark).collect(),
                                  conf=ansi_conf,
-                                 error_message=err_exp + err_mess)
+                                 error_message=err_message)
     else:
         assert_gpu_and_cpu_are_equal_collect(div_by_zero_func, ansi_conf)
 

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -19,7 +19,7 @@ from data_gen import *
 from marks import ignore_order, incompat, approximate_float, allow_non_gpu
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
-from spark_session import with_cpu_session, with_gpu_session, with_spark_session, is_before_spark_320, is_before_spark_330, is_databricks91_or_later, is_databricks104_or_later, is_spark_330_or_later
+from spark_session import *
 import pyspark.sql.functions as f
 from datetime import timedelta
 
@@ -798,13 +798,25 @@ def _test_div_by_zero(ansi_mode, expr):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_mode == 'ansi'}
     data_gen = lambda spark: two_col_df(spark, IntegerGen(), IntegerGen(min_val=0, max_val=0), length=1)
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
+    err_exp = 'java.lang.ArithmeticException' if is_before_spark_320() else \
+        'SparkArithmeticException'
+    # 3.3.0
+    #      org.apache.spark.SparkArithmeticException: divide by zero. XXXX
+    # 3.3.1
+    #      org.apache.spark.SparkArithmeticException: Division by zero. XXXX
+    # 3.4.0
+    #      org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero. XXXX
+    if is_before_spark_331():
+        err_mess = ': divide by zero'
+    elif not is_before_spark_331() and is_before_spark_340():
+        err_mess = ': Division by zero'
+    else:
+        err_mess = ': [DIVIDE_BY_ZERO] Division by zero'
 
     if ansi_mode == 'ansi':
         assert_gpu_and_cpu_error(df_fun=lambda spark: div_by_zero_func(spark).collect(),
                                  conf=ansi_conf,
-                                 error_message=
-                                    'java.lang.ArithmeticException: divide by zero' if is_before_spark_320() else 
-                                    'SparkArithmeticException: divide by zero')
+                                 error_message=err_exp + err_mess)
     else:
         assert_gpu_and_cpu_are_equal_collect(div_by_zero_func, ansi_conf)
 
@@ -836,13 +848,15 @@ div_overflow_exprs = [
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
 def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_enabled}
-    exception_str = "java.lang.ArithmeticException: Overflow in integral divide" if is_before_spark_330() \
-        else "org.apache.spark.SparkArithmeticException: Overflow in integral divide"
+    err_exp = 'java.lang.ArithmeticException' if is_before_spark_330() \
+        else 'org.apache.spark.SparkArithmeticException'
+    err_mess = ': Overflow in integral divide' if is_before_spark_340() \
+        else ': [ARITHMETIC_OVERFLOW] Overflow in integral divide'
     if ansi_enabled == 'true':
         assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_div_overflow_df(spark, expr).collect(),
             conf=ansi_conf,
-            error_message=exception_str)
+            error_message=err_exp + err_mess)
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: _get_div_overflow_df(spark, expr),

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -800,7 +800,7 @@ def _test_div_by_zero(ansi_mode, expr):
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
     if is_before_spark_320():
         err_message = 'java.lang.ArithmeticException: divide by zero'
-    if is_before_spark_331():
+    elif is_before_spark_331():
         err_message = 'SparkArithmeticException: divide by zero'
     elif is_before_spark_340():
         err_message = 'SparkArithmeticException: Division by zero'

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -136,6 +136,9 @@ def is_before_spark_320():
 def is_before_spark_330():
     return spark_version() < "3.3.0"
 
+def is_before_spark_331():
+    return spark_version() < "3.3.1"
+
 def is_before_spark_340():
     return spark_version() < "3.4.0"
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/5480.
Spark 340 has changed the error messages for some arithmetic expressions, so update the messages to be checked in related tests accordingly.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
