### PR TITLE
Removing --help tools tests that trigger System.exit()

### DIFF
--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -848,19 +848,4 @@ class ApplicationInfoSuite extends FunSuite with Logging {
       }
     }
   }
-
-  test("--help at end of command line arguments") {
-    val testLogDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
-    val eventLog = s"$logDir/rp_sql_eventlog.zstd"
-    TrampolineUtil.withTempDir { outpath =>
-      val allArgs = Array(
-        "--output-directory",
-        eventLog)
-      val lastArgs = Array("--help")
-
-      val appArgs = new ProfileArgs(allArgs ++ lastArgs)
-      val (exit, _) = ProfileMain.mainInternal(appArgs)
-      assert(exit == 0)
-    }
-  }
 }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -1045,22 +1045,6 @@ class QualificationSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
     }
   }
-
-  test("--help at end of command line arguments") {
-    val qualLogDir = ToolTestUtils.getTestResourcePath("spark-events-qualification")
-    val logFiles = Array(s"$qualLogDir/gpu_eventlog")
-    TrampolineUtil.withTempDir { outpath =>
-      val allArgs = Array(
-        "--output-directory",
-        outpath.getAbsolutePath())
-      val lastArgs = Array("--help")
-
-      val appArgs = new QualificationArgs(allArgs ++ logFiles ++ lastArgs)
-      val (exit, appSum) = QualificationMain.mainInternal(appArgs)
-      assert(exit == 0)
-      assert(appSum.size == 0)
-    }
-  }
 }
 
 class ToolTestListener extends SparkListener {


### PR DESCRIPTION
Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Unit tests that triggered --help scenario with System.exit() was causing test suite to stop before completing.  Removing tests.