### PR TITLE
Revert "Enable testing zstd for spark releases 3.2.0 and later (#5898)"

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -145,9 +145,6 @@ def test_parquet_read_round_trip_binary_as_string(std_input_path, read_func, rea
             conf=all_confs)
 
 parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
-# zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320():
-    parquet_compress_options.append('zstd')
 # The following need extra jars 'lzo', 'lz4', 'brotli', 'zstd'
 # https://github.com/NVIDIA/spark-rapids/issues/143
 


### PR DESCRIPTION
This reverts commit 321f9b98a72ba3465f8d72c42c62ee9c1fd25d10.

Signed-off-by: Jim Brennan <jimb@nvidia.com>

I jumped the gun on putting in #5898.  It currently requires setting an environment variable to work.
LIBCUDF_NVCOMP_POLICY=ALWAYS.  I don't think it is appropriate to set this in the unit tests, because it could cause the use of experimental releases in the future.

I am reverting this now and will bring it back once ZSTD is available with the default of LIBCUDF_NVCOMP_POLICY=STABLE.
