### PR TITLE
Improve check for UTF-8 in integration tests by testing from the JVM

### DIFF
--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from spark_session import is_before_spark_320, is_jvm_charset_not_utf8
+from spark_session import is_before_spark_320, is_jvm_charset_utf8
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
@@ -199,7 +199,7 @@ def test_conditional_with_side_effects_col_scalar(data_gen):
             conf = ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,20}')], ids=idfn)
-@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expressions require UTF-8")
+@pytest.mark.skipif(not is_jvm_charset_utf8(), reason="regular expressions require UTF-8")
 def test_conditional_with_side_effects_cast(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})
@@ -209,7 +209,7 @@ def test_conditional_with_side_effects_cast(data_gen):
             conf = test_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,9}')], ids=idfn)
-@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expressions require UTF-8")
+@pytest.mark.skipif(not is_jvm_charset_utf8(), reason="regular expressions require UTF-8")
 def test_conditional_with_side_effects_case_when(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -20,6 +20,8 @@ from spark_session import is_before_spark_320
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
 
+from spark_session import is_jvm_charset_not_utf8
+
 def mk_str_gen(pattern):
     return StringGen(pattern).with_special_case('').with_special_pattern('.{0,10}')
 
@@ -199,6 +201,7 @@ def test_conditional_with_side_effects_col_scalar(data_gen):
             conf = ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,20}')], ids=idfn)
+@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expression does not work without UTF-8")
 def test_conditional_with_side_effects_cast(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})
@@ -208,6 +211,7 @@ def test_conditional_with_side_effects_cast(data_gen):
             conf = test_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,9}')], ids=idfn)
+@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expression does not work without UTF-8")
 def test_conditional_with_side_effects_case_when(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -199,7 +199,7 @@ def test_conditional_with_side_effects_col_scalar(data_gen):
             conf = ansi_enabled_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,20}')], ids=idfn)
-@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expression does not work without UTF-8")
+@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expressions require UTF-8")
 def test_conditional_with_side_effects_cast(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})
@@ -209,7 +209,7 @@ def test_conditional_with_side_effects_cast(data_gen):
             conf = test_conf)
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[0-9]{1,9}')], ids=idfn)
-@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expression does not work without UTF-8")
+@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="regular expressions require UTF-8")
 def test_conditional_with_side_effects_case_when(data_gen):
     test_conf=copy_and_update(
         ansi_enabled_conf, {'spark.rapids.sql.regexp.enabled': True})

--- a/integration_tests/src/main/python/conditionals_test.py
+++ b/integration_tests/src/main/python/conditionals_test.py
@@ -16,11 +16,9 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
-from spark_session import is_before_spark_320
+from spark_session import is_before_spark_320, is_jvm_charset_not_utf8
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
-
-from spark_session import is_jvm_charset_not_utf8
 
 def mk_str_gen(pattern):
     return StringGen(pattern).with_special_case('').with_special_pattern('.{0,10}')

--- a/integration_tests/src/main/python/qa_nightly_select_test.py
+++ b/integration_tests/src/main/python/qa_nightly_select_test.py
@@ -22,7 +22,7 @@ from decimal import Decimal
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from qa_nightly_sql import *
 import pytest
-from spark_session import with_cpu_session
+from spark_session import with_cpu_session, is_jvm_charset_not_utf8
 from marks import approximate_float, ignore_order, incompat, qarun
 from data_gen import copy_and_update
 
@@ -218,3 +218,16 @@ def test_select_float_order_local(sql_query_line, pytestconfig):
         with_cpu_session(num_stringDf)
         assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)
 
+
+@approximate_float(abs=1e-6)
+@incompat
+@ignore_order(local=True)
+@qarun
+@pytest.mark.parametrize('sql_query_line', SELECT_REGEXP_SQL, ids=idfn)
+@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="Regular expressions require UTF-8")
+def test_select_float_order_local(sql_query_line, pytestconfig):
+    sql_query = sql_query_line[0]
+    if sql_query:
+        print(sql_query)
+        with_cpu_session(num_stringDf)
+        assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.sql(sql_query), conf=_qa_conf)

--- a/integration_tests/src/main/python/qa_nightly_select_test.py
+++ b/integration_tests/src/main/python/qa_nightly_select_test.py
@@ -225,7 +225,7 @@ def test_select_float_order_local(sql_query_line, pytestconfig):
 @qarun
 @pytest.mark.parametrize('sql_query_line', SELECT_REGEXP_SQL, ids=idfn)
 @pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="Regular expressions require UTF-8")
-def test_select_float_order_local(sql_query_line, pytestconfig):
+def test_select_regexp(sql_query_line, pytestconfig):
     sql_query = sql_query_line[0]
     if sql_query:
         print(sql_query)

--- a/integration_tests/src/main/python/qa_nightly_select_test.py
+++ b/integration_tests/src/main/python/qa_nightly_select_test.py
@@ -22,7 +22,7 @@ from decimal import Decimal
 from asserts import assert_gpu_and_cpu_are_equal_collect
 from qa_nightly_sql import *
 import pytest
-from spark_session import with_cpu_session, is_jvm_charset_not_utf8
+from spark_session import with_cpu_session, is_jvm_charset_utf8
 from marks import approximate_float, ignore_order, incompat, qarun
 from data_gen import copy_and_update
 
@@ -224,7 +224,7 @@ def test_select_float_order_local(sql_query_line, pytestconfig):
 @ignore_order(local=True)
 @qarun
 @pytest.mark.parametrize('sql_query_line', SELECT_REGEXP_SQL, ids=idfn)
-@pytest.mark.skipif(is_jvm_charset_not_utf8(), reason="Regular expressions require UTF-8")
+@pytest.mark.skipif(not is_jvm_charset_utf8(), reason="Regular expressions require UTF-8")
 def test_select_regexp(sql_query_line, pytestconfig):
     sql_query = sql_query_line[0]
     if sql_query:

