### PR TITLE
Address feedback in "Improve regular expression error messages" PR

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -734,7 +734,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case _ => false
     }
   }
-  
+
   private def getUnsupportedRepetitionBase(e: RegexAST): Option[RegexAST] = {
     e match {
       case RegexEscaped(ch) => ch match {
@@ -752,7 +752,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
       case RegexSequence(parts) =>
         parts.foreach { part => getUnsupportedRepetitionBase(part) match {
             case r @ Some(_) => return r
-            case _ =>
+            case None =>
           } 
         }
         None


### PR DESCRIPTION
Follow up to https://github.com/NVIDIA/spark-rapids/pull/5871 to address some feedback. 

Refactored `isSupportedRepetitionBase` into two separate functions `isSupportedRepetitionBase` and `getUnsupportedRepetitionBase`. 

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
