### PR TITLE
Qualification tool: Parse expressions in ProjectExec

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/ProjectExecParser.scala
@@ -30,7 +30,11 @@ case class ProjectExecParser(
   override def parse: ExecInfo = {
     // Project doesn't have duration
     val duration = None
-    val (speedupFactor, isSupported) = if (checker.isExecSupported(fullExecName)) {
+    val exprString = node.desc.replaceFirst("Project ", "")
+    val expressions = SQLPlanParser.parseProjectExpressions(exprString)
+    val isAllExprsSupported = expressions.forall(expr => checker.isExprSupported(expr))
+    val (speedupFactor, isSupported) = if (checker.isExecSupported(fullExecName) &&
+        isAllExprsSupported) {
       (checker.getSpeedupFactor(fullExecName), true)
     } else {
       (1.0, false)

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -266,10 +266,15 @@ object SQLPlanParser extends Logging {
 
   def parseProjectExpressions(exprStr: String): Array[String] = {
     val parsedExpressions = ArrayBuffer[String]()
+    // Project [cast(value#136 as string) AS value#144, CEIL(value#136) AS CEIL(value)#143L]
     // remove the alias names before parsing
     val pattern = """(AS) ([(\w# )]+)""".r
     // This is to split multiple column names in Project. Project may have a function on a column.
-    // This will contain array of columns names specified in ProjectExec.
+    // This will contain array of columns names specified in ProjectExec. Below regex will first
+    // remove the alias names from the string followed by a split which produces an array containing
+    // column names. Finally we remove the paranthesis from the beginning and end to get only
+    // the expressions. Result will be as below.
+    // paranRemoved = Array(cast(value#136 as string), CEIL(value#136))
     val paranRemoved = pattern.replaceAllIn(exprStr.replace("),", "::"), "")
         .split(",").map(_.trim).map(_.replaceAll("""^\[+""", "").replaceAll("""\]+$""", ""))
     val functionPattern = """(\w+)\(.*\)""".r
@@ -341,6 +346,7 @@ object SQLPlanParser extends Logging {
               case ">" => "GreaterThan"
               case "<=" => "LessThanOrEqual"
               case ">=" => "GreaterThanOrEqual"
+              case "+" => "Add"
             }
             logDebug(s"predicate string is $predStr")
             parsedExpressions += predStr

--- a/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
+++ b/tools/src/test/resources/QualificationExpectations/qual_test_simple_expectation.csv
@@ -2,4 +2,4 @@ App Name,App ID,Recommendation,Estimated GPU Speedup,Estimated GPU Duration,Esti
 Rapids Spark Profiling Tool Unit Tests,local-1622043423018,Recommended,1.71,9497.79,6821.2,12434,132257,16319,10589,37.7,"","",JSON,"","","",7143,4717,19616,112641,2.81,false
 Spark shell,local-1651187225439,Not Recommended,1.0,355496.4,140.59,760,180,355637,350,87.88,"",JSON[string:bigint:int],"","","","",498,343411,97,83,1.67,false
 Spark shell,local-1651188809790,Not Recommended,1.0,166192.46,22.53,911,283,166215,45,81.18,"",JSON[string:bigint:int],"","","",UDF,715,133608,269,14,2.0,false
-Rapids Spark Profiling Tool Unit Tests,local-1623281204390,Not Recommended,1.0,6239.7,0.29,2032,4666,6240,0,46.27,"",JSON[string:bigint:int],JSON,"","",UDF,1209,5793,4664,2,1.5,false
+Rapids Spark Profiling Tool Unit Tests,local-1623281204390,Not Recommended,1.0,6240.0,0.0,2032,4666,6240,0,46.27,"",JSON[string:bigint:int],JSON,"","",UDF,1209,5793,4664,2,1.0,false

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -559,14 +559,14 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
   }
 
   test("Expressions supported in ProjectExec") {
-    TrampolineUtil.withTempDir { outputLoc =>
+    TrampolineUtil.withTempDir { parquetoutputLoc =>
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsSupported") { spark =>
           import spark.implicits._
           val df1 = Seq(9.9, 10.2, 11.6, 12.5).toDF("value")
-          df1.write.parquet(s"$outputLoc/testtext")
-          val df2 = spark.read.parquet(s"$outputLoc/testtext")
+          df1.write.parquet(s"$parquetoutputLoc/testtext")
+          val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
           df2.select(df2("value").cast(StringType), ceil(df2("value")), df2("value"))
         }
         val pluginTypeChecker = new PluginTypeChecker()
@@ -587,14 +587,14 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
   }
 
   test("Expressions not supported in ProjectExec") {
-    TrampolineUtil.withTempDir { outputLoc =>
+    TrampolineUtil.withTempDir { parquetoutputLoc =>
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
           "ProjectExprsNotSupported") { spark =>
           import spark.implicits._
           val df1 = spark.sparkContext.parallelize(List(10, 20, 30, 40)).toDF
-          df1.write.parquet(s"$outputLoc/testtext")
-          val df2 = spark.read.parquet(s"$outputLoc/testtext")
+          df1.write.parquet(s"$parquetoutputLoc/testtext")
+          val df2 = spark.read.parquet(s"$parquetoutputLoc/testtext")
           df2.select(hex($"value") === "A")
         }
         val pluginTypeChecker = new PluginTypeChecker()

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -24,9 +24,10 @@ import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
 import org.apache.spark.sql.expressions.Window
-import org.apache.spark.sql.functions.{broadcast, col, collect_list, explode, hex, sum}
+import org.apache.spark.sql.functions.{broadcast, ceil, col, collect_list, explode, hex, sum}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
+import org.apache.spark.sql.types.StringType
 
 
 class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
@@ -553,6 +554,61 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val allChildren = wholeStages.flatMap(_.children).flatten
         val filters = allChildren.filter(_.exec == "Filter")
         assertSizeAndNotSupported(1, filters)
+      }
+    }
+  }
+
+  test("Expressions supported in ProjectExec") {
+    TrampolineUtil.withTempDir { outputLoc =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
+          "ProjectExprsSupported") { spark =>
+          import spark.implicits._
+          val df1 = Seq(9.9, 10.2, 11.6, 12.5).toDF("value")
+          df1.write.parquet(s"$outputLoc/testtext")
+          val df2 = spark.read.parquet(s"$outputLoc/testtext")
+          df2.select(df2("value").cast(StringType), ceil(df2("value")), df2("value"))
+        }
+        val pluginTypeChecker = new PluginTypeChecker()
+        val app = createAppFromEventlog(eventLog)
+        assert(app.sqlPlans.size == 2)
+        val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+          SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, pluginTypeChecker, app)
+        }
+        val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+        val wholeStages = allExecInfo.filter(_.exec.contains("WholeStageCodegen"))
+        assert(wholeStages.size == 1)
+        assert(wholeStages.forall(_.duration.nonEmpty))
+        val allChildren = wholeStages.flatMap(_.children).flatten
+        val projects = allChildren.filter(_.exec == "Project")
+        assertSizeAndSupported(1, projects)
+      }
+    }
+  }
+
+  test("Expressions not supported in ProjectExec") {
+    TrampolineUtil.withTempDir { outputLoc =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir,
+          "ProjectExprsNotSupported") { spark =>
+          import spark.implicits._
+          val df1 = spark.sparkContext.parallelize(List(10, 20, 30, 40)).toDF
+          df1.write.parquet(s"$outputLoc/testtext")
+          val df2 = spark.read.parquet(s"$outputLoc/testtext")
+          df2.select(hex($"value") === "A")
+        }
+        val pluginTypeChecker = new PluginTypeChecker()
+        val app = createAppFromEventlog(eventLog)
+        assert(app.sqlPlans.size == 2)
+        val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+          SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, pluginTypeChecker, app)
+        }
+        val allExecInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+        val wholeStages = allExecInfo.filter(_.exec.contains("WholeStageCodegen"))
+        assert(wholeStages.forall(_.duration.nonEmpty))
+        val allChildren = wholeStages.flatMap(_.children).flatten
+        val projects = allChildren.filter(_.exec == "Project")
+        assertSizeAndNotSupported(1, projects)
       }
     }
   }


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids/issues/5617 .
In this PR we parse expressions which are in ProjectExec. Project may have aliases so made sure we are taking that into account. Tested with several expressions locally but added only 1 test each for supporting and non-supporting case. Supporting case pretty much covers all cases where the ProjectExec string needs to be parsed.
There was a bug in FilterExec parser where we are not taking into account if the predicate was `+`. Updated that as well.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
