### PR TITLE
GpuBatchScanExec partitions should be marked transient

### DIFF
--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -30,7 +30,7 @@ case class GpuBatchScanExec(
     @transient scan: Scan) extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
   @transient lazy val batch: Batch = scan.toBatch
 
-  override lazy val partitions: Seq[InputPartition] = batch.planInputPartitions()
+  @transient override lazy val partitions: Seq[InputPartition] = batch.planInputPartitions()
 
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 


### PR DESCRIPTION
[SPARK-32168](https://issues.apache.org/jira/browse/SPARK-32168) marked the `partitions` member as `@transient`, but this change was not ported to the Spark 3.1.x version of `GpuBatchScanExec`.  This can cause a significant increase in serialized task binary size when the query plan is inadvertently serialized when the partition objects are relatively large, as is the case with Apache Iceberg partitions.