### PR TITLE
Cleans up some of the redundant code in proxy/internal RAPIDS Shuffle Managers [databricks]

### DIFF
--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -28,6 +28,6 @@ com/nvidia/spark/rapids/SparkShimVersion*
 com/nvidia/spark/rapids/SparkShims*
 com/nvidia/spark/udf/Plugin*
 org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase*
-org/apache/spark/sql/rapids/VisibleShuffleManager*
+org/apache/spark/sql/rapids/RapidsShuffleManagerLike*
 rapids/*.py
 rapids4spark-version-info.properties

--- a/sql-plugin/src/main/311-nondb/scala/org/apache/spark/sql/rapids/shims/spark311/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/311-nondb/scala/org/apache/spark/sql/rapids/shims/spark311/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark311
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,34 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+      with ShuffleManager

--- a/sql-plugin/src/main/312-nondb/scala/org/apache/spark/sql/rapids/shims/spark312/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/312-nondb/scala/org/apache/spark/sql/rapids/shims/spark312/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark312
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+    with ShuffleManager

--- a/sql-plugin/src/main/312db/scala/org/apache/spark/sql/rapids/shims/spark312db/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/312db/scala/org/apache/spark/sql/rapids/shims/spark312db/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark312db
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,34 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+      with ShuffleManager

--- a/sql-plugin/src/main/313/scala/org/apache/spark/sql/rapids/shims/spark313/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/313/scala/org/apache/spark/sql/rapids/shims/spark313/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark313
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,34 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+      with ShuffleManager

--- a/sql-plugin/src/main/314/scala/org/apache/spark/sql/rapids/shims/spark314/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/314/scala/org/apache/spark/sql/rapids/shims/spark314/RapidsShuffleInternalManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark314
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,34 +26,9 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+      with ShuffleManager

--- a/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/spark320/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/320/scala/org/apache/spark/sql/rapids/shims/spark320/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark320
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+    with ShuffleManager

--- a/sql-plugin/src/main/321/scala/org/apache/spark/sql/rapids/shims/spark321/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/321/scala/org/apache/spark/sql/rapids/shims/spark321/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark321
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+    with ShuffleManager

--- a/sql-plugin/src/main/321cdh/scala/org/apache/spark/sql/rapids/shims/spark321cdh/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/321cdh/scala/org/apache/spark/sql/rapids/shims/spark321cdh/RapidsShuffleInternalManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark321cdh
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+    with ShuffleManager

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/spark321db/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/spark321db/RapidsShuffleInternalManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark321db
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,34 +26,8 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+    extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)
+      with ShuffleManager

--- a/sql-plugin/src/main/322/scala/org/apache/spark/sql/rapids/shims/spark322/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/322/scala/org/apache/spark/sql/rapids/shims/spark322/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark322
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,7 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager

--- a/sql-plugin/src/main/330/scala/org/apache/spark/sql/rapids/shims/spark330/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/330/scala/org/apache/spark/sql/rapids/shims/spark330/RapidsShuffleInternalManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark330
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,7 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager

--- a/sql-plugin/src/main/331/scala/org/apache/spark/sql/rapids/shims/spark331/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/331/scala/org/apache/spark/sql/rapids/shims/spark331/RapidsShuffleInternalManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark331
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,7 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager

--- a/sql-plugin/src/main/340/scala/org/apache/spark/sql/rapids/shims/spark340/RapidsShuffleInternalManager.scala
+++ b/sql-plugin/src/main/340/scala/org/apache/spark/sql/rapids/shims/spark340/RapidsShuffleInternalManager.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.shims.spark340
 
-import org.apache.spark.{SparkConf, TaskContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.shuffle._
 import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, RapidsShuffleInternalManagerBase}
 
@@ -26,35 +26,7 @@ import org.apache.spark.sql.rapids.{ProxyRapidsShuffleInternalManagerBase, Rapid
  *       `ShuffleManager` and `SortShuffleManager` classes.
  */
 class RapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-    extends RapidsShuffleInternalManagerBase(conf, isDriver) {
-
-  def getReader[K, C](
-      handle: ShuffleHandle,
-      startMapIndex: Int,
-      endMapIndex: Int,
-      startPartition: Int,
-      endPartition: Int,
-      context: TaskContext,
-      metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderInternal(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
-
+    extends RapidsShuffleInternalManagerBase(conf, isDriver)
 
 class ProxyRapidsShuffleInternalManager(conf: SparkConf, isDriver: Boolean)
-  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager {
-
-  def getReader[K, C](
-    handle: ShuffleHandle,
-    startMapIndex: Int,
-    endMapIndex: Int,
-    startPartition: Int,
-    endPartition: Int,
-    context: TaskContext,
-    metrics: ShuffleReadMetricsReporter
-  ): ShuffleReader[K, C] = {
-    self.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context,
-      metrics)
-  }
-}
+  extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver) with ShuffleManager

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuShuffleEnv.scala
@@ -73,7 +73,7 @@ object GpuShuffleEnv extends Logging {
     // check for nulls in tests
     Option(SparkEnv.get)
       .map(_.shuffleManager)
-      .collect { case sm: VisibleShuffleManager => sm }
+      .collect { case sm: RapidsShuffleManagerLike => sm }
       .foreach(_.stop())
 
     // when we shut down, make sure we clear `env`, as the convention is that
@@ -102,8 +102,8 @@ object GpuShuffleEnv extends Logging {
   //
   def initShuffleManager(): Unit = {
     SparkEnv.get.shuffleManager match {
-      case visibleMgr: VisibleShuffleManager =>
-        visibleMgr.initialize
+      case rapidsShuffleManager: RapidsShuffleManagerLike =>
+        rapidsShuffleManager.initialize
       case _ =>
         throw new IllegalStateException(s"Cannot initialize the RAPIDS Shuffle Manager")
     }
@@ -112,7 +112,7 @@ object GpuShuffleEnv extends Logging {
   def isRapidsShuffleAvailable(conf: RapidsConf): Boolean = {
     // the driver has `mgr` defined when this is checked
     val sparkEnv = SparkEnv.get
-    val isRapidsManager = sparkEnv.shuffleManager.isInstanceOf[VisibleShuffleManager]
+    val isRapidsManager = sparkEnv.shuffleManager.isInstanceOf[RapidsShuffleManagerLike]
     if (isRapidsManager) {
       validateRapidsShuffleManager(sparkEnv.shuffleManager.getClass.getName)
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes #3624.

I am looking to cleanup some of the proxy/base/internal classes in RapidsShuffleManager as per the issue @gerashegalov raised a while back. As it is now, each shim has 3 things: 

- RapidsShuffleManager (what the user sets, which subclasses `ProxyRapidsShuffleInternalManager`)
- ProxyRapidsShuffleInternalManager (which subclasses from `ProxyRapidsShuffleInternalManagerBase`)
- RapidsShuffleInternalManager (which subclasses from `RapidsShuffleInternalManagerBase`)

And essentially the `RapidsShuffleManager` (aka the proxy) loads the internal manager later in time. We have different versions of this so we get one specific to each shim, for binary compatibility reasons.

This change mainly moves `getReader` back to the `RapidsShuffleInternalManagerBase` so we can remove some redundant code (this path was the same everywhere I saw). It also renames `VisibleShuffleManager` to `RapidsShuffleManagerLike`, but this is not something I feel too strongly about. @gerashegalov could you take a look to see if you have other recommendations that can be done here?

There's more that can be done, for example `ShuffleManager` is consistent for all the spark versions we support (well not sure about the vendor specific ones as much), so we could in theory have a single `RapidsShuffleManager` that really just subclasses from `ProxyRapidsShuffleInternalManagerBase` directly and also implements `ShuffleManager`... but that seems like a bigger change.