### PR TITLE
Support bool/int8/int16/int32/int64 castings for ORC reading.

### DIFF
--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -18,28 +18,44 @@ from asserts import assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from pyspark.sql.types import *
 from spark_session import with_cpu_session
+from orc_test import reader_opt_confs
 
+@pytest.mark.parametrize('offset', [1,2,3,4], ids=idfn)
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
+def test_read_type_casting_integral(spark_tmp_path, offset, reader_confs, v1_enabled_list):
+    int_gens = [boolean_gen] + integral_gens
+    gen_list = [('c' + str(i), gen) for i, gen in enumerate(int_gens)]
+    data_path = spark_tmp_path + '/ORC_DATA'
+    with_cpu_session(
+        lambda spark: gen_df(spark, gen_list).write.orc(data_path))
 
-def create_orc_dataframe(output_orc, col_name, col_gen):
+    # build the read schema by a left shift of int_gens
+    shifted_int_gens = int_gens[offset:] + int_gens[:offset]
+    rs_gen_list = [('c' + str(i), gen) for i, gen in enumerate(shifted_int_gens)]
+    rs = StructGen(rs_gen_list, nullable=False).data_type
+    all_confs = copy_and_update(reader_confs,
+                                {'spark.sql.sources.useV1SourceList': v1_enabled_list})
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema(rs).orc(data_path),
+        conf=all_confs)
+
+@pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
+def test_casting_from_integer(spark_tmp_path, to_type):
+    orc_path = spark_tmp_path + 'test_orc_casting'
+    # Since the library 'datatime' in python, the max-year it supports is 10000, for the max value of
+    # Long type, set it to '1e11'. If the long-value is out of this range, pytest will throw exception.
+    data_gen = [('boolean', boolean_gen), ('tinyint', byte_gen),
+                ('smallint', ShortGen(min_val=BYTE_MAX + 1)),
+                ('int', IntegerGen(min_val=SHORT_MAX + 1)),
+                ('bigint', LongGen(min_val=INT_MAX + 1, max_val=int(1e11))),
+                ('negint', IntegerGen(max_val=-1))]
     # generate ORC dataframe, and dump it to local file
     with_cpu_session(
-        lambda spark: gen_df(spark, [(col_name, col_gen)]).write.mode('overwrite').orc(output_orc)
+        lambda spark: gen_df(spark, data_gen).write.mode('overwrite').orc(orc_path)
     )
 
-
-# Since the library 'datatime' in python, the max-year it supports is 10000, for the max value of
-# Long type, set it to '1e11'. If the long-value is out of this range, pytest will throw exception.
-@pytest.mark.parametrize('from_type', [('boolean', boolean_gen), ('tinyint', byte_gen),
-                                       ('smallint', ShortGen(min_val=BYTE_MAX + 1)),
-                                       ('int', IntegerGen(min_val=SHORT_MAX + 1)),
-                                       ('bigint', LongGen(min_val=INT_MAX + 1,
-                                                          max_val=int(1e11))),
-                                       ('negint', IntegerGen(max_val=-1))])
-@pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
-def test_casting_from_integer(spark_tmp_path, from_type, to_type):
-    from_type, from_type_gen = from_type
-    orc_path = spark_tmp_path + from_type
-    create_orc_dataframe(orc_path, 'c0', from_type_gen)
+    schema_str = "boolean {}, tinyint {}, smallint {}, int {}, bigint {}, negint {}"
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema("c0 {}".format(to_type)).orc(orc_path)
+        lambda spark: spark.read.schema(schema_str.format(*([to_type] * 6))).orc(orc_path)
     )

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -51,7 +51,7 @@ def test_read_type_casting_integral(spark_tmp_path, offset, reader_confs, v1_ena
 
 @pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
 def test_casting_from_integer(spark_tmp_path, to_type):
-    orc_path = spark_tmp_path + '/test_orc_casting'
+    orc_path = spark_tmp_path + '/orc_cast_integer'
     # Since the library 'datatime' in python, the max-year it supports is 10000, for the max value of
     # Long type, set it to '1e11'. If the long-value is out of this range, pytest will throw exception.
     data_gen = [('boolean', boolean_gen), ('tinyint', byte_gen),
@@ -67,18 +67,18 @@ def test_casting_from_integer(spark_tmp_path, to_type):
             schema_str.format(*([to_type] * len(data_gen)))).orc(orc_path)
     )
 
