### PR TITLE
Include filterblock time in scan time metric for Coalescing readers

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -316,7 +316,6 @@ case class GpuOrcMultiFilePartitionReaderFactory(
     // we must split the different compress files into different ColumnarBatch.
     // So here try the best to group the same compression files together before hand.
     val compressionAndStripes = LinkedHashMap[CompressionKind, ArrayBuffer[OrcSingleStripeMeta]]()
-    val scanTimeMetrics = metrics("scanTime")
     val currentTime = System.nanoTime()
     files.map { file =>
       val orcPartitionReaderContext = filterHandler.filterStripes(file, dataSchema,
@@ -331,7 +330,9 @@ case class GpuOrcMultiFilePartitionReaderFactory(
             OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
             OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
     }
-    scanTimeMetrics += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    if (metrics.contains("scanTime")) {
+      metrics("scanTime") += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    }
     val clippedStripes = compressionAndStripes.values.flatten.toSeq
     new MultiFileOrcPartitionReader(conf, files, clippedStripes, readDataSchema, debugDumpPrefix,
       maxReadBatchSizeRows, maxReadBatchSizeBytes, metrics, partitionSchema, numThreads,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -330,8 +330,8 @@ case class GpuOrcMultiFilePartitionReaderFactory(
             OrcSchemaWrapper(orcPartitionReaderContext.updatedReadSchema),
             OrcExtraInfo(orcPartitionReaderContext.requestedMapping)))
     }
-    if (metrics.contains("scanTime")) {
-      metrics("scanTime") += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    metrics.get("scanTime").foreach {
+      _ += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
     }
     val clippedStripes = compressionAndStripes.values.flatten.toSeq
     new MultiFileOrcPartitionReader(conf, files, clippedStripes, readDataSchema, debugDumpPrefix,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1004,8 +1004,8 @@ case class GpuParquetMultiFilePartitionReaderFactory(
           ParquetExtraInfo(singleFileInfo.isCorrectedRebaseMode,
             singleFileInfo.isCorrectedInt96RebaseMode, singleFileInfo.hasInt96Timestamps)))
     }
-    if (metrics.contains("scanTime")) {
-      metrics("scanTime") += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    metrics.get("scanTime").foreach {
+      _ += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
     }
     new MultiFileParquetPartitionReader(conf, files, clippedBlocks,
       isCaseSensitive, readDataSchema, debugDumpPrefix,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -248,7 +248,6 @@ case class GpuAvroMultiFilePartitionReaderFactory(
     val clippedBlocks = ArrayBuffer[AvroSingleDataBlockInfo]()
     val mapPathHeader = LinkedHashMap[Path, Header]()
     val filterHandler = AvroFileFilterHandler(conf, options)
-    val scanTimeMetrics = metrics("scanTime")
     val currentTime = System.nanoTime()
     files.foreach { file =>
       val singleFileInfo = try {
@@ -277,7 +276,9 @@ case class GpuAvroMultiFilePartitionReaderFactory(
         mapPathHeader.put(fPath, singleFileInfo.header)
       }
     }
-    scanTimeMetrics += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    if (metrics.contains("scanTime")) {
+      metrics("scanTime") += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    }
     new GpuMultiFileAvroPartitionReader(conf, files, clippedBlocks, readDataSchema,
       partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads,
       debugDumpPrefix, metrics, mapPathHeader.toMap)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -276,8 +276,8 @@ case class GpuAvroMultiFilePartitionReaderFactory(
         mapPathHeader.put(fPath, singleFileInfo.header)
       }
     }
-    if (metrics.contains("scanTime")) {
-      metrics("scanTime") += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
+    metrics.get("scanTime").foreach {
+      _ += TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - currentTime)
     }
     new GpuMultiFileAvroPartitionReader(conf, files, clippedBlocks, readDataSchema,
       partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads,


### PR DESCRIPTION
The coalescing readers (parquet, ORC and Avro), don't include the time it takes to filter block in the scan time because it is called before the `hasNext()` function, which is where we track the scan time.

This PR includes filter block time in "scan time" metric for Coalescing readers. 

I checked that filter time is included in scan time in Spark, and also included in the plugin's per-file and multi-thread reader.

I add a temporary "scan time 2" metric locally to track time in filter block for tests. The metric will > 0ms only when the read type is Coalescing for parquet, ORC and Avro.

Note that there is no metric "scan time" in both spark and plugin when using DataSource V2, so it needs to check the existence of "scan time" metric.

Fixes #6303

Signed-off-by: thirtiseven <ntlihy@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
