### PR TITLE
Remove caching of needles in GpuInSet

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,32 +18,19 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, Predicate}
 
 case class GpuInSet(
     child: Expression,
     list: Seq[Any]) extends GpuUnaryExpression with Predicate {
-  @transient private[this] lazy val _needles: ThreadLocal[ColumnVector] =
-    new ThreadLocal[ColumnVector]
-
   require(list != null, "list should not be null")
 
   override def nullable: Boolean = child.nullable || list.contains(null)
 
   override def doColumnar(haystack: GpuColumnVector): ColumnVector = {
-    val needles = getNeedles
-    haystack.getBase.contains(needles)
-  }
-
-  private def getNeedles: ColumnVector = {
-    var needleVec = _needles.get
-    if (needleVec == null) {
-      needleVec = buildNeedles
-      _needles.set(needleVec)
-      TaskContext.get.addTaskCompletionListener[Unit](_ => _needles.get.close())
+    withResource(buildNeedles) { needles =>
+      haystack.getBase.contains(needles)
     }
-    needleVec
   }
 
   private def buildNeedles: ColumnVector =


### PR DESCRIPTION
Fixes #6447.  It's possible for GpuInSet to be called for a task in different threads (e.g.: when using Python UDFs), and that breaks the caching of needles which assumes the thread that causes the needles to be created will be the same thread used for the task completion callback.

Since the caching of needles can be problematic, this removes that caching.  I suspect this won't be a problem in just about all cases, and we can investigate alternatives to cache this if we see a use-case where it is clearly needed.