### PR TITLE
Fix AutoTuner yaml error handling and discovery script rounding

### DIFF
--- a/tools/scripts/discoveryScript.sh
+++ b/tools/scripts/discoveryScript.sh
@@ -80,9 +80,8 @@ function get_gpu_properties() {
   IFS=',' read -ra gpuInfoArr <<< "$gpuInfo"
   gpuCount=${gpuInfoArr[0]}
   gpuName=${gpuInfoArr[1]}
-  local gpuMemoryInMb="$(echo ${gpuInfoArr[2]} | cut -d' ' -f1)"
-  gpuMemoryInGb=$((gpuMemoryInMb / 1024))
-  gpuMemoryInGb="${gpuMemoryInGb}gb"
+  # GPU memory should have units but separated by space so remove the space
+  gpuMemoryInMb="$(echo ${gpuInfoArr[2]} | sed 's/ //g')"
 }
 
 function get_disk_space() {

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -45,10 +45,12 @@ class GpuWorkerProps(
     this("0m", 0, "None")
   }
   def isMissingInfo: Boolean = {
-    count == 0 || memory.startsWith("0") || name == "None"
+    memory == null || memory.isEmpty || name == null || name.isEmpty ||
+       count == 0 || memory.startsWith("0") || name == "None"
   }
   def isEmpty: Boolean = {
-    count == 0 && memory.startsWith("0") && name == "None"
+    count == 0 && (memory == null || memory.isEmpty || memory.startsWith("0")) &&
+      (name == null || name.isEmpty || name == "None")
   }
   /**
    * If the GPU count is missing, it will set 1 as a default value
@@ -64,7 +66,7 @@ class GpuWorkerProps(
     }
   }
   def setDefaultGpuNameIfMissing: Boolean = {
-    if (name == "None") {
+    if (name == null || name.isEmpty || name == "None") {
       name = AutoTuner.DEF_WORKER_GPU_NAME
       true
     } else {
@@ -75,13 +77,13 @@ class GpuWorkerProps(
   /**
    * If the GPU memory is missing, it will sets a default valued based on the GPU device and the
    * static HashMap [[AutoTuner.DEF_WORKER_GPU_MEMORY_MB]].
-   * If it is still missing, it sets a default to 16384m.
+   * If it is still missing, it sets a default to 15109m.
    *
    * @return true if the value has been updated.
    */
   def setDefaultGpuMemIfMissing: Boolean = {
-    if (memory.startsWith("0")) {
-      memory = AutoTuner.DEF_WORKER_GPU_MEMORY_MB.getOrElse(getName, "16384m")
+    if (memory == null || memory.isEmpty || memory.startsWith("0")) {
+      memory = AutoTuner.DEF_WORKER_GPU_MEMORY_MB.getOrElse(getName, "15109m")
       true
     } else {
       false
@@ -129,7 +131,7 @@ class SystemClusterProps(
   }
   def isEmpty: Boolean = {
     // consider the object incorrect if either numCores or memory are not set.
-    numCores <= 0 || memory.startsWith("0")
+    memory == null || memory.isEmpty || numCores <= 0 || memory.startsWith("0")
   }
   def setDefaultNumWorkersIfMissing(): Boolean = {
     if (numWorkers <= 0) {

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -209,7 +209,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.sql.files.maxPartitionBytes" -> "512m",
       "spark.task.resource.gpu.amount" -> "0.0625")
     val sparkProps = defaultDataprocProps.++(customProps)
-    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(0))
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
+      Some("122880MiB"), Some(4), Some(0))
     val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -268,8 +269,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.sql.files.maxPartitionBytes" -> "512m",
       "spark.task.resource.gpu.amount" -> "0.0625")
     val sparkProps = defaultDataprocProps.++(customProps)
-    val dataprocWorkerInfo =
-      buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), Some("0M"))
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
+      Some("122880MiB"), Some(4), Some(2), Some("0M"))
     val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -295,8 +296,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.sql.files.maxPartitionBytes" -> "512m",
       "spark.task.resource.gpu.amount" -> "0.0625")
     val sparkProps = defaultDataprocProps.++(customProps)
-    val dataprocWorkerInfo =
-      buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), Some("0MiB"), None)
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
+      Some("122880MiB"), Some(4), Some(2), Some("0MiB"), None)
     val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
@@ -324,8 +325,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
       "spark.sql.files.maxPartitionBytes" -> "512m",
       "spark.task.resource.gpu.amount" -> "0.0625")
     val sparkProps = defaultDataprocProps.++(customProps)
-    val dataprocWorkerInfo =
-      buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), Some("0MiB"), Some("GPU-X"))
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
+      Some("122880MiB"), Some(4), Some(2), Some("0MiB"), Some("GPU-X"))
     val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)


### PR DESCRIPTION
Fix an issue with discovery script and rounding. for T4 for memory was reported as 15109 it would end up rounding down to 14GB and we would recommend 1 concurrent instead of 2.
 
Fix AutoTuner handling when yaml file missing a value or value is empty for the things that are strings. Added tests.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
