### PR TITLE
Nightly spark-tests script to follow PYSP_TEST pattern [skip ci]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -168,8 +168,8 @@ else
 
     if [[ ${TEST_PARALLEL} -lt 2 ]];
     then
-        # With xdist 0 and 1 are the same parallelsm but
-        # 0 is more effecient
+        # With xdist 0 and 1 are the same parallelism but
+        # 0 is more efficient
         TEST_PARALLEL_OPTS=()
     else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -39,7 +39,7 @@ RUN if [ "$CENTOS_VER" == "8" ]; then\
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
     yum install epel-release -y && \
-    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect parallel rsync zip unzip
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect rsync zip unzip
 
 # The default mvn verision is 3.0.5 on centos7 docker container.
 # The plugin: net.alchim31.maven requires a higher mvn version.

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -60,6 +60,8 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \
     conda clean -ay
+# install pytest plugins for xdist parallel run
+RUN python -m pip install findspark pytest-xdist pytest-order
 
 # Set default java as 1.8.0
 ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk"

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -33,7 +33,7 @@ ARG URM_URL
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
     yum install epel-release -y && \
-    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect parallel rsync zip unzip
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect rsync zip unzip
 
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -53,6 +53,8 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \
     conda clean -ay
+# install pytest plugins for xdist parallel run
+RUN python -m pip install findspark pytest-xdist pytest-order
 
 # Set default java as 1.8.0
 ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk"

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -40,7 +40,7 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget parallel
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
 RUN python3.8 -m easy_install pip
 
 # Set default jdk as 1.8.0

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -58,6 +58,8 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \
     conda clean -ay
+# install pytest plugins for xdist parallel run
+RUN python -m pip install findspark pytest-xdist pytest-order
 
 RUN apt install -y inetutils-ping expect
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -125,13 +125,8 @@ export PYTHONPATH="$CONDA_ROOT/lib/python$PYTHON_VER/site-packages:$PYTHONPATH"
 
 echo "----------------------------START TEST------------------------------------"
 pushd $RAPIDS_INT_TESTS_HOME
-
-export TEST_PARALLEL=0  # disable spark local parallel in run_pyspark_from_build.sh
 export TEST_TYPE="nightly"
 export LOCAL_JAR_PATH=$ARTF_ROOT
-# test collect-only in advance to terminate earlier if ENV issue
-COLLECT_BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS" # if passed custom params
-SPARK_SUBMIT_FLAGS="$COLLECT_BASE_SPARK_SUBMIT_ARGS" ./run_pyspark_from_build.sh --collect-only -qqq
 
 export SPARK_TASK_MAXFAILURES=1
 export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
@@ -139,39 +134,47 @@ export PATH="$SPARK_HOME/bin:$SPARK_HOME/sbin:$PATH"
 # if failed, we abort the test instantly, so the failed executor log should still be left there for debugging
 export SPARK_WORKER_OPTS="$SPARK_WORKER_OPTS -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.interval=120 -Dspark.worker.cleanup.appDataTtl=60"
 #stop and restart SPARK ETL
-stop-slave.sh
+stop-worker.sh
 stop-master.sh
 start-master.sh
-start-slave.sh spark://$HOSTNAME:7077
+start-worker.sh spark://$HOSTNAME:7077
 jps
 
-export BASE_SPARK_SUBMIT_ARGS="$BASE_SPARK_SUBMIT_ARGS \
---master spark://$HOSTNAME:7077 \
---conf spark.sql.shuffle.partitions=12 \
---conf spark.task.maxFailures=$SPARK_TASK_MAXFAILURES \
---conf spark.dynamicAllocation.enabled=false \
---conf spark.driver.extraJavaOptions=-Duser.timezone=UTC \
---conf spark.executor.extraJavaOptions=-Duser.timezone=UTC \
---conf spark.sql.session.timeZone=UTC"
+# BASE spark test configs
+export PYSP_TEST_spark_master=spark://$HOSTNAME:7077
+export PYSP_TEST_spark_sql_shuffle_partitions=12
+export PYSP_TEST_spark_task_maxFailures=$SPARK_TASK_MAXFAILURES
+export PYSP_TEST_spark_dynamicAllocation_enabled=false
+export PYSP_TEST_spark_driver_extraJavaOptions=-Duser.timezone=UTC
+export PYSP_TEST_spark_executor_extraJavaOptions=-Duser.timezone=UTC
+export PYSP_TEST_spark_sql_session_timeZone=UTC
 
