### PR TITLE
Delta Lake and AQE on Databricks 10.4 workaround [databricks]

### DIFF
--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,8 +16,6 @@
 
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.RapidsConf
-
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
+import com.nvidia.spark.rapids.RapidsConf
+
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 
@@ -26,5 +28,5 @@ object AQEUtils {
     sqse.newReuseInstance(sqse.id, newOutput)
   }
 
-  def isAdaptiveExecutionSupportedInSparkVersion: Boolean = true
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = true
 }

--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -20,6 +20,7 @@ import com.nvidia.spark.rapids.RapidsConf
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
 object AQEUtils {
@@ -28,5 +29,5 @@ object AQEUtils {
     sqse.newReuseInstance(sqse.id, newOutput)
   }
 
-  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = true
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = true
 }

--- a/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
+import com.nvidia.spark.rapids.RapidsConf
+
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
@@ -28,5 +30,5 @@ object AQEUtils {
     ShuffleQueryStageExec(sqse.id, reusedExchange, sqse.originalPlan)
   }
 
-  def isAdaptiveExecutionSupportedInSparkVersion: Boolean = true
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = true
 }

--- a/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.RapidsConf
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
 object AQEUtils {
@@ -30,5 +31,5 @@ object AQEUtils {
     ShuffleQueryStageExec(sqse.id, reusedExchange, sqse.originalPlan)
   }
 
-  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = true
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = true
 }

--- a/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,8 +16,6 @@
 
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.RapidsConf
-
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
+import com.nvidia.spark.rapids.RapidsConf
+
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
@@ -28,5 +30,12 @@ object AQEUtils {
     ShuffleQueryStageExec(sqse.id, reusedExchange, sqse.originalPlan, sqse.isSparkExchange)
   }
 
-  def isAdaptiveExecutionSupportedInSparkVersion: Boolean = true
+  // Databricks 10.4 has an issue where if you turn off AQE it can still use it for
+  // certain operations. This causes issues with the plugin so this is to work around
+  // that.
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = {
+    val res = conf.get("spark.sql.adaptive.enabled")
+    logWarning(s"in is adaptive on: $res ")
+    res
+  }
 }

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,14 +16,13 @@
 
 package com.nvidia.spark.rapids.shims
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
-object AQEUtils extends Logging {
+object AQEUtils {
   /** Return a new QueryStageExec reuse instance with updated output attributes */
   def newReuseInstance(sqse: ShuffleQueryStageExec, newOutput: Seq[Attribute]): QueryStageExec = {
     val reusedExchange = ReusedExchangeExec(newOutput, sqse.shuffle)
@@ -34,8 +33,6 @@ object AQEUtils extends Logging {
   // certain operations. This causes issues with the plugin so this is to work around
   // that.
   def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = {
-    val res = conf.getConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
-    logWarning(s"in is adaptive on: $res ")
-    res
+    conf.getConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
   }
 }

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,14 +16,14 @@
 
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.RapidsConf
-
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
-object AQEUtils {
+object AQEUtils extends Logging {
   /** Return a new QueryStageExec reuse instance with updated output attributes */
   def newReuseInstance(sqse: ShuffleQueryStageExec, newOutput: Seq[Attribute]): QueryStageExec = {
     val reusedExchange = ReusedExchangeExec(newOutput, sqse.shuffle)
@@ -33,8 +33,8 @@ object AQEUtils {
   // Databricks 10.4 has an issue where if you turn off AQE it can still use it for
   // certain operations. This causes issues with the plugin so this is to work around
   // that.
-  def isAdaptiveExecutionSupportedInSparkVersion(conf: RapidsConf): Boolean = {
-    val res = conf.get("spark.sql.adaptive.enabled")
+  def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = {
+    val res = conf.getConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
     logWarning(s"in is adaptive on: $res ")
     res
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4425,7 +4425,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(plan.conf) =>
         logDebug(s"AdaptiveSparkPlanExec found on unsupported Spark Version: $aqe")
         true
-      case project: ProjectExec if !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(plan.conf) =>
+      case project: ProjectExec if
+        !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(plan.conf) =>
         val foundExprs = project.expressions.flatMap { e =>
           PlanUtils.findExpressions(e, {
             case udf: ScalaUDF =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4422,10 +4422,10 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         }
         found
       case aqe: AdaptiveSparkPlanExec if 
-        !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(conf) =>
+        !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(plan.conf) =>
         logDebug(s"AdaptiveSparkPlanExec found on unsupported Spark Version: $aqe")
         true
-      case project: ProjectExec if !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(conf) =>
+      case project: ProjectExec if !AQEUtils.isAdaptiveExecutionSupportedInSparkVersion(plan.conf) =>
         val foundExprs = project.expressions.flatMap { e =>
           PlanUtils.findExpressions(e, {
             case udf: ScalaUDF =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4393,7 +4393,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
    *  to have to copy the data to GPU and then back off after it does the scan on
    *  Delta Table Checkpoint, so have the entire plan fallback to CPU at that point.
    */
-  def isDeltaLakeMetadataQuery(plan: SparkPlan, conf: RapidsConf): Boolean = {
+  def isDeltaLakeMetadataQuery(plan: SparkPlan): Boolean = {
     val deltaLogScans = PlanUtils.findOperators(plan, {
       case f: FileSourceScanExec if f.requiredSchema.fields
          .exists(_.name.startsWith("_databricks_internal")) =>
@@ -4450,7 +4450,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private def applyOverrides(plan: SparkPlan, conf: RapidsConf): SparkPlan = {
     val wrap = GpuOverrides.wrapAndTagPlan(plan, conf)
-    if (conf.isDetectDeltaLogQueries && isDeltaLakeMetadataQuery(plan, conf)) {
+    if (conf.isDetectDeltaLogQueries && isDeltaLakeMetadataQuery(plan)) {
       wrap.entirePlanWillNotWork("Delta Lake metadata queries are not efficient on GPU")
     }
     val reasonsToNotReplaceEntirePlan = wrap.getReasonsNotToReplaceEntirePlan


### PR DESCRIPTION

fixes https://github.com/NVIDIA/spark-rapids/issues/6539

Databricks 10.4 has a bug where even when AQE is off it still uses it. We started to support AQE on databricks in https://github.com/NVIDIA/spark-rapids/pull/6461, but that causes issue when we hit this databricks bug.  In order to work around this we key off the AQE setting and when its off we have to not convert certain operations.

Tested on Databricks 9.1 and 10.4 using customer notebook that reproduced the issue.