### PR TITLE
Add missing subnet option to dataproc cluster example [skip ci]

### DIFF
--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -83,7 +83,8 @@ gcloud dataproc clusters create $CLUSTER_NAME  \
     --optional-components=JUPYTER,ZEPPELIN \
     --metadata=rapids-runtime=SPARK \
     --bucket=$GCS_BUCKET \
-    --enable-component-gateway
+    --enable-component-gateway \
+    --subnet=default
 ```
 
 This may take around 10-15 minutes to complete.  You can navigate to the Dataproc clusters tab in the


### PR DESCRIPTION
The getting started guide for Dataproc includes an example for creating a dataproc cluster that will fail with an invalid argument error due to unspecified network parameters, e.g.:
```
$ gcloud dataproc clusters create $CLUSTER_NAME  \
>     --region=$REGION \
>     --image-version=2.0-ubuntu18 \
>     --master-machine-type=n1-standard-16 \
>     --num-workers=$NUM_WORKERS \
>     --worker-accelerator=type=nvidia-tesla-t4,count=$NUM_GPUS \
>     --worker-machine-type=n1-highmem-32\
>     --num-worker-local-ssds=4 \
>     --initialization-actions=gs://goog-dataproc-initialization-actions-${REGION}/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-${REGION}/rapids/rapids.sh \
>     --optional-components=JUPYTER,ZEPPELIN \
>     --metadata=rapids-runtime=SPARK \
>     --bucket=$GCS_BUCKET \
>     --enable-component-gateway
ERROR: (gcloud.dataproc.clusters.create) INVALID_ARGUMENT: Network 'default' requires explicit subnetworks for instance creation. Specify a 'legacy' or 'auto' network, or specify subnetwork explicitly.
```

This fixes the example by adding `--subnet=default` which already appears in the other dataproc cluster creation examples.