### PR TITLE
Simplify how we transpile negated character classes and add more tests

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -147,7 +147,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("cuDF does not support quantifier syntax when not quantifying anything") {
     // note that we could choose to transpile and escape the '{' and '}' characters
-    val patterns = Seq("{1,2}", "{1,}", "{1}")
+    val patterns = Seq("{1,2}", "{1,}", "{1}", "{2,1}")
     patterns.foreach(pattern => {
       assertUnsupported(pattern, RegexFindMode,
         "Token preceding '{' is not quantifiable near index 0")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -541,9 +541,15 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("compare CPU and GPU: regexp replace negated character class") {
-    val inputs = Seq("a", "b", "a\r", "a\n", "a\r\n", "a\n\r", "a\nb",
-      "a\r\nb\n\rc\rd", "\r", "\r\n", "\n")
-    val patterns = Seq("[^a]", "[^a\r]", "[^a\n]", "[^a\r\n]", "[^z]", "[^\r]", "[^\n]", "[^\r]",
+    val inputs = Seq(
+      "a", "a\r", "a\n", "a\r\n", "a\n\r",
+      "b", "b\r", "b\n", "b\r\n", "b\n\r",
+      "a\nb", "b", "a\r\nb\n\rc\rd", "\r", "\r\n", "\n")
+    val patterns = Seq(
+      "[^a]", "[^a\r]", "[^a\n]", "[^a\r\n]",
+      "[a]", "[a\r]", "[a\n]", "[a\r\n]",
+      "[^b]", "[^b\r]", "[^b\n]", "[^b\r\n]",
+      "[^z]", "[^\r]", "[^\n]", "[^\r]",
       "[^\r\n]", "[^b\r]", "[^bc\r\n]", "[^\\r\\n]", "[^\r\r]", "[^\r\n\r]", "[^\n\n\r\r]")
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -30,21 +30,6 @@ import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
-  test("negated character class newline handling") {
-    // tests behavior of com.nvidia.spark.rapids.CudfRegexTranspiler.negateCharacterClass
-
-    def test(pattern: String, expected: String): Unit = {
-      val t = new CudfRegexTranspiler(RegexFindMode)
-      val (actual, _) = t.transpile(pattern, None)
-      assert(toReadableString(expected) === toReadableString(actual))
-    }
-
-    test(raw"[^a]", raw"(?:[\r]|[^a])")
-    test(raw"[^a\r]", raw"[^a\r]")
-    test(raw"[^a\n]", raw"(?:[\r]|[^a\n])")
-    test(raw"[^a\r\n]", raw"[^a\r\n]")
-  }
-
   test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged
     // but we still reject them because we see failures in fuzz testing if we allow them
@@ -540,10 +525,26 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     )
   }
 
+  test("negated character class newline handling") {
+    // tests behavior of com.nvidia.spark.rapids.CudfRegexTranspiler.negateCharacterClass
+
+    def test(pattern: String, expected: String): Unit = {
+      val t = new CudfRegexTranspiler(RegexFindMode)
+      val (actual, _) = t.transpile(pattern, None)
+      assert(toReadableString(expected) === toReadableString(actual))
+    }
+
+    test(raw"[^a]", raw"(?:[\r]|[^a])")
+    test(raw"[^a\n]", raw"(?:[\r]|[^a\n])")
+    test(raw"[^a\r]", raw"[^a\r]")
+    test(raw"[^a\r\n]", raw"[^a\r\n]")
+  }
+
   test("compare CPU and GPU: regexp replace negated character class") {
-    val inputs = Seq("a", "b", "a\nb", "a\r\nb\n\rc\rd", "\r", "\r\n", "\n")
-    val patterns = Seq("[^z]", "[^\r]", "[^\n]", "[^\r]", "[^\r\n]",
-      "[^a\n]", "[^b\r]", "[^bc\r\n]", "[^\\r\\n]", "[^\r\r]", "[^\r\n\r]", "[^\n\n\r\r]")
+    val inputs = Seq("a", "b", "a\r", "a\n", "a\r\n", "a\n\r", "a\nb",
+      "a\r\nb\n\rc\rd", "\r", "\r\n", "\n")
+    val patterns = Seq("[^a]", "[^a\r]", "[^a\n]", "[^a\r\n]", "[^z]", "[^\r]", "[^\n]", "[^\r]",
+      "[^\r\n]", "[^b\r]", "[^bc\r\n]", "[^\\r\\n]", "[^\r\r]", "[^\r\n\r]", "[^\n\n\r\r]")
     assertCpuGpuMatchesRegexpReplace(patterns, inputs)
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -30,6 +30,21 @@ import org.apache.spark.sql.types.DataTypes
 
 class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
+  test("negated character class newline handling") {
+    // tests behavior of com.nvidia.spark.rapids.CudfRegexTranspiler.negateCharacterClass
+
+    def test(pattern: String, expected: String): Unit = {
+      val t = new CudfRegexTranspiler(RegexFindMode)
+      val (actual, _) = t.transpile(pattern, None)
+      assert(toReadableString(expected) === toReadableString(actual))
+    }
+
+    test(raw"[^a]", raw"(?:[\r]|[^a])")
+    test(raw"[^a\r]", raw"[^a\r]")
+    test(raw"[^a\n]", raw"(?:[\r]|[^a\n])")
+    test(raw"[^a\r\n]", raw"[^a\r\n]")
+  }
+
   test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged
     // but we still reject them because we see failures in fuzz testing if we allow them


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/6518 but does not close the issue. There will be additional PRs for other items before we can close this.

The main goal of this PR is to simplify how we transpile negated character classes and to add additional tests.

Also reinstated a test for `{2,1}` that was previously removed.
