### PR TITLE
Fix the qualification tool per sql number output rows option

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualOutputWriter.scala
@@ -123,7 +123,7 @@ class QualOutputWriter(outputDir: String, reportReadSchema: Boolean,
       sortedAsc.reverse
     }
     val finalSums = sorted.take(numOutputRows)
-    sorted.foreach { estInfo =>
+    finalSums.foreach { estInfo =>
       val wStr = QualOutputWriter.constructPerSqlSummaryInfo(estInfo, headersAndSizes,
         appIdMaxSize, TEXT_DELIMITER, true, maxSQLDescLength)
       writer.write(wStr)

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -312,7 +312,7 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
       try {
         val lines = persqlInputSource.getLines
         // 4 lines of header and footer, limit is 2
-        assert(lines.size == (4 + 17))
+        assert(lines.size == (4 + 2))
       } finally {
         persqlInputSource.close()
       }


### PR DESCRIPTION
Somehow I broke this and twice as bad, I updated the test to have the wrong value.  

Simple fix of just using the right variable where we limit the rows. Updated the test.

fixes https://github.com/NVIDIA/spark-rapids/issues/6179

Signed-off-by: Thomas Graves <tgraves@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
