### PR TITLE
Qualification tool application time calculation can count stages twice if in separate sql queries 

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -298,7 +298,6 @@ class QualificationAppInfo(
         // don't worry about supported execs for these are these are mostly indicator of I/O
         val execRunTime = sqlIDToTaskEndSum.get(sqlID).map(_.executorRunTime).getOrElse(0L)
         val execCPUTime = sqlIDToTaskEndSum.get(sqlID).map(_.executorCPUTime).getOrElse(0L)
-
         SQLStageSummary(stageSum, sqlID, estimateWallclockSupported,
           execCPUTime, execRunTime)
       }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -614,7 +614,8 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
         val (exit, appSum) = QualificationMain.mainInternal(appArgs)
         assert(exit == 0)
         assert(appSum.size == 1)
-        // note this would have failed an assert if we didn't dedup states
+        // note this would have failed an assert with total task time to small if we
+        // didn't dedup stages
       }
     }
   }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -597,12 +597,14 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
       TrampolineUtil.withTempDir { eventLogDir =>
         val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "dot") { spark =>
           import spark.implicits._
-          val df = spark.sparkContext.makeRDD(1 to 10000000, 6).toDF
-          val df2 = spark.sparkContext.makeRDD(1 to 10000000, 6).toDF
+          val df = spark.sparkContext.makeRDD(1 to 1000, 6).toDF
+          val df2 = spark.sparkContext.makeRDD(1 to 1000, 6).toDF
           val j1 = df.select( $"value" as "a")
             .join(df2.select($"value" as "b"), $"a" === $"b").cache()
           j1.count()
-          j1.union(j1)
+          j1.union(j1).count()
+          // count above is important thing, here we just make up small df to return
+          spark.sparkContext.makeRDD(1 to 2).toDF
         }
 
         val allArgs = Array(


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6637

the same stage might be referenced from multiple sql queries, we have to dedup them
with the assumption the stage was reused so time only counts once

Manually verified with customer event log and also wrote unit test. Without the fix the unit test fails when hits assert at:

```
java.lang.AssertionError: assertion failed
    at scala.Predef$.assert(Predef.scala:208)
    at org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo.calculateNonSQLTaskDataframeDuration(QualificationAppInfo.scala:134)
    at org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo.$anonfun$aggregateStats$1(QualificationAppInfo.scala:396)
   
```

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
