### PR TITLE
Fix a minor potential issue when rebatching for GpuArrowEvalPythonExec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -160,7 +160,7 @@ class RebatchingRoundoffIterator(
 
     val rc: Long = combined.numRows()
 
-    if (rc % targetRoundoff == 0 || rc < targetRoundoff) {
+    if (rc <= targetRoundoff) {
       return combined
     }
 


### PR DESCRIPTION
There is a chance that the row number of the combined batches is
just a multiple of batch size, which results in returning this huge
ColumnBatch directly.

``` patch
-    if (rc % targetRoundoff == 0 || rc < targetRoundoff) {
+    if (rc <= targetRoundoff) {
       return combined
     }
 
```