### PR TITLE
Remove scaladoc warning 

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -778,7 +778,7 @@ object GpuRegExpUtils {
   /**
    * Convert symbols of back-references if input string contains any.
    * In spark's regex rule, there are two patterns of back-references:
-   * \group_index and \$group_index
+   * \group_index and \$group_index 
    * This method transforms above two patterns into cuDF pattern \${group_index}, except they are
    * preceded by escape character.
    *

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -778,7 +778,7 @@ object GpuRegExpUtils {
   /**
    * Convert symbols of back-references if input string contains any.
    * In spark's regex rule, there are two patterns of back-references:
-   * \group_index and \$group_index 
+   * \group_index and \$group_index
    * This method transforms above two patterns into cuDF pattern \${group_index}, except they are
    * preceded by escape character.
    *

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -778,8 +778,8 @@ object GpuRegExpUtils {
   /**
    * Convert symbols of back-references if input string contains any.
    * In spark's regex rule, there are two patterns of back-references:
-   * \group_index and $group_index
-   * This method transforms above two patterns into cuDF pattern ${group_index}, except they are
+   * \group_index and \$group_index
+   * This method transforms above two patterns into cuDF pattern \${group_index}, except they are
    * preceded by escape character.
    *
    * @param rep replacement string


### PR DESCRIPTION
Escape `$` in a comment to remove scaladoc warnings.    
Fixes #5956