### PR TITLE
Use ShimLoader to access PlanShims

### DIFF
--- a/dist/unshimmed-from-each-spark3xx.txt
+++ b/dist/unshimmed-from-each-spark3xx.txt
@@ -2,5 +2,6 @@ com/nvidia/spark/rapids/*/RapidsShuffleManager*
 com/nvidia/spark/rapids/AvroProvider.class
 com/nvidia/spark/rapids/HiveProvider.class
 com/nvidia/spark/rapids/iceberg/IcebergProvider.class
+com/nvidia/spark/rapids/PlanShims*
 org/apache/spark/sql/rapids/shims/*/ProxyRapidsShuffleInternalManager*
 spark-*-info.properties

--- a/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
+++ b/sql-plugin/src/main/311until320-all/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
@@ -16,11 +16,10 @@
 
 package com.nvidia.spark.rapids.shims
 
-import org.apache.spark.sql.execution.{CommandResultExec, SparkPlan}
+import com.nvidia.spark.rapids.PlanShims
 
-object PlanShims {
-  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan match {
-    case p: CommandResultExec => p.commandPhysicalPlan
-    case _ => plan
-  }
+import org.apache.spark.sql.execution.SparkPlan
+
+class PlanShimsImpl extends PlanShims {
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan
 }

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
@@ -16,8 +16,13 @@
 
 package com.nvidia.spark.rapids.shims
 
-import org.apache.spark.sql.execution.SparkPlan
+import com.nvidia.spark.rapids.PlanShims
 
-object PlanShims {
-  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan
+import org.apache.spark.sql.execution.{CommandResultExec, SparkPlan}
+
+class PlanShimsImpl extends PlanShims {
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = plan match {
+    case p: CommandResultExec => p.commandPhysicalPlan
+    case _ => plan
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PlanShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PlanShims.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.execution.SparkPlan
+
+trait PlanShims {
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan
+}
+
+object PlanShims {
+  private lazy val shims = ShimLoader.newPlanShims()
+
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = {
+    shims.extractExecutedPlan(plan)
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -27,7 +27,6 @@ import scala.util.matching.Regex
 
 import ai.rapids.cudf.{CudaException, CudaFatalException, CudfException, MemoryCleaner}
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
-import com.nvidia.spark.rapids.shims.PlanShims
 
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -409,4 +409,8 @@ object ShimLoader extends Logging {
 
   def newIcebergProvider(): IcebergProvider = ShimLoader.newInstanceOf[IcebergProvider](
     "com.nvidia.spark.rapids.iceberg.IcebergProviderImpl")
+
+  def newPlanShims(): PlanShims = ShimLoader.newInstanceOf[PlanShims](
+    "com.nvidia.spark.rapids.shims.PlanShimsImpl"
+  )
 }


### PR DESCRIPTION
Fixes #6520.  Moves PlanShims implementation to PlanShimsImpl and provides an unshimmed PlanShims interface to access the implementation via ShimLoader.