### PR TITLE
Allow percent_rank to not need an entire group in memory [databricks]

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -702,6 +702,29 @@ def test_multi_types_window_aggs_for_rows(a_b_gen, c_gen):
     assert_gpu_and_cpu_are_equal_collect(do_it, conf={'spark.rapids.sql.hasNans': 'false'})
 
 
+def test_percent_rank_no_part_multiple_batches():
+    data_gen = [('a', long_gen)]
+    # The goal of this is to have multiple batches so we can verify that the code
+    # is working properly, but not so large that it takes forever to run.
+    baseWindowSpec = Window.orderBy('a')
+
+    def do_it(spark):
+        return gen_df(spark, data_gen, length=8000) \
+                .withColumn('percent_rank_val', f.percent_rank().over(baseWindowSpec))
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {'spark.rapids.sql.batchSizeBytes': '100'})
+
+def test_percent_rank_single_part_multiple_batches():
+    data_gen = [('a', long_gen)]
+    # The goal of this is to have multiple batches so we can verify that the code
+    # is working properly, but not so large that it takes forever to run.
+    baseWindowSpec = Window.partitionBy('b').orderBy('a')
+
+    def do_it(spark):
+        return gen_df(spark, data_gen, length=8000) \
+                .withColumn('b', f.lit(1)) \
+                .withColumn('percent_rank_val', f.percent_rank().over(baseWindowSpec))
+    assert_gpu_and_cpu_are_equal_collect(do_it, conf = {'spark.rapids.sql.batchSizeBytes': '100'})
+
 @pytest.mark.skipif(is_before_spark_320(), reason="Only in Spark 3.2.0 is IGNORE NULLS supported for lead and lag by Spark")
 @allow_non_gpu('WindowExec', 'Alias', 'WindowExpression', 'Lead', 'Literal', 'WindowSpecDefinition', 'SpecifiedWindowFrame')
 @ignore_order(local=True)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -29,7 +29,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, AttributeSeq, AttributeSet, CurrentRow, Expression, FrameType, NamedExpression, RangeFrame, RowFrame, SortOrder, UnboundedPreceding}
+import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, AttributeSeq, AttributeSet, CurrentRow, Expression, FrameType, NamedExpression, RangeFrame, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.window.WindowExec
@@ -132,20 +132,9 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
       remappedWindowOps
     }
 
