### PR TITLE
Disable UCX smoke test temporarily [databricks]

### DIFF
--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -109,8 +109,9 @@ rapids_shuffle_smoke_test() {
     }
 
     # using UCX shuffle
-    PYSP_TEST_spark_executorEnv_UCX_ERROR_SIGNALS="" \
-        invoke_shuffle_integration_test
+    # Disabled temporarily due to: https://github.com/NVIDIA/spark-rapids/issues/6572
+    # PYSP_TEST_spark_executorEnv_UCX_ERROR_SIGNALS="" \
+    #     invoke_shuffle_integration_test
 
     # using MULTITHREADED shuffle
     PYSP_TEST_spark_rapids_shuffle_mode=MULTITHREADED \


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Temporary workaround for: https://github.com/NVIDIA/spark-rapids/issues/6572.

Will be fixed (better?) by: https://github.com/NVIDIA/spark-rapids/pull/6573.

For now, this disables the smoke test for UCX (leaving the MULTITHREADED shuffle mode enabled) due to an increased frequency in failures that are blocking CI.