### PR TITLE
Fix IcebergProvider classname in unshim exceptions

### DIFF
--- a/dist/unshimmed-from-each-spark3xx.txt
+++ b/dist/unshimmed-from-each-spark3xx.txt
@@ -1,6 +1,6 @@
 com/nvidia/spark/rapids/*/RapidsShuffleManager*
 com/nvidia/spark/rapids/AvroProvider.class
 com/nvidia/spark/rapids/HiveProvider.class
-com/nvidia/spark/rapids/IcebergProvider.class
+com/nvidia/spark/rapids/iceberg/IcebergProvider.class
 org/apache/spark/sql/rapids/shims/*/ProxyRapidsShuffleInternalManager*
 spark-*-info.properties


### PR DESCRIPTION
Fixes #6167.  The IcebergProvider package name was incorrect in the unshim list.