### PR TITLE
Fix bug where AQE does not respect `entirePlanWillNotWork`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -195,6 +195,10 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
    */
   final def entirePlanWillNotWork(because: String): Unit = {
     cannotReplaceAnyOfPlanReasons.get.add(because)
+    // recursively tag the plan so that AQE does not attempt
+    // to run any of the child query stages on the GPU
+    willNotWorkOnGpu(because)
+    childPlans.foreach(_.entirePlanWillNotWork(because))
   }
 
   final def shouldBeRemoved(because: String): Unit =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -233,8 +233,8 @@ abstract class RapidsMeta[INPUT <: BASE, BASE, OUTPUT <: BASE](
    * set means the entire plan is ok to be replaced, do the normal checking
    * per exec and children.
    */
-  final def entirePlanExcludedReasons: Seq[String] = {
-    cannotReplaceAnyOfPlanReasons.getOrElse(mutable.Set.empty).toSeq
+  final def entirePlanExcludedReasons: Set[String] = {
+    cannotReplaceAnyOfPlanReasons.getOrElse(mutable.Set.empty).toSet
   }
 
   /**
@@ -613,7 +613,7 @@ abstract class SparkPlanMeta[INPUT <: SparkPlan](plan: INPUT,
     wrapped.withNewChildren(childPlans.map(_.convertIfNeeded()))
   }
 
-  def getReasonsNotToReplaceEntirePlan: Seq[String] = {
+  def getReasonsNotToReplaceEntirePlan: Set[String] = {
     val childReasons = childPlans.flatMap(_.getReasonsNotToReplaceEntirePlan)
     entirePlanExcludedReasons ++ childReasons
   }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/6230

While testing some changes related to Delta Lake fallback, I discovered that `entirePlanWillNotWork` is not always respected by AQE because we weren't tagging the underlying plan, so during the planning for individual query stages, we could decide to run on GPU, and this can lead to invalid plans with mixed CPU/GPU usage that then fail to run.

For the example that I hit, the query failed with the following error due to an invalid transition being inserted. See the issue for more details.

```
java.lang.AssertionError: assertion failed
  at scala.Predef$.assert(Predef.scala:208)
  at org.apache.spark.sql.execution.ColumnarToRowExec.<init>(Columnar.scala:69)
```

This issue can only happen when `spark.rapids.sql.detectDeltaLogQueries` is enabled (because that is the only time we call `entirePlanWillNotWork`). This setting is currently enabled by default.

I have tried some different approaches to writing unit or integration tests for this change, but it is proving to be challenging, so I am open to suggestions on how to do this. I hit the error with some changes on another branch that I am no longer planning on merging.