### PR TITLE
[WIP] Enable Strings as a supported type for GpuColumnarToRow transitions

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/JCudfUtil.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/JCudfUtil.java
@@ -20,12 +20,10 @@ import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.DecimalType;
-import scala.Tuple2;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.spark.sql.types.DataTypes.*;
@@ -170,12 +168,6 @@ public final class JCudfUtil {
         // all other types are aligned based on the size.
         return rapidsType.getSizeInBytes();
     }
-  }
-
-  public static int[] getPackedSchema(Attribute[] attributes) {
-    Tuple2[] tuples = new Tuple2[attributes.length];
-    int[] result = new int[attributes.length];
-    return result;
   }
 
   /**

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/JCudfUtil.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/JCudfUtil.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nvidia.spark.rapids;
+
+import ai.rapids.cudf.DType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StringType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.spark.sql.types.DataTypes.*;
+
+public final class JCudfUtil {
+  /**
+   * Each JCUDF Row is 64-bit aligned.
+   */
+  public static final int JCUDF_ROW_ALIGNMENT = 8;
+  /**
+   * For Variable length fields, a record of (int offset, int elements) is 32-bit aligned.
+   */
+  public static final int JCUDF_VAR_LENGTH_FIELD_ALIGNMENT = 4;
+  /**
+   * Default alignment for data of variable length size. i.e., Struct data is 64-bit aligned.
+   */
+  public static final int JCUDF_VAR_LENGTH_DATA_DEFAULT_ALIGNMENT = 8;
+  /**
+   * The size of the variable length record.
+   * It has (Int offset, Int length/elements).
+   */
+  public static final int JCUDF_VAR_LENGTH_FIELD_SIZE = 8;
+  /**
+   * An estimate of the String data size in bytes.
+   */
+  public static final int JCUDF_TYPE_STRING_LENGTH_ESTIMATE = 20;
+
+  public static final Set<DataType> fixedLengthDataTypes;
+
+  // Decimal type of precision 8 bytes is also fixed-length.
+  // See {@link #isFixedLength(DataType)}.
+  static {
+    fixedLengthDataTypes = Collections.unmodifiableSet(
+        new HashSet<>(
+            Arrays.asList(
+                ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType,
+                BooleanType, DateType, TimestampType
+            )));
+  }
+
+  public static boolean isFixedLength(DataType dt) {
+    if (dt instanceof DecimalType) {
+      return ((DecimalType) dt).precision() <= Decimal.MAX_LONG_DIGITS();
+    }
+    return fixedLengthDataTypes.contains(dt);
+  }
+
+  /**
+   * Given a spark SQL datatype, it returns the size in bytes.
+   *
+   * @param dt Spark datatype.
+   * @return size in bytes of dt
+   */
+  public static int getSizeForFixedLengthDataType(DataType dt) {
+    if (dt instanceof DecimalType) {
+      int precision = ((DecimalType) dt).precision();
+      if (precision <= Decimal.MAX_INT_DIGITS()) {
+        return 4;
+      }
+    }
+    return dt.defaultSize();
+  }
+
+  /**
+   * A method that represents the order of datatypes.
+   * It is used to order the datatypes in order to generate a packed schema.
+   * The order of all fixed length types is positive, while the variable length data types are
+   * represented by negative values.
+   * For fixed columns, alignment is equivalent to the type size in bytes.
+   * For variable length data types, the order is a function of the equivalent data alignment.
+   * For example, Strings are 1-byte aligned while Structs are 8-byte aligned. Therefore, Struct
+   * columns are aligned first in the JCUDF.
+   * TypeOrder(String) = 1 - 16 = -15
+   * TypeOrder(Struct) = 8 - 16 = -8
+   *
+   * @param dt the type of the data column.
+   * @return the size of the datatype in bytes if dt is a fixed size typ. Otherwise, it returns
+   *         a negative value (dataType_alignment - 16).
+   */
+  public static int getDataTypeOrder(DataType dt) {
+    if (isFixedLength(dt)) {
+      // for fixed sized data, order is equivalent to the type size
+      return getSizeForFixedLengthDataType(dt);
+    }
+    // for variable data types, return negative number to indicate alignment
+    int alignment = JCUDF_VAR_LENGTH_DATA_DEFAULT_ALIGNMENT;
+    if (dt instanceof StringType) {
+      // Strings are 1 byte aligned
+      alignment = 1;
+    }
+//    else if (dt instanceof ArrayType) {
+//      // for Arrays, the alignment depends on the Array type
+//      // array of byte, is 1 byte aligned, array[int] is aligned by 4,
+//      // Array[Long] or Array[Struct] alignment = 8;
+//      // Array[int], alignment = 4;
+//      // Array[byte], alignment = 1;
+//    }
+    // the bigger the alignment the higher the order of the data type.
+    return alignment - 16;
+  }
+
+  /**
+   * Sets the alignment for variable length data types.
+   * This is used to align the data in the variable width section of the JCUDF row.
+   * For fixed-length types, the alignment is equivalent to the type size in bytes.
+   *
+   * @param rapidsType a variable length data type.
+   * @return the alignment in bytes of the RAPIDS type in the variable width JCUDF.
+   */
+  public static int getDataAlignmentForDataType(DType rapidsType) {
+    switch (rapidsType.getTypeId()) {
+      case STRING:
+        // Strings are 1-byte aligned
+        return 1;
+      case LIST:
+        // Data aligned depends on the datatype. return 8 bytes for now.
+      case STRUCT:
+        // Structs are 8-bytes aligned
+        return JCUDF_VAR_LENGTH_DATA_DEFAULT_ALIGNMENT;
+      default:
+        // all other types are aligned based on the size.
+        return rapidsType.getSizeInBytes();
+    }
+  }
+
+  /**
+   * Sets an estimate size in bytes for variable-length data types.
+   * This is used to get a rough estimate of the bytes needed to allocate JCUDF row.
+   *
+   * @param rapidsType a variable length data type.
+   * @return size in bytes of the variable length datatype.
+   */
+  public static int getEstimateSizeForVarLengthTypes(DType rapidsType) {
+    switch (rapidsType.getTypeId()) {
+      case STRING:
+        return JCUDF_TYPE_STRING_LENGTH_ESTIMATE;
+      case LIST:
+      case STRUCT:
+        // Return 32 bytes for other types until we decide on how to handle each type.
+        return 32;
+      default:
+        throw new IllegalArgumentException(rapidsType + " estimated size is not supported yet.");
+    }
+  }
+
+  /**
+   * Checks if CUDF Kernel can apply optimized row conversion on the Spark schema represented by
+   * {@link CudfUnsafeRow}.
+   * The fixed-width optimized cudf kernel only supports up to 1.5 KB per row which means at
+   * Spark by default limits codegen to 100 fields "spark.sql.codegen.maxFields".
+   * So, we are going to be cautious and start with that until we have tested it more.
+   * The rough initial estimate size of the CudfUnsafeRow during initialization
+   * {@link CudfUnsafeRow#getInitialSizeEstimate()}.
+   * Note that the latter does not include alignment of the variable-width data types.
+   *
+   * @param cudfUnsafeRow the unsafeRow object that represents the Spark SQL Schema.
+   * @return true if {@link CudfUnsafeRow#getInitialSizeEstimate()} is less than 1.1 KB.
+   */
+  public static boolean fitsOptimizedConversion(CudfUnsafeRow cudfUnsafeRow) {
+    return cudfUnsafeRow.getInitialSizeEstimate() < 1152;
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -264,7 +264,6 @@ class ColumnarToRowIterator(batches: Iterator[ColumnarBatch],
 
 object CudfRowTransitions {
   def isSupportedType(dataType: DataType): Boolean = dataType match {
-    // Only fixed width for now...
     case ByteType | ShortType | IntegerType | LongType |
          FloatType | DoubleType | BooleanType | DateType | TimestampType | StringType => true
     case dt: DecimalType if dt.precision <= Decimal.MAX_LONG_DIGITS => true
@@ -279,7 +278,7 @@ object CudfRowTransitions {
       .zipWithIndex
       .sortWith {
         (x, y) =>
-          JCudfUtil.getDataTypeOrder(x._1.dataType) > JCudfUtil.getDataTypeOrder(y._1.dataType)
+          JCudfUtil.compareDataTypePrecedence(x._1.dataType, y._1.dataType)
       }.map(_._2).toArray
     packedColumns
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -734,7 +734,7 @@ object GeneratedInternalRowToCudfRowIterator extends Logging {
       val colLength = jcudfRowVisitor.getColLength()
       val ret = jcudfRowVisitor.getColLength() match {
         // strings return -15
-        case -15 => s"$cudfDataOffsetTmp += copyUTF8StringInto($rowBaseObj, $rowBaseOffset + ${sparkValidityOffset + (colIndex * 8)}, $cudfColOff, $cudfDataOffsetTmp);"
+        case -15 => s"$cudfDataOffsetTmp += copyUTF8StringInto($colIndex, $rowBaseObj,  $rowBaseOffset, $sparkValidityOffset, $cudfColOff, $cudfDataOffsetTmp);"
         case 1 => s"Platform.putByte(null, startAddress + $cudfColOff, Platform.getByte($rowBaseObj, $rowBaseOffset + ${sparkValidityOffset + (colIndex * 8)}));"
         case 2 => s"Platform.putShort(null, startAddress + $cudfColOff, Platform.getShort($rowBaseObj, $rowBaseOffset + ${sparkValidityOffset + (colIndex * 8)}));"
         case 4 => s"Platform.putInt(null, startAddress + $cudfColOff, Platform.getInt($rowBaseObj, $rowBaseOffset + ${sparkValidityOffset + (colIndex * 8)}));"
@@ -835,7 +835,17 @@ object GeneratedInternalRowToCudfRowIterator extends Logging {
          |  }
          |
          |  private int copyUTF8StringInto(
-         |      Object src, long baseOffset, int cudfColOffset, int dataDstOffset) {
+         |      int ordinal, Object src, long baseOffset, int sparkValidityOffset, int cudfColOffset, int dataDstOffset) {
+         |    // check that the field is not null
+         |    if (!org.apache.spark.unsafe.bitset.BitSetMethods.isSet(src, baseOffset, ordinal)) {
+         |      // this string is null
+         |      // the size should be 0, the address is 0 since no data is stored.
+         |      Platform.putInt(null, cudfColOffset, 0);
+         |      Platform.putInt(null, cudfColOffset + 4, 0);
+         |      return 0;
+         |    }
+         |    // calculate the spark offset
+         |    baseOffset = baseOffset + sparkValidityOffset + (ordinal * 8);
          |    // get the offset and the size from Spark UnsafeFormat
          |    final long strOffsetAndSize = Platform.getLong(src, baseOffset);
          |    final int strOffset = (int) (strOffsetAndSize >> 32);
@@ -844,7 +854,7 @@ object GeneratedInternalRowToCudfRowIterator extends Logging {
          |    Platform.putInt(null, cudfColOffset, dataDstOffset);
          |    Platform.putInt(null, cudfColOffset + 4, strSize);
          |    // copy the data
-         |    Platform.copyMemory(src, baseOffset, null, dataDstOffset, strSize);
+         |    Platform.copyMemory(src, strOffset, null, dataDstOffset, strSize);
          |    return strSize;
          |  }
          |

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -857,7 +857,7 @@ object GeneratedInternalRowToCudfRowIterator extends Logging {
          |    Object $rowBaseObj = input.getBaseObject();
          |    long $rowBaseOffset = input.getBaseOffset();
          |
-         |    long $cudfDataOffsetTmp;
+         |    int $cudfDataOffsetTmp;
          |    ${cudfDataOffsetInit}
          |
          |    ${copyData.mkString("\n")}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JCudfUtilSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JCudfUtilSuite.scala
@@ -53,12 +53,6 @@ class JCudfUtilSuite extends FunSuite with Logging {
     ("col-bool-23", IntegerType))
 
   private val schema = new StructType(fieldsArray.map(f => StructField(f._1, f._2, true)).toArray)
-  private val typeOrderMap = mutable.LinkedHashMap[DataType, Int](
-    StringType -> 39,
-    DoubleType -> 80,
-    LongType -> 80,
-    BooleanType -> 10,
-    IntegerType -> 40)
 
   private val dataTypeAlignmentMap = mutable.LinkedHashMap[DataType, Int](
     StringType -> 1,
@@ -67,21 +61,15 @@ class JCudfUtilSuite extends FunSuite with Logging {
     BooleanType -> 1,
     IntegerType -> 4)
 
-  private val expectedPackedOffsets : Array[Int] =
-    Array(0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 100, 104, 112, 120, 128, 136, 144,
-      152, 160, 168, 169)
-
   private val expectedPackedMap : Array[Int] =
-    Array(4, 5, 6, 7, 8, 9, 10, 17, 18, 19, 20, 21, 2, 23, 0, 3, 11, 12, 13, 14, 15, 16, 1, 22)
+    Array(4, 5, 6, 7, 8, 9, 10, 17, 18, 19, 20, 21, 0, 2, 3, 11, 12, 13, 14, 15, 16, 23, 1, 22)
+
+  private val expectedPackedOffsets : Array[Int] =
+    Array(0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 108, 116, 124, 132, 140, 148, 156,
+      164, 168, 169)
 
   private val expectedUnPackedMap : Array[Int] =
-    Array(14, 22, 12, 15, 0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 7, 8, 9, 10, 11, 23, 13)
-
-  test("test dataType Order used for sorting columns in JCudf") {
-    schema.foreach { colF =>
-      assert(JCudfUtil.getDataTypeOrder(colF.dataType) == typeOrderMap(colF.dataType))
-    }
-  }
+    Array(12, 22, 13, 14, 0, 1, 2, 3, 4, 5, 6, 15, 16, 17, 18, 19, 20, 7, 8, 9, 10, 11, 23, 21)
 
   test("test dataType Alignment used for the JCudf") {
     schema.foreach { colF =>
@@ -128,9 +116,9 @@ class JCudfUtilSuite extends FunSuite with Logging {
       val colLength = cudfRowVisitor.getColLength
       colLength match {
         case -15 =>
-          assert(packedAttributes(colIndex).dataType.isInstanceOf[StringType])
           // assume length is 20;
           varDataOffsetRef += 20
+          assert(packedAttributes(colIndex).dataType.isInstanceOf[StringType])
         case _ => assert(!stringColumns.contains(colIndex))
       }
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JCudfUtilSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JCudfUtilSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import scala.collection.mutable.LinkedHashMap
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.types.{BooleanType, DataType, DoubleType, IntegerType, LongType, StringType, StructField, StructType}
+
+class JCudfUtilSuite extends FunSuite with Logging {
+
+  private val fieldsArray = Seq(
+    ("col-str-00", StringType),
+    ("col-bool-01", BooleanType),
+    ("col-int-02", IntegerType),
+    ("col-str-03", StringType),
+    ("col-dbl-04", DoubleType),
+    ("col-dbl-05", DoubleType),
+    ("col-long-06", LongType),
+    ("col-long-07", LongType),
+    ("col-long-08", LongType),
+    ("col-long-09", LongType),
+    ("col-dbl-10", DoubleType),
+    ("col-str-11", StringType),
+    ("col-str-12", StringType),
+    ("col-str-13", StringType),
+    ("col-str-14", StringType),
+    ("col-str-15", StringType),
+    ("col-str-16", StringType),
+    ("col-long-17", LongType),
+    ("col-long-18", LongType),
+    ("col-long-19", LongType),
+    ("col-long-20", LongType),
+    ("col-dbl-21", DoubleType),
+    ("col-bool-22", BooleanType),
+    ("col-bool-23", IntegerType))
+
+  private val schema = new StructType(fieldsArray.map(f => StructField(f._1, f._2, true)).toArray)
+  private val typeOrderMap = LinkedHashMap[DataType, Int](
+    StringType -> 39,
+    DoubleType -> 80,
+    LongType -> 80,
+    BooleanType -> 10,
+    IntegerType -> 40)
+
+  private val dataTypeAlignmentMap = LinkedHashMap[DataType, Int](
+    StringType -> 1,
+    DoubleType -> 8,
+    LongType -> 8,
+    BooleanType -> 1,
+    IntegerType -> 4)
+
+  test("test dataTypeOrder used for sorting columns in CUDF") {
+    schema.foreach { colF =>
+      assert(JCudfUtil.getDataTypeOrder(colF.dataType) == typeOrderMap(colF.dataType))
+    }
+  }
+
+  test("test dataType Alignment used for the JCudf") {
+    schema.foreach { colF =>
+      val rapidsType = GpuColumnVector.getNonNestedRapidsType(colF.dataType)
+      assert(
+        JCudfUtil.getDataAlignmentForDataType(rapidsType) == dataTypeAlignmentMap(colF.dataType))
+    }
+  }
+
+  test("test offset calculations") {
+    val expectedPackedMap: Array[Int] =
+      Array(4, 5, 6, 7, 8, 9, 10, 17, 18, 19, 20, 21, 2, 23, 0, 3, 11, 12, 13, 14, 15, 16, 1, 22)
+    val expectedUnpackedMap: Array[Int] =
+      Array(14, 22, 12, 15, 0, 1, 2, 3, 4, 5, 6, 16, 17, 18, 19, 20, 21, 7, 8, 9, 10, 11, 23, 13)
+    val expectedOffsets: Array[Int] =
+      Array(0, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 100, 104, 112, 120, 128, 136, 144,
+        152, 160, 168, 169)
+    // test packing
+    val attributes = TrampolineUtil.toAttributes(schema)
+    val packedMaps = CudfRowTransitions.reorderSchemaToPackedColumns(attributes)
+    assert(packedMaps.deep == expectedPackedMap.deep)
+    val unpackedMap = CudfRowTransitions.getUnpackedMapForSchema(packedMaps)
+    assert(unpackedMap.deep == expectedUnpackedMap.deep)
+    // test offset calculator
+    val startOffsets: Array[Int] = new Array[Int](attributes.length)
+    val jCudfBuilder = JCudfUtil.getJCudfRowEstimator(packedMaps.map(attributes(_)))
+    val fixedWidthSize = jCudfBuilder.setColumnOffsets(startOffsets)
+
+    assert(jCudfBuilder.hasVarSizeData)
+    assert(170 == fixedWidthSize)
+    assert(startOffsets.deep == expectedOffsets.deep)
+  }
+}


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #5633


**Changes:**

Addressing points in https://github.com/rapidsai/cudf/issues/10033#issuecomment-1132121915

1. Added new JCudfUtil. I hope that this Util class will hide all the details of how data types should be aligned in the unsafeRow. This will make code it easier to use the same code as we: estimate size, set offsets, build the unsafeRow
2. Added String types to the supported transitions.
3. Updated `AcceleratedColumnarToRowIterator` and how the packMap is constructed.
4. Added a new variable to CudfUnsafeRow that represents an initial rough estimate of the unsafeRow. This estimate can be later used to decide if the schema fits the CUDF optimized conversion.

**TODO:**

- Update [GeneratedInternalRowToCudfRowIterator](https://github.com/NVIDIA/spark-rapids/blob/67c34e2b40ec196b12d83667aadd85ba9d45c8b6/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala#L682).
- I think it can be better if all the code of updating offset is inside the new class JCudfUtil. In that case, alignment is hidden from the rest of the call sites.