### PR TITLE
Enable null in regex character classes

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -585,9 +585,6 @@ These are the known edge cases where running on the GPU will produce different r
 - Regular expressions that contain an end of line anchor '$' or end of string anchor '\Z' or '\z' immediately
  next to a newline or a repetition that produces zero or more results
  ([#5610](https://github.com/NVIDIA/spark-rapids/pull/5610))`
-- The character class `\p{ASCII}` matches only `[\x01-\x7F]` as opposed to Java's definition which matches `[\x00-\x7F]`,
- since null characters are not currently supported. Similarily, `\p{Cntrl}` matches only `[\x01-\x1F\x7F]` as 
- opposed to Java's `[\x00-\x1F\x7F]`
 
 The following regular expression patterns are not yet supported on the GPU and will fall back to the CPU.
 
@@ -604,7 +601,6 @@ The following regular expression patterns are not yet supported on the GPU and w
 - Character classes that use union, intersection, or subtraction semantics, such as `[a-d[m-p]]`, `[a-z&&[def]]`, 
   or `[a-z&&[^bc]]`
 - Empty groups: `()`
-- Regular expressions containing null characters (unless the pattern is a simple literal string)
 - `regexp_replace` does not support back-references
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -655,7 +655,10 @@ def test_re_replace_null():
                 'REGEXP_REPLACE(a, "\x00", "NULL")',
                 'REGEXP_REPLACE(a, "\0", "NULL")',
                 'REGEXP_REPLACE(a, "TE\u0000ST", "PROD")',
-                'REGEXP_REPLACE(a, "TE\u0000\u0000ST", "PROD")'),
+                'REGEXP_REPLACE(a, "TE\u0000\u0000ST", "PROD")',
+                'REGEXP_REPLACE(a, "[\x00TEST]", "PROD")',
+                'REGEXP_REPLACE(a, "[TE\00ST]", "PROD")',
+                'REGEXP_REPLACE(a, "[\u0000-z]", "PROD")'),
         conf=_regexp_conf)
 
 def test_length():

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -818,7 +818,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
           case r @ RegexOctalChar(_) => r.codePoint.toChar
           case r @ RegexHexDigit(_) => r.codePoint.toChar
           case other => throw new RegexUnsupportedException(
-            s"Unexpected expression at start of character range: ${other.toString}", other.position)
+            s"Unexpected expression at start of character range: ${other.toRegexString}", 
+            other.position)
         }
         if (start <= '\n' && end >= '\r') {
           Seq('\n', '\r')

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -450,8 +450,7 @@ class RegexParser(pattern: String) {
         case "Upper" => 
           ListBuffer(RegexCharacterRange(RegexChar('A'), RegexChar('Z')))
         case "ASCII" =>
-          // should be \u0000-\u007f, see: https://github.com/NVIDIA/spark-rapids/issues/5909
-          ListBuffer(RegexCharacterRange(RegexChar('\u0001'), RegexChar('\u007f')))
+          ListBuffer(RegexCharacterRange(RegexHexDigit("00"), RegexChar('\u007f')))
         case "Alpha" => 
           ListBuffer(getCharacters("Lower"), getCharacters("Upper")).flatten
         case "Digit" =>
@@ -470,8 +469,7 @@ class RegexParser(pattern: String) {
         case "Blank" =>
           ListBuffer(RegexChar(' '), RegexEscaped('t'))
         case "Cntrl" =>
-          // should be \u0000-\u001f, see: https://github.com/NVIDIA/spark-rapids/issues/5909
-          ListBuffer(RegexCharacterRange(RegexChar('\u0001'), RegexChar('\u001f')), 
+          ListBuffer(RegexCharacterRange(RegexHexDigit("00"), RegexChar('\u001f')), 
             RegexChar('\u007f'))
         case "XDigit" =>
           ListBuffer(RegexCharacterRange(RegexChar('0'), RegexChar('9')),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -166,14 +166,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     })
   }
 
-  test("cuDF does not support null in character classes") {
-    val patterns = Seq(raw"[\00]", "[a\u0000 b]", raw"[\x00]", raw"[\x{0000}]")
-    patterns.foreach(pattern => {
-      assertUnsupported(pattern, RegexFindMode,
-        "cuDF does not support null characters in character classes")
-    })
-  }
-
   test("cuDF does not support class intersection &&") {
     val patterns = Seq("[a&&b]", "[&&1]")
     patterns.foreach(pattern =>


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/5909

Enable the null terminator `\u0000` in character classes, character class ranges, and in the POSIX predefined character classes. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
