### PR TITLE
Enable anchors in regexp string split

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -100,7 +100,11 @@ def test_split_re_no_limit():
             'split(a, "[^o]")',
             'split(a, "[o]{1,2}")',
             'split(a, "[bf]")',
-            'split(a, "[o]")'),
+            'split(a, "[o]")',
+            'split(a, "^(boo|foo):$")',
+            'split(a, "[bf]$:")',
+            'split(a, "b^")',
+            'split(a, "^[o]")'),
             conf=_regexp_conf)
 
 def test_split_optimized_no_re():

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -29,10 +29,6 @@ import org.apache.spark.sql.rapids.GpuRegExpUtils
 import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
-  // test("test1") {
-  //   doStringSplitTest(Set("cc$"), Seq("\rcc\r"), -1)
-  // }
-
 
   test("transpiler detects invalid cuDF patterns") {
     // The purpose of this test is to document some examples of valid Java regular expressions


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/4719

This took some time to grok but it appears like Java's implementation for `\z`, `$`, and `^` in specifically string split is inconsistent with it's own implementation in find/replace. `\z`, `$`, and `^` do not respect new lines/line terminators in string split. Conveniently, `\Z` and `\A` in cuDF also do not match line terminators so we can transpile to that. 

I also needed to disable repetitions of `\A` in split because of some fuzzer failures. I think it's possible to support it but I'm not sure how and it isn't a priority.  

Signed-off-by: Anthony Chang <antchang@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
