### PR TITLE
Qualification tool Enable UI by default

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -125,10 +125,12 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   val userName: ScallopOption[String] =
     opt[String](required = false,
       descr = "Applications which a particular user has submitted." )
-  val uiEnabled: ScallopOption[Boolean] =
-    opt[Boolean](required = false,
-      descr = "Whether to render the report into HTML pages. Default is false",
-      default = Some(QualificationArgs.DEFAULT_UI_ENABLED))
+  val htmlReport : ScallopOption[Boolean] =
+    toggle("html-report",
+      default = Some(true),
+      prefix = "no-",
+      descrYes = "Generates an HTML Report. Enabled by default.",
+      descrNo = "Disables generating the HTML report.")
 
   validate(order) {
     case o if (QualificationArgs.isOrderAsc(o) || QualificationArgs.isOrderDesc(o)) => Right(Unit)
@@ -158,8 +160,6 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
 }
 
 object QualificationArgs {
-  val DEFAULT_UI_ENABLED = false
-
   def isOrderAsc(order: String): Boolean = {
     order.toLowerCase.startsWith("asc")
   }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationMain.scala
@@ -53,7 +53,7 @@ object QualificationMain extends Logging {
     val timeout = appArgs.timeout.toOption
     val reportReadSchema = appArgs.reportReadSchema.getOrElse(false)
     val order = appArgs.order.getOrElse("desc")
-    val uiEnabled = appArgs.uiEnabled.getOrElse(false)
+    val uiEnabled = appArgs.htmlReport.getOrElse(false)
 
     val hadoopConf = new Configuration()
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #5566 


Added a toggle option to generate the HTML Report. By default, it is enabled.

```
  -h, --html-report                   Generates an HTML Report. Enabled by default.
        --no-html-report             Disables generating the HTML report.
```

The HTML report is generated in the following cases:

- not passing any argument
- passing `--html-report `
- passing `-h`

To disable the HTML report, the user needs to pass `--no-html-report`

