### PR TITLE
Add `Nan` handling in `GpuArrayMin`

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -310,6 +310,12 @@ def test_array_transform(data_gen):
 array_min_max_gens_no_nan = [byte_gen, short_gen, int_gen, long_gen, FloatGen(no_nans=True), DoubleGen(no_nans=True),
         string_gen, boolean_gen, date_gen, timestamp_gen, null_gen] + decimal_gens
 
+@pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
+def test_array_min_with_nans(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, ArrayGen(data_gen), length=10).selectExpr(
+                'array_min(a)'))
+
 @pytest.mark.parametrize('data_gen', array_min_max_gens_no_nan, ids=idfn)
 def test_array_min(data_gen):
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -316,7 +316,7 @@ def test_array_min_max(data_gen):
             lambda spark : unary_op_df(spark, ArrayGen(data_gen)).selectExpr(
                 'array_min(a)', 'array_max(a)'))
 
-@pytest.mark.parametrize('data_gen', [ArrayGen(gen, all_null=True) for gen in [int_gen, float_gen, double_gen]], ids=idfn)
+@pytest.mark.parametrize('data_gen', [ArrayGen(int_gen, all_null=True)], ids=idfn)
 def test_array_min_max_all_nulls(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -316,7 +316,7 @@ def test_array_min_max(data_gen):
             lambda spark : unary_op_df(spark, ArrayGen(data_gen)).selectExpr(
                 'array_min(a)', 'array_max(a)'))
 
-@pytest.mark.parametrize('data_gen', [ArrayGen(gen, all_null=True) for gen in [FloatGen(all_nans=True), DoubleGen(all_nans=True)]], ids=idfn)
+@pytest.mark.parametrize('data_gen', [ArrayGen(SetValuesGen(datatype, [math.nan, None])) for datatype in [FloatType(), DoubleType()]], ids=idfn)
 def test_array_min_max_all_nans(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).selectExpr(

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -316,6 +316,12 @@ def test_array_min_max(data_gen):
             lambda spark : unary_op_df(spark, ArrayGen(data_gen)).selectExpr(
                 'array_min(a)', 'array_max(a)'))
 
+@pytest.mark.parametrize('data_gen', [ArrayGen(gen, all_null=True) for gen in [FloatGen(all_nans=True), DoubleGen(all_nans=True)]], ids=idfn)
+def test_array_min_max_all_nans(data_gen):
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, data_gen).selectExpr(
+                'array_min(a)', 'array_max(a)'))
+
 @pytest.mark.parametrize('data_gen', [ArrayGen(int_gen, all_null=True)], ids=idfn)
 def test_array_min_max_all_nulls(data_gen):
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -323,8 +323,9 @@ POS_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0x7fffffff))[0]
 class FloatGen(DataGen):
     """Generate floats, which some built in corner cases."""
     def __init__(self, nullable=True,
-            no_nans=False, special_cases=None):
+            no_nans=False, special_cases=None, all_nans=False):
         self._no_nans = no_nans
+        self._all_nans = all_nans
         if special_cases is None:
             special_cases = [FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, 1.0, -1.0]
             if not no_nans:
@@ -341,9 +342,12 @@ class FloatGen(DataGen):
 
     def start(self, rand):
         def gen_float():
-            i = rand.randint(INT_MIN, INT_MAX)
-            p = struct.pack('i', i)
-            return self._fixup_nans(struct.unpack('f', p)[0])
+            if self._all_nans:
+                return math.nan
+            else:
+                i = rand.randint(INT_MIN, INT_MAX)
+                p = struct.pack('i', i)
+                return self._fixup_nans(struct.unpack('f', p)[0])
         self._start(rand, gen_float)
 
 DOUBLE_MIN_EXP = -1022