-export SEQ_CONF="--executor-memory 16G \
---total-executor-cores 6"
+# PARALLEL or non-PARALLEL specific configs
+if [[ $PARALLEL_TEST == "true" ]]; then
+  export PYSP_TEST_spark_cores_max=1
+  export PYSP_TEST_spark_executor_memory=4g
+  export PYSP_TEST_spark_executor_cores=1
+  export PYSP_TEST_spark_task_cores=1
+  export PYSP_TEST_spark_rapids_sql_concurrentGpuTasks=1
+  export PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0
 
-export PARALLEL_CONF="--executor-memory 4G \
---total-executor-cores 1 \
---conf spark.executor.cores=1 \
---conf spark.task.cpus=1 \
---conf spark.rapids.sql.concurrentGpuTasks=1 \
---conf spark.rapids.memory.gpu.minAllocFraction=0"
+  if [[ "${PARALLELISM}" == "" ]]; then
+    PARALLELISM=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader | \
+      awk '{if (MAX < $1){ MAX = $1}} END {print int(MAX / (2 * 1024))}')
+  fi
+  # parallelism > 6 could slow down the whole process, so we have a limitation for it
+  # this is based on our CI gpu types, so we do not put it into the run_pyspark_from_build.sh
+  [[ ${PARALLELISM} -gt 6 ]] && PARALLELISM=6
+  MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 0.1))")
 
-export CUDF_UDF_TEST_ARGS="--conf spark.rapids.memory.gpu.allocFraction=0.1 \
---conf spark.rapids.memory.gpu.minAllocFraction=0 \
---conf spark.rapids.python.memory.gpu.allocFraction=0.1 \
---conf spark.rapids.python.concurrentPythonWorkers=2 \
---conf spark.executorEnv.PYTHONPATH=${RAPIDS_PLUGIN_JAR} \
---conf spark.pyspark.python=/opt/conda/bin/python \
---py-files ${RAPIDS_PLUGIN_JAR}"
-
+  export TEST_PARALLEL=${PARALLELISM}
+  export PYSP_TEST_spark_rapids_memory_gpu_allocFraction=${MEMORY_FRACTION}
+  export PYSP_TEST_spark_rapids_memory_gpu_maxAllocFraction=${MEMORY_FRACTION}
+else
+  export PYSP_TEST_spark_cores_max=6
+  export PYSP_TEST_spark_executor_memory=16g
+  export TEST_PARALLEL=1
+fi
 
 export SCRIPT_PATH="$(pwd -P)"
 export TARGET_DIR="$SCRIPT_PATH/target"
