### PR TITLE
Fix count() in avro failed when reader_types is coalescing

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -141,9 +141,8 @@ def test_avro_read_with_corrupt_files(spark_tmp_path, reader_type, v1_enabled_li
 @pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
 def test_read_count(spark_tmp_path, v1_enabled_list, reader_type):
-    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(support_gens)]
     data_path = spark_tmp_path + '/AVRO_DATA'
-    gen_avro_files(gen_list, data_path)
+    gen_avro_files([('_c0', int_gen)], data_path)
 
     all_confs = copy_and_update(_enable_all_types_conf, {
         'spark.rapids.sql.format.avro.reader.type': reader_type,

--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -139,10 +139,11 @@ def test_avro_read_with_corrupt_files(spark_tmp_path, reader_type, v1_enabled_li
 
 
 @pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
-@pytest.mark.parametrize('reader_type', ['PERFILE', 'MULTITHREADED'])
+@pytest.mark.parametrize('reader_type', rapids_reader_types)
 def test_read_count(spark_tmp_path, v1_enabled_list, reader_type):
+    gen_list = [('_c' + str(i), gen) for i, gen in enumerate(support_gens)]
     data_path = spark_tmp_path + '/AVRO_DATA'
-    gen_avro_files([('_c0', int_gen)], data_path)
+    gen_avro_files(gen_list, data_path)
 
     all_confs = copy_and_update(_enable_all_types_conf, {
         'spark.rapids.sql.format.avro.reader.type': reader_type,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -40,7 +40,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.avro.AvroOptions
+import org.apache.spark.sql.avro.{AvroOptions, SchemaConverters}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
@@ -268,7 +268,7 @@ case class GpuAvroMultiFilePartitionReaderFactory(
             fPath,
             AvroDataBlock(block),
             file.partitionValues,
-            AvroSchemaWrapper(singleFileInfo.header.schema),
+            AvroSchemaWrapper(SchemaConverters.toAvroType(readDataSchema)),
             AvroExtraInfo()))
       if (singleFileInfo.blocks.nonEmpty) {
         // No need to check the header since it can not be null when blocks is not empty here.


### PR DESCRIPTION
`spark.read.format("avro").load(data_path).count()` reports error: `QueryExecutionException: Expected 0 columns but read 8 from ArrayBuffer`, if reader_types is `COALESCING`. It is because Avro reader always specifies the schema from a file when coalescing reading, causing it to always read all columns of data.

This PR use readDataSchema instead the schema from a file to quick fix this bug. 

Further, we should build an evolved schema from readschema and dataSchema to do type checking and filtering, just like orc reader and parquet reader do. We also use readschema when [reading files from cudf](https://github.com/NVIDIA/spark-rapids/blob/branch-22.08/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala#L312) now, so it will be a bit complicated to make this change. Filed a followed issue #6226 to track it. 

Fixes #6131 

Signed-off-by: thirtiseven <ntlihy@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
