### PR TITLE
Filter profiling tool based on start time. 

### DIFF
--- a/docs/spark-profiling-tool.md
+++ b/docs/spark-profiling-tool.md
@@ -528,11 +528,13 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
                                   applications). Default is false.
       --csv                       Output each table to a CSV file as well
                                   creating the summary text file.
-  -f, --filter-criteria  <arg>    Filter newest or oldest N eventlogs for
-                                  processing.eg: 100-newest-filesystem (for
-                                  processing newest 100 event logs). eg:
-                                  100-oldest-filesystem (for processing oldest
-                                  100 event logs)
+  -f, --filter-criteria  <arg>    Filter newest or oldest N eventlogs based on
+                                  application start timestamp for processing.
+                                  Filesystem based filtering happens before
+                                  application based filtering (see start-app-time).
+                                  eg: 100-newest-filesystem (for processing newest
+                                  100 event logs). eg: 100-oldest-filesystem (for
+                                  processing oldest 100 event logs).
   -g, --generate-dot              Generate query visualizations in DOT format.
                                   Default is false
       --generate-timeline         Write an SVG graph out for the full
@@ -553,6 +555,12 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   -p, --print-plans               Print the SQL plans to a file named
                                   'planDescriptions.log'.
                                   Default is false.
+  -s, --start-app-time  <arg>     Filter event logs whose application start
+                                  occurred within the past specified time
+                                  period. Valid time periods are
+                                  min(minute),h(hours),d(days),w(weeks),m(months).
+                                  If a period is not specified it defaults to
+                                  days.
   -t, --timeout  <arg>            Maximum time in seconds to wait for the event
                                   logs to be processed. Default is 24 hours
                                   (86400 seconds) and must be greater than 3

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -15,9 +15,9 @@
  */
 package com.nvidia.spark.rapids.tool.profiling
 