-    // When we support multiple ways to avoid batching the input data like with
-    // https://github.com/NVIDIA/spark-rapids/issues/1860 we should check if all of
-    // the operations fit into one of the supported groups and then split them up into
-    // multiple execs if they do, so that we can avoid batching on all of them.
-    val allBatchedRunning = fixedUpWindowOps.forall {
+    val allBatched = fixedUpWindowOps.forall {
       case GpuAlias(GpuWindowExpression(func, spec), _) =>
-        val isRunningFunc = func match {
-          case _: GpuBatchedRunningWindowWithFixer => true
-          case GpuAggregateExpression(_: GpuBatchedRunningWindowWithFixer, _, _, _ , _) => true
-          case _ => false
-        }
-        // Running windows are limited to row based queries with a few changes we could make this
-        // work for range based queries too https://github.com/NVIDIA/spark-rapids/issues/2708
-        isRunningFunc && GpuWindowExec.isRunningWindow(spec)
+        GpuWindowExec.isBatchedFunc(func, spec)
       case GpuAlias(_: AttributeReference, _) | _: AttributeReference =>
         // We allow pure result columns for running windows
         true
@@ -162,12 +151,14 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
       childPlans.head.convertIfNeeded()
     }
 
-    val windowExpr = if (allBatchedRunning) {
-      GpuRunningWindowExec(
-        fixedUpWindowOps,
+    val windowExpr = if (allBatched) {
+      val batchedOps = GpuWindowExec.splitBatchedOps(fixedUpWindowOps)
+      batchedOps.getWindowExec(
         partitionSpec.map(_.convertToGpu()),
         orderSpec.map(_.convertToGpu().asInstanceOf[SortOrder]),
-        input)(getPartitionSpecs, getOrderSpecs)
+        input,
+        getPartitionSpecs,
+        getOrderSpecs)
     } else {
       GpuWindowExec(
         fixedUpWindowOps,
@@ -231,10 +222,71 @@ class GpuWindowExecMeta(windowExec: WindowExec,
   override def getResultColumnsOnly: Boolean = resultColumnsOnly
 }
 
+case class BatchedOps(running: Seq[NamedExpression],
+    unboundedToUnbounded: Seq[NamedExpression],
+    passThrough: Seq[NamedExpression]) {
+  def getRunningExpressionsWithPassthrough: Seq[NamedExpression] =
+    passThrough ++ running
+
+  private def getRunningWindowExec(
+      gpuPartitionSpec: Seq[Expression],
+      gpuOrderSpec: Seq[SortOrder],
+      child: SparkPlan,
+      cpuPartitionSpec: Seq[Expression],
+      cpuOrderSpec: Seq[SortOrder]): GpuExec =
+    GpuRunningWindowExec(
+      getRunningExpressionsWithPassthrough,
+      gpuPartitionSpec,
+      gpuOrderSpec,
+      child)(cpuPartitionSpec, cpuOrderSpec)
+
+  private def getDoublePassWindowExec(
+      gpuPartitionSpec: Seq[Expression],
+      gpuOrderSpec: Seq[SortOrder],
+      child: SparkPlan,
+      cpuPartitionSpec: Seq[Expression],
+      cpuOrderSpec: Seq[SortOrder]): GpuExec =
+    GpuCachedDoublePassWindowExec(
+      getDoublePassExpressionsWithRunningAsPassthrough,
+      gpuPartitionSpec,
+      gpuOrderSpec,
+      child)(cpuPartitionSpec, cpuOrderSpec)
+
+  def getWindowExec(
+      gpuPartitionSpec: Seq[Expression],
+      gpuOrderSpec: Seq[SortOrder],
+      child: SparkPlan,
+      cpuPartitionSpec: Seq[Expression],
+      cpuOrderSpec: Seq[SortOrder]): GpuExec = {
+    // The order of these matter so we can pass the output of the first through the second one
+    if (hasRunning) {
+      val running = getRunningWindowExec(gpuPartitionSpec, gpuOrderSpec, child,
+        cpuPartitionSpec, cpuOrderSpec)
+      if (hasDoublePass) {
+        getDoublePassWindowExec(gpuPartitionSpec, gpuOrderSpec, running,
+          cpuPartitionSpec, cpuOrderSpec)
+      } else {
+        running
+      }
+    } else {
+      getDoublePassWindowExec(gpuPartitionSpec, gpuOrderSpec, child,
+        cpuPartitionSpec, cpuOrderSpec)
+    }
+  }
+
+  def hasRunning: Boolean = running.nonEmpty
+
+  def getDoublePassExpressionsWithRunningAsPassthrough: Seq[NamedExpression] =
+    passThrough ++ unboundedToUnbounded ++ running.map(_.toAttribute)
+
+  def hasDoublePass: Boolean = unboundedToUnbounded.nonEmpty
+}
+
 object GpuWindowExec extends Arm {
   /**
    * As a part of `splitAndDedup` the dedup part adds a layer of indirection. This attempts to
    * remove that layer of indirection.
+   *
    * @param windowOps the windowOps output of splitAndDedup
    * @param post the post output of splitAndDedup
    * @return a version of windowOps that has removed as many un-needed temp aliases as possible.
@@ -381,6 +433,60 @@ object GpuWindowExec extends Arm {
     GpuSpecialFrameBoundary(UnboundedPreceding), GpuLiteral(value, _))) if value == 0 => true
     case _ => false
   }
+
+  def isUnboundedToUnboundedWindow(spec: GpuWindowSpecDefinition): Boolean = spec match {
+    case GpuWindowSpecDefinition(_, _, GpuSpecifiedWindowFrame(_,
+    GpuSpecialFrameBoundary(UnboundedPreceding),
+    GpuSpecialFrameBoundary(UnboundedFollowing))) => true
+    case _ => false
+  }
+
+  def isBatchedRunningFunc(func: Expression, spec: GpuWindowSpecDefinition): Boolean = {
+    val isSpecOkay = isRunningWindow(spec)
+    val isFuncOkay = func match {
+      case _: GpuBatchedRunningWindowWithFixer => true
+      case GpuAggregateExpression(_: GpuBatchedRunningWindowWithFixer, _, _, _ , _) => true
+      case _ => false
+    }
+    isSpecOkay && isFuncOkay
+  }
+
+  def isBatchedUnboundedToUnboundedFunc(func: Expression, spec: GpuWindowSpecDefinition): Boolean =
+    func match {
+      case _: GpuUnboundToUnboundWindowWithFixer
+        if GpuWindowExec.isUnboundedToUnboundedWindow(spec) => true
+      case GpuAggregateExpression(_: GpuUnboundToUnboundWindowWithFixer, _, _, _ , _)
+        if GpuWindowExec.isUnboundedToUnboundedWindow(spec) => true
+      case _ => false
+    }
+
+  def isBatchedFunc(func: Expression, spec: GpuWindowSpecDefinition): Boolean =
+    isBatchedRunningFunc(func, spec) || isBatchedUnboundedToUnboundedFunc(func, spec)
+
+  def splitBatchedOps(windowOps: Seq[NamedExpression]): BatchedOps = {
+    val running = ArrayBuffer[NamedExpression]()
+    val doublePass = ArrayBuffer[NamedExpression]()
+    val passThrough = ArrayBuffer[NamedExpression]()
+    windowOps.foreach {
+      case expr@GpuAlias(GpuWindowExpression(func, spec), _) =>
+        if (isBatchedRunningFunc(func, spec)) {
+          running.append(expr)
+        } else if (isBatchedUnboundedToUnboundedFunc(func, spec)) {
+          doublePass.append(expr)
+        } else {
+          throw new IllegalArgumentException(
+            s"Found unexpected expression $expr in window exec ${expr.getClass}")
+        }
+      case expr@(GpuAlias(_: AttributeReference, _) | _: AttributeReference) =>
+        passThrough.append(expr)
+      case other =>
+        // This should only happen if we did something wrong in splitting/deduping
+        // the window expressions.
+        throw new IllegalArgumentException(
+          s"Found unexpected expression $other in window exec ${other.getClass}")
+    }
+    BatchedOps(running, doublePass, passThrough)
+  }
 }
 
 trait GpuWindowBaseExec extends ShimUnaryExecNode with GpuExec {
@@ -392,9 +498,17 @@ trait GpuWindowBaseExec extends ShimUnaryExecNode with GpuExec {
 
   import GpuMetric._
 
-  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
-    OP_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME)
-  )
+  def needsSpillMetrics: Boolean = false
+
+  override lazy val additionalMetrics: Map[String, GpuMetric] = {
+    val required = Map(
+      OP_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME))
+    if (needsSpillMetrics) {
+      required ++ spillMetrics
+    } else {
+      required
+    }
+  }
 
   override def output: Seq[Attribute] = windowOps.map(_.toAttribute)
 
@@ -1108,8 +1222,8 @@ class GpuWindowIterator(
   }
 }
 
-object GpuRunningWindowIterator extends Arm {
-  private def cudfAnd(lhs: cudf.ColumnVector,
+object GpuBatchedWindowIterator extends Arm {
+  def cudfAnd(lhs: cudf.ColumnVector,
       rhs: cudf.ColumnVector): cudf.ColumnVector = {
     withResource(lhs) { lhs =>
       withResource(rhs) { rhs =>
@@ -1118,7 +1232,22 @@ object GpuRunningWindowIterator extends Arm {
     }
   }
 
-  private def arePartsEqual(
+  def areRowPartsEqual(
+      scalars: Seq[Scalar],
+      columns: Seq[cudf.ColumnVector],
+      indexes: Seq[Int]): Array[Boolean] = {
+    withResourceIfAllowed(arePartsEqual(scalars, columns)) {
+      case scala.util.Right(ret) => Seq.fill(indexes.length)(ret).toArray
+      case scala.util.Left(column) =>
+        indexes.map { index =>
+          withResource(column.getScalarElement(index)) { scalar =>
+            scalar.isValid && scalar.getBoolean
+          }
+        }.toArray
+    }
+  }
+
+  def arePartsEqual(
       scalars: Seq[Scalar],
       columns: Seq[cudf.ColumnVector]): Either[cudf.ColumnVector, Boolean] = {
     if (scalars.length != columns.length) {
@@ -1159,7 +1288,7 @@ object GpuRunningWindowIterator extends Arm {
     }
   }
 
-  private def areOrdersEqual(
+  def areOrdersEqual(
       scalars: Seq[Scalar],
       columns: Seq[cudf.ColumnVector],
       partsEqual: Either[cudf.ColumnVector, Boolean]): Either[cudf.ColumnVector, Boolean] = {
@@ -1185,7 +1314,7 @@ object GpuRunningWindowIterator extends Arm {
     }
   }
 
-  private def getScalarRow(index: Int, columns: Seq[cudf.ColumnVector]): Array[Scalar] =
+  def getScalarRow(index: Int, columns: Seq[cudf.ColumnVector]): Array[Scalar] =
     columns.map(_.getScalarElement(index)).toArray
 }
 
@@ -1205,7 +1334,7 @@ class GpuRunningWindowIterator(
     numOutputBatches: GpuMetric,
     numOutputRows: GpuMetric,
     opTime: GpuMetric) extends Iterator[ColumnarBatch] with BasicWindowCalc {
-  import GpuRunningWindowIterator._
+  import GpuBatchedWindowIterator._
   TaskContext.get().addTaskCompletionListener[Unit](_ => close())
 
   override def isRunningBatched: Boolean = true
@@ -1344,6 +1473,12 @@ class GpuRunningWindowIterator(
   }
 }
 
+/**
+ * This allows for batches of data to be processed without needing them to correspond to
+ * the partition by boundaries, but only for window operations that are unbounded preceding
+ * to current row (Running Window). This works because a small amount of data can be saved
+ * from a previous batch and used to update the current batch.
+ */
 case class GpuRunningWindowExec(
     windowOps: Seq[NamedExpression],
     gpuPartitionSpec: Seq[Expression],
@@ -1366,6 +1501,316 @@ case class GpuRunningWindowExec(
     child.executeColumnar().mapPartitions { iter =>
       new GpuRunningWindowIterator(iter, boundWindowOps, boundPartitionSpec, boundOrderSpec,
         output.map(_.dataType).toArray, numOutputBatches, numOutputRows, opTime)
+    }
+  }
+}
+
+class FixerPair(op: GpuUnboundToUnboundWindowWithFixer) extends AutoCloseable {
+  var fixing: BatchedUnboundedToUnboundedWindowFixer = op.newUnboundedToUnboundedFixer
+  var collecting: BatchedUnboundedToUnboundedWindowFixer = op.newUnboundedToUnboundedFixer
+
+  def updateState(scalar: Scalar): Unit = {
+    collecting.updateState(scalar)
+  }
+
+  def fixUp(samePartitionMask: Either[cudf.ColumnVector, Boolean],
+      column: cudf.ColumnVector): cudf.ColumnVector =
+    fixing.fixUp(samePartitionMask, column)
+
+  def swap: Unit = {
+    val tmp = fixing
+    tmp.reset()
+    fixing = collecting
+    collecting = tmp
+  }
+
+  override def close(): Unit = {
+    fixing.close()
+    collecting.close()
+  }
+}
+
+/**
+ * An iterator that can do aggregations on window queries that need a small amount of
+ * information from all of the batches to update the result in a second pass. It does this by
+ * having the aggregations be instances of GpuUnboundToUnboundWindowWithFixer
+ * which can fix up the window output for unbounded to unbounded windows.
+ * Because of this there is no requirement about how the input data is batched, but it  must
+ * be sorted by both partitioning and ordering.
+ */
+class GpuCachedDoublePassWindowIterator(
+    input: Iterator[ColumnarBatch],
+    override val boundWindowOps: Seq[GpuExpression],
+    override val boundPartitionSpec: Seq[GpuExpression],
+    override val boundOrderSpec: Seq[SortOrder],
+    val outputTypes: Array[DataType],
+    numOutputBatches: GpuMetric,
+    numOutputRows: GpuMetric,
+    opTime: GpuMetric,
+    spillCallback: SpillCallback) extends Iterator[ColumnarBatch] with BasicWindowCalc {
+  import GpuBatchedWindowIterator._
+  TaskContext.get().addTaskCompletionListener[Unit](_ => close())
+
+  override def isRunningBatched: Boolean = true
+
+  private var readyForPostProcessing = mutable.Queue[SpillableColumnarBatch]()
+  private var firstPassProcessed = mutable.Queue[SpillableColumnarBatch]()
+  // This should only ever be cached in between calls to `hasNext` and `next`.
+  // This is just to let us filter out empty batches.
+  private var waitingForFirstPass: Option[ColumnarBatch] = None
+  private var lastPartsCaching: Array[Scalar] = Array.empty
+  private var lastPartsProcessing: Array[Scalar] = Array.empty
+  private var isClosed: Boolean = false
+
+  private def saveLastPartsCaching(newLastParts: Array[Scalar]): Unit = {
+    lastPartsCaching.foreach(_.close())
+    lastPartsCaching = newLastParts
+  }
+
+  def close(): Unit = {
+    if (!isClosed) {
+      isClosed = true
+
+      fixerIndexMap.values.foreach(_.close())
+
+      saveLastPartsCaching(Array.empty)
+
+      lastPartsProcessing.foreach(_.close())
+      lastPartsProcessing = Array.empty
+
+      firstPassProcessed.foreach(_.close())
+      firstPassProcessed = mutable.Queue[SpillableColumnarBatch]()
+
+      readyForPostProcessing.foreach(_.close())
+      readyForPostProcessing = mutable.Queue[SpillableColumnarBatch]()
+    }
+  }
+
+  private lazy val fixerIndexMap: Map[Int, FixerPair] =
+    boundWindowOps.zipWithIndex.flatMap {
+      case (GpuAlias(GpuWindowExpression(func, _), _), index) =>
+        func match {
+          case f: GpuUnboundToUnboundWindowWithFixer =>
+            Some((index, new FixerPair(f)))
+          case GpuAggregateExpression(f: GpuUnboundToUnboundWindowWithFixer, _, _, _, _) =>
+            Some((index, new FixerPair(f)))
+          case _ => None
+        }
+      case _ => None
+    }.toMap
+
+  // Do any post processing fixup for the batch before it is sent out the door
+  def postProcess(cb: ColumnarBatch): ColumnarBatch = {
+    val computedWindows = GpuColumnVector.extractBases(cb)
+    withResource(GpuProjectExec.project(cb, boundPartitionSpec)) { parts =>
+      val partColumns = GpuColumnVector.extractBases(parts)
+      withResourceIfAllowed(arePartsEqual(lastPartsProcessing, partColumns)) { samePartitionMask =>
+        withResource(ArrayBuffer[cudf.ColumnVector]()) { newColumns =>
+          boundWindowOps.indices.foreach { idx =>
+            val column = computedWindows(idx)
+            fixerIndexMap.get(idx) match {
+              case Some(fixer) =>
+                closeOnExcept(fixer.fixUp(samePartitionMask, column)) { finalOutput =>
+                  newColumns += finalOutput
+                }
+              case None =>
+                newColumns += column.incRefCount()
+            }
+          }
+          makeBatch(newColumns)
+        }
+      }
+    }
+  }
+
+  def makeBatch(columns: Seq[cudf.ColumnVector]): ColumnarBatch = {
+    withResource(new cudf.Table(columns: _*)) { table =>
+      GpuColumnVector.from(table, outputTypes)
+    }
+  }
+
+  def swapFirstPassIsReadyForPost(): Unit = {
+    // Swap the caching so it is ready to be used for updating
+    fixerIndexMap.values.foreach(_.swap)
+
+    // Swap the parts so we know what mask to use for updating
+    lastPartsProcessing = lastPartsCaching
+    lastPartsCaching = Array.empty
+
+    // Swap the queues so we are ready to dequeue the data
+    readyForPostProcessing = firstPassProcessed
+    firstPassProcessed = mutable.Queue[SpillableColumnarBatch]()
+  }
+
+  // The last batch was already processed so everything in processed needs to be moved to
+  // readyForPostProcessing
+  def lastBatch(): Unit = swapFirstPassIsReadyForPost()
+
+  private def cacheInFixers(computedWindows: Array[cudf.ColumnVector],
+      fixers: Map[Int, FixerPair],
+      rowIndex: Int): Unit =
+    fixers.foreach {
+      case (columnIndex, fixer) =>
+        val column = computedWindows(columnIndex)
+        withResource(column.getScalarElement(rowIndex)) { scalar =>
+          fixer.updateState(scalar)
+        }
+    }
+
+  def saveBatchForPostProcessing(batch: ColumnarBatch): Unit = {
+    firstPassProcessed += SpillableColumnarBatch(batch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY,
+      spillCallback)
+  }
+
+  def saveBatchForPostProcessing(basic: Array[cudf.ColumnVector]): Unit = {
+    closeOnExcept(makeBatch(basic)) { batch =>
+      saveBatchForPostProcessing(batch)
+    }
+  }
+
+  // Compute the window operation and cache/update caches as needed.
+  def firstPassComputeAndCache(cb: ColumnarBatch): Unit = {
+    val fixers = fixerIndexMap
+    val numRows = cb.numRows()
+    withResource(computeBasicWindow(cb)) { basic =>
+      withResource(GpuProjectExec.project(cb, boundPartitionSpec)) { parts =>
+        val partColumns = GpuColumnVector.extractBases(parts)
+
+        val firstLastEqual = areRowPartsEqual(lastPartsCaching, partColumns, Seq(0, numRows - 1))
+        val firstEqual = firstLastEqual(0)
+        val lastEqual = firstLastEqual(1)
+        if (firstEqual) {
+          // This batch is a continuation of the previous batch so we need to update the
+          // fixer with info from it.
+          // This assumes that the window is unbounded to unbounded. We will need to update
+          // APIs in the future and rename things if we want to support more than this.
+          cacheInFixers(basic, fixers, 0)
+        }
+
+        // If the last part entry in this batch does not match the last entry in the previous batch
+        // then we need to start post-processing the batches.
+        if (!lastEqual) {
+          // We swap the fixers and queues so we are ready to start on the next partition by group
+          swapFirstPassIsReadyForPost()
+          // Collect/Cache the needed info from the end of this batch
+          cacheInFixers(basic, fixers, numRows - 1)
+          saveLastPartsCaching(getScalarRow(numRows - 1, partColumns))
+
+          if (firstEqual) {
+            // Process the batch now, but it will only be for the first part of the batch
+            // the last part may need to be fixed again, so put it into the queue for
+            // when the next round finishes.
+            val processedBatch = withResource(makeBatch(basic)) { basicBatch =>
+              postProcess(basicBatch)
+            }
+            closeOnExcept(processedBatch) { processedBatch =>
+              saveBatchForPostProcessing(processedBatch)
+            }
+          } else {
+            // We split on a partition boundary, so just need to save it
+            saveBatchForPostProcessing(basic)
+          }
+        } else {
+          // No need to save the parts, it was equal...
+          saveBatchForPostProcessing(basic)
+        }
+      }
+    }
+  }
+
+  private def cacheBatchIfNeeded(): Unit = {
+    while (waitingForFirstPass.isEmpty && input.hasNext) {
+      closeOnExcept(input.next()) { cb =>
+        if (cb.numRows() > 0) {
+          waitingForFirstPass = Some(cb)
+        } else {
+          cb.close()
+        }
+      }
+    }
+  }
+
+  override def hasNext: Boolean = {
+    if (readyForPostProcessing.nonEmpty || firstPassProcessed.nonEmpty) {
+      true
+    } else {
+      cacheBatchIfNeeded()
+      waitingForFirstPass.isDefined
+    }
+  }
+
+  override def next(): ColumnarBatch = {
+    if (!hasNext) {
+      throw new NoSuchElementException()
+    }
+    while (readyForPostProcessing.isEmpty) {
+      // Keep reading and processing data until we have something to output
+      cacheBatchIfNeeded()
+      if (waitingForFirstPass.isEmpty) {
+        lastBatch()
+      } else {
+        withResource(waitingForFirstPass.get) { cb =>
+          waitingForFirstPass = None
+          withResource(
+            new NvtxWithMetrics("DoubleBatchedWindow_PRE", NvtxColor.CYAN, opTime)) { _ =>
+            firstPassComputeAndCache(cb)
+          }
+        }
+      }
+    }
+    val cb = withResource(readyForPostProcessing.dequeue()) { sb =>
+      sb.getColumnarBatch()
+    }
+    withResource(cb) { cb =>
+      val ret = withResource(
+        new NvtxWithMetrics("DoubleBatchedWindow_POST", NvtxColor.BLUE, opTime)) { _ =>
+        postProcess(cb)
+      }
+      numOutputBatches += 1
+      numOutputRows += ret.numRows()
+      ret
+    }
+  }
+}
+
+/**
+ * This allows for batches of data to be processed without needing them to correspond to
+ * the partition by boundaries. This is similar to GpuRunningWindowExec, but for operations
+ * that need a small amount of information from all of the batches associated with a partition
+ * instead of just the previous batch. It does this by processing a batch, collecting and
+ * updating a small cache of information about the last partition in the batch, and then putting
+ * that batch into a form that would let it be spilled if needed. A batch is released when the
+ * last partition key in the batch is fully processed. Before it is released it will be updated
+ * to include any information needed from the cached data.
+ *
+ * Currently this only works for unbounded to unbounded windows, but could be extended to more.
+ */
+case class GpuCachedDoublePassWindowExec(
+    windowOps: Seq[NamedExpression],
+    gpuPartitionSpec: Seq[Expression],
+    gpuOrderSpec: Seq[SortOrder],
+    child: SparkPlan)(
+    override val cpuPartitionSpec: Seq[Expression],
+    override val cpuOrderSpec: Seq[SortOrder]) extends GpuWindowBaseExec {
+
+  override def needsSpillMetrics: Boolean = true
+
+  override def otherCopyArgs: Seq[AnyRef] = cpuPartitionSpec :: cpuOrderSpec :: Nil
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val numOutputBatches = gpuLongMetric(GpuMetric.NUM_OUTPUT_BATCHES)
+    val numOutputRows = gpuLongMetric(GpuMetric.NUM_OUTPUT_ROWS)
+    val opTime = gpuLongMetric(GpuMetric.OP_TIME)
+    val spillCallback = GpuMetric.makeSpillCallback(allMetrics)
+
+    val boundWindowOps = GpuBindReferences.bindGpuReferences(windowOps, child.output)
+    val boundPartitionSpec = GpuBindReferences.bindGpuReferences(gpuPartitionSpec, child.output)
+    val boundOrderSpec = GpuBindReferences.bindReferences(gpuOrderSpec, child.output)
+
+    child.executeColumnar().mapPartitions { iter =>
+      new GpuCachedDoublePassWindowIterator(iter, boundWindowOps, boundPartitionSpec,
+        boundOrderSpec, output.map(_.dataType).toArray, numOutputBatches, numOutputRows, opTime,
+        spillCallback)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -27,7 +27,8 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{TypeCheckFailure, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.rapids.{GpuAdd, GpuAggregateExpression, GpuCreateNamedStruct}
+import org.apache.spark.sql.rapids.{GpuAdd, GpuAggregateExpression, GpuCount, GpuCreateNamedStruct, GpuDivide, GpuSubtract}
+import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 
@@ -811,10 +812,73 @@ trait BatchedRunningWindowFixer extends AutoCloseable {
 
   def needsOrderMask: Boolean = false
 
-  protected def incRef(col: cudf.ColumnView): cudf.ColumnVector = col match {
-    case cv: cudf.ColumnVector => cv.incRefCount()
-    case _ => col.copyToColumnVector()
-  }
+  protected def incRef(col: cudf.ColumnView): cudf.ColumnVector = col.copyToColumnVector()
+}
+
+/**
+ * Provides a way to process window operations without needing to buffer and split the
+ * batches on partition by boundaries. When this happens part of a partition by key set may
+ * have been processed in the previous batches, and may need to be updated. For example
+ * if we are doing a min operation with unbounded preceding and unbounded following.
+ * We may first get in something like
+ * <code>
+ * PARTS:  1, 1,  2, 2
+ * VALUES: 2, 3, 10, 9
+ * </code>
+ *
+ * The output of processing this would result in a new column that would look like
+ * <code>
+ *   MINS: 2, 2, 9, 9
+ * </code>
+ *
+ * But we don't know if the group with 2 in PARTS is done or not. So the fixer saved
+ * the last value in MINS, which is a 9, and caches the batch. When the next batch shows up
+ *
+ * <code>
+ *  PARTS:  2,  2,  3,  3
+ * VALUES: 11,  5, 13, 14
+ * </code>
+ *
+ * We generate the window result again and get
+ *
+ * <code>
+ *    MINS: 5, 5, 13, 13
+ * </code>
+ *
+ * And now we need to grab the first entry which is a 5 and update the cached data with another min.
+ * The cached data for PARTS=2 is now 5. We then need to go back and fix up all of the previous
+ * batches that had something to do with PARTS=2. The first batch will be pulled from the cache
+ * and updated to look like
+ *
+ * <code>
+ *  PARTS: 1, 1,  2, 2
+ * VALUES: 2, 3, 10, 9
+ *   MINS: 2, 2,  5, 5
+ * </code>
+ * which can be output because we were able to fix up all of the PARTS in that batch.
+ */
+trait BatchedUnboundedToUnboundedWindowFixer extends AutoCloseable {
+  /**
+   * Called to fix up a batch. There is no guarantee on the order the batches are fixed. The only
+   * ordering guarantee is that the state will be updated for all batches before any are "fixed"
+   * @param samePartitionMask indicates which rows are a part of the same partition.
+   * @param column the column of data to be fixed.
+   * @return a column of data that was fixed.
+   */
+  def fixUp(samePartitionMask: Either[ColumnVector, Boolean], column: ColumnVector): ColumnVector
+
+  /**
+   * Clear any state so that updateState can be called again for a new partition by group.
+   */
+  def reset(): Unit
+
+  /**
+   * Cache and update any state needed. Because this is specific to unbounded preceding to
+   * unbounded following the result should be the same for any row within a batch. As such, this is
+   * only guaranteed to be called once per batch with the value from a row within the batch.
+   * @param scalar the value to use to update what is cached.
+   */
+  def updateState(scalar: Scalar): Unit
 }
 
 /**
@@ -826,9 +890,74 @@ trait BatchedRunningWindowFixer extends AutoCloseable {
 trait GpuBatchedRunningWindowWithFixer {
 
   /**
-   * Get a new class that can be used to fix up batched RunningWindowOperations.
+   * Get a new class that can be used to fix up batched running window operations.
    */
   def newFixer(): BatchedRunningWindowFixer
+}
+
+/**
+ * For many window operations the results in earlier rows depends on the results from the last
+ * or later rows. In many of these cases we chunk the data based off of the partition by groups
+ * and process the data at once. But this can lead to out of memory errors, or hitting the
+ * row limit on some columns. Doing two passes through the data where the first pass processes
+ * the data and a second pass fixes up the data can let us keep the data in the original batches
+ * and reduce total memory usage. But this requires that some of the batches be made spillable
+ * while we wait for the end of the partition by group.
+ *
+ * Right now this is written to be specific to windows that are unbounded preceding to unbounded
+ * following, but it could be adapted to also work for current row to unbounded following, and
+ * possibly more situations.
+ */
+trait GpuUnboundToUnboundWindowWithFixer {
+  def newUnboundedToUnboundedFixer: BatchedUnboundedToUnboundedWindowFixer
+}
+
+/**
+ * Fixes up a count operation for unbounded preceding to unbounded following
+ * @param errorOnOverflow if we need to throw an exception when an overflow happens or not.
+ */
+class CountUnboundedToUnboundedFixer(errorOnOverflow: Boolean)
+    extends BatchedUnboundedToUnboundedWindowFixer with Arm {
+  private var previousValue: Option[Long] = None
+
+  override def reset(): Unit = {
+    previousValue = None
+  }
+
+  override def updateState(scalar: Scalar): Unit = {
+    // It should be impossible for count to produce a null.
+    // Even if the input was all nulls the count is 0
+    assert(scalar.isValid)
+    if (previousValue.isEmpty) {
+      previousValue = Some(scalar.getLong)
+    } else {
+      val old = previousValue.get
+      previousValue = Some(old + scalar.getLong)
+      if (errorOnOverflow && previousValue.get < 0) {
+        // This matches what would happen in an add operation, which is where the overflow
+        // in the CPU count would happen
+        throw RapidsErrorUtils.arithmeticOverflowError(
+          "One or more rows overflow for Add operation.")
+      }
+    }
+  }
+
+  override def close(): Unit = reset()
+
+  override def fixUp(samePartitionMask: Either[ColumnVector, Boolean],
+      column: ColumnVector): ColumnVector = {
+    assert(previousValue.nonEmpty)
+    withResource(Scalar.fromLong(previousValue.get)) { scalar =>
+      samePartitionMask match {
+        case scala.Left(cv) =>
+          cv.ifElse(scalar, column)
+        case scala.Right(true) =>
+          ColumnVector.fromScalar(scalar, column.getRowCount.toInt)
+        case _ =>
+          column.incRefCount()
+      }
+    }
+  }
 }
 
 /**
@@ -1529,36 +1658,47 @@ case class GpuLag(input: Expression, offset: Expression, default: Expression)
 
 /**
  * percent_rank() is a running window function in that it only operates on a window of unbounded
- * preceding to current row. But, an entire window has to be in the batch because the rank is
- * divided by the number of entries in the window to get the percent rank. We cannot know the number
- * of entries in the window without the entire window. This is why it is not a
- * `GpuBatchedRunningWindowWithFixer`.
+ * preceding to current row. But the percent part actually makes it need a full count of the number
+ * of rows in the window. This is why we rewrite the operator to allow us to compute the result
+ * in a way that will not overflow memory.
  */
-case class GpuPercentRank(children: Seq[Expression]) extends GpuRunningWindowFunction {
+case class GpuPercentRank(children: Seq[Expression]) extends GpuReplaceWindowFunction {
   override def nullable: Boolean = false
   override def dataType: DataType = DoubleType
 
-  override def groupByScanInputProjection(isRunningBatched: Boolean): Seq[Expression] = {
-    val orderedBy = if (children.length == 1) {
-      children.head
-    } else {
-      val childrenWithNames = children.zipWithIndex.flatMap {
-        case (expr, idx) => Seq(GpuLiteral(idx.toString, StringType), expr)
-      }
-      GpuCreateNamedStruct(childrenWithNames)
-    }
-    Seq(orderedBy)
-  }
-  
-  override def groupByScanAggregation(
-      isRunningBatched: Boolean): Seq[AggAndReplace[GroupByScanAggregation]] = {
-    Seq(AggAndReplace(GroupByScanAggregation.percentRank(), None))
-  }
-
-  override def scanInputProjection(isRunningBatched: Boolean): Seq[Expression] =
-    groupByScanInputProjection(isRunningBatched)
-
-  override def scanAggregation(isRunningBatched: Boolean): Seq[AggAndReplace[ScanAggregation]] = {
-    Seq(AggAndReplace(ScanAggregation.percentRank(), None))
+  override def windowReplacement(spec: GpuWindowSpecDefinition): Expression = {
+    // Spark writes this as
+    // If(n > one, (rank - one).cast(DoubleType) / (n - one).cast(DoubleType), 0.0d)
+    // where n is the count of all values in the window and rank is the rank.
+    //
+    // The databricks docs describe it as
+    // nvl(
+    //     (rank() over (PARTITION BY p ORDER BY o) - 1) /
+    //     (nullif(count(1) over(PARTITION BY p) - 1, 0)),
+    //     0.0)
+    //
+    // We do it slightly differently to try and optimize things for the GPU.
+    // We ignore ANSI mode because the count agg will take care of overflows already
+    // and n - 1 cannot overflow. It also cannot be negative because it is COUNT(1) and 1
+    // cannot be null.
+    // A divide by 0 in non-ANSI mode produces a null, which we can use to avoid extra data copies.
+    // The If/Else from the original Spark expression on the GPU needs to split the input data to
+    // avoid the ANSI divide throwing an error on the divide by 0 that it is trying to avoid. We
+    // skip that and just take the null as output, which we can replace with 0.0 afterwards.
+    // That is the only case when we would get a null as output.
+    // From this we essentially do
+    // coalesce(CAST(rank - 1 AS DOUBLE) / CAST(n - 1 AS DOUBLE), 0.0)
+    val isAnsi = false
+    val fullUnboundedFrame = GpuSpecifiedWindowFrame(RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding),
+      GpuSpecialFrameBoundary(UnboundedFollowing))
+    val fullUnboundedSpec = GpuWindowSpecDefinition(spec.partitionSpec, spec.orderSpec,
+      fullUnboundedFrame)
+    val count = GpuWindowExpression(GpuCount(Seq(GpuLiteral(1))), fullUnboundedSpec)
+    val rank = GpuWindowExpression(GpuRank(children), spec)
+    val rankMinusOne = GpuCast(GpuSubtract(rank, GpuLiteral(1), isAnsi), DoubleType, isAnsi)
+    val countMinusOne = GpuCast(GpuSubtract(count, GpuLiteral(1L), isAnsi), DoubleType, isAnsi)
+    val divided = GpuDivide(rankMinusOne, countMinusOne, failOnErrorOverride = isAnsi)
+    GpuCoalesce(Seq(divided, GpuLiteral(0.0)))
   }
 }


### PR DESCRIPTION
This fixes #4713 
This fixes #6519 

The performance is not as high as I would like it to be.

When I ran

```
spark.time(spark.range(2000000000L).selectExpr("id DIV 300000000 as part", "id DIV 2 as data").selectExpr("*", "percent_rank() OVER (PARTITION BY part ORDER BY data) as pr").orderBy("pr", "part", "data").show())
```

on my desktop, the performance dropped from 36 seconds to 39.8 seconds. About a 10% drop in total performance for this use case.  But it is capable of running queries that would not work before, and it is 11.7x faster than the CPU for the same query (compared to 12.9x faster before). There is also a lot of potential follow on work that could improve performance. I will file and link that work here.

I mostly wanted to get this up so we could get a fix out and then deal with performance improvements later on.