### PR TITLE
Mitigate non-test failure and remove 21.xx premerge support [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -41,9 +41,6 @@ def PROJECT_VER // project version retrieved from 'version-def.sh' to determine 
 def major_ver // major version extracted from project version
 def minor_ver // minor version extracted from project version
 def PREMERGE_CI_2_ARGUMENT // argument for 'spark-premerge-build.sh' running from stage of Premerge CI 2
-def TestResult1 // keep ci_1 pytest result files that's in JUnit-XML style
-def TestResult2 // keep ci_2 pytest result files that's in JUnit-XML style
-
 def sourcePattern = 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,' +
     'sql-plugin/src/main/java/,sql-plugin/src/main/scala/'
 
@@ -73,12 +70,6 @@ ID_SPARK = 1
 ID_INITSCRIPTS = 2
 ID_INSTALL = 3
 RUNTIME_MAP = [
-        '7.3': [
-                '7.3.x-gpu-ml-scala2.12',
-                '3.0.1',
-                'init_cudf_udf.sh,init_cuda11_runtime.sh',
-                '3.0.1'
-        ],
         '9.1': [
                 '9.1.x-gpu-ml-scala2.12',
                 '3.1.2',
@@ -183,14 +174,7 @@ pipeline {
                     major_ver = versions[0].toInteger()
                     minor_ver = versions[1].toInteger()
 
-                    // TODO: remove major version 21.XX pre-merge support
-                    if (major_ver == 21) {
-                        if (minor_ver == 8) {
-                            PREMERGE_CI_2_ARGUMENT = "unit_test" // for '21.08' version
-                        } else if (minor_ver >= 10) {
-                            PREMERGE_CI_2_ARGUMENT = "ci_2" // for '21.10' or later version
-                        }
-                    } else if (major_ver >= 22) {
+                    if (major_ver >= 22) {
                         PREMERGE_CI_2_ARGUMENT = "ci_2"
                     } else {
                         error("Unsupported major version: $major_ver")
@@ -253,7 +237,7 @@ pipeline {
             when {
                 beforeAgent true
                 expression {
-                    db_build && major_ver >= 21
+                    db_build
                 }
             }
             agent {
@@ -319,8 +303,7 @@ pipeline {
                                               sourcePattern         : sourcePattern
                                         ])
                                     } finally {
-                                        // Save pytest result and publish to Jenkins at last
-                                        TestResult1 = stashPytestResult("testResult1")
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
                                     }
                                 }
                             }
@@ -333,7 +316,6 @@ pipeline {
                         beforeAgent true
                         beforeOptions true
                         anyOf {
-                            expression { major_ver >= 21 && minor_ver >= 8 }
                             expression { major_ver >= 22 }
                         }
                     }
@@ -359,8 +341,7 @@ pipeline {
                                     try {
                                         sh "$PREMERGE_SCRIPT $PREMERGE_CI_2_ARGUMENT"
                                     } finally {
-                                        // Save pytest result and publish to Jenkins at last
-                                        TestResult2 = stashPytestResult("testResult2")
+                                        common.publishPytestResult(this, "${STAGE_NAME}")
                                     }
                                 }
                             }
@@ -368,45 +349,10 @@ pipeline {
                     }
                 } // end of Unit Test stage
 
-                stage('DB runtime 7.3') {
-                    when {
-                        beforeAgent true
-                        anyOf {
-                            expression { db_build && major_ver == 21 }
-                            expression { db_build && major_ver == 22 && minor_ver <= 2 }
-                        }
-                    }
-
-                    agent {
-                        kubernetes {
-                            label "premerge-ci-db-7.3-${BUILD_NUMBER}"
-                            cloud 'sc-ipp-blossom-prod'
-                            yaml "${IMAGE_DB}"
-                        }
-                    }
-                    environment {
-                        DB_RUNTIME = '7.3'
-                        DATABRICKS_RUNTIME = "${RUNTIME_MAP["$DB_RUNTIME"][ID_RUNTIME]}"
-                        BASE_SPARK_VERSION = "${RUNTIME_MAP["$DB_RUNTIME"][ID_SPARK]}"
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = "${RUNTIME_MAP["$DB_RUNTIME"][ID_INSTALL]}"
-                        INIT_SCRIPTS = getInitScripts("$INIT_SCRIPTS_DIR",
-                                "${RUNTIME_MAP["$DB_RUNTIME"][ID_INITSCRIPTS]}")
-                    }
-                    steps {
-                        script {
-                            timeout(time: 5, unit: 'HOURS') {
-                                unstash "source_tree"
-                                databricksBuild()
-                            }
-                        }
-                    }
-                } // end of DB runtime 7.3
-
                 stage('DB runtime 9.1') {
                     when {
                         beforeAgent true
                         anyOf {
-                            expression { db_build && major_ver == 21 && minor_ver >= 12}
                             expression { db_build && major_ver >= 22 }
                         }
                     }
@@ -511,21 +457,6 @@ pipeline {
                         deleteDockerTempTag("${PREMERGE_TAG}") // clean premerge temp image
                     }
                 }
-
-                // Collect test results
-                if (TestResult1) {
-                    unstash "testResult1"
-                }
-                if (TestResult2) {
-                    unstash "testResult2"
-                }
-
-                // Record test results to Jenkins
-                if (TestResult1 || TestResult2) {
-                    junit skipPublishingChecks: true, testResults: '**/TEST-pytest*.xml'
-                } else {
-                    echo 'Skip recording test results'
-                }
             }
         }
     }
@@ -577,13 +508,17 @@ void databricksBuild() {
         stage("Test agaist $SPARK_MAJOR DB") {
             script {
                 container('cpu') {
-                    withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
-                        def TEST_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID" +
+                    try {
+                        withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
+                            def TEST_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID" +
                                 " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/test.sh -v $BASE_SPARK_VERSION -d /home/ubuntu/test.sh"
-                        if (params.SPARK_CONF) {
-                            TEST_PARAMS += " -f ${params.SPARK_CONF}"
+                            if (params.SPARK_CONF) {
+                                TEST_PARAMS += " -f ${params.SPARK_CONF}"
+                            }
+                            sh "python3 ./jenkins/databricks/run-tests.py $TEST_PARAMS"
                         }
-                        sh "python3 ./jenkins/databricks/run-tests.py $TEST_PARAMS"
+                    } finally {
+                        common.publishPytestResult(this, "${STAGE_NAME}")
                     }
                 }
             }
@@ -635,17 +570,6 @@ void abortDupBuilds() {
         }
         prevBuild = prevBuild.getPreviousBuildInProgress()
     }
-}
-
-String stashPytestResult(String name) {
-    def result = sh(returnStdout: true, script: "find . -name 'TEST-pytest*.xml' -exec ls -l {} \\;")
-    echo result
-
-    if (result) {
-        stash(name: name, includes: "**/TEST-pytest*.xml")
-    }
-
-    return result
 }
 
 void checkoutCode(String url, String sha) {


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

1. use common pytest publish func (will not fail the CI if pytest-report related errors)
2. remove 21.xx premerge support including databricks 7.3 runtime test support

Will tmply switch to the feature branch and verify the premerge CI