@@ -358,10 +362,11 @@ POS_DOUBLE_NAN_MAX_VALUE = struct.unpack('d', struct.pack('L', 0x7ffffffffffffff
 class DoubleGen(DataGen):
     """Generate doubles, which some built in corner cases."""
     def __init__(self, min_exp=DOUBLE_MIN_EXP, max_exp=DOUBLE_MAX_EXP, no_nans=False,
-            nullable=True, special_cases = None):
+            nullable=True, special_cases = None, all_nans=False):
         self._min_exp = min_exp
         self._max_exp = max_exp
         self._no_nans = no_nans
+        self._all_nans = all_nans
         self._use_full_range = (self._min_exp == DOUBLE_MIN_EXP) and (self._max_exp == DOUBLE_MAX_EXP)
         if special_cases is None:
             special_cases = [
@@ -399,6 +404,10 @@ class DoubleGen(DataGen):
         return v
 
     def start(self, rand):
+        if self._all_nans:
+            def gen_nan():
+                return math.nan
+            self._start(rand, gen_nan)
         if self._use_full_range:
             def gen_double():
                 i = rand.randint(LONG_MIN, LONG_MAX)

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -307,7 +307,7 @@ class SetValuesGen(DataGen):
         self._vals = data
 
     def __repr__(self):
-        return super().__repr__() + '(' + str(self._child) + ')'
+        return super().__repr__() +'(' + str(self.data_type) + ',' + str(self._vals) + ')'
 
     def start(self, rand):
         data = self._vals
@@ -323,9 +323,8 @@ POS_FLOAT_NAN_MAX_VALUE = struct.unpack('f', struct.pack('I', 0x7fffffff))[0]
 class FloatGen(DataGen):
     """Generate floats, which some built in corner cases."""
     def __init__(self, nullable=True,
-            no_nans=False, special_cases=None, all_nans=False):
+            no_nans=False, special_cases=None):
         self._no_nans = no_nans
-        self._all_nans = all_nans
         if special_cases is None:
             special_cases = [FLOAT_MIN, FLOAT_MAX, 0.0, -0.0, 1.0, -1.0]
             if not no_nans:
@@ -342,12 +341,9 @@ class FloatGen(DataGen):
 
     def start(self, rand):
         def gen_float():
-            if self._all_nans:
-                return math.nan
-            else:
-                i = rand.randint(INT_MIN, INT_MAX)
-                p = struct.pack('i', i)
-                return self._fixup_nans(struct.unpack('f', p)[0])
+            i = rand.randint(INT_MIN, INT_MAX)
+            p = struct.pack('i', i)
+            return self._fixup_nans(struct.unpack('f', p)[0])
         self._start(rand, gen_float)
 
 DOUBLE_MIN_EXP = -1022
@@ -362,11 +358,10 @@ POS_DOUBLE_NAN_MAX_VALUE = struct.unpack('d', struct.pack('L', 0x7ffffffffffffff
 class DoubleGen(DataGen):
     """Generate doubles, which some built in corner cases."""
     def __init__(self, min_exp=DOUBLE_MIN_EXP, max_exp=DOUBLE_MAX_EXP, no_nans=False,
-            nullable=True, special_cases = None, all_nans=False):
+            nullable=True, special_cases = None):
         self._min_exp = min_exp
         self._max_exp = max_exp
         self._no_nans = no_nans
-        self._all_nans = all_nans
         self._use_full_range = (self._min_exp == DOUBLE_MIN_EXP) and (self._max_exp == DOUBLE_MAX_EXP)
         if special_cases is None:
             special_cases = [
@@ -404,10 +399,6 @@ class DoubleGen(DataGen):
         return v
 
     def start(self, rand):
-        if self._all_nans:
-            def gen_nan():
-                return math.nan
-            self._start(rand, gen_nan)
         if self._use_full_range:
             def gen_double():
                 i = rand.randint(LONG_MIN, LONG_MAX)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2738,14 +2738,9 @@ object GpuOverrides extends Logging {
       ExprChecks.unaryProject(
         TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL,
         TypeSig.orderable,
-        TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL)
-            .withPsNote(Seq(TypeEnum.DOUBLE, TypeEnum.FLOAT), nanAggPsNote),
+        TypeSig.ARRAY.nested(TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL),
         TypeSig.ARRAY.nested(TypeSig.orderable)),
       (in, conf, p, r) => new UnaryExprMeta[ArrayMin](in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          checkAndTagFloatNanAgg("Min", in.dataType, conf, this)
-        }
-
         override def convertToGpu(child: Expression): GpuExpression =
           GpuArrayMin(child)
       }),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -511,7 +511,7 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
               _.listReduce(listAny)
             }
             withResource(anyNan) { anyNan =>
-              withResource(getNanSalar) { nanScalar =>
+              withResource(getNanScalar) { nanScalar =>
                 withResource(getNullScalar) { nullScalar =>
                   anyNan.ifElse(nanScalar, nullScalar)
                 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -482,25 +482,29 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
 
     withResource(base.getChildColumnView(0)) {child => 
       withResource(child.isNan()){child_is_nan =>
-        // if all values in each array are nans or nulls
+        // if all values in each list are nans or nulls
         val all_nan_or_null = {
           val child_is_nan_or_null = withResource(child.isNull()) {_.or(child_is_nan)}
           val nan_or_null_list = withResource(child_is_nan_or_null) {base.replaceListChild(_)}
           withResource(nan_or_null_list) {_.listReduce(listAll)}
         }
+        // if all values in one list are nans or nulls
+        // return nan if the list contains nan, else return null
+        val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
+          withResource(nan_list.listReduce(listAny)) {any_nan =>
+            withResource(Seq(getNanSalar, getNullScalar)) {
+              case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
+            }
+          }
+        }
+        // if a list contains values other than nan or null
+        // we replace all nans to nulls, and then find the min value.
+        val false_option = withResource(child.nansToNulls()) {no_nan_child =>
+          withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
+            no_nan_list.listReduce(SegmentedReductionAggregation.min())
+          }
+        }
         withResource(all_nan_or_null) {all_nan_or_null =>
-          val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
-            withResource(nan_list.listReduce(listAny)) {any_nan =>
-              withResource(Seq(getNanSalar, getNullScalar)) {
-                case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
-              }
-            }
-          }
-          val false_option = withResource(child.nansToNulls()) {no_nan_child =>
-            withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
-              no_nan_list.listReduce(SegmentedReductionAggregation.min())
-            }
-          }
           withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) =>
             all_nan_or_null.ifElse(true_option, false_option)
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -511,9 +511,11 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
               _.listReduce(listAny)
             }
             withResource(anyNan) { anyNan =>
-              withResource(Seq(getNanSalar, getNullScalar)) { case Seq(nanScalar, nullScalar) =>
+              withResource(getNanSalar) { nanScalar =>
+                withResource(getNullScalar) { nullScalar =>
                   anyNan.ifElse(nanScalar, nullScalar)
                 }
+              }
             }
           }
           withResource(trueOption){ trueOption =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -482,25 +482,24 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
 
     withResource(base.getChildColumnView(0)) {child => 
       withResource(child.isNan()){child_is_nan =>
-        withResource(child.isNull()){child_is_null =>
-          withResource(child_is_null.or(child_is_nan)) {child_is_nan_or_null =>
-            withResource(base.replaceListChild(child_is_nan_or_null)) {nan_or_null_list =>
-              withResource(nan_or_null_list.listReduce(listAll)) {all_nan_or_null =>
-                val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
-                  withResource(nan_list.listReduce(listAny)) {any_nan =>
-                    withResource(Seq(getNanSalar, getNullScalar)) {
-                      case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
-                    }
-                  }  
-                }
-                val false_option = withResource(child.nansToNulls()) {no_nan_child =>
-                  withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
-                    no_nan_list.listReduce(SegmentedReductionAggregation.min())
+        val child_is_nan_or_null = withResource(child.isNull()) {_.or(child_is_nan)}
+        withResource(child_is_nan_or_null) {child_is_nan_or_null =>
+          withResource(base.replaceListChild(child_is_nan_or_null)) {nan_or_null_list =>
+            withResource(nan_or_null_list.listReduce(listAll)) {all_nan_or_null =>
+              val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
+                withResource(nan_list.listReduce(listAny)) {any_nan =>
+                  withResource(Seq(getNanSalar, getNullScalar)) {
+                    case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
                   }
                 }
-                withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) => 
-                  all_nan_or_null.ifElse(true_option, false_option)
+              }
+              val false_option = withResource(child.nansToNulls()) {no_nan_child =>
+                withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
+                  no_nan_list.listReduce(SegmentedReductionAggregation.min())
                 }
+              }
+              withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) => 
+                all_nan_or_null.ifElse(true_option, false_option)
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -479,7 +479,7 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
     )
   }
 
-  protected def getNanSalar: Scalar = dataType match {
+  protected def getNanScalar: Scalar = dataType match {
     case FloatType => Scalar.fromFloat(Float.NaN)
     case DoubleType => Scalar.fromDouble(Double.NaN)
     case t => throw new IllegalStateException(s"dataType $t is not FloatType or DoubleType")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -486,23 +486,23 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
           withResource(child_is_null.or(child_is_nan)) {child_is_nan_or_null =>
             withResource(base.replaceListChild(child_is_nan_or_null)) {nan_or_null_list =>
               withResource(nan_or_null_list.listReduce(listAll)) {all_nan_or_null =>
-                all_nan_or_null.ifElse(
-                  withResource(base.replaceListChild(child_is_nan)) {nan_list =>
-                    withResource(nan_list.listReduce(listAny)) {any_nan =>
-                      withResource(Seq(getNanSalar, getNullScalar)) {case Seq(nan_scalar, null_scalar) =>
-                        any_nan.ifElse(nan_scalar, null_scalar)
-                      }
-                    }  
-                  },
-                  withResource(child.nansToNulls()) {no_nan_child =>
+                val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
+                  withResource(nan_list.listReduce(listAny)) {any_nan =>
+                    withResource(Seq(getNanSalar, getNullScalar)) {
+                      case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
+                    }
+                  }  
+                }
+                val false_option = withResource(child.nansToNulls()) {no_nan_child =>
                     withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
                       no_nan_list.listReduce(SegmentedReductionAggregation.min())
                     }  
-                  }
-                )
+                }
+                withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) => 
+                  all_nan_or_null.ifElse(true_option, false_option)
               }
             }
-          }
+          }}
         }
       } 
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -494,15 +494,16 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
                   }  
                 }
                 val false_option = withResource(child.nansToNulls()) {no_nan_child =>
-                    withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
-                      no_nan_list.listReduce(SegmentedReductionAggregation.min())
-                    }  
+                  withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
+                    no_nan_list.listReduce(SegmentedReductionAggregation.min())
+                  }
                 }
                 withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) => 
                   all_nan_or_null.ifElse(true_option, false_option)
