### PR TITLE
Bump snakeyaml version to 1.32

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.31</version>
+            <version>1.32</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updates the snakeyaml dependency to the latest version to pick up bugfixes.