### PR TITLE
Adding error handling to print help out when at end of command

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileArgs.scala
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids.tool.profiling
 
 import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
 
 import org.apache.spark.sql.rapids.tool.AppFilterImpl
 
@@ -116,4 +117,14 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   }
 
   verify()
+
+  override def onError(e: Throwable) = e match {
+    case ScallopException(message) =>
+      if (args.contains("--help")) {
+        printHelp
+        System.exit(0)
+      }
+      errorMessageHandler(message)
+    case ex => super.onError(ex)
+  }
 }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/QualificationArgs.scala
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids.tool.qualification
 
 import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
 
 import org.apache.spark.sql.rapids.tool.AppFilterImpl
 
@@ -165,6 +166,16 @@ Usage: java -cp rapids-4-spark-tools_2.12-<version>.jar:$SPARK_HOME/jars/*
   }
 
   verify()
+
+  override def onError(e: Throwable) = e match {
+    case ScallopException(message) =>
+      if (args.contains("--help")) {
+        printHelp
+        System.exit(0)
+      }
+      errorMessageHandler(message)
+    case ex => super.onError(ex)
+  }
 }
 
 object QualificationArgs {

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -848,4 +848,19 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       }
     }
   }
+
+  test("--help at end of command line arguments") {
+    val testLogDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
+    val eventLog = s"$logDir/rp_sql_eventlog.zstd"
+    TrampolineUtil.withTempDir { outpath =>
+      val allArgs = Array(
+        "--output-directory",
+        eventLog)
+      val lastArgs = Array("--help")
+
+      val appArgs = new ProfileArgs(allArgs ++ lastArgs)
+      val (exit, _) = ProfileMain.mainInternal(appArgs)
+      assert(exit == 0)
+    }
+  }
 }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -948,6 +948,22 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
     }
   }
+
+  test("--help at end of command line arguments") {
+    val qualLogDir = ToolTestUtils.getTestResourcePath("spark-events-qualification")
+    val logFiles = Array(s"$qualLogDir/gpu_eventlog")
+    TrampolineUtil.withTempDir { outpath =>
+      val allArgs = Array(
+        "--output-directory",
+        outpath.getAbsolutePath())
+      val lastArgs = Array("--help")
+
+      val appArgs = new QualificationArgs(allArgs ++ logFiles ++ lastArgs)
+      val (exit, appSum) = QualificationMain.mainInternal(appArgs)
+      assert(exit == 0)
+      assert(appSum.size == 0)
+    }
+  }
 }
 
 class ToolTestListener extends SparkListener {


### PR DESCRIPTION

Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Closed #2654 

Validated with manual tests for qualification and profiling tools

1. --help at end of command (help prints out)
2. --help after class designation (help prints out)
3. no "--help", positive case (success)
4. no "--help", negative case with malformed arguments (proper error message, same as before)
