### PR TITLE
Fixes for recent cuDF regexp changes

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -36,7 +36,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     val cudfInvalidPatterns = Seq(
       "\t+|a",
       "(\t+|a)Dc$1",
-      "$|$[^\n]2]}|B",
       "a^|b",
       "w$|b",
       "\n[^\r\n]x*|^3x",
@@ -46,6 +45,13 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     for (pattern <- cudfInvalidPatterns) {
       assertUnsupported(pattern, RegexFindMode,
         "cuDF does not support repetition on one side of a choice")
+    }
+    val cudfInvalidPatterns2 = Seq(
+      "$|$[^\n]2]}|B"
+    )
+    for (pattern <- cudfInvalidPatterns2) {
+      assertUnsupported(pattern, RegexFindMode,
+        "End of line/string anchor is not supported in this context")
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -33,25 +33,17 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   test("") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged
     // but we still reject them because we see failures in fuzz testing if we allow them
-    val cudfInvalidPatterns = Seq(
-      "\t+|a",
-      "(\t+|a)Dc$1",
-      "a^|b",
-      "w$|b",
-      "\n[^\r\n]x*|^3x",
-      "]*\\wWW$|zb",
-      "(\\A|\\05)?"
-    )
-    for (pattern <- cudfInvalidPatterns) {
+    for (pattern <- Seq("\t+|a", "(\t+|a)Dc$1", "\n[^\r\n]x*|^3x")) {
       assertUnsupported(pattern, RegexFindMode,
         "cuDF does not support repetition on one side of a choice")
     }
-    val cudfInvalidPatterns2 = Seq(
-      "$|$[^\n]2]}|B"
-    )
-    for (pattern <- cudfInvalidPatterns2) {
+    for (pattern <- Seq("$|$[^\n]2]}|B")) {
       assertUnsupported(pattern, RegexFindMode,
         "End of line/string anchor is not supported in this context")
+    }
+    for (pattern <- Seq("a^|b", "w$|b", "]*\\wWW$|zb", "(\\A|\\05)?")) {
+      assertUnsupported(pattern, RegexFindMode,
+        "cuDF does not support terms ending with line anchors on one side of a choice")
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
-  test("") {
+  test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged
     // but we still reject them because we see failures in fuzz testing if we allow them
     for (pattern <- Seq("\t+|a", "(\t+|a)Dc$1", "\n[^\r\n]x*|^3x")) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -44,7 +44,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
       "(\\A|\\05)?"
     )
     for (pattern <- cudfInvalidPatterns) {
-      assertUnsupported(pattern, RegexFindMode, "invalid regex pattern: nothing to repeat")
+      assertUnsupported(pattern, RegexFindMode,
+        "cuDF does not support repetition on one side of a choice")
     }
   }
 
@@ -111,15 +112,16 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("cuDF unsupported choice cases") {
-    val input = Seq("cat", "dog")
     val patterns = Seq("c*|d*", "c*|dog", "[cat]{3}|dog")
     patterns.foreach(pattern => {
-      assertUnsupported(pattern, RegexFindMode, "invalid regex pattern: nothing to repeat")
+      assertUnsupported(pattern, RegexFindMode,
+        "cuDF does not support repetition on one side of a choice")
     })
   }
 
   test("sanity check: choice edge case 2") {
-    assertUnsupported("c+|d+", RegexFindMode, "invalid regex pattern: nothing to repeat")
+    assertUnsupported("c+|d+", RegexFindMode,
+      "cuDF does not support repetition on one side of a choice")
   }
 
   test("newline before $ in replace mode") {
@@ -149,8 +151,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     // note that we could choose to transpile and escape the '{' and '}' characters
     val patterns = Seq("{1,2}", "{1,}", "{1}")
     patterns.foreach(pattern => {
-      println(pattern)
-      assertUnsupported(pattern, RegexFindMode, 
+      assertUnsupported(pattern, RegexFindMode,
         "Token preceding '{' is not quantifiable near index 0")
         }
     )

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -37,15 +37,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     // random inputs.
     val cudfInvalidPatterns = Seq(
       "a*+",
-      "\t+|a",
-      "(\t+|a)Dc$1",
-      "(?d)",
-      "$|$[^\n]2]}|B",
-      "a^|b",
-      "w$|b",
-      "\n[^\r\n]x*|^3x",
-      "]*\\wWW$|zb",
-      "(\\A|\\05)?"
+      "(?d)"
     )
     // data is not relevant because we are checking for compilation errors
     val inputs = Seq("a")
@@ -87,7 +79,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   test("cuDF does not support choice with repetition") {
     val patterns = Seq("b+|^\t")
     patterns.foreach(pattern =>
-      assertUnsupported(pattern, RegexFindMode, 
+      assertUnsupported(pattern, RegexFindMode,
         "cuDF does not support repetition on one side of a choice")
     )
   }
@@ -100,7 +92,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     )
   }
 
-  test("cuDF unsupported choice cases") {
+  ignore("cuDF unsupported choice cases") {
     val input = Seq("cat", "dog")
     val patterns = Seq("c*|d*", "c*|dog", "[cat]{3}|dog")
     patterns.foreach(pattern => {
@@ -111,7 +103,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     })
   }
 
-  test("sanity check: choice edge case 2") {
+  ignore("sanity check: choice edge case 2") {
     assertThrows[CudfException] {
       gpuContains("c+|d+", Seq("cat", "dog"))
     }
@@ -142,10 +134,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("cuDF does not support quantifier syntax when not quantifying anything") {
     // note that we could choose to transpile and escape the '{' and '}' characters
-    val patterns = Seq("{1,2}", "{1,}", "{1}", "{2,1}")
-    patterns.foreach(pattern =>
+    val patterns = Seq("{1,2}", "{1,}", "{1}")
+    patterns.foreach(pattern => {
+      println(pattern)
       assertUnsupported(pattern, RegexFindMode, 
         "Token preceding '{' is not quantifiable near index 0")
+        }
     )
   }
 
@@ -376,7 +370,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("transpile character class unescaped range symbol") {
     val patterns = Seq("a[-b]", "a[+-]", "a[-+]", "a[-]", "a[^-]")
-    val expected = Seq(raw"a[\-b]", raw"a[+\-]", raw"a[\-+]", raw"a[\-]", "a(?:[\r\n]|[^\\-])")
+    val expected = Seq(raw"a[\-b]", raw"a[+\-]", raw"a[\-+]", raw"a[\-]", "a(?:[\r]|[^\\-])")
     val transpiler = new CudfRegexTranspiler(RegexFindMode)
     val transpiled = patterns.map(transpiler.transpile(_, None)._1)
     assert(transpiled === expected)


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/6518

There are two recent cuDF changes that impact us:

- https://github.com/rapidsai/cudf/pull/11644
- https://github.com/rapidsai/cudf/pull/11654

This PR aims to make minimal changes just to fix the build. We should leave the issue open for any follow on work that we identify through the PR review.