### PR TITLE
Fix a Delta Lake Deletes issue[databricks]

### DIFF
--- a/sql-plugin/src/main/311+-db/scala/org/apache/spark/sql/rapids/shims/GpuFileScanRDD.scala
+++ b/sql-plugin/src/main/311+-db/scala/org/apache/spark/sql/rapids/shims/GpuFileScanRDD.scala
@@ -72,6 +72,7 @@ class GpuFileScanRDD(
         context.killTaskIfInterrupted()
         (currentIterator != null && currentIterator.hasNext) || nextIterator()
       }
+
       def next(): Object = {
         val nextElement = currentIterator.next()
         // TODO: we should have a better separation of row based and batch based scan, so that we
@@ -169,7 +170,11 @@ class GpuFileScanRDD(
           }
         } else {
           currentFile = null
-          InputFileBlockHolder.unset()
+          // Removed "InputFileBlockHolder.unset()", because for some cases on DB,
+          // cleaning the input file holder here is too early. Some operators are still
+          // leveraging this holder to get the current file path even after hasNext
+          // returns false.
+          // See https://github.com/NVIDIA/spark-rapids/issues/6592
           false
         }
       }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6592

The Delta Lake delelting command executed a plan as below. You can see the first `FilterExec` ran on CPU.
```
22/09/26 02:19:17 WARN GpuOverrides: 
*Exec <HashAggregateExec> will run on GPU
  *Exec <ShuffleExchangeExec> will run on GPU
    *Partitioning <HashPartitioning> will run on GPU
    *Exec <HashAggregateExec> will run on GPU
      *Exec <ProjectExec> will run on GPU
        *Expression <Alias> input_file_name() AS input_file_name()#8385 will run on GPU
          *Expression <InputFileName> input_file_name() will run on GPU
        !Exec <FilterExec> cannot run on GPU because not all expressions can be replaced
          !Expression <ScalaUDF> UDF() cannot run on GPU because neither UDF implemented by class com.databricks.sql.transaction.tahoe.commands.DeleteCommandEdge$$Lambda$8354/1314591671 provides a GPU implementation, nor the conf `spark.rapids.sql.rowBasedUDF.enabled` is enabled
          *Exec <FilterExec> will run on GPU
            *Expression <And> (isnotnull(c1#8354) AND (c1#8354 = tom44)) will run on GPU
              *Expression <IsNotNull> isnotnull(c1#8354) will run on GPU
              *Expression <EqualTo> (c1#8354 = tom44) will run on GPU
            *Exec <FileSourceScanExec> will run on GPU
```
In this plan, it is too early to clean the input file holder in the `hasNext` method of `GpuFileScanRDD` just after reaching the last file. Some operators are still leveraging the holder to get the current file path at the that time. If cleaning the holder here, an empty file path will be produced and fails the file check in the delta library.

This PR only removes the clean of the input file holder in `hasNext`, and it is ok because the holder can still be cleaned when the task is done.

The linked issue mentioned the multi-threaded reader works well because it never cleans the holder after setting it.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
