### PR TITLE
[databricks] Fix 3.3 shim to include castTo handling AnyTimestampType and minor spacing

### DIFF
--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/types/shims/PartitionValueCastShims.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/types/shims/PartitionValueCastShims.scala
@@ -18,13 +18,15 @@ package org.apache.spark.sql.types.shims
 
 import java.time.ZoneId
 
+import scala.util.Try
+
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.unescapePathName
 import org.apache.spark.sql.catalyst.expressions.{Cast, Literal}
-import org.apache.spark.sql.types.{AnsiIntervalType, DataType}
+import org.apache.spark.sql.types.{AnsiIntervalType, AnyTimestampType, DataType, DateType}
 
 object PartitionValueCastShims {
   def isSupportedType(dt: DataType): Boolean = dt match {
-    // AnsiIntervalType
+    case dt if AnyTimestampType.acceptsType(dt) => true
     case it: AnsiIntervalType => true
     case _ => false
   }
@@ -32,6 +34,12 @@ object PartitionValueCastShims {
   // Only for AnsiIntervalType
   def castTo(desiredType: DataType, value: String, zoneId: ZoneId): Any = desiredType match {
     // Copied from org/apache/spark/sql/execution/datasources/PartitionUtils.scala
+    case dt if AnyTimestampType.acceptsType(desiredType) =>
+      Try {
+        Cast(Literal(unescapePathName(value)), dt, Some(zoneId.getId)).eval()
+      }.getOrElse {
+        Cast(Cast(Literal(value), DateType, Some(zoneId.getId)), dt).eval()
+      }
     case it: AnsiIntervalType =>
       Cast(Literal(unescapePathName(value)), it).eval()
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/rapids/GpuPartitioningUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/rapids/GpuPartitioningUtils.scala
@@ -206,25 +206,25 @@ object GpuPartitioningUtils extends SQLConfHelper {
    * }}}
    */
   private[datasources] def parsePartitions(
-    paths: Seq[Path],
-    typeInference: Boolean,
-    basePaths: Set[Path],
-    userSpecifiedSchema: Option[StructType],
-    caseSensitive: Boolean,
-    validatePartitionColumns: Boolean,
-    timeZoneId: String): PartitionSpec = {
+      paths: Seq[Path],
+      typeInference: Boolean,
+      basePaths: Set[Path],
+      userSpecifiedSchema: Option[StructType],
+      caseSensitive: Boolean,
+      validatePartitionColumns: Boolean,
+      timeZoneId: String): PartitionSpec = {
     parsePartitions(paths, typeInference, basePaths, userSpecifiedSchema, caseSensitive,
       validatePartitionColumns, DateTimeUtils.getZoneId(timeZoneId))
   }
 
   private[datasources] def parsePartitions(
-    paths: Seq[Path],
-    typeInference: Boolean,
-    basePaths: Set[Path],
-    userSpecifiedSchema: Option[StructType],
-    caseSensitive: Boolean,
-    validatePartitionColumns: Boolean,
-    zoneId: ZoneId): PartitionSpec = {
+      paths: Seq[Path],
+      typeInference: Boolean,
+      basePaths: Set[Path],
+      userSpecifiedSchema: Option[StructType],
+      caseSensitive: Boolean,
+      validatePartitionColumns: Boolean,
+      zoneId: ZoneId): PartitionSpec = {
     val userSpecifiedDataTypes = if (userSpecifiedSchema.isDefined) {
       val nameToDataType = userSpecifiedSchema.get.fields.map(f => f.name -> f.dataType).toMap
       if (!caseSensitive) {


### PR DESCRIPTION
followup from https://github.com/NVIDIA/spark-rapids/pull/6048, specifically comment: https://github.com/NVIDIA/spark-rapids/pull/6048#discussion_r929941030

The Spark 3.3 shim needs to handle both types AnyTimestampType and AnsiIntervalType

fixes https://github.com/NVIDIA/spark-rapids/issues/6026

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
