### PR TITLE
Fixes threaded shuffle writer test mocks for spark 3.3.0+ [databricks]

### DIFF
--- a/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -119,12 +119,17 @@ class BadSerializable(i: Int) extends Serializable {
 }
 
 // Added so that we can mock a method that was created in Spark 3.3.0
+// and the override can be used in all versions of Spark
+trait ShimIndexShuffleBlockResolver330 {
+  def createTempFile(file: File): File
+}
 class TestIndexShuffleBlockResolver(
     conf: SparkConf,
     bm: BlockManager)
-      extends IndexShuffleBlockResolver(conf, bm) {
+      extends IndexShuffleBlockResolver(conf, bm)
+        with ShimIndexShuffleBlockResolver330 {
   // implemented in Spark 3.3.0
-  def createTempFile(file: File): File = { null }
+  override def createTempFile(file: File): File = { null }
 }
 
 class RapidsShuffleThreadedWriterSuite extends FunSuite

--- a/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -118,6 +118,15 @@ class BadSerializable(i: Int) extends Serializable {
   }
 }
 
+// Added so that we can mock a method that was created in Spark 3.3.0
+class TestIndexShuffleBlockResolver(
+    conf: SparkConf,
+    bm: BlockManager)
+      extends IndexShuffleBlockResolver(conf, bm) {
+  // implemented in Spark 3.3.0
+  def createTempFile(file: File): File = { null }
+}
+
 class RapidsShuffleThreadedWriterSuite extends FunSuite
     with BeforeAndAfterEach
     with MockitoSugar
@@ -125,7 +134,7 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
   @Mock(answer = RETURNS_SMART_NULLS) private var blockManager: BlockManager = _
   @Mock(answer = RETURNS_SMART_NULLS) private var diskBlockManager: DiskBlockManager = _
   @Mock(answer = RETURNS_SMART_NULLS) private var taskContext: TaskContext = _
-  @Mock(answer = RETURNS_SMART_NULLS) private var blockResolver: IndexShuffleBlockResolver = _
+  @Mock(answer = RETURNS_SMART_NULLS) private var blockResolver: TestIndexShuffleBlockResolver = _
   @Mock(answer = RETURNS_SMART_NULLS) private var dependency: ShuffleDependency[Int, Int, Int] = _
   @Mock(answer = RETURNS_SMART_NULLS)
     private var dependencyBad: ShuffleDependency[Int, BadSerializable, BadSerializable] = _
@@ -188,6 +197,12 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
           syncWrites = false,
           args(4).asInstanceOf[ShuffleWriteMetrics],
           blockId = args(0).asInstanceOf[BlockId])
+      }
+
+    when(blockResolver.createTempFile(any(classOf[File])))
+      .thenAnswer { invocationOnMock =>
+        val file = invocationOnMock.getArguments()(0).asInstanceOf[File]
+        Utils.tempFileWith(file)
       }
 
     when(diskBlockManager.createTempShuffleBlock())
@@ -321,7 +336,9 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
   }
 
   test("write checksum file") {
-    val blockResolver = new IndexShuffleBlockResolver(conf, blockManager)
+    // this is a spy so we can intercept calls to `createTempShuffleBlock`
+    // in spark 3.3.0+
+    val blockResolver = spy(new TestIndexShuffleBlockResolver(conf, blockManager))
     val shuffleId = shuffleHandle.shuffleId
     val mapId = 0
     val checksumBlockId = ShuffleChecksumBlockId(shuffleId, mapId, 0)
@@ -343,6 +360,12 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
         val file = new File(tempDir, blockId.name)
         temporaryFilesCreated += file
         (blockId, file)
+      }
+
+    when(blockResolver.createTempFile(any(classOf[File])))
+      .thenAnswer { invocationOnMock =>
+        val file = invocationOnMock.getArguments()(0).asInstanceOf[File]
+        Utils.tempFileWith(file)
       }
 
     val numPartition = shuffleHandle.dependency.partitioner.numPartitions


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This PR https://github.com/NVIDIA/spark-rapids/pull/6052, broke one of our nightly jobs for Spark 3.3.0+. This was due to the test not mocking a new method added in Spark 3.3.0.

This adds the mock and defines a subclass of `IndexShuffleBlockResolver` that defines the method for versions before 3.3.0.