### PR TITLE
[BUG] Fix IT discrepancy which depending on TEST_PARALLEL

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -243,6 +243,10 @@ else
         # buffers as large as batchSizeBytes can be allocated, and the fewer of them we have the better.
         LOCAL_PARALLEL=$(( $CPU_CORES > 4 ? 4 : $CPU_CORES ))
         export PYSP_TEST_spark_master="local[$LOCAL_PARALLEL,$SPARK_TASK_MAXFAILURES]"
+      else
+        # If specified master, set `spark.executor.extraClassPath` due to issue https://github.com/NVIDIA/spark-rapids/issues/5796
+        # Remove this line if the issue is fixed
+        export PYSP_TEST_spark_executor_extraClassPath="${ALL_JARS}"
       fi
     fi
 


### PR DESCRIPTION
Fixes #5714

### Changes:

- Use `spark.jars` configuration instead of `spark.executor.extraClassPath` and `spark.driver.extraClassPath`.
  There're 2 paths depending on `TEST_PARALLEL`.
```
    if ((${#TEST_PARALLEL_OPTS[@]} > 0));
    then
        exec python "${RUN_TESTS_COMMAND[@]}" "${TEST_PARALLEL_OPTS[@]}" "${TEST_COMMON_OPTS[@]}"
    else
        # We set the GPU memory size to be a constant value even if only running with a parallelism of 1
        # because it helps us have consistent test runs.
        exec "$SPARK_HOME"/bin/spark-submit --jars "${ALL_JARS// /,}" \
            --driver-java-options "$PYSP_TEST_spark_driver_extraJavaOptions" \
            $SPARK_SUBMIT_FLAGS \
            --conf 'spark.rapids.memory.gpu.allocSize='"$PYSP_TEST_spark_rapids_memory_gpu_allocSize" \
            "${RUN_TESTS_COMMAND[@]}" "${TEST_COMMON_OPTS[@]}"
    fi
```

Update the first path, also use `spark.jars` which is same as `--jars`

  `spark.executor.extraClassPath` is deprecated see: 
  https://spark.apache.org/docs/latest/configuration.html

```
spark.executor.extraClassPath: 
Extra classpath entries to prepend to the classpath of executors. 
This exists primarily for backwards-compatibility with older versions of Spark. 
Users typically should not need to set this option.	
```

We can also find the `spark.jars` configure from the above link.

- Update `bash` script to test jar file existence before set JAR_PATH


Signed-off-by: Chong Gao <res_life@163.com>
