### PR TITLE
Fall back to CPU for Delta Lake metadata queries [databricks]

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -71,6 +71,7 @@ Name | Description | Default Value
 <a name="sql.csv.read.double.enabled"></a>spark.rapids.sql.csv.read.double.enabled|CSV reading is not 100% compatible when reading doubles.|false
 <a name="sql.csv.read.float.enabled"></a>spark.rapids.sql.csv.read.float.enabled|CSV reading is not 100% compatible when reading floats.|true
 <a name="sql.decimalOverflowGuarantees"></a>spark.rapids.sql.decimalOverflowGuarantees|FOR TESTING ONLY. DO NOT USE IN PRODUCTION. Please see the decimal section of the compatibility documents for more information on this config.|true
+<a name="sql.detectDeltaLogQueries"></a>spark.rapids.sql.detectDeltaLogQueries|Queries against Delta Lake _delta_log JSON files are not efficient on the GPU. When this option is enabled, the plugin will attempt to detect these queries and fall back to the CPU.|true
 <a name="sql.enabled"></a>spark.rapids.sql.enabled|Enable (true) or disable (false) sql operations on the GPU|true
 <a name="sql.explain"></a>spark.rapids.sql.explain|Explain why some parts of a query were not placed on a GPU or not. Possible values are ALL: print everything, NONE: print nothing, NOT_ON_GPU: print only parts of a query that did not go on the GPU|NONE
 <a name="sql.fast.sample"></a>spark.rapids.sql.fast.sample|Option to turn on fast sample. If enable it is inconsistent with CPU sample because of GPU sample algorithm is inconsistent with CPU.|false

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -45,3 +45,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--iceberg", action="store_true", default=False, help="if true enable Iceberg tests"
     )
+    parser.addoption(
+        "--delta_lake", action="store_true", default=False, help="if true enable Delta Lake tests"
+    )

--- a/integration_tests/src/main/python/delta_lake_test.py
+++ b/integration_tests/src/main/python/delta_lake_test.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from asserts import assert_gpu_fallback_collect
+from marks import allow_non_gpu, delta_lake
+from spark_session import with_cpu_session
+
+_conf = {'spark.rapids.sql.explain': 'ALL'}
+
+@delta_lake
+@allow_non_gpu('FileSourceScanExec')
+def test_delta_metadata_query_fallback(spark_tmp_table_factory):
+    table = spark_tmp_table_factory.get()
+    def setup_delta_table(spark):
+        df = spark.createDataFrame([(1, 'a'), (2, 'b'), (3, 'c')], ["id", "data"])
+        df.write.format("delta").save("/tmp/delta-table/{}".format(table))
+    with_cpu_session(setup_delta_table)
+    # note that this is just testing that any reads against a delta log json file fall back to CPU and does
+    # not test the actual metadata queries that the delta lake plugin generates
+    assert_gpu_fallback_collect(
+        lambda spark : spark.read.json("/tmp/delta-table/{}/_delta_log/00000000000000000000.json".format(table)),
+        "FileSourceScanExec", conf = _conf)

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -28,3 +28,4 @@ nightly_gpu_mem_consuming_case = pytest.mark.nightly_gpu_mem_consuming_case
 nightly_host_mem_consuming_case = pytest.mark.nightly_host_mem_consuming_case
 fuzz_test = pytest.mark.fuzz_test
 iceberg = pytest.mark.iceberg
+delta_lake = pytest.mark.delta_lake

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -138,4 +138,10 @@ else
         SPARK_SUBMIT_FLAGS="$SPARK_CONF $ICEBERG_CONFS" TEST_PARALLEL=1 \
             bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m iceberg --iceberg --test_type=$TEST_TYPE
     fi
+
+    if [[ "$TEST_MODE" == "ALL" || "$TEST_MODE" == "DELTA_LAKE_ONLY" ]]; then
+        ## Run Delta Lake tests
+        SPARK_SUBMIT_FLAGS="$SPARK_CONF $ICEBERG_CONFS" TEST_PARALLEL=1 \
+            bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "delta_lake" --delta_lake --test_type=$TEST_TYPE
+    fi
 fi

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -84,6 +84,8 @@ ICEBERG_CONFS="--packages org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPA
  --conf spark.sql.catalog.spark_catalog.type=hadoop \
  --conf spark.sql.catalog.spark_catalog.warehouse=/tmp/spark-warehouse-$$"
 
+DELTA_LAKE_CONFS=""
+
 # Enable event log for qualification & profiling tools testing
 export PYSP_TEST_spark_eventLog_enabled=true
 mkdir -p /tmp/spark-events
@@ -141,7 +143,7 @@ else
 
     if [[ "$TEST_MODE" == "ALL" || "$TEST_MODE" == "DELTA_LAKE_ONLY" ]]; then
         ## Run Delta Lake tests
-        SPARK_SUBMIT_FLAGS="$SPARK_CONF" TEST_PARALLEL=1 \
+        SPARK_SUBMIT_FLAGS="$SPARK_CONF $DELTA_LAKE_CONFS" TEST_PARALLEL=1 \
             bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "delta_lake" --delta_lake --test_type=$TEST_TYPE
     fi
 fi

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -141,7 +141,7 @@ else
 
     if [[ "$TEST_MODE" == "ALL" || "$TEST_MODE" == "DELTA_LAKE_ONLY" ]]; then
         ## Run Delta Lake tests
-        SPARK_SUBMIT_FLAGS="$SPARK_CONF $ICEBERG_CONFS" TEST_PARALLEL=1 \
+        SPARK_SUBMIT_FLAGS="$SPARK_CONF" TEST_PARALLEL=1 \
             bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "delta_lake" --delta_lake --test_type=$TEST_TYPE
     fi
 fi

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4272,7 +4272,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         rdd.inputRDD != null &&
           rdd.inputRDD.name != null &&
           rdd.inputRDD.name.startsWith("Delta Table State") &&
-          rdd.inputRDD.name.endsWith("/_delta_log") &&
+          rdd.inputRDD.name.endsWith("/_delta_log")
       case _ =>
         false
     })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4267,7 +4267,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         f.relation.inputFiles.exists(_.contains("_delta_log"))
       case rdd: RDDScanExec =>
         // TODO check FilePartition paths instead of checking the name?
-        rdd.inputRDD.name.contains("Delta Table State")
+        rdd.inputRDD != null && rdd.inputRDD.name != null &&
+          rdd.inputRDD.name.contains("Delta Table State")
       case _ =>
         false
     })

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1440,6 +1440,13 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(value = false)
 
+  val DETECT_DELTA_LOG_QUERIES = conf("spark.rapids.sql.detectDeltaLogQueries")
+    .doc("Queries against Delta Lake _delta_log JSON files are not efficient on the GPU. When " +
+      "this option is enabled, the plugin will attempt to detect these queries and fall back " +
+      "to the CPU.")
+    .booleanConf
+    .createWithDefault(value = true)
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -1926,6 +1933,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isCpuBasedUDFEnabled: Boolean = get(ENABLE_CPU_BASED_UDF)
 
   lazy val isFastSampleEnabled: Boolean = get(ENABLE_FAST_SAMPLE)
+
+  lazy val isDetectDeltaLogQueries: Boolean = get(DETECT_DELTA_LOG_QUERIES)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/5624

This PR adds a very specific "is this a Delta Lake metadata query?" check and then falls back to CPU in this case.

The integration test currently only runs on Databricks. I filed https://github.com/NVIDIA/spark-rapids/issues/5966 to expand Delta Lake testing to other Spark versions.