--- a/integration_tests/src/main/python/qa_nightly_sql.py
+++ b/integration_tests/src/main/python/qa_nightly_sql.py
@@ -194,7 +194,7 @@ SELECT_SQL = [
 ("SELECT * FROM test_table WHERE strF LIKE 'Y%'", "* WHERE strF LIKE 'Y%'"),
 ("SELECT * FROM test_table WHERE strF LIKE '%an' ", "* WHERE strF LIKE '%an'"),
 ("SELECT REPLACE(strF, 'Yuan', 'Eric') FROM test_table", "REPLACE(strF, 'Yuan', 'Eric')"),
-("SELECT REGEXP_REPLACE(strF, 'Yu', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Yu', 'Eric')"),
+# ("SELECT REGEXP_REPLACE(strF, 'Yu', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Yu', 'Eric')"),
 #("SELECT REGEXP_REPLACE(strF, 'Y*', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Y*', 'Eric')"),
 ("SELECT CONCAT(strF, strF) FROM test_table", "CONCAT(strF, strF)"),
 # (" DATETIME", "DATETIME"),

--- a/integration_tests/src/main/python/qa_nightly_sql.py
+++ b/integration_tests/src/main/python/qa_nightly_sql.py
@@ -194,7 +194,6 @@ SELECT_SQL = [
 ("SELECT * FROM test_table WHERE strF LIKE 'Y%'", "* WHERE strF LIKE 'Y%'"),
 ("SELECT * FROM test_table WHERE strF LIKE '%an' ", "* WHERE strF LIKE '%an'"),
 ("SELECT REPLACE(strF, 'Yuan', 'Eric') FROM test_table", "REPLACE(strF, 'Yuan', 'Eric')"),
-# ("SELECT REGEXP_REPLACE(strF, 'Yu', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Yu', 'Eric')"),
 #("SELECT REGEXP_REPLACE(strF, 'Y*', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Y*', 'Eric')"),
 ("SELECT CONCAT(strF, strF) FROM test_table", "CONCAT(strF, strF)"),
 # (" DATETIME", "DATETIME"),
@@ -815,4 +814,8 @@ SELECT_PRE_ORDER_SQL=[
 SELECT_FLOAT_SQL=[
 ("SELECT IFNULL(floatF, 0) as if_null FROM test_table", "IFNULL(floatF, 0)"),
 ("SELECT floatF, COALESCE(floatF, 0) FROM test_table", "floatF, COALESCE(floatF,0)"),
+]
+
+SELECT_REGEXP_SQL=[
+("SELECT REGEXP_REPLACE(strF, 'Yu', 'Eric') FROM test_table", "REGEXP_REPLACE(strF, 'Yu', 'Eric')"),
 ]

--- a/integration_tests/src/main/python/regexp_no_unicode_test.py
+++ b/integration_tests/src/main/python/regexp_no_unicode_test.py
@@ -20,7 +20,9 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 
-if locale.nl_langinfo(locale.CODESET) == 'UTF-8':
+from spark_session import is_jvm_charset_utf8
+
+if is_jvm_charset_utf8():
     pytestmark = pytest.mark.skip(reason=str("Current locale uses UTF-8, fallback will not occur"))
 
 _regexp_conf = { 'spark.rapids.sql.regexp.enabled': 'true' }

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -21,9 +21,9 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_co
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import is_before_spark_320, is_jvm_charset_not_utf8
+from spark_session import is_before_spark_320, is_jvm_charset_utf8
 
-if is_jvm_charset_not_utf8():
+if not is_jvm_charset_utf8():
     pytestmark = [pytest.mark.regexp, pytest.mark.skip(reason=str("Current locale doesn't support UTF-8, regexp support is disabled"))]
 else:
     pytestmark = pytest.mark.regexp

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -21,9 +21,9 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_co
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import is_before_spark_320
+from spark_session import is_before_spark_320, is_jvm_charset_not_utf8
 
-if locale.nl_langinfo(locale.CODESET) != 'UTF-8':
+if is_jvm_charset_not_utf8():
     pytestmark = [pytest.mark.regexp, pytest.mark.skip(reason=str("Current locale doesn't support UTF-8, regexp support is disabled"))]
 else:
     pytestmark = pytest.mark.regexp

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -189,3 +189,13 @@ def get_java_major_version():
     elif dash_pos != -1:
         ver = ver[0:dash_pos]
     return int(ver)
+
+def get_jvm_charset():
+    sc = SparkContext.getOrCreate()
+    return str(sc._jvm.java.nio.charset.Charset.defaultCharset())
+
+def is_jvm_charset_utf8():
+    return get_jvm_charset() == 'UTF-8'
+
+def is_jvm_charset_not_utf8():
+    return get_jvm_charset() != 'UTF-8'

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -191,7 +191,7 @@ def get_java_major_version():
     return int(ver)
 
 def get_jvm_charset():
-    sc = SparkContext.getOrCreate()
+    sc = _spark.sparkContext
     return str(sc._jvm.java.nio.charset.Charset.defaultCharset())
 
 def is_jvm_charset_utf8():

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -196,6 +196,3 @@ def get_jvm_charset():
 
 def is_jvm_charset_utf8():
     return get_jvm_charset() == 'UTF-8'
-
-def is_jvm_charset_not_utf8():
-    return get_jvm_charset() != 'UTF-8'


### PR DESCRIPTION
Fix for #6028.

This moves the check for UTF-8 to using the underlying JVM from the spark context instead of checking from the Python locale.  Also checks are added to handle specific regular expression integration tests to ensure that UTF-8 is available to ensure the test can run properly.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
