### PR TITLE
Change GpuKryoRegistrator to load the classes we want to register with the ShimLoader

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKryoRegistrator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKryoRegistrator.scala
@@ -20,13 +20,14 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.{JavaSerializer => KryoJavaSerializer}
 
 import org.apache.spark.serializer.KryoRegistrator
-import org.apache.spark.sql.rapids.execution.{SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 
 class GpuKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo): Unit = {
-    kryo.register(classOf[SerializeConcatHostBuffersDeserializeBatch],
-      new KryoJavaSerializer())
-    kryo.register(classOf[SerializeBatchDeserializeHostBuffer],
-      new KryoJavaSerializer())
+    val allClassesToRegister = Seq(
+      "org.apache.spark.sql.rapids.execution.SerializeConcatHostBuffersDeserializeBatch",
+      "org.apache.spark.sql.rapids.execution.SerializeBatchDeserializeHostBuffer")
+    allClassesToRegister.foreach { classToRegister =>
+      kryo.register(ShimLoader.loadClass(classToRegister), new KryoJavaSerializer())
+    }
   }
 }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6442

The kryo serializer Spark code gets the classloader and then runs with that as the context. That doesn't have our gpu parallel world classes laoded into it for this repl one.

To get around this use the ShimLoader to load the classes we want to register with kryo. When we get those classes it associates the classloader used that has all our classes with it so all other classes within the class we load will use that the correct classloader as well.

Tested this in standalone repl and no repl, also tested on CDH where they default to the kryo serializer and it was testing in our integration tests.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
