### PR TITLE
Enable zstd integration tests for parquet and orc

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -174,6 +174,10 @@ def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func, v1_enabled_lis
             conf=all_confs)
 
 orc_compress_options = ['none', 'uncompressed', 'snappy', 'zlib']
+# zstd is available in spark 3.2.0 and later.
+if not is_before_spark_320():
+    orc_compress_options.append('zstd')
+
 # The following need extra jars 'lzo'
 # https://github.com/NVIDIA/spark-rapids/issues/143
 

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -145,6 +145,9 @@ def test_parquet_read_round_trip_binary_as_string(std_input_path, read_func, rea
             conf=all_confs)
 
 parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
+# zstd is available in spark 3.2.0 and later.
+if not is_before_spark_320():
+    parquet_compress_options.append('zstd')
 # The following need extra jars 'lzo', 'lz4', 'brotli', 'zstd'
 # https://github.com/NVIDIA/spark-rapids/issues/143
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

This is a followup to #5898 and #5916.
Now that cuDF PR  [11226](https://github.com/rapidsai/cudf/pull/11226) has been merged, we no longer need to specify LIBCUDF_NVCOMP_POLICY=ALWAYS to use zstd.

This also updates to include orc_test.py, since cuDF supports zstd for both parquet and orc.

Closes https://github.com/NVIDIA/spark-rapids/issues/5580