### PR TITLE
Revert "Temporarily disable Parquet unsigned int test in ParquetScanS…

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
@@ -157,8 +157,6 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
    *  |    |    |-- c3: long (nullable = true)
    *
    */
-  // temporarily disabled for https://github.com/NVIDIA/spark-rapids/issues/6054
-/*
   testSparkResultsAreEqual("Test Parquet nested unsigned int: uint8, uint16, uint32",
     frameFromParquet("nested-unsigned.parquet"),
     // CPU version throws an exception when Spark < 3.2, so skip when Spark < 3.2.
@@ -166,7 +164,6 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
     assumeCondition = (_ => (VersionUtils.isSpark320OrLater, "Spark version not 3.2.0+"))) {
     frame => frame.select(col("*"))
   }
-*/
 
   /**
    * Parquet file with 2 columns


### PR DESCRIPTION
Fixes #6054

[cuDF](https://github.com/rapidsai/cudf/pull/11353) have fixed.
This reverts commit 2c35b99d62f1688698835f667532e9d3aee92291.

Signed-off-by: Chong Gao <res_life@163.com>