### PR TITLE
Fix auto merge conflict 5789

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -272,6 +272,32 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>${maven.clean.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>clean-copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <filesets>
+                                    <directory>target/dependency</directory>
+                                    <includes>
+                                        <include>parquet-hadoop*.jar</include>
+                                        <include>spark-avro*.jar</include>
+                                    </includes>
+                                </filesets>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
@@ -287,6 +313,12 @@
                                     <groupId>org.apache.spark</groupId>
                                     <artifactId>spark-avro_${scala.binary.version}</artifactId>
                                     <version>${spark.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.parquet</groupId>
+                                    <artifactId>parquet-hadoop</artifactId>
+                                    <version>${parquet.hadoop.version}</version>
+                                    <classifier>tests</classifier>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -48,10 +48,16 @@ else
     if [ -d "$LOCAL_JAR_PATH" ]; then
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
         PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
+        # TODO - need to update jenkins scripts to upload this jar
+        # https://github.com/NVIDIA/spark-rapids/issues/5771
+        export INCLUDE_PARQUET_HADOOP_TEST_JAR=false
+        PARQUET_HADOOP_TESTS=
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     else
         AVRO_JARS=$(echo "$SCRIPTPATH"/target/dependency/spark-avro*.jar)
+        PARQUET_HADOOP_TESTS=$(echo "$SCRIPTPATH"/target/dependency/parquet-hadoop*.jar)
+        export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
         PLUGIN_JARS=$(echo "$SCRIPTPATH"/../dist/target/rapids-4-spark_*.jar)
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$SCRIPTPATH"/target/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
@@ -70,7 +76,7 @@ else
     fi
 
     # Only 3 jars: dist.jar integration-test.jar avro.jar
-    ALL_JARS="$PLUGIN_JARS $TEST_JARS $AVRO_JARS"
+    ALL_JARS="$PLUGIN_JARS $TEST_JARS $AVRO_JARS $PARQUET_HADOOP_TESTS"
     echo "AND PLUGIN JARS: $ALL_JARS"
     if [[ "${TEST}" != "" ]];
     then

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -487,9 +487,19 @@ def test_shift_right_unsigned(data_gen):
                 'shiftrightunsigned(a, cast(null as INT))',
                 'shiftrightunsigned(a, b)'))
 
+_arith_data_gens_for_round = numeric_gens +  _arith_decimal_gens_no_neg_scale + [
+    decimal_gen_32bit_neg_scale,
+    DecimalGen(precision=15, scale=-8),
+    DecimalGen(precision=30, scale=-5),
+    pytest.param(_decimal_gen_36_neg5, marks=pytest.mark.skipif(
+        is_spark_330_or_later(), reason='This case overflows in Spark 3.3.0+')),
+    pytest.param(_decimal_gen_38_neg10, marks=pytest.mark.skipif(
+        is_spark_330_or_later(), reason='This case overflows in Spark 3.3.0+'))
+]
+
 @incompat
 @approximate_float
