### PR TITLE
Add rocky Dockerfiles and refine docker documentation

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -142,16 +142,15 @@ configurations as we are able to test different scenarios.
 NOTE: A system administrator should have performed Step 1 in [Baremetal](#baremetal) in the host
 system if you have RDMA capable hardware.
 
-Within the Docker container we need to install UCX and its requirements. These are Dockerfile
-examples for Ubuntu 18.04:
+The following are examples of Docker containers with UCX 1.12.1 and CUDA 11.5 support.
 
-The following are examples of Docker containers with UCX 1.12.1 and cuda-11.2 support.
-
-| OS Type | RDMA | Dockerfile |
-| ------- | ---- | ---------- |
-| Ubuntu  | Yes  | [Dockerfile.ubuntu_rdma](shuffle-docker-examples/Dockerfile.ubuntu_rdma) |
+| OS Type | RDMA | Dockerfile                                                                     |
+|---------| ---- |--------------------------------------------------------------------------------|
+| Ubuntu  | Yes  | [Dockerfile.ubuntu_rdma](shuffle-docker-examples/Dockerfile.ubuntu_rdma)       |
 | Ubuntu  | No   | [Dockerfile.ubuntu_no_rdma](shuffle-docker-examples/Dockerfile.ubuntu_no_rdma) |
-| CentOS  | Yes  | [Dockerfile.centos_rdma](shuffle-docker-examples/Dockerfile.centos_rdma) |
+| Rocky   | Yes  | [Dockerfile.rocky_rdma](shuffle-docker-examples/Dockerfile.rocky_rdma)         |
+| Rocky   | No   | [Dockerfile.rocky_no_rdma](shuffle-docker-examples/Dockerfile.rocky_no_rdma)   |
+| CentOS  | Yes  | [Dockerfile.centos_rdma](shuffle-docker-examples/Dockerfile.centos_rdma)       |
 | CentOS  | No   | [Dockerfile.centos_no_rdma](shuffle-docker-examples/Dockerfile.centos_no_rdma) |
 
 ### Validating UCX Environment
@@ -160,14 +159,15 @@ After installing UCX you can utilize `ucx_info` and `ucx_perftest` to validate t
 
 In this section, we are using a docker container built using the sample dockerfile above.
 
-1. Start the docker container with `--privileged` mode. In this example, we are also adding
-   `--device /dev/infiniband` to make Mellanox devices available for our test, but this is only
-   required if you are using RDMA:
+1. Start the docker container with `--privileged` mode, which makes Mellanox devices available 
+   for our test (this is only required if you are using RDMA), `pid=host` and `ipc=host` are
+   requirements for container communication within the same machine:
     ```
     nvidia-docker run \
-     --network=host \
-     --device /dev/infiniband \
      --privileged \
+     --pid=host \
+     --ipc=host \
+     --network=host \
      -it \
      ucx_container:latest \
      /bin/bash

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.centos_rdma
@@ -19,7 +19,7 @@
 # The parameters are: 
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
 #                        released MLNX_OFED 5.x driver
-#   - CUDA_VER: 11.2.2 to pick up the latest 11.2 CUDA base layer
+#   - CUDA_VER: 11.5.1 by default
 #   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
 #                               CUDA runtime from the UCX github repo.
 #                               See: https://github.com/openucx/ucx/releases/
@@ -28,7 +28,7 @@
 # the ucx-ib and ucx-rdma RPMs.
 
 ARG RDMA_CORE_VERSION=32.1
-ARG CUDA_VER=11.2.2
+ARG CUDA_VER=11.5.1
 ARG UCX_VER=1.12.1
 ARG UCX_CUDA_VER=11
 

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,25 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Sample Dockerfile to install UCX in a CentosOS 7 image 
+# Sample Dockerfile to install UCX in a Rocky Linux 8 image.
 #
 # The parameters are: 
 #   - CUDA_VER: 11.5.1 by default
 #   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
 #                               CUDA runtime from the UCX github repo.
 #                               See: https://github.com/openucx/ucx/releases/
+#   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=11.5.1
 ARG UCX_VER=1.12.1
 ARG UCX_CUDA_VER=11
-
-FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
+ARG CUDA_VER=11.5.1
+ARG ROCKY_VER=8
+FROM nvidia/cuda:${CUDA_VER}-runtime-rockylinux${ROCKY_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
 
 RUN yum update -y && yum install -y wget bzip2
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5-cuda$UCX_CUDA_VER.tar.bz2
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER.tar.bz2
 RUN cd /tmp && tar -xvf *.bz2 && \
-  yum install -y ucx-$UCX_VER-1.el7.x86_64.rpm && \
-  yum install -y ucx-cuda-$UCX_VER-1.el7.x86_64.rpm && \
+  yum install -y ucx-$UCX_VER-1.el8.x86_64.rpm && \
+  yum install -y ucx-cuda-$UCX_VER-1.el8.x86_64.rpm && \
   rm -rf /tmp/*.rpm

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,25 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Sample Dockerfile to install UCX in a CentosOS 7 image 
+# Sample Dockerfile to install UCX in a Rocky Linux 8 image with RDMA support.
 #
 # The parameters are: 
 #   - CUDA_VER: 11.5.1 by default
 #   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
 #                               CUDA runtime from the UCX github repo.
 #                               See: https://github.com/openucx/ucx/releases/
+#   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=11.5.1
 ARG UCX_VER=1.12.1
 ARG UCX_CUDA_VER=11
+ARG ROCKY_VER=8
 
-FROM nvidia/cuda:${CUDA_VER}-runtime-centos7
+FROM nvidia/cuda:${CUDA_VER}-runtime-rockylinux${ROCKY_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
 
-RUN yum update -y && yum install -y wget bzip2
-RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos7-mofed5-cuda$UCX_CUDA_VER.tar.bz2
-RUN cd /tmp && tar -xvf *.bz2 && \
-  yum install -y ucx-$UCX_VER-1.el7.x86_64.rpm && \
-  yum install -y ucx-cuda-$UCX_VER-1.el7.x86_64.rpm && \
-  rm -rf /tmp/*.rpm
+RUN yum update -y
+RUN yum install -y wget bzip2 rdma-core
+RUN cd /tmp && wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-v$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER.tar.bz2
+RUN cd /tmp && \
+  tar -xvf *.bz2 && \
+  yum install -y ucx-$UCX_VER-1.el8.x86_64.rpm && \
+  yum install -y ucx-cuda-$UCX_VER-1.el8.x86_64.rpm && \
+  yum install -y ucx-ib-$UCX_VER-1.el8.x86_64.rpm && \
+  yum install -y ucx-rdmacm-$UCX_VER-1.el8.x86_64.rpm

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -16,12 +16,12 @@
 # Sample Dockerfile to install UCX in a Ubuntu 18.04 image
 #
 # The parameters are: 
-#   - CUDA_VER: 11.2.2 to pick up the latest 11.2 CUDA base layer
+#   - CUDA_VER: 11.5.1 by default
 #   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and 
 #                               CUDA runtime from the UCX github repo.
 #                               See: https://github.com/openucx/ucx/releases/
 
-ARG CUDA_VER=11.2.2
+ARG CUDA_VER=11.5.1
 ARG UCX_VER=1.12.1
 ARG UCX_CUDA_VER=11
 

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -19,7 +19,7 @@
 # The parameters are: 
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
 #                        released MLNX_OFED 5.x driver
-#   - CUDA_VER: 11.2.2 to pick up the latest 11.2 CUDA base layer
+#   - CUDA_VER: 11.5.1 by default
 #   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
 #                               CUDA runtime from the UCX github repo.
 #                               See: https://github.com/openucx/ucx/releases/
@@ -28,7 +28,7 @@
 # the ucx-ib and ucx-rdma RPMs.
 
 ARG RDMA_CORE_VERSION=32.1
-ARG CUDA_VER=11.2.2
+ARG CUDA_VER=11.5.1
 ARG UCX_VER=1.12.1
 ARG UCX_CUDA_VER=11
 


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This PR adds Rocky Linux 8 example dockerfiles for UCX. It uses the rdma-core from the distribution, and I tested that this worked fine with ucx_perftest with RoCE and CUDA/Host memory between two hosts with Mellanox nics. 

I updated the docker run example command as it was missing ipc/pid flags so that we could use docker containers to communicate between two GPUs in the same host.

I changed the CUDA version picked here for all images to 11.5.1 so all images match.