### PR TITLE
Release host buffers when Avro read schema is empty

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -16,10 +16,9 @@ import os
 from spark_session import with_cpu_session, with_gpu_session
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal
 from data_gen import *
 from marks import *
-from pyspark.sql.types import *
 
 if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'false':
     pytestmark = pytest.mark.skip(reason=str("INCLUDE_SPARK_AVRO_JAR is disabled"))
@@ -137,3 +136,17 @@ def test_avro_read_with_corrupt_files(spark_tmp_path, reader_type, v1_enabled_li
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : spark.read.format("avro").load([first_dpath, second_dpath, third_dpath]),
             conf=all_confs)
+
+
+@pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
+@pytest.mark.parametrize('reader_type', ['PERFILE', 'MULTITHREADED'])
+def test_read_count(spark_tmp_path, v1_enabled_list, reader_type):
+    data_path = spark_tmp_path + '/AVRO_DATA'
+    gen_avro_files([('_c0', int_gen)], data_path)
+
+    all_confs = copy_and_update(_enable_all_types_conf, {
+        'spark.rapids.sql.format.avro.reader.type': reader_type,
+        'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark: spark.read.format("avro").load(data_path),
+        conf=all_confs)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -777,6 +777,7 @@ class GpuMultiFileCloudAvroPartitionReader(
 
           val bufAndSize: Array[(HostMemoryBuffer, Long)] = if (readDataSchema.isEmpty) {
             // Overload the size to be the number of rows with null buffer
+            hostBuffers.foreach(_._1.safeClose(new Exception))
             Array((null, totalRowsNum))
           } else if (isDone) {
             // got close before finishing, return null buffer and zero size


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/6220.

Host buffers are not needed when Avro read schema is empty, so need to release them.

What's more, the host buffers are not necessary for empty read schema, so this can be an improvement. Tracked by https://github.com/NVIDIA/spark-rapids/issues/6219

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
