### PR TITLE
Qualification tool: Read SQL function names for parsing expressions

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -84,7 +84,7 @@ class PluginTypeChecker extends Logging {
 
   private def readOperatorsScore: Map[String, Double] = {
     val source = Source.fromResource(OPERATORS_SCORE_FILE)
-    readSupportedOperators(source).map(x => (x._1, x._2.toDouble))
+    readSupportedOperators(source, "score").map(x => (x._1, x._2.toDouble))
   }
 
   private def readSupportedExecs: Map[String, String] = {
@@ -94,7 +94,10 @@ class PluginTypeChecker extends Logging {
 
   private def readSupportedExprs: Map[String, String] = {
     val source = Source.fromResource(SUPPORTED_EXPRS_FILE)
-    readSupportedOperators(source).map(x => (x._1.toLowerCase, x._2))
+    // Some SQL function names have backquotes(`) around their names,
+    // so we remove them before saving.
+      readSupportedOperators(source, "exprs").map(
+      x => (x._1.toLowerCase.replaceAll("\\`", ""), x._2))
   }
 
   private def readSupportedTypesForPlugin: (
@@ -103,7 +106,10 @@ class PluginTypeChecker extends Logging {
     readSupportedTypesForPlugin(source)
   }
 
-  private def readSupportedOperators(source: BufferedSource): Map[String, String] = {
+  // operatorType can be exprs, score or execs(default). Reads the columns in file depending
+  // on the operatorType passed to this function.
+  private def readSupportedOperators(source: BufferedSource,
+      operatorType: String = "execs"): Map[String, String] = {
     val supportedOperators = HashMap.empty[String, String]
     try {
       val fileContents = source.getLines().toSeq
@@ -121,7 +127,27 @@ class PluginTypeChecker extends Logging {
               s" header length doesn't match rows length. Row that doesn't match is " +
               s"${cols.mkString(",")}")
         }
-        supportedOperators.put(cols(0), cols(1))
+        // There are addidtional checks for Expressions. In physical plan, SQL function name is
+        // printed instead of expression name. We have to save both expression name and
+        // SQL function name(if there is one) so that we don't miss the expression while
+        // parsing the execs.
+        // Ex: Expression name = Substring, SQL function= `substr`; `substring`
+        // Ex: Expression name = Average, SQL function name = `avg`
+        if (operatorType.equals("exprs")) {
+          // save expression name
+          supportedOperators.put(cols(0), cols(1))
+          // Check if there is SQL function name for the above expression
+          if (cols(2).nonEmpty && cols(2) != None) {
+            // Split on `;` if there are multiple SQL names as shown in above example and
+            // save each SQL function name as a separate key.
+            val sqlFuncNames = cols(2).split(";")
+            for (i <- sqlFuncNames) {
+              supportedOperators.put(i, cols(1))
+            }
+          }
+        } else {
+          supportedOperators.put(cols(0), cols(1))
+        }
       }
     } finally {
       source.close()

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/qualification/PluginTypeChecker.scala
@@ -96,7 +96,7 @@ class PluginTypeChecker extends Logging {
     val source = Source.fromResource(SUPPORTED_EXPRS_FILE)
     // Some SQL function names have backquotes(`) around their names,
     // so we remove them before saving.
-      readSupportedOperators(source, "exprs").map(
+    readSupportedOperators(source, "exprs").map(
       x => (x._1.toLowerCase.replaceAll("\\`", ""), x._2))
   }
 

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -669,4 +669,27 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
       }
     }
   }
+
+  test("Parse SQL function Name in HashAggregateExec") {
+    TrampolineUtil.withTempDir { eventLogDir =>
+      val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "sqlmetric") { spark =>
+        import spark.implicits._
+        val df1 = Seq((1, "a"), (1, "aa"), (1, "a"), (2, "b"),
+          (2, "b"), (3, "c"), (3, "c")).toDF("num", "letter")
+        // Average is Expression name and `avg` is SQL function name.
+        // SQL function name is in the eventlog as shown below.
+        // HashAggregate(keys=[letter#187], functions=[avg(cast(num#186 as bigint))])
+        df1.groupBy("letter").avg("num")
+      }
+      val pluginTypeChecker = new PluginTypeChecker()
+      val app = createAppFromEventlog(eventLog)
+      assert(app.sqlPlans.size == 1)
+      val parsedPlans = app.sqlPlans.map { case (sqlID, plan) =>
+        SQLPlanParser.parseSQLPlan(app.appId, plan, sqlID, "", pluginTypeChecker, app)
+      }
+      val execInfo = getAllExecsFromPlan(parsedPlans.toSeq)
+      val hashAggregate = execInfo.filter(_.exec == "HashAggregate")
+      assertSizeAndSupported(2, hashAggregate, 4.5)
+    }
+  }
 }


### PR DESCRIPTION
This fixes a bug where some of the expressions were marked as not supported even though those were supported in spark-rapids.
Earlier we were reading Expression name and saving that as key which was later used to check if a particular expression is supported or not.
Issue was for some of the expressions, their corresponding SQL function names were different. In the eventlog, SQL function name is present which is parsed in the tool.
Examples: 
1. Expression name - Average, SQL function name - avg
2. Expression name -Substring, SQL function name - substr; substring

This PR fixes the bug where it reads the SQL function names as well and stores them as key in addition to Expression names.
Added unit test which verfies reading of SQL function name and parsing it correctly. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
