### PR TITLE
Disable overflow tableInsert tests for 331+

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -559,6 +559,11 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   // Writing to Hive tables, which has special rules
   ///////////////////////////////////////////////////////////////////////////
 
+  // Disable tests for Spark-3.3.1+ until new support to CheckOverflowInTableInsert is added
+  def before3_3_1(s: SparkSession): (Boolean, String) = {
+    (s.version < "3.3.1", s"Spark version must be prior to 3.3.1")
+  }
+
   testSparkResultsAreEqual("Write bytes to string", testBytes, sparkConf) {
     frame => doTableInsert(frame, HIVE_STRING_SQL_TYPE)
   }
@@ -580,72 +585,72 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   }
 
   testSparkResultsAreEqual("Write longs to int (values within range)", intsAsLongs,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write longs to short (values within range)", shortsAsLongs,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write longs to byte (values within range)", bytesAsLongs,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write ints to short (values within range)", shortsAsInts,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write ints to byte (values within range)", bytesAsInts,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write shorts to byte (values within range)", bytesAsShorts,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write floats to long (values within range)", longsAsFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write floats to int (values within range)", intsAsFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write floats to short (values within range)", shortsAsFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write floats to byte (values within range)", bytesAsFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write doubles to long (values within range)", longsAsDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write doubles to int (values within range)", intsAsDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write doubles to short (values within range)",
-    shortsAsDoubles, sparkConf) {
+    shortsAsDoubles, sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testSparkResultsAreEqual("Write doubles to byte (values within range)", bytesAsDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
@@ -653,65 +658,73 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   // Test for exceptions when casting out of range values
   ///////////////////////////////////////////////////////////////////////////
 
-  testCastFailsForBadInputs("Detect overflow from long to int", testLongs, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from long to int", testLongs, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from long to short", testLongs, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from long to short", testLongs, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from long to byte", testLongs, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from long to byte", testLongs, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from int to short", testInts, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from int to short", testInts, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from int to byte", testInts, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from int to byte", testInts, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from short to byte", testShorts, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from short to byte", testShorts, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from float to long", testFloats, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from float to long", testFloats, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 
-  testCastFailsForBadInputs("Detect overflow from float to int", testFloats, sparkConf) {
+  testCastFailsForBadInputs("Detect overflow from float to int", testFloats, sparkConf,
+    assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from float to short", testFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from float to byte", testFloats,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from double to long", testDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_LONG_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from double to int", testDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_INT_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from double to short", testDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_SHORT_SQL_TYPE)
   }
 
   testCastFailsForBadInputs("Detect overflow from double to byte", testDoubles,
-    sparkConf) {
+    sparkConf, assumeCondition = before3_3_1) {
     frame => doTableInsert(frame, HIVE_BYTE_SQL_TYPE)
   }
 


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Related to #6165 

Disable tests with overflow table inserts for Spark3.3.1+ until shims supports the new UnaryExpre `CheckOverflowInTableInsert`

Context:

- https://github.com/NVIDIA/spark-rapids/issues/6185
- https://github.com/NVIDIA/spark-rapids/issues/6165




