### PR TITLE
Improve coverage in mvn verify check github workflow

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -92,7 +92,9 @@ jobs:
       # includes RAT, code style and doc-gen checks of default shim
       - name: verify all modules with lowest-supported Spark version
         run: >
-          mvn -B verify -P 'individual,pre-merge'
+          mvn -B verify
+          -P 'individual,pre-merge'
+          -Dbuildver=${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           set -x
           noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)\
-          # remove newlines
           noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -x
           noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
-          noSnapshotVersionsArr=($(echo ${noSnapshotVersionStr//[$'\n',]/}))
+          noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")
           echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,8 +42,7 @@ jobs:
         id: noSnapshotVersionsStep
         run: |
           set -x
-          noSnapshotVersionsStr=$(mvn help:evaluate -q -pl dist
-          -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
+          noSnapshotVersionsStr=$(mvn help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
           noSnapshotVersionsArr=($(echo ${noSnapshotVersionStr//[$'\n',]/}))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -46,16 +46,13 @@ jobs:
           noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionsStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
-          tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")
-          export tailNoSnapshotVersionsJSONStr=$(echo [$tailNoSnapshotVersionsCSV])
           echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}
-          echo ::set-output name=tailVersions::${{ toJSON(env.tailNoSnapshotVersionsJSONStr) }}
+          echo ::set-output name=tailVersions::{\"include\":[{\"v\":\"311\"}]}
 
   package-aggregator:
     needs: get-noSnapshot-versions-from-dist
     strategy:
-      matrix:
-        spark-version: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
+      matrix: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -46,8 +46,11 @@ jobs:
           noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionsStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
+          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${tailNoSnapshotVersionsArr[@]}")
+          svArrBody=${svArrBody:1}
+          svJsonStr=$(printf {\"include\":[%s]} $svArrBody)
           echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}
-          echo ::set-output name=tailVersions::{\"include\":[{\"v\":\"311\"}]}
+          echo ::set-output name=tailVersions::$svJsonStr
 
   package-aggregator:
     needs: get-noSnapshot-versions-from-dist

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # A workflow to run mvn verify check
-name: Maven
+name: mvn[compile,RAT,scalastyle,docgen]
 
 on:
   pull_request:
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mvn-package-except-311:
+  package-aggregator:
     strategy:
       matrix:
         spark-version: [312, 313, 320, 321, 322, 330]
@@ -41,7 +41,7 @@ jobs:
       - name: package aggregator check
         run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
 
-  mvn-verify-check-311:
+  verify-all-modules-with-spark311:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: 8
 
       - name: package aggregator check
-        run: >-
+        run: >
           mvn package -pl aggregator -am
             -P 'individual,pre-merge'
             -Dbuildver=${{ spark-version }}
@@ -62,7 +62,7 @@ jobs:
 
       # includes RAT, code style and doc-gen checks of default shim
       - name: verify all modules 311
-        run: >-
+        run: |
           mvn verify -P 'individual,pre-merge'
             -DskipTests
             -Dskip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -54,7 +54,7 @@ jobs:
     needs: get-noSnapshot-versions-from-dist
     strategy:
       matrix:
-        spark-version: ${{ fromJson(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
+        spark-version: ${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,10 +24,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-noSnapshot-versions-from-dist:
+    runs-on: ubuntu-latest
+    outputs:
+      sparkHeadVersion: ${{ steps.noSnapshotVersionsStep.outputs.headVersion }}
+      sparkTailVersions: ${{ steps.noSnapshotVersionsStep.outputs.tailVersions }}
+    steps:
+      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+
+      - name: Setup Java and Maven Env
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 8
+
+      - name: all noSnapshot versions
+        id: noSnapshotVersionsStep
+        run: >
+          set -x
+          noSnapshotVersionsStr=$(mvn help:evaluate -q -pl dist
+          -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
+          noSnapshotVersionsArr=($(echo ${noSnapshotVersionStr//[$'\n',]/}))
+          tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
+          tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")
+          echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}
+          echo ::set-output name=tailVersions::[$tailNoSnapshotVersionsCSV]
+
   package-aggregator:
+    needs: get-noSnapshot-versions-from-dist
     strategy:
       matrix:
-        spark-version: [312, 313, 320, 321, 322, 330]
+        spark-version: ${{ fromJson(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
@@ -49,7 +76,7 @@ jobs:
           -Dmaven.scalastyle.skip=true
           -Drat.skip=true
 
-  verify-all-modules-with-spark311:
+  verify-all-modules-with-headSparkVersion:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
@@ -61,7 +88,7 @@ jobs:
           java-version: 8
 
       # includes RAT, code style and doc-gen checks of default shim
-      - name: verify all modules 311
+      - name: verify all modules with lowest-supported Spark version
         run: >
           mvn -B verify -P 'individual,pre-merge'
           -DskipTests

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,22 +24,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mvn-package-except-311:
-    strategy:
-      matrix:
-        spark-version: [312, 313, 320, 321, 322, 330]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+  # mvn-package-except-311:
+  #   strategy:
+  #     matrix:
+  #       spark-version: [312, 313, 320, 321, 322, 330]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
 
-      - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 8
+  #     - name: Setup Java and Maven Env
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         distribution: adopt
+  #         java-version: 8
 
-      - name: mvn package check
-        run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
+  #     - name: mvn package check
+  #       run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
   mvn-verify-check-311:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,7 +42,7 @@ jobs:
         id: noSnapshotVersionsStep
         run: |
           set -x
-          noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)\
+          noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
           noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: all noSnapshot versions
         id: noSnapshotVersionsStep
-        run: >
+        run: |
           set -x
           noSnapshotVersionsStr=$(mvn help:evaluate -q -pl dist
           -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -77,6 +77,7 @@ jobs:
           -Drat.skip=true
 
   verify-all-modules-with-headSparkVersion:
+    needs: get-noSnapshot-versions-from-dist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -44,7 +44,7 @@ jobs:
           set -x
           noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
           noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
-          noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionStr))
+          noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionsStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")
           echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,7 +24,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mvn-verify-check:
+  mvn-package-except-311:
+    strategy:
+      matrix:
+        spark-version: [321cdh, 312, 313, 320, 321, 322, 330]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
@@ -35,6 +38,18 @@ jobs:
           distribution: adopt
           java-version: 8
 
+      - name: mvn package check ${{ spark-version }}
+        run: >-
+          mvn package -pl aggregator -am
+          -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip
+          -Dmaven.scalastyle.skip=true -Drat.skip=true
+
+  mvn-verify-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mvn-package-except-311
       # includes RAT, code style and doc-gen checks of default shim
       - name: mvn verify check
-        run: mvn verify -P 'individual,pre-merge' -pl dist -am -DskipTests -Dskip -Dmaven.javadoc.skip
+        run: >-
+          mvn verify
+          -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -41,13 +41,13 @@ jobs:
       - name: package aggregator check
         run: >
           mvn package -pl aggregator -am
-            -P 'individual,pre-merge'
-            -Dbuildver=${{ spark-version }}
-            -DskipTests
-            -Dskip
-            -Dmaven.javadoc.skip
-            -Dmaven.scalastyle.skip=true
-            -Drat.skip=true
+          -P 'individual,pre-merge'
+          -Dbuildver=${{ spark-version }}
+          -DskipTests
+          -Dskip
+          -Dmaven.javadoc.skip
+          -Dmaven.scalastyle.skip=true
+          -Drat.skip=true
 
   verify-all-modules-with-spark311:
     runs-on: ubuntu-latest
@@ -62,8 +62,8 @@ jobs:
 
       # includes RAT, code style and doc-gen checks of default shim
       - name: verify all modules 311
-        run: |
+        run: >
           mvn verify -P 'individual,pre-merge'
-            -DskipTests
-            -Dskip
-            -Dmaven.javadoc.skip
+          -DskipTests
+          -Dskip
+          -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,7 +42,7 @@ jobs:
         id: noSnapshotVersionsStep
         run: |
           set -x
-          noSnapshotVersionsStr=$(mvn help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
+          noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
           noSnapshotVersionsArr=($(echo ${noSnapshotVersionStr//[$'\n',]/}))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -39,7 +39,15 @@ jobs:
           java-version: 8
 
       - name: package aggregator check
-        run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
+        run: >-
+          mvn package -pl aggregator -am
+            -P 'individual,pre-merge'
+            -Dbuildver=${{ spark-version }}
+            -DskipTests
+            -Dskip
+            -Dmaven.javadoc.skip
+            -Dmaven.scalastyle.skip=true
+            -Drat.skip=true
 
   verify-all-modules-with-spark311:
     runs-on: ubuntu-latest
@@ -54,4 +62,8 @@ jobs:
 
       # includes RAT, code style and doc-gen checks of default shim
       - name: verify all modules 311
-        run: mvn verify -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip
+        run: >-
+          mvn verify -P 'individual,pre-merge'
+            -DskipTests
+            -Dskip
+            -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: mvn package check
         run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
-
   mvn-verify-check-311:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,7 +42,6 @@ jobs:
         run: >
           mvn package -pl aggregator -am
           -P 'individual,pre-merge'
-          -Dbuildver="${{ spark-version }}"
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -40,8 +40,9 @@ jobs:
 
       - name: package aggregator check
         run: >
-          mvn package -pl aggregator -am
+          mvn -B package -pl aggregator -am
           -P 'individual,pre-merge'
+          -Dbuildver=${{ matrix.spark-version }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip
@@ -62,7 +63,7 @@ jobs:
       # includes RAT, code style and doc-gen checks of default shim
       - name: verify all modules 311
         run: >
-          mvn verify -P 'individual,pre-merge'
+          mvn -B verify -P 'individual,pre-merge'
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -94,7 +94,7 @@ jobs:
         run: >
           mvn -B verify
           -P 'individual,pre-merge'
-          -Dbuildver=${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions }}
+          -Dbuildver=${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkHeadVersion }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,7 +42,7 @@ jobs:
         run: >
           mvn package -pl aggregator -am
           -P 'individual,pre-merge'
-          -Dbuildver=${{ spark-version }}
+          -Dbuildver="${{ spark-version }}"
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -42,7 +42,9 @@ jobs:
         id: noSnapshotVersionsStep
         run: |
           set -x
-          noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)
+          noSnapshotVersionsStr=$(mvn -B help:evaluate -q -pl dist -PnoSnapshots -Dexpression=included_buildvers -DforceStdout)\
+          # remove newlines
+          noSnapshotVersionsStr=$(echo $noSnapshotVersionsStr)
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # A workflow to run mvn verify check
-name: Maven verify checks (Scala style, Compile and Doc-gen w/ base Spark version)
+name: Maven
 
 on:
   pull_request:
@@ -38,7 +38,7 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      - name: mvn package check
+      - name: package aggregator check
         run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
 
   mvn-verify-check-311:
@@ -53,5 +53,5 @@ jobs:
           java-version: 8
 
       # includes RAT, code style and doc-gen checks of default shim
-      - name: mvn verify check all 311
+      - name: verify all modules 311
         run: mvn verify -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -27,7 +27,7 @@ jobs:
   mvn-package-except-311:
     strategy:
       matrix:
-        spark-version: [321cdh, 312, 313, 320, 321, 322, 330]
+        spark-version: [312, 313, 320, 321, 322, 330]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
@@ -38,18 +38,15 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      - name: mvn package check ${{ spark-version }}
-        run: >-
-          mvn package -pl aggregator -am
-          -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip
-          -Dmaven.scalastyle.skip=true -Drat.skip=true
+      - name: mvn package check
+        run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
 
-  mvn-verify-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mvn-package-except-311
-      # includes RAT, code style and doc-gen checks of default shim
-      - name: mvn verify check
-        run: >-
-          mvn verify
-          -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip
+  # mvn-verify-check:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: mvn-package-except-311
+  #     # includes RAT, code style and doc-gen checks of default shim
+  #     - name: mvn verify check
+  #       run: >-
+  #         mvn verify
+  #         -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -47,14 +47,15 @@ jobs:
           noSnapshotVersionsArr=($(IFS=", "; echo $noSnapshotVersionsStr))
           tailNoSnapshotVersionsArr=(${noSnapshotVersionsArr[@]:1})
           tailNoSnapshotVersionsCSV=$(IFS=", " ; echo "${tailNoSnapshotVersionsArr[*]}")
+          export tailNoSnapshotVersionsJSONStr=$(echo [$tailNoSnapshotVersionsCSV])
           echo ::set-output name=headVersion::${noSnapshotVersionsArr[0]}
-          echo ::set-output name=tailVersions::[$tailNoSnapshotVersionsCSV]
+          echo ::set-output name=tailVersions::${{ toJSON(env.tailNoSnapshotVersionsJSONStr) }}
 
   package-aggregator:
     needs: get-noSnapshot-versions-from-dist
     strategy:
       matrix:
-        spark-version: ${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions }}
+        spark-version: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # refs/pull/:prNumber/merge

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,22 +24,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # mvn-package-except-311:
-  #   strategy:
-  #     matrix:
-  #       spark-version: [312, 313, 320, 321, 322, 330]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+  mvn-package-except-311:
+    strategy:
+      matrix:
+        spark-version: [312, 313, 320, 321, 322, 330]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
 
-  #     - name: Setup Java and Maven Env
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         distribution: adopt
-  #         java-version: 8
+      - name: Setup Java and Maven Env
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 8
 
-  #     - name: mvn package check
-  #       run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
+      - name: mvn package check
+        run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
+
   mvn-verify-check-311:
     runs-on: ubuntu-latest
     steps:
@@ -50,8 +51,7 @@ jobs:
         with:
           distribution: adopt
           java-version: 8
-    steps:
-      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+
       # includes RAT, code style and doc-gen checks of default shim
       - name: mvn verify check all 311
         run: mvn verify -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -41,12 +41,18 @@ jobs:
       - name: mvn package check
         run: mvn package -pl aggregator -am -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip -Dmaven.scalastyle.skip=true -Drat.skip=true
 
-  # mvn-verify-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: mvn-package-except-311
-  #     # includes RAT, code style and doc-gen checks of default shim
-  #     - name: mvn verify check
-  #       run: >-
-  #         mvn verify
-  #         -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip
+  mvn-verify-check-311:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+
+      - name: Setup Java and Maven Env
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 8
+    steps:
+      - uses: actions/checkout@v2 # refs/pull/:prNumber/merge
+      # includes RAT, code style and doc-gen checks of default shim
+      - name: mvn verify check all 311
+        run: mvn verify -P 'individual,pre-merge' -DskipTests -Dskip -Dmaven.javadoc.skip

--- a/pom.xml
+++ b/pom.xml
@@ -1039,6 +1039,7 @@
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.scalastyle.skip>false</maven.scalastyle.skip>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Addresses the issue slipped into #6141 . Workflow improvements:
- Dynamically generate builds for all shims without hardcoding versions using https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
- Imitate `buildall`. Verify shim-specific code is buildable in parallel. In another parallel check RAT, scalastyle, and verify all modules with the default spark version
- add default value `false` for maven.scalastyle.skip 
    
Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
