### PR TITLE
Tag `GpuWindow` child expressions for GPU execution

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -86,6 +86,10 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
   lazy val inputFields: Seq[BaseExprMeta[Attribute]] =
     windowExec.children.head.output.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
+  /**
+   * Define all dependency expressions as `childExprs`.
+   * This ensures that they are tagged for GPU execution.
+   */
   override val childExprs: Seq[BaseExprMeta[_]] =
         windowExpressions ++ partitionSpec ++ orderSpec ++ inputFields
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -83,10 +83,11 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     getPartitionSpecs.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
   val orderSpec: Seq[BaseExprMeta[SortOrder]] =
     getOrderSpecs.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
-
   lazy val inputFields: Seq[BaseExprMeta[Attribute]] =
     windowExec.children.head.output.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
 
+  override val childExprs: Seq[BaseExprMeta[_]] =
+        windowExpressions ++ partitionSpec ++ orderSpec ++ inputFields
 
   override def namedChildExprs: Map[String, Seq[BaseExprMeta[_]]] = Map(
     "partitionSpec" -> partitionSpec

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -374,19 +374,26 @@ abstract class UnixTimeExprMeta[A <: BinaryExpression with TimeZoneAwareExpressi
    rule: DataFromReplacementRule)
   extends BinaryExprMeta[A](expr, conf, parent, rule) {
 
-  var sparkFormat: String = _
-  var strfFormat: String = _
+  val optionalRightStringLit: Option[String] =
+    if (expr.right.dataType == StringType) {
+      extractStringLit(expr.right)
+    } else {
+      None
+    }
+
+  lazy val (sparkFormat, strfFormat): (String, String) =
+    optionalRightStringLit match {
+      case Some(rightLit) =>
+        (rightLit,
+         DateUtils.tagAndGetCudfFormat(this, rightLit,
+                                       expr.left.dataType == DataTypes.StringType))
+      case None => (null, null)
+    }
+
   override def tagExprForGpu(): Unit = {
     // Date and Timestamp work too
-    if (expr.right.dataType == StringType) {
-      extractStringLit(expr.right) match {
-        case Some(rightLit) =>
-          sparkFormat = rightLit
-          strfFormat = DateUtils.tagAndGetCudfFormat(this,
-            sparkFormat, expr.left.dataType == DataTypes.StringType)
-        case None =>
-          willNotWorkOnGpu("format has to be a string literal")
-      }
+    if (expr.right.dataType == StringType && optionalRightStringLit.isEmpty) {
+      willNotWorkOnGpu("format has to be a string literal")
     }
   }
 }


### PR DESCRIPTION
Fixes #5984.

This change tags the child expressions of a GpuWindowExecMeta, to ensure
that all dependency expressions initialized correctly.
    
Certain child expressions might not be completely initialized even after
`GpuOverrides#wrapExpr()` has been called. For instance, `UnixTimeExprMeta`
postpones some of its initialization until `tagExprForGpu()` is called.
    
By declaring `windowExpressions`, `partitionSpec`, `orderSpec`, etc. as
`childExprs` of `GpuWindowExecMeta`, one guarantees that the
`GpuOverrides` infrastructure will tag them for GPU execution.

Signed-off-by: MithunR <mythrocks@gmail.com>
