### PR TITLE
Profiling tool add wholestagecodegen to execs mapping, sql to stage info and job end time

### DIFF
--- a/docs/spark-profiling-tool.md
+++ b/docs/spark-profiling-tool.md
@@ -120,7 +120,7 @@ Run `--help` for more information.
 - Executors information
 - Job, stage and SQL ID information
 - SQL to stage information
-- WholeStageCodeGen to node mappings (only applies to CPU)
+- WholeStageCodeGen to node mappings (only applies to CPU plans)
 - Rapids related parameters
 - Spark Properties
 - Rapids Accelerator Jar and cuDF Jar

--- a/docs/spark-profiling-tool.md
+++ b/docs/spark-profiling-tool.md
@@ -265,6 +265,7 @@ Rapids Accelerator Jar and cuDF Jar:
 - Job, stage and SQL ID information(not in `compare` mode yet):
 
 ```
+Job Information:
 +--------+-----+---------+-----+-------------+-------------+
 |appIndex|jobID|stageIds |sqlID|startTime    |endTime      |
 +--------+-----+---------+-----+-------------+-------------+
@@ -275,7 +276,10 @@ Rapids Accelerator Jar and cuDF Jar:
 
 - SQL to Stage Information (sorted by stage duration)
 
+Note that not all SQL nodes have a mapping to stage id so some nodes might be missing.
+
 ```
+SQL to Stage Information:
 +--------+-----+-----+-------+--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |appIndex|sqlID|jobID|stageId|stageAttemptId|Stage Duration|SQL Nodes(IDs)                                                                                                                                                     |
 +--------+-----+-----+-------+--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -289,6 +293,7 @@ Rapids Accelerator Jar and cuDF Jar:
 - SQL Plan Metrics for Application for each SQL plan node in each SQL:
 
 These are also called accumulables in Spark.
+Note that not all SQL nodes have a mapping to stage id.
 
 ```
 SQL Plan Metrics for Application:
@@ -306,13 +311,15 @@ SQL Plan Metrics for Application:
 - WholeStageCodeGen to Node Mapping:
 
 ```
