### PR TITLE
Perform columnar-to-row transition in GpuBringBackToHost.doExecute

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBringBackToHost.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBringBackToHost.scala
@@ -35,7 +35,8 @@ case class GpuBringBackToHost(child: SparkPlan) extends ShimUnaryExecNode with G
   override def supportsColumnar: Boolean = true
 
   override protected def doExecute(): RDD[InternalRow] = {
-    child.execute()
+    val columnarToRow = GpuColumnarToRowExec(child)
+    columnarToRow.execute()
   }
 
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuBringBackToHostSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuBringBackToHostSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.types.LongType
+
+class GpuBringBackToHostSuite extends SparkQueryCompareTestSuite {
+  test("doExecute") {
+    val numRows = 1024 * 1024
+    val rows = withGpuSparkSession { _ =>
+      val plan = GpuBringBackToHost(
+        GpuRangeExec(start=0, end=numRows, step=1, numSlices=1,
+          output=Seq(AttributeReference("id", LongType)()),
+          targetSizeBytes=Math.max(numRows / 10, 1)))
+      plan.executeCollect()
+    }
+
+    var rowId = 0
+    rows.foreach { row =>
+      assertResult(1)(row.numFields)
+      assertResult(rowId)(row.getLong(0))
+      rowId += 1
+    }
+    assertResult(numRows)(rowId)
+  }
+}


### PR DESCRIPTION
Fixes #6397.  GpuBringBackToHost needs to perform a columnar-to-row conversion when its doExecute is called, so the method was updated to leverage ColumnarToRowExec to perform the necessary conversion.  The unit test manually constructs a SparkPlan with GpuBringBackToHost since it is difficult to construct a DataFrame plan that will contain this node, as it normally gets automatically replaced with GpuColumnarToRowExec during planning.