### PR TITLE
Use tiered projections for hash aggregates

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -724,6 +724,12 @@ object RapidsConf {
       .booleanConf
       .createWithDefault(false)
 
+  val ENABLE_TIERED_PROJECT = conf("spark.rapids.sql.tiered.project.enabled")
+      .doc("Enable tiered project for aggregations.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   // FILE FORMATS
   val MULTITHREAD_READ_NUM_THREADS = conf("spark.rapids.sql.multiThreadedRead.numThreads")
       .doc("The maximum number of threads on each executor to use for reading small " +
@@ -1799,6 +1805,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isCastDecimalToStringEnabled: Boolean = get(ENABLE_CAST_DECIMAL_TO_STRING)
 
   lazy val isProjectAstEnabled: Boolean = get(ENABLE_PROJECT_AST)
+
+  lazy val isTieredProjectEnabled: Boolean = get(ENABLE_TIERED_PROJECT)
 
   lazy val multiThreadReadNumThreads: Int = {
     // Use the largest value set among all the options.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -177,6 +177,7 @@ object AggregateModeInfo {
  * @param modeInfo identifies which aggregation modes are being used
  * @param metrics metrics that will be updated during aggregation
  * @param configuredTargetBatchSize user-specified value for the targeted input batch size
+ * @param useTieredProject user-specified option to enable tiered projections
  */
 class GpuHashAggregateIterator(
     cbIter: Iterator[ColumnarBatch],
@@ -187,7 +188,8 @@ class GpuHashAggregateIterator(
     resultExpressions: Seq[NamedExpression],
     modeInfo: AggregateModeInfo,
     metrics: GpuHashAggregateMetrics,
-    configuredTargetBatchSize: Long)
+    configuredTargetBatchSize: Long,
+    useTieredProject: Boolean)
     extends Iterator[ColumnarBatch] with Arm with AutoCloseable with Logging {
 
   // Partial mode:
@@ -278,7 +280,7 @@ class GpuHashAggregateIterator(
 
   /** Aggregate all input batches and place the results in the aggregatedBatches queue. */
   private def aggregateInputBatches(): Unit = {
-    val aggHelper = new AggHelper(forceMerge = false)
+    val aggHelper = new AggHelper(forceMerge = false, useTieredProject = useTieredProject)
     while (cbIter.hasNext) {
       withResource(cbIter.next()) { childBatch =>
         val isLastInputBatch = GpuColumnVector.isTaggedAsFinalBatch(childBatch)
@@ -383,7 +385,8 @@ class GpuHashAggregateIterator(
     wasBatchMerged
   }
 
-  private lazy val concatAndMergeHelper = new AggHelper(forceMerge = true)
+  private lazy val concatAndMergeHelper =
+    new AggHelper(forceMerge = true, useTieredProject = useTieredProject)
 
   /**
    * Concatenate batches together and perform a merge aggregation on the result. The input batches
@@ -465,7 +468,8 @@ class GpuHashAggregateIterator(
     new Iterator[ColumnarBatch] {
       override def hasNext: Boolean = keyBatchingIter.hasNext
 
-      private val mergeSortedHelper = new AggHelper(true, isSorted = true)
+      private val mergeSortedHelper =
+        new AggHelper(true, isSorted = true, useTieredProject = useTieredProject)
 
       override def next(): ColumnarBatch = {
         // batches coming out of the sort need to be merged
@@ -627,8 +631,10 @@ class GpuHashAggregateIterator(
    *                the merge steps for each aggregate function
    * @param isSorted - if the batch is sorted this is set to true and is passed to cuDF
    *                   as an optimization hint
+   * @param useTieredProject - if true, used tiered project for input projections
    */
-  class AggHelper(forceMerge: Boolean, isSorted: Boolean = false) {
+  class AggHelper(forceMerge: Boolean, isSorted: Boolean = false,
+      useTieredProject : Boolean = true) {
     // `CudfAggregate` instances to apply, either update or merge aggregates
     private val cudfAggregates = new mutable.ArrayBuffer[CudfAggregate]()
 
@@ -690,10 +696,16 @@ class GpuHashAggregateIterator(
     }
 
     // a bound expression that is applied before the cuDF aggregate
-    private val preStepBound = if (forceMerge) {
-      GpuBindReferences.bindGpuReferences(preStep.toList, aggBufferAttributes.toList)
+    private val preStepAttributes = if (forceMerge) {
+      aggBufferAttributes
     } else {
-      GpuBindReferences.bindGpuReferences(preStep, inputAttributes)
+      inputAttributes
+    }
+    private val (preStepBound, preStepBoundTiered) = if (useTieredProject) {
+      (None, Some(GpuBindReferences.bindGpuReferencesTiered(preStep.toList,
+        preStepAttributes.toList)))
+    } else {
+      (Some(GpuBindReferences.bindGpuReferences(preStep, preStepAttributes.toList)), None)
     }
 
     // a bound expression that is applied after the cuDF aggregate
@@ -708,7 +720,11 @@ class GpuHashAggregateIterator(
      */
     def preProcess(toAggregateBatch: ColumnarBatch): ColumnarBatch = {
       withResource(new NvtxRange("pre-process", NvtxColor.DARK_GREEN)) { _ =>
-        GpuProjectExec.project(toAggregateBatch, preStepBound)
+        if (useTieredProject) {
+          preStepBoundTiered.get.tieredProject(toAggregateBatch)
+        } else {
+          GpuProjectExec.project(toAggregateBatch, preStepBound.get)
+        }
       }
     }
 
@@ -976,7 +992,8 @@ abstract class GpuBaseAggregateMeta[INPUT <: SparkPlan](
       aggregateAttributes.map(_.convertToGpu().asInstanceOf[Attribute]),
       resultExpressions.map(_.convertToGpu().asInstanceOf[NamedExpression]),
       childPlans.head.convertIfNeeded(),
-      conf.gpuTargetBatchSizeBytes)
+      conf.gpuTargetBatchSizeBytes,
+      conf.isTieredProjectEnabled)
   }
 }
 
@@ -1057,7 +1074,8 @@ abstract class GpuTypedImperativeSupportedAggregateExecMeta[INPUT <: BaseAggrega
         aggAttributes.map(_.convertToGpu().asInstanceOf[Attribute]),
         retExpressions.map(_.convertToGpu().asInstanceOf[NamedExpression]),
         childPlans.head.convertIfNeeded(),
-        conf.gpuTargetBatchSizeBytes)
+        conf.gpuTargetBatchSizeBytes,
+        conf.isTieredProjectEnabled)
     } else {
       super.convertToGpu()
     }
@@ -1370,6 +1388,7 @@ class GpuObjectHashAggregateExecMeta(
  *                          node should project)
  * @param child incoming plan (where we get input columns from)
  * @param configuredTargetBatchSize user-configured maximum device memory size of a batch
+ * @param configuredTieredProjectEnabled configurable optimization to use tiered projections
  */
 case class GpuHashAggregateExec(
     requiredChildDistributionExpressions: Option[Seq[Expression]],
@@ -1378,7 +1397,8 @@ case class GpuHashAggregateExec(
     aggregateAttributes: Seq[Attribute],
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan,
-    configuredTargetBatchSize: Long) extends ShimUnaryExecNode with GpuExec with Arm {
+    configuredTargetBatchSize: Long,
+    configuredTieredProjectEnabled: Boolean) extends ShimUnaryExecNode with GpuExec with Arm {
 
   // lifted directly from `BaseAggregateExec.inputAttributes`, edited comment.
   def inputAttributes: Seq[Attribute] = {
@@ -1456,6 +1476,7 @@ case class GpuHashAggregateExec(
     val resultExprs = resultExpressions
     val modeInfo = AggregateModeInfo(uniqueModes)
     val targetBatchSize = configuredTargetBatchSize
+    val useTieredProject = configuredTieredProjectEnabled
 
     val rdd = child.executeColumnar()
 
@@ -1469,7 +1490,8 @@ case class GpuHashAggregateExec(
         resultExprs,
         modeInfo,
         aggMetrics,
-        targetBatchSize)
+        targetBatchSize,
+        useTieredProject)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -267,7 +267,7 @@ case class GpuProjectAstExec(
  *   Input columns for tier 3: a, b, c, d, e, f, ref1, ref2, ref3
  *   Tier 3: (ref2 * e), (ref3 * f), (a + e), (c + f)
  */
- case class GpuTieredProject(val exprSets: Seq[Seq[GpuExpression]]) extends Arm with Logging {
+ case class GpuTieredProject(val exprSets: Seq[Seq[GpuExpression]]) extends Arm {
 
   @tailrec
   private def projectTier(boundExprs: Seq[Seq[GpuExpression]],

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf
-import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
+import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, NvtxColor, NvtxRange, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, ShimUnaryExpression}
 
@@ -802,23 +802,25 @@ case class GpuExtractChunk32(
   override def sql: String = data.sql
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuProjectExec.projectSingle(batch, data)) { dataCol =>
-      val dtype = if (chunkIdx < 3) DType.UINT32 else DType.INT32
-      val chunkCol = Aggregation128Utils.extractInt32Chunk(dataCol.getBase, dtype, chunkIdx)
-      val replacedCol = if (replaceNullsWithZero) {
-        withResource(chunkCol) { chunkCol =>
-          val zero = dtype match {
-            case DType.INT32 => Scalar.fromInt(0)
-            case DType.UINT32 => Scalar.fromUnsignedInt(0)
+    withResource(new NvtxRange("GpuExtractChunk32", NvtxColor.RED)) { _ =>
+      withResource(GpuProjectExec.projectSingle(batch, data)) { dataCol =>
+        val dtype = if (chunkIdx < 3) DType.UINT32 else DType.INT32
+        val chunkCol = Aggregation128Utils.extractInt32Chunk(dataCol.getBase, dtype, chunkIdx)
+        val replacedCol = if (replaceNullsWithZero) {
+          withResource(chunkCol) { chunkCol =>
+            val zero = dtype match {
+              case DType.INT32 => Scalar.fromInt(0)
+              case DType.UINT32 => Scalar.fromUnsignedInt(0)
+            }
+            withResource(zero) { zero =>
+              chunkCol.replaceNulls(zero)
+            }
           }
-          withResource(zero) { zero =>
-            chunkCol.replaceNulls(zero)
-          }
+        } else {
+          chunkCol
         }
-      } else {
-        chunkCol
+        GpuColumnVector.from(replacedCol, dataType)
       }
-      GpuColumnVector.from(replacedCol, dataType)
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf
-import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, NvtxColor, NvtxRange, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
+import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, ShimUnaryExpression}
 
@@ -802,25 +802,23 @@ case class GpuExtractChunk32(
   override def sql: String = data.sql
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(new NvtxRange("GpuExtractChunk32", NvtxColor.RED)) { _ =>
-      withResource(GpuProjectExec.projectSingle(batch, data)) { dataCol =>
-        val dtype = if (chunkIdx < 3) DType.UINT32 else DType.INT32
-        val chunkCol = Aggregation128Utils.extractInt32Chunk(dataCol.getBase, dtype, chunkIdx)
-        val replacedCol = if (replaceNullsWithZero) {
-          withResource(chunkCol) { chunkCol =>
-            val zero = dtype match {
-              case DType.INT32 => Scalar.fromInt(0)
-              case DType.UINT32 => Scalar.fromUnsignedInt(0)
-            }
-            withResource(zero) { zero =>
-              chunkCol.replaceNulls(zero)
-            }
+    withResource(GpuProjectExec.projectSingle(batch, data)) { dataCol =>
+      val dtype = if (chunkIdx < 3) DType.UINT32 else DType.INT32
+      val chunkCol = Aggregation128Utils.extractInt32Chunk(dataCol.getBase, dtype, chunkIdx)
+      val replacedCol = if (replaceNullsWithZero) {
+        withResource(chunkCol) { chunkCol =>
+          val zero = dtype match {
+            case DType.INT32 => Scalar.fromInt(0)
+            case DType.UINT32 => Scalar.fromUnsignedInt(0)
           }
-        } else {
-          chunkCol
+          withResource(zero) { zero =>
+            chunkCol.replaceNulls(zero)
+          }
         }
-        GpuColumnVector.from(replacedCol, dataType)
+      } else {
+        chunkCol
       }
+      GpuColumnVector.from(replacedCol, dataType)
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalenExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalenExpressions.scala
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Note: This is derived from EquivalentExpressions in Apache Spark
+ * with changes to adapt it for GPU.
+ */
+package org.apache.spark.sql.rapids.catalyst.expressions
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, CaseWhen, Coalesce, Expression, If, LeafExpression, PlanExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.objects.LambdaVariable
+
+/**
+ * This class is used to compute equality of (sub)expression trees. Expressions can be added
+ * to this class and they subsequently query for expression equality. Expression trees are
+ * considered equal if for the same input(s), the same result is produced.
+ */
+class GpuEquivalentExpressions {
+  // For each expression, the set of equivalent expressions.
+  private val equivalenceMap = mutable.HashMap.empty[GpuExpressionEquals, GpuExpressionStats]
+
+  /**
+   * Adds each expression to this data structure, grouping them with existing equivalent
+   * expressions. Non-recursive.
+   * Returns true if there was already a matching expression.
+   */
+  def addExpr(expr: Expression): Boolean = {
+    addExprToMap(expr, equivalenceMap)
+  }
+
+  private def addExprToMap(
+      expr: Expression, map: mutable.HashMap[GpuExpressionEquals, GpuExpressionStats]): Boolean = {
+    if (expr.deterministic) {
+      val wrapper = GpuExpressionEquals(expr)
+      map.get(wrapper) match {
+        case Some(stats) =>
+          stats.useCount += 1
+          true
+        case _ =>
+          map.put(wrapper, GpuExpressionStats(expr)())
+          false
+      }
+    } else {
+      false
+    }
+  }
+
+  /**
+   * Adds only expressions which are common in each of given expressions, in a recursive way.
+   * For example, given two expressions `(a + (b + (c + 1)))` and `(d + (e + (c + 1)))`,
+   * the common expression `(c + 1)` will be added into `equivalenceMap`.
+   *
+   * Note that as we don't know in advance if any child node of an expression will be common
+   * across all given expressions, we count all child nodes when looking through the given
+   * expressions. But when we call `addExprTree` to add common expressions into the map, we
+   * will add recursively the child nodes. So we need to filter the child expressions first.
+   * For example, if `((a + b) + c)` and `(a + b)` are common expressions, we only add
+   * `((a + b) + c)`.
+   */
+  private def addCommonExprs(
+      exprs: Seq[Expression],
+      map: mutable.HashMap[GpuExpressionEquals, GpuExpressionStats]): Unit = {
+    assert(exprs.length > 1)
+    var localEquivalenceMap = mutable.HashMap.empty[GpuExpressionEquals, GpuExpressionStats]
+    addExprTree(exprs.head, localEquivalenceMap)
+
+    exprs.tail.foreach { expr =>
+      val otherLocalEquivalenceMap = mutable.HashMap.empty[GpuExpressionEquals, GpuExpressionStats]
+      addExprTree(expr, otherLocalEquivalenceMap)
+      localEquivalenceMap = localEquivalenceMap.filter { case (key, _) =>
+        otherLocalEquivalenceMap.contains(key)
+      }
+    }
+
+    localEquivalenceMap.foreach { case (commonExpr, state) =>
+      val possibleParents = localEquivalenceMap.filter { case (_, v) => v.height > state.height }
+      val notChild = possibleParents.forall { case (k, _) =>
+        k == commonExpr || k.e.find(_.semanticEquals(commonExpr.e)).isEmpty
+      }
+      if (notChild) {
+        // If the `commonExpr` already appears in the equivalence map, calling `addExprTree` will
+        // increase the `useCount` and mark it as a common subexpression. Otherwise, `addExprTree`
+        // will recursively add `commonExpr` and its descendant to the equivalence map, in case
+        // they also appear in other places. For example, `If(a + b > 1, a + b + c, a + b + c)`,
+        // `a + b` also appears in the condition and should be treated as common subexpression.
+        addExprTree(commonExpr.e, map)
+      }
+    }
+  }
+
+  // There are some special expressions that we should not recurse into all of its children.
+  //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
+  //   2. If/GpuIf: common subexpressions will always be evaluated at the beginning, but the true
+  //          and false expressions in `If` may not get accessed, according to the predicate
+  //          expression. We should only recurse into the predicate expression.
+  //   3. CaseWhen/GpuCaseWhen: like `If`, the children of `CaseWhen` only get accessed in a certain
+  //                condition. We should only recurse into the first condition expression as it
+  //                will always get accessed.
+  //   4. Coalesce/GpuCoalesce: it's also a conditional expression, we should only recurse into the
+  //                first children, because others may not get accessed.
+  private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
+    case _: CodegenFallback => Nil
+    case i: If => i.predicate :: Nil
+    case i: GpuIf => i.predicateExpr :: Nil
+    case c: CaseWhen => c.children.head :: Nil
+    case c: GpuCaseWhen => c.children.head :: Nil
+    case c: Coalesce => c.children.head :: Nil
+    case c: GpuCoalesce => c.children.head :: Nil
+    case other => other.children
+  }
+
+  // For some special expressions we cannot just recurse into all of its children, but we can
+  // recursively add the common expressions shared between all of its children.
+  private def commonChildrenToRecurse(expr: Expression): Seq[Seq[Expression]] = expr match {
+    case _: CodegenFallback => Nil
+    case i: If => Seq(Seq(i.trueValue, i.falseValue))
+    case i: GpuIf => Seq(Seq(i.trueExpr, i.falseExpr))
+    case c: CaseWhen =>
+      // We look at subexpressions in conditions and values of `CaseWhen` separately. It is
+      // because a subexpression in conditions will be run no matter which condition is matched
+      // if it is shared among conditions, but it doesn't need to be shared in values. Similarly,
+      // a subexpression among values doesn't need to be in conditions because no matter which
+      // condition is true, it will be evaluated.
+      val conditions = if (c.branches.length > 1) {
+        c.branches.map(_._1)
+      } else {
+        // If there is only one branch, the first condition is already covered by
+        // `childrenToRecurse` and we should exclude it here.
+        Nil
+      }
+      // For an expression to be in all branch values of a CaseWhen statement, it must also be in
+      // the elseValue.
+      val values = if (c.elseValue.nonEmpty) {
+        c.branches.map(_._2) ++ c.elseValue
+      } else {
+        Nil
+      }
+      Seq(conditions, values)
+    case c: GpuCaseWhen =>
+      // We look at subexpressions in conditions and values of `CaseWhen` separately. It is
+      // because a subexpression in conditions will be run no matter which condition is matched
+      // if it is shared among conditions, but it doesn't need to be shared in values. Similarly,
+      // a subexpression among values doesn't need to be in conditions because no matter which
+      // condition is true, it will be evaluated.
+      val conditions = if (c.branches.length > 1) {
+        c.branches.map(_._1)
+      } else {
+        // If there is only one branch, the first condition is already covered by
+        // `childrenToRecurse` and we should exclude it here.
+        Nil
+      }
+      // For an expression to be in all branch values of a CaseWhen statement, it must also be in
+      // the elseValue.
+      val values = if (c.elseValue.nonEmpty) {
+        c.branches.map(_._2) ++ c.elseValue
+      } else {
+        Nil
+      }
+      Seq(conditions, values)
+    // If there is only one child, the first child is already covered by
+    // `childrenToRecurse` and we should exclude it here.
+    case c: Coalesce if c.children.length > 1 => Seq(c.children)
+    case c: GpuCoalesce if c.children.length > 1 => Seq(c.children)
+    case _ => Nil
+  }
+
+  /**
+   * Adds the expression to this data structure recursively. Stops if a matching expression
+   * is found. That is, if `expr` has already been added, its children are not added.
+   */
+  def addExprTree(
+      expr: Expression,
+      map: mutable.HashMap[GpuExpressionEquals, GpuExpressionStats] = equivalenceMap): Unit = {
+    val skip = expr.isInstanceOf[LeafExpression] ||
+      expr.isInstanceOf[GpuLeafExpression] ||
+      expr.isInstanceOf[GpuUnevaluable] ||
+      (expr.isInstanceOf[GpuExpression] && expr.asInstanceOf[GpuExpression].hasSideEffects) ||
+      // `LambdaVariable` is usually used as a loop variable, which can't be evaluated ahead of the
+      // loop. So we can't evaluate sub-expressions containing `LambdaVariable` at the beginning.
+      expr.find(_.isInstanceOf[LambdaVariable]).isDefined ||
+      // `PlanExpression` wraps query plan. To compare query plans of `PlanExpression` on executor,
+      // can cause error like NPE.
+      (expr.find(_.isInstanceOf[PlanExpression[_]]).isDefined && TaskContext.get != null)
+
+    if (!skip && !addExprToMap(expr, map)) {
+      childrenToRecurse(expr).foreach(addExprTree(_, map))
+      commonChildrenToRecurse(expr).filter(_.nonEmpty).foreach(addCommonExprs(_, map))
+    }
+  }
+
+  /**
+   * Returns the state of the given expression in the `equivalenceMap`. Returns None if there is no
+   * equivalent expressions.
+   */
+  def getExprState(e: Expression): Option[GpuExpressionStats] = {
+    equivalenceMap.get(GpuExpressionEquals(e))
+  }
+
+  // Exposed for testing.
+  private[sql] def getAllExprStates(count: Int = 0): Seq[GpuExpressionStats] = {
+    equivalenceMap.values.filter(_.useCount > count).toSeq.sortBy(_.height)
+  }
+
+  /**
+   * Returns a sequence of expressions that more than one equivalent expressions.
+   */
+  def getCommonSubexpressions: Seq[Expression] = {
+    getAllExprStates(1).map(_.expr)
+  }
+
+  /**
+   * Returns the state of the data structure as a string. If `all` is false, skips sets of
+   * equivalent expressions with cardinality 1.
+   */
+  def debugString(all: Boolean = false): String = {
+    val sb = new java.lang.StringBuilder()
+    sb.append("GPU Equivalent expressions:\n")
+    equivalenceMap.values.filter(stats => all || stats.useCount > 1).foreach { stats =>
+      sb.append("  ").append(s"${stats.expr}: useCount = ${stats.useCount}").append('\n')
+    }
+    sb.toString()
+  }
+}
+
+object GpuEquivalentExpressions extends Logging {
+  def logExprTree(expr : Expression): Unit = {
+    logWarning("nodeName: " + expr.nodeName + "\n" + expr.treeString)
+  }
+
+  def logExprs(title: String, exprs: Seq[Expression]): Unit = {
+    if (!exprs.isEmpty) {
+      logWarning("Start: " + title)
+      exprs.foreach(logExprTree)
+      logWarning("  End: " + title)
+    }
+  }
+
+  def logExprTiers(title: String, tiers: Seq[Seq[Expression]]): Unit = {
+    tiers.foreach(logExprs(title, _))
+  }
+
+  /**
+   * Recursively replaces expression with its proxy expression in `substitutionMap`.
+   */
+  def replaceWithCommonRef(
+      expr: Expression,
+      substitutionMap: Map[Expression, Expression]): Expression = {
+    expr match {
+      case e : AttributeReference => expr
+      case _ =>
+        substitutionMap.get(expr) match {
+          case Some(e) => e
+          case None => expr.mapChildren(replaceWithCommonRef(_, substitutionMap))
+        }
+    }
+  }
+
+  // Given a set of expressions, recursively extract all of the common expressions
+  def getExprTiers(expressions : Seq[Expression]): Seq[Seq[Expression]] = {
+    def recurse(exprs: Seq[Expression], startIdx: Int): Seq[Seq[Expression]] = {
+      val equivalentExpressions = new GpuEquivalentExpressions
+
+      // Filter out some expressions that we know are problematic
+      // This won't be necessary if we replace EquivalentExpressions
+      exprs.foreach(equivalentExpressions.addExprTree(_))
+      val commonExprs = equivalentExpressions.getCommonSubexpressions
+
+      if (commonExprs.isEmpty) {
+        Seq(exprs)
+      } else {
+        val newExprs = commonExprs.zipWithIndex.map {
+          case (e, i) =>
+            GpuAlias(e, s"tiered_input_${startIdx + i}")()
+        }
+        val subMap = commonExprs.zip(newExprs).map {
+          case (e, r) => (e, r.toAttribute)
+        }.toMap[Expression, Expression]
+
+        val updatedExpressions = exprs.map(replaceWithCommonRef(_, subMap))
+        recurse(newExprs, startIdx + newExprs.size) ++ Seq(updatedExpressions)
+      }
+    }
+    recurse(expressions, 0)
+  }
+
+  // Given expression tiers as created by getExprTiers and a set of input attributes,
+  // return the tiers of input attributes that correspond with the expression tiers.
+  def getInputTiers(exprTiers: Seq[Seq[Expression]], inputAttrs: AttributeSeq):
+  Seq[AttributeSeq] = {
+    def recurse(et: Seq[Seq[Expression]], inputs: AttributeSeq): Seq[AttributeSeq] = {
+      et match {
+        case Nil => Nil
+        case s :: tail => {
+          val newInputs = if (tail.isEmpty) {
+            Nil
+          } else {
+            s.filter(e => e.isInstanceOf[GpuAlias]).map(_.asInstanceOf[GpuAlias].toAttribute)
+          }
+          val attrSeq = AttributeSeq(inputs.attrs ++ newInputs)
+          val recursionResult = recurse(tail, attrSeq)
+          Seq(inputs) ++ recursionResult
+        }
+      }
+    }
+    recurse(exprTiers, inputAttrs)
+  }
+}
+
+/**
+ * Wrapper around an Expression that provides semantic equality.
+ */
+case class GpuExpressionEquals(e: Expression) {
+  override def equals(o: Any): Boolean = o match {
+    case other: GpuExpressionEquals => e.semanticEquals(other.e)
+    case _ => false
+  }
+
+  override def hashCode: Int = e.semanticHash()
+}
+
+/**
+ * A wrapper in place of using Seq[Expression] to record a group of equivalent expressions.
+ *
+ * This saves a lot of memory when there are a lot of expressions in a same equivalence group.
+ * Instead of appending to a mutable list/buffer of Expressions, just update the "flattened"
+ * useCount in this wrapper in-place.
+ */
+case class GpuExpressionStats(expr: Expression)(var useCount: Int = 1) {
+  // This is used to do a fast pre-check for child-parent relationship. For example, expr1 can
+  // only be a parent of expr2 if expr1.height is larger than expr2.height.
+  lazy val height = getHeight(expr)
+
+  private def getHeight(tree: Expression): Int = {
+    tree.children.map(getHeight).reduceOption(_ max _).getOrElse(0) + 1
+  }
+}
+

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalenExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalenExpressions.scala
@@ -210,8 +210,9 @@ class GpuEquivalentExpressions {
   /**
    * Returns the state of the given expression in the `equivalenceMap`. Returns None if there is no
    * equivalent expressions.
+   * Exposed for testing.
    */
-  def getExprState(e: Expression): Option[GpuExpressionStats] = {
+  private[sql] def getExprState(e: Expression): Option[GpuExpressionStats] = {
     equivalenceMap.get(GpuExpressionEquals(e))
   }
 
@@ -278,9 +279,6 @@ object GpuEquivalentExpressions extends Logging {
   def getExprTiers(expressions : Seq[Expression]): Seq[Seq[Expression]] = {
     def recurse(exprs: Seq[Expression], startIdx: Int): Seq[Seq[Expression]] = {
       val equivalentExpressions = new GpuEquivalentExpressions
-
-      // Filter out some expressions that we know are problematic
-      // This won't be necessary if we replace EquivalentExpressions
       exprs.foreach(equivalentExpressions.addExprTree(_))
       val commonExprs = equivalentExpressions.getCommonSubexpressions
 

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
@@ -1,0 +1,671 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.catalyst.expressions
+
+import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCast, GpuCoalesce, GpuIf, GpuIsNull, GpuLiteral, GpuMonotonicallyIncreasingID}
+import org.scalatest.FunSuite
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression}
+import org.apache.spark.sql.rapids.{GpuAbs, GpuAdd, GpuAnd, GpuDecimalMultiply, GpuExtractChunk32, GpuGreaterThan, GpuLessThanOrEqual, GpuMultiply, GpuSqrt, GpuSubtract}
+import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
+
+/*
+ * Many of these tests were derived from SubexpressionEliminationSuite in Apache Spark,
+ * and changed to use GPU expressions.
+ */
+class GpuEquivalentExpressionsSuite extends FunSuite with Logging {
+
+  test("Gpu Expression Equivalence - basic") {
+    val equivalence = new GpuEquivalentExpressions
+    assert(equivalence.getAllExprStates().isEmpty)
+
+    val oneA = GpuLiteral(1)
+    val oneB = GpuLiteral(1)
+    val twoA = GpuLiteral(2)
+
+    assert(equivalence.getExprState(oneA).isEmpty)
+    assert(equivalence.getExprState(twoA).isEmpty)
+
+    // GpuAdd oneA and test if it is returned. Since it is a group of one, it does not.
+    assert(!equivalence.addExpr(oneA))
+    assert(equivalence.getExprState(oneA).get.useCount == 1)
+    assert(equivalence.getExprState(twoA).isEmpty)
+    assert(equivalence.addExpr(oneA))
+    assert(equivalence.getExprState(oneA).get.useCount == 2)
+
+    // GpuAdd B and make sure they can see each other.
+    assert(equivalence.addExpr(oneB))
+    // Use exists and reference equality because of how equals is defined.
+    assert(equivalence.getExprState(oneA).exists(_.expr eq oneA))
+    assert(equivalence.getExprState(oneB).exists(_.expr eq oneA))
+    assert(equivalence.getExprState(twoA).isEmpty)
+    assert(equivalence.getAllExprStates().size == 1)
+    assert(equivalence.getAllExprStates().head.useCount == 3)
+    assert(equivalence.getAllExprStates().head.expr eq oneA)
+
+    val add1 = GpuAdd(oneA, oneB, false)
+    val add2 = GpuAdd(oneA, oneB, false)
+
+    equivalence.addExpr(add1)
+    equivalence.addExpr(add2)
+
+    assert(equivalence.getAllExprStates().size == 2)
+    assert(equivalence.getExprState(add1).exists(_.expr eq add1))
+    assert(equivalence.getExprState(add2).get.useCount == 2)
+    assert(equivalence.getExprState(add2).exists(_.expr eq add1))
+  }
+
+  test("Get Expression Tiers - two the same") {
+    val oneA = AttributeReference("oneA", IntegerType)()
+    val oneB = AttributeReference("oneB", IntegerType)()
+
+    val add1 = GpuAdd(oneA, oneB, false)
+    val add2 = GpuAdd(oneA, oneB, false)
+
+    val initialExprs = Seq(add1, add2)
+    val inputAttrs = AttributeSeq(Seq(oneA, oneB))
+    validateExpressionTiers(initialExprs, inputAttrs,
+      Seq(add1, add2), // Both are the same, so sub-expression should match both
+      Seq(),
+      Seq(add1, add2)) // Both will be updated
+  }
+
+  test("GpuExpression Equivalence - Trees") {
+    val one = GpuLiteral(1)
+    val two = GpuLiteral(2)
+
+    val add = GpuAdd(one, two, false)
+    val abs = GpuAbs(add, false)
+    val add2 = GpuAdd(add, add, false)
+
+    var equivalence = new GpuEquivalentExpressions
+    equivalence.addExprTree(add)
+    equivalence.addExprTree(abs)
+    equivalence.addExprTree(add2)
+
+    // Should only have one equivalence for `one + two`
+    assert(equivalence.getAllExprStates(1).size == 1)
+    assert(equivalence.getAllExprStates(1).head.useCount == 4)
+
+    // Set up the expressions
+    //   one * two,
+    //   (one * two) * (one * two)
+    //   sqrt( (one * two) * (one * two) )
+    //   (one * two) + sqrt( (one * two) * (one * two) )
+    equivalence = new GpuEquivalentExpressions
+    val mul = GpuMultiply(one, two)
+    val mul2 = GpuMultiply(mul, mul)
+    val sqrt = GpuSqrt(mul2)
+    val sum = GpuAdd(mul2, sqrt, false)
+    equivalence.addExprTree(mul)
+    equivalence.addExprTree(mul2)
+    equivalence.addExprTree(sqrt)
+    equivalence.addExprTree(sum)
+
+    // (one * two), (one * two) * (one * two) and sqrt( (one * two) * (one * two) ) should be found
+    assert(equivalence.getAllExprStates(1).size == 3)
+    assert(equivalence.getExprState(mul).get.useCount == 3)
+    assert(equivalence.getExprState(mul2).get.useCount == 3)
+    assert(equivalence.getExprState(sqrt).get.useCount == 2)
+    assert(equivalence.getExprState(sum).get.useCount == 1)
+  }
+
+  test("Get Expression Tiers - Trees") {
+    // Set up the expressions
+    //   one * two,
+    //   (one * two) * (one * two)
+    //   sqrt( (one * two) * (one * two) )
+    //   (one * two) + sqrt( (one * two) * (one * two) )
+    val one = AttributeReference("one", DoubleType)()
+    val two = AttributeReference("two", DoubleType)()
+    val mul = GpuMultiply(one, two)
+    val mul2 = GpuMultiply(mul, mul)
+    val sqrt = GpuSqrt(mul2)
+    val sum = GpuAdd(mul2, sqrt, false)
+
+    // (one * two), (one * two) * (one * two) and sqrt( (one * two) * (one * two) ) are all subs
+    val initialExprs = Seq(mul, mul2, sqrt, sum)
+    val inputAttrs = AttributeSeq(Seq(one, two))
+    validateExpressionTiers(initialExprs, inputAttrs,
+      Seq(mul, mul2, sqrt),
+      Seq(),
+      Seq(mul, mul2, sqrt, sum))
+  }
+
+  test("Gpu Expression equivalence - non deterministic") {
+    val sum = GpuAdd(GpuMonotonicallyIncreasingID(), GpuMonotonicallyIncreasingID(), false)
+    val equivalence = new GpuEquivalentExpressions
+    equivalence.addExpr(sum)
+    equivalence.addExpr(sum)
+    assert(equivalence.getAllExprStates().isEmpty)
+  }
+
+  test("Get Expression Tiers - non deterministic") {
+    val sum = GpuAdd(GpuMonotonicallyIncreasingID(), GpuMonotonicallyIncreasingID(), false)
+    val initialExprs = Seq(sum)
+    val inputAttrs = AttributeSeq(Seq.empty)
+    validateExpressionTiers(initialExprs, inputAttrs,
+      Seq.empty, // No subexpressions
+      Seq(sum),  // Should be unchanged
+      Seq.empty) // No modified expressions
+  }
+
+  test("Children of conditional expressions: GpuIf") {
+    val add = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+    val condition = GpuGreaterThan(add, GpuLiteral(3))
+
+    val ifExpr1 = GpuIf(condition, add, add)
+    val equivalence1 = new GpuEquivalentExpressions
+    equivalence1.addExprTree(ifExpr1)
+
+    // `add` is in both two branches of `If` and predicate.
+    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
+    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add)
+    // one-time expressions: only ifExpr and its predicate expression
+    assert(equivalence1.getAllExprStates().count(_.useCount == 1) == 2)
+    assert(equivalence1.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq ifExpr1))
+    assert(equivalence1.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq condition))
+
+    // Repeated `add` is only in one branch, so we don't count it.
+    val ifExpr2 = GpuIf(condition, GpuAdd(GpuLiteral(1), GpuLiteral(3), false),
+      GpuAdd(add, add, false))
+    val equivalence2 = new GpuEquivalentExpressions
+    equivalence2.addExprTree(ifExpr2)
+
+    assert(equivalence2.getAllExprStates(1).isEmpty)
+    assert(equivalence2.getAllExprStates().count(_.useCount == 1) == 3)
+
+    val ifExpr3 = GpuIf(condition, ifExpr1, ifExpr1)
+    val equivalence3 = new GpuEquivalentExpressions
+    equivalence3.addExprTree(ifExpr3)
+
+    // `add`: 2, `condition`: 2
+    assert(equivalence3.getAllExprStates().count(_.useCount == 2) == 2)
+    assert(equivalence3.getAllExprStates().filter(_.useCount == 2).exists(_.expr eq condition))
+    assert(equivalence3.getAllExprStates().filter(_.useCount == 2).exists(_.expr eq add))
+
+    // `ifExpr1`, `ifExpr3`
+    assert(equivalence3.getAllExprStates().count(_.useCount == 1) == 2)
+    assert(equivalence3.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq ifExpr1))
+    assert(equivalence3.getAllExprStates().filter(_.useCount == 1).exists(_.expr eq ifExpr3))
+  }
+
+  test("Get Expression Tiers GpuIf") {
+    val one = AttributeReference("one", IntegerType)()
+    val two = AttributeReference("two", IntegerType)()
+    val three = AttributeReference("three", IntegerType)()
+    val add = GpuAdd(one, two, false)
+    val condition = GpuGreaterThan(add, three)
+    // if ((one + two) > three) then (one + two) else (one + two)
+    // `add` is in both branches of `If` and predicate.
+    val ifExpr1 = GpuIf(condition, add, add)
+    val initialExprs = Seq(ifExpr1)
+    val inputAttrs = AttributeSeq(Seq(one, two, three))
+    validateExpressionTiers(initialExprs, inputAttrs,
+    Seq(add), // subexpressions
+    Seq.empty,  // Should be unchanged
+    Seq(ifExpr1)) // modified expressions
+
+    // if ((one + two) > three) then (one + three) else ((one + two) + (one + two))
+    // Repeated `add` is only in one branch, so we don't count it.
+    val ifExpr2 = GpuIf(condition, GpuAdd(one, three, false),
+      GpuAdd(add, add, false))
+    val initialExprs2 = Seq(ifExpr2)
+    val inputAttrs2 = AttributeSeq(Seq(one, two, three))
+    validateExpressionTiers(initialExprs2, inputAttrs2,
+      Seq.empty, // subexpressions
+      Seq(ifExpr2),  // Should be unchanged
+      Seq.empty) // modified expressions
+
+    // if ((one + two) > three)
+    //   if ((one + two) > three) then (one + two) else (one + two)
+    // else
+    //   if ((one + two) > three) then (one + two) else (one + two)
+    val ifExpr3 = GpuIf(condition, ifExpr1, ifExpr1)
+    val initialExprs3 = Seq(ifExpr3)
+    val inputAttrs3 = AttributeSeq(Seq(one, two, three))
+    validateExpressionTiers(initialExprs3, inputAttrs3,
+      Seq(add, condition), // subexpressions
+      Seq.empty,  // Should be unchanged
+      Seq(condition, ifExpr1, ifExpr3)) // modified expressions
+  }
+
+  test("Children of conditional expressions: GpuCaseWhen") {
+    val add1 = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+    val add2 = GpuAdd(GpuLiteral(2), GpuLiteral(3), false)
+    val conditions1 = (GpuGreaterThan(add2, GpuLiteral(3)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(4)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(5)), add1) :: Nil
+
+    val caseWhenExpr1 = GpuCaseWhen(conditions1, None)
+    val equivalence1 = new GpuEquivalentExpressions
+    equivalence1.addExprTree(caseWhenExpr1)
+
+    // `add2` is repeatedly in all conditions.
+    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
+    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
+
+    val conditions2 = (GpuGreaterThan(add1, GpuLiteral(3)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(4)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(5)), add1) :: Nil
+
+    val caseWhenExpr2 = GpuCaseWhen(conditions2, Some(add1))
+    val equivalence2 = new GpuEquivalentExpressions
+    equivalence2.addExprTree(caseWhenExpr2)
+
+    // `add1` is repeatedly in all branch values, and first predicate.
+    assert(equivalence2.getAllExprStates().count(_.useCount == 2) == 1)
+    assert(equivalence2.getAllExprStates().filter(_.useCount == 2).head.expr eq add1)
+
+    // Negative case. `add1` or `add2` is not commonly used in all predicates/branch values.
+    val conditions3 = (GpuGreaterThan(add1, GpuLiteral(3)), add2) ::
+      (GpuGreaterThan(add2, GpuLiteral(4)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(5)), add1) :: Nil
+
+    val caseWhenExpr3 = GpuCaseWhen(conditions3, None)
+    val equivalence3 = new GpuEquivalentExpressions
+    equivalence3.addExprTree(caseWhenExpr3)
+    assert(equivalence3.getAllExprStates().count(_.useCount == 2) == 0)
+  }
+
+  test("Get Expression Tiers - GpuCaseWhen") {
+    val one = AttributeReference("one", IntegerType)()
+    val two = AttributeReference("two", IntegerType)()
+    val three = AttributeReference("three", IntegerType)()
+    val four = AttributeReference("four", IntegerType)()
+    val five = AttributeReference("five", IntegerType)()
+
+    val add1 = GpuAdd(one, two, false)
+    val add2 = GpuAdd(two, three, false)
+    val cond1 = GpuGreaterThan(add2, three)
+    val cond2 = GpuGreaterThan(add2, four)
+    val cond3 = GpuGreaterThan(add2, five)
+    val cond4 = GpuGreaterThan(add1, three)
+    val conditions1 = (cond1, add1) :: (cond2, add1) :: (cond3, add1) :: Nil
+    val caseWhenExpr1 = GpuCaseWhen(conditions1, None)
+    val inputAttrs1 = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs1 = Seq(caseWhenExpr1)
+    // `add2` is repeatedly in all conditions.
+    validateExpressionTiers(initialExprs1, inputAttrs1,
+      Seq(add2), // subexpressions
+      Seq.empty,  // Should be unchanged
+      Seq(cond1, cond2, cond3, caseWhenExpr1)) // modified expressions
+
+    val conditions2 = (cond4, add1) :: (cond2, add1) :: (cond3, add1) :: Nil
+    val caseWhenExpr2 = GpuCaseWhen(conditions2, Some(add1))
+    val inputAttrs2 = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs2 = Seq(caseWhenExpr2)
+    // `add1` is repeatedly in all branch values, and first predicate.
+    validateExpressionTiers(initialExprs2, inputAttrs2,
+      Seq(add1), // subexpressions
+      Seq.empty,  // Should be unchanged
+      Seq(caseWhenExpr2)) // modified expressions
+
+    // Negative case. `add1` or `add2` is not commonly used in all predicates/branch values.
+    val conditions3 = (cond4, add2) :: (cond2, add1) :: (cond3, add1) :: Nil
+    val caseWhenExpr3 = GpuCaseWhen(conditions3, None)
+    val inputAttrs3 = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs3 = Seq(caseWhenExpr3)
+    // `add1` is repeatedly in all branch values, and first predicate.
+    validateExpressionTiers(initialExprs3, inputAttrs3,
+      Seq.empty, // subexpressions
+      Seq(caseWhenExpr3),  // Should be unchanged
+      Seq.empty) // modified expressions
+  }
+
+  test("Children of conditional expressions: GpuCoalesce") {
+    val add1 = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+    val add2 = GpuAdd(GpuLiteral(2), GpuLiteral(3), false)
+    val conditions1 = GpuGreaterThan(add2, GpuLiteral(3)) ::
+        GpuGreaterThan(add2, GpuLiteral(4)) ::
+        GpuGreaterThan(add2, GpuLiteral(5)) :: Nil
+
+    val coalesceExpr1 = GpuCoalesce(conditions1)
+    val equivalence1 = new GpuEquivalentExpressions
+    equivalence1.addExprTree(coalesceExpr1)
+
+    // `add2` is repeatedly in all conditions.
+    assert(equivalence1.getAllExprStates().count(_.useCount == 2) == 1)
+    assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add2)
+
+    // Negative case. `add1` and `add2` both are not used in all branches.
+    val conditions2 = GpuGreaterThan(add1, GpuLiteral(3)) ::
+        GpuGreaterThan(add2, GpuLiteral(4)) ::
+        GpuGreaterThan(add2, GpuLiteral(5)) :: Nil
+
+    val coalesceExpr2 = GpuCoalesce(conditions2)
+    val equivalence2 = new GpuEquivalentExpressions
+    equivalence2.addExprTree(coalesceExpr2)
+
+    assert(equivalence2.getAllExprStates().count(_.useCount == 2) == 0)
+  }
+
+  test("Get Expression Tiers: GpuCoalesce") {
+    val one = AttributeReference("one", IntegerType)()
+    val two = AttributeReference("two", IntegerType)()
+    val three = AttributeReference("three", IntegerType)()
+    val four = AttributeReference("four", IntegerType)()
+    val five = AttributeReference("five", IntegerType)()
+
+    val add1 = GpuAdd(one, two, false)
+    val add2 = GpuAdd(two, three, false)
+    val cond1 = GpuGreaterThan(add2, three)
+    val cond2 = GpuGreaterThan(add2, four)
+    val cond3 = GpuGreaterThan(add2, five)
+    val cond4 = GpuGreaterThan(add1, three)
+
+    val conditions1 = cond1 :: cond2 :: cond3 :: Nil
+    val coalesceExpr1 = GpuCoalesce(conditions1)
+    val inputAttrs1 = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs1 = Seq(coalesceExpr1)
+    // `add2` is repeatedly in all conditions.
+    validateExpressionTiers(initialExprs1, inputAttrs1,
+      Seq(add2), // subexpressions
+      Seq.empty,  // Should be unchanged
+      Seq(cond1, cond2, cond3, coalesceExpr1)) // modified expressions
+
+    val conditions2 = cond4 :: cond2 :: cond3 :: Nil
+    val coalesceExpr2 = GpuCoalesce(conditions2)
+    val inputAttrs2 = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs2 = Seq(coalesceExpr2)
+    // Negative case. `add1` and `add2` both are not used in all branches.
+    validateExpressionTiers(initialExprs2, inputAttrs2,
+      Seq.empty, // subexpressions
+      Seq(coalesceExpr2),  // Should be unchanged
+      Seq.empty) // modified expressions
+  }
+
+  test("SPARK-35410: SubExpr elimination should not include redundant child exprs " +
+    "for conditional expressions") {
+    val add1 = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+    val add2 = GpuAdd(GpuLiteral(2), GpuLiteral(3), false)
+    val add3 = GpuAdd(add1, add2, false)
+    val condition = (GpuGreaterThan(add3, GpuLiteral(3)), add3) :: Nil
+
+    val caseWhenExpr = GpuCaseWhen(condition, Some(GpuAdd(add3, GpuLiteral(1), false)))
+    val equivalence = new GpuEquivalentExpressions
+    equivalence.addExprTree(caseWhenExpr)
+
+    val commonExprs = equivalence.getAllExprStates(1)
+    assert(commonExprs.size == 1)
+    assert(commonExprs.head.useCount == 2)
+    assert(commonExprs.head.expr eq add3)
+  }
+
+  test("Get Expression Tiers - SPARK-35410: SubExpr elimination should not include " +
+      "redundant child exprs for conditional expressions") {
+    val one = AttributeReference("one", IntegerType)()
+    val two = AttributeReference("two", IntegerType)()
+    val three = AttributeReference("three", IntegerType)()
+
+    val add1 = GpuAdd(one, two, false)
+    val add2 = GpuAdd(two, three, false)
+    val add3 = GpuAdd(add1, add2, false)
+    val add4 = GpuAdd(add3, one, false)
+    val condition = (GpuGreaterThan(add3, three), add3) :: Nil
+    val caseWhenExpr = GpuCaseWhen(condition, Some(add4))
+    val inputAttrs = AttributeSeq(Seq(one, two, three))
+    val initialExprs = Seq(caseWhenExpr)
+    validateExpressionTiers(initialExprs, inputAttrs,
+      Seq(add3), // subexpressions
+      Seq.empty,  // Should be unchanged
+      Seq(caseWhenExpr)) // modified expressions
+  }
+
+  test("SPARK-35439: Children subexpr should come first than parent subexpr") {
+    val add = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+
+    val equivalence1 = new GpuEquivalentExpressions
+
+    equivalence1.addExprTree(add)
+    assert(equivalence1.getAllExprStates().head.expr eq add)
+
+    equivalence1.addExprTree(GpuAdd(GpuLiteral(3), add, false))
+    assert(equivalence1.getAllExprStates().map(_.useCount) === Seq(2, 1))
+    assert(equivalence1.getAllExprStates().map(_.expr) ===
+        Seq(add, GpuAdd(GpuLiteral(3), add, false)))
+
+    equivalence1.addExprTree(GpuAdd(GpuLiteral(3), add, false))
+    assert(equivalence1.getAllExprStates().map(_.useCount) === Seq(2, 2))
+    assert(equivalence1.getAllExprStates().map(_.expr) ===
+        Seq(add, GpuAdd(GpuLiteral(3), add, false)))
+
+    val equivalence2 = new GpuEquivalentExpressions
+
+    equivalence2.addExprTree(GpuAdd(GpuLiteral(3), add, false))
+    assert(equivalence2.getAllExprStates().map(_.useCount) === Seq(1, 1))
+    assert(equivalence2.getAllExprStates().map(_.expr) ===
+        Seq(add, GpuAdd(GpuLiteral(3), add, false)))
+
+    equivalence2.addExprTree(add)
+    assert(equivalence2.getAllExprStates().map(_.useCount) === Seq(2, 1))
+    assert(equivalence2.getAllExprStates().map(_.expr) ===
+        Seq(add, GpuAdd(GpuLiteral(3), add, false)))
+
+    equivalence2.addExprTree(GpuAdd(GpuLiteral(3), add, false))
+    assert(equivalence2.getAllExprStates().map(_.useCount) === Seq(2, 2))
+    assert(equivalence2.getAllExprStates().map(_.expr) ===
+        Seq(add, GpuAdd(GpuLiteral(3), add, false)))
+  }
+
+  test("SPARK-35499: Subexpressions should only be extracted from CaseWhen "
+      + "values with an elseValue") {
+    val add1 = GpuAdd(GpuLiteral(1), GpuLiteral(2), false)
+    val add2 = GpuAdd(GpuLiteral(2), GpuLiteral(3), false)
+    val conditions = (GpuGreaterThan(add1, GpuLiteral(3)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(4)), add1) ::
+      (GpuGreaterThan(add2, GpuLiteral(5)), add1) :: Nil
+
+    val caseWhenExpr = GpuCaseWhen(conditions, None)
+    val equivalence = new GpuEquivalentExpressions
+    equivalence.addExprTree(caseWhenExpr)
+
+    // `add1` is not in the elseValue, so we can't extract it from the branches
+    assert(equivalence.getAllExprStates().count(_.useCount == 2) == 0)
+  }
+
+  test("Get Expression Tiers - SPARK-35499: Subexpressions should only be extracted " +
+      "from CaseWhen values with an elseValue") {
+    val one = AttributeReference("one", IntegerType)()
+    val two = AttributeReference("two", IntegerType)()
+    val three = AttributeReference("three", IntegerType)()
+    val four = AttributeReference("four", IntegerType)()
+    val five = AttributeReference("five", IntegerType)()
+
+    val add1 = GpuAdd(one, two, false)
+    val add2 = GpuAdd(two, three, false)
+    val cond1 = GpuGreaterThan(add1, three)
+    val cond2 = GpuGreaterThan(add2, four)
+    val cond3 = GpuGreaterThan(add2, five)
+    val conditions = (cond1, add1) :: (cond2, add1) :: (cond3, add1) :: Nil
+    val caseWhenExpr = GpuCaseWhen(conditions, None)
+    // `add1` is not in the elseValue, so we can't extract it from the branches
+    val inputAttrs = AttributeSeq(Seq(one, two, three, four, five))
+    val initialExprs = Seq(caseWhenExpr)
+    // Negative case. `add1` and `add2` both are not used in all branches.
+    validateExpressionTiers(initialExprs, inputAttrs,
+      Seq.empty, // subexpressions
+      Seq(caseWhenExpr),  // Should be unchanged
+      Seq.empty) // modified expressions
+  }
+
+  test("Get Expression Tiers - Query derived from nds q4") {
+    val customer: AttributeReference = AttributeReference("customer", IntegerType)()
+    val quantity: AttributeReference = AttributeReference("quantity", IntegerType)()
+    val price: AttributeReference = AttributeReference("price", DecimalType(7, 2))()
+    val inputAttrs = AttributeSeq(Seq(customer, quantity, price))
+
+    val product = GpuDecimalMultiply(
+      GpuCast(quantity, DecimalType(10, 0)), price, DecimalType(18,2))
+    val nullCheck = GpuIsNull(product)
+    val castProduct = GpuCast(product, DecimalType(28,2))
+    val extract0 = GpuExtractChunk32(castProduct, 0, true)
+    val extract1 = GpuExtractChunk32(castProduct, 1, true)
+    val extract2 = GpuExtractChunk32(castProduct, 2, true)
+    val extract3 = GpuExtractChunk32(castProduct, 3, true)
+    val initialExprs = Seq(customer, extract0, extract1, extract2, extract3, nullCheck)
+    val exprTiers = GpuEquivalentExpressions.getExprTiers(initialExprs)
+    validateExprTiers(exprTiers, initialExprs,
+      Seq(product, castProduct),  // Common sub-expression
+      Seq(customer), // Unchanged
+      Seq(extract0, extract1, extract2, extract3, nullCheck)) // updated
+    validateInputTiers(exprTiers, inputAttrs)
+  }
+
+  test("Get Expression Tiers - Query derived from nds q62") {
+    val group: AttributeReference = AttributeReference("group", StringType)()
+    val smType: AttributeReference = AttributeReference("type", StringType)()
+    val webName: AttributeReference = AttributeReference("web name", StringType)()
+    val shipDate: AttributeReference = AttributeReference("ship date", IntegerType)()
+    val soldDate: AttributeReference = AttributeReference("sold date", IntegerType)()
+    val inputAttrs = AttributeSeq(Seq(group, smType, webName, shipDate, soldDate))
+
+    val dateDiff = GpuSubtract(shipDate, soldDate, false)
+    val caseWhen1 =
+      GpuCaseWhen(
+        Seq((GpuLessThanOrEqual(dateDiff, GpuLiteral(30)), GpuLiteral(1))), Some(GpuLiteral(0)))
+    val caseWhen2 =
+      GpuCaseWhen(
+        Seq((GpuAnd(
+          GpuGreaterThan(dateDiff, GpuLiteral(30)),
+          GpuLessThanOrEqual(dateDiff, GpuLiteral(60))), GpuLiteral(1))), Some(GpuLiteral(0)))
+    val caseWhen3 =
+      GpuCaseWhen(
+        Seq((GpuAnd(
+          GpuGreaterThan(dateDiff, GpuLiteral(60)),
+          GpuLessThanOrEqual(dateDiff, GpuLiteral(90))), GpuLiteral(1))), Some(GpuLiteral(0)))
+    val caseWhen4 =
+      GpuCaseWhen(Seq((GpuAnd(
+        GpuGreaterThan(dateDiff, GpuLiteral(90)),
+        GpuLessThanOrEqual(dateDiff, GpuLiteral(120))), GpuLiteral(1))), Some(GpuLiteral(0)))
+    val caseWhen5 =
+        GpuCaseWhen(
+          Seq((GpuGreaterThan(dateDiff, GpuLiteral(120)), GpuLiteral(1))),
+          Some(GpuLiteral(0)))
+
+    val initialExprs =
+      Seq(group, smType, webName, caseWhen1, caseWhen2, caseWhen3, caseWhen4, caseWhen5)
+    val exprTiers = GpuEquivalentExpressions.getExprTiers(initialExprs)
+    validateExprTiers(exprTiers, initialExprs,
+      Seq(dateDiff),                // sub-expressions
+      Seq(group, smType, webName),  // unchanged exprs
+      Seq(caseWhen1, caseWhen2, caseWhen2, caseWhen3, caseWhen4, caseWhen5))  // updated exprs
+    validateInputTiers(exprTiers, inputAttrs)
+  }
+
+  private def realExpr(expr: Expression): Expression = expr match {
+    case e: GpuAlias => e.child
+    case _ => expr
+  }
+
+  private def checkEquals(expr: Expression, other: Expression): Boolean = {
+    realExpr(expr).semanticEquals(realExpr(other))
+  }
+
+  /**
+   * ValidateExprTiers: run checks on exprTiers vs what is expected
+   * Args:
+   *   exprTiers - expression tiers we are checking
+   *   initialExprs - original list of expressions
+   *   subExprs - expected lowest level sub-expressions
+   *   unchanged - expressions that are unmodified from the original list
+   *   updated - expressions from the original list that should be updated
+   */
+  private def validateExprTiers(exprTiers: Seq[Seq[Expression]], initialExprs: Seq[Expression],
+      subExprs: Seq[Expression], unChanged: Seq[Expression], updated: Seq[Expression]): Unit = {
+    if (subExprs.isEmpty) {
+      assert(exprTiers.size == 1)
+      // The one tier should match the initial list
+      initialExprs.foreach(e => assert(exprTiers(0).contains(e)))
+    } else {
+      // Should be more than one tier
+      assert(exprTiers.size > 1)
+    }
+    // Last tier should be same size as initial list
+    assert(exprTiers.last.size == initialExprs.size)
+
+    // substituted expressions should be in one of the tiers before the last one.
+    val unSubbed = undoSubstitutions(exprTiers.dropRight(1).flatten)
+    subExprs.foreach(sub =>
+      assert(unSubbed.exists(e => checkEquals(e, sub)),
+        "Expected: " + sub.toString() + " not found in: " + unSubbed.toString()))
+
+    // Unchanged expressions should be in the last tier.
+    unChanged.foreach(expected =>
+      assert(exprTiers.last.contains(expected),
+        "Expected: " + expected.toString() + " not found in: " + exprTiers.last.toString()))
+
+    // Updated expressions should not match, since they have been updated
+    updated.foreach(expected =>
+      assert(exprTiers.last.forall(e => !checkEquals(e, expected)),
+        "Unexpected: " + expected.toString() + " was found in: " + exprTiers.last.toString()))
+  }
+
+  private def validateInputTiers(exprTiers: Seq[Seq[Expression]],
+      initialInputs: AttributeSeq): Unit = {
+    val inputTiers = GpuEquivalentExpressions.getInputTiers(exprTiers, initialInputs)
+    assert(exprTiers.size == inputTiers.size)
+    // First tier should have same inputs as original inputs
+    // Subsequent tiers should add inputs for each expr in previous tier
+    var expectedNumInputs = initialInputs.attrs.size
+    var curTier = 0
+    while (curTier < inputTiers.size) {
+      assert(inputTiers(curTier).attrs.size == expectedNumInputs)
+      expectedNumInputs += exprTiers(curTier).size
+      curTier += 1
+    }
+    initialInputs.attrs.foreach(a => assert(inputTiers.last.attrs.contains(a)))
+  }
+
+  /**
+   * ValidateGetExprTiers: run checks on exprTiers vs what is expected
+   * Args:
+   *   initialExprs - original list of expressions
+   *   inputAttrs - original list of input attributes
+   *   subExprs - expected lowest level sub-expressions
+   *   unchanged - expressions that are unmodified from the original list
+   *   updated - expressions from the original list that should be updated
+   */
+  private def validateExpressionTiers(initialExprs: Seq[Expression], inputAttrs: AttributeSeq,
+      subExprs: Seq[Expression], unChanged: Seq[Expression], updated: Seq[Expression]) = {
+    val exprTiers = GpuEquivalentExpressions.getExprTiers(initialExprs)
+    validateExprTiers(exprTiers, initialExprs, subExprs, unChanged, updated)
+    validateInputTiers(exprTiers, inputAttrs)
+  }
+
+  def restoreOriginalExpr(
+      expr: Expression,
+      substitutionMap: Map[Expression, Expression]): Expression = {
+    val newExpr = substitutionMap.get(expr) match {
+      case Some(e) => e
+      case None => expr
+    }
+    newExpr.mapChildren(restoreOriginalExpr(_, substitutionMap))
+  }
+
+  private def undoSubstitutions(subExprs: Seq[Expression]): Seq[Expression] = {
+    if (subExprs.isEmpty) {
+      subExprs
+    } else {
+      val subMap = subExprs.filter(p => p.isInstanceOf[GpuAlias]).map {
+        case e: GpuAlias => (e.toAttribute, e.child)
+      }.toMap[Expression, Expression]
+      subExprs.map(restoreOriginalExpr(_, subMap))
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Closes #5085.

This implements a tiered approach for input projections in hash aagregations.  This is a performance optimization to reduce computation by pulling out common sub-expressions and doing them once.  The general approach is to provide an alternative to bindGpuReferences, currently called bindGpuReferencesTiered, which returns a case class that contains a tiered list of references, and the corresponding method in that case class that applies the tiered projections in order. The tiered list of references are created by recursively pulling out common sub-expressions from the initial list of expressions and rewriting expressions to refer to the output of the sub-expressions.

This feature is enabled by default, but there is a configuration property, `spark.rapids.sql.tiered.project.enabled` that can be used to disable it.

See #5085 for more discussion and performance.  If this works well for aggregations, we will consider enabling it for other projections in the plugin.