### PR TITLE
GpuGlobalLimitExec and GpuCollectLimitExec support offset

### DIFF
--- a/integration_tests/src/main/python/limit_test.py
+++ b/integration_tests/src/main/python/limit_test.py
@@ -30,19 +30,45 @@ def test_simple_limit(data_gen):
 
 @allow_non_gpu('CollectLimitExec', 'GlobalLimitExec', 'ShuffleExchangeExec')
 @pytest.mark.skipif(is_before_spark_340(), reason='offset is introduced from Spark 3.4.0')
-def test_non_zero_offset_fallback():
-    def test_fn(spark):
-        unary_op_df(spark, int_gen, num_slices=1).createOrReplaceTempView("offset_tmp")
-        # `offset` is not exposed to Pyspark, so use the sql string.
-        return spark.sql("select * from offset_tmp limit 10 offset 1")
+@allow_non_gpu('CollectLimitExec', 'GlobalLimitExec', 'ShuffleExchangeExec')
+@pytest.mark.skipif(is_before_spark_340(), reason='offset is introduced from Spark 3.4.0')
+def test_non_zero_offset_on_gpu():
+    conf = {
+        'spark.rapids.sql.exec.CollectLimitExec': 'true',
+        'spark.rapids.sql.exec.GlobalLimitExec': 'true'
+    }
 
-    assert_gpu_fallback_collect(
-        # We need some processing after the limit to avoid a CollectLimitExec
-        lambda spark: test_fn(spark).repartition(1),
-        'GlobalLimitExec',
-        conf = {'spark.sql.execution.sortBeforeRepartition': 'false'})
+    # num_slices is the number of partitions of data frame
+    def test_runner(sql, num_slices):
+        def test_instance(spark):
+            df = unary_op_df(spark, int_gen, num_slices=num_slices)
+            df.createOrReplaceTempView("tmp_table")
+            return spark.sql(sql)
+        return test_instance
 
-    assert_gpu_fallback_collect(
-        test_fn,
-        'CollectLimitExec',
-        conf = {'spark.sql.execution.sortBeforeRepartition': 'false'})
+    sql = "select * from tmp_table limit {} offset {}"
+    # Only one partition
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(0, 0), 1), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(10, 2), 1), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2, 10), 1), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1024, 1024), 1), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 2), 1), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(4096, 222), 1), conf=conf)
+
+    # More than one partition
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(4096, 222), 2), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 999), 3), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(213, 123), 4), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(10000, 123), 10), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(20481, 0), 10), conf=conf)
+
+    # With "sort by"
+    sql = "select * from tmp_table sort by a limit {} offset {}"
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1123, 50), 2), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(200, 150), 3), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 200), 2), conf=conf)
+
+    sql = "select * from tmp_table sort by a desc limit {} offset {}"
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(200, 50), 5), conf=conf)
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1230, 50), 5), conf=conf)
+

--- a/integration_tests/src/main/python/limit_test.py
+++ b/integration_tests/src/main/python/limit_test.py
@@ -30,7 +30,7 @@ def test_simple_limit(data_gen):
 
 @allow_non_gpu('CollectLimitExec', 'GlobalLimitExec', 'ShuffleExchangeExec')
 @pytest.mark.skipif(is_before_spark_340(), reason='offset is introduced from Spark 3.4.0')
-def test_non_zero_offset_on_gpu():
+def test_non_zero_offset():
     conf = {
         'spark.rapids.sql.exec.CollectLimitExec': 'true',
         'spark.rapids.sql.exec.GlobalLimitExec': 'true'

--- a/integration_tests/src/main/python/limit_test.py
+++ b/integration_tests/src/main/python/limit_test.py
@@ -30,8 +30,6 @@ def test_simple_limit(data_gen):
 
 @allow_non_gpu('CollectLimitExec', 'GlobalLimitExec', 'ShuffleExchangeExec')
 @pytest.mark.skipif(is_before_spark_340(), reason='offset is introduced from Spark 3.4.0')
-@allow_non_gpu('CollectLimitExec', 'GlobalLimitExec', 'ShuffleExchangeExec')
-@pytest.mark.skipif(is_before_spark_340(), reason='offset is introduced from Spark 3.4.0')
 def test_non_zero_offset_on_gpu():
     conf = {
         'spark.rapids.sql.exec.CollectLimitExec': 'true',
@@ -39,6 +37,7 @@ def test_non_zero_offset_on_gpu():
     }
 
     # num_slices is the number of partitions of data frame
+    # The number of rows in the dataframe is 2048
     def test_runner(sql, num_slices):
         def test_instance(spark):
             df = unary_op_df(spark, int_gen, num_slices=num_slices)
@@ -47,26 +46,42 @@ def test_non_zero_offset_on_gpu():
         return test_instance
 
     sql = "select * from tmp_table limit {} offset {}"
+
     # Only one partition
+    # Corner case: both limit and offset are 0
     assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(0, 0), 1), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(10, 2), 1), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2, 10), 1), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1024, 1024), 1), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 2), 1), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(4096, 222), 1), conf=conf)