+                }
               }
             }
-          }}
+          }
         }
       } 
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -486,23 +486,23 @@ case class GpuFloatArrayMin(child: Expression) extends GpuArrayMin(child) {
         val child_is_nan_or_null = withResource(child.isNull()) {_.or(child_is_nan)}
         // replace the child array using `child_is_nan_or_null`
         val nan_or_null_list = withResource(child_is_nan_or_null) {base.replaceListChild(_)}
-        withResource(nan_or_null_list) {nan_or_null_list =>
-          withResource(nan_or_null_list.listReduce(listAll)) {all_nan_or_null =>
-            val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
-              withResource(nan_list.listReduce(listAny)) {any_nan =>
-                withResource(Seq(getNanSalar, getNullScalar)) {
-                  case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
-                }
+        // if all values in each array are nans or nulls
+        val all_nan_or_null = withResource(nan_or_null_list) {_.listReduce(listAll)}
+        withResource(all_nan_or_null) {all_nan_or_null =>
+          val true_option = withResource(base.replaceListChild(child_is_nan)) {nan_list =>
+            withResource(nan_list.listReduce(listAny)) {any_nan =>
+              withResource(Seq(getNanSalar, getNullScalar)) {
+                case Seq(nan_scalar, null_scalar) => any_nan.ifElse(nan_scalar, null_scalar)
               }
             }
-            val false_option = withResource(child.nansToNulls()) {no_nan_child =>
-              withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
-                no_nan_list.listReduce(SegmentedReductionAggregation.min())
-              }
+          }
+          val false_option = withResource(child.nansToNulls()) {no_nan_child =>
+            withResource(base.replaceListChild(no_nan_child)) { no_nan_list =>
+              no_nan_list.listReduce(SegmentedReductionAggregation.min())
             }
-            withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) =>
-              all_nan_or_null.ifElse(true_option, false_option)
-            }
+          }
+          withResource(Seq(true_option, false_option)){case Seq(true_option, false_option) =>
+            all_nan_or_null.ifElse(true_option, false_option)
           }
         }
       } 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

Close #6317 
Close #6330 
Close #6332 

# Changes in this PR
1. remove the `hasNan` configuration on `GpuArrayMin`
2. Add `Nan` handling in `GpuArrayMin`
  - Just as `GpuMax` and `GpuArrayMax`, we create `GpuBasicArrayMin` and `GpuFloatArrayMIn`
  - The method to handle `Nan`s is:
    + If a list only contains `Nan`s or `null`, then we return `Nan` if the list contains `Nan`, otherwise return `null`
       Else, we replace all `Nan`s to `null` and then call cuDF kernel to get the min value
4. Update docs and tests

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

5. Please ensure that you have written units tests for the changes made/features
   added.

6. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

7. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

8. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

9. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
