### PR TITLE
Add `GpuMapConcat` support for nested type keys.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3206,10 +3206,6 @@ object GpuOverrides extends Logging {
       }),
     expr[MapConcat](
       "Returns the union of all the given maps",
-      // Currently, GpuMapConcat supports nested values but not nested keys.
-      // We will add the nested key support after
-      // cuDF can fully support nested types in lists::drop_list_duplicates.
-      // Issue link: https://github.com/rapidsai/cudf/issues/11093
       ExprChecks.projectOnly(TypeSig.MAP.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 +
           TypeSig.NULL + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP),
         TypeSig.MAP.nested(TypeSig.all),
@@ -3218,13 +3214,6 @@ object GpuOverrides extends Logging {
           TypeSig.NULL + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP),
           TypeSig.MAP.nested(TypeSig.all)))),
       (a, conf, p, r) => new ComplexTypeMergingExprMeta[MapConcat](a, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          a.dataType.keyType match {
-            case MapType(_,_,_) | ArrayType(_,_) | StructType(_) => willNotWorkOnGpu(
-              s"GpuMapConcat does not currently support the key type ${a.dataType.keyType}.")
-            case _ =>
-          }
-        }
         override def convertToGpu(child: Seq[Expression]): GpuExpression = GpuMapConcat(child)
       }),
     expr[ConcatWs](

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CollectionOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CollectionOpSuite.scala
@@ -19,22 +19,18 @@ package com.nvidia.spark.rapids
 import org.apache.spark.sql.functions.map_concat
 
 class CollectionOpSuite extends SparkQueryCompareTestSuite {
-  testGpuFallback(
-    "MapConcat with Array keys fall back",
-    "ProjectExec",
-    ArrayKeyMapDF, 
-    execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+  testSparkResultsAreEqual(
+    "MapConcat with Array keys",
+    ArrayKeyMapDF) {
     frame => {
       import frame.sparkSession.implicits._
       frame.select(map_concat($"col1", $"col2"))
     }
   }
 
-  testGpuFallback(
-    "MapConcat with Struct keys fall back",
-    "ProjectExec",
-    StructKeyMapDF, 
-    execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+   testSparkResultsAreEqual(
+    "MapConcat with Struct keys",
+    StructKeyMapDF) {
     frame => {
       import frame.sparkSession.implicits._
       frame.select(map_concat($"col1", $"col2"))


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
This is a subtask of #5559.

The `GpuMaxConcat` could support array typed keys and struct typed keys.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
