### PR TITLE
Use non-capture groups in LIKE regexp pattern

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -763,8 +763,8 @@ case class GpuLike(left: Expression, right: Expression, escapeChar: Char)
             case _ => fail(s"the escape character is not allowed to precede '$c'")
           }
         case c if c == escapeChar => fail("it is not allowed to end with the escape character")
-        case '_' => out ++= "(.|\n)"
-        case '%' => out ++= "(.|\n)*"
+        case '_' => out ++= "(?:.|\n)"
+        case '%' => out ++= "(?:.|\n)*"
         case c => out ++= cudfQuote(c)
       }
     }


### PR DESCRIPTION
This is a small optimization that does not change existing functionality.

LIKE is implemented by translating the pattern to regexp and calling cuDF `matches_re`. We have capture groups in the regexp pattern, which could be non-capture groups instead. I saw a ~30% performance improvement for one use case after making this change.