-
+@pytest.mark.parametrize('overflow_long_gen', [LongGen(min_val=int(1e13)),
+                                               LongGen(max_val=int(-1e13))])
 @pytest.mark.parametrize('to_type', ['timestamp'])
-def test_casting_from_overflow_long(spark_tmp_path, to_type):
+def test_casting_from_overflow_long(spark_tmp_path, overflow_long_gen,to_type):
     # Timestamp(micro-seconds) is actually type of int64, when casting long(int64) to timestamp,
     # we need to multiply 1e6, and it may cause overflow. This function aims to test whether if
     # 'ArithmeticException' is caught.
-    orc_path = spark_tmp_path + '/long_overflow'
-    data_gen = [('long_column', LongGen(min_val=int(1e13)))]
-    create_orc(data_gen, orc_path)
+    orc_path = spark_tmp_path + '/orc_cast_overflow_long'
+    create_orc([('long_column', overflow_long_gen)], orc_path)
     schema_str = "long_column {}".format(to_type)
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: spark.read.schema(schema_str).orc(orc_path).collect(),
         conf={},
-        error_message="java.lang.ArithmeticException"
+        error_message="ArithmeticException"
     )

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -33,7 +33,8 @@ def create_orc_dataframe(output_orc, col_name, col_gen):
                                        ('smallint', ShortGen(min_val=BYTE_MAX + 1)),
                                        ('int', IntegerGen(min_val=SHORT_MAX + 1)),
                                        ('bigint', LongGen(min_val=INT_MAX + 1,
-                                                          max_val=int(1e11)))])
+                                                          max_val=int(1e11))),
+                                       ('negint', IntegerGen(max_val=-1))])
 @pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
 def test_casting_from_integer(spark_tmp_path, from_type, to_type):
     from_type, from_type_gen = from_type

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_are_equal_collect
+from data_gen import *
+from pyspark.sql.types import *
+from spark_session import with_cpu_session
+
+
+def create_orc_dataframe(output_orc, col_name, col_gen):
+    # generate ORC dataframe, and dump it to local file
+    with_cpu_session(
+        lambda spark: gen_df(spark, [(col_name, col_gen)]).write.mode('overwrite').orc(output_orc)
+    )
+
+
+# Since the library 'datatime' in python, the max-year it supports is 10000, for the max value of
+# Long type, set it to '1e11'. If the long-value is out of this range, pytest will throw exception.
+@pytest.mark.parametrize('from_type', [('boolean', boolean_gen), ('tinyint', byte_gen),
+                                       ('smallint', ShortGen(min_val=BYTE_MAX + 1)),
+                                       ('int', IntegerGen(min_val=SHORT_MAX + 1)),
+                                       ('bigint', LongGen(min_val=INT_MAX + 1,
+                                                          max_val=int(1e11)))])
+@pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
+def test_casting_from_integer(spark_tmp_path, from_type, to_type):
+    from_type, from_type_gen = from_type
+    orc_path = spark_tmp_path + from_type
+    create_orc_dataframe(orc_path, 'c0', from_type_gen)
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema("c0 {}".format(to_type)).orc(orc_path)
+    )

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error
 from data_gen import *
 from pyspark.sql.types import *
 from spark_session import with_cpu_session
@@ -24,6 +24,7 @@ from orc_test import reader_opt_confs
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 @pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
 def test_read_type_casting_integral(spark_tmp_path, offset, reader_confs, v1_enabled_list):
+    # cast integral types to another integral types
     int_gens = [boolean_gen] + integral_gens
     gen_list = [('c' + str(i), gen) for i, gen in enumerate(int_gens)]
     data_path = spark_tmp_path + '/ORC_DATA'
@@ -40,9 +41,10 @@ def test_read_type_casting_integral(spark_tmp_path, offset, reader_confs, v1_ena
         lambda spark: spark.read.schema(rs).orc(data_path),
         conf=all_confs)
 
+
 @pytest.mark.parametrize('to_type', ['float', 'double', 'string', 'timestamp'])
 def test_casting_from_integer(spark_tmp_path, to_type):