-@pytest.mark.parametrize('data_gen', _arith_data_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _arith_data_gens_for_round, ids=idfn)
 def test_decimal_bround(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(
@@ -501,7 +511,7 @@ def test_decimal_bround(data_gen):
 
 @incompat
 @approximate_float
-@pytest.mark.parametrize('data_gen', _arith_data_gens, ids=idfn)
+@pytest.mark.parametrize('data_gen', _arith_data_gens_for_round, ids=idfn)
 def test_decimal_round(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr(

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -285,8 +285,12 @@ def test_mod_pmod_long_min_value():
     'cast(-12 as {}) % cast(0 as {})'], ids=idfn)
 def test_mod_pmod_by_zero(data_gen, overflow_exp):
     string_type = to_cast_string(data_gen.data_type)
-    exception_str = "java.lang.ArithmeticException: divide by zero" if is_before_spark_320() else \
-        "org.apache.spark.SparkArithmeticException: divide by zero" 
+    if is_before_spark_320():
+        exception_str = 'java.lang.ArithmeticException: divide by zero'
+    elif is_before_spark_330():
+        exception_str = 'SparkArithmeticException: divide by zero'
+    else:
+        exception_str = 'SparkArithmeticException: Division by zero'
         
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 import pytest
 
@@ -20,7 +21,7 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 from pyspark.sql.functions import *
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_320, is_before_spark_330, is_spark_321cdh
 from conftest import is_databricks_runtime
 
 
@@ -969,3 +970,37 @@ def test_parquet_check_schema_compatibility_nested_types(spark_tmp_path):
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_map_str_str_as_str_int).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
+
+@pytest.mark.skipif(is_before_spark_320() or is_spark_321cdh(), reason='Encryption is not supported before Spark 3.2.0 or Parquet < 1.12')
+@pytest.mark.skipif(os.environ.get('INCLUDE_PARQUET_HADOOP_TEST_JAR', 'false') == 'false', reason='INCLUDE_PARQUET_HADOOP_TEST_JAR is disabled')
+@pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
+@pytest.mark.parametrize('reader_confs', reader_opt_confs)
+def test_parquet_read_encryption(spark_tmp_path, reader_confs, v1_enabled_list):
+
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    gen_list = [('one', int_gen), ('two', byte_gen), ('THREE', boolean_gen)]
+
+    encryption_confs = {
+        'parquet.encryption.kms.client.class': 'org.apache.parquet.crypto.keytools.mocks.InMemoryKMS',
+        'parquet.encryption.key.list': 'keyA:AAECAwQFBgcICQoLDA0ODw== ,  keyB:AAECAAECAAECAAECAAECAA==',
+        'parquet.crypto.factory.class': 'org.apache.parquet.crypto.keytools.PropertiesDrivenCryptoFactory'
+    }
+
+    conf = copy_and_update(reader_confs, encryption_confs)
+
+    with_cpu_session(
+        lambda spark : gen_df(spark, gen_list).write.
+            option("parquet.encryption.column.keys" , "keyA:one").
+            option("parquet.encryption.footer.key" , "keyB").
+            parquet(data_path), conf=encryption_confs)
+
+    # test with missing encryption conf reading encrypted file
+    assert_py4j_exception(
+        lambda: with_gpu_session(
+            lambda spark: spark.read.parquet(data_path).collect()),
+        error_message='Could not read footer for file')
+
+    assert_py4j_exception(
+        lambda: with_gpu_session(
+            lambda spark: spark.read.parquet(data_path).collect(), conf=conf),
+        error_message='The GPU does not support reading encrypted Parquet files')

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -151,6 +151,9 @@ def is_before_spark_340():
 def is_spark_330_or_later():
     return spark_version() >= "3.3.0"
 
+def is_spark_321cdh():
+    return "3.2.1.3.2.717" in spark_version()
+
 def is_databricks_version_or_later(major, minor):
     spark = get_spark_i_know_what_i_am_doing()
     version = spark.conf.get("spark.databricks.clusterUsageTags.sparkVersion", "0.0")

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
             <properties>
                 <spark.version>${spark311.version}</spark.version>
                 <spark.test.version>${spark311.version}</spark.test.version>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -166,6 +167,7 @@
                 <spark.test.version>${spark312db.version}</spark.test.version>
                 <hadoop.client.version>2.7.4</hadoop.client.version>
                 <rat.consoleOutput>true</rat.consoleOutput>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -216,6 +218,7 @@
             <properties>
                 <spark.version>${spark312.version}</spark.version>
                 <spark.test.version>${spark312.version}</spark.test.version>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -270,6 +273,7 @@
             <properties>
                 <spark.version>${spark313.version}</spark.version>
                 <spark.test.version>${spark313.version}</spark.test.version>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -323,6 +327,7 @@
             <properties>
                 <spark.version>${spark314.version}</spark.version>
                 <spark.test.version>${spark314.version}</spark.test.version>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -386,6 +391,7 @@
             <properties>
                 <spark.version>${spark320.version}</spark.version>
                 <spark.test.version>${spark320.version}</spark.test.version>
+                <parquet.hadoop.version>1.12.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -452,6 +458,7 @@
             <properties>
                 <spark.version>${spark321.version}</spark.version>
                 <spark.test.version>${spark321.version}</spark.test.version>
+                <parquet.hadoop.version>1.12.2</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -519,6 +526,7 @@
             <properties>
                 <spark.version>${spark321cdh.version}</spark.version>
                 <spark.test.version>${spark321cdh.version}</spark.test.version>
+                <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -590,6 +598,7 @@
             <properties>
                 <spark.version>${spark322.version}</spark.version>
                 <spark.test.version>${spark322.version}</spark.test.version>
+                <parquet.hadoop.version>1.12.2</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -670,6 +679,7 @@
                 <spark.test.version>${spark321db.version}</spark.test.version>
                 <hadoop.client.version>3.3.1</hadoop.client.version>
                 <rat.consoleOutput>true</rat.consoleOutput>
+                <parquet.hadoop.version>1.12.0</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -723,6 +733,7 @@
             <properties>
                 <spark.version>${spark330.version}</spark.version>
                 <spark.test.version>${spark330.version}</spark.test.version>
+                <parquet.hadoop.version>1.12.2</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -785,6 +796,7 @@
             <properties>
                 <spark.version>${spark340.version}</spark.version>
                 <spark.test.version>${spark340.version}</spark.test.version>
+                <parquet.hadoop.version>1.12.3</parquet.hadoop.version>
             </properties>
             <build>
                 <plugins>
@@ -887,6 +899,7 @@
         <java.major.version>8</java.major.version>
         <spark.version>${spark311.version}</spark.version>
         <spark.test.version>${spark.version}</spark.test.version>
+        <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <spark-rapids-jni.version>22.08.0-SNAPSHOT</spark-rapids-jni.version>

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims
+
+object GpuParquetCrypto {
+  /**
+   * Columnar encryption was added in Spark 3.2.0 
+   */
+  def isColumnarCryptoException(e: Throwable): Boolean = false
+}

--- a/sql-plugin/src/main/320+-noncdh/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
+++ b/sql-plugin/src/main/320+-noncdh/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims
+
+import org.apache.parquet.crypto.ParquetCryptoRuntimeException
+
+object GpuParquetCrypto {
+  /**
+   * Columnar encryption was added in Spark 3.2.0 
+   */
+  def isColumnarCryptoException(e: Throwable): Boolean = {
+    e match {
+      case crypto: ParquetCryptoRuntimeException => true
+      case _ => false
+    }
+  }
+}

--- a/sql-plugin/src/main/321cdh/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
+++ b/sql-plugin/src/main/321cdh/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids.shims
+
+object GpuParquetCrypto {
+  /**
+   * Columnar encryption was added in Spark 3.2.0 but CDH doesn't have Parquet 1.12. 
+   */
+  def isColumnarCryptoException(e: Throwable): Boolean = false
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2401,7 +2401,7 @@ object GpuOverrides extends Logging {
           }
         }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuBRound(lhs, rhs)
+          GpuBRound(lhs, rhs, a.dataType)
       }),
     expr[Round](
       "Round an expression to d decimal places using HALF_UP rounding mode",
@@ -2422,7 +2422,7 @@ object GpuOverrides extends Logging {
           }
         }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuRound(lhs, rhs)
