### PR TITLE
Make run_pyspark to report fail and error as default [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -181,8 +181,9 @@ else
       "$LOCAL_ROOTDIR"
       "$LOCAL_ROOTDIR"/src/main/python)
 
+    REPORT_CHARS=${REPORT_CHARS:="fE"} # default as (f)ailed, (E)rror
     TEST_COMMON_OPTS=(-v
-          -rfExXs
+          -r"$REPORT_CHARS"
           "$TEST_TAGS"
           --std_input_path="$INPUT_PATH"/src/test/resources
           --color=yes


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #6046 

For run_pyspark script, we update the defaults of short test summary as fail and error.
So people could see actual failures or errors quickly from the tail of logs if any. If no fail or error, there will be no short test summary.

To use customized summary report, people could do, e.g.
```
REPORT_CHARS=fExXs integration_tests/run_pyspark_from_build.sh -k array_test
```

