### PR TITLE
Fix crash when casting decimals to long

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -378,17 +378,17 @@ object GpuCast extends Arm {
       // ansi cast from larger-than-long integral-like types, to long
       case (dt: DecimalType, LongType) if ansiMode =>
         // This is a work around for https://github.com/rapidsai/cudf/issues/9282
-        val bigDecimalMin = BigDecimal(Long.MinValue)
+        val min = BigDecimal(Long.MinValue)
             .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
-        val bigDecimalMax = BigDecimal(Long.MaxValue)
+        val max = BigDecimal(Long.MaxValue)
             .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
         // We are going against our convention of calling assertValuesInRange()
         // because the min/max values are a different decimal type i.e. Decimal 128 as opposed to
         // the incoming input column type.
-        withResource(input.min()) { min =>
-          withResource(input.max()) { max =>
-            if (min.isValid && min.getBigDecimal().compareTo(bigDecimalMin) == -1 ||
-                max.isValid && max.getBigDecimal().compareTo(bigDecimalMax) == 1) {
+        withResource(input.min()) { minInput =>
+          withResource(input.max()) { maxInput =>
+            if (minInput.isValid && minInput.getBigDecimal().compareTo(min) == -1 ||
+                maxInput.isValid && maxInput.getBigDecimal().compareTo(max) == 1) {
               throw new ArithmeticException(GpuCast.INVALID_INPUT_MESSAGE)
             }
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -387,8 +387,8 @@ object GpuCast extends Arm {
         // the incoming input column type.
         withResource(input.min()) { min =>
           withResource(input.max()) { max =>
-            if (min.getBigDecimal().compareTo(bigDecimalMin) == -1 ||
-                max.getBigDecimal().compareTo(bigDecimalMax) == 1) {
+            if (min.isValid && min.getBigDecimal().compareTo(bigDecimalMin) == -1 ||
+                max.isValid && max.getBigDecimal().compareTo(bigDecimalMax) == 1) {
               throw new ArithmeticException(GpuCast.INVALID_INPUT_MESSAGE)
             }
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -386,7 +386,7 @@ object GpuCast extends Arm {
           withResource(input.max()) { max =>
             if (min.getBigDecimal().compareTo(bigDecimalMin) == -1 ||
                 max.getBigDecimal().compareTo(bigDecimalMax) == 1) {
-              throw new IllegalStateException(GpuCast.INVALID_INPUT_MESSAGE)
+              throw new ArithmeticException(GpuCast.INVALID_INPUT_MESSAGE)
             }
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -177,6 +177,8 @@ object GpuCast extends Arm {
   private val TIMESTAMP_TRUNCATE_REGEX = "^([0-9]{4}-[0-9]{2}-[0-9]{2} " +
     "[0-9]{2}:[0-9]{2}:[0-9]{2})" +
     "(.[1-9]*(?:0)?[1-9]+)?(.0*[1-9]+)?(?:.0*)?$"
+  private val bigDecimalLongMin = BigDecimal(Long.MinValue)
+  private val bigDecimalLongMax = BigDecimal(Long.MaxValue)
 
   val INVALID_INPUT_MESSAGE: String = "Column contains at least one value that is not in the " +
     "required range"
@@ -378,10 +380,8 @@ object GpuCast extends Arm {
       // ansi cast from larger-than-long integral-like types, to long
       case (dt: DecimalType, LongType) if ansiMode =>
         // This is a work around for https://github.com/rapidsai/cudf/issues/9282
-        val min = BigDecimal(Long.MinValue)
-            .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
-        val max = BigDecimal(Long.MaxValue)
-            .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
+        val min = bigDecimalLongMin.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
+        val max = bigDecimalLongMax.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
         // We are going against our convention of calling assertValuesInRange()
         // because the min/max values are a different decimal type i.e. Decimal 128 as opposed to
         // the incoming input column type.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -177,8 +177,8 @@ object GpuCast extends Arm {
   private val TIMESTAMP_TRUNCATE_REGEX = "^([0-9]{4}-[0-9]{2}-[0-9]{2} " +
     "[0-9]{2}:[0-9]{2}:[0-9]{2})" +
     "(.[1-9]*(?:0)?[1-9]+)?(.0*[1-9]+)?(?:.0*)?$"
-  private val bigDecimalLongMin = BigDecimal(Long.MinValue)
-  private val bigDecimalLongMax = BigDecimal(Long.MaxValue)
+  private val BIG_DECIMAL_LONG_MIN = BigDecimal(Long.MinValue)
+  private val BIG_DECIMAL_LONG_MAX = BigDecimal(Long.MaxValue)
 
   val INVALID_INPUT_MESSAGE: String = "Column contains at least one value that is not in the " +
     "required range"
@@ -380,8 +380,8 @@ object GpuCast extends Arm {
       // ansi cast from larger-than-long integral-like types, to long
       case (dt: DecimalType, LongType) if ansiMode =>
         // This is a work around for https://github.com/rapidsai/cudf/issues/9282
-        val min = bigDecimalLongMin.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
-        val max = bigDecimalLongMax.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
+        val min = BIG_DECIMAL_LONG_MIN.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
+        val max = BIG_DECIMAL_LONG_MAX.setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
         // We are going against our convention of calling assertValuesInRange()
         // because the min/max values are a different decimal type i.e. Decimal 128 as opposed to
         // the incoming input column type.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -382,6 +382,9 @@ object GpuCast extends Arm {
             .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
         val bigDecimalMax = BigDecimal(Long.MaxValue)
             .setScale(dt.scale, BigDecimal.RoundingMode.DOWN).bigDecimal
+        // We are going against our convention of calling assertValuesInRange()
+        // because the min/max values are a different decimal type i.e. Decimal 128 as opposed to
+        // the incoming input column type.
         withResource(input.min()) { min =>
           withResource(input.max()) { max =>
             if (min.getBigDecimal().compareTo(bigDecimalMin) == -1 ||

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -466,6 +466,11 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
     }
   }
 
+  testSparkResultsAreEqual("ansi_cast decimals to long",
+    generateValidValuesDecimalDF(Short.MinValue, Short.MaxValue, 18, 3), sparkConf) {
+    frame => testCastTo(DataTypes.LongType)(frame)
+  }
+
   private def castToStringExpectedFun[T]: T => Option[String] = (d: T) => Some(String.valueOf(d))
 
   private def testCastToString[T](dataType: DataType, ansiMode: Boolean,


### PR DESCRIPTION
This PR avoids type mismatch that can occur if the min/max decimal values are a different precision than the column being casted in ANSI mode.

e.g. 
Casting 222.22 to long will result in a call to check to see the values are in range before converting them to long values. That check will cause a crash as the minimum value possible in decimal(5,2) will result in a Decimal 128 value and the `assertValuesInRange` method in `GpuCast` will result in a type mismatch error from cudf when it calls `lessThan`.

@ttnghia Suggested a way around this is to first find the minimum value in the input column and compare that value to the decimal 128 value using a Java `BigDecimal.compareTo` which can handle comparing Decimals of different precisions. 

fixes #6128 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
