### PR TITLE
Update unit test doc

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,8 +16,9 @@ and the code is in the `com.nvidia.spark.rapids.tests.mortgage` package.
 Unit tests exist in the [tests]() directory. This is unconventional and is done so we can run the 
 tests on the final shaded version of the plugin. It also helps with how we collect code coverage. 
 
-The `tests` module depends on the `aggregator` module which is shading the dependencies.
-Should first `mvn install` the aggregator jar to local Maven repository due to a limitation of the shading system.
+The `tests` module depends on the `aggregator` module which shades dependencies. When running the
+tests via `mvn test`, make sure to do an install via `mvn install` for the aggregator jar to the
+local maven repository.
 The steps to run the unit tests:
 ```bash
 cd <root-path-of-spark-rapids>

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,15 @@ and the code is in the `com.nvidia.spark.rapids.tests.mortgage` package.
 Unit tests exist in the [tests]() directory. This is unconventional and is done so we can run the 
 tests on the final shaded version of the plugin. It also helps with how we collect code coverage. 
 
-Use Maven to run the unit tests via `mvn test`.
+The `tests` module depends on the `aggregator` module which is shading the dependencies.
+Should first `mvn install` the aggregator jar to local Maven repository due to a limitation of the shading system.
+The steps to run the unit tests:
+```bash
+cd <root-path-of-spark-rapids>
+mvn clean install
+cd tests
+mvn test
+```
 
 To run targeted Scala tests append `-DwildcardSuites=<comma separated list of wildcard suite
  names to execute>` to the above command. 


### PR DESCRIPTION
Closes #5467 

### Problem
#### case 1
```
cd spark-rapids
mvn test
```
The aggregator is a shading module, there are no classes under the `aggregator/target/Sparkxxx/classes/` path.
So Maven tries to find the aggregator jar from local or remote repositories.

#### case 2
```
cd spark-rapids/tests
mvn test
```

By default, Maven tries to find an aggregator jar from local or remote repositories.


### Changes
Due to the limitation of Maven, should first install the aggregator jar to the local repository.
Only need to update the doc.

### Other context
The aggregator jar is not published to Maven Central.  
   
Signed-off-by: Chong Gao <res_life@163.com>