### PR TITLE
Normalize nans in GpuSortArray

### DIFF
--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -163,10 +163,14 @@ def test_sort_array_normalize_nans():
     nan1 = struct.unpack('d', bytes1)[0]
     nan2 = struct.unpack('d', bytes2)[0]
     other = struct.unpack('d', bytes3)[0]
-    data = [([nan2] + [other for _ in range(256)] + [nan1],)]
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.createDataFrame(data).selectExpr('sort_array(_1, true)', 'sort_array(_1, false)')
-    )
+
+    data1 = [([nan2] + [other for _ in range(256)] + [nan1],)]
+    # array of struct
+    data2 = [([(nan2, nan1)] + [(other, nan2) for _ in range(256)] + [(nan1, nan2)],)]
+    for data in [data1, data2]:
+        assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: spark.createDataFrame(data).selectExpr('sort_array(_1, true)', 'sort_array(_1, false)')
+        )
 
 # For functionality test, the sequence length in each row should be limited,
 # to avoid the exception as below,

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -149,7 +149,14 @@ def test_sort_array_lit(data_gen):
             f.sort_array(f.lit(array_lit), True),
             f.sort_array(f.lit(array_lit), False)))
 
+
 def test_sort_array_normalize_nans():
+    """
+    When the average length of array is > 100,
+    and there are `-Nan`s in the data, the sorting order
+    of `Nan` is inconsistent in cuDF (https://github.com/rapidsai/cudf/issues/11630).
+    `GpuSortArray` fixes the inconsistency by normalizing `Nan`s.
+    """
     bytes1 = struct.pack('L', 0x7ff83cec2c05b870)
     bytes2 = struct.pack('L', 0xfff5101d3f1cd31b)
     bytes3 = struct.pack('L', 0x7c22453f18c407a8)

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -165,7 +165,7 @@ def test_sort_array_normalize_nans():
     other = struct.unpack('d', bytes3)[0]
     data = [([nan2] + [other for _ in range(256)] + [nan1],)]
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.createDataFrame(data).selectExpr('sort_array(_1)')
+        lambda spark: spark.createDataFrame(data).selectExpr('sort_array(_1, true)', 'sort_array(_1, false)')
     )
 
 # For functionality test, the sequence length in each row should be limited,

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -149,6 +149,18 @@ def test_sort_array_lit(data_gen):
             f.sort_array(f.lit(array_lit), True),
             f.sort_array(f.lit(array_lit), False)))
 
+def test_sort_array_normalize_nans():
+    bytes1 = struct.pack('L', 0x7ff83cec2c05b870)
+    bytes2 = struct.pack('L', 0xfff5101d3f1cd31b)
+    bytes3 = struct.pack('L', 0x7c22453f18c407a8)
+    nan1 = struct.unpack('d', bytes1)[0]
+    nan2 = struct.unpack('d', bytes2)[0]
+    other = struct.unpack('d', bytes3)[0]
+    data = [([nan2] + [other for _ in range(256)] + [nan1],)]
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.createDataFrame(data).selectExpr('sort_array(_1)')
+    )
+
 # For functionality test, the sequence length in each row should be limited,
 # to avoid the exception as below,
 #     "Too long sequence: 2147483745. Should be <= 2147483632"

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -424,21 +424,8 @@ case class GpuSortArray(base: Expression, ascendingOrder: Expression)
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): cudf.ColumnVector = {
-    val isDescending = isDescendingOrder(rhs)
     withResource(GpuColumnVector.from(lhs, numRows, left.dataType)) { cv =>
-      val base = cv.getBase()
-      dataType match {
-        case ArrayType(FloatType | DoubleType, _) =>
-          withResource(base.getChildColumnView(0)) {child =>
-            withResource(child.normalizeNANsAndZeros()) {normalizedChild =>
-              withResource(base.replaceListChild(normalizedChild)) {normalizedList =>
-                normalizedList.listSortRows(isDescending, true)
-              }
-            }
-          }
-        case _ =>
-          base.listSortRows(isDescending, true)
-      }
+      doColumnar(cv, rhs)
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -420,7 +420,6 @@ case class GpuSortArray(base: Expression, ascendingOrder: Expression)
       case _ =>
         base.listSortRows(isDescending, true)
     }
-
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): cudf.ColumnVector = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -409,6 +409,11 @@ case class GpuSortArray(base: Expression, ascendingOrder: Expression)
     val isDescending = isDescendingOrder(rhs)
     val base = lhs.getBase()
     dataType match {
+      // When the average length of array is > 100
+      // and there are `-Nan`s in the data, the sort ordering
+      // of `Nan`s is inconsistent. So we need to normalize the data
+      // before sorting. This workaround can be removed after
+      // solving https://github.com/rapidsai/cudf/issues/11630
       case ArrayType(FloatType | DoubleType, _) =>
         withResource(base.getChildColumnView(0)) {child =>
           withResource(child.normalizeNANsAndZeros()) {normalizedChild =>


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Close #6438.

## Changes in this PR.
In `GpuSortArray`, we call `normalize_nans_and_zeros` on the child column of the input before sorting. 

### Pros
`Nans` can have different orderings in `sort_array` because of the different bit representation. The normalization can make the ordering of sorting result to be stable when the array contains nans.

### Cons
`normalize_nans_and_zeros` will also normalize `0.0` and `-0.0`, which makes them indistinguishable. But as this is a known compatibility issue (https://github.com/NVIDIA/spark-rapids/blob/branch-22.10/docs/compatibility.md#00-vs--00), it will not introduce new bugs.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
