### PR TITLE
Print nvidia-smi output when a task fails due to a cuda fatal exception.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -274,7 +274,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       // sticks around without any useful info until it hearbeat times out. Print what happened
       // and exit immediately.
       case e: CudaFatalException =>
-      logError("Fatal Exception in the executor plugin, shutting down!", e)
+        logError("Fatal Exception in the executor plugin, shutting down!", e)
         logGpuDebugInfoAndExit(systemExitCode = 1)
       case e: Throwable =>
         logError("Exception in the executor plugin, shutting down!", e)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -337,7 +337,9 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
         return Some(cmd.exitValue())
       }
     } while (System.currentTimeMillis() < endTime)
-    None // Timed out
+    // Timed out
+    cmd.destroy()
+    None
   }
 
   // Try to run nvidia-smi when task fails due to a cuda exception.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -370,7 +370,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
             logGpuDebugInfo()
             System.exit(20)
           case Some(_: CudaException) =>
-            logWarning(s"Executor onTaskFailed because of a non-fatal CUDA error: " +
+            logDebug(s"Executor onTaskFailed because of a non-fatal CUDA error: " +
               s"${ef.toErrorString}")
           case Some(_: CudfException) =>
             logDebug(s"Executor onTaskFailed because of a CUDF error: ${ef.toErrorString}")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -273,8 +273,8 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       // Exceptions in executor plugin can cause a single thread to die but the executor process
       // sticks around without any useful info until it hearbeat times out. Print what happened
       // and exit immediately.
-      case e: CudaFatalException =>
-        logError("Fatal Exception in the executor plugin, shutting down!", e)
+      case e: CudaException =>
+        logError("Exception in the executor plugin, shutting down!", e)
         logGpuDebugInfoAndExit(systemExitCode = 1)
       case e: Throwable =>
         logError("Exception in the executor plugin, shutting down!", e)


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Closes #5028.

When the plugin onTaskFailure callback is called and the failure reason is a CudaFatalException, log the output of nvidia-smi.

Putting this up as a draft to invite comments.  Is there a better way to do this?