### PR TITLE
Qualification tool UI. fix Read-Schema column broken [skip ci]

### DIFF
--- a/tools/src/main/resources/ui/js/uiutils.js
+++ b/tools/src/main/resources/ui/js/uiutils.js
@@ -1214,7 +1214,6 @@ function getAppDetailsTableTemplate() {
             <th>Supported SQL DF Task Duration</th>
             <th>SQL Dataframe Task Duration</th>
             <th>Executor CPU Time Percent</th>
-            <th>Executor CPU Time Percent</th>
             <th>Longest SQL Duration</th>
             <th>NONSQL Task Duration Plus Overhead</th>
             <th>App Duration Estimated</th>


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #5939 


I spotted a bug in the application-details table.
There was a typo in the JS that broke the map between HTML and the datatable code.
The fix was easy: remove the redundant line .

The change won't affect the unit-test or the main functionality of RAPIDS.