### PR TITLE
[WIP] Add support for null characters in regular expressions

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -159,13 +159,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     })
   }
 
-  test("cuDF does not support null in pattern") {
-    val patterns = Seq("\u0000", "a\u0000b", "a(\u0000)b", "a[a-b][\u0000]")
-    patterns.foreach(pattern =>
-      assertUnsupported(pattern, RegexFindMode,
-        "cuDF does not support null characters in regular expressions"))
-  }
-
   test("cuDF does not support class intersection &&") {
     val patterns = Seq("[a&&b]", "[&&1]")
     patterns.foreach(pattern =>
@@ -434,7 +427,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   private val REGEXP_LIMITED_CHARS_COMMON = "|()[]{},-./;:!^$#%&*+?<=>@\"'~`" +
-    "abc123x\\ \t\r\n\f\u000bBsdwSDWzZ"
+    "abc0123x\\ \t\r\n\f\u000b\u0000BsdwSDWzZ"
 
   private val REGEXP_LIMITED_CHARS_FIND = REGEXP_LIMITED_CHARS_COMMON
 


### PR DESCRIPTION
Adds support for the null character `\u0000` in regular expressions. 

cuDF requires null characters to be represented as `\0` rather than the literal `\u0000`. But we can't simply transpile `\u0000` to `\0` since patterns such as `\u00002` (ie. null character followed by a 2) would transpile to `\02` (ie. the octal digit with codepoint=2) so we instead transpile `\u0000` to `(?:\0)`

I've also left null characters disabled in character classes due to a cuDF bug https://github.com/rapidsai/cudf/issues/11109

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
