### PR TITLE
Qualification tool: Add test for stage failures

### DIFF
--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -251,6 +251,17 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assertSizeAndNotSupported(1, parquet.toSeq)
   }
 
+  test("Stages and jobs failure") {
+    val eventLog = s"$profileLogDir/tasks_executors_fail_compressed_eventlog.zstd"
+    val app = createAppFromEventlog(eventLog)
+    val stats = app.aggregateStats()
+    assert(stats.nonEmpty)
+    val estimatedGpuSpeed = stats.get.estimatedInfo.estimatedGpuSpeedup
+    val recommendation = stats.get.estimatedInfo.recommendation
+    assert (estimatedGpuSpeed == -1)
+    assert(recommendation.equals("Not Applicable"))
+  }
+
   test("InMemoryTableScan") {
     TrampolineUtil.withTempDir { eventLogDir =>
       val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,


### PR DESCRIPTION
This closes https://github.com/NVIDIA/spark-rapids/issues/5569 .
Added a test which reads eventlog which has jobs/stage failures. For such eventlogs, the recommendation is "Not Applicable" as there isn't sufficient data. Test asserts expected behavior.
Other than this, I manually verified the UI when either job or stage failed. It recommends as "Not applicable" for both cases.  

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
