### PR TITLE
Fix leaks in GpuShuffledHashJoinExecSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
@@ -206,7 +206,7 @@ class GpuShuffledHashJoinExecSuite extends FunSuite with Arm with MockitoSugar {
 
   test("test a SerializedTableColumn") {
     TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      closeOnExcept(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
+      withResource(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
         val cv = GpuColumnVector.from(cudfCol, IntegerType)
         val batch = new ColumnarBatch(Seq(cv).toArray, 5)
         withResource(GpuColumnVector.from(batch)) { tbl =>
@@ -242,7 +242,7 @@ class GpuShuffledHashJoinExecSuite extends FunSuite with Arm with MockitoSugar {
 
   test("test two batches, going over the limit") {
     TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      closeOnExcept(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
+      withResource(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
         val cv = GpuColumnVector.from(cudfCol, IntegerType)
         val batch = new ColumnarBatch(Seq(cv).toArray, 5)
         withResource(GpuColumnVector.from(batch)) { tbl =>
@@ -281,7 +281,7 @@ class GpuShuffledHashJoinExecSuite extends FunSuite with Arm with MockitoSugar {
 
   test("test two batches, stating within the limit") {
     TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      closeOnExcept(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
+      withResource(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
         val cv = GpuColumnVector.from(cudfCol, IntegerType)
         val batch = new ColumnarBatch(Seq(cv).toArray, 5)
         withResource(GpuColumnVector.from(batch)) { tbl =>


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Fixes leaks in `GpuShuffledHashJoinExecSuite` where `withResource` should have been used instead of `closeOnExcept`.

Closes: #6426