@@ -181,11 +184,11 @@ run_delta_lake_tests() {
   echo "run_delta_lake_tests SPARK_VER = $SPARK_VER"
   SPARK_321_PATTERN="(3\.2\.[1-9])"
   DELTA_LAKE_VER="1.2.1"
+
   if [[ $SPARK_VER =~ $SPARK_321_PATTERN ]]; then
-    SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF \
-      --packages io.delta:delta-core_2.12:$DELTA_LAKE_VER \
-      --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
-      --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+    PYSP_TEST_spark_jars_packages="io.delta:delta-core_2.12:$DELTA_LAKE_VER" \
+      PYSP_TEST_spark_sql_extensions="io.delta.sql.DeltaSparkSessionExtension" \
+      PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.spark.sql.delta.catalog.DeltaCatalog" \
       ./run_pyspark_from_build.sh -m delta_lake --delta_lake
   else
     echo "Skipping Delta Lake tests. Delta Lake does not support Spark version $SPARK_VER"
@@ -199,154 +202,54 @@ run_iceberg_tests() {
 
   # Iceberg does not support Spark 3.3+ yet
   if [[ "$ICEBERG_SPARK_VER" < "3.3" ]]; then
-    SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF \
-      --packages org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_2.12:${ICEBERG_VERSION} \
-      --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
-      --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
-      --conf spark.sql.catalog.spark_catalog.type=hadoop \
-      --conf spark.sql.catalog.spark_catalog.warehouse=/tmp/spark-warehouse-$$" \
+    PYSP_TEST_spark_jars_packages=org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_2.12:${ICEBERG_VERSION} \
+      PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
+      PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
+      PYSP_TEST_spark_sql_catalog_spark__catalog_type="hadoop" \
+      PYSP_TEST_spark_sql_catalog_spark__catalog_warehouse="/tmp/spark-warehouse-$RANDOM" \
       ./run_pyspark_from_build.sh -m iceberg --iceberg
   else
     echo "Skipping Iceberg tests. Iceberg does not support Spark $ICEBERG_SPARK_VER"
   fi
 }
 
-run_test_not_parallel() {
-    local TEST=${1//\.py/}
-    local LOG_FILE
-    case $TEST in
-      all)
-        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF" \
-          ./run_pyspark_from_build.sh
-        ;;
-
-      cudf_udf_test)
-        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF $CUDF_UDF_TEST_ARGS" \
-          ./run_pyspark_from_build.sh -m cudf_udf --cudf_udf
-        ;;
-
-      cache_serializer)
-        SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $SEQ_CONF \
-        --conf spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer" \
-          ./run_pyspark_from_build.sh -k cache_test
-        ;;
-
-      delta_lake)
-        run_delta_lake_tests
-        ;;
-
-      iceberg)
-        run_iceberg_tests
-        ;;
-
-      *)
-        echo -e "\n\n>>>>> $TEST...\n"
-        LOG_FILE="$TARGET_DIR/$TEST.log"
-        # set dedicated RUN_DIRs here to avoid conflict between parallel tests
-        RUN_DIR="$TARGET_DIR/run_dir_$TEST" \
-          SPARK_SUBMIT_FLAGS="$BASE_SPARK_SUBMIT_ARGS $PARALLEL_CONF $MEMORY_FRACTION_CONF" \
-          ./run_pyspark_from_build.sh -k $TEST >"$LOG_FILE" 2>&1
-
-        CODE="$?"
-        if [[ $CODE == "0" ]]; then
-          sed -n -e '/test session starts/,/deselected,/ p' "$LOG_FILE" || true
-        else
-          cat "$LOG_FILE" || true
-          cat /tmp/artifacts-build.info || true
-        fi
-        return $CODE
-        ;;
-    esac
-}
-export -f run_test_not_parallel
-
-get_cases_by_tags() {
-  local cases
-  local args=${2}
-  cases=$(TEST_TAGS="${1}" SPARK_SUBMIT_FLAGS="$COLLECT_BASE_SPARK_SUBMIT_ARGS" \
-           ./run_pyspark_from_build.sh "${args}" --collect-only -p no:warnings -qq 2>/dev/null \
-           | grep -oP '(?<=::).*?(?=\[)' | uniq | xargs)
-  echo "$cases"
-}
-export -f get_cases_by_tags
-
-get_tests_by_tags() {
-  local tests
-  local args=${2}
-  tests=$(TEST_TAGS="${1}" SPARK_SUBMIT_FLAGS="$COLLECT_BASE_SPARK_SUBMIT_ARGS" \
-           ./run_pyspark_from_build.sh "${args}" --collect-only -qqq -p no:warnings 2>/dev/null \
-           | grep -oP '(?<=python/).*?(?=.py)' | xargs)
-  echo "$tests"
-}
-export -f get_tests_by_tags
-
 # TEST_MODE
 # - DEFAULT: all tests except cudf_udf tests
-# - CUDF_UDF_ONLY: cudf_udf tests only, requires extra conda cudf-py lib
-# - ICEBERG_ONLY: iceberg tests only
 # - DELTA_LAKE_ONLY: Delta Lake tests only
+# - ICEBERG_ONLY: iceberg tests only
+# - CUDF_UDF_ONLY: cudf_udf tests only, requires extra conda cudf-py lib
 TEST_MODE=${TEST_MODE:-'DEFAULT'}
 if [[ $TEST_MODE == "DEFAULT" ]]; then
-  # integration tests
-  if [[ $PARALLEL_TEST == "true" ]] && [ -x "$(command -v parallel)" ]; then
-    # separate run for special cases that require smaller parallelism
-    special_cases=$(get_cases_by_tags "nightly_resource_consuming_test \
-                                      and (nightly_gpu_mem_consuming_case or nightly_host_mem_consuming_case)")
-    # hardcode parallelism as 2 for special cases
-    export MEMORY_FRACTION_CONF="--conf spark.rapids.memory.gpu.allocFraction=0.45 \
-    --conf spark.rapids.memory.gpu.maxAllocFraction=0.45"
-    # --halt "now,fail=1": exit when the first job fail, and kill running jobs.
-    #                      we can set it to "never" and print failed ones after finish running all tests if needed
-    # --group: print stderr after test finished for better readability
-    parallel --group --halt "now,fail=1" -j2 run_test_not_parallel ::: ${special_cases}
+  ./run_pyspark_from_build.sh
 
