### PR TITLE
Disable 22.10 snapshot builds

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -49,11 +49,16 @@
             321cdh,
             322,
             330,
-            330cdh
-        </noSnapshot.buildvers>
-        <snapshot.buildvers>
-            314,
+            330cdh,
             331
+        </noSnapshot.buildvers>
+        <!--
+            We move 331 as noSnapshot here to make sure we still build and test the shim for 22.10 (pre-release)
+            TODO: If we decide not to support spark 3.3.1 in 22.10,
+                  then we should move it back to snapshot before release
+        -->
+        <snapshot.buildvers>
+            314
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -165,11 +165,11 @@ BUILD_MAINTENANCE_VERSION_SNAPSHOTS="false"
 # controls whether we build snapshots for the next Spark major or feature version like 3.4.0 or 4.0.0
 BUILD_FEATURE_VERSION_SNAPSHOTS="false"
 PREMERGE_PROFILES="-PnoSnapshots,pre-merge"
-if [[ ${PROJECT_VER} =~ ^22\.10\. ]]; then # enable snapshot builds for active development branch only
+if [[ ${PROJECT_VER} =~ ^22\.12\. ]]; then # enable snapshot builds for active development branch only
   BUILD_MAINTENANCE_VERSION_SNAPSHOTS="true"
   BUILD_FEATURE_VERSION_SNAPSHOTS="false"
   PREMERGE_PROFILES="-Psnapshots,pre-merge"
-elif [[ ${PROJECT_VER} =~ ^22\.12\. ]]; then
+elif [[ ${PROJECT_VER} =~ ^23\.02\. ]]; then
   BUILD_MAINTENANCE_VERSION_SNAPSHOTS="true"
   BUILD_FEATURE_VERSION_SNAPSHOTS="true"
   PREMERGE_PROFILES="-Psnapshots,pre-merge"

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -20,7 +20,7 @@ set -e
 # PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
 # regular: noSnapshots + snapshots
 # pre-release: noSnapshots only
-PHASE_TYPE=regular
+PHASE_TYPE=pre-release # TODO: update it to regular in branch-22.12 when CI is available
 
 if [[ $# -eq 1 ]]; then
     PHASE_TYPE=$1

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -17,18 +17,6 @@
 
 set -e
 
-# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
-# regular: noSnapshots + snapshots
-# pre-release: noSnapshots only
-PHASE_TYPE=pre-release # TODO: update it to regular in branch-22.12 when CI is available
-
-if [[ $# -eq 1 ]]; then
-    PHASE_TYPE=$1
-elif [[ $# -gt 1 ]]; then
-    >&2 echo "ERROR: too many parameters are provided"
-    exit 1
-fi
-
 # Split abc=123 from $OVERWRITE_PARAMS
 # $OVERWRITE_PARAMS patten 'abc=123;def=456;'
 PRE_IFS=$IFS
@@ -74,8 +62,13 @@ SPARK_SHIM_VERSIONS_SNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 # PnoSnapshots: noSnapshots only
 set_env_var_SPARK_SHIM_VERSIONS_ARR -PnoSnapshots
 SPARK_SHIM_VERSIONS_NOSNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
-# Spark shim versions list based on given profile option (snapshots or noSnapshots)
+
+# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
+# regular: noSnapshots + snapshots
+# pre-release: noSnapshots only
+PHASE_TYPE=${PHASE_TYPE:-"pre-release"} # TODO: update it to regular in branch-22.12 when CI is available
 case $PHASE_TYPE in
+    # SPARK_SHIM_VERSIONS will be used for nightly artifact build
     pre-release)
         SPARK_SHIM_VERSIONS=("${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]}")
         ;;


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Disable snapshot builds for pre release branch
Also updated PHASE_TYPE in version-def script to avoid transitive params passing

**NOTE:** spark 331 has not passed the vote yet. To make sure we still verifying the 331 shim, I moved the 331 shim to nosnapshot shims list. 
If we decide not to support the release, we should revert the noSnapshot and snapshot properties changes before we actually do the release