### PR TITLE
Adds link to spark supporting shuffle classes and fix copyright

### DIFF
--- a/sql-plugin/src/main/311until320-all/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
+++ b/sql-plugin/src/main/311until320-all/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
@@ -42,6 +42,9 @@ import org.apache.spark.util.{CompletionIterator, TaskCompletionListener, Utils}
  * Instead of this iterator owning the result and clearing it on `next`, the
  * `BufferReleasingInputStream` is in charge of that. This allows for multiple threads
  *  to consume different `BufferReleasingInputStream`s produced from this single iterator.
+ *
+ *  Compare to https://github.com/apache/spark/blob/branch-3.1: 
+ *   ./core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
  */
 
 /**

--- a/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
+++ b/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
+++ b/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
@@ -33,6 +33,15 @@ import org.apache.spark.storage.BlockManagerId.SHUFFLE_MERGER_IDENTIFIER
 import org.apache.spark.storage.RapidsShuffleBlockFetcherIterator._
 
 /**
+ * Taken mostly verbatim from `PushBasedFetchHelper` because of the type 
+ * hierarchy (specific type for `iterator`).
+ *
+ *  Compare to https://github.com/apache/spark/blob/branch-3.2, and 
+ *  https://github.com/apache/spark/blob/branch-3.3: 
+ *   ./core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+ */
+
+/**
  * Helper class for [[ShuffleBlockFetcherIterator]] that encapsulates all the push-based
  * functionality to fetch push-merged block meta and shuffle chunks.
  * A push-merged block contains multiple shuffle chunks where each shuffle chunk contains multiple

--- a/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
+++ b/sql-plugin/src/main/320+/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
@@ -50,6 +50,10 @@ import org.apache.spark.util.{CompletionIterator, TaskCompletionListener, Utils}
  *
  *  Reverts usage of `SparkCoreErrors` to just use the original exception here,
  *  as this was done in Spark 3.3.0 and is rather minor.
+ *
+ *  Compare to https://github.com/apache/spark/blob/branch-3.2, and 
+ *  https://github.com/apache/spark/blob/branch-3.3: 
+ *   ./core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
  */
 
 /**


### PR DESCRIPTION
This PR does minor follow up as this comment states: https://github.com/NVIDIA/spark-rapids/pull/6511#discussion_r975458436.

It also fixes a missing copyright that was committed in the same PR.