### PR TITLE
Fix validity checks for large decimal window bounds

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -376,12 +376,12 @@ abstract class GpuSpecifiedWindowFrameMetaBase(
           return None
         }
 
-        val value: Long = bounds match {
+        val value: BigInt = bounds match {
           case Literal(value, ByteType) => value.asInstanceOf[Byte].toLong
           case Literal(value, ShortType) => value.asInstanceOf[Short].toLong
           case Literal(value, IntegerType) => value.asInstanceOf[Int].toLong
           case Literal(value, LongType) => value.asInstanceOf[Long]
-          case Literal(value: Decimal, DecimalType()) => value.toLong
+          case Literal(value: Decimal, DecimalType()) => value.toJavaBigDecimal.unscaledValue()
           case Literal(ci: CalendarInterval, CalendarIntervalType) =>
             if (ci.months != 0) {
               willNotWorkOnGpu("interval months isn't supported")


### PR DESCRIPTION
For RANGE window aggregations where the order-by column is `BigDecimal`, (E.g. `DECIMAL(38,2)`), it is incorrect to check their equivalent Long values. 128-bit values shouldn't be compared as 64-bit values.

This commit ensures that DECIMAL values are checked using their unscaled `BigInt` values.

Note: This applies only to the validity checks, (where upper bounds cannot be negative, etc.). The actual window aggregation is unaffected, because it already uses BigDecimal.
