### PR TITLE
[WIP] Implement a tiered projection

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -691,9 +691,9 @@ class GpuHashAggregateIterator(
 
     // a bound expression that is applied before the cuDF aggregate
     private val preStepBound = if (forceMerge) {
-      GpuBindReferences.bindGpuReferences(preStep.toList, aggBufferAttributes.toList)
+      GpuBindReferences.bindGpuReferencesTiered(preStep.toList, aggBufferAttributes.toList)
     } else {
-      GpuBindReferences.bindGpuReferences(preStep, inputAttributes)
+      GpuBindReferences.bindGpuReferencesTiered(preStep, inputAttributes)
     }
 
     // a bound expression that is applied after the cuDF aggregate
@@ -708,7 +708,8 @@ class GpuHashAggregateIterator(
      */
     def preProcess(toAggregateBatch: ColumnarBatch): ColumnarBatch = {
       withResource(new NvtxRange("pre-process", NvtxColor.DARK_GREEN)) { _ =>
-        GpuProjectExec.project(toAggregateBatch, preStepBound)
+        //GpuProjectExec.project(toAggregateBatch, preStepBound)
+        preStepBound.tieredProject(toAggregateBatch)
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

This is an initial proof-of-concept for https://github.com/NVIDIA/spark-rapids/issues/5085.
I am putting this up as a draft to get some feedback.

The general approach is to provide an alternative to bindGpuReferences, currently called bindGpuReferencesTiered, which returns a case class that contains a tiered list of references, and the corresponding method in that case class that applies the tiered projections in order.  The tiered list of references are created by recursively pulling out common sub-expressions from the initial list of expressions and rewriting expressions to refer to the output of the sub-expressions.

There are some known problems with this initial POC.

1.  It currently depends on EquivalentExpressions.scala in Spark, and the name for the method we are calling changes between 3.1 and 3.2.  This patch currently uses the 3.1 version.  If we were to continue to use this, I think we would need a shim to deal with the differences.
2. EquivalentExpressions has rules that control which nodes in the expression tree are evaluated, so it can avoid conditional expressions and expressions with side-effects.  These rules don't know anything about GpuExpressions, so for instance, the rules for handling `if` expressions or `case when` expressions won't be applied for the GPU equivalents, and we'll end up getting more sub-expressions than we should.  For the POC, I added some checks on the results from EquivalentExpressions to try to simulate this, but I think for the final patch we may need to replicate what EquivalentExpressions is doing instead of using it directly.
3. Need to add unit tests.
4. Need to remove debug code.