### PR TITLE
Add string split support for limit = 0 and limit =1 

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -47,27 +47,23 @@ def test_split_negative_limit():
             'split(a, "_", -999)'),
             conf=_regexp_conf)
 
-# https://github.com/NVIDIA/spark-rapids/issues/4720
-@allow_non_gpu('ProjectExec', 'StringSplit')
-def test_split_zero_limit_fallback():
+def test_split_zero_limit():
     data_gen = mk_str_gen('([ABC]{0,3}_?){0,7}')
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
+    assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'split(a, "AB", 0)'),
-        conf=_regexp_conf,
-        exist_classes= "ProjectExec",
-        non_exist_classes= "GpuProjectExec")
+            'split(a, "AB", 0)',
+            'split(a, "C", 0)',
+            'split(a, "_", 0)'),
+        conf=_regexp_conf)
 
-# https://github.com/NVIDIA/spark-rapids/issues/4720
-@allow_non_gpu('ProjectExec', 'StringSplit')
-def test_split_one_limit_fallback():
-    data_gen = mk_str_gen('([ABC]{0,3}_?){0,7}')
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
+def test_split_one_limit():
+    data_gen = mk_str_gen('([ABC]{0,3}_?){1,7}')
+    assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'split(a, "AB", 1)'),
-        conf=_regexp_conf,
-        exist_classes= "ProjectExec",
-        non_exist_classes= "GpuProjectExec")
+            'split(a, "AB", 1)',
+            'split(a, "C", 1)',
+            'split(a, "_", 1)'),
+        conf=_regexp_conf)
 
 def test_split_positive_limit():
     data_gen = mk_str_gen('([ABC]{0,3}_?){0,7}')
@@ -89,33 +85,35 @@ def test_split_re_negative_limit():
             'split(a, "[o]{1,2}", -1)',
             'split(a, "[bf]", -1)',
             'split(a, "[o]", -2)'),
-            conf=_regexp_conf)
+        conf=_regexp_conf)
 
-# https://github.com/NVIDIA/spark-rapids/issues/4720
-@allow_non_gpu('ProjectExec', 'StringSplit')
-def test_split_re_zero_limit_fallback():
+def test_split_re_zero_limit():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
         .with_special_case('boo:and:foo')
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
+    assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             'split(a, "[:]", 0)',
             'split(a, "[o:]", 0)',
+            'split(a, "[^:]", 0)',
+            'split(a, "[^o]", 0)',
+            'split(a, "[o]{1,2}", 0)',
+            'split(a, "[bf]", 0)',
             'split(a, "[o]", 0)'),
-            exist_classes= "ProjectExec",
-            non_exist_classes= "GpuProjectExec")
+        conf=_regexp_conf)
 
-# https://github.com/NVIDIA/spark-rapids/issues/4720
-@allow_non_gpu('ProjectExec', 'StringSplit')
-def test_split_re_one_limit_fallback():
+def test_split_re_one_limit():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
         .with_special_case('boo:and:foo')
-    assert_cpu_and_gpu_are_equal_collect_with_capture(
+    assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
             'split(a, "[:]", 1)',
             'split(a, "[o:]", 1)',
+            'split(a, "[^:]", 1)',
+            'split(a, "[^o]", 1)',
+            'split(a, "[o]{1,2}", 1)',
+            'split(a, "[bf]", 1)',
             'split(a, "[o]", 1)'),
-        exist_classes= "ProjectExec",
-        non_exist_classes= "GpuProjectExec")
+        conf=_regexp_conf)
 
 def test_split_re_positive_limit():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1484,10 +1484,6 @@ class GpuStringSplitMeta(
 
     extractLit(expr.limit) match {
       case Some(Literal(n: Int, _)) =>
-        if (n == 0 || n == 1) {
-          // https://github.com/NVIDIA/spark-rapids/issues/4720
-          willNotWorkOnGpu("limit of 0 or 1 is not supported")
-        }
       case _ =>
         willNotWorkOnGpu("only literal limit is supported")
     }
@@ -1515,8 +1511,15 @@ case class GpuStringSplit(str: Expression, regex: Expression, limit: Expression,
 
   override def doColumnar(str: GpuColumnVector, regex: GpuScalar,
       limit: GpuScalar): ColumnVector = {
-    val intLimit = limit.getValue.asInstanceOf[Int]
-    str.getBase.stringSplitRecord(pattern, intLimit, isRegExp)
+    limit.getValue.asInstanceOf[Int] match {
+      case 0 =>
+        // Same as splitting as many times as possible
+        str.getBase.stringSplitRecord(pattern, -1, isRegExp)
+      case 1 =>
+        str.getBase
+      case n =>
+        str.getBase.stringSplitRecord(pattern, n, isRegExp)
+    }
   }
 
   override def doColumnar(numRows: Int, val0: GpuScalar, val1: GpuScalar,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -29,6 +29,14 @@ import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
+  test("string split - limit = 0,1") {
+    val patterns = Set("[^A-Z]+", "[0-9]+", ":", "o", "[:o]")
+    val data = Seq("abc", "123", "1\n2\n3\n", "boo:and:foo")
+    for(Seq(0, 1) <- limit) {
+      doStringSplitTest(patterns, data, limit)
+    }
+  }
+
   test("transpiler detects invalid cuDF patterns") {
     // The purpose of this test is to document some examples of valid Java regular expressions
     // that fail to compile in cuDF and to check that the transpiler detects these correctly.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -29,14 +29,6 @@ import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
-  test("string split - limit = 0,1") {
-    val patterns = Set("[^A-Z]+", "[0-9]+", ":", "o", "[:o]")
-    val data = Seq("abc", "123", "1\n2\n3\n", "boo:and:foo")
-    for(Seq(0, 1) <- limit) {
-      doStringSplitTest(patterns, data, limit)
-    }
-  }
-
   test("transpiler detects invalid cuDF patterns") {
     // The purpose of this test is to document some examples of valid Java regular expressions
     // that fail to compile in cuDF and to check that the transpiler detects these correctly.


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/4720

This PR adds support for GpuStringSplit with a limit of 0 or 1. 
- For a limit of 0 it splits as many times as possible, so it is equivalent to a split with any negative limit. 
- For a limit of 1, it doesn't perform any splits so we just return a list containing only the original string. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
