### PR TITLE
Don't calculate the pool size when disabling RMM

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -232,7 +232,9 @@ object GpuDeviceManager extends Logging {
       val conf = rapidsConf.getOrElse(new RapidsConf(SparkEnv.get.conf))
       val info = Cuda.memGetInfo()
 
-      val poolAllocation = computeRmmPoolSize(conf, info)
+      val poolAllocation = if (conf.isPooledMemEnabled && !"none".equalsIgnoreCase(conf.rmmPool)) {
+        computeRmmPoolSize(conf, info)
+      } else 0L // Don't calculate pool size when disabling RMM
       var init = RmmAllocationMode.CUDA_DEFAULT
       val features = ArrayBuffer[String]()
       if (conf.isPooledMemEnabled) {


### PR DESCRIPTION
Although I disabled the RMM pool, most of the time it throws the exception that "xxx free memory) was less than xx the minimum xxx" in my gpu-memory-tight PC. I know I can add minAllocation/poolAllocation ... to bypass this. but it really does not make sense (at least for me) to still calculate the pool size since I've already disabled it. 