### PR TITLE
Avoid serializing plan in GpuCoalesceBatches, GpuHashAggregateExec, and GpuTopN

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -705,6 +705,7 @@ case class GpuCoalesceBatches(child: SparkPlan, goal: CoalesceGoal)
     val decompressMemoryTarget = maxDecompressBatchMemory
 
     val batches = child.executeColumnar()
+    val localCodecConfigs = codecConfigs
     if (outputSchema.isEmpty) {
       batches.mapPartitions { iter =>
         val numRows = iter.map(_.numRows).sum
@@ -720,7 +721,7 @@ case class GpuCoalesceBatches(child: SparkPlan, goal: CoalesceGoal)
               iter, dataTypes, sizeGoal, decompressMemoryTarget,
               numInputRows, numInputBatches, numOutputRows, numOutputBatches, NoopMetric,
               concatTime, opTime, peakDevMemory, callback, "GpuCoalesceBatches",
-              codecConfigs)
+              localCodecConfigs)
           }
         case batchingGoal: BatchedByKey =>
           val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -1438,25 +1438,27 @@ case class GpuHashAggregateExec(
       makeSpillCallback(allMetrics))
 
     // cache in a local variable to avoid serializing the full child plan
+    val inputAttrs = inputAttributes
     val groupingExprs = groupingExpressions
     val aggregateExprs = aggregateExpressions
     val aggregateAttrs = aggregateAttributes
     val resultExprs = resultExpressions
     val modeInfo = AggregateModeInfo(uniqueModes)
+    val targetBatchSize = configuredTargetBatchSize
 
     val rdd = child.executeColumnar()
 
     rdd.mapPartitions { cbIter =>
       new GpuHashAggregateIterator(
         cbIter,
-        inputAttributes,
+        inputAttrs,
         groupingExprs,
         aggregateExprs,
         aggregateAttrs,
         resultExprs,
         modeInfo,
         aggMetrics,
-        configuredTargetBatchSize)
+        targetBatchSize)
     }
   }
 


### PR DESCRIPTION
This fixes issues with the RDD closures in GpuCoalesceBatches, GpuHashAggregateExec, and GpuTopN to avoid serializing the plan object and all child nodes.  References to member variables were converted into local variables to sever the dependency between the closure and exec node object.