-+--------+-----+------+---------------------+-----------------------+
-|appIndex|sqlID|nodeID|SQL Node             |Child Node(ID)         |
-+--------+-----+------+---------------------+-----------------------+
-|1       |0    |0     |WholeStageCodegen (6)|HashAggregate(1)       |
-|1       |0    |3     |WholeStageCodegen (5)|HashAggregate(4)       |
-|1       |0    |3     |WholeStageCodegen (5)|Project(5)             |
-|1       |0    |3     |WholeStageCodegen (5)|SortMergeJoin(6)       |
+WholeStageCodeGen Mapping:
++--------+-----+------+---------------------+-------------------+------------+
+|appIndex|sqlID|nodeID|SQL Node             |Child Node         |Child NodeID|
++--------+-----+------+---------------------+-------------------+------------+
+|1       |0    |0     |WholeStageCodegen (6)|HashAggregate      |1           |
+|1       |0    |3     |WholeStageCodegen (5)|HashAggregate      |4           |
+|1       |0    |3     |WholeStageCodegen (5)|Project            |5           |
+|1       |0    |3     |WholeStageCodegen (5)|SortMergeJoin      |6           |
+|1       |0    |7     |WholeStageCodegen (2)|Sort               |8           |
 ```
 
 - Print SQL Plans (-p option):

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -34,4 +34,6 @@ case class ApplicationSummaryInfo(
     val removedBMs: Seq[BlockManagerRemovedProfileResult],
     val removedExecutors: Seq[ExecutorsRemovedProfileResult],
     val unsupportedOps: Seq[UnsupportedOpsProfileResult],
-    val sparkProps: Seq[RapidsPropertyProfileResult])
+    val sparkProps: Seq[RapidsPropertyProfileResult],
+    val sqlStageInfo: Seq[SQLStageInfoProfileResult],
+    val wholeStage: Seq[WholeStageCodeGenResults])

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -158,12 +158,12 @@ class SQLExecutionInfoClass(
 
 case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
     nodeName: String, accumulatorId: Long, name: String, max_value: Long,
-    metricType: String, stages: Seq[Int]) extends ProfileResult {
+    metricType: String, stages: String) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "nodeName", "accumulatorId",
     "name", "max_value", "metricType", "stageIds")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeID.toString, nodeName, accumulatorId.toString,
-      name, max_value.toString, metricType, stages.mkString(","))
+      name, max_value.toString, metricType, stages))
   }
 }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -616,14 +616,17 @@ case class WholeStageCodeGenResults(
     sqlID: Long,
     nodeID: Long,
     parent: String,
-    child: String
+    child: String,
+    childNodeID: Long
 ) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "SQL Node", "Child Node(ID)")
+  override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "SQL Node",
+    "Child Node", "Child Node ID")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString,
       sqlID.toString,
       nodeID.toString,
       parent,
-      child)
+      child,
+      childNodeID.toString)
   }
 }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -113,7 +113,7 @@ case class SQLStageInfoProfileResult(
     duration: Option[Long],
     nodeNames: Seq[String]) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "jobID", "stageId",
-    "stageAttemptId", "stage duration", "SQL node names")
+    "stageAttemptId", "Stage Duration", "SQL Node Names")
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, jobID.toString, stageId.toString,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -163,7 +163,7 @@ case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
     "name", "max_value", "metricType", "stageIds")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeID.toString, nodeName, accumulatorId.toString,
-      name, max_value.toString, metricType, stages))
+      name, max_value.toString, metricType, stages)
   }
 }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -113,7 +113,7 @@ case class SQLStageInfoProfileResult(
     duration: Option[Long],
     nodeNames: Seq[String]) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "jobID", "stageId",
-    "stageAttemptId", "Stage Duration", "SQL Node Names(Ids)")
+    "stageAttemptId", "Stage Duration", "SQL Nodes(IDs)")
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, jobID.toString, stageId.toString,
@@ -618,7 +618,7 @@ case class WholeStageCodeGenResults(
     parent: String,
     child: String
 ) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "parent", "child")
+  override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "SQL Node", "Child Node(ID)")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString,
       sqlID.toString,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -620,7 +620,7 @@ case class WholeStageCodeGenResults(
     childNodeID: Long
 ) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "SQL Node",
-    "Child Node", "Child Node ID")
+    "Child Node", "Child NodeID")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString,
       sqlID.toString,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -93,11 +93,32 @@ case class JobInfoProfileResult(
     appIndex: Int,
     jobID: Int,
     stageIds: Seq[Int],
-    sqlID: Option[Long]) extends ProfileResult {
-  override val outputHeaders = Seq("appIndex", "jobID", "stageIds", "sqlID")
+    sqlID: Option[Long],
+    startTime: Long,
+    endTime: Option[Long]) extends ProfileResult {
+  override val outputHeaders = Seq("appIndex", "jobID", "stageIds", "sqlID", "startTime", "endTime")
   override def convertToSeq: Seq[String] = {
     val stageIdStr = s"[${stageIds.mkString(",")}]"
-    Seq(appIndex.toString, jobID.toString, stageIdStr, sqlID.map(_.toString).getOrElse(null))
+    Seq(appIndex.toString, jobID.toString, stageIdStr, sqlID.map(_.toString).getOrElse(null),
+      startTime.toString, endTime.map(_.toString).getOrElse(null))
+  }
+}
+
+case class SQLStageInfoProfileResult(
+    appIndex: Int,
+    sqlID: Long,
+    jobID: Int,
+    stageId: Int,
+    stageAttemptId: Int,
+    duration: Option[Long],
+    nodeNames: Seq[String]) extends ProfileResult {
+  override val outputHeaders = Seq("appIndex", "sqlID", "jobID", "stageId",
+    "stageAttemptId", "stage duration", "SQL node names")
+
+  override def convertToSeq: Seq[String] = {
+    Seq(appIndex.toString, sqlID.toString, jobID.toString, stageId.toString,
+      stageAttemptId.toString, duration.map(_.toString).getOrElse(null),
+      nodeNames.mkString(","))
   }
 }
 
@@ -136,13 +157,13 @@ class SQLExecutionInfoClass(
     var sqlCpuTimePercent: Double = -1)
 
 case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
-    nodeName: String, accumulatorId: Long,
-    name: String, max_value: Long, metricType: String) extends ProfileResult {
+    nodeName: String, accumulatorId: Long, name: String, max_value: Long,
+    metricType: String, stages: Seq[Int]) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "nodeName", "accumulatorId",
-    "name", "max_value", "metricType")
+    "name", "max_value", "metricType", "stageIds")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeID.toString, nodeName, accumulatorId.toString,
-      name, max_value.toString, metricType)
+      name, max_value.toString, metricType, stages.mkString(","))
   }
 }
 
@@ -238,7 +259,8 @@ case class SQLMetricInfoCase(
     metricType: String,
     nodeID: Long,
     nodeName: String,
-    nodeDesc: String)
+    nodeDesc: String,
+    stages: Seq[Int])
 
 case class DriverAccumCase(
     sqlID: Long,
@@ -587,4 +609,21 @@ case class CompareProfileResults(outputHeadersIn: Seq[String],
 
   override val outputHeaders: Seq[String] = outputHeadersIn
   override def convertToSeq: Seq[String] = rows
+}
+
+case class WholeStageCodeGenResults(
+    appIndex: Int,
+    sqlID: Long,
+    nodeID: Long,
+    parent: String,
+    child: String
+) extends ProfileResult {
+  override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "parent", "child")
+  override def convertToSeq: Seq[String] = {
+    Seq(appIndex.toString,
+      sqlID.toString,
+      nodeID.toString,
+      parent,
+      child)
+  }
 }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -158,12 +158,12 @@ class SQLExecutionInfoClass(
 
 case class SQLAccumProfileResults(appIndex: Int, sqlID: Long, nodeID: Long,
     nodeName: String, accumulatorId: Long, name: String, max_value: Long,
-    metricType: String, stages: String) extends ProfileResult {
+    metricType: String, stageIds: String) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "nodeID", "nodeName", "accumulatorId",
     "name", "max_value", "metricType", "stageIds")
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, nodeID.toString, nodeName, accumulatorId.toString,
-      name, max_value.toString, metricType, stages)
+      name, max_value.toString, metricType, stageIds)
   }
 }
 
@@ -260,7 +260,7 @@ case class SQLMetricInfoCase(
     nodeID: Long,
     nodeName: String,
     nodeDesc: String,
-    stages: Seq[Int])
+    stageIds: Seq[Int])
 
 case class DriverAccumCase(
     sqlID: Long,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -113,7 +113,7 @@ case class SQLStageInfoProfileResult(
     duration: Option[Long],
     nodeNames: Seq[String]) extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "sqlID", "jobID", "stageId",
-    "stageAttemptId", "Stage Duration", "SQL Node Names")
+    "stageAttemptId", "Stage Duration", "SQL Node Names(Ids)")
 
   override def convertToSeq: Seq[String] = {
     Seq(appIndex.toString, sqlID.toString, jobID.toString, stageId.toString,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -181,8 +181,13 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
 
   // Print SQL whole stage code gen mapping
   def getWholeStageCodeGenMapping: Seq[WholeStageCodeGenResults] = {
-    apps.flatMap { app =>
+    val allWholeStages = apps.flatMap { app =>
       app.wholeStage
+    }
+    if (allWholeStages.size > 0) {
+      allWholeStages.sortBy(cols => (cols.appIndex, cols.sqlID, cols.nodeID))
+    } else {
+      Seq.empty
     }
   }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -135,7 +135,7 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
 
   def getSQLToStage: Seq[SQLStageInfoProfileResult] = {
     val allRows = apps.flatMap { app =>
-      app.aggregateSQLInfo
+      app.aggregateSQLStageInfo
     }
     if (allRows.size > 0) {
       case class Reverse[T](t: T)

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -250,7 +250,7 @@ object CollectInformation extends Logging {
           val max = Math.max(driverMax.getOrElse(0L), taskMax.getOrElse(0L))
           Some(SQLAccumProfileResults(app.index, metric.sqlID,
             metric.nodeID, metric.nodeName, metric.accumulatorId,
-            metric.name, max, metric.metricType, metric.stages))
+            metric.name, max, metric.metricType, metric.stages.mkString(",")))
         } else {
           None
         }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -142,6 +142,8 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
       implicit def ReverseOrdering[T: Ordering]: Ordering[Reverse[T]] =
         Ordering[T].reverse.on(_.t)
 
+      // intentionally sort this table by the duration to be able to quickly
+      // see the stage that took the longest
       allRows.sortBy(cols => (cols.appIndex, Reverse(cols.duration)))
     } else {
       Seq.empty

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -252,7 +252,7 @@ object CollectInformation extends Logging {
           val max = Math.max(driverMax.getOrElse(0L), taskMax.getOrElse(0L))
           Some(SQLAccumProfileResults(app.index, metric.sqlID,
             metric.nodeID, metric.nodeName, metric.accumulatorId,
-            metric.name, max, metric.metricType, metric.stages.mkString(",")))
+            metric.name, max, metric.metricType, metric.stageIds.mkString(",")))
         } else {
           None
         }

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -336,7 +336,7 @@ class ApplicationInfo(
     }
   }
 
-  def aggregateSQLInfo: Seq[SQLStageInfoProfileResult] = {
+  def aggregateSQLStageInfo: Seq[SQLStageInfoProfileResult] = {
     val jobsWithSQL = jobIdToInfo.filter { case (id, j) =>
       j.sqlID.nonEmpty
     }
@@ -346,21 +346,13 @@ class ApplicationInfo(
         stages.contains(sid)
       }
       stagesInJob.map { case ((s,sa), info) =>
-        val nodeIds = sqlPlanNodeIdToStageIds.filter { case (k, v) =>
+        val nodeIds = sqlPlanNodeIdToStageIds.filter { case (_, v) =>
           v.contains(s)
         }.keys.toSeq
         val nodeNames = sqlPlan.get(j.sqlID.get).map { planInfo =>
           val nodes = SparkPlanGraph(planInfo).allNodes
           val validNodes = nodes.filter { n =>
             nodeIds.contains((j.sqlID.get, n.id))
-          }
-          val metricsForStage = allSQLMetrics.filter { m =>
-            m.stages.contains(s)
-          }
-          val withTimes = metricsForStage.filter { m =>
-            // TODO - is this ok or should we put all times?
-            val allNames = Seq("duration", "sort time", "scan time")
-            allNames.contains(m.name)
           }
           validNodes.map(n => s"${n.name}(${n.id.toString})")
         }.getOrElse(null)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -256,7 +256,6 @@ class ApplicationInfo(
         val mappedStages = SQLPlanParser.getStagesInSQLNode(node, this)
         ((sqlId, node.id), mappedStages)
       }.toMap
-      logWarning("nodeIdToStage  is: " + nodeIdToStage.mkString(","))
       sqlPlanNodeIdToStageIds ++= nodeIdToStage
     }
   }

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -270,8 +270,7 @@ class ApplicationInfo(
         if (n.isInstanceOf[org.apache.spark.sql.execution.ui.SparkPlanGraphCluster]) {
           val ch = n.asInstanceOf[org.apache.spark.sql.execution.ui.SparkPlanGraphCluster].nodes
           ch.foreach { c =>
-            val nodeNameIdStr = s"${c.name}(${c.id})"
-            wholeStage += WholeStageCodeGenResults(index, sqlID, n.id, n.name, nodeNameIdStr)
+            wholeStage += WholeStageCodeGenResults(index, sqlID, n.id, n.name, c.name, c.id)
           }
         }
       }

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -20,7 +20,7 @@ import scala.collection.{mutable, Map}
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import com.nvidia.spark.rapids.tool.EventLogInfo
-import com.nvidia.spark.rapids.tool.planparser
+import com.nvidia.spark.rapids.tool.planparser.SQLPlanParser
 import com.nvidia.spark.rapids.tool.profiling._
 import org.apache.hadoop.conf.Configuration
 
@@ -308,9 +308,10 @@ class ApplicationInfo(
 
         // Then process SQL plan metric type
         for (metric <- node.metrics) {
+          val stages = sqlPlanNodeIdToStageIds.get((sqlID, node.id)).getOrElse(Seq.empty)
           val allMetric = SQLMetricInfoCase(sqlID, metric.name,
             metric.accumulatorId, metric.metricType, node.id,
-            node.name, node.desc)
+            node.name, node.desc, stages)
 
           allSQLMetrics += allMetric
           if (this.sqlPlanMetricsAdaptive.nonEmpty) {
@@ -320,7 +321,7 @@ class ApplicationInfo(
             adaptive.foreach { adaptiveMetric =>
               val allMetric = SQLMetricInfoCase(sqlID, adaptiveMetric.name,
                 adaptiveMetric.accumulatorId, adaptiveMetric.metricType, node.id,
-                node.name, node.desc)
+                node.name, node.desc, stages)
               // could make this more efficient but seems ok for now
               val exists = allSQLMetrics.filter { a =>
                 ((a.accumulatorId == adaptiveMetric.accumulatorId) && (a.sqlID == sqlID)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -270,7 +270,8 @@ class ApplicationInfo(
         if (n.isInstanceOf[org.apache.spark.sql.execution.ui.SparkPlanGraphCluster]) {
           val ch = n.asInstanceOf[org.apache.spark.sql.execution.ui.SparkPlanGraphCluster].nodes
           ch.foreach { c =>
-            wholeStage += WholeStageCodeGenResults(index, sqlID, n.id, n.name, c.name)
+            val nodeNameIdStr = s"${c.name}(${c.id})"
+            wholeStage += WholeStageCodeGenResults(index, sqlID, n.id, n.name, nodeNameIdStr)
           }
         }
       }

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -259,7 +259,7 @@ class ApplicationInfo(
    * Function to process SQL Plan Metrics after all events are processed
    */
   def processSQLPlanMetrics(): Unit = {
-    connectOperatorToStage
+    connectOperatorToStage()
     for ((sqlID, planInfo) <- sqlPlan) {
       checkMetadataForReadSchema(sqlID, planInfo)
       val planGraph = SparkPlanGraph(planInfo)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -241,12 +241,7 @@ class ApplicationInfo(
     })
   }
 
-  /**
-   *  Connects Operators to Stages by doing the following:
-   * 1. Read SparkGraph to get every Node's name and respective AccumulatorIDs.
-   * 2. Gets each stage's AccumulatorIDs.
-   * 3. Maps Operators to stages by checking for non-zero intersection of 1 and 2's AccumulatorIDs.
-   */
+  // Connects Operators to Stages using AccumulatorIDs
   def connectOperatorToStage(): Unit = {
     for ((sqlId, planInfo) <- sqlPlan) {
       val planGraph = SparkPlanGraph(planInfo)

--- a/tools/src/test/resources/ProfilingExpectations/rapids_join_eventlog_sqlmetrics_expectation.csv
+++ b/tools/src/test/resources/ProfilingExpectations/rapids_join_eventlog_sqlmetrics_expectation.csv
@@ -1,84 +1,84 @@
-appIndex,sqlID,nodeID,nodeName,accumulatorId,name,max_value,metricType
-1,0,0,GpuColumnarToRow,33,total time,857404,nsTiming
-1,0,1,GpuHashAggregate,34,output rows,1,sum
-1,0,1,GpuHashAggregate,35,output columnar batches,1,sum
-1,0,1,GpuHashAggregate,36,total time,4212819,nsTiming
-1,0,1,GpuHashAggregate,37,aggregation time,3846803,nsTiming
-1,0,2,GpuShuffleCoalesce,39,output rows,200,sum
-1,0,2,GpuShuffleCoalesce,40,output columnar batches,1,sum
-1,0,2,GpuShuffleCoalesce,41,total time,3803240,nsTiming
-1,0,2,GpuShuffleCoalesce,42,collect batch time,3277904,nsTiming
-1,0,2,GpuShuffleCoalesce,43,concat batch time,392509,nsTiming
-1,0,3,GpuColumnarExchange,44,partition data size,16000,sum
-1,0,3,GpuColumnarExchange,45,partitions,1,sum
-1,0,3,GpuColumnarExchange,46,output rows,200,sum
-1,0,3,GpuColumnarExchange,47,output columnar batches,200,sum
-1,0,3,GpuColumnarExchange,48,data size,19600,size
-1,0,3,GpuColumnarExchange,50,local blocks read,200,sum
-1,0,3,GpuColumnarExchange,53,local bytes read,15400,size
-1,0,3,GpuColumnarExchange,54,fetch wait time,0,timing
-1,0,3,GpuColumnarExchange,55,records read,200,sum
-1,0,3,GpuColumnarExchange,56,shuffle bytes written,15400,size
-1,0,3,GpuColumnarExchange,57,shuffle records written,200,sum
-1,0,3,GpuColumnarExchange,58,shuffle write time,93193331,nsTiming
-1,0,4,GpuHashAggregate,59,output rows,200,sum
-1,0,4,GpuHashAggregate,60,output columnar batches,200,sum
-1,0,4,GpuHashAggregate,61,total time,80781515,nsTiming
-1,0,4,GpuHashAggregate,62,aggregation time,31923387,nsTiming
-1,0,5,GpuProject,64,total time,5377158,nsTiming
-1,0,6,GpuShuffledHashJoin,65,output rows,10000000,sum
-1,0,6,GpuShuffledHashJoin,66,output columnar batches,200,sum
-1,0,6,GpuShuffledHashJoin,67,total time,3904332009,nsTiming
-1,0,6,GpuShuffledHashJoin,68,build side size,80000000,size
-1,0,6,GpuShuffledHashJoin,69,build time,3448606506,nsTiming
-1,0,6,GpuShuffledHashJoin,70,stream time,260796041,nsTiming
-1,0,6,GpuShuffledHashJoin,71,join time,178084313,nsTiming
-1,0,6,GpuShuffledHashJoin,72,join output rows,10000000,sum
-1,0,7,GpuShuffleCoalesce,74,output rows,10000000,sum
-1,0,7,GpuShuffleCoalesce,75,output columnar batches,200,sum
-1,0,7,GpuShuffleCoalesce,76,total time,261389422,nsTiming
-1,0,7,GpuShuffleCoalesce,77,collect batch time,167775821,nsTiming
-1,0,7,GpuShuffleCoalesce,78,concat batch time,83550919,nsTiming
-1,0,8,GpuColumnarExchange,79,partition data size,42872100,sum
-1,0,8,GpuColumnarExchange,80,partitions,200,sum
-1,0,8,GpuColumnarExchange,81,output rows,10000000,sum
-1,0,8,GpuColumnarExchange,82,output columnar batches,1200,sum
-1,0,8,GpuColumnarExchange,83,data size,40076192,size
-1,0,8,GpuColumnarExchange,85,local blocks read,1200,sum
-1,0,8,GpuColumnarExchange,88,local bytes read,40132258,size
-1,0,8,GpuColumnarExchange,89,fetch wait time,0,timing
-1,0,8,GpuColumnarExchange,90,records read,1200,sum
-1,0,8,GpuColumnarExchange,91,shuffle bytes written,40132258,size
-1,0,8,GpuColumnarExchange,92,shuffle records written,1200,sum
-1,0,8,GpuColumnarExchange,93,shuffle write time,508750471,nsTiming
-1,0,9,GpuProject,94,total time,6667140,nsTiming
-1,0,10,GpuRowToColumnar,95,total time,61112304,nsTiming
-1,0,11,WholeStageCodegen (1),96,duration,5463,timing
-1,0,13,Scan,97,number of output rows,10000000,sum
-1,0,14,GpuCoalesceBatches,98,output rows,10000000,sum
-1,0,14,GpuCoalesceBatches,99,output columnar batches,200,sum
-1,0,14,GpuCoalesceBatches,100,total time,3383354389,nsTiming
-1,0,14,GpuCoalesceBatches,101,collect batch time,3275108263,nsTiming
-1,0,14,GpuCoalesceBatches,102,concat batch time,20312708,nsTiming
-1,0,14,GpuCoalesceBatches,103,peak device memory,80000000,size
-1,0,15,GpuShuffleCoalesce,107,output rows,10000000,sum
-1,0,15,GpuShuffleCoalesce,108,output columnar batches,200,sum
-1,0,15,GpuShuffleCoalesce,109,total time,3266208420,nsTiming
-1,0,15,GpuShuffleCoalesce,110,collect batch time,359397047,nsTiming
-1,0,15,GpuShuffleCoalesce,111,concat batch time,104974316,nsTiming
-1,0,16,GpuColumnarExchange,112,partition data size,42872100,sum
-1,0,16,GpuColumnarExchange,113,partitions,200,sum
-1,0,16,GpuColumnarExchange,114,output rows,10000000,sum
-1,0,16,GpuColumnarExchange,115,output columnar batches,1200,sum
-1,0,16,GpuColumnarExchange,116,data size,40076192,size
-1,0,16,GpuColumnarExchange,118,local blocks read,1200,sum
-1,0,16,GpuColumnarExchange,121,local bytes read,40132250,size
-1,0,16,GpuColumnarExchange,122,fetch wait time,0,timing
-1,0,16,GpuColumnarExchange,123,records read,1200,sum
-1,0,16,GpuColumnarExchange,124,shuffle bytes written,40132250,size
-1,0,16,GpuColumnarExchange,125,shuffle records written,1200,sum
-1,0,16,GpuColumnarExchange,126,shuffle write time,400284505,nsTiming
-1,0,17,GpuProject,127,total time,207820,nsTiming
-1,0,18,GpuRowToColumnar,128,total time,58640462,nsTiming
-1,0,19,WholeStageCodegen (2),129,duration,5920,timing
-1,0,21,Scan,130,number of output rows,10000000,sum
+appIndex,sqlID,nodeID,nodeName,accumulatorId,name,max_value,metricType,stageIds
+1,0,0,GpuColumnarToRow,33,total time,857404,nsTiming,3
+1,0,1,GpuHashAggregate,34,output rows,1,sum,3
+1,0,1,GpuHashAggregate,35,output columnar batches,1,sum,3
+1,0,1,GpuHashAggregate,36,total time,4212819,nsTiming,3
+1,0,1,GpuHashAggregate,37,aggregation time,3846803,nsTiming,3
+1,0,2,GpuShuffleCoalesce,39,output rows,200,sum,3
+1,0,2,GpuShuffleCoalesce,40,output columnar batches,1,sum,3
+1,0,2,GpuShuffleCoalesce,41,total time,3803240,nsTiming,3
+1,0,2,GpuShuffleCoalesce,42,collect batch time,3277904,nsTiming,3
+1,0,2,GpuShuffleCoalesce,43,concat batch time,392509,nsTiming,3
+1,0,3,GpuColumnarExchange,44,partition data size,16000,sum,2;3
+1,0,3,GpuColumnarExchange,45,partitions,1,sum,2;3
+1,0,3,GpuColumnarExchange,46,output rows,200,sum,2;3
+1,0,3,GpuColumnarExchange,47,output columnar batches,200,sum,2;3
+1,0,3,GpuColumnarExchange,48,data size,19600,size,2;3
+1,0,3,GpuColumnarExchange,50,local blocks read,200,sum,2;3
+1,0,3,GpuColumnarExchange,53,local bytes read,15400,size,2;3
+1,0,3,GpuColumnarExchange,54,fetch wait time,0,timing,2;3
+1,0,3,GpuColumnarExchange,55,records read,200,sum,2;3
+1,0,3,GpuColumnarExchange,56,shuffle bytes written,15400,size,2;3
+1,0,3,GpuColumnarExchange,57,shuffle records written,200,sum,2;3
+1,0,3,GpuColumnarExchange,58,shuffle write time,93193331,nsTiming,2;3
+1,0,4,GpuHashAggregate,59,output rows,200,sum,2
+1,0,4,GpuHashAggregate,60,output columnar batches,200,sum,2
+1,0,4,GpuHashAggregate,61,total time,80781515,nsTiming,2
+1,0,4,GpuHashAggregate,62,aggregation time,31923387,nsTiming,2
+1,0,5,GpuProject,64,total time,5377158,nsTiming,2
+1,0,6,GpuShuffledHashJoin,65,output rows,10000000,sum,2
+1,0,6,GpuShuffledHashJoin,66,output columnar batches,200,sum,2
+1,0,6,GpuShuffledHashJoin,67,total time,3904332009,nsTiming,2
+1,0,6,GpuShuffledHashJoin,68,build side size,80000000,size,2
+1,0,6,GpuShuffledHashJoin,69,build time,3448606506,nsTiming,2
+1,0,6,GpuShuffledHashJoin,70,stream time,260796041,nsTiming,2
+1,0,6,GpuShuffledHashJoin,71,join time,178084313,nsTiming,2
+1,0,6,GpuShuffledHashJoin,72,join output rows,10000000,sum,2
+1,0,7,GpuShuffleCoalesce,74,output rows,10000000,sum,2
+1,0,7,GpuShuffleCoalesce,75,output columnar batches,200,sum,2
+1,0,7,GpuShuffleCoalesce,76,total time,261389422,nsTiming,2
+1,0,7,GpuShuffleCoalesce,77,collect batch time,167775821,nsTiming,2
+1,0,7,GpuShuffleCoalesce,78,concat batch time,83550919,nsTiming,2
+1,0,8,GpuColumnarExchange,79,partition data size,42872100,sum,2;1
+1,0,8,GpuColumnarExchange,80,partitions,200,sum,2;1
+1,0,8,GpuColumnarExchange,81,output rows,10000000,sum,2;1
+1,0,8,GpuColumnarExchange,82,output columnar batches,1200,sum,2;1
+1,0,8,GpuColumnarExchange,83,data size,40076192,size,2;1
+1,0,8,GpuColumnarExchange,85,local blocks read,1200,sum,2;1
+1,0,8,GpuColumnarExchange,88,local bytes read,40132258,size,2;1
+1,0,8,GpuColumnarExchange,89,fetch wait time,0,timing,2;1
+1,0,8,GpuColumnarExchange,90,records read,1200,sum,2;1
+1,0,8,GpuColumnarExchange,91,shuffle bytes written,40132258,size,2;1
+1,0,8,GpuColumnarExchange,92,shuffle records written,1200,sum,2;1
+1,0,8,GpuColumnarExchange,93,shuffle write time,508750471,nsTiming,2;1
+1,0,9,GpuProject,94,total time,6667140,nsTiming,1
+1,0,10,GpuRowToColumnar,95,total time,61112304,nsTiming,1
+1,0,11,WholeStageCodegen (1),96,duration,5463,timing,1
+1,0,13,Scan,97,number of output rows,10000000,sum,1
+1,0,14,GpuCoalesceBatches,98,output rows,10000000,sum,2
+1,0,14,GpuCoalesceBatches,99,output columnar batches,200,sum,2
+1,0,14,GpuCoalesceBatches,100,total time,3383354389,nsTiming,2
+1,0,14,GpuCoalesceBatches,101,collect batch time,3275108263,nsTiming,2
+1,0,14,GpuCoalesceBatches,102,concat batch time,20312708,nsTiming,2
+1,0,14,GpuCoalesceBatches,103,peak device memory,80000000,size,2
+1,0,15,GpuShuffleCoalesce,107,output rows,10000000,sum,2
+1,0,15,GpuShuffleCoalesce,108,output columnar batches,200,sum,2
+1,0,15,GpuShuffleCoalesce,109,total time,3266208420,nsTiming,2
+1,0,15,GpuShuffleCoalesce,110,collect batch time,359397047,nsTiming,2
+1,0,15,GpuShuffleCoalesce,111,concat batch time,104974316,nsTiming,2
+1,0,16,GpuColumnarExchange,112,partition data size,42872100,sum,2;0
+1,0,16,GpuColumnarExchange,113,partitions,200,sum,2;0
+1,0,16,GpuColumnarExchange,114,output rows,10000000,sum,2;0
+1,0,16,GpuColumnarExchange,115,output columnar batches,1200,sum,2;0
+1,0,16,GpuColumnarExchange,116,data size,40076192,size,2;0
+1,0,16,GpuColumnarExchange,118,local blocks read,1200,sum,2;0
+1,0,16,GpuColumnarExchange,121,local bytes read,40132250,size,2;0
+1,0,16,GpuColumnarExchange,122,fetch wait time,0,timing,2;0
+1,0,16,GpuColumnarExchange,123,records read,1200,sum,2;0
+1,0,16,GpuColumnarExchange,124,shuffle bytes written,40132250,size,2;0
+1,0,16,GpuColumnarExchange,125,shuffle records written,1200,sum,2;0
+1,0,16,GpuColumnarExchange,126,shuffle write time,400284505,nsTiming,2;0
+1,0,17,GpuProject,127,total time,207820,nsTiming,0
+1,0,18,GpuRowToColumnar,128,total time,58640462,nsTiming,0
+1,0,19,WholeStageCodegen (2),129,duration,5920,timing,0
+1,0,21,Scan,130,number of output rows,10000000,sum,0

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -409,11 +409,15 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstRow.jobID === 0)
     assert(firstRow.stageIds.size === 1)
     assert(firstRow.sqlID === None)
+    assert(firstRow.startTime === 1622846402778L)
+    assert(firstRow.endTime === Some(1622846410240L))
 
     val secondRow = jobInfo(1)
     assert(secondRow.jobID === 1)
     assert(secondRow.stageIds.size === 4)
     assert(secondRow.sqlID.isDefined && secondRow.sqlID.get === 0)
+    assert(secondRow.startTime === 1622846431114L)
+    assert(secondRow.endTime === Some(1622846441591L))
   }
 
   test("test multiple resource profile in single app") {

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -190,8 +190,11 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     val resultExpectation =
       new File(expRoot, "rapids_join_eventlog_sqlmetrics_expectation.csv")
     assert(sqlMetrics.size == 83)
+    val sqlMetricsWithDelim = sqlMetrics.map { metrics =>
+      metrics.copy(stages = ProfileUtils.replaceDelimiter(metrics.stages, ","))
+    }
     import sparkSession.implicits._
-    val df = sqlMetrics.toDF
+    val df = sqlMetricsWithDelim.toDF
     val dfExpect = ToolTestUtils.readExpectationCSV(sparkSession, resultExpectation.getPath())
     ToolTestUtils.compareDataFrames(df, dfExpect)
   }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -468,10 +468,10 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstRow.parent === "WholeStageCodegen (6)")
     assert(firstRow.child === "HashAggregate")
     val lastRow = wholeStageMapping(9)
-    assert(firstRow.nodeID === 17)
-    assert(firstRow.sqlID === 0)
-    assert(firstRow.parent === "WholeStageCodegen (3)")
-    assert(firstRow.child === "SerializeFromObject")
+    assert(lastRow.nodeID === 17)
+    assert(lastRow.sqlID === 0)
+    assert(lastRow.parent === "WholeStageCodegen (3)")
+    assert(lastRow.child === "SerializeFromObject")
   }
 
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -467,13 +467,13 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstRow.sqlID === 0)
     assert(firstRow.parent === "WholeStageCodegen (6)")
     assert(firstRow.child === "HashAggregate")
-    assert(firstRow.childNodeID === "1")
+    assert(firstRow.childNodeID === 1)
     val lastRow = wholeStageMapping(9)
     assert(lastRow.nodeID === 17)
     assert(lastRow.sqlID === 0)
     assert(lastRow.parent === "WholeStageCodegen (3)")
     assert(lastRow.child === "SerializeFromObject")
-    assert(lastRow.childNodeID === "19")
+    assert(lastRow.childNodeID === 19)
   }
 
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -191,7 +191,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       new File(expRoot, "rapids_join_eventlog_sqlmetrics_expectation.csv")
     assert(sqlMetrics.size == 83)
     val sqlMetricsWithDelim = sqlMetrics.map { metrics =>
-      metrics.copy(stages = ProfileUtils.replaceDelimiter(metrics.stages, ","))
+      metrics.copy(stageIds = ProfileUtils.replaceDelimiter(metrics.stageIds, ","))
     }
     import sparkSession.implicits._
     val df = sqlMetricsWithDelim.toDF

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -466,12 +466,12 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstRow.nodeID === 0)
     assert(firstRow.sqlID === 0)
     assert(firstRow.parent === "WholeStageCodegen (6)")
-    assert(firstRow.child === "HashAggregate")
+    assert(firstRow.child === "HashAggregate(1)")
     val lastRow = wholeStageMapping(9)
     assert(lastRow.nodeID === 17)
     assert(lastRow.sqlID === 0)
     assert(lastRow.parent === "WholeStageCodegen (3)")
-    assert(lastRow.child === "SerializeFromObject")
+    assert(lastRow.child === "SerializeFromObject(19)")
   }
 
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -466,12 +466,14 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(firstRow.nodeID === 0)
     assert(firstRow.sqlID === 0)
     assert(firstRow.parent === "WholeStageCodegen (6)")
-    assert(firstRow.child === "HashAggregate(1)")
+    assert(firstRow.child === "HashAggregate")
+    assert(firstRow.childNodeID === "1")
     val lastRow = wholeStageMapping(9)
     assert(lastRow.nodeID === 17)
     assert(lastRow.sqlID === 0)
     assert(lastRow.parent === "WholeStageCodegen (3)")
-    assert(lastRow.child === "SerializeFromObject(19)")
+    assert(lastRow.child === "SerializeFromObject")
+    assert(lastRow.childNodeID === "19")
   }
 
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -658,7 +658,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 13)
+      assert(dotDirs.length === 15)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -685,7 +685,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 9)
+      assert(dotDirs.length === 11)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -715,7 +715,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 13)
+      assert(dotDirs.length === 15)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly
@@ -745,7 +745,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       val dotDirs = ToolTestUtils.listFilesMatching(tempSubDir, { f =>
         f.endsWith(".csv")
       })
-      assert(dotDirs.length === 11)
+      assert(dotDirs.length === 13)
       for (file <- dotDirs) {
         assert(file.getAbsolutePath.endsWith(".csv"))
         // just load each one to make sure formatted properly


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/5515

We add more information to the profiling tool for multiple things:
1) add job start and end times
2) Add the mapping of SQL queries to stage ids. This tables includes the stage duration and the mapping to specific SQL node names(node ids). This will help to quickly see longest stage and see associated nodes and sql query. Note this new table is specifically sorted by the stage time, which is different than all the others..  Note that not all exec nodes have mappings to stage ids so this isn't perfect
3) Add a mapping of the wholestage code gen id to the actual execs contained in it. This is useful for timings and looking a the metrics to see what was included in each of the wholeStage code gen execs
4) Add stage ids to the sql plan metrics table

These features were requested to be able to do some post processing on the profile logs to gather more insight into which execs are taking longest and what types of speedup between cpu and gpu runs.  For this is needs to map wholestagecodegen into the node types and try to determine how much time each node is taking to compare to the gpu nodes.

New tables look like:

```
Job Information:
+--------+-----+---------+-----+-------------+-------------+
|appIndex|jobID|stageIds |sqlID|startTime    |endTime      |
+--------+-----+---------+-----+-------------+-------------+
|1       |0    |[0]      |null |1622846402778|1622846410240|
|1       |1    |[1,2,3,4]|0    |1622846431114|1622846441591|
+--------+-----+---------+-----+-------------+-------------+
```

```
SQL to Stage Information:
+--------+-----+-----+-------+--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|appIndex|sqlID|jobID|stageId|stageAttemptId|Stage Duration|SQL Nodes(IDs)                                                                                                                                                     |
+--------+-----+-----+-------+--------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|1       |0    |1    |1      |0             |8174          |Exchange(9),WholeStageCodegen (1)(10),Scan(13)                                                                                                                     |
|1       |0    |1    |2      |0             |8154          |Exchange(16),WholeStageCodegen (3)(17),Scan(20)
```

```
SQL Plan Metrics for Application:
+--------+-----+------+---------------------+-------------+-------------------------+-----------+----------+--------+
|appIndex|sqlID|nodeID|nodeName             |accumulatorId|name                     |max_value  |metricType|stageIds|
+--------+-----+------+---------------------+-------------+-------------------------+-----------+----------+--------+
|1       |0    |0     |WholeStageCodegen (6)|91           |duration                 |3          |timing    |4       |
|1       |0    |1     |HashAggregate        |92           |number of output rows    |1          |sum       |4       |
|1       |0    |1     |HashAggregate        |95           |time in aggregation build|3          |timing    |4       |

```

```
WholeStageCodeGen Mapping:
+--------+-----+------+---------------------+-------------------+------------+
|appIndex|sqlID|nodeID|SQL Node             |Child Node         |Child NodeID|
+--------+-----+------+---------------------+-------------------+------------+
|1       |0    |0     |WholeStageCodegen (6)|HashAggregate      |1           |
|1       |0    |3     |WholeStageCodegen (5)|HashAggregate      |4           |
|1       |0    |3     |WholeStageCodegen (5)|Project            |5           |
|1       |0    |3     |WholeStageCodegen (5)|SortMergeJoin      |6           |
|1       |0    |7     |WholeStageCodegen (2)|Sort               |8           |
```
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
