### PR TITLE
Take semaphore after first stream batch is materialized (broadcast)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.TaskContext
+
+/**
+ * Helper iterator that wraps a BufferedIterator of AutoCloseable subclasses.
+ * This iterator also implements AutoCloseable, so it can be closed in case
+ * of exceptions.
+ *
+ * @param wrapped the buffered iterator
+ * @tparam T an AutoCloseable subclass
+ */
+class CloseableBufferedIterator[T <: AutoCloseable](wrapped: BufferedIterator[T])
+  extends BufferedIterator[T] with AutoCloseable {
+  // register against task completion to close any leaked buffered items
+  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+
+  private[this] var isClosed = false
+  override def head: T = wrapped.head
+  override def headOption: Option[T] = wrapped.headOption
+  override def next: T = wrapped.next
+  override def hasNext: Boolean = wrapped.hasNext
+  override def close(): Unit = {
+    if (!isClosed) {
+      headOption.foreach(_.close())
+      isClosed = true
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBroadcastHashJoinExec.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.GpuShuffledHashJoinExec.CloseableBufferedIterator
 import com.nvidia.spark.rapids.shims.ShimBinaryExecNode
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBroadcastHashJoinExec.scala
@@ -164,7 +164,7 @@ case class GpuBroadcastHashJoinExec(
    * (including IO) to produce that first batch. Once the first stream batch is produced,
    * the build side is materialized to the GPU (while holding the semaphore).
    *
-   * TODO: This could try to trigger the broadcast meterialization on the host before
+   * TODO: This could try to trigger the broadcast materialization on the host before
    *   getting started on the stream side (e.g. call `broadcastRelation.value`).
    */
   private def getBroadcastBuiltBatchAndStreamIter(


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/6708. 

This PR fixes a performance regression unintentionally introduced in https://github.com/NVIDIA/spark-rapids/pull/6604, where the semaphore  was acquired too early in the broadcast join, early enough that it would include the IO required for the stream side to materialize. It is a similar fix to what was merged in this PR https://github.com/NVIDIA/spark-rapids/pull/4588 for `GpuShuffledHashJoinExec`. 

Note: We could also try to trigger the broadcast materialization on the host before getting started on the stream side, but this code doesn't do that right now. Materializing the broadcast on the host before the semaphore would be more inline with what the code was doing before the spillable patch.

With this fix we recovered the performance loss in the benchmark.