### PR TITLE
Fix DOP calculation for xdist

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -131,7 +131,7 @@ else
         # Account for intra-Spark parallelism
         numGpuJVM=1
         if [[ "$NUM_LOCAL_EXECS" != "" ]]; then
-            numGpuJVM = $NUM_LOCAL_EXECS
+            numGpuJVM=$NUM_LOCAL_EXECS
         elif [[ "$PYSP_TEST_spark_cores_max" != "" && "$PYSP_TEST_spark_executor_cores" != "" ]]; then
             numGpuJVM=$(( $PYSP_TEST_spark_cores_max /  $PYSP_TEST_spark_executor_cores ))
         fi

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -127,14 +127,20 @@ else
         HOST_MEM_PARALLEL=`cat /proc/meminfo | grep MemAvailable | awk '{print int($2 / (5 * 1024))}'`
         TMP_PARALLEL=$(( $GPU_MEM_PARALLEL > $CPU_CORES ? $CPU_CORES : $GPU_MEM_PARALLEL ))
         TMP_PARALLEL=$(( $TMP_PARALLEL > $HOST_MEM_PARALLEL ? $HOST_MEM_PARALLEL : $TMP_PARALLEL ))
-        if [[ $TMP_PARALLEL -gt 1 ]];
-        then
-            # We subtract 1 from the parallel number because xdist launches a process to
-            # control and monitor the other processes. It takes up one available parallel
-            # slot, even if it is not truly using all of the resources we give it.
-            TEST_PARALLEL=$(( $TMP_PARALLEL - 1 ))
-        else
+
+        # Account for intra-Spark parallelism
+        numGpuJVM=1
+        if [[ "$NUM_LOCAL_EXECS" != "" ]]; then
+            numGpuJVM = $NUM_LOCAL_EXECS
+        elif [[ "$PYSP_TEST_spark_cores_max" != "" && "$PYSP_TEST_spark_executor_cores" != "" ]]; then
+            numGpuJVM=$(( $PYSP_TEST_spark_cores_max /  $PYSP_TEST_spark_executor_cores ))
+        fi
+        TMP_PARALLEL=$(( $TMP_PARALLEL / $numGpuJVM ))
+
+        if  (( $TMP_PARALLEL <= 1 )); then
             TEST_PARALLEL=1
+        else
+            TEST_PARALLEL=$TMP_PARALLEL
         fi
 
         echo "AUTO DETECTED PARALLELISM OF $TEST_PARALLEL"

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -98,26 +98,24 @@ rapids_shuffle_smoke_test() {
     $SPARK_HOME/sbin/spark-daemon.sh start org.apache.spark.deploy.worker.Worker 1 $SPARK_MASTER
 
     invoke_shuffle_integration_test() {
-      SPECIFIC_SHUFFLE_FLAGS=$1
       PYSP_TEST_spark_master=$SPARK_MASTER \
-        TEST_PARALLEL=0 \
         PYSP_TEST_spark_cores_max=2 \
         PYSP_TEST_spark_executor_cores=1 \
         PYSP_TEST_spark_shuffle_manager=com.nvidia.spark.rapids.$SHUFFLE_SPARK_SHIM.RapidsShuffleManager \
         PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0 \
         PYSP_TEST_spark_rapids_memory_gpu_maxAllocFraction=0.1 \
         PYSP_TEST_spark_rapids_memory_gpu_allocFraction=0.1 \
-        SPARK_SUBMIT_FLAGS=$SPECIFIC_SHUFFLE_FLAGS \
         ./integration_tests/run_pyspark_from_build.sh -m shuffle_test
     }
 
     # using UCX shuffle
-    invoke_shuffle_integration_test "--conf spark.executorEnv.UCX_ERROR_SIGNALS="
+    PYSP_TEST_spark_executorEnv_UCX_ERROR_SIGNALS="" \
+        invoke_shuffle_integration_test
 
     # using MULTITHREADED shuffle
-    invoke_shuffle_integration_test "\
-      --conf spark.rapids.shuffle.mode=MULTITHREADED \
-      --conf spark.rapids.shuffle.multiThreaded.writer.threads=2"
+    PYSP_TEST_spark_rapids_shuffle_mode=MULTITHREADED \
+    PYSP_TEST_spark_rapids_shuffle_multiThreaded_writer_threads=2 \
+        invoke_shuffle_integration_test
 
     $SPARK_HOME/sbin/spark-daemon.sh stop org.apache.spark.deploy.worker.Worker 1
     $SPARK_HOME/sbin/stop-master.sh


### PR DESCRIPTION
This PR fixes #6467, contrbutes to #6403

Improve TEST_PARALLEL formula by accounting for
- number of executor JVMs
- the fact that xdist master no longer starts a dummy Spark app

Use UCX shuffle test as a POC

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
