### PR TITLE
Avoid failing test on cleanup when filesystem has issues

### DIFF
--- a/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -22,6 +22,7 @@ import java.util.zip.CheckedInputStream
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
@@ -245,11 +246,11 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
     try {
       Utils.deleteRecursively(tempDir)
     } catch {
-      case t: Throwable =>
-        // Catch any error here as we are cleaning up directories using a Spark utility
-        // and we shouldn't fail a test in this case: 
+      case NonFatal(e) =>
+        // Catch non-fatal errors here as we are cleaning up directories using a Spark utility
+        // and we shouldn't fail a test for these exceptions. See:
         // https://github.com/NVIDIA/spark-rapids/issues/6515
-        logWarning(s"Error while cleaning up $tempDir", t)
+        logWarning(s"Error while cleaning up $tempDir", e)
     } finally {
       super.afterEach()
     }

--- a/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/320+-noncdh-nondb/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.mockito.MockitoSugar
 
 import org.apache.spark.{HashPartitioner, SparkConf, SparkException, TaskContext}
 import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
-import org.apache.spark.internal.config
+import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.network.shuffle.checksum.ShuffleChecksumHelper
 import org.apache.spark.network.util.LimitedInputStream
 import org.apache.spark.serializer.{JavaSerializer, SerializerInstance, SerializerManager}
@@ -135,7 +135,8 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with MockitoSugar
-    with ShuffleChecksumTestHelper {
+    with ShuffleChecksumTestHelper 
+    with Logging {
   @Mock(answer = RETURNS_SMART_NULLS) private var blockManager: BlockManager = _
   @Mock(answer = RETURNS_SMART_NULLS) private var diskBlockManager: DiskBlockManager = _
   @Mock(answer = RETURNS_SMART_NULLS) private var taskContext: TaskContext = _
@@ -239,10 +240,16 @@ class RapidsShuffleThreadedWriterSuite extends FunSuite
 
   override def afterEach(): Unit = {
     TaskContext.unset()
+    blockIdToFileMap.clear()
+    temporaryFilesCreated.clear()
     try {
       Utils.deleteRecursively(tempDir)
-      blockIdToFileMap.clear()
-      temporaryFilesCreated.clear()
+    } catch {
+      case t: Throwable =>
+        // Catch any error here as we are cleaning up directories using a Spark utility
+        // and we shouldn't fail a test in this case: 
+        // https://github.com/NVIDIA/spark-rapids/issues/6515
+        logWarning(s"Error while cleaning up $tempDir", t)
     } finally {
       super.afterEach()
     }


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/6515.

This fixes a sporadic issue in CI where we have seen failures when cleaning up temporary shuffle data, when what looks like NFS is failing to delete. We create a new temporary directory for each test, and we are not writing a ton of data, so I feel is fairly safe to ignore this.