### PR TITLE
Skip Iceberg tests on Databricks [databricks]

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -183,6 +183,8 @@ def pytest_runtest_setup(item):
     if item.get_closest_marker('iceberg'):
         if not item.config.getoption('iceberg'):
             pytest.skip('Iceberg tests not configured to run')
+        elif is_databricks_runtime():
+            pytest.skip('Iceberg tests skipped on Databricks')
 
 def pytest_configure(config):
     global _runtime_env


### PR DESCRIPTION
Fixes #6022

Apache Iceberg 0.13.x is not compatible with Databricks 10.4.  It's very likely those on Databricks are using Delta Engine rather than Iceberg, so this is probably a very rare setup that isn't surprising to be non-functional given Iceberg relies on evolving/unstable DataSource V2 Spark APIs.

This change simply skips the Iceberg tests on Databricks.