### PR TITLE
Update gcp cluster init option [skip ci]

### DIFF
--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -281,7 +281,7 @@ python generate_custom_image.py \
     --machine-type n1-standard-4 \
     --accelerator type=$GPU_NAME,count=$GPU_COUNT \
     --disk-size 200 \
-    --subnetwork default 
+    --subnet default 
 ```
 
 See [here](https://cloud.google.com/dataproc/docs/guides/dataproc-images#running_the_code) for more
@@ -313,7 +313,7 @@ gcloud dataproc clusters create $CLUSTER_NAME  \
     --metadata=rapids-runtime=SPARK \
     --bucket=$GCS_BUCKET \
     --enable-component-gateway \
-    --subnetwork=default 
+    --subnet=default 
 ```
 
 The new cluster should be up and running within 3-4 minutes!


### PR DESCRIPTION
Signed-off-by: Sameer Raheja <sraheja@nvidia.com>

Updating the GCP cluster init option from `subnetwork` to `subnet` per https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/network#create_a_cluster_with_internal_ip_addresses_only