### PR TITLE
Make the error message of changing decimal type the same as Spark's [databricks]

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -450,7 +450,8 @@ def test_ceil_scale_zero(data_gen):
 
 @pytest.mark.parametrize('data_gen', [_decimal_gen_36_neg5, _decimal_gen_38_neg10], ids=idfn)
 def test_floor_ceil_overflow(data_gen):
-    exception_type = "java.lang.ArithmeticException" if is_before_spark_330() else "SparkArithmeticException"
+    exception_type = "java.lang.ArithmeticException" if is_before_spark_330() and not is_databricks104_or_later() \
+        else "SparkArithmeticException"
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('floor(a)').collect(),
         conf={},

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import exception
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql
@@ -449,14 +450,15 @@ def test_ceil_scale_zero(data_gen):
 
 @pytest.mark.parametrize('data_gen', [_decimal_gen_36_neg5, _decimal_gen_38_neg10], ids=idfn)
 def test_floor_ceil_overflow(data_gen):
+    exception_type = "java.lang.ArithmeticException" if is_before_spark_330() else "SparkArithmeticException"
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('floor(a)').collect(),
         conf={},
-        error_message="ArithmeticException")
+        error_message=exception_type)
     assert_gpu_and_cpu_error(
         lambda spark: unary_op_df(spark, data_gen).selectExpr('ceil(a)').collect(),
         conf={},
-        error_message="ArithmeticException")
+        error_message=exception_type)
 
 @pytest.mark.parametrize('data_gen', double_gens, ids=idfn)
 def test_rint(data_gen):

--- a/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.types.DataType
+import ai.rapids.cudf.{ColumnVector}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
 
-object RapidsErrorUtils {
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.types.{DataType, DecimalType}
+
+object RapidsErrorUtils extends Arm {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     // Follow the Spark string format before 3.3.0
@@ -51,5 +54,33 @@ object RapidsErrorUtils {
       hint: String = "",
       errorContext: String = ""): ArithmeticException = {
     new ArithmeticException(message)
+  }
+
+  /**
+   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
+   *
+   * @param values A decimal column which contains values that try to cast.
+   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
+   * Users must make sure that there is at least one `true` in this column.
+   * @param fromType The current decimal type.
+   * @param toType The type to cast.
+   * @param context The error context, default value is "".
+   */
+  def cannotChangeDecimalPrecisionError(      
+      values: GpuColumnVector,
+      outOfBounds: ColumnVector,
+      fromType: DecimalType,
+      toType: DecimalType,
+      context: String = ""): ArithmeticException = {
+    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
+      (0.toLong until outOfBounds.getRowCount())
+        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+        .get
+    }
+    val value = withResource(values.copyToHost()){hcv =>  
+      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
+    }
+    new ArithmeticException(s"${value.toDebugString} cannot be represented as " +
+      s"Decimal(${toType.precision}, ${toType.scale}).")
   }
 }

--- a/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.types.DataType
+import ai.rapids.cudf.{ColumnVector}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
 
-object RapidsErrorUtils {
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.types.{DataType, DecimalType}
+
+object RapidsErrorUtils extends Arm {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     // Follow the Spark string format before 3.3.0
@@ -51,5 +54,33 @@ object RapidsErrorUtils {
       hint: String = "",
       errorContext: String = ""): ArithmeticException = {
     new ArithmeticException(message)
+  }
+
+  /**
+   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
+   *
+   * @param values A decimal column which contains values that try to cast.
+   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
+   * Users must make sure that there is at least one `true` in this column.
+   * @param fromType The current decimal type.
+   * @param toType The type to cast.
+   * @param context The error context, default value is "".
+   */
+  def cannotChangeDecimalPrecisionError(      
+      values: GpuColumnVector,
+      outOfBounds: ColumnVector,
+      fromType: DecimalType,
+      toType: DecimalType,
+      context: String = ""): ArithmeticException = {
+    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
+      (0.toLong until outOfBounds.getRowCount())
+        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+        .get
+    }
+    val value = withResource(values.copyToHost()){hcv =>  
+      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
+    }
+    new ArithmeticException(s"${value.toDebugString} cannot be represented as " +
+      s"Decimal(${toType.precision}, ${toType.scale}).")
   }
 }

