### PR TITLE
Support Apache Iceberg 0.14.0

### DIFF
--- a/docs/additional-functionality/iceberg-support.md
+++ b/docs/additional-functionality/iceberg-support.md
@@ -12,8 +12,8 @@ This document details the Apache Iceberg features that are supported.
 
 ## Apache Iceberg Versions
 
-The RAPIDS Accelerator supports Apache Iceberg 0.13.x. Earlier versions of Apache Iceberg are
-not supported.
+The RAPIDS Accelerator supports Apache Iceberg 0.13.x through 0.14.0. Earlier versions of
+Apache Iceberg are not supported.
 
 ## Reading Tables
 

--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -101,7 +101,7 @@ def test_iceberg_unsupported_formats(spark_tmp_table_factory, data_gens, iceberg
         "UnsupportedOperationException")
 
 @iceberg
-@allow_non_gpu("BatchScanExec")
+@allow_non_gpu("BatchScanExec", "ColumnarToRowExec")
 @ignore_order(local=True) # Iceberg plans with a thread pool and is not deterministic in file ordering
 @pytest.mark.parametrize("disable_conf", ["spark.rapids.sql.format.iceberg.enabled",
                                           "spark.rapids.sql.format.iceberg.read.enabled"], ids=idfn)

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -77,7 +77,7 @@ TEST_MODE=${TEST_MODE:-'DEFAULT'}
 TEST_TYPE="nightly"
 PCBS_CONF="com.nvidia.spark.ParquetCachedBatchSerializer"
 
-ICEBERG_VERSION=0.13.2
+ICEBERG_VERSION=${ICEBERG_VERSION:-0.14.0}
 ICEBERG_SPARK_VER=$(echo $BASE_SPARK_VER | cut -d. -f1,2)
 # Classloader config is here to work around classloader issues with
 # --packages in distributed setups, should be fixed by

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -173,12 +173,12 @@ export TARGET_DIR="$SCRIPT_PATH/target"
 mkdir -p $TARGET_DIR
 
 run_iceberg_tests() {
-  ICEBERG_VERSION="0.13.2"
+  ICEBERG_VERSION=${ICEBERG_VERSION:-0.14.0}
   # get the major/minor version of Spark
   ICEBERG_SPARK_VER=$(echo $SPARK_VER | cut -d. -f1,2)
 
-  # Iceberg does not support Spark 3.3+ yet
-  if [[ "$ICEBERG_SPARK_VER" < "3.3" ]]; then
+  # Iceberg does not support Spark 3.4+ yet
+  if [[ "$ICEBERG_SPARK_VER" < "3.4" ]]; then
     # Classloader config is here to work around classloader issues with
     # --packages in distributed setups, should be fixed by
     # https://github.com/NVIDIA/spark-rapids/pull/5646

--- a/pom.xml
+++ b/pom.xml
@@ -1035,7 +1035,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <flatbuffers.java.version>1.11.0</flatbuffers.java.version>
         <hadoop.client.version>3.3.1</hadoop.client.version>
-        <iceberg.version>0.13.2</iceberg.version>
+        <iceberg.version>0.14.0</iceberg.version>
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>


### PR DESCRIPTION
This updates the GPU acceleration for Apache Iceberg to support the recent release of Apache Iceberg 0.14.0  which now supports Apache Spark 3.3.x.