### PR TITLE
Provision hive scratch dir before test execution

### DIFF
--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import re
+import stat
 import sys
 
 logging.basicConfig(
@@ -81,7 +82,23 @@ def pyspark_ready():
         return False
 
 
+def global_init():
+    logging.info("Executing global initialization tasks before test launches")
+    create_tmp_hive()
+
+def create_tmp_hive():
+    path = '/tmp/hive'
+    mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+    logging.info(f"Creating directory {path} with permissions {oct(mode)}")
+    os.makedirs(path, mode, exist_ok=True)
+    os.chmod(path, mode)
+
 def pytest_sessionstart(session):
+    # initializations that must happen globally once before tests start
+    # if xdist in the coordinator, if not xdist in the pytest process
+    if not running_with_xdist(session, is_worker=True):
+        global_init()
+
     if running_with_xdist(session, is_worker = True):
         logging.info("Initializing findspark because running with xdist worker")
         findspark_init()


### PR DESCRIPTION
Fixes #6146

- Create a place holder for global initialization for pytests
- Add /tmp/hive provisioning. It's a world-writable dir where hive creates user-writable dirs `/tmp/hive/$USER`

Tested with:
```bash
rm -rf /tmp/hive; \
PYSP_TEST_spark_rapids_memory_gpu_minAllocFraction=0 \
PYSP_TEST_spark_rapids_memory_gpu_allocFraction=0.1 \
./integration_tests/run_pyspark_from_build.sh -k existence -s -x
```
for `TEST_PARALLEL=0` and `TEST_PARALLEL=2`

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