--- a/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,14 +16,11 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
-
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{DataType, DecimalType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
-object RapidsErrorUtils extends Arm{
+object RapidsErrorUtils {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     // Follow the Spark string format before 3.3.0
@@ -57,30 +54,10 @@ object RapidsErrorUtils extends Arm{
     new ArithmeticException(message)
   }
 
-  /**
-   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
-   *
-   * @param values A decimal column which contains values that try to cast.
-   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
-   * Users must make sure that there is at least one `true` in this column.
-   * @param fromType The current decimal type.
-   * @param toType The type to cast.
-   * @param context The error context, default value is "".
-   */
   def cannotChangeDecimalPrecisionError(      
-      values: GpuColumnVector,
-      outOfBounds: ColumnVector,
-      fromType: DecimalType,
+      value: Decimal,
       toType: DecimalType,
       context: String = ""): ArithmeticException = {
-    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
-      (0.toLong until outOfBounds.getRowCount())
-        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
-        .get
-    }
-    val value = withResource(values.copyToHost()){hcv =>  
-      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
-    }
     QueryExecutionErrors.cannotChangeDecimalPrecisionError(
       value, toType.precision, toType.scale
     )

--- a/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,11 +16,14 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import ai.rapids.cudf.{ColumnVector}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
+
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, DecimalType}
 
-object RapidsErrorUtils {
+object RapidsErrorUtils extends Arm{
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     // Follow the Spark string format before 3.3.0
@@ -52,6 +55,35 @@ object RapidsErrorUtils {
       hint: String = "",
       errorContext: String = ""): ArithmeticException = {
     new ArithmeticException(message)
+  }
+
+  /**
+   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
+   *
+   * @param values A decimal column which contains values that try to cast.
+   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
+   * Users must make sure that there is at least one `true` in this column.
+   * @param fromType The current decimal type.
+   * @param toType The type to cast.
+   * @param context The error context, default value is "".
+   */
+  def cannotChangeDecimalPrecisionError(      
+      values: GpuColumnVector,
+      outOfBounds: ColumnVector,
+      fromType: DecimalType,
+      toType: DecimalType,
+      context: String = ""): ArithmeticException = {
+    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
+      (0.toLong until outOfBounds.getRowCount())
+        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+        .get
+    }
+    val value = withResource(values.copyToHost()){hcv =>  
+      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
+    }
+    QueryExecutionErrors.cannotChangeDecimalPrecisionError(
+      value, toType.precision, toType.scale
+    )
   }
 }
 

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,14 +16,11 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
-
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{DataType, DecimalType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
-object RapidsErrorUtils extends Arm {
+object RapidsErrorUtils extends {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     if (isElementAtF) {
@@ -60,30 +57,10 @@ object RapidsErrorUtils extends Arm {
     new ArithmeticException(message)
   }
 
-  /**
-   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
-   *
-   * @param values A decimal column which contains values that try to cast.
-   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
-   * Users must make sure that there is at least one `true` in this column.
-   * @param fromType The current decimal type.
-   * @param toType The type to cast.
-   * @param context The error context, default value is "".
-   */
   def cannotChangeDecimalPrecisionError(      
-      values: GpuColumnVector,
-      outOfBounds: ColumnVector,
-      fromType: DecimalType,
+      value: Decimal,
       toType: DecimalType,
       context: String = ""): ArithmeticException = {
-    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
-      (0.toLong until outOfBounds.getRowCount())
-        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
-        .get
-    }
-    val value = withResource(values.copyToHost()){hcv =>  
-      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
-    }
     QueryExecutionErrors.cannotChangeDecimalPrecisionError(
       value, toType.precision, toType.scale
     )

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
-object RapidsErrorUtils extends {
+object RapidsErrorUtils {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     if (isElementAtF) {

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,11 +16,14 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import ai.rapids.cudf.{ColumnVector}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
+
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, DecimalType}
 
-object RapidsErrorUtils {
+object RapidsErrorUtils extends Arm {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     if (isElementAtF) {
@@ -55,5 +58,34 @@ object RapidsErrorUtils {
       hint: String = "",
       errorContext: String = ""): ArithmeticException = {
     new ArithmeticException(message)
+  }
+
+  /**
+   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
+   *
+   * @param values A decimal column which contains values that try to cast.
+   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
+   * Users must make sure that there is at least one `true` in this column.
+   * @param fromType The current decimal type.
+   * @param toType The type to cast.
+   * @param context The error context, default value is "".
+   */
+  def cannotChangeDecimalPrecisionError(      
+      values: GpuColumnVector,
+      outOfBounds: ColumnVector,
+      fromType: DecimalType,
+      toType: DecimalType,
+      context: String = ""): ArithmeticException = {
+    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
+      (0.toLong until outOfBounds.getRowCount())
+        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+        .get
+    }
+    val value = withResource(values.copyToHost()){hcv =>  
+      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
+    }
+    QueryExecutionErrors.cannotChangeDecimalPrecisionError(
+      value, toType.precision, toType.scale
+    )
   }
 }

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,14 +16,11 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
-
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{DataType, DecimalType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
-object RapidsErrorUtils extends Arm {
+object RapidsErrorUtils {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     if (isElementAtF) {
@@ -59,30 +56,10 @@ object RapidsErrorUtils extends Arm {
     QueryExecutionErrors.arithmeticOverflowError(message, hint, errorContext)
   }
 
-  /**
-   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
-   *
-   * @param values A decimal column which contains values that try to cast.
-   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
-   * Users must make sure that there is at least one `true` in this column.
-   * @param fromType The current decimal type.
-   * @param toType The type to cast.
-   * @param context The error context, default value is "".
-   */
   def cannotChangeDecimalPrecisionError(      
-      values: GpuColumnVector,
-      outOfBounds: ColumnVector,
-      fromType: DecimalType,
+      value: Decimal,
       toType: DecimalType,
       context: String = ""): ArithmeticException = {
-    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
-      (0.toLong until outOfBounds.getRowCount())
-        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
-        .get
-    }
-    val value = withResource(values.copyToHost()){hcv =>  
-      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
-    }
     QueryExecutionErrors.cannotChangeDecimalPrecisionError(
       value, toType.precision, toType.scale, context
     )

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,11 +16,14 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import ai.rapids.cudf.{ColumnVector}
+import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
+
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, DecimalType}
 
-object RapidsErrorUtils {
+object RapidsErrorUtils extends Arm {
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {
     if (isElementAtF) {
@@ -54,5 +57,34 @@ object RapidsErrorUtils {
       hint: String = "",
       errorContext: String = ""): ArithmeticException = {
     QueryExecutionErrors.arithmeticOverflowError(message, hint, errorContext)
+  }
+
+  /**
+   * Wrapper of the `cannotChangeDecimalPrecisionError` in Spark.
+   *
+   * @param values A decimal column which contains values that try to cast.
+   * @param outOfBounds A boolean column that indicates which value cannot be casted. 
+   * Users must make sure that there is at least one `true` in this column.
+   * @param fromType The current decimal type.
+   * @param toType The type to cast.
+   * @param context The error context, default value is "".
+   */
+  def cannotChangeDecimalPrecisionError(      
+      values: GpuColumnVector,
+      outOfBounds: ColumnVector,
+      fromType: DecimalType,
+      toType: DecimalType,
+      context: String = ""): ArithmeticException = {
+    val row_id = withResource(outOfBounds.copyToHost()) {hcv =>
+      (0.toLong until outOfBounds.getRowCount())
+        .find(i => !hcv.isNull(i) && hcv.getBoolean(i))
+        .get
+    }
+    val value = withResource(values.copyToHost()){hcv =>  
+      hcv.getDecimal(row_id.toInt, fromType.precision, fromType.scale)
+    }
+    QueryExecutionErrors.cannotChangeDecimalPrecisionError(
+      value, toType.precision, toType.scale, context
+    )
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -23,6 +23,7 @@ import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
+import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 
 abstract class CudfUnaryMathExpression(name: String) extends GpuUnaryMathExpression(name)
@@ -198,7 +199,9 @@ case class GpuCeil(child: Expression, outputType: DataType)
           withResource(DecimalUtil.outOfBounds(input.getBase, outputType)) { outOfBounds =>
             withResource(outOfBounds.any()) { isAny =>
               if (isAny.isValid && isAny.getBoolean) {
-                throw new ArithmeticException(s"Some data cannot be represented as $outputType")
+                throw RapidsErrorUtils.cannotChangeDecimalPrecisionError(
+                  input, outOfBounds, dt, outputType
+                )
               }
             }
           }
@@ -272,7 +275,9 @@ case class GpuFloor(child: Expression, outputType: DataType)
           withResource(DecimalUtil.outOfBounds(input.getBase, outputType)) { outOfBounds =>
             withResource(outOfBounds.any()) { isAny =>
               if (isAny.isValid && isAny.getBoolean) {
-                throw new ArithmeticException(s"Some data cannot be represented as $outputType")
+                throw RapidsErrorUtils.cannotChangeDecimalPrecisionError(
+                  input, outOfBounds, dt, outputType
+                )
               }
             }
           }


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Related to #5196.

## Rationale for this change
We want to throw the same error message as Spark.

## Changes in this PR.
1. Make the error message of changing decimal type be consistent with Spark's. 
- I add some extra compution in `cannotChangeDecimalPrecisionError` to find which value causes the error, so that we could throw the same error message as Spark.
3. Update `update_test_floor_ceil_overflow` to check the error message more precisely.
- So far I only check the exception type (`java.lang.ArithmeticException` before Spark 3.3.0 and `SparkArithmeticException` after 330). The content of error message is not checked because I don't find a good way to get the value of `data_gen`
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

4. Please ensure that you have written units tests for the changes made/features
   added.

5. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

6. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

7. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

8. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