-import org.apache.spark.sql.rapids.tool.AppFilterImpl
-
 import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+import org.apache.spark.sql.rapids.tool.AppFilterImpl
 
 class ProfileArgs(arguments: Seq[String]) extends ScallopConf(arguments) {
 

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppFilterImpl.scala
@@ -27,10 +27,9 @@ import com.nvidia.spark.rapids.tool.EventLogInfo
 import com.nvidia.spark.rapids.tool.profiling.ProfileArgs
 import com.nvidia.spark.rapids.tool.qualification.QualificationArgs
 import org.apache.hadoop.conf.Configuration
+import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 import org.apache.spark.internal.Logging
-
-import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 class AppFilterImpl(
     numRows: Int,
@@ -93,7 +92,6 @@ class AppFilterImpl(
     } else {
       apps
     }
-
     appTimeFiltered.map(_.eventlog)
   }
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AppFilterSuite.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.profiling
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.Calendar
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.rapids.tool.AppFilterImpl
+
+class AppFilterSuite extends FunSuite {
+
+  test("illegal args") {
+    assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("0"))
+    assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("1hd"))
+    assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("1yr"))
+    assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("-1d"))
+    assertThrows[IllegalArgumentException](AppFilterImpl.parseAppTimePeriod("0m"))
+  }
+
+  test("time period minute parsing") {
+    testTimePeriod(msMinAgo(6), "10min")
+  }
+
+  test("time period hour parsing") {
+    testTimePeriod(msHoursAgo(10), "14h")
+  }
+
+  test("time period day parsing") {
+    testTimePeriod(msDaysAgo(40), "41d")
+  }
+
+  test("time period day parsing default") {
+    testTimePeriod(msDaysAgo(5), "6")
+  }
+
+  test("time period week parsing") {
+    testTimePeriod(msWeeksAgo(2), "3w")
+  }
+
+  test("time period month parsing") {
+    testTimePeriod(msMonthsAgo(8), "10m")
+  }
+
+  test("time period minute parsing fail") {
+    testTimePeriod(msMinAgo(16), "10min", failFilter=true)
+  }
+
+  test("time period hour parsing fail") {
+    testTimePeriod(msHoursAgo(10), "8h", failFilter=true)
+  }
+
+  test("time period day parsing fail") {
+    testTimePeriod(msDaysAgo(40), "38d", failFilter=true)
+  }
+
+  test("time period week parsing fail") {
+    testTimePeriod(msWeeksAgo(2), "1w", failFilter=true)
+  }
+
+  test("time period month parsing fail") {
+    testTimePeriod(msMonthsAgo(8), "7m", failFilter=true)
+  }
+
+  private def testTimePeriod(eventLogTime: Long, startTimePeriod: String,
+      failFilter: Boolean = false): Unit = {
+    TrampolineUtil.withTempDir { outpath =>
+      TrampolineUtil.withTempDir { tmpEventLogDir =>
+
+        val elogFile = Paths.get(tmpEventLogDir.getAbsolutePath, "testTimeEventLog")
+
+        // scalastyle:off line.size.limit
+        val supText =
+          s"""{"Event":"SparkListenerLogStart","Spark Version":"3.1.1"}
+             |{"Event":"SparkListenerApplicationStart","App Name":"Spark shell","App ID":"local-1626104300434","Timestamp":${eventLogTime},"User":"user1"}""".stripMargin
+        // scalastyle:on line.size.limit
+        Files.write(elogFile, supText.getBytes(StandardCharsets.UTF_8))
+
+        val allArgs = Array(
+          "--output-directory",
+          outpath.getAbsolutePath(),
+          "--start-app-time",
+          startTimePeriod
+        )
+        val appArgs = new ProfileArgs(allArgs ++ Array(elogFile.toString()))
+        val (exit, filteredSize) = ProfileMain.mainInternal(appArgs)
+        assert(exit == 0)
+        if (failFilter) {
+          assert(filteredSize == 0)
+        } else {
+          assert(filteredSize == 1)
+        }
+      }
+    }
+  }
+
+  case class TestEventLogFSAndAppStartInfo(fileName: String, fsTime: Long,
+    appTime: Long, uniqueId: Int)
+
+  private val appsWithFsAndStartTimeToTest = Array(
+    TestEventLogFSAndAppStartInfo("app-ndshours18", msHoursAgo(16),msHoursAgo(18), 1),
+    TestEventLogFSAndAppStartInfo("app-ndsweeks2", msWeeksAgo(2), msWeeksAgo(2), 1),
+    TestEventLogFSAndAppStartInfo("app-nds86-1", msDaysAgo(3), msDaysAgo(4), 1),
+    TestEventLogFSAndAppStartInfo("app-nds86-2", msDaysAgo(13), msWeeksAgo(2), 2))
+
+  test("10-newest-filesystem and 6 days") {
+    testFileSystemTimeAndAppStartTime(appsWithFsAndStartTimeToTest, "10-newest-filesystem",
+      "6d", 2)
+  }
+
+  test("2-oldest-filesystem no match from app start") {
+    testFileSystemTimeAndAppStartTime(appsWithFsAndStartTimeToTest, "2-oldest-filesystem",
+      "6d", 0)
+  }
+
+  test("2-oldest-filesystem") {
+    testFileSystemTimeAndAppStartTime(appsWithFsAndStartTimeToTest, "2-oldest-filesystem",
+      "3w", 2)
+  }
+
+  test("10-oldest-filesystem and 3w") {
+    testFileSystemTimeAndAppStartTime(appsWithFsAndStartTimeToTest, "10-oldest-filesystem",
+      "3w", 4)
+  }
+
+  private def testFileSystemTimeAndAppStartTime(apps: Array[TestEventLogFSAndAppStartInfo],
+      filterCriteria: String, startTimePeriod: String,
+      expectedFilterSize: Int): Unit = {
+    TrampolineUtil.withTempDir { outpath =>
+      TrampolineUtil.withTempDir { tmpEventLogDir =>
+
+        val fileNames = apps.map { app =>
+          val elogFile = Paths.get(tmpEventLogDir.getAbsolutePath, app.fileName)
+          // scalastyle:off line.size.limit
+          val supText =
+            s"""{"Event":"SparkListenerLogStart","Spark Version":"3.1.1"}
+               |{"Event":"SparkListenerApplicationStart","App Name":"Spark-shell","App ID":"local-16261043003${app.uniqueId}","Timestamp":${app.appTime},"User":"user1"}""".stripMargin
+          // scalastyle:on line.size.limit
+          Files.write(elogFile, supText.getBytes(StandardCharsets.UTF_8))
+          new File(elogFile.toString).setLastModified(app.fsTime)
+          elogFile.toString
+        }
+
+        val allArgs = Array(
+          "--output-directory",
+          outpath.getAbsolutePath(),
+          "--filter-criteria",
+          filterCriteria,
+          "--start-app-time",
+          startTimePeriod
+        )
+        val appArgs = new ProfileArgs(allArgs ++ fileNames)
+        val (exit, filteredSize) = ProfileMain.mainInternal(appArgs)
+        assert(exit == 0)
+        assert(filteredSize == expectedFilterSize)
+      }
+    }
+  }
+
+  private def msMonthsAgo(months: Int): Long = {
+    val c = Calendar.getInstance
+    c.add(Calendar.MONTH, -months)
+    c.getTimeInMillis
+  }
+
+  private def msWeeksAgo(weeks: Int): Long = {
+    val c = Calendar.getInstance
+    c.add(Calendar.WEEK_OF_YEAR, -weeks)
+    c.getTimeInMillis
+  }
+
+  private def msDaysAgo(days: Int): Long = {
+    val c = Calendar.getInstance
+    c.add(Calendar.DATE, -days)
+    c.getTimeInMillis
+  }
+
+  private def msMinAgo(mins: Int): Long = {
+    val c = Calendar.getInstance
+    c.add(Calendar.MINUTE, -mins)
+    c.getTimeInMillis
+  }
+
+  private def msHoursAgo(hours: Int): Long = {
+    val c = Calendar.getInstance
+    c.add(Calendar.HOUR, -hours)
+    c.getTimeInMillis
+  }
+}

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -142,7 +142,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         "--output-directory",
         tempDir.getAbsolutePath,
         eventLog))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
     }
   }
