### PR TITLE
Qualification tool: Print cluster usage tags to csv and log file

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -94,8 +94,8 @@ class RunningQualificationApp() extends QualificationAppInfo(None, None,
           Seq(info).map(_.unSupportedExprs.size),
           QualOutputWriter.UNSUPPORTED_EXPRS_MAX_SIZE,
           QualOutputWriter.UNSUPPORTED_EXPRS.size)
-        val clusterTags = info.clusterTags.nonEmpty
-        val (clusterIdMax, jobIdMax, runNameMax) = if (clusterTags) {
+        val hasClusterTags = info.clusterTags.nonEmpty
+        val (clusterIdMax, jobIdMax, runNameMax) = if (hasClusterTags) {
           (QualOutputWriter.getMaxSizeForHeader(Seq(info).map(
             _.allClusterTagsMap.getOrElse(QualOutputWriter.CLUSTER_ID, "").size),
             QualOutputWriter.CLUSTER_ID),
@@ -110,12 +110,12 @@ class RunningQualificationApp() extends QualificationAppInfo(None, None,
             QualOutputWriter.RUN_NAME_STR_SIZE)
         }
         val headersAndSizes = QualOutputWriter.getSummaryHeaderStringsAndSizes(Seq(info),
-          appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, clusterTags,
+          appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, hasClusterTags,
           clusterIdMax, jobIdMax, runNameMax)
         val headerStr = QualOutputWriter.constructOutputRowFromMap(headersAndSizes,
           delimiter, prettyPrint)
         val appInfoStr = QualOutputWriter.constructAppSummaryInfo(info.estimatedInfo,
-          headersAndSizes, appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, clusterTags,
+          headersAndSizes, appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, hasClusterTags,
           clusterIdMax, jobIdMax, runNameMax, delimiter, prettyPrint)
         headerStr + appInfoStr
       case None =>

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -96,11 +96,14 @@ class RunningQualificationApp() extends QualificationAppInfo(None, None,
           QualOutputWriter.UNSUPPORTED_EXPRS.size)
         val clusterTags = info.clusterTags.nonEmpty
         val (clusterIdMax, jobIdMax, runNameMax) = if (clusterTags) {
-          (QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.clusterId.size),
+          (QualOutputWriter.getMaxSizeForHeader(Seq(info).map(
+            _.allClusterTagsMap.getOrElse(QualOutputWriter.CLUSTER_ID, "").size),
             QualOutputWriter.CLUSTER_ID),
-            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.jobId.size),
+            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(
+              _.allClusterTagsMap.getOrElse(QualOutputWriter.JOB_ID, "").size),
               QualOutputWriter.JOB_ID),
-            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.runName.size),
+            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(
+              _.allClusterTagsMap.getOrElse(QualOutputWriter.RUN_NAME, "").size),
               QualOutputWriter.RUN_NAME))
         } else {
           (QualOutputWriter.CLUSTER_ID_STR_SIZE, QualOutputWriter.JOB_ID_STR_SIZE,

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/RunningQualificationApp.scala
@@ -94,13 +94,26 @@ class RunningQualificationApp() extends QualificationAppInfo(None, None,
           Seq(info).map(_.unSupportedExprs.size),
           QualOutputWriter.UNSUPPORTED_EXPRS_MAX_SIZE,
           QualOutputWriter.UNSUPPORTED_EXPRS.size)
+        val clusterTags = info.clusterTags.nonEmpty
+        val (clusterIdMax, jobIdMax, runNameMax) = if (clusterTags) {
+          (QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.clusterId.size),
+            QualOutputWriter.CLUSTER_ID),
+            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.jobId.size),
+              QualOutputWriter.JOB_ID),
+            QualOutputWriter.getMaxSizeForHeader(Seq(info).map(_.runName.size),
+              QualOutputWriter.RUN_NAME))
+        } else {
+          (QualOutputWriter.CLUSTER_ID_STR_SIZE, QualOutputWriter.JOB_ID_STR_SIZE,
+            QualOutputWriter.RUN_NAME_STR_SIZE)
+        }
         val headersAndSizes = QualOutputWriter.getSummaryHeaderStringsAndSizes(Seq(info),
-          appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize)
+          appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, clusterTags,
+          clusterIdMax, jobIdMax, runNameMax)
         val headerStr = QualOutputWriter.constructOutputRowFromMap(headersAndSizes,
           delimiter, prettyPrint)
         val appInfoStr = QualOutputWriter.constructAppSummaryInfo(info.estimatedInfo,
-          headersAndSizes, appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize,
-          delimiter, prettyPrint)
+          headersAndSizes, appIdMaxSize, unSupExecMaxSize, unSupExprMaxSize, clusterTags,
+          clusterIdMax, jobIdMax, runNameMax, delimiter, prettyPrint)
         headerStr + appInfoStr
       case None =>
         logWarning(s"Unable to get qualification information for this application")

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -39,6 +39,8 @@ class QualificationEventProcessor(app: QualificationAppInfo)
     if (ToolUtils.isPluginEnabled(sparkProperties)) {
       throw GpuEventLogException(s"Eventlog is from GPU run. Skipping ...")
     }
+    app.clusterTags = sparkProperties.getOrElse(
+      "spark.databricks.clusterUsageTags.clusterAllTags", "")
   }
 
   override def doSparkListenerApplicationStart(

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationEventProcessor.scala
@@ -132,6 +132,11 @@ class QualificationEventProcessor(app: QualificationAppInfo)
         app.stageIdToSqlID.getOrElseUpdate(stageId, sqlID)
       }
     }