+          GpuRound(lhs, rhs, a.dataType)
       }),
     expr[PythonUDF](
       "UDF run in an external python process. Does not actually run on the GPU, but " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -37,7 +37,7 @@ import com.nvidia.spark.rapids.ParquetPartitionReader.CopyRange
 import com.nvidia.spark.rapids.RapidsConf.ParquetFooterReaderType
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.ParquetFooter
-import com.nvidia.spark.rapids.shims.{GpuTypeShims, ParquetFieldIdShims, ParquetSchemaClipShims, ParquetStringPredShims, ShimFilePartitionReaderFactory, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{GpuParquetCrypto, GpuTypeShims, ParquetFieldIdShims, ParquetSchemaClipShims, ParquetStringPredShims, ShimFilePartitionReaderFactory, SparkShimImpl}
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, Path}
@@ -474,6 +474,10 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
   private val useFieldId = ParquetSchemaClipShims.useFieldId(sqlConf)
   private val timestampNTZEnabled = ParquetSchemaClipShims.timestampNTZEnabled(sqlConf)
 
+  private val PARQUET_ENCRYPTION_CONFS = Seq("parquet.encryption.kms.client.class",
+    "parquet.encryption.kms.client.class", "parquet.crypto.factory.class")
+  private val PARQUET_MAGIC_ENCRYPTED = "PARE".getBytes(StandardCharsets.US_ASCII)
+
   def isParquetTimeInInt96(parquetType: Type): Boolean = {
     parquetType match {
       case p:PrimitiveType =>
@@ -561,9 +565,15 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
         val magic = new Array[Byte](MAGIC.length)
         inputStream.readFully(magic)
         if (!util.Arrays.equals(MAGIC, magic)) {
-          throw new RuntimeException(s"$filePath is not a Parquet file. " +
+          if (util.Arrays.equals(PARQUET_MAGIC_ENCRYPTED, magic)) {
+            throw new RuntimeException("The GPU does not support reading encrypted Parquet " +
+              "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
+              s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.")
+          } else {
+            throw new RuntimeException(s"$filePath is not a Parquet file. " +
               s"Expected magic number at tail ${util.Arrays.toString(MAGIC)} " +
               s"but found ${util.Arrays.toString(magic)}")
+          }
         }
         val footerIndex = footerLengthIndex - footerLength
         if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
@@ -619,32 +629,47 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
       readDataSchema: StructType): ParquetFileInfoWithBlockMeta = {
     withResource(new NvtxRange("filterBlocks", NvtxColor.PURPLE)) { _ =>
       val filePath = new Path(new URI(file.filePath))
-      val footer = footerReader match {
-        case ParquetFooterReaderType.NATIVE =>
-          val serialized = withResource(readAndFilterFooter(file, conf, readDataSchema, filePath)) {
-            tableFooter =>
-              if (tableFooter.getNumColumns <= 0) {
-                // Special case because java parquet reader does not like having 0 columns.
-                val numRows = tableFooter.getNumRows
-                val block = new BlockMetaData()
-                block.setRowCount(numRows)
-                val schema = new MessageType("root")
-                return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
-                  schema, false, false, false)
-              }
+      // Make sure we aren't trying to read encrypted files. For now, remove the related
+      // parquet confs from the hadoop configuration and try to catch the resulting
+      // exception and print a useful message
+      PARQUET_ENCRYPTION_CONFS.foreach { encryptConf =>
+        if (conf.get(encryptConf) != null) {
+          conf.unset(encryptConf)
+        }
+      }
+      val footer = try {
+         footerReader match {
+          case ParquetFooterReaderType.NATIVE =>
+            val serialized = withResource(readAndFilterFooter(file, conf,
+              readDataSchema, filePath)) { tableFooter =>
+                if (tableFooter.getNumColumns <= 0) {
+                  // Special case because java parquet reader does not like having 0 columns.
+                  val numRows = tableFooter.getNumRows
+                  val block = new BlockMetaData()
+                  block.setRowCount(numRows)
+                  val schema = new MessageType("root")
+                  return ParquetFileInfoWithBlockMeta(filePath, Seq(block), file.partitionValues,
+                    schema, false, false, false)
+                }
 
-              tableFooter.serializeThriftFile()
-          }
-          withResource(serialized) { serialized =>
-            withResource(new NvtxRange("readFilteredFooter", NvtxColor.YELLOW)) { _ =>
-              val inputFile = new HMBInputFile(serialized)
-
-              // We already filtered the ranges so no need to do more here...
-              ParquetFileReader.readFooter(inputFile, ParquetMetadataConverter.NO_FILTER)
+                tableFooter.serializeThriftFile()
             }
-          }
-        case _ =>
-          readAndSimpleFilterFooter(file, conf, filePath)
+            withResource(serialized) { serialized =>
+              withResource(new NvtxRange("readFilteredFooter", NvtxColor.YELLOW)) { _ =>
+                val inputFile = new HMBInputFile(serialized)
+
+                // We already filtered the ranges so no need to do more here...
+                ParquetFileReader.readFooter(inputFile, ParquetMetadataConverter.NO_FILTER)
+              }
+            }
+          case _ =>
+            readAndSimpleFilterFooter(file, conf, filePath)
+        }
+      } catch {
+        case e if GpuParquetCrypto.isColumnarCryptoException(e) =>
+          throw new RuntimeException("The GPU does not support reading encrypted Parquet " +
+            "files. To read encrypted or columnar encrypted files, disable the GPU Parquet " +
+            s"reader via ${RapidsConf.ENABLE_PARQUET_READ.key}.", e)
       }
 
       val fileSchema = footer.getFileMetaData.getSchema

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -702,6 +702,22 @@ class CastOpSuite extends GpuExpressionTestSuite {
     }
   }
 
+  test("cast float/double to decimal (include upcast of cuDF decimal type)") {
+    val genFloats: SparkSession => DataFrame = (ss: SparkSession) => {
+      ss.createDataFrame(List(Tuple1(459.288333f), Tuple1(-123.456789f), Tuple1(789.100001f)))
+        .selectExpr("_1 AS col")
+    }
+    testCastToDecimal(DataTypes.FloatType, precision = 9, scale = 6,
+      customDataGenerator = Option(genFloats))
+
+    val genDoubles: SparkSession => DataFrame = (ss: SparkSession) => {
+      ss.createDataFrame(List(Tuple1(459.288333), Tuple1(-123.456789), Tuple1(789.100001)))
+        .selectExpr("_1 AS col")
+    }
+    testCastToDecimal(DataTypes.DoubleType, precision = 9, scale = 6,
+      customDataGenerator = Option(genDoubles))
+  }
+
   test("cast decimal to decimal") {
     // fromScale == toScale
     testCastToDecimal(DataTypes.createDecimalType(18, 0),


### PR DESCRIPTION
fixes merge conflicts from https://github.com/NVIDIA/spark-rapids/pull/5789

Merge conflicts were in the imports in GpuParquetScan and in the adding in vals  PARQUET_ENCRYPTION_CONFS

The arithmetic_ops_test was conflict due to Spark 3.1.4, 3.2.2 and 3.4.0 being handled by code in 22.08.

I also updated the pom.xml to put the parquet.hadoop.version into the 3.4.0 section.

NOTE: This needs to be committed with a merge commit, not squashed!

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
