### PR TITLE
Update doc to indicate ORC and Parquet zstd read support [skip ci]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -366,9 +366,10 @@ similar issue exists for writing dates as described
 to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140).
 
-The plugin supports reading `uncompressed`, `snappy` and `zlib` ORC files and writing `uncompressed`
- and `snappy` ORC files.  At this point, the plugin does not have the ability to fall back to the
- CPU when reading an unsupported compression format, and will error out in that case.
+The plugin supports reading `uncompressed`, `snappy`, `zlib` and `zstd` ORC files and writing
+ `uncompressed`, `snappy` and `zstd` ORC files.  At this point, the plugin does not have the ability
+ to fall back to the CPU when reading an unsupported compression format, and will error out in that
+ case.
 
 ### Push Down Aggregates for ORC
 
@@ -437,8 +438,8 @@ issue, turn off the ParquetWriter acceleration for timestamp columns by either s
 set `spark.sql.parquet.outputTimestampType` to `TIMESTAMP_MICROS` or `TIMESTAMP_MILLIS` to by
 -pass the issue entirely.
 
-The plugin supports reading `uncompressed`, `snappy` and `gzip` Parquet files and writing
-`uncompressed` and `snappy` Parquet files.  At this point, the plugin does not have the ability to
+The plugin supports reading `uncompressed`, `snappy`, `gzip` and `zstd` Parquet files and writing
+`uncompressed`, `snappy` and `zstd` Parquet files.  At this point, the plugin does not have the ability to
 fall back to the CPU when reading an unsupported compression format, and will error out in that
 case.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -367,9 +367,8 @@ to work for dates after the epoch as described
 [here](https://github.com/NVIDIA/spark-rapids/issues/140).
 
 The plugin supports reading `uncompressed`, `snappy`, `zlib` and `zstd` ORC files and writing
- `uncompressed`, `snappy` and `zstd` ORC files.  At this point, the plugin does not have the ability
- to fall back to the CPU when reading an unsupported compression format, and will error out in that
- case.
+ `uncompressed` and `snappy` ORC files.  At this point, the plugin does not have the ability to fall
+ back to the CPU when reading an unsupported compression format, and will error out in that case.
 
 ### Push Down Aggregates for ORC
 
@@ -439,7 +438,7 @@ set `spark.sql.parquet.outputTimestampType` to `TIMESTAMP_MICROS` or `TIMESTAMP_
 -pass the issue entirely.
 
 The plugin supports reading `uncompressed`, `snappy`, `gzip` and `zstd` Parquet files and writing
-`uncompressed`, `snappy` and `zstd` Parquet files.  At this point, the plugin does not have the ability to
+`uncompressed` and `snappy` Parquet files.  At this point, the plugin does not have the ability to
 fall back to the CPU when reading an unsupported compression format, and will error out in that
 case.
 


### PR DESCRIPTION
Update compatibility.md to note read and write support for zstd for ORC and Parquet.  

Closes issue #6570 