### PR TITLE
Fix non-deterministic overflows in test_hash_grpby_sum_full_decimal

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -111,15 +111,6 @@ a few operations that we cannot support to the same degree as Spark can on the C
 
 ### Decimal Sum Aggregation
 
-A number of fixes for overflow detection went into Spark 3.1.0. Please see
-[SPARK-28067](https://issues.apache.org/jira/browse/SPARK-28067) and
-[SPARK-32018](https://issues.apache.org/jira/browse/SPARK-32018) for more detailed information.
-Some of these fixes we were able to back port, but some of them require Spark 3.1.0 or above to
-fully be able to detect overflow in all cases. As such on versions of Spark older than 3.1.0 for
-large decimal values there is the possibility of data corruption in some corner cases. 
-This is true for both the CPU and GPU implementations, but there are fewer of these cases for the 
-GPU. If this concerns you, you should upgrade to Spark 3.1.0 or above. 
-
 When Apache Spark does a sum aggregation on decimal values it will store the result in a value
 with a precision that is the input precision + 10, but with a maximum precision of 38.
 For an input precision of 9 and above, Spark will do the aggregations as a Java `BigDecimal`
@@ -131,8 +122,13 @@ longer detected. Even then all the values would need to be either the largest or
 possible to be stored in the type for the overflow to cause data corruption.
 
 For the RAPIDS Accelerator we don't have direct access to unlimited precision for our calculations
-like the CPU does. For input values with a precision of 8 and below we follow Spark and process the
-data the same way, as a 64-bit value. For larger values we will do extra calculations looking at the
+like the CPU does, and the aggregations are processed in batches within each task. Therefore it is
+possible for the GPU to detect an intermediate overflow after aggregating a batch, e.g.: a sum
+aggregation on positive and negative values, where the accumulating sum value temporarily
+overflows but returns within bounds before the final cast back into a decimal with precision 38.
+
+For input values with a precision of 8 and below we follow Spark and process the data the
+same way, as a 64-bit value. For larger values we will do extra calculations looking at the
 higher order digits to be able to detect overflow in all cases. But because of this you may see
 some performance differences depending on the input precision used. The differences will show up
 when going from an input precision of 8 to 9 and again when going from an input precision of 28 to 29.

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -215,19 +215,22 @@ class IntegerGen(DataGen):
 
 class DecimalGen(DataGen):
     """Generate Decimals, with some built in corner cases."""
-    def __init__(self, precision=None, scale=None, nullable=True, special_cases=None):
+    def __init__(self, precision=None, scale=None, nullable=True, special_cases=None, avoid_positive_values=False):
         if precision is None:
             #Maximum number of decimal digits a Long can represent is 18
             precision = 18
             scale = 0
         DECIMAL_MIN = Decimal('-' + ('9' * precision) + 'e' + str(-scale))
         DECIMAL_MAX = Decimal(('9'* precision) + 'e' + str(-scale))
-        if (special_cases is None):
-            special_cases = [DECIMAL_MIN, DECIMAL_MAX, Decimal('0')]
+        if special_cases is None:
+            special_cases = [DECIMAL_MIN, Decimal('0')]
+            if not avoid_positive_values:
+                special_cases.append(DECIMAL_MAX)
         super().__init__(DecimalType(precision, scale), nullable=nullable, special_cases=special_cases)
         self.scale = scale
         self.precision = precision
-        pattern = "-?[0-9]{1,"+ str(precision) + "}e" + str(-scale)
+        negative_pattern = "-" if avoid_positive_values else "-?"
+        pattern = negative_pattern + "[0-9]{1,"+ str(precision) + "}e" + str(-scale)
         self.base_strs = sre_yield.AllStrings(pattern, flags=0, charset=sre_yield.CHARSET, max_count=_MAX_CHOICES)
 
     def __repr__(self):


### PR DESCRIPTION
Fixes #6460.  The test was failing because the test setup is not deterministic.  We are summing positive and negative decimals, and the accumulating sum can temporarily overflow a Decimal(38) within a batch depending on the input partition order which is not deterministic.  This updates the sum and average tests on full Decimal(38) to use only negative decimals so the accumulating sum can only move in one direction -- once it overflows, it can't "unoverflow" later.  The documentation has also been updated to note the corner-case difference in overflow detection between CPU and GPU since we are not accumulating in infinite precision and checking for overflow after each aggregation batch.