### PR TITLE
Move spark331 back to list of snapshot shims

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -49,16 +49,11 @@
             321cdh,
             322,
             330,
-            330cdh,
-            331
+            330cdh
         </noSnapshot.buildvers>
-        <!--
-            We move 331 as noSnapshot here to make sure we still build and test the shim for 22.10 (pre-release)
-            TODO: If we decide not to support spark 3.3.1 in 22.10,
-                  then we should move it back to snapshot before release
-        -->
         <snapshot.buildvers>
-            314
+            314,
+            331
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

as discussed, we will not officially support spark 3.3.1 in release 22.10.
revert back temporary dist/pom file change