### PR TITLE
Fix test hang caused by parquet hadoop test jar log4j file

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -51,6 +51,9 @@ else
         if [ -f $(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar) ]; then
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
             PARQUET_HADOOP_TESTS=$(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar)
+            # remove the log4j.properties file so it doesn't conflict with ours, ignore errors
+            # if it isn't present or already removed
+            zip -d $PARQUET_HADOOP_TESTS log4j.properties || true
         else
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=false
             PARQUET_HADOOP_TESTS=
@@ -60,10 +63,13 @@ else
     else
         AVRO_JARS=$(echo "$SCRIPTPATH"/target/dependency/spark-avro*.jar)
         PARQUET_HADOOP_TESTS=$(echo "$SCRIPTPATH"/target/dependency/parquet-hadoop*.jar)
+        # remove the log4j.properties file so it doesn't conflict with ours, ignore errors
+        # if it isn't present or already removed
+        zip -d $PARQUET_HADOOP_TESTS log4j.properties || true
         MIN_PARQUET_JAR="$SCRIPTPATH/target/dependency/parquet-hadoop-1.12.0-tests.jar"
         # Make sure we have Parquet version >= 1.12 in the dependency
         LOWEST_PARQUET_JAR=$(echo -e "$MIN_PARQUET_JAR\n$PARQUET_HADOOP_TESTS" | sort -V | head -1)
-        export INCLUDE_PARQUET_HADOOP_TEST_JAR=$([[ "$LOWEST_PARQUET_JAR" == "MIN_PARQUET_JAR" ]] && echo true || echo false)
+        export INCLUDE_PARQUET_HADOOP_TEST_JAR=$([[ "$LOWEST_PARQUET_JAR" == "$MIN_PARQUET_JAR" ]] && echo true || echo false)
         PLUGIN_JARS=$(echo "$SCRIPTPATH"/../dist/target/rapids-4-spark_*.jar)
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$SCRIPTPATH"/target/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6017

The issue here is that the parquet-hadoop-1.X-tests.jar contains a log4j.properties file that was being picked up by the executors. It has debug turned on and causes a ton of logging.  This might be a bit hacky but just remove the log4j.properties file from the parquet hadoop test jar before we run the tests.  This seems the most straight forward thing without having to create our own shims for the test jar.  Open to other ideas if people have them.

Also fixes an issue with the comparison where it wasn't actually running the encryption test when it should be.  The check was missing the $ in the variable name.

tested on standalone 3.2.2 and 3.3 and in local mode.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
