### PR TITLE
Fix intermittent failure on test_cast_float_to_timestamp_side_effect

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_py4j_exception
 from data_gen import *
 from spark_session import is_before_spark_320, is_before_spark_330, is_databricks91_or_later, with_gpu_session
-from marks import allow_non_gpu, approximate_float
+from marks import allow_non_gpu, approximate_float, ignore_order
 from pyspark.sql.types import *
 from spark_init_internal import spark_version
 from datetime import datetime
@@ -395,6 +395,7 @@ def test_cast_float_to_timestamp_ansi_overflow(type, invalid_value):
         return df.select(f.col('value').cast(TimestampType())).collect()
     assert_gpu_and_cpu_error(fun, {"spark.sql.ansi.enabled": True}, "ArithmeticException")
 
+@ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_330(), reason='330+ throws exception in ANSI mode')
 def test_cast_float_to_timestamp_side_effect():
     def getDf(spark):

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_py4j_exception
 from data_gen import *
 from spark_session import is_before_spark_320, is_before_spark_330, is_databricks91_or_later, with_gpu_session
-from marks import allow_non_gpu, approximate_float, ignore_order
+from marks import allow_non_gpu, approximate_float
 from pyspark.sql.types import *
 from spark_init_internal import spark_version
 from datetime import datetime
@@ -395,12 +395,12 @@ def test_cast_float_to_timestamp_ansi_overflow(type, invalid_value):
         return df.select(f.col('value').cast(TimestampType())).collect()
     assert_gpu_and_cpu_error(fun, {"spark.sql.ansi.enabled": True}, "ArithmeticException")
 
-@ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_330(), reason='330+ throws exception in ANSI mode')
 def test_cast_float_to_timestamp_side_effect():
     def getDf(spark):
-        return spark.createDataFrame([(True, float(LONG_MAX) + 100), (False, float(1))],
-                                     "c_b boolean, c_f float").repartition(1)
+        data = [(True, float(LONG_MAX) + 100), (False, float(1))]
+        distData = spark.sparkContext.parallelize(data, 1)
+        return spark.createDataFrame(distData, "c_b boolean, c_f float")
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: getDf(spark).selectExpr("if(c_b, cast(0 as timestamp), cast(c_f as timestamp))"),
         conf=ansi_enabled_conf)


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6478

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

It was reported that the newest version of CDH (which is not yet released) based on Spark 3.3.0 using spark rapids 22.06 is intermittently failing test test_cast_float_to_timestamp_side_effect.
https://github.com/NVIDIA/spark-rapids/blob/branch-22.06/integration_tests/src/main/python/cast_test.py#L389

When it is wrong the results are:

```
CPU OUTPUT: [Row((IF(c_b, CAST(0 AS TIMESTAMP), CAST(c_f AS TIMESTAMP)))=datetime.datetime(1970, 1, 1, 0, 0, 1)), Row((IF(c_b, CAST(0 AS TIMESTAMP), CAST(c_f AS TIMESTAMP)))=datetime.datetime(1970, 1, 1, 0, 0))]
GPU OUTPUT: [Row((IF(c_b, CAST(0 AS TIMESTAMP), CAST(c_f AS TIMESTAMP)))=datetime.datetime(1970, 1, 1, 0, 0)), Row((IF(c_b, CAST(0 AS TIMESTAMP), CAST(c_f AS TIMESTAMP)))=datetime.datetime(1970, 1, 1, 0, 0, 1))]
```

It looks like just an issue with not ignoring the output order since the values are correct just in the wrong order.

I was able to reproduce this about every 1 in 4 times.  So I did the fix and ran about 20 times without it failing now.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
