### PR TITLE
Update the error message to be checked for 330

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -800,8 +800,6 @@ def _test_div_by_zero(ansi_mode, expr):
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
     if is_before_spark_320():
         err_message = 'java.lang.ArithmeticException: divide by zero'
-    elif is_before_spark_331():
-        err_message = 'SparkArithmeticException: divide by zero'
     elif is_before_spark_340():
         err_message = 'SparkArithmeticException: Division by zero'
     else:

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -800,6 +800,8 @@ def _test_div_by_zero(ansi_mode, expr):
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
     if is_before_spark_320():
         err_message = 'java.lang.ArithmeticException: divide by zero'
+    elif is_before_spark_330():
+        err_message = 'SparkArithmeticException: divide by zero'
     elif is_before_spark_340():
         err_message = 'SparkArithmeticException: Division by zero'
     else:

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -136,9 +136,6 @@ def is_before_spark_320():
 def is_before_spark_330():
     return spark_version() < "3.3.0"
 
-def is_before_spark_331():
-    return spark_version() < "3.3.1"
-
 def is_before_spark_340():
     return spark_version() < "3.4.0"
 


### PR DESCRIPTION
PR https://github.com/NVIDIA/spark-rapids/pull/5675 updated the error message before but according to the old Spark 3.3.0 snapshot jars (May 3).


While spark 3.3.0 release is still being produced, and the error message has been changed by https://github.com/apache/spark/pull/36428 according to its development branch `branch-3.3`.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
