### PR TITLE
Add more infomation in FileSourceScanExec log when timezone is not UTC

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -791,9 +791,9 @@ abstract class TypeChecks[RET] {
           checkCustomMessageType(elementType)
         case MapType(keyType, valueType, _) =>
           // prevent short-circuit evaluation
-          val keySupported = checkCustomMessageType(keyType)
-          val valueSupported = checkCustomMessageType(valueType)
-          keySupported || valueSupported
+          val keyChecked = checkCustomMessageType(keyType)
+          val valueChecked = checkCustomMessageType(valueType)
+          keyChecked || valueChecked
         case StructType(fields) =>
           fields.map(field => checkCustomMessageType(field.dataType)).exists(identity)
         case _ => true

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -924,7 +924,6 @@ class FileFormatChecks private (
       schema: StructType,
       fileType: FileFormatType,
       op: FileFormatOp): Unit = {
-    // tagTimestampUtcCheck(meta, schema.fields)
     tagUnsupportedTypes(meta, sig, schema.fields,
       s"unsupported data types %s in $op for $fileType")
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -25,7 +25,6 @@ import com.nvidia.spark.rapids.shims.{GpuTypeShims, TypeSigUtil}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 
 /** Trait of TypeSigUtil for different spark versions */
@@ -777,6 +776,23 @@ abstract class TypeChecks[RET] {
     }.mkString(", ")
   }
 
+  private def tagCustomMessage(
+    groupedByType: Map[DataType, Set[String]],
+    meta: RapidsMeta[_, _, _]
+    ): Map[DataType, Set[String]] = {
+    groupedByType.filterKeys {
+      case TimestampType if !(TypeChecks.areTimestampsSupported(ZoneId.systemDefault()) &&
+        TypeChecks.areTimestampsSupported(SQLConf.get.sessionLocalTimeZone))=> {
+        //  Add more infomation in log when timezone not UTC
+        meta.willNotWorkOnGpu(s"your timezone isn't in UTC (JVM:" +
+          s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
+          s" Set both of the timezones to UTC to enable TimestampType support")
+        false
+      }
+      case _ => true
+    }
+  }
+
   protected def tagUnsupportedTypes(
     meta: RapidsMeta[_, _, _],
     sig: TypeSig,
@@ -788,24 +804,10 @@ abstract class TypeChecks[RET] {
       .groupBy(_.dataType)
       .mapValues(_.map(_.name).toSet)
 
-    if (unsupportedTypes.nonEmpty) {
-      meta.willNotWorkOnGpu(msgFormat.format(stringifyTypeAttributeMap(unsupportedTypes)))
-    }
-  }
+    val defaultUnsupportedTypes = tagCustomMessage(unsupportedTypes, meta)
 
-  /** Add more infomation in log when timezone not UTC */
-  protected def tagTimestampUtcCheck(
-    meta: RapidsMeta[_, _, _],
-    fields: Seq[StructField]
-    ): Unit = {
-    val schemaHasTimestamps = fields.exists { field =>
-      TrampolineUtil.dataTypeExistsRecursively(field.dataType, _.isInstanceOf[TimestampType])
-    }
-    if (schemaHasTimestamps && !(TypeChecks.areTimestampsSupported(ZoneId.systemDefault()) &&
-        TypeChecks.areTimestampsSupported(SQLConf.get.sessionLocalTimeZone))) {
-      meta.willNotWorkOnGpu(s"your timezone isn't in UTC (JVM:" +
-          s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
-          s" Set both of the timezones to UTC to enable TimestampType support")
+    if (defaultUnsupportedTypes.nonEmpty) {
+      meta.willNotWorkOnGpu(msgFormat.format(stringifyTypeAttributeMap(unsupportedTypes)))
     }
   }
 }
@@ -922,7 +924,7 @@ class FileFormatChecks private (
       schema: StructType,
       fileType: FileFormatType,
       op: FileFormatOp): Unit = {
-    tagTimestampUtcCheck(meta, schema.fields)
+    // tagTimestampUtcCheck(meta, schema.fields)
     tagUnsupportedTypes(meta, sig, schema.fields,
       s"unsupported data types %s in $op for $fileType")
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -781,8 +781,8 @@ abstract class TypeChecks[RET] {
     meta: RapidsMeta[_, _, _]
     ): Map[DataType, Set[String]] = {
     groupedByType.filterKeys {
-      case TimestampType if !(TypeChecks.areTimestampsSupported(ZoneId.systemDefault()) &&
-        TypeChecks.areTimestampsSupported(SQLConf.get.sessionLocalTimeZone))=> {
+      case TimestampType if !TypeChecks.areTimestampsSupported(ZoneId.systemDefault()) ||
+        !TypeChecks.areTimestampsSupported(SQLConf.get.sessionLocalTimeZone) => {
         //  Add more infomation in log when timezone not UTC
         meta.willNotWorkOnGpu(s"your timezone isn't in UTC (JVM:" +
           s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -791,13 +791,14 @@ abstract class TypeChecks[RET] {
         }
         case ArrayType(elementType, _) =>
           checkTimestampType(elementType)
+          true
         case MapType(keyType, valueType, _) =>
-          // prevent short-circuit evaluation
-          val keyChecked = checkTimestampType(keyType)
-          val valueChecked = checkTimestampType(valueType)
-          keyChecked || valueChecked
+          checkTimestampType(keyType)
+          checkTimestampType(valueType)
+          true
         case StructType(fields) =>
-          fields.map(field => checkTimestampType(field.dataType)).exists(identity)
+          fields.foreach(field => checkTimestampType(field.dataType))
+          true
         case _ => true
     }
     unsupportedTypes.filterKeys(checkTimestampType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -796,6 +796,8 @@ abstract class TypeChecks[RET] {
           checkTimestampType(valueType)
         case StructType(fields) =>
           fields.foreach(field => checkTimestampType(field.dataType))
+        case _ =>
+          // do nothing
     }
     unsupportedTypes.foreach { case (dataType, nameSet) =>
       checkTimestampType(dataType)


### PR DESCRIPTION
When reading a ORC file that has a TimestampType but your timezone isn't set to UTC we just print:

`!Exec <FileSourceScanExec> cannot run on GPU because unsupported data types in output: TimestampType [_c9#9]; unsupported data types TimestampType [_c9] in read for ORC`

It didn't give enough information.

This PR add a function in FileFormatChecks to check if the file contains TimestampType and the timezone isn't set to UTC. If so, we will add an additional warning message in FileSourceScanExec log. 

`!Exec <FileSourceScanExec> cannot run on GPU because unsupported data types TimestampType [_c0] in read for ORC; your timezone isn't in UTC (JVM: GMT-08:00, session: GMT-08:00). Set both of the timezones to UTC to enable TimestampType support; unsupported data types in output: TimestampType [_c0#0]`

This change also works for parquet files.

Closes #6213 

Signed-off-by: thirtiseven <ntlihy@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
