### PR TITLE
Disable zstd orc tests in cdh

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -175,7 +175,7 @@ def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func, v1_enabled_lis
 
 orc_compress_options = ['none', 'uncompressed', 'snappy', 'zlib']
 # zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320():
+if not is_before_spark_320() and not is_spark_321cdh():
     orc_compress_options.append('zstd')
 
 # The following need extra jars 'lzo'

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -146,7 +146,7 @@ def test_parquet_read_round_trip_binary_as_string(std_input_path, read_func, rea
 
 parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
 # zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320():
+if not is_before_spark_320() and not is_spark_321cdh():
     parquet_compress_options.append('zstd')
 # The following need extra jars 'lzo', 'lz4', 'brotli', 'zstd'
 # https://github.com/NVIDIA/spark-rapids/issues/143

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -146,7 +146,7 @@ def test_parquet_read_round_trip_binary_as_string(std_input_path, read_func, rea
 
 parquet_compress_options = ['none', 'uncompressed', 'snappy', 'gzip']
 # zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320() and not is_spark_321cdh():
+if not is_before_spark_320():
     parquet_compress_options.append('zstd')
 # The following need extra jars 'lzo', 'lz4', 'brotli', 'zstd'
 # https://github.com/NVIDIA/spark-rapids/issues/143


### PR DESCRIPTION
Fixes #6056.

Apparently cdh 3.2.1 does not support zstd compression, at least for orc.
Disabling this test for orc on cdh.
