### PR TITLE
Fix case where number of shuffle writer threads is set to 0

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1053,7 +1053,10 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
       if (rapidsConf.isCacheOnlyShuffleManagerMode) {
         "Transport disabled (local cached blocks only)"
       } else {
-        "Experimental threaded shuffle mode"
+        val numWriteThreads = rapidsConf.shuffleMultiThreadedWriterThreads
+        val numReadThreads = rapidsConf.shuffleMultiThreadedReaderThreads
+        s"Experimental threaded shuffle mode " +
+          s"(write threads=$numWriteThreads, read threads=$numReadThreads)"
       }
     } else {
       s"Transport enabled (remote fetches will use ${rapidsConf.shuffleTransportClassName}"


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes: https://github.com/NVIDIA/spark-rapids/issues/6621.

This fixes a bug when `spark.rapids.shuffle.multiThreaded.writer.threads=0`, which is documented to be supported and means we fallback the shuffle writer to the one supplied by Spark without any modifications by us. Before this change, there could be a divide-by-zero error when we try to submit writer tasks.