### PR TITLE
Avoid passing duplicate conf to spark_init_internal [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -273,10 +273,20 @@ else
             jarOpts=(--driver-class-path "${PYSP_TEST_spark_driver_extraClassPath}")
         fi
 
+        driverJavaOpts="$PYSP_TEST_spark_driver_extraJavaOptions"
+        gpuAllocSize="$PYSP_TEST_spark_rapids_memory_gpu_allocSize"
+
+        # avoid double processing of variables passed to spark in
+        # spark_conf_init
+        unset PYSP_TEST_spark_driver_extraClassPath
+        unset PYSP_TEST_spark_driver_extraJavaOptions
+        unset PYSP_TEST_spark_jars
+        unset PYSP_TEST_spark_rapids_memory_gpu_allocSize
+
         exec "$SPARK_HOME"/bin/spark-submit "${jarOpts[@]}" \
-            --driver-java-options "$PYSP_TEST_spark_driver_extraJavaOptions" \
+            --driver-java-options "$driverJavaOpts" \
             $SPARK_SUBMIT_FLAGS \
-            --conf 'spark.rapids.memory.gpu.allocSize='"$PYSP_TEST_spark_rapids_memory_gpu_allocSize" \
+            --conf 'spark.rapids.memory.gpu.allocSize='"$gpuAllocSize" \
             "${RUN_TESTS_COMMAND[@]}" "${TEST_COMMON_OPTS[@]}"
     fi
 fi


### PR DESCRIPTION
Fixes #6344

Avoid passing In non-xdist execution the same config by different means. In spark.jars case it may corrupt the classpath. 

Verified with
```
SPARK_HOME=~/dist/spark-3.2.2-bin-hadoop3.2 \
NUM_LOCAL_EXECS=1 \
SPARK_SUBMIT_FLAGS="--packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:0.13.2 
  --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions 
  --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog 
  --conf spark.sql.catalog.spark_catalog.type=hadoop 
  --conf spark.sql.catalog.spark_catalog.warehouse=$(mktemp -d -p /tmp spark-warehouse-XXXXXX) 
  --conf spark.rapids.force.caller.classloader=false" \
./integration_tests/run_pyspark_from_build.sh -m iceberg --iceberg \
-k 'test_iceberg_read_partition_key[PERFILE-Long]'
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