+    // If the confs are set after SparkSession initialization, it is captured in this event.
+    if (app.clusterTags.isEmpty) {
+      app.clusterTags = event.properties.getProperty(
+        "spark.databricks.clusterUsageTags.clusterAllTags", "")
+    }
   }
 
   override def doSparkListenerJobEnd(

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -631,6 +631,42 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
     }
   }
 
+  test("test clusterTags configs ") {
+    TrampolineUtil.withTempDir { outpath =>
+      TrampolineUtil.withTempDir { eventLogDir =>
+
+        val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "clustertags") { spark =>
+          import spark.implicits._
+          spark.conf.set("spark.databricks.clusterUsageTags.clusterAllTags",
+            """[{"key":"Vendor",
+              |"value":"Databricks"},{"key":"Creator","value":"abc@company.com"},
+              |{"key":"ClusterName","value":"job-215-run-1"},{"key":"ClusterId",
+              |"value":"0617-131246-dray530"},{"key":"JobId","value":"215"},
+              |{"key":"RunName","value":"test73longer"},{"key":"DatabricksEnvironment",
+              |"value":"workerenv-7026851462233806"}]""".stripMargin)
+
+          val df1 = spark.sparkContext.makeRDD(1 to 1000, 6).toDF
+          df1.sample(0.1)
+        }
+        val expectedClusterId = "0617-131246-dray530"
+        val expectedJobId = "215"
+        val expectedRunName = "test73longer"
+
+        val allArgs = Array(
+          "--output-directory",
+          outpath.getAbsolutePath())
+        val appArgs = new QualificationArgs(allArgs ++ Array(eventLog))
+        val (exit, appSum) = QualificationMain.mainInternal(appArgs)
+        assert(exit == 0)
+        assert(appSum.size == 1)
+        val allTags = appSum.flatMap(_.allClusterTagsMap).toMap
+        assert(allTags("ClusterId") == expectedClusterId)
+        assert(allTags("JobId") == expectedJobId)
+        assert(allTags("RunName") == expectedRunName)
+      }
+    }
+  }
+
   test("test read datasource v1") {
     val profileLogDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
     val logFiles = Array(s"$profileLogDir/eventlog_dsv1.zstd")


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/6067 .

In this PR, we check if spark property clusterUsageTags.clusterAllTags is set and if so then extract and parse fields within that property. We print all the fields in csv file and  print clusterId, jobId and run Name in logFile and stdOut.

Extra columns are added to the output only if any of the eventlogs have above properties in them.
Output of running qualification tool on eventlog without the above property:

```
===========================================================================================================================================================================================================================
|   App Name|             App ID|App Duration|SQL DF Duration|GPU Opportunity|Estimated GPU Duration|Estimated GPU Speedup|Estimated GPU Time Saved|      Recommendation|        Unsupported Execs|Unsupported Expressions|
===========================================================================================================================================================================================================================
|Spark shell|local-1663070753792|       66760|           1285|              0|               66760.0|                  1.0|                     0.0|     Not Recommended|Scan;Filter;SerializeF...|                    hex|
===========================================================================================================================================================================================================================

```  
Output of running qualification tool when run of combination of eventlogs where only one eventlog has the above property set:

```
==============================================================================================================================================================================================================================================================================
|        App Name|                 App ID|App Duration|SQL DF Duration|GPU Opportunity|Estimated GPU Duration|Estimated GPU Speedup|Estimated GPU Time Saved|      Recommendation|        Unsupported Execs|  Unsupported Expressions|         Cluster Id|Job Id|    Run Name|
==============================================================================================================================================================================================================================================================================
|Databricks Shell|app-20210617131655-0000|     2209568|        2155388|        1473006|            1194017.08|                 1.85|              1015550.91|         Recommended|SortAggregate;Adaptive...|finalmerge_sum;Some;fi...|0617-131246-dray530|   215|test73longer|
|     Spark shell|    local-1663070753792|       66760|           1285|              0|               66760.0|                  1.0|                     0.0|     Not Recommended|Scan;Filter;SerializeF...|                      hex|                   |      |            |
==============================================================================================================================================================================================================================================================================

```

csv output:

```
App Name,App ID,Recommendation,Estimated GPU Speedup,Estimated GPU Duration,Estimated GPU Time Saved,SQL DF Duration,SQL Dataframe Task Duration,App Duration,GPU Opportunity,Executor CPU Time Percent,SQL Ids with Failures,Unsupported Read File Formats and Types,Unsupported Write Data Format,Complex Types,Nested Complex Types,Potential Problems,Longest SQL Duration,NONSQL Task Duration Plus Overhead,Unsupported Task Duration,Supported SQL DF Task Duration,Task Speedup Factor,App Duration Estimated,Unsupported Execs,Unsupported Expressions,Cluster Tags
Databricks Shell,app-20210617131655-0000,Recommended,1.9,2776590.74,2508750.25,5229603,40993162,5285341,3623750,48.38,"","","","","","",1133554,155599,12587758,28405404,3.25,true,SortAggregate;AdaptiveSparkPlan;HashAggregate;Project;Execute CreateViewCommand;ColumnarToRow,finalmerge_sum;Some;finalmerge_min,ClusterId -> 0617-131246-dray530;DatabricksEnvironment -> workerenv-7026851462233806;ClusterName -> job-215-run-1;JobId -> 215;RunName -> test73longer;Creator -> abc@company.com;Vendor -> Databricks
```
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
