### PR TITLE
Add test for encrypted ORC write [databricks]

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -148,6 +148,25 @@
                     </exclusions>
                 </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-321cdh-test-src</id>
+                                <goals><goal>add-test-source</goal></goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.basedir}/src/test/320+/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <!--
@@ -274,6 +293,62 @@
             </dependencies>
         </profile>
         <profile>
+            <id>release321</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>321</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-321-test-src</id>
+                                <goals><goal>add-test-source</goal></goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.basedir}/src/test/320+/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release322</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>322</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-322-test-src</id>
+                                <goals><goal>add-test-source</goal></goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.basedir}/src/test/320+/scala</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release330</id>
             <activation>
                 <property>
@@ -293,6 +368,7 @@
                                 <configuration>
                                     <sources>
                                         <source>${project.basedir}/src/test/330/scala</source>
+                                        <source>${project.basedir}/src/test/320+/scala</source>
                                     </sources>
                                 </configuration>
                             </execution>

--- a/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
+++ b/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
@@ -55,7 +55,7 @@ class OrcEncryptionSuite extends SparkQueryCompareTestSuite {
       }
       assume(isValidTestForSparkVersion)
 
-     val tempFile = File.createTempFile("orc-encryption-test", "")
+      val tempFile = File.createTempFile("orc-encryption-test", "")
       frame.write.options(Map("orc.key.provider" -> "memory",
         "orc.encrypt" -> "pii:ints,more_ints",
         "orc.mask" -> "sha256:ints,more_ints")).mode("overwrite").orc(tempFile.getAbsolutePath)

--- a/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
+++ b/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
@@ -26,6 +26,8 @@ import org.apache.orc.impl.CryptoUtils
 
 class OrcEncryptionSuite extends SparkQueryCompareTestSuite {
 
+  // Create an InMemoryKeystore provider and addKey `pii` to it.
+  // CryptoUtils caches it so it can be used later by the test
   val hadoopConf = new Configuration()
   hadoopConf.set("orc.key.provider", "memory")
   val random = new SecureRandom()

--- a/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
+++ b/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.io.File
+import java.util.Random
+
+import org.apache.orc.impl.HadoopShimsFactory
+
+import org.apache.spark.SparkConf
+
+class OrcEncryptionSuite extends SparkQueryCompareTestSuite {
+  testGpuFallback(
+    "Write encrypted ORC fallback",
+    "DataWritingCommandExec",
+    intsDf,
+    conf = new SparkConf().set("hadoop.security.key.provider.path", "test:///")
+        .set("orc.key.provider", "hadoop")
+        .set("orc.encrypt", "pii:ints,more_ints")
+        .set("orc.mask", "sha256:ints,more_ints")) {
+    frame =>
+      withCpuSparkSession(session => {
+        val conf = session.sessionState.newHadoopConf()
+        val provider = HadoopShimsFactory.get.getHadoopKeyProvider(conf, new Random)
+        assume(!provider.getKeyNames.isEmpty,
+          s"$provider doesn't has the test keys. ORC shim is created with old Hadoop libraries")
+      }
+      )
+
+      val tempFile = File.createTempFile("orc-encryption-test", "")
+      frame.write.mode("overwrite").orc(tempFile.getAbsolutePath)
+      frame.selectExpr("*")
+  }
+}

--- a/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
+++ b/tests/src/test/320+/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
@@ -17,10 +17,8 @@
 package com.nvidia.spark.rapids
 
 import java.io.File
-import java.util.Random
 
 import com.nvidia.spark.rapids.shims.SparkShimImpl
-import org.apache.orc.impl.HadoopShimsFactory
 
 import org.apache.spark.SparkConf
 
@@ -43,13 +41,13 @@ class OrcEncryptionSuite extends SparkQueryCompareTestSuite {
       }
       assume(isValidTestForSparkVersion)
 
-      withCpuSparkSession(session => {
-        val conf = session.sessionState.newHadoopConf()
-        val provider = HadoopShimsFactory.get.getHadoopKeyProvider(conf, new Random)
-        assume(!provider.getKeyNames.isEmpty,
-          s"$provider doesn't has the test keys. ORC shim is created with old Hadoop libraries")
-      }
-      )
+//      withCpuSparkSession(session => {
+//        val conf = session.sessionState.newHadoopConf()
+//        val provider = HadoopShimsFactory.get.getHadoopKeyProvider(conf, new Random)
+//        assume(!provider.getKeyNames.isEmpty,
+//          s"$provider doesn't has the test keys. ORC shim is created with old Hadoop libraries")
+//      }
+//      )
 
       val tempFile = File.createTempFile("orc-encryption-test", "")
       frame.write.mode("overwrite").orc(tempFile.getAbsolutePath)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -249,7 +249,7 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     }
   }
 
-  def writeOnCpuAndGpuWithCapture(df: SparkSession => DataFrame,
+  def executeFunOnCpuAndGpuWithCapture(df: SparkSession => DataFrame,
       fun: DataFrame => Unit,
       conf: SparkConf = new SparkConf(),
       repart: Integer = 1)
@@ -368,7 +368,7 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
       setupTestConfAndQualifierName(testName, incompat, sort, conf, execsAllowedNonGpu,
         maxFloatDiff, sortBeforeRepart)
     test(qualifiedTestName) {
-      val (_, gpuPlan) = writeOnCpuAndGpuWithCapture(df, fun,
+      val (_, gpuPlan) = executeFunOnCpuAndGpuWithCapture(df, fun,
         conf = testConf,
         repart = repart)
       // Now check the GPU Conditions


### PR DESCRIPTION
This PR uses the `InMemoryKeystore` to write ORC and make sure we fallback to the CPU 

* Added a test method to `SparkQueryCompareTestSuite` to capture the `DataWritingCommandExec`
* Added `OrcEncryptionSuite` to test the encrypted ORC write
* Added the `OrcEncryptionSuite` to different Spark 3.2+ profiles 

fixes #5722 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
