### PR TITLE
Read metadata only when read schema is empty in Avro multi-threaded reading

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -138,14 +138,15 @@ def test_avro_read_with_corrupt_files(spark_tmp_path, reader_type, v1_enabled_li
             conf=all_confs)
 
 
+# 10 rows is a small batch size for multi-batch read test, 2147483647 is the default value
+@pytest.mark.parametrize('batch_size_rows', [10, 2147483647])
 @pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
-@pytest.mark.parametrize('batch_size_rows', [10, 2147483647])
-def test_avro_read_count(spark_tmp_path, v1_enabled_list, reader_type, batch_size_rows):
+def test_read_count(spark_tmp_path, v1_enabled_list, reader_type, batch_size_rows):
     data_path = spark_tmp_path + '/AVRO_DATA'
 
-    # the max block size of the avro file is about 64kb, so we need to generate a larger file
-    # to test multi-batch read
+    # the default block size of the avro file is about 64kb, so we need to generate a larger file
+    # to test multi-batch read. length=30000 will generate 2 blocks in each partition.
     with_cpu_session(
         lambda spark: gen_df(spark, [('_c0', int_gen)], length=30000)
             .repartition(2).write.format("avro").save(data_path)
@@ -156,8 +157,6 @@ def test_avro_read_count(spark_tmp_path, v1_enabled_list, reader_type, batch_siz
         'spark.sql.sources.useV1SourceList': v1_enabled_list,
         'spark.rapids.sql.reader.batchSizeRows': batch_size_rows})
 
-    print(with_gpu_session(lambda spark: spark.read.format("avro").load(data_path).count(),
-        conf=all_confs))
     assert_gpu_and_cpu_row_counts_equal(
         lambda spark: spark.read.format("avro").load(data_path),
         conf=all_confs)

