### PR TITLE
Temporarily disable Parquet unsigned int test in ParquetScanSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
@@ -157,6 +157,8 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
    *  |    |    |-- c3: long (nullable = true)
    *
    */
+  // temporarily disabled for https://github.com/NVIDIA/spark-rapids/issues/6054
+/*
   testSparkResultsAreEqual("Test Parquet nested unsigned int: uint8, uint16, uint32",
     frameFromParquet("nested-unsigned.parquet"),
     // CPU version throws an exception when Spark < 3.2, so skip when Spark < 3.2.
@@ -164,6 +166,7 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
     assumeCondition = (_ => (VersionUtils.isSpark320OrLater, "Spark version not 3.2.0+"))) {
     frame => frame.select(col("*"))
   }
+*/
 
   /**
    * Parquet file with 2 columns


### PR DESCRIPTION
After discussing #6054 with @nvdbaranec, there's reason to believe only this one test is problematic.  This disables the failing test to unblock CI for other PRs while the fix is being worked on in libcudf.  We can use #6054 to track re-enabling the test when libcudf is fixed.