### PR TITLE
Fix Alluxio inferring partitions for BooleanType with Hive

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
@@ -301,7 +301,7 @@ object AlluxioUtils extends Logging {
           spec: PartitionSpec,
           rootPaths: Seq[Path]): InMemoryFileIndex = {
         val specAdjusted = replacePathsInPartitionSpec(spec)
-        val replacedPaths = rootPaths.map(p => replaceFunc.get(p))
+        val replacedPaths = rootPaths.map(replaceFunc.get)
         new InMemoryFileIndex(
           relation.sparkSession,
           replacedPaths,


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6029

So when setting alluxio up, our code tries to replace paths specified with alluxio paths. The code to do this runs through creating a whole new FileIndex. This including inferring partitioning.  The Spark code we use to do this doesn't properly handle Boolean type (https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala#L433).    

To work around this I have changed the code to specifically handle certain file index types (CatalogFileIndex for hive and PartitionAware for regular file types with partitioning) and to only update the paths within those and not call the inferring code.  This handle this specific issue and the normal paths one would take for hive and reading files directly.   Unfortunately if we end up not knowing the file index type (like custom CSP file indexes) we use the old inferring code so it possible to still hit a case like this.   We have issue https://github.com/NVIDIA/spark-rapids/issues/6070 to followup.

Tested this manually on Databricks using different file types - hive, parquet directly, delta and all worked.  Also tested locally with reproduce case listed in the issue.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