-    orc_path = spark_tmp_path + 'test_orc_casting'
+    orc_path = spark_tmp_path + '/test_orc_casting'
     # Since the library 'datatime' in python, the max-year it supports is 10000, for the max value of
     # Long type, set it to '1e11'. If the long-value is out of this range, pytest will throw exception.
     data_gen = [('boolean', boolean_gen), ('tinyint', byte_gen),
@@ -57,5 +59,24 @@ def test_casting_from_integer(spark_tmp_path, to_type):
 
     schema_str = "boolean {}, tinyint {}, smallint {}, int {}, bigint {}, negint {}"
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(schema_str.format(*([to_type] * 6))).orc(orc_path)
+        lambda spark: spark.read.schema(
+            schema_str.format(*([to_type] * len(data_gen)))).orc(orc_path)
+    )
+
+
+@pytest.mark.parametrize('to_type', ['timestamp'])
+def test_casting_from_overflow_long(spark_tmp_path, to_type):
+    # Timestamp(micro-seconds) is actually type of int64, when casting long(int64) to timestamp,
+    # we need to multiply 1e6, and it may cause overflow. This function aims to test whether if
+    # 'ArithmeticException' is caught.
+    orc_path = spark_tmp_path + '/long_overflow'
+    data_gen = [('long_column', LongGen(min_val=int(1e13)))]
+    with_cpu_session(
+        lambda spark: gen_df(spark, data_gen).write.mode('overwrite').orc(orc_path)
+    )
+    schema_str = "long_column {}".format(to_type)
+    assert_gpu_and_cpu_error(
+        df_fun=lambda spark: spark.read.schema(schema_str).orc(orc_path).collect(),
+        conf={},
+        error_message="java.lang.ArithmeticException"
     )

--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -67,13 +67,13 @@ def test_casting_from_integer(spark_tmp_path, to_type):
             schema_str.format(*([to_type] * len(data_gen)))).orc(orc_path)
     )
 
-@pytest.mark.parametrize('overflow_long_gen', [LongGen(min_val=int(1e13)),
-                                               LongGen(max_val=int(-1e13))])
+@pytest.mark.parametrize('overflow_long_gen', [LongGen(min_val=int(1e16)),
+                                               LongGen(max_val=int(-1e16))])
 @pytest.mark.parametrize('to_type', ['timestamp'])
 def test_casting_from_overflow_long(spark_tmp_path, overflow_long_gen,to_type):
     # Timestamp(micro-seconds) is actually type of int64, when casting long(int64) to timestamp,
-    # we need to multiply 1e6, and it may cause overflow. This function aims to test whether if
-    # 'ArithmeticException' is caught.
+    # we need to multiply 1e6 (or 1e3), and it may cause overflow. This function aims to test
+    # whether if 'ArithmeticException' is caught.
     orc_path = spark_tmp_path + '/orc_cast_overflow_long'
     create_orc([('long_column', overflow_long_gen)], orc_path)
     schema_str = "long_column {}".format(to_type)

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -645,26 +645,6 @@ def test_orc_scan_with_aggregate_no_pushdown_on_col_partition(spark_tmp_path, ag
                 conf=_orc_aggregate_pushdown_enabled_conf)
 
 
-@pytest.mark.parametrize('offset', [1,2,3,4], ids=idfn)
-@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
-@pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
-def test_read_type_casting_integral(spark_tmp_path, offset, reader_confs, v1_enabled_list):
-    int_gens = [boolean_gen] + integral_gens
-    gen_list = [('c' + str(i), gen) for i, gen in enumerate(int_gens)]
-    data_path = spark_tmp_path + '/ORC_DATA'
-    with_cpu_session(
-        lambda spark: gen_df(spark, gen_list).write.orc(data_path))
-
-    # build the read schema by a left shift of int_gens
-    shifted_int_gens = int_gens[offset:] + int_gens[:offset]
-    rs_gen_list = [('c' + str(i), gen) for i, gen in enumerate(shifted_int_gens)]
-    rs = StructGen(rs_gen_list, nullable=False).data_type
-    all_confs = copy_and_update(reader_confs,
-        {'spark.sql.sources.useV1SourceList': v1_enabled_list})
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.schema(rs).orc(data_path),
-        conf=all_confs)
-
 def test_orc_read_count(spark_tmp_path):
     data_path = spark_tmp_path + '/ORC_DATA'
     orc_gens = [int_gen, string_gen, double_gen]

