### PR TITLE
Check more places for Parquet encryption configs

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -306,7 +306,7 @@ def test_parquet_write_legacy_fallback(spark_tmp_path, ts_write, ts_rebase, spar
 @pytest.mark.parametrize('write_options', [{"parquet.encryption.footer.key": "k1"},
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
-def test_parquet_write_encryption_fallback(spark_tmp_path, spark_tmp_table_factory, write_options):
+def test_parquet_write_encryption_option_fallback(spark_tmp_path, spark_tmp_table_factory, write_options):
     def write_func(spark, path):
         writer = unary_op_df(spark, gen).coalesce(1).write
         for key in write_options:
@@ -319,6 +319,44 @@ def test_parquet_write_encryption_fallback(spark_tmp_path, spark_tmp_table_facto
         lambda spark, path: spark.read.parquet(path),
         data_path,
         'DataWritingCommandExec')
+
+@allow_non_gpu("DataWritingCommandExec")
+@pytest.mark.parametrize("write_options", [{"parquet.encryption.footer.key": "k1"},
+                                           {"parquet.encryption.column.keys": "k2:a"},
+                                           {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
+def test_parquet_write_encryption_runtimeconfig_fallback(spark_tmp_path, write_options):
+    gen = IntegerGen()
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    with_cpu_session(lambda spark: print("FOOTER CONF: ", spark.sparkContext._jsc.hadoopConfiguration().get("parquet.encryption.footer.key", "NOT HERE")))
+    assert_gpu_fallback_write(
+        lambda spark, path: unary_op_df(spark, gen).coalesce(1).write.parquet(path),
+        lambda spark, path: spark.read.parquet(path),
+        data_path,
+        "DataWritingCommandExec",
+        conf=write_options)
+
+@allow_non_gpu("DataWritingCommandExec")
+@pytest.mark.parametrize("write_options", [{"parquet.encryption.footer.key": "k1"},
+                                           {"parquet.encryption.column.keys": "k2:a"},
+                                           {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
+def test_parquet_write_encryption_hadoopconfig_fallback(spark_tmp_path, write_options):
+    gen = IntegerGen()
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    def setup_hadoop_confs(spark):
+        for k, v in write_options.items():
+            spark.sparkContext._jsc.hadoopConfiguration().set(k, v)
+    def reset_hadoop_confs(spark):
+        for k in write_options.keys():
+            spark.sparkContext._jsc.hadoopConfiguration().unset(k)
+    try:
+        with_cpu_session(setup_hadoop_confs)
+        assert_gpu_fallback_write(
+            lambda spark, path: unary_op_df(spark, gen).coalesce(1).write.parquet(path),
+            lambda spark, path: spark.read.parquet(path),
+            data_path,
+            "DataWritingCommandExec")
+    finally:
+        with_cpu_session(reset_hadoop_confs)
 
 @allow_non_gpu('DataWritingCommandExec')
 # note that others should fail as well but requires you to load the libraries for them

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -327,7 +327,6 @@ def test_parquet_write_encryption_option_fallback(spark_tmp_path, spark_tmp_tabl
 def test_parquet_write_encryption_runtimeconfig_fallback(spark_tmp_path, write_options):
     gen = IntegerGen()
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    with_cpu_session(lambda spark: print("FOOTER CONF: ", spark.sparkContext._jsc.hadoopConfiguration().get("parquet.encryption.footer.key", "NOT HERE")))
     assert_gpu_fallback_write(
         lambda spark, path: unary_op_df(spark, gen).coalesce(1).write.parquet(path),
         lambda spark, path: spark.read.parquet(path),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -47,10 +47,22 @@ object GpuParquetFileFormat {
 
     val parquetOptions = new ParquetOptions(options, sqlConf)
 
-    val columnEncryption = options.getOrElse("parquet.encryption.column.keys", "")
-    val footerEncryption = options.getOrElse("parquet.encryption.footer.key", "")
+    // lookup encryption keys in the options, then Hadoop conf, then Spark runtime conf
+    def lookupEncryptionConfig(key: String): String = {
+      options.getOrElse(key, {
+        val hadoopConf = spark.sparkContext.hadoopConfiguration.get(key, "")
+        if (hadoopConf.nonEmpty) {
+          hadoopConf
+        } else {
+          spark.conf.get(key, "")
+        }
+      })
+    }
 
-    if (!columnEncryption.isEmpty || !footerEncryption.isEmpty) {
+    val columnEncryption = lookupEncryptionConfig("parquet.encryption.column.keys")
+    val footerEncryption = lookupEncryptionConfig("parquet.encryption.footer.key")
+
+    if (columnEncryption.nonEmpty || footerEncryption.nonEmpty) {
       meta.willNotWorkOnGpu("Encryption is not yet supported on GPU. If encrypted Parquet " +
           "writes are not required unset the \"parquet.encryption.column.keys\" and " +
           "\"parquet.encryption.footer.key\" in Parquet options")


### PR DESCRIPTION
Fixes #6471.  Updates the tagging code to check for encryption configs in the write options, Hadoop configuration and the Spark runtime configuration, in that order.