### PR TITLE
Fix fake memory leaks in some test cases [databricks]

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -27,11 +27,6 @@ class MortgageSparkSuite extends FunSuite {
   /**
    * This is intentionally a def rather than a val so that scalatest uses the correct value (from
    * this class or the derived class) when registering tests.
-   *
-   * @note You are likely to see device/host leaks from this test when using the
-   *       RAPIDS Shuffle Manager. The reason for that is a race between cuDF's MemoryCleaner
-   *       and the SparkContext shutdown. Because of this, shuffle buffers cached may not get
-   *       cleaned (on shuffle unregister) when the MemoryCleaner exits.
    */
   def adaptiveQueryEnabled = false
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -211,7 +211,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       extraConf: java.util.Map[String, String]): Unit = {
     try {
       // if configured, re-register checking leaks hook.
-      ReRegisterCheckLeakHook
+      ReRegisterCheckLeakHook()
 
       val conf = new RapidsConf(extraConf.asScala.toMap)
 
@@ -266,7 +266,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   /**
    * Re-register leaks checking hook if configured.
    */
-  private def ReRegisterCheckLeakHook: Unit = {
+  private def ReRegisterCheckLeakHook(): Unit = {
     // DEFAULT_SHUTDOWN_THREAD in MemoryCleaner is responsible to check the leaks at shutdown time,
     // it expects all other hooks are done before the checking
     // as other hooks will close some resources.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -211,7 +211,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       extraConf: java.util.Map[String, String]): Unit = {
     try {
       // if configured, re-register checking leaks hook.
-      ReRegisterCheckLeakHook()
+      reRegisterCheckLeakHook()
 
       val conf = new RapidsConf(extraConf.asScala.toMap)
 
@@ -266,7 +266,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   /**
    * Re-register leaks checking hook if configured.
    */
-  private def ReRegisterCheckLeakHook(): Unit = {
+  private def reRegisterCheckLeakHook(): Unit = {
     // DEFAULT_SHUTDOWN_THREAD in MemoryCleaner is responsible to check the leaks at shutdown time,
     // it expects all other hooks are done before the checking
     // as other hooks will close some resources.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.rapids.shims.SparkUpgradeExceptionShims
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.BlockManagerId
-import org.apache.spark.util.Utils
+import org.apache.spark.util.{ShutdownHookManager, Utils}
 
 object TrampolineUtil {
   def doExecuteBroadcast[T](child: SparkPlan): Broadcast[T] = child.doExecuteBroadcast()
@@ -152,4 +152,9 @@ object TrampolineUtil {
 
   /** Remove the task context for the current thread */
   def unsetTaskContext(): Unit = TaskContext.unset()
+
+  /** Add shutdown hook with priority */
+  def addShutdownHook(priority: Int, runnable: Runnable): AnyRef = {
+    ShutdownHookManager.addShutdownHook(priority)(() => runnable.run())
+  }
 }


### PR DESCRIPTION
Contributes to #5854

### Problem
Prints RapidsHostMemoryStore.pool leaked error log when running Rapids Accelerator test cases.
```
All tests passed.

22/06/27 17:45:57.298 Thread-7 ERROR HostMemoryBuffer: A HOST BUFFER WAS LEAKED (ID: 1 7f8557fff010)
22/06/27 17:45:57.303 Thread-7 ERROR MemoryCleaner: Leaked host buffer (ID: 1): 2022-06-27 09:45:16.0171 UTC: INC
java.lang.Thread.getStackTrace(Thread.java:1559)
ai.rapids.cudf.MemoryCleaner$RefCountDebugItem.<init>(MemoryCleaner.java:301)
ai.rapids.cudf.MemoryCleaner$Cleaner.addRef(MemoryCleaner.java:82)
ai.rapids.cudf.MemoryBuffer.incRefCount(MemoryBuffer.java:232)
ai.rapids.cudf.MemoryBuffer.<init>(MemoryBuffer.java:98)
ai.rapids.cudf.HostMemoryBuffer.<init>(HostMemoryBuffer.java:196)
ai.rapids.cudf.HostMemoryBuffer.<init>(HostMemoryBuffer.java:192)
ai.rapids.cudf.HostMemoryBuffer.allocate(HostMemoryBuffer.java:144)
com.nvidia.spark.rapids.RapidsHostMemoryStore.<init>(RapidsHostMemoryStore.scala:38)
```

### Root cause
RapidsHostMemoryStore.pool is not closed before MemoryCleaner checking the leaks.
It's actually not a leak, it's caused by hooks execution order.
RapidsHostMemoryStore.pool is closed in the [Spark executor plugin hook](https://github.com/apache/spark/blob/v3.3.0/core/src/main/scala/org/apache/spark/executor/Executor.scala#L351toL381).

plugins.foreach(_.shutdown())  // this line will eventually close the RapidsHostMemoryStore.pool
The close path is:
```
  The close path is: 
    Spark executor plugin hook ->
      RapidsExecutorPlugin.shutdown ->
        GpuDeviceManager.shutdown ->
          RapidsBufferCatalog.close() ->
            RapidsHostMemoryStore.close ->
              RapidsHostMemoryStore.pool.close ->
```

### Solution
First, remove the default hook in MemoryCleaner, then add the default hook by leveraging Spark ShutdownHookManager

See the cuDF side change:  https://github.com/rapidsai/cudf/pull/11161

Signed-off-by: Chong Gao <res_life@163.com>
