### PR TITLE
Fix handling of older array encodings in Parquet

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -765,10 +765,18 @@ private case class GpuParquetFileFilterHandler(@transient sqlConf: SQLConf) exte
           }
         }
       case array: ArrayType =>
-        val fileChild = fileType.asGroupType().getType(0)
-          .asGroupType().getType(0)
-        checkSchemaCompat(fileChild, array.elementType, errorCallback, isCaseSensitive, useFieldId,
-          rootFileType, rootReadType)
+        if (fileType.isPrimitive) {
+          if (fileType.getRepetition == Type.Repetition.REPEATED) {
+            checkSchemaCompat(fileType, array.elementType, errorCallback, isCaseSensitive,
+              useFieldId, rootFileType, rootReadType)
+          } else {
+            errorCallback(fileType, readType)
+          }
+        } else {
+          val fileChild = fileType.asGroupType().getType(0).asGroupType().getType(0)
+          checkSchemaCompat(fileChild, array.elementType, errorCallback, isCaseSensitive,
+            useFieldId, rootFileType, rootReadType)
+        }
 
       case map: MapType =>
         val parquetMap = fileType.asGroupType().getType(0).asGroupType()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -367,6 +367,7 @@ object ParquetSchemaUtils extends Arm {
     // Unannotated repeated group should be interpreted as required list of required element, so
     // list element type is just the group itself.
     // TODO: When we drop Spark 3.1.x, this should use Parquet's LogicalTypeAnnotation
+    //       Note that the original type is not null for leaf nodes.
     //if (parquetList.getLogicalTypeAnnotation == null &&
     val newSparkType = if (parquetList.getOriginalType == null &&
         parquetList.isRepetition(Repetition.REPEATED)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -345,7 +345,7 @@ object ParquetSchemaUtils extends Arm {
     sparkType match {
       case t: ArrayType =>
         // Only clips array types with nested type as element type.
-        clipSparkArrayType(t, parquetType.asGroupType(), caseSensitive, useFieldId)
+        clipSparkArrayType(t, parquetType, caseSensitive, useFieldId)
 
       case t: MapType =>
         clipSparkMapType(t, parquetType.asGroupType(), caseSensitive, useFieldId)
@@ -360,7 +360,7 @@ object ParquetSchemaUtils extends Arm {
 
   private def clipSparkArrayType(
       sparkType: ArrayType,
-      parquetList: GroupType,
+      parquetList: Type,
       caseSensitive: Boolean,
       useFieldId: Boolean): DataType = {
     val elementType = sparkType.elementType
@@ -368,10 +368,11 @@ object ParquetSchemaUtils extends Arm {
     // list element type is just the group itself.
     // TODO: When we drop Spark 3.1.x, this should use Parquet's LogicalTypeAnnotation
     //if (parquetList.getLogicalTypeAnnotation == null &&
-    if (parquetList.getOriginalType == null &&
+    val newSparkType = if (parquetList.getOriginalType == null &&
         parquetList.isRepetition(Repetition.REPEATED)) {
       clipSparkType(elementType, parquetList, caseSensitive, useFieldId)
     } else {
+      val parquetListGroup = parquetList.asGroupType()
       assert(
         // TODO: When we drop Spark 3.1.x, this should use Parquet's LogicalTypeAnnotation
         //parquetList.getLogicalTypeAnnotation.isInstanceOf[ListLogicalTypeAnnotation],
@@ -381,14 +382,15 @@ object ParquetSchemaUtils extends Arm {
             "ListLogicalTypeAnnotation: " + parquetList.toString)
 
       assert(
-        parquetList.getFieldCount == 1 && parquetList.getType(0).isRepetition(Repetition.REPEATED),
+        parquetListGroup.getFieldCount == 1 &&
+            parquetListGroup.getType(0).isRepetition(Repetition.REPEATED),
         "Invalid Parquet schema. " +
             "LIST-annotated group should only have exactly one repeated field: " +
             parquetList)
 
-      val repeated = parquetList.getType(0)
-      val newSparkType = if (repeated.isPrimitive) {
-        clipSparkType(elementType, parquetList.getType(0), caseSensitive, useFieldId)
+      val repeated = parquetListGroup.getType(0)
+      if (repeated.isPrimitive) {
+        clipSparkType(elementType, parquetListGroup.getType(0), caseSensitive, useFieldId)
       } else {
         val repeatedGroup = repeated.asGroupType()
 
@@ -408,9 +410,9 @@ object ParquetSchemaUtils extends Arm {
         }
         clipSparkType(elementType, parquetElementType, caseSensitive, useFieldId)
       }
-
-      sparkType.copy(elementType = newSparkType)
     }
+
+    sparkType.copy(elementType = newSparkType)
   }
 
   private def clipSparkMapType(


### PR DESCRIPTION
Older encodings of arrays in Parquet can omit the surrounding `GroupType`, but there were places in the code that blindly assumed there would always be a group type surrounding the repeated type.  This updates the schema compatibility and clipping code to handle the case where the surrounding group is omitted.