### PR TITLE
Fix a couple of markdown links that are now permanently moved [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -52,8 +52,8 @@ The minimum UCX requirement for the RAPIDS Shuffle Manager is
 
 #### Baremetal
 
-1. If you have Mellanox hardware, please ensure you have the [MLNX_OFED driver](https://www.mellanox.com/products/infiniband-drivers/linux/mlnx_ofed), and the
-[`nv_peer_mem` kernel module](https://www.mellanox.com/products/GPUDirect-RDMA) installed. UCX packages
+1. If you have Mellanox hardware, please ensure you have the [MLNX_OFED driver](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed), and the
+[`nv_peer_mem` kernel module](https://network.nvidia.com/products/GPUDirect-RDMA) installed. UCX packages
    are compatible with MLNX_OFED 5.0+. Please install the latest driver available.
 
    With `nv_peer_mem` (GPUDirectRDMA), IB/RoCE-based transfers can perform zero-copy transfers

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -52,8 +52,8 @@ The minimum UCX requirement for the RAPIDS Shuffle Manager is
 
 #### Baremetal
 
-1. If you have Mellanox hardware, please ensure you have the [MLNX_OFED driver](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed), and the
-[`nv_peer_mem` kernel module](https://network.nvidia.com/products/GPUDirect-RDMA) installed. UCX packages
+1. If you have Mellanox hardware, please ensure you have the [MLNX_OFED driver](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/), and the
+[`nv_peer_mem` kernel module](https://network.nvidia.com/products/GPUDirect-RDMA/) installed. UCX packages
    are compatible with MLNX_OFED 5.0+. Please install the latest driver available.
 
    With `nv_peer_mem` (GPUDirectRDMA), IB/RoCE-based transfers can perform zero-copy transfers


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

There are a couple of links in the shuffle documentation that have permanently moved to `network.nvidia.com`. It looks like sometimes the redirect or the original host can be flaky, so making the change permanent in the docs.