--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -140,13 +140,15 @@ def test_avro_read_with_corrupt_files(spark_tmp_path, reader_type, v1_enabled_li
 
 @pytest.mark.parametrize('v1_enabled_list', ["avro", ""], ids=["v1", "v2"])
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
-def test_read_count(spark_tmp_path, v1_enabled_list, reader_type):
+@pytest.mark.parametrize('batch_size_rows', [10, 2147483647])
+def test_read_count(spark_tmp_path, v1_enabled_list, reader_type, batch_size_rows):
     data_path = spark_tmp_path + '/AVRO_DATA'
     gen_avro_files([('_c0', int_gen)], data_path)
 
     all_confs = copy_and_update(_enable_all_types_conf, {
         'spark.rapids.sql.format.avro.reader.type': reader_type,
-        'spark.sql.sources.useV1SourceList': v1_enabled_list})
+        'spark.sql.sources.useV1SourceList': v1_enabled_list,
+        'spark.rapids.sql.reader.batchSizeRows': batch_size_rows})
     assert_gpu_and_cpu_row_counts_equal(
         lambda spark: spark.read.format("avro").load(data_path),
         conf=all_confs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
@@ -205,6 +205,11 @@ abstract class AvroFileReader(si: SeekableInput) extends AutoCloseable {
     (curBlockStart >= position + SYNC_SIZE) || (curBlockStart >= sin.length())
   }
 
+  // skip next length bytes
+  def skip(length: Int): Unit = {
+    vin.skipFixed(length)
+  }
+
   /**
    * Move to the next synchronization point after a position. To process a range
    * of file entries, call this with the starting position, then check
@@ -444,7 +449,7 @@ class AvroDataFileReader(si: SeekableInput) extends AvroFileReader(si) {
       throw new NoSuchElementException
     }
     val dataSize = curDataSize.toInt
-    vin.skipFixed(dataSize + SYNC_SIZE)
+    skip(dataSize + SYNC_SIZE)
     curBlockStart = sin.tell - vin.inputStream.available
     curBlockReady = false
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
@@ -442,7 +442,7 @@ class AvroDataFileReader(si: SeekableInput) extends AvroFileReader(si) {
   }
 
   /**
-   * Skip the current block raw data to the given output stream.
+   * Skip the current raw block
    */
   def skipCurrentBlock(): Unit = {
     if (!hasNextBlock) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
@@ -205,7 +205,7 @@ abstract class AvroFileReader(si: SeekableInput) extends AutoCloseable {
     (curBlockStart >= position + SYNC_SIZE) || (curBlockStart >= sin.length())
   }
 
-  // skip next length bytes
+   /** Skip next length bytes */
   def skip(length: Int): Unit = {
     vin.skipFixed(length)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
@@ -436,6 +436,19 @@ class AvroDataFileReader(si: SeekableInput) extends AvroFileReader(si) {
     curBlockReady = false
   }
 
+  /**
+   * Skip the current block raw data to the given output stream.
+   */
+  def skipCurrentBlock(): Unit = {
+    if (!hasNextBlock) {
+      throw new NoSuchElementException
+    }
+    val dataSize = curDataSize.toInt
+    vin.skipFixed(dataSize + SYNC_SIZE)
+    curBlockStart = sin.tell - vin.inputStream.available
+    curBlockReady = false
+  }
+
 }
 
 object AvroFileReader extends Arm {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -761,7 +761,12 @@ class GpuMultiFileCloudAvroPartitionReader(
               var batchSize: Long = 0
               var hasNextBlock = true
               do {
-                optOut.map(reader.readNextRawBlock(_)).getOrElse(reader.skipCurrentBlock())
+                if (optOut.nonEmpty) {
+                  reader.readNextRawBlock(optOut.get)
+                } else {
+                  // skip the current block
+                  reader.skipCurrentBlock()
+                }
                 batchRowsNum += curBlock.count.toInt
                 estSizeToRead -= curBlock.blockSize
                 batchSize += curBlock.blockSize

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -761,12 +761,13 @@ class GpuMultiFileCloudAvroPartitionReader(
               var batchSize: Long = 0
               var hasNextBlock = true
               do {
-                if (optOut.nonEmpty) {
-                  reader.readNextRawBlock(optOut.get)
-                } else {
-                  // skip the current block
-                  reader.skipCurrentBlock()
-                }
+                optOut.map(reader.readNextRawBlock(_)).getOrElse(reader.skipCurrentBlock())
+                // if (optOut.nonEmpty) {
+                //   reader.readNextRawBlock(optOut.get)
+                // } else {
+                //   // skip the current block
+                //   reader.skipCurrentBlock()
+                // }
                 batchRowsNum += curBlock.count.toInt
                 estSizeToRead -= curBlock.blockSize
                 batchSize += curBlock.blockSize

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -762,12 +762,6 @@ class GpuMultiFileCloudAvroPartitionReader(
               var hasNextBlock = true
               do {
                 optOut.map(reader.readNextRawBlock(_)).getOrElse(reader.skipCurrentBlock())
-                // if (optOut.nonEmpty) {
-                //   reader.readNextRawBlock(optOut.get)
-                // } else {
-                //   // skip the current block
-                //   reader.skipCurrentBlock()
-                // }
                 batchRowsNum += curBlock.count.toInt
                 estSizeToRead -= curBlock.blockSize
                 batchSize += curBlock.blockSize

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -782,9 +782,7 @@ class GpuMultiFileCloudAvroPartitionReader(
                   batchRowsNum <= maxReadBatchSizeRows)
 
               // One batch is done
-              if (optOut.nonEmpty) {
-                hostBuffers += ((optHmb.get, optOut.get.getPos))
-              }
+              optOut.foreach(out => hostBuffers += ((optHmb.get, out.getPos))) 
               totalRowsNum += batchRowsNum
               estBlocksSize -= batchSize
             }


### PR DESCRIPTION
Currently, the Avro multi-threaded reader will still read the block data despite empty read schema (e.g. for count operation), however reading only block meta is enough for this case. This can be optimized.

This PR
- makes GpuAvroScan read metadata only when readDataSchema is empty in multi-threaded reading.
- add `skip()` and `skipCurrentBlock()` in AvroDataFileReader
- add test for multi-batch case when testing count.

Closes #6219 

Signed-off-by: thirtiseven <ntlihy@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
