### PR TITLE
Changing toList to toIterator to improve memory optimization and runt…

### DIFF
--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -114,7 +114,7 @@ abstract class AppBase(
           val logFiles = reader.listEventLogFiles
           logFiles.foreach { file =>
             Utils.tryWithResource(openEventLogInternal(file.getPath, fs)) { in =>
-              val lines = Source.fromInputStream(in)(Codec.UTF8).getLines().toList
+              val lines = Source.fromInputStream(in)(Codec.UTF8).getLines().toIterator
               // Using find as foreach with conditional to exit early if we are done.
               // Do NOT use a while loop as it is much much slower.
               lines.find { line =>


### PR DESCRIPTION
…ime performance

Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Closes #6198 

Tested on set of ~100 log files totally 15GB in size.  Runtime performance numbers:
- With my change: 506.16s user 911.55s system 258% cpu 9:08.09 total
- Without my change: 1707.42s user 1647.09s system 198% cpu 28:07.51 total

Also confirmed that full GC is happening less with change (32 times vs 26 times).