### PR TITLE
Parallelize tests using spark packages feature [databricks]

### DIFF
--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -113,6 +113,7 @@ def pytest_sessionstart(session):
         wid = os.environ['PYTEST_XDIST_WORKER']
         _handle_derby_dir(_sb, driver_opts, wid)
         _handle_event_log_dir(_sb, wid)
+        _handle_ivy_cache_dir(_sb, wid)
     else:
         _sb.config('spark.driver.extraJavaOptions', driver_opts)
         _handle_event_log_dir(_sb, 'gw0')
@@ -165,6 +166,14 @@ def _handle_event_log_dir(sb, wid):
         .config('spark.eventLog.compress', True) \
         .config('spark.eventLog.enabled', True) \
         .config('spark.eventLog.compression.codec', event_log_codec)
+
+def _handle_ivy_cache_dir(sb, wid):
+    if os.environ.get('SPARK_IVY_CACHE_ENABLED', str(True)).lower() in [
+        str(False).lower(), 'off', '0'
+    ]:
+        logging.info('Automatic configuration for spark ivy cache dir disabled')
+        return
+    sb.config('spark.jars.ivy', '/tmp/.ivy2_{}'.format(wid))
 
 def get_spark_i_know_what_i_am_doing():
     """

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -186,10 +186,7 @@ run_delta_lake_tests() {
   DELTA_LAKE_VER="1.2.1"
 
   if [[ $SPARK_VER =~ $SPARK_321_PATTERN ]]; then
-    # Avoid parallel testing to work around issues with multiple processes trying to
-    # download and update Ivy cache
-    TEST_PARALLEL=0 \
-      PYSP_TEST_spark_jars_packages="io.delta:delta-core_2.12:$DELTA_LAKE_VER" \
+    PYSP_TEST_spark_jars_packages="io.delta:delta-core_2.12:$DELTA_LAKE_VER" \
       PYSP_TEST_spark_sql_extensions="io.delta.sql.DeltaSparkSessionExtension" \
       PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.spark.sql.delta.catalog.DeltaCatalog" \
       ./run_pyspark_from_build.sh -m delta_lake --delta_lake
@@ -205,10 +202,7 @@ run_iceberg_tests() {
 
   # Iceberg does not support Spark 3.3+ yet
   if [[ "$ICEBERG_SPARK_VER" < "3.3" ]]; then
-    # Avoid parallel testing to work around issues with multiple processes trying to
-    # download and update Ivy cache
-    TEST_PARALLEL=0 \
-      PYSP_TEST_spark_jars_packages=org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_2.12:${ICEBERG_VERSION} \
+    PYSP_TEST_spark_jars_packages=org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_2.12:${ICEBERG_VERSION} \
       PYSP_TEST_spark_sql_extensions="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions" \
       PYSP_TEST_spark_sql_catalog_spark__catalog="org.apache.iceberg.spark.SparkSessionCatalog" \
       PYSP_TEST_spark_sql_catalog_spark__catalog_type="hadoop" \
@@ -223,10 +217,7 @@ run_avro_tests() {
   # Workaround to avoid appending avro jar file by '--jars',
   # which would be addressed by https://github.com/NVIDIA/spark-rapids/issues/6532
   rm -vf $LOCAL_JAR_PATH/spark-avro*.jar
-  # Avoid parallel testing to work around issues with multiple processes trying to
-  # download and update Ivy cache
-  TEST_PARALLEL=0 \
-    PYSP_TEST_spark_jars_packages="org.apache.spark:spark-avro_2.12:${SPARK_VER}" \
+  PYSP_TEST_spark_jars_packages="org.apache.spark:spark-avro_2.12:${SPARK_VER}" \
     ./run_pyspark_from_build.sh -k avro
 }
 


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #6580 
override spark.jars.ivy if xdist parallel cases
This way does not require changes to test scripts, and there is no extra overhead of maintaining ivy config files

```
Ivy Default Cache set to: /tmp/.ivy2_gw0/cache
The jars for the packages stored in: /tmp/.ivy2_gw0/jars
org.apache.spark#spark-avro_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-1757e458-90fb-4f1a-8591-b2c1bac88c57;1.0
	confs: [default]
Ivy Default Cache set to: /tmp/.ivy2_gw1/cache
The jars for the packages stored in: /tmp/.ivy2_gw1/jars
org.apache.spark#spark-avro_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-2ce829a5-6e45-4c52-b365-9fb5c98a27fc;1.0
	confs: [default]
Ivy Default Cache set to: /tmp/.ivy2_gw2/cache
The jars for the packages stored in: /tmp/.ivy2_gw2/jars
org.apache.spark#spark-avro_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-0f7bc488-f641-42b2-a364-257c04d0d461;1.0
	confs: [default]
Ivy Default Cache set to: /tmp/.ivy2_gw3/cache
The jars for the packages stored in: /tmp/.ivy2_gw3/jars
org.apache.spark#spark-avro_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-2c60f409-fe6c-4f8b-a3cd-77f2945f505f;1.0
	confs: [default]
```

FYI
1. I also tried use `spark.jars.ivySettings` to point custom ivysettings.xml w/ cache lock, but did not work well in our case
2. We could also use other command to warm up cache before the actual xdist run so the xdist workers would not conflict w/ each other
