### PR TITLE
Remove SNAPSHOT support from Spark 3.3.0 shim

### DIFF
--- a/sql-plugin/src/main/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimServiceProvider.scala
+++ b/sql-plugin/src/main/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimServiceProvider.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.SparkShimVersion
 
 object SparkShimServiceProvider {
   val VERSION = SparkShimVersion(3, 3, 0)
-  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+  val VERSIONNAMES = Seq(s"$VERSION")
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {


### PR DESCRIPTION
#5848 updated the Spark 3.3.0 shim to support the released artifact but left in support for SNAPSHOT artifacts.  This removes support for SNAPSHOT versions of Spark 3.3.0, as we only want to support the released artifact with this shim.