-    resource_consuming_cases=$(get_cases_by_tags "nightly_resource_consuming_test \
-                                                and not nightly_gpu_mem_consuming_case \
-                                                and not nightly_host_mem_consuming_case")
-    other_tests=$(get_tests_by_tags "not nightly_resource_consuming_test")
-    tests=$(echo "${resource_consuming_cases} ${other_tests}" | tr ' ' '\n' | awk '!x[$0]++' | xargs)
-
-    if [[ "${PARALLELISM}" == "" ]]; then
-      PARALLELISM=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader | \
-                    awk '{if (MAX < $1){ MAX = $1}} END {print int(MAX / (2 * 1024))}')
-    fi
-    # parallelism > 7 could slow down the whole process, so we have a limitation for it
-    [[ ${PARALLELISM} -gt 7 ]] && PARALLELISM=7
-    MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 0.1))")
-    export MEMORY_FRACTION_CONF="--conf spark.rapids.memory.gpu.allocFraction=${MEMORY_FRACTION} \
-    --conf spark.rapids.memory.gpu.maxAllocFraction=${MEMORY_FRACTION}"
-    parallel --group --halt "now,fail=1" -j"${PARALLELISM}" run_test_not_parallel ::: ${tests}
-  else
-    run_test_not_parallel all
-  fi
-
-  if [[ $PARALLEL_TEST == "true" ]] && [ -x "$(command -v parallel)" ]; then
-    cache_test_cases=$(get_cases_by_tags "" "-k cache_test")
-    # hardcode parallelism as 5
-    export MEMORY_FRACTION_CONF="--conf spark.rapids.memory.gpu.allocFraction=0.18 \
-    --conf spark.rapids.memory.gpu.maxAllocFraction=0.18 \
-    --conf spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer"
-    parallel --group --halt "now,fail=1" -j5 run_test_not_parallel ::: ${cache_test_cases}
-  else
-    run_test_not_parallel cache_serializer
-  fi
-fi
-
-# cudf_udf_test
-if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
-  run_test_not_parallel cudf_udf_test
+  # ParquetCachedBatchSerializer cache_test
+  PYSP_TEST_spark_sql_cache_serializer=com.nvidia.spark.ParquetCachedBatchSerializer \
+    ./run_pyspark_from_build.sh -k cache_test
 fi
 
 # Delta Lake tests
 if [[ "$TEST_MODE" == "DEFAULT" || "$TEST_MODE" == "DELTA_LAKE_ONLY" ]]; then
-  run_test_not_parallel delta_lake
+  run_delta_lake_tests
 fi
 
 # Iceberg tests
 if [[ "$TEST_MODE" == "DEFAULT" || "$TEST_MODE" == "ICEBERG_ONLY" ]]; then
-  run_test_not_parallel iceberg
+  run_iceberg_tests
+fi
+
+# cudf_udf test: this mostly depends on cudf-py, so we run it into an independent CI
+if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
+  # hardcode config
+  [[ ${TEST_PARALLEL} -gt 2 ]] && export TEST_PARALLEL=2
+  PYSP_TEST_spark_rapids_memory_gpu_allocFraction=0.1 \
+    PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0 \
+    PYSP_TEST_spark_rapids_python_memory_gpu_allocFraction=0.1 \
+    PYSP_TEST_spark_rapids_python_concurrentPythonWorkers=2 \
+    PYSP_TEST_spark_executorEnv_PYTHONPATH=${RAPIDS_PLUGIN_JAR} \
+    PYSP_TEST_spark_python=${CONDA_ROOT}/bin/python \
+    ./run_pyspark_from_build.sh -m cudf_udf --cudf_udf
 fi
 
 popd
-stop-slave.sh
+stop-worker.sh
 stop-master.sh

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -225,6 +225,7 @@ run_avro_tests() {
 # - DEFAULT: all tests except cudf_udf tests
 # - DELTA_LAKE_ONLY: Delta Lake tests only
 # - ICEBERG_ONLY: iceberg tests only
+# - AVRO_ONLY: avro tests only (with --packages option instead of --jars)
 # - CUDF_UDF_ONLY: cudf_udf tests only, requires extra conda cudf-py lib
 TEST_MODE=${TEST_MODE:-'DEFAULT'}
 if [[ $TEST_MODE == "DEFAULT" ]]; then

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -173,7 +173,7 @@ if [[ $PARALLEL_TEST == "true" ]]; then
 else
   export PYSP_TEST_spark_cores_max=6
   export PYSP_TEST_spark_executor_memory=16g
-  export TEST_PARALLEL=1
+  export TEST_PARALLEL=0
 fi
 
 export SCRIPT_PATH="$(pwd -P)"


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #6403,
remove `GNU parallel` requirement,
use PYSP_TEST_ to pass config if possible,
make all tests support parallel run

verified spark311+321 locally, will monitor status of other spark shims in nightly runs

Also will update avro test after https://github.com/NVIDIA/spark-rapids/pull/6505 merged