### PR TITLE
Fix repeated runs mvn package without clean lead to missing spark-rapids spark-rapids-jni-version-info.properties in dist jar

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -432,18 +432,21 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!-- if add new artifacts, should set `overWrite` as true -->
                                 <artifactItem>
                                     <groupId>com.nvidia</groupId>
                                     <artifactId>spark-rapids-jni</artifactId>
                                     <classifier>${cuda.version}</classifier>
                                     <excludes>META-INF</excludes>
                                     <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
+                                    <overWrite>true</overWrite>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.openucx</groupId>
                                     <artifactId>jucx</artifactId>
                                     <excludes>META-INF</excludes>
                                     <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
+                                    <overWrite>true</overWrite>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>


### PR DESCRIPTION
Fixes #5777

The second `mvn package without clean` will skip the unpacking in `unpack-spark-rapids-jni-and-ucx` execution
Add `overWrite` property for `unpack-spark-rapids-jni-and-ucx` execution in dist pom.xml to force unpack JNI and UCX jars.

Signed-off-by: Chong Gao <res_life@163.com>
