### PR TITLE
Update the configs used to choose the Python runner for flat-map Pandas UDF [databricks]

### DIFF
--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuFlatMapGroupsInPandasExec.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuFlatMapGroupsInPandasExec.scala
@@ -122,8 +122,8 @@ case class GpuFlatMapGroupsInPandasExec(
         StructField("out_struct", StructType.fromAttributes(localOutput)) :: Nil)
 
     // Configs from DB 10.4 runtime
-    val maxBytes = conf.pandasZeroConfConversionMaxBytesPerSlice
-    val zeroConfEnabled = conf.pandasZeroConfConversionEnabled
+    val maxBytes = conf.pandasZeroConfConversionGroupbyApplyMaxBytesPerSlice
+    val zeroConfEnabled = conf.pandasZeroConfConversionGroupbyApplyEnabled
 
     // Resolve the argument offsets and related attributes.
     val GroupArgs(dedupAttrs, argOffsets, groupingOffsets) =


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/6157.

Databricks 10.4 is using the same configs with 9.1 to pick the Python runner for flat-map Pandas UDF.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
