### PR TITLE
[Doc] Adding Dataproc quick start steps to use new user tools package [skip ci]

### DIFF
--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -7,7 +7,14 @@ parent: Getting-Started
 
 # Getting started with RAPIDS Accelerator on GCP Dataproc
  [Google Cloud Dataproc](https://cloud.google.com/dataproc) is Google Cloud's fully managed Apache
- Spark and Hadoop service.  This guide will walk through the steps to:
+ Spark and Hadoop service.  The quick start guide will go through:
+
+* [Quick Start Prerequisitves](#quick-start-prerequisites) 
+* [Qualify CPU workloads for GPU acceleration](#qualify-cpu-workloads-for-gpu-acceleration)
+* [Bootstrap GPU cluster with optimized settings](#bootstrap-gpu-cluster-with-optimized-settings)
+* [Tune applications on GPU cluster](#tune-applications-on-gpu-cluster)
+
+The advanced guide will walk through the steps to:
 
 * [Create a Dataproc Cluster Accelerated by GPUs](#create-a-dataproc-cluster-accelerated-by-gpus)
 * [Run Pyspark or Scala ETL and XGBoost training Notebook on a Dataproc Cluster Accelerated by
@@ -15,6 +22,102 @@ parent: Getting-Started
 * [Submit the same sample ETL application as a Spark job to a Dataproc Cluster Accelerated by
   GPUs](#submit-spark-jobs-to-a-dataproc-cluster-accelerated-by-gpus)
 * [Build custom Dataproc image to accelerate cluster initialization time](#build-custom-dataproc-image-to-accelerate-cluster-init-time)
+
+## Quick Start Prerequisites
+
+* gcloud CLI is installed: https://cloud.google.com/sdk/docs/install
+* python 3.8+
+* `pip install spark-rapids-user-tools`
+
+## Qualify CPU Workloads for GPU Acceleration
+
+The qualification tool is run on a Dataproc cluster that has applications that have already run.
+The tool will output the applications recommended for acceleration along with estimated speed-up
+and cost saving metrics.  Additionally, it will provide information on how to launch a GPU-
+accelerated cluster to take advantage of the speed-up and cost savings.
+
+Usage: `spark_rapids_dataproc qualification --cluster <cluster-name> --region <region>`
+
+Example output:
+```bash
++----+------------+--------------------------------+----------------------+-----------------+-----------------+---------------+-----------------+
+|    | App Name   | App ID                         | Recommendation       |   Estimated GPU |   Estimated GPU |           App |   Estimated GPU |
+|    |            |                                |                      |         Speedup |     Duration(s) |   Duration(s) |      Savings(%) |
+|----+------------+--------------------------------+----------------------+-----------------+-----------------+---------------+-----------------|
+|  0 | query24    | application_1664888311321_0011 | Strongly Recommended |            3.49 |          257.18 |        897.68 |           59.70 |
+|  1 | query78    | application_1664888311321_0009 | Strongly Recommended |            3.35 |          113.89 |        382.35 |           58.10 |
+|  2 | query23    | application_1664888311321_0010 | Strongly Recommended |            3.08 |          325.77 |       1004.28 |           54.37 |
+|  3 | query64    | application_1664888311321_0008 | Strongly Recommended |            2.91 |          150.81 |        440.30 |           51.82 |
+|  4 | query50    | application_1664888311321_0003 | Recommended          |            2.47 |          101.54 |        250.95 |           43.08 |
+|  5 | query16    | application_1664888311321_0005 | Recommended          |            2.36 |          106.33 |        251.95 |           40.63 |
+|  6 | query38    | application_1664888311321_0004 | Recommended          |            2.29 |           67.37 |        154.33 |           38.59 |
+|  7 | query87    | application_1664888311321_0006 | Recommended          |            2.25 |           75.67 |        170.69 |           37.64 |
+|  8 | query51    | application_1664888311321_0002 | Recommended          |            1.53 |           53.94 |         82.63 |            8.18 |
++----+------------+--------------------------------+----------------------+-----------------+-----------------+---------------+-----------------+
+To launch a GPU-accelerated cluster with Spark RAPIDS, add the following to your cluster creation script:
+        --initialization-actions=gs://goog-dataproc-initialization-actions-us-central1/gpu/install_gpu_driver.sh,gs://goog-dataproc-initialization-actions-us-central1/rapids/rapids.sh \
+        --worker-accelerator type=nvidia-tesla-t4,count=2 \
+        --metadata gpu-driver-provider="NVIDIA" \
+        --metadata rapids-runtime=SPARK \
+        --cuda-version=11.5
+```
+
+## Bootstrap GPU Cluster with Optimized Settings
+
+The bootstrap tool will apply optimized settings for the RAPIDS Accelerator on Apache Spark on a 
+GPU cluster for Dataproc.  The tool will fetch the characteristics of the cluster -- including 
+number of workers, worker cores, worker memory, and GPU accelerator type and count.  It will use
+the cluster properties to then determine the optimal settings for running GPU-accelerated Spark 
+applications.
+
+Usage: `spark_rapids_dataproc bootstrap --cluster <cluster-name> --region <region>`
+
+Example output: 
+```bash
+##### BEGIN : RAPIDS bootstrap settings for gpu-cluster
+spark.executor.cores=16
+spark.executor.memory=32768m
+spark.executor.memoryOverhead=7372m
+spark.rapids.sql.concurrentGpuTasks=2
+spark.rapids.memory.pinnedPool.size=4096m
+spark.sql.files.maxPartitionBytes=512m
+spark.task.resource.gpu.amount=0.0625
+##### END : RAPIDS bootstrap settings for gpu-cluster
+```
+
+## Tune Applications on GPU Cluster
+
+Once Spark applications have been run on the GPU cluster, the profiling tool can be run to 
+analyze the event logs of the applications to determine if more optimal settings should be
+configured.  The tool will output a per-application set of config settings to be adjusted for
+enhanced performance.
+
+Usage: `spark_rapids_dataproc profiling --cluster <cluster-name> --region <region>`
+
+Example output:
+```bash
++--------------------------------+--------------------------------------------------+--------------------------------------------------------------------------------------------------+
+| App Name                       | Recommendations                                  | Comments                                                                                         |
++================================+==================================================+==================================================================================================+
+| application_1664894105643_0011 | --conf spark.executor.cores=16                   | - 'spark.task.resource.gpu.amount' was not set.                                                  |
+|                                | --conf spark.executor.memory=32768m              | - 'spark.rapids.sql.concurrentGpuTasks' was not set.                                             |
+|                                | --conf spark.executor.memoryOverhead=7372m       | - 'spark.rapids.memory.pinnedPool.size' was not set.                                             |
+|                                | --conf spark.rapids.memory.pinnedPool.size=4096m | - 'spark.executor.memoryOverhead' was not set.                                                   |
+|                                | --conf spark.rapids.sql.concurrentGpuTasks=2     | - 'spark.sql.files.maxPartitionBytes' was not set.                                               |
+|                                | --conf spark.sql.files.maxPartitionBytes=1571m   | - 'spark.sql.shuffle.partitions' was not set.                                                    |
+|                                | --conf spark.sql.shuffle.partitions=200          |                                                                                                  |
+|                                | --conf spark.task.resource.gpu.amount=0.0625     |                                                                                                  |
++--------------------------------+--------------------------------------------------+--------------------------------------------------------------------------------------------------+
+| application_1664894105643_0002 | --conf spark.executor.cores=16                   | - 'spark.task.resource.gpu.amount' was not set.                                                  |
+|                                | --conf spark.executor.memory=32768m              | - 'spark.rapids.sql.concurrentGpuTasks' was not set.                                             |
+|                                | --conf spark.executor.memoryOverhead=7372m       | - 'spark.rapids.memory.pinnedPool.size' was not set.                                             |
+|                                | --conf spark.rapids.memory.pinnedPool.size=4096m | - 'spark.executor.memoryOverhead' was not set.                                                   |
+|                                | --conf spark.rapids.sql.concurrentGpuTasks=2     | - 'spark.sql.files.maxPartitionBytes' was not set.                                               |
+|                                | --conf spark.sql.files.maxPartitionBytes=3844m   | - 'spark.sql.shuffle.partitions' was not set.                                                    |
+|                                | --conf spark.sql.shuffle.partitions=200          |                                                                                                  |
+|                                | --conf spark.task.resource.gpu.amount=0.0625     |                                                                                                  |
++--------------------------------+--------------------------------------------------+--------------------------------------------------------------------------------------------------+
+```
 
 ## Create a Dataproc Cluster Accelerated by GPUs
  

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -41,7 +41,7 @@ Usage: `spark_rapids_dataproc qualification --cluster <cluster-name> --region <r
 Help (to see all options available): `spark_rapids_dataproc qualification --help`
 
 Example output:
-```bash
+```
 +----+------------+--------------------------------+----------------------+-----------------+-----------------+---------------+-----------------+
 |    | App Name   | App ID                         | Recommendation       |   Estimated GPU |   Estimated GPU |           App |   Estimated GPU |
 |    |            |                                |                      |         Speedup |     Duration(s) |   Duration(s) |      Savings(%) |
@@ -77,7 +77,7 @@ Usage: `spark_rapids_dataproc bootstrap --cluster <cluster-name> --region <regio
 Help (to see all options available): `spark_rapids_dataproc bootstrap --help`
 
 Example output: 
-```bash
+```
 ##### BEGIN : RAPIDS bootstrap settings for gpu-cluster
 spark.executor.cores=16
 spark.executor.memory=32768m
@@ -101,7 +101,7 @@ Usage: `spark_rapids_dataproc profiling --cluster <cluster-name> --region <regio
 Help (to see all options available): `spark_rapids_dataproc profiling --help`
 
 Example output:
-```bash
+```
 +--------------------------------+--------------------------------------------------+--------------------------------------------------------------------------------------------------+
 | App ID                         | Recommendations                                  | Comments                                                                                         |
 +================================+==================================================+==================================================================================================+

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -97,7 +97,7 @@ Usage: `spark_rapids_dataproc profiling --cluster <cluster-name> --region <regio
 Example output:
 ```bash
 +--------------------------------+--------------------------------------------------+--------------------------------------------------------------------------------------------------+
-| App Name                       | Recommendations                                  | Comments                                                                                         |
+| App ID                         | Recommendations                                  | Comments                                                                                         |
 +================================+==================================================+==================================================================================================+
 | application_1664894105643_0011 | --conf spark.executor.cores=16                   | - 'spark.task.resource.gpu.amount' was not set.                                                  |
 |                                | --conf spark.executor.memory=32768m              | - 'spark.rapids.sql.concurrentGpuTasks' was not set.                                             |

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -89,6 +89,8 @@ spark.task.resource.gpu.amount=0.0625
 ##### END : RAPIDS bootstrap settings for gpu-cluster
 ```
 
+A detailed description for bootstrap settings with usage information is available in the [Configs](https://nvidia.github.io/spark-rapids/docs/configs.html) page.
+
 ## Tune Applications on GPU Cluster
 
 Once Spark applications have been run on the GPU cluster, the [profiling tool](https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html) can be run to 

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -89,7 +89,7 @@ spark.task.resource.gpu.amount=0.0625
 ##### END : RAPIDS bootstrap settings for gpu-cluster
 ```
 
-A detailed description for bootstrap settings with usage information is available in the [Configs](https://nvidia.github.io/spark-rapids/docs/configs.html) page.
+A detailed description for bootstrap settings with usage information is available in the [RAPIDS Accelerator for Apache Spark Configuration](https://nvidia.github.io/spark-rapids/docs/configs.html) and [Spark Configuration](https://spark.apache.org/docs/latest/configuration.html) page.
 
 ## Tune Applications on GPU Cluster
 

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -9,7 +9,7 @@ parent: Getting-Started
  [Google Cloud Dataproc](https://cloud.google.com/dataproc) is Google Cloud's fully managed Apache
  Spark and Hadoop service.  The quick start guide will go through:
 
-* [Quick Start Prerequisitves](#quick-start-prerequisites) 
+* [Quick Start Prerequisites](#quick-start-prerequisites) 
 * [Qualify CPU workloads for GPU acceleration](#qualify-cpu-workloads-for-gpu-acceleration)
 * [Bootstrap GPU cluster with optimized settings](#bootstrap-gpu-cluster-with-optimized-settings)
 * [Tune applications on GPU cluster](#tune-applications-on-gpu-cluster)
@@ -31,12 +31,14 @@ The advanced guide will walk through the steps to:
 
 ## Qualify CPU Workloads for GPU Acceleration
 
-The qualification tool is run on a Dataproc cluster that has applications that have already run.
+The [qualification tool](https://nvidia.github.io/spark-rapids/docs/spark-qualification-tool.html) is launched on a Dataproc cluster that has applications that have already run.
 The tool will output the applications recommended for acceleration along with estimated speed-up
 and cost saving metrics.  Additionally, it will provide information on how to launch a GPU-
 accelerated cluster to take advantage of the speed-up and cost savings.
 
 Usage: `spark_rapids_dataproc qualification --cluster <cluster-name> --region <region>`
+
+Help (to see all options available): `spark_rapids_dataproc qualification --help`
 
 Example output:
 ```bash
@@ -72,6 +74,8 @@ applications.
 
 Usage: `spark_rapids_dataproc bootstrap --cluster <cluster-name> --region <region>`
 
+Help (to see all options available): `spark_rapids_dataproc bootstrap --help`
+
 Example output: 
 ```bash
 ##### BEGIN : RAPIDS bootstrap settings for gpu-cluster
@@ -87,12 +91,14 @@ spark.task.resource.gpu.amount=0.0625
 
 ## Tune Applications on GPU Cluster
 
-Once Spark applications have been run on the GPU cluster, the profiling tool can be run to 
+Once Spark applications have been run on the GPU cluster, the [profiling tool](https://nvidia.github.io/spark-rapids/docs/spark-profiling-tool.html) can be run to 
 analyze the event logs of the applications to determine if more optimal settings should be
 configured.  The tool will output a per-application set of config settings to be adjusted for
 enhanced performance.
 
 Usage: `spark_rapids_dataproc profiling --cluster <cluster-name> --region <region>`
+
+Help (to see all options available): `spark_rapids_dataproc profiling --help`
 
 Example output:
 ```bash


### PR DESCRIPTION
Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Updating GCP Dataproc getting started page with new quick start steps to utilize the soon-to-be-released spark-rapids-user-tools package