--- a/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
+++ b/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import ai.rapids.cudf.{ColumnView, DType, Scalar}
+import com.nvidia.spark.rapids.GpuOrcScan.{testLongMultiplicationOverflow, withResource}
+
+object OrcCastingShims {
+  /**
+   * Cast ColumnView of integer types to timestamp (in milliseconds).
+   * @param col The column view of integer types.
+   * @param fromType BOOL8, INT8/16/32/64
+   * @return A new timestamp columnar vector.
+   */
+  def castIntegerToTimestamp(col: ColumnView, fromType: DType): ColumnView = {
+    fromType match {
+      case DType.BOOL8 | DType.INT8 | DType.INT16 | DType.INT32 =>
+        // From spark311 until spark330 (not include it), spark consider the integers as
+        // milli-seconds.
+        // cuDF requires casting to Long first, then we can cast Long to Timestamp(in microseconds)
+        // In CPU code of ORC casting, its conversion is 'integer -> milliseconds -> microseconds'
+        withResource(col.castTo(DType.INT64)) { longs =>
+          withResource(Scalar.fromLong(1000L)) { thousand =>
+            withResource(longs.mul(thousand)) { milliSeconds =>
+              milliSeconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+            }
+          }
+        }
+      case DType.INT64 =>
+        // We need overflow checking here, since max value of INT64 is about 9 * 1e18, and convert
+        // INT64 to milliseconds(also a INT64 actually), we need multiply 1000, it may cause long
+        // integer-overflow.
+        // If these two 'testLongMultiplicationOverflow' throw no exception, it means no
+        // Long-overflow when casting 'col' to TIMESTAMP_MICROSECONDS.
+        if (col.max() != null) {
+          testLongMultiplicationOverflow(col.max().getLong, 1000L)
+        }
+        if (col.min() != null) {
+          testLongMultiplicationOverflow(col.min().getLong, 1000L)
+        }
+        withResource(Scalar.fromLong(1000L)) { thousand =>
+          withResource(col.mul(thousand)) { milliSeconds =>
+            milliSeconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+          }
+        }
+    }
+  }
+}

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import ai.rapids.cudf.{ColumnView, DType, Scalar}
+import com.nvidia.spark.rapids.GpuOrcScan.{testLongMultiplicationOverflow, withResource}
+
+object OrcCastingShims {
+  /**
+   * Cast ColumnView of integer types to timestamp (in milliseconds).
+   * @param col The column view of integer types.
+   * @param fromType BOOL8, INT8/16/32/64
+   * @return A new timestamp columnar vector.
+   */
+  def castIntegerToTimestamp(col: ColumnView, fromType: DType): ColumnView = {
+    fromType match {
+      case DType.BOOL8 | DType.INT8 | DType.INT16 | DType.INT32 =>
+        // From spark330, spark consider the integers as seconds.
+        withResource(col.castTo(DType.INT64)) { longs =>
+          // In CPU, ORC assumes the integer value is in seconds, and returns timestamp in
+          // micro seconds, so we need to multiply 1e6 here.
+          withResource(Scalar.fromLong(1000000L)) { value =>
+            withResource(longs.mul(value)) { microSeconds =>
+              microSeconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+            }
+          }
+        }
+
+      case DType.INT64 =>
+        // In CPU code of ORC casting, its conversion is 'integer -> milliseconds -> microseconds'
+        withResource(Scalar.fromLong(1000L)) { thousand =>
+          withResource(col.mul(thousand)) { milliSeconds =>
+            // We need to check long-overflow here. If milliseconds can not convert to
+            // micorseconds, then testLongMultiplicationOverflow will throw exception.
+            if (milliSeconds.max() != null) {
+              testLongMultiplicationOverflow(milliSeconds.max().getLong, 1000L)
+            }
+            if (milliSeconds.min() != null) {
+              testLongMultiplicationOverflow(milliSeconds.min().getLong, 1000L)
+            }
+            withResource(milliSeconds.mul(thousand)) { microSeconds =>
+              microSeconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+            }
+          }
+        }
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -277,39 +277,15 @@ object GpuOrcScan extends Arm {
     }
     val toType = to.getCategory
     from.getCategory match {
-      case BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DECIMAL =>
+      case BOOLEAN | BYTE | SHORT | INT | LONG =>
         toType match {
-          case BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DECIMAL | STRING |
+          case BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | STRING |
                TIMESTAMP => true
           // BINARY and DATE are not supported by design.
           // The 'to' type (aka read schema) is from Spark, and VARCHAR and CHAR will
           // be replaced by STRING. Meanwhile, cuDF doesn't support them as output
           // types, and also replaces them with STRING.
           // TIMESTAMP_INSTANT is not supported by cuDF.
-          case _ => false
-        }
-      case STRING | CHAR | VARCHAR =>
-        toType match {
-          case BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DECIMAL | STRING |
-               TIMESTAMP | DATE => true
-          // BINARY, TIMESTAMP_INSTANT is not supported by cuDF.
-          // VARCHAR and CHAR will be replaced with STRING in Spark as told above.
-          case _ => false
-        }
-      case TIMESTAMP =>
-        toType match {
-          case BOOLEAN | BYTE | SHORT | INT | LONG | FLOAT | DOUBLE | DECIMAL | STRING |
-               TIMESTAMP | DATE => true
-          case _ => false
-        }
-      case DATE =>
-        toType match {
-          case STRING | TIMESTAMP | DATE => true
-          case _ => false
-        }
-      case BINARY =>
-        toType match {
-          case STRING | BINARY => true
           case _ => false
         }
       case _ => false

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -234,8 +234,10 @@ object GpuOrcScan extends Arm {
         withResource(col.castTo(DType.INT64)) { longs =>
           // In CPU, ORC assumes the integer value is in seconds, and returns timestamp in
           // micro seconds.
-          withResource(longs.bitCastTo(DType.TIMESTAMP_SECONDS)) { seconds =>
-            seconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+          withResource(Scalar.fromLong(1e6.toLong)) { value =>
+            withResource(longs.mul(value)) { microSeconds =>
+              microSeconds.castTo(DType.TIMESTAMP_MICROSECONDS)
+            }
           }
         }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -238,7 +238,7 @@ object GpuOrcScan extends Arm {
         // We need overflow checking here, since max value of INT64 is about 9 * 1e18, and convert
         // INT64 to micro seconds(also a INT64 actually), we need multiply 1e6, it may cause long
         // overflow.
-        // If val * 1e6 / 1e6 == val, the there is no overflow.
+        // If val * 1e6 / 1e6 == val, then there is no overflow.
         withResource(ColumnVector.fromScalar(Scalar.fromLong(1000000),
           col.getRowCount().toInt)) { vec =>
           withResource(col.mul(vec)) { mulRes =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -289,7 +289,7 @@ object GpuOrcScan extends Arm {
           // TIMESTAMP_INSTANT is not supported by cuDF.
           case _ => false
         }
-      case CHAR | VARCHAR =>
+      case VARCHAR =>
         toType == STRING
       case _ => false
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -22,12 +22,14 @@ import java.nio.ByteBuffer
 import java.nio.channels.{Channels, WritableByteChannel}
 import java.util
 import java.util.concurrent.Callable
+
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.math.max
+
 import ai.rapids.cudf._
 import com.google.protobuf.CodedOutputStream
 import com.nvidia.spark.rapids.GpuMetric._
@@ -41,6 +43,7 @@ import org.apache.orc.{CompressionKind, DataReader, OrcConf, OrcFile, OrcProto, 
 import org.apache.orc.impl._
 import org.apache.orc.impl.RecordReaderImpl.SargApplier
 import org.apache.orc.mapred.OrcInputFormat
+
 import org.apache.spark.TaskContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging


### PR DESCRIPTION
Close #6272 (which is sub-issue of https://github.com/NVIDIA/spark-rapids/issues/6149 ).

Implemented casting bool/int8/int16/int32/int64 -> {string, float, double(float64), timestamp}.

When casting `Long -> timestamp`, we need overflow checking. And if there is long-overflow, we should throw an exception. We do similar thing as CPU code.




## Implementation

| Casting                                | Implementation Description                                   |
| :------------------------------------- | :----------------------------------------------------------- |
| `bool -> float/double`                 | Based on `ColumnVector.castTo` in cuDF.                      |
| `bool -> string`                       | Call `castTo`, and convert them into upper cases `TRUE/FALSE` (as CPU code did). |
| `int8/16/32/64 -> float/double/string` | Call `castTo`                                                |
| `bool/int8/16/32 -> timestamp`         | The original value is in seconds, and convert them into micro-seconds. Since `timestamp` is stored in `int64`, there is no integer-overflow. |
| `int64 -> timestamp`                   | The original values of `int64` is in seconds. And `max(int64) <= 9 * 1e18` . <br />To convert them to micro-seconds, we need to multiply `1e6`, so there may be integer-overflow when original `int64` value  is greater than `1e12`.<br />We check the overflowings via `Math.multiply`, which will throw `ArithmeticException` if there is any integer-overflow. |




## Test

+ All the above cases are tested by `test_casting_from_integer`.
+ `test_casting_from_overflow_long` will test some large `long` integers, which will cause long-integer-overflow. This function aims to test whether if 'ArithmeticException' is caught.