+    # offset < limit && limit < numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1024, 500), 1), conf=conf)
+    # offset < limit && limit = numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 456), 1), conf=conf)
+    # offset < limit && limit > numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(3000, 111), 1), conf=conf)
+    # offset = limit
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 100), 1), conf=conf)
+    # offset > limit
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 600), 1), conf=conf)
+
+
 
     # More than one partition
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(4096, 222), 2), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 999), 3), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(213, 123), 4), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(10000, 123), 10), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(20481, 0), 10), conf=conf)
+    # limit = offset = 0
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(0, 0), 20), conf=conf)
+    # offset < limit && limit < numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1111, 500), 23), conf=conf)
+    # offset < limit && limit = numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(2048, 789), 11), conf=conf)
+    # offset < limit && limit > numRows
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(3000, 789), 101), conf=conf)
+    # offset = limit
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 100), 67), conf=conf)
+    # offset > limit
+    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 600), 18), conf=conf)
+
 
     # With "sort by"
     sql = "select * from tmp_table sort by a limit {} offset {}"
     assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(1123, 50), 2), conf=conf)
     assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(200, 150), 3), conf=conf)
-    assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(100, 200), 2), conf=conf)
 
     sql = "select * from tmp_table sort by a desc limit {} offset {}"
     assert_gpu_and_cpu_are_equal_collect(test_runner(sql.format(200, 50), 5), conf=conf)

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -35,12 +35,6 @@ object SparkShimImpl extends Spark330PlusShims {
         TypeSig.all),
       (globalLimit, conf, p, r) =>
         new SparkPlanMeta[GlobalLimitExec](globalLimit, conf, p, r) {
-          override def tagPlanForGpu(): Unit = {
-            if (globalLimit.offset != 0) {
-              willNotWorkOnGpu("non-zero offset is not supported")
-            }
-          }
-
           override def convertToGpu(): GpuExec =
             GpuGlobalLimitExec(
               globalLimit.limit, childPlans.head.convertIfNeeded(), globalLimit.offset)
@@ -51,12 +45,6 @@ object SparkShimImpl extends Spark330PlusShims {
           TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all),
       (collectLimit, conf, p, r) => new GpuCollectLimitMeta(collectLimit, conf, p, r) {
-        override def tagPlanForGpu(): Unit = {
-          if (collectLimit.offset != 0) {
-            willNotWorkOnGpu("non-zero offset is not supported")
-          }
-        }
-
         override def convertToGpu(): GpuExec =
           GpuGlobalLimitExec(collectLimit.limit,
             GpuShuffleExchangeExec(

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -26,10 +26,20 @@ object GlobalLimitShims {
    * Estimate the number of rows for a GlobalLimitExec.
    */
   def visit(plan: SparkPlanMeta[GlobalLimitExec]): Option[BigInt] = {
-    // offset is ignored now, but we should support it.
-    // See https://github.com/NVIDIA/spark-rapids/issues/5589
-    //val offset = plan.wrapped.limit
+    // offset is introduce in spark-3.4.0
+    val offset = plan.wrapped.limit
     val limit = plan.wrapped.limit
-    RowCountPlanVisitor.visit(plan.childPlans.head).map(_.min(limit)).orElse(Some(limit))
+    val sliced = if (limit > 0) {
+      Some(limit - offset)
+    } else {
+      // limit can be -1, meaning no limit
+      None
+    }
+    RowCountPlanVisitor.visit(plan.childPlans.head)
+      .map { rowNum =>
+        val remaining = Math.max(rowNum - offset, 0)
+        sliced.map(_.min(remaining)).getOrElse(remaining)
+      }
+      .orElse(sliced)
   }
 }

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -26,7 +26,8 @@ object GlobalLimitShims {
    * Estimate the number of rows for a GlobalLimitExec.
    */
   def visit(plan: SparkPlanMeta[GlobalLimitExec]): Option[BigInt] = {
-    // offset is introduce in spark-3.4.0
+    // offset is introduce in spark-3.4.0, and it ensures that offset >= 0
+    // limit can be -1, such case happens only when we execute sql like 'select * from table offset 10'
     val offset = plan.wrapped.offset
     val limit = plan.wrapped.limit
     val sliced = if (limit >= 0) {

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -29,15 +29,15 @@ object GlobalLimitShims {
     // offset is introduce in spark-3.4.0
     val offset = plan.wrapped.offset
     val limit = plan.wrapped.limit
-    val sliced = if (limit > 0) {
-      Some(limit - offset)
+    val sliced = if (limit >= 0) {
+      Some(BigInt(limit - offset).max(0))
     } else {
       // limit can be -1, meaning no limit
       None
     }
     RowCountPlanVisitor.visit(plan.childPlans.head)
       .map { rowNum =>
-        val remaining = Math.max(rowNum - offset, 0)
+        val remaining = (rowNum - offset).max(0)
         sliced.map(_.min(remaining)).getOrElse(remaining)
       }
       .orElse(sliced)

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -27,7 +27,7 @@ object GlobalLimitShims {
    */
   def visit(plan: SparkPlanMeta[GlobalLimitExec]): Option[BigInt] = {
     // offset is introduce in spark-3.4.0
-    val offset = plan.wrapped.limit
+    val offset = plan.wrapped.offset
     val limit = plan.wrapped.limit
     val sliced = if (limit > 0) {
       Some(limit - offset)

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -26,8 +26,8 @@ object GlobalLimitShims {
    * Estimate the number of rows for a GlobalLimitExec.
    */
   def visit(plan: SparkPlanMeta[GlobalLimitExec]): Option[BigInt] = {
-    // offset is introduce in spark-3.4.0, and it ensures that offset >= 0
-    // limit can be -1, such case happens only when we execute sql like 'select * from table offset 10'
+    // offset is introduce in spark-3.4.0, and it ensures that offset >= 0. And limit can be -1,
+    // such case happens only when we execute sql like 'select * from table offset 10'
     val offset = plan.wrapped.offset
     val limit = plan.wrapped.limit
     val sliced = if (limit >= 0) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -126,16 +126,16 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec with ShimUnaryExecNode {
           withResource(batch) { _ =>
             // result buffer need to be closed when there is an exception
             closeOnExcept(new ArrayBuffer[GpuColumnVector](numCols)) { result =>
-              withResource(GpuColumnVector.from(batch)) { table =>
-                if (numCols > 0) {
+              if (numCols > 0) {
+                withResource(GpuColumnVector.from(batch)) { table =>
                   (0 until numCols).zip(output).foreach{ case (i, attr) =>
                     val subVector = table.getColumn(i).subVector(offset, end)
                     assert(subVector != null)
                     result.append(GpuColumnVector.from(subVector, attr.dataType))
                   }
                 }
-                new ColumnarBatch(result.toArray, end - offset)
               }
+              new ColumnarBatch(result.toArray, end - offset)
             }
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -152,8 +152,8 @@ case class GpuLocalLimitExec(limit: Int, child: SparkPlan) extends GpuBaseLimitE
 /**
  * Take the first `limit` elements of the child's single output partition.
  */
-case class GpuGlobalLimitExec(limit: Int = -1, child: SparkPlan, offset: Int = 0) extends
-  GpuBaseLimitExec {
+case class GpuGlobalLimitExec(limit: Int = -1, child: SparkPlan,
+                              offset: Int = 0) extends GpuBaseLimitExec {
   // In CPU code of spark, there is an assertion 'limit >= 0 || (limit == -1 && offset > 0)'.
 
   override def requiredChildDistribution: List[Distribution] = AllTuples :: Nil

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -137,7 +137,6 @@ case class GpuGlobalLimitExec(limit: Int, child: SparkPlan, offset: Int) extends
     val childRdd = child.executeColumnar()
     childRdd.mapPartitions {
       iter => new Iterator[ColumnarBatch] {
-        println(iter.hashCode())
         private var remainingLimit = limit - offset
         private var remainingOffset = offset
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -73,7 +73,7 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec with ShimUnaryExecNode {
         override def hasNext: Boolean = (limit == -1 || remainingLimit > 0) && iter.hasNext
 
         override def next(): ColumnarBatch = {
-          if (!iter.hasNext) {
+          if (!this.hasNext) {
             throw new NoSuchElementException("Next on empty iterator")
           }
 
@@ -84,7 +84,7 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec with ShimUnaryExecNode {
           while (batch != null && remainingOffset >= batch.numRows()) {
             remainingOffset -= batch.numRows()
             batch.safeClose()
-            batch = if (iter.hasNext) { iter.next() } else { null }
+            batch = if (this.hasNext) { iter.next() } else { null }
           }
 
           // If the last batch is null, then we have offset >= numRows in this partition.
@@ -112,10 +112,10 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec with ShimUnaryExecNode {
               }
               result = sliceBatchWithOffset(batch, remainingOffset, length)
               remainingOffset = 0
-              remainingLimit -= result.numRows()
             }
-            numOutputRows += result.numRows()
             numOutputBatches += 1
+            numOutputRows += result.numRows()
+            remainingLimit -= result.numRows()
             result
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -89,7 +89,7 @@ trait GpuBaseLimitExec extends LimitExec with GpuExec with ShimUnaryExecNode {
 
           // If the last batch is null, then we have offset >= numRows in this partition.
           // In such case, we should return an empty batch
-          if (batch == null) {
+          if (batch == null || batch.numRows() == 0) {
             return new ColumnarBatch(new ArrayBuffer[GpuColumnVector](numCols).toArray, 0)
           }
 


### PR DESCRIPTION
Closes #5589
Support the parameter `offset` in `GpuGlobalLimitExec` and `GpuCollectLimitExec`, which is introduced in spark-3.4.0.

Since spark-rapids are failing to build against spark-3.4.0, I verified this locally with some local changes.