### PR TITLE
Enable testing parquet with zstd for spark releases 3.2.0 and later

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -145,6 +145,9 @@ def test_parquet_read_round_trip_binary_as_string(std_input_path, read_func, rea
             conf=all_confs)
 
 parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
+# zstd is available in spark 3.2.0 and later.
+if not is_before_spark_320():
+    parquet_compress_options.append('zstd')
 # The following need extra jars 'lzo', 'lz4', 'brotli', 'zstd'
 # https://github.com/NVIDIA/spark-rapids/issues/143
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Closes [#5580](https://github.com/NVIDIA/spark-rapids/issues/5580)

Spark releases starting with 3.2.0 include support for zstd compression without requiring any additional jars/libs.  Now that we have zstd decompression support in cuDF, we should add zstd to the list of compressors to use in `test_parquet_compress_read_round_trip`.
