### PR TITLE
Add config option to log all query transformations

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4374,10 +4374,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         val updatedPlan = updateForAdaptivePlan(plan, conf)
         val newPlan = applyOverrides(updatedPlan, conf)
         if (conf.logQueryTransformations) {
-          val logPrefix = context match {
-            case Some(str) => s"[$str] "
-            case _ => ""
-          }
+          val logPrefix = context.map(str => s"[$str]").getOrElse("")
           logWarning(s"${logPrefix}Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$newPlan")
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4349,7 +4349,7 @@ object GpuOverrideUtil extends Logging {
 }
 
 object GpuOverridesContext {
-    private val local = ThreadLocal.withInitial[String](() => null);
+  private val local = ThreadLocal.withInitial[String](() => null);
   def set(s: String): Unit = local.set(s)
 
   def get(): Option[String] = Option(local.get())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4369,7 +4369,12 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       GpuOverrides.logDuration(conf.shouldExplain,
         t => f"Plan conversion to the GPU took $t%.2f ms") {
         val updatedPlan = updateForAdaptivePlan(plan, conf)
-        applyOverrides(updatedPlan, conf)
+        val newPlan = applyOverrides(updatedPlan, conf)
+        if (conf.logQueryTransformations) {
+          logWarning(s"Transformed query to run on GPU:" +
+            s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$newPlan")
+        }
+        newPlan
       }
     } else if (conf.isSqlEnabled && conf.isSqlExplainOnlyEnabled) {
       // this mode logs the explain output and returns the original CPU plan

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -590,6 +590,12 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
           updatedPlan.canonicalized
           validateExecsInGpuPlan(updatedPlan, rapidsConf)
         }
+
+        if (rapidsConf.logQueryTransformations) {
+          logWarning(s"Transformed query:" +
+            s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
+        }
+
         updatedPlan
       }
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1093,6 +1093,12 @@ object RapidsConf {
     .toSequence
     .createWithDefault(Nil)
 
+  val LOG_TRANSFORMATIONS = conf("spark.rapids.sql.debug.logTransformations")
+    .doc("TBD")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
   val PARQUET_DEBUG_DUMP_PREFIX = conf("spark.rapids.sql.parquet.debug.dumpPrefix")
     .doc("A path prefix where Parquet split file data is dumped for debugging.")
     .internal()
@@ -1675,6 +1681,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val testingAllowedNonGpu: Seq[String] = get(TEST_ALLOWED_NONGPU)
 
   lazy val validateExecsInGpuPlan: Seq[String] = get(TEST_VALIDATE_EXECS_ONGPU)
+
+  lazy val logQueryTransformations: Boolean = get(LOG_TRANSFORMATIONS)
 
   lazy val rmmDebugLocation: String = get(RMM_DEBUG)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1094,7 +1094,7 @@ object RapidsConf {
     .createWithDefault(Nil)
 
   val LOG_TRANSFORMATIONS = conf("spark.rapids.sql.debug.logTransformations")
-    .doc("TBD")
+    .doc("When enabled, all query transformations will be logged.")
     .internal()
     .booleanConf
     .createWithDefault(false)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/6195

When debugging AQE issues or Delta Lake metadata queries, I often find myself adding temporary debug logging in `GpuOverrides` to show the plans being passed to `com.nvidia.spark.rapids.GpuOverrides#apply` and how they are transformed by the plugin.

This PR adds this debug logging permanently but is only enabled when an internal config option is set.

# Example Output

```
22/08/04 14:17:43 WARN GpuOverrides: Transformed query:
Original Plan:
...
Transformed Plan:
...

22/08/04 14:17:43 WARN GpuTransitionOverrides: Transformed query:
Original Plan:
...
Transformed Plan:
...

22/08/04 14:17:43 WARN GpuOverrides: [AQE Query Stage Prep] Transformed query:
Original Plan:
...
Transformed Plan:
...
```