### PR TITLE
Add Apache snapshot repository when running Avro tests

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -289,6 +289,10 @@ else
             jarOpts+=(--packages "${PYSP_TEST_spark_jars_packages}")
         fi
 
+        if [[ -n "$PYSP_TEST_spark_jars_repositories" ]]; then
+            jarOpts+=(--repositories "${PYSP_TEST_spark_jars_repositories}")
+        fi
+
         if [[ -n "$PYSP_TEST_spark_driver_extraClassPath" ]]; then
             jarOpts+=(--driver-class-path "${PYSP_TEST_spark_driver_extraClassPath}")
         fi

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -216,8 +216,12 @@ run_iceberg_tests() {
 run_avro_tests() {
   # Workaround to avoid appending avro jar file by '--jars',
   # which would be addressed by https://github.com/NVIDIA/spark-rapids/issues/6532
+  # Adding the Apache snapshots repository since we may be running with a snapshot
+  # version of Apache Spark which requires accessing the snapshot repository to
+  # fetch the spark-avro jar.
   rm -vf $LOCAL_JAR_PATH/spark-avro*.jar
   PYSP_TEST_spark_jars_packages="org.apache.spark:spark-avro_2.12:${SPARK_VER}" \
+    PYSP_TEST_spark_jars_repositories="https://repository.apache.org/snapshots" \
     ./run_pyspark_from_build.sh -k avro
 }
 


### PR DESCRIPTION
Fixes #6593.  This adds handling of the new `PYSP_TEST_spark_jars_repositories` environment variable that, when set, allows the user to control the `--repositories` argument to the spark-submit command.  Updated the nightly spark tests script to add the Apache snapshots repository when running the Avro tests which allows Ivy to find the spark-avro dependency when it is a snapshot version.