### PR TITLE
Workflow to add new issues to Github global project [skip ci]

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Add new issues to spark-rapids project
+name: Add new issues to project
 
 on:
   issues:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add new issues to spark-rapids project
+    name: Add new issues to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.3.0
@@ -15,4 +15,4 @@ jobs:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/users/mattahrens/projects/2
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Add new issues to project
 
 on:
@@ -7,12 +21,11 @@ on:
 
 jobs:
   add-to-project:
+    if: github.repository == 'NVIDIA/spark-rapids'
     name: Add new issues to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:
-          # You can target a repository in a different organization
-          # to the issue
-          project-url: https://github.com/users/mattahrens/projects/2
-          github-token: ${{ secrets.MATTAHRENS_TOKEN }}
+          project-url: https://github.com/orgs/NVIDIA/projects/4
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+name: Add new issues to spark-rapids project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add new issues to spark-rapids project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/users/mattahrens/projects/2
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -15,5 +15,4 @@ jobs:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/users/mattahrens/projects/2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.MATTAHRENS_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -15,4 +15,5 @@ jobs:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/users/mattahrens/projects/2
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add new issues to spark-rapids project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@RELEASE_VERSION
+      - uses: actions/add-to-project@v0.3.0
         with:
           # You can target a repository in a different organization
           # to the issue


### PR DESCRIPTION
Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Closes #6639 

Setting up an automated workflow to add new issues in the spark-rapids repo to the global spark-rapids project for task and release tracking. 

Initial test version of this is point to personal project board for validation ahead of setting up for official project.
