### PR TITLE
Configure log4j version 2.x for test cases

### DIFF
--- a/integration_tests/src/test/resources/log4j2.properties
+++ b/integration_tests/src/test/resources/log4j2.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# log level of log4j itself
+status=warn
+
+# rolling appender
+appender.rolling.type=File
+appender.rolling.name=fileAppender
+appender.rolling.filter.threshold.type=ThresholdFilter
+appender.rolling.filter.threshold.level=info
+appender.rolling.layout.type=PatternLayout
+appender.rolling.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+appender.rolling.append=true
+appender.rolling.fileName=target/surefire-reports/scala-test-detailed-output.log
+
+# console appender
+appender.console.type=Console
+appender.console.name=consoleAppender
+appender.console.filter.threshold.type=ThresholdFilter
+# print error log and system.err to console
+appender.console.filter.threshold.level=error
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+rootLogger.level=info
+rootLogger.appenderRef.rolling.ref=fileAppender
+rootLogger.appenderRef.console.ref=consoleAppender

--- a/sql-plugin/src/test/resources/log4j2.properties
+++ b/sql-plugin/src/test/resources/log4j2.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# log level of log4j itself
+status=warn
+
+# rolling appender
+appender.rolling.type=File
+appender.rolling.name=fileAppender
+appender.rolling.filter.threshold.type=ThresholdFilter
+appender.rolling.filter.threshold.level=info
+appender.rolling.layout.type=PatternLayout
+appender.rolling.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+appender.rolling.append=true
+appender.rolling.fileName=target/surefire-reports/scala-test-detailed-output.log
+
+# console appender
+appender.console.type=Console
+appender.console.name=consoleAppender
+appender.console.filter.threshold.type=ThresholdFilter
+# print error log and system.err to console
+appender.console.filter.threshold.level=error
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+rootLogger.level=info
+rootLogger.appenderRef.rolling.ref=fileAppender
+rootLogger.appenderRef.console.ref=consoleAppender

--- a/tests/src/test/resources/log4j2.properties
+++ b/tests/src/test/resources/log4j2.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# log level of log4j itself
+status=warn
+
+# rolling appender
+appender.rolling.type=File
+appender.rolling.name=fileAppender
+appender.rolling.filter.threshold.type=ThresholdFilter
+appender.rolling.filter.threshold.level=info
+appender.rolling.layout.type=PatternLayout
+appender.rolling.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+appender.rolling.append=true
+appender.rolling.fileName=target/surefire-reports/scala-test-detailed-output.log
+
+# console appender
+appender.console.type=Console
+appender.console.name=consoleAppender
+appender.console.filter.threshold.type=ThresholdFilter
+# print error log and system.err to console
+appender.console.filter.threshold.level=error
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+rootLogger.level=info
+rootLogger.appenderRef.rolling.ref=fileAppender
+rootLogger.appenderRef.console.ref=consoleAppender

--- a/tools/src/test/resources/log4j2.properties
+++ b/tools/src/test/resources/log4j2.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# log level of log4j itself
+status=warn
+
+# rolling appender
+appender.rolling.type=File
+appender.rolling.name=fileAppender
+appender.rolling.filter.threshold.type=ThresholdFilter
+appender.rolling.filter.threshold.level=info
+appender.rolling.layout.type=PatternLayout
+appender.rolling.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+appender.rolling.append=true
+appender.rolling.fileName=target/surefire-reports/scala-test-detailed-output.log
+
+# console appender
+appender.console.type=Console
+appender.console.name=consoleAppender
+appender.console.filter.threshold.type=ThresholdFilter
+# print error log and system.err to console
+appender.console.filter.threshold.level=error
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+rootLogger.level=info
+rootLogger.appenderRef.rolling.ref=fileAppender
+rootLogger.appenderRef.console.ref=consoleAppender

--- a/udf-compiler/src/test/resources/log4j2.properties
+++ b/udf-compiler/src/test/resources/log4j2.properties
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# log level of log4j itself
+status=warn
+
+# rolling appender
+appender.rolling.type=File
+appender.rolling.name=fileAppender
+appender.rolling.filter.threshold.type=ThresholdFilter
+appender.rolling.filter.threshold.level=info
+appender.rolling.layout.type=PatternLayout
+appender.rolling.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+appender.rolling.append=true
+appender.rolling.fileName=target/surefire-reports/scala-test-detailed-output.log
+
+# console appender
+appender.console.type=Console
+appender.console.name=consoleAppender
+appender.console.filter.threshold.type=ThresholdFilter
+# print error log and system.err to console
+appender.console.filter.threshold.level=error
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+rootLogger.level=info
+rootLogger.appenderRef.rolling.ref=fileAppender
+rootLogger.appenderRef.console.ref=consoleAppender


### PR DESCRIPTION
Closes #5145 

Fix: Running Scala tests against Spark 3.3 results in lots of Spark logging output
### problem:
`Log4j` changed to version 2.x from 1.x on Spark330+, `log4j2.properties` is needed instead of `log4j.properties`
```
cd spark-rapids/sql-plugin
mvn dependency:tree -Dbuildver=330 | grep log4j
[INFO] |  |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.17.2:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.17.2:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-core:jar:2.17.2:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.17.2:provided

mvn dependency:tree -Dbuildver=320 | grep log4j
[INFO] |  |  +- log4j:log4j:jar:1.2.17:provided
[INFO] |  |  +- org.slf4j:slf4j-log4j12:jar:1.7.30:provided
```

### changes:
`find . -name log4j.properties` prints the log4j files add a coresponding `log4j2.properties`
```
./api_validation/src/main/resources/log4j.properties
./integration_tests/src/test/resources/log4j.properties
./tests/src/test/resources/log4j.properties
./tools/src/test/resources/log4j.properties
./udf-compiler/src/test/resources/log4j.properties
./sql-plugin/src/test/resources/log4j.properties
```
Did not configure for the `api_validation` module, because it's only compiled for `buildver=31x`
Note the log path is in `target/surefire-reports` as before, not `target/spark33x/surefire-reports`

Signed-off-by: Chong Gao <res_life@163.com>
