### PR TITLE
Improve tiered project by eliminating eclipsed columns in each tier

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -139,10 +139,11 @@ object GpuBindReferences extends Logging {
 
     val exprTiers = GpuEquivalentExpressions.getExprTiers(expressions)
     val inputTiers = GpuEquivalentExpressions.getInputTiers(exprTiers, input)
+    val columnSkipTiers = GpuEquivalentExpressions.getColumnSkipTiers(inputTiers)
     GpuTieredProject(exprTiers.zip(inputTiers).map {
       case (es:Seq[Expression], is:AttributeSeq) =>
         es.map(GpuBindReferences.bindGpuReference(_, is)).toList
-    })
+    }, columnSkipTiers)
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable
 import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
 
 import org.apache.spark.TaskContext
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, CaseWhen, Coalesce, Expression, If, LeafExpression, PlanExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, AttributeSet, CaseWhen, Coalesce, Expression, If, LeafExpression, PlanExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.objects.LambdaVariable
 
@@ -300,7 +300,7 @@ object GpuEquivalentExpressions {
   private def recurseUpdateTiers(exprTiers: Seq[Seq[Expression]],
       updatedTiers: Seq[Seq[Expression]],
       substitutionMap: mutable.HashMap[Expression, Expression],
-      startIndex: Int):Seq[Seq[Expression]] = {
+      startIndex: Int): Seq[Seq[Expression]] = {
     exprTiers match {
       case Nil => updatedTiers
       case tier :: tail => {
@@ -330,7 +330,7 @@ object GpuEquivalentExpressions {
     }
   }
 
-  def getExprTiers(expressions : Seq[Expression]): Seq[Seq[Expression]] = {
+  def getExprTiers(expressions: Seq[Expression]): Seq[Seq[Expression]] = {
     // Get tiers of common expressions
     val expressionTiers = recurseCommonExpressions(expressions, Seq(expressions))
     val substitutionMap = mutable.HashMap.empty[Expression, Expression]
@@ -338,26 +338,74 @@ object GpuEquivalentExpressions {
     recurseUpdateTiers(expressionTiers, Seq.empty, substitutionMap, 0)
   }
 
+  // For a given set of input attr tiers, determine which attributes can be
+  // skipped when building the list of attributes for the next tier.
+  // Returns a set of tiers that are the same size as the input tiers, but
+  // are lists of boolean values that are true if the column can be skipped.
+  // The indices of the attributes correspond to the columns that
+  // are bound via GpuBindReferences.bindGpuReference.
+  def getColumnSkipTiers(inputTiers: Seq[AttributeSeq]): Seq[Seq[Boolean]] = {
+    @tailrec
+    def recurse(curTier: AttributeSeq, remainingTiers: Seq[AttributeSeq],
+        skipTiers: Seq[Seq[Boolean]]): Seq[Seq[Boolean]] = remainingTiers match {
+      case Nil =>
+        // For the last tier, fill with all true (skip) values, because the output
+        // of the last tier does not include any input columns.
+        skipTiers ++ Seq(Seq.fill(curTier.attrs.size)(true))
+      case nextTier :: tail =>
+        val curAttrs = curTier.attrs
+        val nextAttrs = nextTier.attrs
+        // This is equivalent to:
+        // skipList = curAttrs.map(a => if (nextAttrs.contains(a)) false else true)
+        // but this should be faster
+        val skipList = new Array[Boolean](curAttrs.size)
+        var curIdx = 0
+        var nextIdx = 0
+        while (curIdx < curAttrs.size) {
+          if (nextAttrs(nextIdx) == curAttrs(curIdx)) {
+            skipList(curIdx) = false
+            nextIdx += 1
+          } else {
+            skipList(curIdx) = true
+          }
+          curIdx += 1
+        }
+        recurse(nextTier, tail, skipTiers ++ Seq(skipList.toSeq))
+    }
+    inputTiers match {
+      case Nil => Seq.empty
+      case _ => recurse(inputTiers.head, inputTiers.tail, Seq.empty)
+    }
+  }
+
+  // Determine which of the inputAttrs are needed for remaining tiers
+  // Filter the inputAttrs using this set to determine which ones
+  // we need for the next tier, and to maintain the ordering.
+  // Exposed for testing.
+  private[sql] def getAttrsForNextTier(inputAttrs: Seq[Attribute],
+      exprTiers: Seq[Seq[Expression]]): Seq[Attribute] = {
+    val needAttrs = exprTiers.tail match {
+      case Nil => AttributeSet.empty
+      case _ => AttributeSet(exprTiers.tail.flatten)
+    }
+    val curAttrs = exprTiers.head.filter(e => e.isInstanceOf[GpuAlias]).
+        map(_.asInstanceOf[GpuAlias].toAttribute)
+    (inputAttrs ++ curAttrs).filter(a => needAttrs.contains(a))
+  }
+
   // Given expression tiers as created by getExprTiers and a set of input attributes,
   // return the tiers of input attributes that correspond with the expression tiers.
   def getInputTiers(exprTiers: Seq[Seq[Expression]], inputAttrs: AttributeSeq):
   Seq[AttributeSeq] = {
-    def recurse(et: Seq[Seq[Expression]], inputs: AttributeSeq): Seq[AttributeSeq] = {
-      et match {
-        case Nil => Nil
-        case s :: tail => {
-          val newInputs = if (tail.isEmpty) {
-            Nil
-          } else {
-            s.filter(e => e.isInstanceOf[GpuAlias]).map(_.asInstanceOf[GpuAlias].toAttribute)
-          }
-          val attrSeq = AttributeSeq(inputs.attrs ++ newInputs)
-          val recursionResult = recurse(tail, attrSeq)
-          Seq(inputs) ++ recursionResult
-        }
-      }
+    @tailrec
+    def recurse(exprs: Seq[Seq[Expression]], inputs: AttributeSeq,
+        attrTiers: Seq[AttributeSeq]): Seq[AttributeSeq] = exprs match {
+      case Nil => attrTiers
+      case _ :: tail =>
+        val nextAttrs = getAttrsForNextTier(inputs.attrs, exprs)
+        recurse(tail, AttributeSeq(nextAttrs), attrTiers ++ Seq(inputs))
     }
-    recurse(exprTiers, inputAttrs)
+    recurse(exprTiers, inputAttrs, Seq.empty)
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Closes #6524 

Tiered projections were added in [#6466](https://github.com/NVIDIA/spark-rapids/pull/6466).
The initial version added the output columns from each tier to the input columns to determine the input columns for the next tier.   This works, but keeps around some columns that are no longer needed.

With this PR, columns that are no longer needed in later tiers are removed.  This should reduce the additional memory needed for tiered projections.

For example, the set of expressions `(a + b), (a + b + c), (a + b + c +d)` now produces these tiers: 
```
Tier 1 Inputs:        a, b, c, d
Tier 1 Expressions:  (a + b) as tmp1

Tier 2 Inputs:        c, d, tmp1  (a, b are removed)
Tier 2 Expressions:   (tmp1 + c) as tmp2

Tier 3 Inputs:        d, tmp1, tmp2  (c is removed)
Tier 3 Expressions:   tmp1, tmp2, (tmp2 + d)
```