### PR TITLE
WIP: Fallback to CPU for Parquet reads with `_databricks_internal` columns

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4431,6 +4431,10 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
    */
   def isDeltaLakeMetadataQuery(plan: SparkPlan): Boolean = {
     val deltaLogScans = PlanUtils.findOperators(plan, {
+      case f: FileSourceScanExec if f.requiredSchema.fields
+         .exists(_.name.startsWith("_databricks_internal")) =>
+        logDebug(s"Fallback for FileSourceScanExec with _databricks_internal: $f")
+        true
       case f: FileSourceScanExec =>
         // example filename: "file:/tmp/delta-table/_delta_log/00000000000000000000.json"
         val found = f.relation.inputFiles.exists(name =>


### PR DESCRIPTION
When performing a Delta Lake MERGE operation on Databricks, a query runs that relies on receiving valid data from computed columns such as `_databricks_internal_edge_computed_column_row_index` and `_databricks_internal_edge_computed_column_skip_row` in the Parquet read. 

For example:

```
+- FileScan parquet [country#755,_databricks_internal_edge_computed_column_row_index#963L] Batched: true, DataFilters: [], Format: Parquet, Location: TahoeBatchFileIndex(1 paths)[file:/tmp/myth/delta/corpus], PartitionFilters: [], PushedFilters: [], ReadSchema: struct<country:string,_databricks_internal_edge_computed_column_row_index:bigint>
```

These columns obviously do not exist if we are reading the files on GPU so we need to fall back to CPU in this case.

This PR is still WIP because there are no tests yet.

