### PR TITLE
[WIP] POC for supporting cuda ipc for XGBoost scenario

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/python/PythonConfEntries.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/python/PythonConfEntries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,15 @@ import com.nvidia.spark.rapids.RapidsConf.{POOLED_MEM, UVM_ENABLED}
 import com.nvidia.spark.rapids.RapidsConf.conf
 
 object PythonConfEntries {
+
+  val PYTHON_ARROW_ZERO_COPY_ENABLED = conf("spark.rapids.sql.python.arrow.zerocopy.enabled")
+    .doc("This is an experimental feature and is likely to change in the future. " +
+      "Enable (true) or disable (false) support for data zero copy from java process to " +
+      "python process by CUDA IPC mechanism. When enabled, The RAPIDs accelerator just copy " +
+      "the meta of the data to python process in the row of pandas DataFrame, and when disabled, " +
+      "The RAPIDS accelerator will copy the whole data to the python process")
+    .booleanConf
+    .createWithDefault(false)
 
   val PYTHON_GPU_ENABLED = conf("spark.rapids.sql.python.gpu.enabled")
     .doc("This is an experimental feature and is likely to change in the future." +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowCudaIpcPythonRunner.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowCudaIpcPythonRunner.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.rapids.execution.python
+
+import java.io.DataOutputStream
+import java.net.Socket
+
+import ai.rapids.cudf._
+import com.nvidia.spark.rapids._
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType, PythonRDD}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.execution.arrow.ArrowWriter
+import org.apache.spark.sql.execution.python.PythonUDFRunner
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.Utils
+
+/**
+ * Similar to `PythonUDFRunner`, but exchange data with Python worker via Arrow stream.
+ */
+class GpuArrowCudaIpcPythonRunner(
+    funcs: Seq[ChainedPythonFunctions],
+    evalType: Int,
+    argOffsets: Array[Array[Int]],
+    pythonInSchema: StructType,
+    timeZoneId: String,
+    conf: Map[String, String],
+    batchSize: Long,
+    semWait: GpuMetric,
+    onDataWriteFinished: () => Unit,
+    pythonOutSchema: StructType,
+    minReadTargetBatchSize: Int = 1)
+  extends GpuArrowPythonRunner(funcs, evalType, argOffsets, pythonInSchema,
+    timeZoneId, conf, batchSize, semWait, onDataWriteFinished,
+    pythonOutSchema, minReadTargetBatchSize) {
+
+  protected override def newWriterThread(
+      env: SparkEnv,
+      worker: Socket,
+      inputIterator: Iterator[ColumnarBatch],
+      partitionIndex: Int,
+      context: TaskContext): WriterThread = {
+    new WriterThread(env, worker, inputIterator, partitionIndex, context) {
+
+      protected override def writeCommand(dataOut: DataOutputStream): Unit = {
+
+        // Write config for the worker as a number of key -> value pairs of strings
+        dataOut.writeInt(conf.size)
+        for ((k, v) <- conf) {
+          PythonRDD.writeUTF(k, dataOut)
+          PythonRDD.writeUTF(v, dataOut)
+        }
+
+        PythonUDFRunner.writeUDFs(dataOut, funcs, argOffsets)
+      }
+
+      protected override def writeIteratorToStream(dataOut: DataOutputStream): Unit = {
+        // create schema with only 1 binary field in which will be filled with IPCMessage
+        val ipcBinarySchema = StructType(
+          StructField("in_struct",
+            StructType(
+              StructField("ipcMessage", BinaryType, false) :: Nil)) :: Nil)
+
+        val arrowSchema = ArrowUtils.toArrowSchema(ipcBinarySchema, timeZoneId)
+
+        val allocator = ArrowUtils.rootAllocator.newChildAllocator(
+          s"stdout writer for $pythonExec", 0, Long.MaxValue)
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+
+        val ipcNames = pythonInSchema.names
+
+        Utils.tryWithSafeFinally {
+          val arrowWriter = ArrowWriter.create(root)
+          val writer = new ArrowStreamWriter(root, null, dataOut)
+          writer.start()
+
+          while (inputIterator.hasNext) {
+            withResource(inputIterator.next()) { columnBatch =>
+              val table = GpuColumnVector.from(columnBatch)
+              val option = IPCWriterOptions.builder().withColumnNames(ipcNames: _*).build()
+              val ipcMessage = table.exportIPC(option)
+              val genericInternalRow = new GenericInternalRow(Array[Any](ipcMessage.getMessage))
+              // There is only one row containing the ipc information in each pandas.DataFrame
+              arrowWriter.write(InternalRow(genericInternalRow))
+              arrowWriter.finish()
+              writer.writeBatch()
+              arrowWriter.reset()
+            }
+          }
+          // end writes footer to the output stream and doesn't clean any resources.
+          // It could throw exception if the output stream is closed, so it should be
+          // in the try block.
+          writer.end()
+        } {
+          // If we close root and allocator in TaskCompletionListener, there could be a race
+          // condition where the writer thread keeps writing to the VectorSchemaRoot while
+          // it's being closed by the TaskCompletion listener.
+          // Closing root and allocator here is cleaner because root and allocator is owned
+          // by the writer thread and is only visible to the writer thread.
+          //
+          // If the writer thread is interrupted by TaskCompletionListener, it should either
+          // (1) in the try block, in which case it will get an InterruptedException when
+          // performing io, and goes into the finally block or (2) in the finally block,
+          // in which case it will ignore the interruption and close the resources.
+          root.close()
+          allocator.close()
+        }
+      }
+    }
+  }
+
+}
+
+object GpuArrowPythonRunnerChooser {
+  def apply(
+      zeroCopy: Boolean,
+      funcs: Seq[ChainedPythonFunctions],
+      argOffsets: Array[Array[Int]],
+      pythonInSchema: StructType,
+      timeZoneId: String,
+      conf: Map[String, String],
+      batchSize: Long,
+      semWait: GpuMetric,
+      onDataWriteFinished: () => Unit,
+      pythonOutSchema: StructType,
+      minReadTargetBatchSize: Int = 1): GpuArrowPythonRunner = {
+    if (zeroCopy) {
+      new GpuArrowCudaIpcPythonRunner(
+        funcs,
+        PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
+        argOffsets,
+        pythonInSchema,
+        timeZoneId,
+        conf,
+        batchSize,
+        semWait,
+        onDataWriteFinished,
+        pythonOutSchema,
+        // We can not assert the result batch from Python has the same row number with the
+        // input batch. Because Map Pandas UDF allows the output of arbitrary length
+        // and columns.
+        // Then try to read as many as possible by specifying `minReadTargetBatchSize` as
+        // `Int.MaxValue` here.
+        Int.MaxValue)
+    } else {
+      new GpuArrowPythonRunner(
+        funcs,
+        PythonEvalType.SQL_MAP_PANDAS_ITER_UDF,
+        argOffsets,
+        pythonInSchema,
+        timeZoneId,
+        conf,
+        batchSize,
+        semWait,
+        onDataWriteFinished,
+        pythonOutSchema,
+        // We can not assert the result batch from Python has the same row number with the
+        // input batch. Because Map Pandas UDF allows the output of arbitrary length
+        // and columns.
+        // Then try to read as many as possible by specifying `minReadTargetBatchSize` as
+        // `Int.MaxValue` here.
+        Int.MaxValue)
+    }
+  }
+}
+

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuPythonHelper.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuPythonHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,10 @@ object GpuPythonHelper extends Logging {
       val cpuTaskSlots = sparkConf.get(EXECUTOR_CORES) / Math.max(1, sparkConf.get(CPUS_PER_TASK))
       (initAllocTotal / cpuTaskSlots, maxAllocTotal / cpuTaskSlots)
     }
+  }
+
+  def isArrowZeroCopyEnabled(sqlConf: SQLConf): Boolean = {
+    new RapidsConf(sqlConf).get(PYTHON_ARROW_ZERO_COPY_ENABLED)
   }
 
   def isPythonOnGpuEnabled(sqlConf: SQLConf, name: String = "spark"): Boolean = {


### PR DESCRIPTION
The GpuMapInPandas still requires copying and passing Data from GPU in java process to python process, which may cause some performance issue see the link https://docs.google.com/spreadsheets/d/1PLZSxyjDAyt9cVe2x3Spgc8iGJq5l0rSibD86Mz5SB8/edit#gid=0.

So we have proposed an alternative way by using CUDA IPC, which can make two processes in a PC exchange data In the same machine with zero-copying. The solution is passing CUDA IPC meta info exported by cudf Table API in the row of Pandas.DataFrame in Java process, while python process first should re-construct the cudf Table by importing the CUDA IPC meta info. So this solution just pass some bytes of the CUDA IPC information instead of the whole real data. BTW, this PR depends on https://github.com/rapidsai/cudf/pull/11564

I had the initial design doc from [here](https://docs.google.com/document/d/1vwz9PvK0pSXqoV9jizyKiWf9o6yOKH7EmOKye6ue3zU/edit#) and the performance testing on XGBoost scenario from [here](https://docs.google.com/spreadsheets/d/1dECQ0K4_55mmqAGLr2l4QZXkx9YTjQYZGXBv0iT_Cow/edit#gid=0)