### PR TITLE
Add GPU acceleration for OptimizedCreateHiveTableAsSelect

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -261,7 +261,7 @@ def _assert_gpu_and_cpu_writes_are_equal(
 def assert_gpu_and_cpu_writes_are_equal_collect(write_func, read_func, base_path, conf={}):
     """
     Assert when running write_func on both the CPU and the GPU and reading using read_func
-    ont he CPU that the results are equal.
+    on the CPU that the results are equal.
     In this case the data is collected back to the driver and compared here, so be
     careful about the amount of data returned.
     """
@@ -270,11 +270,62 @@ def assert_gpu_and_cpu_writes_are_equal_collect(write_func, read_func, base_path
 def assert_gpu_and_cpu_writes_are_equal_iterator(write_func, read_func, base_path, conf={}):
     """
     Assert when running write_func on both the CPU and the GPU and reading using read_func
-    ont he CPU that the results are equal.
+    on the CPU that the results are equal.
     In this case the data is pulled back to the driver in chunks and compared here
     so any amount of data can work, just be careful about how long it might take.
     """
     _assert_gpu_and_cpu_writes_are_equal(write_func, read_func, base_path, 'ITERATOR', conf=conf)
+
+def _assert_gpu_and_cpu_sql_writes_are_equal(table_name_factory, write_sql_func, mode, conf={}):
+    conf = _prep_incompat_conf(conf)
+
+    print('### CPU RUN ###')
+    cpu_table = table_name_factory.get()
+    cpu_start = time.time()
+    def do_write(spark, table_name):
+        sql_text = write_sql_func(spark, table_name)
+        spark.sql(sql_text)
+        return None
+    with_cpu_session(lambda spark : do_write(spark, cpu_table), conf=conf)
+    cpu_end = time.time()
+    print('### GPU RUN ###')
+    gpu_start = time.time()
+    gpu_table = table_name_factory.get()
+    with_gpu_session(lambda spark : do_write(spark, gpu_table), conf=conf)
+    gpu_end = time.time()
+    print('### WRITE: GPU TOOK {} CPU TOOK {} ###'.format(
+        gpu_end - gpu_start, cpu_end - cpu_start))
+
+    (cpu_bring_back, cpu_collect_type) = _prep_func_for_compare(
+        lambda spark: spark.sql("SELECT * FROM {}".format(cpu_table)), mode)
+    (gpu_bring_back, gpu_collect_type) = _prep_func_for_compare(
+        lambda spark: spark.sql("SELECT * FROM {}".format(gpu_table)), mode)
+
+    from_cpu = with_cpu_session(cpu_bring_back, conf=conf)
+    from_gpu = with_cpu_session(gpu_bring_back, conf=conf)
+    if should_sort_locally():
+        from_cpu.sort(key=_RowCmp)
+        from_gpu.sort(key=_RowCmp)
+
+    assert_equal(from_cpu, from_gpu)
+
+def assert_gpu_and_cpu_sql_writes_are_equal_collect(table_name_factory, write_sql_func, conf={}):
+    """
+    Assert when running SQL text from write_sql_func on both the CPU and the GPU and reading
+    both resulting tables on the CPU that the results are equal.
+    In this case the data is collected back to the driver and compared here, so be
+    careful about the amount of data returned.
+    """
+    _assert_gpu_and_cpu_sql_writes_are_equal(table_name_factory, write_sql_func, 'COLLECT', conf=conf)
+
+def assert_gpu_and_cpu_sql_writes_are_equal_iterator(table_name_factory, write_sql_func, conf={}):
+    """
+    Assert when running SQL text from write_sql_func on both the CPU and the GPU and reading
+    both resulting tables on the CPU that the results are equal.
+    In this case the data is pulled back to the driver in chunks and compared here
+    so any amount of data can work, just be careful about how long it might take.
+    """
+    _assert_gpu_and_cpu_sql_writes_are_equal(table_name_factory, write_sql_func, 'ITERATOR', conf=conf)
 
 def assert_gpu_fallback_write(write_func,
         read_func,

--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -13,39 +13,34 @@
 # limitations under the License.
 import pytest
 
-from asserts import assert_gpu_fallback_write
+from asserts import assert_gpu_fallback_collect
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
+from spark_session import is_hive_available, is_spark_330_or_later, with_cpu_session
 
 @ignore_order
 @allow_non_gpu('DataWritingCommandExec')
+@pytest.mark.skip_if(not (is_hive_available() and is_spark_330_or_later()), "Must have Hive on Spark 3.3+")
 @pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
-def test_write_hive_bucketed_table_fallback(spark_tmp_path, spark_tmp_table_factory, fileFormat):
+def test_write_hive_bucketed_table_fallback(spark_tmp_table_factory, fileFormat):
     """
     fallback because GPU does not support Hive hash partition
     """
-    src = spark_tmp_table_factory.get()
     table = spark_tmp_table_factory.get()
 
-    def write_hive_table(spark):
-        
-        data = map(lambda i: (i % 13, str(i), i % 5), range(50))
-        df = spark.createDataFrame(data, ["i", "j", "k"])
-        df.write.mode("overwrite").partitionBy("k").bucketBy(8, "i", "j").format(fileFormat).saveAsTable(src)
+    def create_hive_table(spark):
+        spark.sql("""create table {0} (a bigint, b bigint, c bigint)
+                  stored as {1}
+                  clustered by (b) into 3 buckets""".format(table, fileFormat))
+        return None
 
-        spark.sql("""
-            create table if not exists {0} 
-            using hive options(fileFormat \"{1}\")
-            as select * from {2} 
-            """.format(table, fileFormat, src))
+    conf = {"hive.enforce.bucketing": "true",
+            "hive.exec.dynamic.partition": "true",
+            "hive.exec.dynamic.partition.mode": "nonstrict"}
+    with_cpu_session(create_hive_table, conf = conf)
 
-    data_path = spark_tmp_path + '/HIVE_DATA'
-
-    assert_gpu_fallback_write(
-        lambda spark, _: write_hive_table(spark),
-        lambda spark, _: spark.sql("SELECT * FROM {}".format(table)),
-        data_path,
+    assert_gpu_fallback_collect(
+        lambda spark: spark.sql("insert into {} values (1, 2, 3)".format(table)),
         'DataWritingCommandExec',
-        conf = {"hive.exec.dynamic.partition": "true",
-                "hive.exec.dynamic.partition.mode": "nonstrict"})
+        conf = conf)

--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -21,7 +21,7 @@ from spark_session import is_hive_available, is_spark_330_or_later, with_cpu_ses
 
 @ignore_order
 @allow_non_gpu('DataWritingCommandExec')
-@pytest.mark.skip_if(not (is_hive_available() and is_spark_330_or_later()), "Must have Hive on Spark 3.3+")
+@pytest.mark.skipif(not (is_hive_available() and is_spark_330_or_later()), reason="Must have Hive on Spark 3.3+")
 @pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
 def test_write_hive_bucketed_table_fallback(spark_tmp_table_factory, fileFormat):
     """

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -55,7 +55,7 @@ _write_gens = [_basic_gens, _struct_gens, _array_gens, _map_gens]
 
 # There appears to be a race when computing tasks for writing, order can be different even on CPU
 @ignore_order(local=True)
-@pytest.mark.skip_if(not is_hive_available(), "Hive is missing")
+@pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", _write_gens, ids=idfn)
 @pytest.mark.parametrize("storage", ["PARQUET", "nativeorc", "hiveorc"])
 def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
@@ -79,7 +79,7 @@ def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
     assert_gpu_and_cpu_sql_writes_are_equal_collect(spark_tmp_table_factory, do_write, conf=conf)
 
 @allow_non_gpu("DataWritingCommandExec")
-@pytest.mark.skip_if(not is_hive_available(), "Hive is missing")
+@pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage_with_confs", [
     ("PARQUET", {"spark.sql.legacy.parquet.datetimeRebaseModeInWrite": "LEGACY",
@@ -100,7 +100,7 @@ def test_optimized_hive_ctas_configs_fallback(gens, storage_with_confs, spark_tm
         "DataWritingCommandExec", conf=confs)
 
 @allow_non_gpu("DataWritingCommandExec")
-@pytest.mark.skip_if(not is_hive_available(), "Hive is missing")
+@pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage_with_opts", [
     ("PARQUET", {"parquet.encryption.footer.key": "k1",
@@ -118,8 +118,8 @@ def test_optimized_hive_ctas_options_fallback(gens, storage_with_opts, spark_tmp
         "DataWritingCommandExec")
 
 @allow_non_gpu("DataWritingCommandExec")
-@pytest.mark.skip_if(not (is_hive_available() and is_spark_330_or_later()),
-                     "Requires Hive and Spark 3.3+ to write bucketed Hive tables")
+@pytest.mark.skipif(not (is_hive_available() and is_spark_330_or_later()),
+                     reason="Requires Hive and Spark 3.3+ to write bucketed Hive tables")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage", ["PARQUET", "ORC"], ids=idfn)
 def test_optimized_hive_bucketed_fallback(gens, storage, spark_tmp_table_factory):

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_fallback_collect
+from data_gen import *
+from datetime import date, datetime, timezone
+from marks import *
+from spark_session import with_cpu_session
+
+# Using positive timestamps to work around a cudf ORC bug
+# https://github.com/rapidsai/cudf/issues/11525
+# Using a limited upper end for timestamps to avoid INT96 overflow on Parquet
+def _restricted_timestamp(nullable=True):
+    return TimestampGen(start=datetime(1970, 1, 1, tzinfo=timezone.utc),
+                        end=datetime(2262, 4, 11, tzinfo=timezone.utc),
+                        nullable=nullable)
+
+_basic_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
+                     string_gen, boolean_gen, DateGen(start=date(1590, 1, 1)),
+                     _restricted_timestamp()
+               ] + decimal_gens
+
+_basic_struct_gen = StructGen([['child'+str(ind), sub_gen] for ind, sub_gen in enumerate(_basic_gens)])
+
+_struct_gens = [_basic_struct_gen,
+                StructGen([['child0', byte_gen], ['child1', _basic_struct_gen]]),
+                StructGen([['child0', ArrayGen(short_gen)], ['child1', double_gen]])]
+
+_array_gens = [ArrayGen(sub_gen) for sub_gen in _basic_gens] + [
+    ArrayGen(ArrayGen(short_gen, max_length=10), max_length=10),
+    ArrayGen(ArrayGen(string_gen, max_length=10), max_length=10),
+    ArrayGen(StructGen([['child0', byte_gen], ['child1', string_gen], ['child2', float_gen]]))]
+
+_map_gens = [simple_string_to_string_map_gen] + [MapGen(f(nullable=False), f()) for f in [
+    BooleanGen, ByteGen, ShortGen, IntegerGen, LongGen, FloatGen, DoubleGen,
+    lambda nullable=True: _restricted_timestamp(nullable=nullable),
+    lambda nullable=True: DateGen(start=date(1590, 1, 1), nullable=nullable),
+    lambda nullable=True: DecimalGen(precision=15, scale=1, nullable=nullable),
+    lambda nullable=True: DecimalGen(precision=36, scale=5, nullable=nullable)]]
+
+_write_gens = [_basic_gens, _struct_gens, _array_gens, _map_gens]
+
+# There appears to be a race when computing tasks for writing, order can be different even on CPU
+@ignore_order(local=True)
+@pytest.mark.parametrize("gens", _write_gens, ids=idfn)
+@pytest.mark.parametrize("storage", ["PARQUET", "nativeorc", "hiveorc"])
+def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
+    data_table = spark_tmp_table_factory.get()
+    gen_list = [('c' + str(i), gen) for i, gen in enumerate(gens)]
+    with_cpu_session(lambda spark: gen_df(spark, gen_list).createOrReplaceTempView(data_table))
+    def do_write(spark, table_name):
+        store_name = storage
+        if storage.endswith("orc"):
+            store_name = "ORC"
+        return "CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
+            table_name, store_name, data_table)
+    conf = {
+        "spark.sql.legacy.parquet.datetimeRebaseModeInWrite": "CORRECTED",
+        "spark.sql.legacy.parquet.int96RebaseModeInWrite": "CORRECTED"
+    }
+    if storage == "nativeorc":
+        conf["spark.sql.orc.impl"] = "native"
+    elif storage == "hiveorc":
+        conf["spark.sql.orc.impl"] = "hive"
+    assert_gpu_and_cpu_sql_writes_are_equal_collect(spark_tmp_table_factory, do_write, conf=conf)
+
+@allow_non_gpu("DataWritingCommandExec")
+@pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
+@pytest.mark.parametrize("storage_with_confs", [
+    ("PARQUET", {"spark.sql.legacy.parquet.datetimeRebaseModeInWrite": "LEGACY",
+                 "spark.sql.legacy.parquet.int96RebaseModeInWrite": "LEGACY"}),
+    ("PARQUET", {"parquet.encryption.footer.key": "k1",
+                 "parquet.encryption.column.keys": "k2:a"}),
+    ("PARQUET", {"spark.sql.parquet.compression.codec": "gzip"}),
+    ("PARQUET", {"spark.sql.parquet.writeLegacyFormat": "true"}),
+    ("ORC", {"spark.sql.orc.compression.codec": "zlib"})], ids=idfn)
+def test_optimized_hive_ctas_configs_fallback(gens, storage_with_confs, spark_tmp_table_factory):
+    data_table = spark_tmp_table_factory.get()
+    gen_list = [('c' + str(i), gen) for i, gen in enumerate(gens)]
+    with_cpu_session(lambda spark: gen_df(spark, gen_list).createOrReplaceTempView(data_table))
+    storage, confs = storage_with_confs
+    assert_gpu_fallback_collect(
+        lambda spark: spark.sql("CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
+            spark_tmp_table_factory.get(), storage, data_table)),
+        "DataWritingCommandExec", conf=confs)
+
+@allow_non_gpu("DataWritingCommandExec")
+@pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
+@pytest.mark.parametrize("storage_with_opts", [
+    ("PARQUET", {"parquet.encryption.footer.key": "k1",
+                 "parquet.encryption.column.keys": "k2:a"}),
+    ("ORC", {"orc.compress": "zlib"})], ids=idfn)
+def test_optimized_hive_ctas_options_fallback(gens, storage_with_opts, spark_tmp_table_factory):
+    data_table = spark_tmp_table_factory.get()
+    gen_list = [('c' + str(i), gen) for i, gen in enumerate(gens)]
+    with_cpu_session(lambda spark: gen_df(spark, gen_list).createOrReplaceTempView(data_table))
+    storage, opts = storage_with_opts
+    opts_string = ", ".join(["'{}'='{}'".format(k, v) for k, v in opts.items()])
+    assert_gpu_fallback_collect(
+        lambda spark: spark.sql("CREATE TABLE {} OPTIONS ({}) STORED AS {} AS SELECT * FROM {}".format(
+            spark_tmp_table_factory.get(), opts_string, storage, data_table)),
+        "DataWritingCommandExec")

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from conftest import is_allowing_any_non_gpu, get_non_gpu_allowed, get_validate_execs_in_gpu_plan, is_databricks_runtime
+from conftest import is_allowing_any_non_gpu, get_non_gpu_allowed, get_validate_execs_in_gpu_plan, is_databricks_runtime, is_at_least_precommit_run
 from pyspark.sql import DataFrame
 from spark_init_internal import get_spark_i_know_what_i_am_doing, spark_version
 
@@ -197,3 +197,10 @@ def get_jvm_charset():
 
 def is_jvm_charset_utf8():
     return get_jvm_charset() == 'UTF-8'
+
+def is_hive_available():
+    # precommit and nightly runs are supposed to have Hive,
+    # so tests should fail if Hive is missing in those environments.
+    if is_at_least_precommit_run():
+        return True
+    return _spark.conf.get("spark.sql.catalogImplementation") == "hive"

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/PlanShims.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/PlanShims.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.execution.SparkPlan
+
+object PlanShims {
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan
+}

--- a/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
@@ -69,5 +71,9 @@ object RapidsErrorUtils {
       requiredFieldName: String, matchedFields: String): Throwable = {
     new RuntimeException(s"""Found duplicate field(s) "$requiredFieldName": """ +
         s"$matchedFields in case-insensitive mode")
+  }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    throw new AnalysisException(s"$tableIdentifier already exists.")
   }
 }

--- a/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
+++ b/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+object CharVarcharUtilsShims {
+  def getRawSchema(schema: StructType, conf: SQLConf): StructType = {
+    CharVarcharUtils.getRawSchema(schema)
+  }
+}

--- a/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
@@ -69,5 +71,9 @@ object RapidsErrorUtils {
       requiredFieldName: String, matchedFields: String): Throwable = {
     new RuntimeException(s"""Found duplicate field(s) "$requiredFieldName": """ +
         s"$matchedFields in case-insensitive mode")
+  }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    throw new AnalysisException(s"$tableIdentifier already exists.")
   }
 }

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/PlanShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/PlanShims.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.execution.{CommandResultExec, SparkPlan}
+
+object PlanShims {
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan match {
+    case p: CommandResultExec => p.commandPhysicalPlan
+    case _ => plan
+  }
+}

--- a/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,8 +16,9 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object RapidsErrorUtils {
@@ -71,5 +72,9 @@ object RapidsErrorUtils {
       requiredFieldName: String, matchedFields: String): Throwable = {
     QueryExecutionErrors.foundDuplicateFieldInCaseInsensitiveModeError(
       requiredFieldName, matchedFields)
+  }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    QueryCompilationErrors.tableIdentifierExistsError(tableIdentifier)
   }
 }

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,8 +16,9 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object RapidsErrorUtils {
@@ -74,5 +75,9 @@ object RapidsErrorUtils {
       requiredFieldName: String, matchedFields: String): Throwable = {
     QueryExecutionErrors.foundDuplicateFieldInCaseInsensitiveModeError(
       requiredFieldName, matchedFields)
+  }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    QueryCompilationErrors.tableIdentifierExistsError(tableIdentifier)
   }
 }

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+object CharVarcharUtilsShims {
+  def getRawSchema(schema: StructType, conf: SQLConf): StructType = {
+    CharVarcharUtils.getRawSchema(schema, conf)
+  }
+}

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,8 +16,9 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object RapidsErrorUtils {
@@ -75,5 +76,9 @@ object RapidsErrorUtils {
       requiredFieldName: String, matchedFields: String): Throwable = {
     QueryExecutionErrors.foundDuplicateFieldInCaseInsensitiveModeError(
       requiredFieldName, matchedFields)
+  }
+
+  def tableIdentifierExistsError(tableIdentifier: TableIdentifier): Throwable = {
+    QueryCompilationErrors.tableIdentifierExistsError(tableIdentifier)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOptimizedCreateHiveTableAsSelectCommand.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOptimizedCreateHiveTableAsSelectCommand.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util.Locale
+
+import scala.util.control.NonFatal
+
+import com.nvidia.spark.rapids.shims.CharVarcharUtilsShims
+
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
+import org.apache.spark.sql.hive.execution.OptimizedCreateHiveTableAsSelectCommand
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.{GpuInsertIntoHadoopFsRelationCommand, GpuOrcFileFormat}
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/** GPU version of Spark's CreateHiveTableAsSelectBase */
+trait GpuCreateHiveTableAsSelectBase extends GpuDataWritingCommand {
+  val tableDesc: CatalogTable
+  val query: LogicalPlan
+  val outputColumnNames: Seq[String]
+  val mode: SaveMode
+
+  protected val tableIdentifier: TableIdentifier = tableDesc.identifier
+
+  override def runColumnar(sparkSession: SparkSession, child: SparkPlan): Seq[ColumnarBatch] = {
+    val catalog = sparkSession.sessionState.catalog
+    val tableExists = catalog.tableExists(tableIdentifier)
+
+    if (tableExists) {
+      assert(mode != SaveMode.Overwrite,
+        s"Expect the table $tableIdentifier has been dropped when the save mode is Overwrite")
+
+      if (mode == SaveMode.ErrorIfExists) {
+        throw RapidsErrorUtils.tableIdentifierExistsError(tableIdentifier)
+      }
+      if (mode == SaveMode.Ignore) {
+        // Since the table already exists and the save mode is Ignore, we will just return.
+        return Seq.empty
+      }
+
+      val command = getWritingCommand(catalog, tableDesc, tableExists = true)
+      command.runColumnar(sparkSession, child)
+      GpuDataWritingCommand.propogateMetrics(sparkSession.sparkContext, command, metrics)
+    } else {
+      tableDesc.storage.locationUri.foreach { p =>
+        GpuDataWritingCommand.assertEmptyRootPath(p, mode, sparkSession.sessionState.newHadoopConf)
+      }
+      // TODO ideally, we should get the output data ready first and then
+      // add the relation into catalog, just in case of failure occurs while data
+      // processing.
+      val tableSchema = CharVarcharUtilsShims.getRawSchema(
+        outputColumns.toStructType, sparkSession.sessionState.conf)
+      assert(tableDesc.schema.isEmpty)
+      catalog.createTable(
+        tableDesc.copy(schema = tableSchema), ignoreIfExists = false)
+
+      try {
+        // Read back the metadata of the table which was created just now.
+        val createdTableMeta = catalog.getTableMetadata(tableDesc.identifier)
+        val command = getWritingCommand(catalog, createdTableMeta, tableExists = false)
+        command.runColumnar(sparkSession, child)
+        GpuDataWritingCommand.propogateMetrics(sparkSession.sparkContext, command, metrics)
+      } catch {
+        case NonFatal(e) =>
+          // drop the created table.
+          catalog.dropTable(tableIdentifier, ignoreIfNotExists = true, purge = false)
+          throw e
+      }
+    }
+
+    Seq.empty[ColumnarBatch]
+  }
+
+  // Returns `GpuDataWritingCommand` which actually writes data into the table.
+  def getWritingCommand(
+      catalog: SessionCatalog,
+      tableDesc: CatalogTable,
+      tableExists: Boolean): GpuDataWritingCommand
+
+  // A subclass should override this with the Class name of the concrete type expected to be
+  // returned from `getWritingCommand`.
+  def writingCommandClassName: String
+
+  override def argString(maxFields: Int): String = {
+    s"[Database: ${tableDesc.database}, " +
+        s"TableName: ${tableDesc.identifier.table}, " +
+        s"$writingCommandClassName]"
+  }
+}
+
+case class GpuOptimizedCreateHiveTableAsSelectCommand(
+    tableDesc: CatalogTable,
+    query: LogicalPlan,
+    outputColumnNames: Seq[String],
+    mode: SaveMode,
+    cpuCmd: OptimizedCreateHiveTableAsSelectCommand) extends GpuCreateHiveTableAsSelectBase {
+  override def getWritingCommand(
+      catalog: SessionCatalog,
+      tableDesc: CatalogTable,
+      tableExists: Boolean): GpuDataWritingCommand = {
+    // Leverage the existing support for InsertIntoHadoopFsRelationCommand to do the write
+    cpuCmd.getWritingCommand(catalog, tableDesc, tableExists) match {
+      case c: InsertIntoHadoopFsRelationCommand =>
+        val rapidsConf = new RapidsConf(conf)
+        val rule = GpuOverrides.dataWriteCmds(c.getClass)
+        val meta = new InsertIntoHadoopFsRelationCommandMeta(c, rapidsConf, None, rule)
+        meta.tagForGpu()
+        if (!meta.canThisBeReplaced) {
+          throw new IllegalStateException("Unable to convert writing command: " +
+              meta.explain(all = false))
+        }
+        meta.convertToGpu()
+      case c =>
+        throw new UnsupportedOperationException(s"Unsupported write command: $c")
+    }
+  }
+
+  override def writingCommandClassName: String =
+    TrampolineUtil.getSimpleName(classOf[GpuInsertIntoHadoopFsRelationCommand])
+
+  // Do not support partitioned or bucketed writes
+  override def requireSingleBatch: Boolean = false
+}
+
+final class OptimizedCreateHiveTableAsSelectCommandMeta(
+    cmd: OptimizedCreateHiveTableAsSelectCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends DataWritingCommandMeta[OptimizedCreateHiveTableAsSelectCommand](
+      cmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    // It would be cleaner if we could simply call `cmd.getWritingCommand` and let
+    // InsertIntoHadoopFsRelationCommandMeta tag the result, but calling getWritingCommand
+    // before the table exists will crash. So this ends up replicating a portion of the logic
+    // from OptimizedCreateHiveTableAsSelectCommand.getWritingCommand and underlying
+    // utility methods to be able to tag whether we can support the optimized Hive write.
+    val spark = SparkSession.active
+    val tableDesc = cmd.tableDesc
+
+    if (tableDesc.partitionColumnNames.nonEmpty) {
+      willNotWorkOnGpu("partitioned writes are not supported")
+    }
+
+    if (tableDesc.bucketSpec.isDefined) {
+      willNotWorkOnGpu("bucketing is not supported")
+    }
+
+    val serde = tableDesc.storage.serde.getOrElse("").toLowerCase(Locale.ROOT)
+    if (serde.contains("parquet")) {
+      val mergeSchemaConfKey = "spark.sql.hive.convertMetastoreParquet.mergeSchema"
+      val shouldMergeSchema = SQLConf.get.getConfString(mergeSchemaConfKey, "false").toBoolean
+      if (shouldMergeSchema) {
+        willNotWorkOnGpu("Merging Parquet schemas across part files is not supported, " +
+            s"see $mergeSchemaConfKey")
+      }
+      val options = tableDesc.properties.filterKeys(isParquetProperty) ++
+          tableDesc.storage.properties
+      GpuParquetFileFormat.tagGpuSupport(this, spark, options, cmd.query.schema)
+    } else if (serde.contains("orc")) {
+      val options = tableDesc.properties.filterKeys(isOrcProperty) ++
+          tableDesc.storage.properties
+      GpuOrcFileFormat.tagGpuSupport(this, spark, options, cmd.query.schema)
+    } else {
+      willNotWorkOnGpu(s"unsupported serde detected: $serde")
+    }
+  }
+
+  override def convertToGpu(): GpuDataWritingCommand = {
+    GpuOptimizedCreateHiveTableAsSelectCommand(
+      wrapped.tableDesc,
+      wrapped.query,
+      wrapped.outputColumnNames,
+      wrapped.mode,
+      cmd)
+  }
+
+  // Return true for Apache ORC and Hive ORC-related configuration names.
+  // Note that Spark doesn't support configurations like `hive.merge.orcfile.stripe.level`.
+  private def isOrcProperty(key: String) =
+    key.startsWith("orc.") || key.contains(".orc.")
+
+  private def isParquetProperty(key: String) =
+    key.startsWith("parquet.") || key.contains(".parquet.")
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -56,6 +56,7 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ENSURE_RE
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.execution.window.WindowExec
+import org.apache.spark.sql.hive.execution.OptimizedCreateHiveTableAsSelectCommand
 import org.apache.spark.sql.hive.rapids.GpuHiveOverrides
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids._
@@ -3749,7 +3750,10 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new InsertIntoHadoopFsRelationCommandMeta(a, conf, p, r)),
     dataWriteCmd[CreateDataSourceTableAsSelectCommand](
       "Create table with select command",
-      (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r))
+      (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r)),
+    dataWriteCmd[OptimizedCreateHiveTableAsSelectCommand](
+      "Create a Hive table from a query result using Spark data source APIs",
+      (a, conf, p, r) => new OptimizedCreateHiveTableAsSelectCommandMeta(a, conf, p, r))
   ).map(r => (r.getClassFor.asSubclass(classOf[DataWritingCommand]), r)).toMap
 
   def wrapPlan[INPUT <: SparkPlan](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HiveProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HiveProvider.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.command.DataWritingCommand
 
 /**
  * The subclass of HiveProvider imports spark-hive classes. This file should not imports
@@ -24,5 +25,8 @@ import org.apache.spark.sql.catalyst.expressions.Expression
  * runtime. Details see: https://github.com/NVIDIA/spark-rapids/issues/5648
  */
 trait HiveProvider {
+  def getDataWriteCmds: Map[Class[_ <: DataWritingCommand],
+      DataWritingCommandRule[_ <: DataWritingCommand]]
+
   def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]]
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -27,6 +27,7 @@ import scala.util.matching.Regex
 
 import ai.rapids.cudf.{CudaException, CudaFatalException, CudfException, MemoryCleaner}
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
+import com.nvidia.spark.rapids.shims.PlanShims
 
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext}
@@ -420,7 +421,7 @@ object ExecutionPlanCaptureCallback {
   def extractExecutedPlan(plan: Option[SparkPlan]): SparkPlan = {
     plan match {
       case Some(p: AdaptiveSparkPlanExec) => p.executedPlan
-      case Some(p) => p
+      case Some(p) => PlanShims.extractExecutedPlan(p)
       case _ => throw new IllegalStateException("No execution plan available")
     }
   }


### PR DESCRIPTION
Fixes #6392.  Implements a GPU acceleration for OptimizedCreateHiveTableAsSelectCommand.  The implementation is very similar to the one in Spark, in which the implementation highly leverages InsertIntoHadoopFsRelationCommand.  The same approach is used here, as GpuInsertIntoHadoopFsRelationCommand is instantiated and leveraged to do the actual write operation.

Unfortunately it was not possible to leverage InsertIntoHadoopFsRelationCommandMeta during the tagging, as getting the underlying CPU InsertIntoHadoopFsRelationCommand requires the table has been created, and that is not the case during query planning and before query execution.  That required replicating some of the analysis and conversion code from Spark that extracts information from the Hive relation, which was needed to properly tag whether we can support the operation on the GPU.

The implementation also mirrors the Spark version in the use of a base class during implementation.  There's currently only one derived class and thus is a bit wasteful, but this should prove useful if and when we support GPU acceleration of CreateHiveTableAsSelectCommand.