@@ -167,7 +167,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         "--output-directory",
         tempDir.getAbsolutePath,
         eventLog))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
     }
   }
@@ -711,7 +711,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         "--output-directory",
         tempDir.getAbsolutePath,
         eventLog))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
       val tempSubDir = new File(tempDir, s"${Profiler.SUBDIR}/application_1603128018386_7846")
 
@@ -738,7 +738,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         "--output-directory",
         tempDir.getAbsolutePath,
         eventLog))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
       val tempSubDir = new File(tempDir, s"${Profiler.SUBDIR}/local-1651188809790")
 
@@ -768,7 +768,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         tempDir.getAbsolutePath,
         eventLog1,
         eventLog2))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
       val tempSubDir = new File(tempDir, s"${Profiler.SUBDIR}/compare")
 
@@ -798,7 +798,7 @@ class ApplicationInfoSuite extends FunSuite with Logging {
         tempDir.getAbsolutePath,
         eventLog1,
         eventLog2))
-      val exit = ProfileMain.mainInternal(appArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
       assert(exit == 0)
       val tempSubDir = new File(tempDir, s"${Profiler.SUBDIR}/combined")
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Closes: #4323 

Added an option (`--start-app-time` and `-s`) in Profiling tool to filter event logs using application start time. This is similar to the one used in Qualification tools.


Examples:
1. `--start-app-time 1d <event-logs>`
```
22/06/27 11:38:02 INFO FilterAppInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514904001
22/06/27 11:38:02 INFO FilterAppInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514789396
22/06/27 11:38:03 INFO FilterAppInfo: Total number of events parsed: 6 for file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514789396
22/06/27 11:38:03 INFO FilterAppInfo: Total number of events parsed: 6 for file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514904001
22/06/27 11:38:03 WARN ProfileMain: No event logs to process after checking paths, exiting!
```
2. `--start-app-time 1m <event-logs>`
```
22/06/27 11:46:40 INFO FilterAppInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514789396
22/06/27 11:46:40 INFO FilterAppInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514904001
22/06/27 11:46:41 INFO FilterAppInfo: Total number of events parsed: 6 for file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514904001
22/06/27 11:46:41 INFO FilterAppInfo: Total number of events parsed: 6 for file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514789396
22/06/27 11:46:41 INFO Profiler: Threadpool size is 3
22/06/27 11:46:41 INFO ApplicationInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514904001
22/06/27 11:46:41 INFO ApplicationInfo: Parsing Event Log: file:/Users/psarthi/Desktop/Work/profiling/event-logs/local-1655514789396
```
Signed-off-by : Partho Sarthi [psarthi@nvidia.com](mailto:psarthi@nvidia.com)