### PR TITLE
Add Nan handling for `GpuArrayMax`

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -325,6 +325,11 @@ def test_array_concat_decimal(data_gen):
             'concat(a, a)')),
         conf=no_nans_conf)
 
+@pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
+def test_array_max_with_nans(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, ArrayGen(data_gen)).selectExpr(
+                'array_max(a)'))
 
 @pytest.mark.parametrize('data_gen', array_min_max_gens_no_nan, ids=idfn)
 def test_array_max(data_gen):
@@ -333,7 +338,7 @@ def test_array_max(data_gen):
                 'array_max(a)'),
             conf=no_nans_conf)
 
-@pytest.mark.parametrize('data_gen', [ArrayGen(int_gen, all_null=True)], ids=idfn)
+@pytest.mark.parametrize('data_gen', [ArrayGen(gen, all_null=True) for gen in [int_gen, float_gen, double_gen]], ids=idfn)
 def test_array_max_all_nulls(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2754,14 +2754,9 @@ object GpuOverrides extends Logging {
       ExprChecks.unaryProject(
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
-        TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+        TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMax](in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          checkAndTagFloatNanAgg("Max", in.dataType, conf, this)
-        }
-
         override def convertToGpu(child: Expression): GpuExpression =
           GpuArrayMax(child)
       }),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -440,7 +440,19 @@ case class GpuArrayMin(child: Expression) extends GpuUnaryExpression with Implic
     input.getBase.listReduce(SegmentedReductionAggregation.min())
 }
 
-case class GpuArrayMax(child: Expression) extends GpuUnaryExpression with ImplicitCastInputTypes {
+object GpuArrayMax {
+  def apply(child: Expression): GpuArrayMax = {
+    child.dataType match {
+      case ArrayType(FloatType | DoubleType, _) => GpuFloatArrayMax(child)
+      case ArrayType(_, _) => GpuBasicArrayMax(child)
+      case _ => throw new IllegalStateException(s"array_max accepts only arrays.")
+    }
+  }
+}
+
+abstract class GpuArrayMax(child: Expression) extends GpuUnaryExpression
+  with ImplicitCastInputTypes
+  with Serializable{
 
   override def nullable: Boolean = true
 
@@ -455,6 +467,34 @@ case class GpuArrayMax(child: Expression) extends GpuUnaryExpression with Implic
 
   override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector =
     input.getBase.listReduce(SegmentedReductionAggregation.max())
+}
+
+case class GpuBasicArrayMax(child: Expression) extends GpuArrayMax(child)
+
+case class GpuFloatArrayMax(child: Expression) extends GpuArrayMax(child){
+  @transient override lazy val dataType: DataType = child.dataType match {
+    case ArrayType(FloatType, _) => FloatType
+    case ArrayType(DoubleType, _) => DoubleType
+    case _ => throw new IllegalStateException(
+      s"GpuFloatArrayMax accepts only float array and double array."
+    )
+  }
+
+  protected def getNanSalar: Scalar = dataType match {
+    case FloatType => Scalar.fromFloat(Float.NaN)
+    case DoubleType => Scalar.fromDouble(Double.NaN)
+    case t => throw new IllegalStateException(s"dataType $t is not FloatType or DoubleType")
+  }
+
+  override protected def doColumnar(input: GpuColumnVector): cudf.ColumnVector = {
+    withResource(getNanSalar){nan =>
+      withResource(input.getBase().listContains(nan)){hasNan =>
+        withResource(input.getBase().listReduce(SegmentedReductionAggregation.max())) {max =>
+          hasNan.ifElse(nan, max)
+        }
+      }
+    }
+  }
 }
 
 case class GpuArrayRepeat(left: Expression, right: Expression) extends GpuBinaryExpression {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Close #6315 

In this PR, we disable the `hasNan` configuration for `GpuArrayMax` and add nan handling for  `GpuArrayMax`.

# Changes in this PR
1. mark the `GpuArrayMax` as an abstract class and create 2 case classes:
    - `GpuBasicArrayMax`: This class has the same functionality as the original `GpuArrayMax` except that this is no for array[float] or array[double]
    - `GpuFloatArrayMax`: This class is for array[float] and array[double]. In this class, we use a workaround way to handle the `nan` values
 
2. Handle `nan` values in `GpuFloatArrayMax`
We firstly check if each array contains `nan`. 
Then we use `SegmentedReductionAggregation.max()` to calculate the max value
If the array has `Nan`, return `Nan`, else return the max value we have calculated.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

4. Please ensure that you have written units tests for the changes made/features
   added.

5. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

6. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

7. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

8. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
