### PR TITLE
Qualification ui output goes to wrong folder

### DIFF
--- a/docs/spark-qualification-tool.md
+++ b/docs/spark-qualification-tool.md
@@ -472,8 +472,8 @@ The HTML report is disabled by passing `--no-html-report` as described in the
 [Qualification tool options](#Qualification-tool-options) section above.  
 To browse the content of the html report:
 
-1. For HDFS or remote node, copy the directory of `${OUTPUT_FOLDER}/ui` to your local node.
-2. Open `ui/index.html` in your local machine's web-browser (Chrome/Firefox are recommended).
+1. For HDFS or remote node, copy the directory of `${OUTPUT_FOLDER}/rapids_4_spark_qualification_output/ui` to your local node.
+2. Open `rapids_4_spark_qualification_output/ui/index.html` in your local machine's web-browser (Chrome/Firefox are recommended).
 
 The HTML view renders the detailed information into tables that allow following features:
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -76,7 +76,7 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
     qWriter.writeExecReport(allAppsSum, order)
     qWriter.writeStageReport(allAppsSum, order)
     if (uiEnabled) {
-      QualificationReportGenerator.generateDashBoard(outputDir, allAppsSum)
+      QualificationReportGenerator.generateDashBoard(getReportOutputPath, allAppsSum)
     }
     sortedDetailed
   }


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #5838

Generate HtmlReport as a subfolder of `rapids_4_spark_qualification_output`

The output folder structure becomes:

```
$OUTPUT_FOLDER/rapids_4_spark_qualification_output/
                                            |
                                            |--> rapids_4_spark_qualification_output.log
                                            |--> rapids_4_spark_qualification_output_execs.csv
                                            |--> rapids_4_spark_qualification_output_stages.csv
                                            |--> rapids_4_spark_qualification_output.csv
                                            |--> ui
                                                    |
                                                    |--> js
                                                            |
                                                            |--> uiutils.js
                                                            |--> ui-config.js
                                                            |--> raw-report.js
                                                            |--> qual-report.js
                                                            |--> data-output.js
                                                            |--> app-report.js
                                                    |--> html
                                                            |
                                                            |--> raw.html
                                                            |--> index.html
                                                            |--> application.html
                                                    |--> css
                                                            |
                                                            |--> rapids-dashboard.css
                                                    |--> assets
                                                            |
                                                            |--> spur
                                                            |--> mustache-js
                                                            |--> jquery
                                                            |--> datatables
                                                            |--> bootstrapuiutils.js

```

Changes:

- change the argument passed to generate HTML dashboard in Qualification.scala
- update the doc 
