### PR TITLE
Reading delta log Table Checkpoint files should fallback the entire plan

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -25,7 +25,6 @@ import scala.util.control.NonFatal
 import ai.rapids.cudf.DType
 import com.nvidia.spark.rapids.RapidsConf.{SUPPRESS_PLANNING_FAILURE, TEST_CONF}
 import com.nvidia.spark.rapids.shims.{AQEUtils, GpuBatchScanExec, GpuHashPartitioning, GpuRangePartitioning, GpuSpecifiedWindowFrameMeta, GpuTypeShims, GpuWindowExpressionMeta, OffsetWindowFunctionMeta, SparkShimImpl}
-import org.apache.hadoop.fs.Path
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
@@ -4434,15 +4433,15 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   }
 
   /**
-   *  Determine whether query is running against Delta Lake _delta_log JSON or checkpoint
-   *  files or if Delta is doing stats collection that ends up hardcoding the use of AQE,
+   *  Determine whether query is running against Delta Lake _delta_log JSON files
+   *  or if Delta is doing stats collection that ends up hardcoding the use of AQE,
    *  even though the AQE setting is disabled. To protect against the latter, we
    *  check for a ScalaUDF using a tahoe.Snapshot function and if we ever see
    *  an AdaptiveSparkPlan on a Spark version we don't expect, fallback to the
    *  CPU for those plans.
    *  Note that the Delta Lake delta log checkpoint parquet files are just inefficient
-   *  to have to copy the data to GPU and then back off so have the entire plan fallback
-   *  to CPU.
+   *  to have to copy the data to GPU and then back off after it does the scan on
+   *  Delta Table Checkpoint, so have the entire plan fallback to CPU at that point.
    */
   def isDeltaLakeMetadataQuery(plan: SparkPlan): Boolean = {
     val deltaLogScans = PlanUtils.findOperators(plan, {
@@ -4451,13 +4450,9 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         logDebug(s"Fallback for FileSourceScanExec with _databricks_internal: $f")
         true
       case f: FileSourceScanExec =>
-        // example filename: "file:/tmp/delta-table/_delta_log/00000000000000000000.json" or
-        // file:/tmp/delta-table/_delta_log/000.checkpoint.1111.parquet or
-        // file:/tmp/delta-table/_delta_log/checkpoint.parquet
-        val found = f.relation.inputFiles.exists{ name =>
-          name.contains("/_delta_log/") &&
-          (name.endsWith(".json") ||
-            (name.endsWith(".parquet") && new Path(name).getName().contains("checkpoint")))
+        // example filename: "file:/tmp/delta-table/_delta_log/00000000000000000000.json"
+        val found = f.relation.inputFiles.exists { name =>
+          name.contains("/_delta_log/") && name.endsWith(".json")
         }
         if (found) {
           logDebug(s"Fallback for FileSourceScanExec delta log: $f")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4470,7 +4470,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         val found = rdd.inputRDD != null &&
           rdd.inputRDD.name != null &&
           (rdd.inputRDD.name.startsWith("Delta Table State")
-            && rdd.inputRDD.name.startsWith("Delta Table Checkpoint")) &&
+            || rdd.inputRDD.name.startsWith("Delta Table Checkpoint")) &&
           rdd.inputRDD.name.endsWith("/_delta_log")
         if (found) {
           logDebug(s"Fallback for RDDScanExec delta log: $rdd")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4433,8 +4433,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   }
 
   /**
-   *  Determine whether query is running against Delta Lake _delta_log JSON files
-   *  or if Delta is doing stats collection that ends up hardcoding the use of AQE,
+   *  Determine whether query is running against Delta Lake _delta_log JSON files or
+   *  if Delta is doing stats collection that ends up hardcoding the use of AQE,
    *  even though the AQE setting is disabled. To protect against the latter, we
    *  check for a ScalaUDF using a tahoe.Snapshot function and if we ever see
    *  an AdaptiveSparkPlan on a Spark version we don't expect, fallback to the

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4451,15 +4451,18 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         true
       case f: FileSourceScanExec =>
         // example filename: "file:/tmp/delta-table/_delta_log/00000000000000000000.json"
-        val found = f.relation.inputFiles.exists(name =>
-          name.contains("/_delta_log/") && (name.endsWith(".json") || name.contains("checkpoint.parquet"))
+        val found = f.relation.inputFiles.exists{ name =>
+          name.contains("/_delta_log/") &&
+          (name.endsWith(".json") || name.contains("checkpoint.parquet"))
+        }
         if (found) {
           logDebug(s"Fallback for FileSourceScanExec delta log: $f")
         }
         found
       case rdd: RDDScanExec =>
         // example rdd name: "Delta Table State #1 - file:///tmp/delta-table/_delta_log" or
-        // "Scan ExistingRDD Delta Table Checkpoint with Stats #1 - file:///tmp/delta-table/_delta_log"
+        // "Scan ExistingRDD Delta Table Checkpoint with Stats #1 -
+        // file:///tmp/delta-table/_delta_log"
         val found = rdd.inputRDD != null &&
           rdd.inputRDD.name != null &&
           (rdd.inputRDD.name.startsWith("Delta Table State")


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6443

I'm seeing queries on Databricks where the query reads delta logs Table Checkpoint files (from the delta_log directory) which runs on the CPU:
Scan ExistingRDD Delta Table Checkpoint with Stats
and then after that it goes to run a filter operation on the GPU which request row to columnar and then columnar to row and those transition look like they just take more time than its worth. It will also cause the use of the gpu semaphore which means it blocks something else from getting on there.

Based on this we should have it fall back to the CPU for the entire plan after seeing the read of delta log table checkpoint parquet files.

Tested this on databricks on customer delta log files and seeing improved query time and cluster throughput.

Unfortunately haven't been able to come up with a basic reproduce case without customer data/query  to be able to add integration test for it - filed https://github.com/NVIDIA/spark-rapids/issues/6456 to keep investigating.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
