### PR TITLE
Make the variable "BASE_SPARK_VERSION" consistent [databricks]

### DIFF
--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -36,7 +36,7 @@ def main():
     subprocess.check_call(rsync_command, shell=True)
 
     ssh_command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@%s -p 2200 -i %s " \
-        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VER=%s bash %s %s 2>&1 | tee testout; " \
+        "'LOCAL_JAR_PATH=%s SPARK_CONF=%s BASE_SPARK_VERSION=%s bash %s %s 2>&1 | tee testout; " \
         "if [ ${PIPESTATUS[0]} -ne 0 ]; then false; else true; fi'" % \
         (master_addr, params.private_key_file, params.jar_path, params.spark_conf, params.base_spark_pom_version,
          params.script_dest, ' '.join(params.script_args))

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -19,8 +19,8 @@ set -ex
 
 LOCAL_JAR_PATH=${LOCAL_JAR_PATH:-''}
 SPARK_CONF=${SPARK_CONF:-''}
-BASE_SPARK_VER=${BASE_SPARK_VER:-'3.1.2'}
-[[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VER//.}db
+BASE_SPARK_VERSION=${BASE_SPARK_VERSION:-'3.1.2'}
+[[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VERSION//.}db
 
 # install required packages
 sudo apt -y install zip unzip
@@ -37,7 +37,7 @@ export SPARK_HOME=/databricks/spark
 # change to not point at databricks confs so we don't conflict with their settings
 export SPARK_CONF_DIR=$PWD
 export PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/pyspark/:$SPARK_HOME/python/lib/py4j-0.10.9-src.zip
-if [[ $BASE_SPARK_VER == "3.2.1" ]]
+if [[ $BASE_SPARK_VERSION == "3.2.1" ]]
 then
   # Databricks Koalas can conflict with the actual Pandas version, so put site packages first
   export PYTHONPATH=/databricks/python3/lib/python3.8/site-packages:$PYTHONPATH
@@ -68,7 +68,7 @@ if [ -n "$SPARK_CONF" ]; then
 fi
 
 IS_SPARK_311_OR_LATER=0
-[[ "$(printf '%s\n' "3.1.1" "$BASE_SPARK_VER" | sort -V | head -n1)" = "3.1.1" ]] && IS_SPARK_311_OR_LATER=1
+[[ "$(printf '%s\n' "3.1.1" "$BASE_SPARK_VERSION" | sort -V | head -n1)" = "3.1.1" ]] && IS_SPARK_311_OR_LATER=1
 
 
 # TEST_MODE
@@ -81,7 +81,7 @@ TEST_TYPE="nightly"
 PCBS_CONF="com.nvidia.spark.ParquetCachedBatchSerializer"
 
 ICEBERG_VERSION=${ICEBERG_VERSION:-0.13.2}
-ICEBERG_SPARK_VER=$(echo $BASE_SPARK_VER | cut -d. -f1,2)
+ICEBERG_SPARK_VER=$(echo $BASE_SPARK_VERSION | cut -d. -f1,2)
 # Classloader config is here to work around classloader issues with
 # --packages in distributed setups, should be fixed by
 # https://github.com/NVIDIA/spark-rapids/pull/5646


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/6368

Make the variable "BASE_SPARK_VERSION" consistent among build and test scripts

Signed-off-by: Tim Liu <timl@nvidia.com>

