### PR TITLE
Enable the `spark.sql.parquet.binaryAsString=true` configuration option on the GPU

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -134,9 +134,9 @@ def test_parquet_read_round_trip_binary_as_string(spark_tmp_path, read_func, rea
     gen_list = [("a", string_gen), ("b", int_gen), ("c", string_gen)]
     data_path = spark_tmp_path + '/binary_as_string.parquet'
     # cast to binary to read back as a string
-    # NOTE: using pyarrow to write the parquet file as writing the parquet files using spark doesn't 
-    # produce a parquet file where the binary values are read back as strings, this simulates reading
-    # a parquet file produced outside of spark
+    # NOTE: using pyarrow to write the parquet file because spark doesn't 
+    # produce a parquet file where the binary values are read back as strings,
+    # ultimately this simulates reading a parquet file produced outside of spark
     def create_parquet_file(spark):
         df = gen_df(spark, gen_list).select(
                 f.col('a').cast("BINARY").alias('a'),\

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -19,6 +19,8 @@ from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gp
     assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_py4j_exception
 from data_gen import *
 from marks import *
+import pyarrow as pa
+import pyarrow.parquet as pa_pq
 from pyspark.sql.types import *
 from pyspark.sql.functions import *
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_320, is_before_spark_330, is_spark_321cdh
@@ -125,16 +127,23 @@ def test_parquet_fallback(spark_tmp_path, read_func, disable_conf):
             conf={disable_conf: 'false',
                 "spark.sql.sources.useV1SourceList": "parquet"})
 
-@pytest.mark.parametrize('parquet_gens', parquet_gens_list, ids=idfn)
 @pytest.mark.parametrize('read_func', [read_parquet_df, read_parquet_sql])
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
-def test_parquet_read_round_trip_binary_as_string(spark_tmp_path, parquet_gens, read_func, reader_confs, v1_enabled_list):
-    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
-    data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_cpu_session(
-            lambda spark : gen_df(spark, gen_list).write.parquet(data_path),
-            conf=rebase_write_corrected_conf)
+def test_parquet_read_round_trip_binary_as_string(spark_tmp_path, read_func, reader_confs, v1_enabled_list):
+    gen_list = [("a", string_gen), ("b", int_gen), ("c", string_gen)]
+    data_path = spark_tmp_path + '/binary_as_string.parquet'
+    # cast to binary to read back as a string
+    # NOTE: using pyarrow to write the parquet file as writing the parquet files using spark doesn't 
+    # produce a parquet file where the binary values are read back as strings, this simulates reading
+    # a parquet file produced outside of spark
+    def create_parquet_file(spark):
+        df = gen_df(spark, gen_list).select(
+                f.col('a').cast("BINARY").alias('a'),\
+                f.col('b'), f.col('c'))
+        pa_pq.write_table(pa.Table.from_pandas(df.toPandas()), data_path)
+
+    with_cpu_session(create_parquet_file, conf=rebase_write_corrected_conf)
     all_confs = copy_and_update(reader_confs, {
         'spark.sql.sources.useV1SourceList': v1_enabled_list,
         'spark.sql.parquet.binaryAsString': 'true',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -193,16 +193,6 @@ object GpuParquetScan {
 
     FileFormatChecks.tag(meta, readSchema, ParquetFormatType, ReadFileOp)
 
-    val schemaHasStrings = readSchema.exists { field =>
-      TrampolineUtil.dataTypeExistsRecursively(field.dataType, _.isInstanceOf[StringType])
-    }
-
-    if (sqlConf.get(SQLConf.PARQUET_BINARY_AS_STRING.key,
-      SQLConf.PARQUET_BINARY_AS_STRING.defaultValueString).toBoolean && schemaHasStrings) {
-      meta.willNotWorkOnGpu(s"GpuParquetScan does not support" +
-          s" ${SQLConf.PARQUET_BINARY_AS_STRING.key}")
-    }
-
     val schemaHasTimestamps = readSchema.exists { field =>
       TrampolineUtil.dataTypeExistsRecursively(field.dataType, _.isInstanceOf[TimestampType])
     }


### PR DESCRIPTION
Fixes #4040.

Now that rapidsai/cudf/pull/10750 has been merged, Parquet files with binary columns can now be read with those values as strings on the GPU. This now enables the Spark configuration option `spark.sql.parquet.binaryAsString=true`, and the expected behavior can now work properly on the GPU. Note that cuDF (and the plugin) still need to support binary types properly (as in reading binary as binary, see #5416 and rapidsai/cudf#11044 for more context).  This pull request removes the check for the configuration that disables running on the GPU, and adds an integration test that tests the end to end reading of strings encoded as binary in parquet (as is the case in some systems outside of Spark) and converting those columns back to strings when read in Spark when `spark.sql.parquet.binaryAsString=true`. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
