### PR TITLE
ORC reading supports mergeSchema

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -286,7 +286,6 @@ def test_partitioned_read_just_partitions(spark_tmp_path, v1_enabled_list, reade
             lambda spark : spark.read.orc(data_path).select("key"),
             conf=all_confs)
 
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/135')
 @pytest.mark.parametrize('v1_enabled_list', ["", "orc"])
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 def test_merge_schema_read(spark_tmp_path, v1_enabled_list, reader_confs):

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -126,9 +126,6 @@ object GpuOrcScan extends Arm {
   def tagSupport(scanMeta: ScanMeta[OrcScan]): Unit = {
     val scan = scanMeta.wrapped
     val schema = StructType(scan.readDataSchema ++ scan.readPartitionSchema)
-    if (scan.options.getBoolean("mergeSchema", false)) {
-      scanMeta.willNotWorkOnGpu("mergeSchema and schema evolution is not supported yet")
-    }
     tagSupport(scan.sparkSession, schema, scanMeta)
   }
 
@@ -147,11 +144,6 @@ object GpuOrcScan extends Arm {
     }
 
     FileFormatChecks.tag(meta, schema, OrcFormatType, ReadFileOp)
-
-    if (sparkSession.conf
-      .getOption("spark.sql.orc.mergeSchema").exists(_.toBoolean)) {
-      meta.willNotWorkOnGpu("mergeSchema and schema evolution is not supported yet")
-    }
   }
 
   private lazy val numericLevels = Seq(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
@@ -61,9 +61,6 @@ class GpuReadOrcFileFormat extends OrcFileFormat with GpuReadFileFormatWithMetri
 object GpuReadOrcFileFormat {
   def tagSupport(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     val fsse = meta.wrapped
-    if (fsse.relation.options.getOrElse("mergeSchema", "false").toBoolean) {
-      meta.willNotWorkOnGpu("mergeSchema and schema evolution is not supported yet")
-    }
     GpuOrcScan.tagSupport(
       SparkShimImpl.sessionFromPlan(fsse),
       fsse.requiredSchema,


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/135.

It is safe to enable the `mergeSchema` because it does not need all the schema evolution functionalities(even we have done most part, see https://github.com/NVIDIA/spark-rapids/issues/5895), and only the support of adding/re-order columns ([already supported on GPU](https://github.com/NVIDIA/spark-rapids/blob/branch-22.10/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala#L846)) will be enough according to the [Schema Merging](https://spark.apache.org/docs/3.3.0/sql-data-sources-parquet.html#schema-merging) doc (Maybe I missed some cases).

Type casting should not happen for `mergeSchema`, because Spark will fail the query if two columns has the same name but different types.
```
scala> val mergedDF = spark.read.option("mergeSchema", "true").parquet("data/test_table")
org.apache.spark.SparkException: Failed merging schema:
root
 |-- value: long (nullable = false)
 |-- cube: integer (nullable = false)

  at org.apache.spark.sql.errors.QueryExecutionErrors$.failedMergingSchemaError(QueryExecutionErrors.scala:1801)
  at org.apache.spark.sql.execution.datasources.SchemaMergeUtils$.$anonfun$mergeSchemasInParallel$5(SchemaMergeUtils.scala:101)
  ...
  at org.apache.spark.sql.DataFrameReader.parquet(DataFrameReader.scala:547)
  ... 49 elided
Caused by: org.apache.spark.SparkException: Failed to merge fields 'value' and 'value'. Failed to merge incompatible data types int and bigint
  at org.apache.spark.sql.errors.QueryExecutionErrors$.failedMergingFieldsError(QueryExecutionErrors.scala:1015)
  at org.apache.spark.sql.types.StructType$.$anonfun$merge$3(StructType.scala:604)
  at scala.Option.map(Option.scala:230)
...
  at org.apache.spark.sql.types.StructType$.$anonfun$merge$1(StructType.scala:594)
  at org.apache.spark.sql.types.StructType$.mergeInternal(StructType.scala:641)
  at org.apache.spark.sql.types.StructType$.merge(StructType.scala:588)
  at org.apache.spark.sql.types.StructType.merge(StructType.scala:496)
  at org.apache.spark.sql.execution.datasources.SchemaMergeUtils$.$anonfun$mergeSchemasInParallel$5(SchemaMergeUtils.scala:99)

```

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
