### PR TITLE
Add edited event action for some workflow trigger [skip ci]

### DIFF
--- a/.github/workflows/markdown-links-check.yml
+++ b/.github/workflows/markdown-links-check.yml
@@ -17,10 +17,13 @@ name: Check Markdown links
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   markdown-link-check:
+    if: |
+      github.event.action != 'edited' ||
+      (github.event.action == 'edited' && github.event.changes.base.ref.from != '')
     runs-on: ubuntu-latest
     steps:
     - name: work around permission issue

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -17,7 +17,7 @@ name: mvn[compile,RAT,scalastyle,docgen]
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -25,6 +25,9 @@ concurrency:
 
 jobs:
   get-noSnapshot-versions-from-dist:
+    if: |
+      github.event.action != 'edited' ||
+      (github.event.action == 'edited' && github.event.changes.base.ref.from != '')
     runs-on: ubuntu-latest
     outputs:
       sparkHeadVersion: ${{ steps.noSnapshotVersionsStep.outputs.headVersion }}

--- a/.github/workflows/signoff-check.yml
+++ b/.github/workflows/signoff-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@ name: signoff check
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   signoff-check:
+    if: |
+      github.event.action != 'edited' ||
+      (github.event.action == 'edited' && github.event.changes.base.ref.from != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #6259

Add `edited` action for several github CIs, so that when people switch base ref, those CI could get triggered automatically.
NOTE: 
1. We target this to 22.10, so only branches later than 22.10 (include this commit) would take effect
2. this one does not include blossom-ci, people should still manually trigger it.

Verified in my forked repo,
reopen https://github.com/pxLi/spark-rapids/actions/runs/2822585591
edited PR description (skipped) https://github.com/pxLi/spark-rapids/actions/runs/2822501330
edited BASE ref https://github.com/pxLi/spark-rapids/actions/runs/2822465324
