### PR TITLE
Fixes excessive ShuffleBlockId object creation due to missing map index bounds [databricks]

### DIFF
--- a/sql-plugin/src/main/311until320-all/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
+++ b/sql-plugin/src/main/311until320-all/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.execution.{CoalescedPartitionSpec, PartialMapperPart
 import org.apache.spark.sql.execution.metric.SQLShuffleReadMetricsReporter
 import org.apache.spark.sql.rapids.execution.ShuffledBatchRDDPartition
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.storage.{BlockId, BlockManagerId}
 
 /**
  * Some APIs for the ShuffledBatchRDD are only accessible from org.apache.spark...
@@ -49,6 +50,13 @@ object ShuffledBatchRDDUtil {
     }
   }
 
+  private def getPartitionSize(
+      blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])]): Long = {
+    blocksByAddress.flatMap { case (_, blockInfos) =>
+      blockInfos.map { case (_, size, _) => size }
+    }.sum
+  }
+
   def getReaderAndPartSize(
       split: Partition,
       context: TaskContext,
@@ -69,9 +77,7 @@ object ShuffledBatchRDDUtil {
           Int.MaxValue, 
           startReducerIndex, 
           endReducerIndex)
-        val partitionSize = blocksByAddress.flatMap(_._2).map(_._2).sum
-        (reader, partitionSize)
-
+        (reader, getPartitionSize(blocksByAddress))
       case PartialReducerPartitionSpec(reducerIndex, startMapIndex, endMapIndex, _) =>
         val reader = SparkEnv.get.shuffleManager.getReader(
           dependency.shuffleHandle,
@@ -87,10 +93,7 @@ object ShuffledBatchRDDUtil {
           endMapIndex, 
           reducerIndex,
           reducerIndex + 1)
-        val partitionSize = blocksByAddress.flatMap(_._2)
-            .filter(tuple => tuple._3 >= startMapIndex && tuple._3 < endMapIndex)
-            .map(_._2).sum
-        (reader, partitionSize)
+        (reader, getPartitionSize(blocksByAddress))
       case PartialMapperPartitionSpec(mapIndex, startReducerIndex, endReducerIndex) =>
         val reader = SparkEnv.get.shuffleManager.getReader(
           dependency.shuffleHandle,
@@ -104,12 +107,9 @@ object ShuffledBatchRDDUtil {
           dependency.shuffleHandle.shuffleId,
           mapIndex, 
           mapIndex + 1, 
-          startReducerIndex, 
+          startReducerIndex,
           endReducerIndex)
-        val partitionSize = blocksByAddress.flatMap(_._2)
-            .filter(_._3 == mapIndex)
-            .map(_._2).sum
-        (reader, partitionSize)
+        (reader, getPartitionSize(blocksByAddress))
     }
   }
 }

--- a/sql-plugin/src/main/311until320-all/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
+++ b/sql-plugin/src/main/311until320-all/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
@@ -64,7 +64,11 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, startReducerIndex, endReducerIndex)
+          dependency.shuffleHandle.shuffleId, 
+          0, 
+          Int.MaxValue, 
+          startReducerIndex, 
+          endReducerIndex)
         val partitionSize = blocksByAddress.flatMap(_._2).map(_._2).sum
         (reader, partitionSize)
 
@@ -78,7 +82,10 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, reducerIndex,
+          dependency.shuffleHandle.shuffleId, 
+          startMapIndex, 
+          endMapIndex, 
+          reducerIndex,
           reducerIndex + 1)
         val partitionSize = blocksByAddress.flatMap(_._2)
             .filter(tuple => tuple._3 >= startMapIndex && tuple._3 < endMapIndex)
@@ -94,7 +101,11 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, startReducerIndex, endReducerIndex)
+          dependency.shuffleHandle.shuffleId,
+          mapIndex, 
+          mapIndex + 1, 
+          startReducerIndex, 
+          endReducerIndex)
         val partitionSize = blocksByAddress.flatMap(_._2)
             .filter(_._3 == mapIndex)
             .map(_._2).sum

--- a/sql-plugin/src/main/320+/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
+++ b/sql-plugin/src/main/320+/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.rapids.shims
 
 import org.apache.spark.{MapOutputTrackerMaster, Partition, ShuffleDependency, SparkEnv, TaskContext}
-
 import org.apache.spark.shuffle.ShuffleReader
 import org.apache.spark.sql.execution.{CoalescedMapperPartitionSpec, CoalescedPartitionSpec, PartialMapperPartitionSpec, PartialReducerPartitionSpec}
 import org.apache.spark.sql.execution.metric.SQLShuffleReadMetricsReporter

--- a/sql-plugin/src/main/320+/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
+++ b/sql-plugin/src/main/320+/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
@@ -67,7 +67,11 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, startReducerIndex, endReducerIndex)
+          dependency.shuffleHandle.shuffleId, 
+          0, 
+          Int.MaxValue, 
+          startReducerIndex, 
+          endReducerIndex)
         val partitionSize = blocksByAddress.flatMap(_._2).map(_._2).sum
         (reader, partitionSize)
 
@@ -81,7 +85,10 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, reducerIndex,
+          dependency.shuffleHandle.shuffleId, 
+          startMapIndex, 
+          endMapIndex, 
+          reducerIndex,
           reducerIndex + 1)
         val partitionSize = blocksByAddress.flatMap(_._2)
             .filter(tuple => tuple._3 >= startMapIndex && tuple._3 < endMapIndex)
@@ -97,7 +104,11 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, 0, Int.MaxValue, startReducerIndex, endReducerIndex)
+          dependency.shuffleHandle.shuffleId,
+          mapIndex, 
+          mapIndex + 1, 
+          startReducerIndex, 
+          endReducerIndex)
         val partitionSize = blocksByAddress.flatMap(_._2)
             .filter(_._3 == mapIndex)
             .map(_._2).sum
@@ -112,7 +123,11 @@ object ShuffledBatchRDDUtil {
           context,
           sqlMetricsReporter)
         val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
-          dependency.shuffleHandle.shuffleId, startMapIndex, endMapIndex, 0, numReducers)
+          dependency.shuffleHandle.shuffleId, 
+          startMapIndex, 
+          endMapIndex, 
+          0, 
+          numReducers)
         val partitionSize = blocksByAddress.flatMap(_._2)
             .filter(tuple => tuple._3 >= startMapIndex && tuple._3 < endMapIndex)
             .map(_._2).sum


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This fixes a bug that was found with larger NDS data scales (10TB) where GC limits would be exceeded. I tracked this down to excessive creation of `ShuffleBlockId`s just to get the "partition size" metric in `ShuffledBatchRDDUtil`.

The GC starts to become a problem when we create hundreds of millions of these, which adds up to single-digit GBs of jvm memory. With this fix, the most I saw created was ~3M and the amount of JVM usage was ~100MB, which allowed the query to succeed.

Note I left some filtering that happened after we got the `ShuffleBlockIds` in place, and it should be a noop. I believe that can be removed.

Adding this as draft as I haven't run through all the tests yet.