### PR TITLE
Configurable task failures in integration tests

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -114,11 +114,11 @@ else
         # free memory. We use free memory to try and avoid issues if the GPU also is working
         # on graphics, which happens with many workstation GPUs. We also reserve 2 GiB for
         # CUDA/CUDF overhead which can be used because of JIT or launching large kernels.
-       
+
         # If you need to increase the amount of GPU memory you need to change it here and
         # below where the processes are launched.
         GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk '{if (MAX < $1){ MAX = $1}} END {print int((MAX - 2 * 1024) / ((1.5 * 1024) + 750))}'`
-        CPU_CORES=`nproc` 
+        CPU_CORES=`nproc`
         HOST_MEM_PARALLEL=`cat /proc/meminfo | grep MemAvailable | awk '{print int($2 / (5 * 1024))}'`
         TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))
         TMP_PARALLEL=$(( $TMP_PARALLEL > $HOST_MEM_PARALLEL ? $HOST_MEM_PARALLEL : $TMP_PARALLEL ))
@@ -192,7 +192,7 @@ else
     MB_PER_EXEC=${MB_PER_EXEC:-1024}
     CORES_PER_EXEC=${CORES_PER_EXEC:-1}
 
-    SPARK_TASK_MAXFAILURES=1
+    SPARK_TASK_MAXFAILURES=${SPARK_TASK_MAXFAILURES:-1}
     [[ "$VERSION_STRING" < "3.1.1" ]] && SPARK_TASK_MAXFAILURES=4
 
     export PYSP_TEST_spark_driver_extraClassPath="${ALL_JARS// /:}"
@@ -234,7 +234,7 @@ else
     else
       # If a master is not specified, use "local[cores, $SPARK_TASK_MAXFAILURES]"
       if [ -z "${PYSP_TEST_spark_master}" ] && [[ "$SPARK_SUBMIT_FLAGS" != *"--master"* ]]; then
-        CPU_CORES=`nproc` 
+        CPU_CORES=`nproc`
         # We are limiting the number of tasks in local mode to 4 because it helps to reduce the
         # total memory usage, especially host memory usage because when copying data to the GPU
         # buffers as large as batchSizeBytes can be allocated, and the fewer of them we have the better.
@@ -243,7 +243,7 @@ else
       fi
     fi
 
-    # If you want to change the amount of GPU memory allocated you have to change it here 
+    # If you want to change the amount of GPU memory allocated you have to change it here
     # and where TEST_PARALLEL is calculated
     export PYSP_TEST_spark_rapids_memory_gpu_allocSize='1536m'
 


### PR DESCRIPTION
Configurable max task faiures for integration tests
    
Running integration tests with the [fault injection tool][1] requires
tolerating falures.
    
[1]: https://github.com/NVIDIA/spark-rapids-jni/tree/branch-22.08/src/main/cpp/faultinj
    
Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
