### PR TITLE
Use schema instead of row field count during columnar conversion

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -44,7 +44,7 @@ private class GpuRowToColumnConverter(schema: StructType) extends Serializable w
    */
   final def convert(row: InternalRow, builders: GpuColumnarBatchBuilder): Double = {
     var bytes: Double = 0
-    for (idx <- 0 until row.numFields) {
+    for (idx <- schema.fields.indices) {
       bytes += converters(idx).append(row, idx, builders.builder(idx))
     }
     bytes


### PR DESCRIPTION
Fixes #6269.  Iceberg is returning a custom row object, StructInternalRow, that has fields in it despite the read schema not wanting to read them.  The columnar conversion code was assuming the row field count matches the read schema field count, and that caused the index error.  This changes the columnar conversion code to use the schema field count rather than relying on the row field count matching the read schema field count.