### PR TITLE
[BUG] Fix databricks test report location [databricks]

### DIFF
--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -45,9 +45,10 @@ def main():
         subprocess.check_call(ssh_command, shell=True)
     finally:
         print("Copying test report tarball back")
+        report_path_prefix = params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids"
         rsync_command = "rsync -I -Pave \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s\"" \
-            " ubuntu@%s:/home/ubuntu/spark-rapids/integration_tests/target/run_dir/TEST-pytest-*.xml ./" % \
-            (params.private_key_file, master_addr)
+            " ubuntu@%s:%s/integration_tests/target/run_dir/TEST-pytest-*.xml ./" % \
+            (params.private_key_file, master_addr, report_path_prefix)
         print("rsync command: %s" % rsync_command)
         subprocess.check_call(rsync_command, shell = True)
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Previous change passed premerge CI but fail to deal w/ nightly case. 

in pre-merge: we build artifacts in place, and do not pass params.jar_path (`LOCAL_JAR_PATH` default as empty)
in nightly testing: we upload plugin artifacts to some dir and explicitly pass it as params.jar_path

This one is to going to fix the report path issue