### PR TITLE
Document that we test on JDK8 and JDK11, other versions are untested [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,9 @@ You can build against different versions of the CUDA Toolkit by using qone of th
 * `-Pcuda11` (CUDA 11.0/11.1/11.2, default)
 
 ### Building and Testing with JDK9+
-We support JDK8 as our main JDK version. However, it's possible to build and run with more modern
-JDK versions as well. To this end set `JAVA_HOME` in the environment to your JDK root directory.
+We support JDK8 as our main JDK version, and test JDK8 and JDK11. It is possible to build and run
+with more modern JDK versions, however these are untested. The first step is to set `JAVA_HOME` in
+the environment to your JDK root directory.
 
 At the time of this writing, the most robust way to run the RAPIDS Accelerator is from a jar dedicated to
 a single Spark version. To this end please use a single shim and specify `-DallowConventionalDistJar=true`


### PR DESCRIPTION
Signed-off-by: Sameer Raheja <sraheja@nvidia.com>

Add documentation to clarify that we do not test on JDK versions other than 8 and 11. 

Closes #6509 