### PR TITLE
Fix NullPointerException in iceberg schema parsing code when selecting single column

### DIFF
--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -78,8 +78,6 @@ def test_iceberg_aqe_dpp(spark_tmp_table_factory, reader_type):
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
 def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, data_gens, reader_type):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(data_gens)]
-    # just change it up from selecting the first column
-    select_column = '_c' + str(len(data_gens))
     table = spark_tmp_table_factory.get()
     tmpview = spark_tmp_table_factory.get()
     def setup_iceberg_table(spark):
@@ -89,7 +87,7 @@ def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, dat
     with_cpu_session(setup_iceberg_table)
     # explicitly only select 1 column to make sure we test that path in the schema parsing code
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : spark.sql("SELECT {} FROM {}".format(select_column, table)),
+        lambda spark : spark.sql("SELECT _c0 FROM {}".format(table)),
         conf={'spark.rapids.sql.format.parquet.reader.type': reader_type})
 
 @iceberg

--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -79,7 +79,7 @@ def test_iceberg_aqe_dpp(spark_tmp_table_factory, reader_type):
 def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, data_gens, reader_type):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(data_gens)]
     # just change it up from selecting the first column
-    select_colunmn = '_c' + str(len(data_gens))
+    select_colunm = '_c' + str(len(data_gens))
     table = spark_tmp_table_factory.get()
     tmpview = spark_tmp_table_factory.get()
     def setup_iceberg_table(spark):

--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -79,7 +79,7 @@ def test_iceberg_aqe_dpp(spark_tmp_table_factory, reader_type):
 def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, data_gens, reader_type):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(data_gens)]
     # just change it up from selecting the first column
-    select_colunm = '_c' + str(len(data_gens))
+    select_column = '_c' + str(len(data_gens))
     table = spark_tmp_table_factory.get()
     tmpview = spark_tmp_table_factory.get()
     def setup_iceberg_table(spark):

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
@@ -311,10 +311,12 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
 
     @Override
     public Type list(Types.ListType expectedList, GroupType list, Type element) {
-      boolean hasConstant = expectedList.fields().stream()
+      if (expectedList != null) {
+        boolean hasConstant = expectedList.fields().stream()
           .anyMatch(f -> idToConstant.containsKey(f.fieldId()));
-      if (hasConstant) {
-        throw new UnsupportedOperationException("constant column in list");
+        if (hasConstant) {
+          throw new UnsupportedOperationException("constant column in list");
+        }
       }
       GroupType repeated = list.getType(0).asGroupType();
       Type originalElement = repeated.getType(0);
@@ -326,10 +328,12 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
 
     @Override
     public Type map(Types.MapType expectedMap, GroupType map, Type key, Type value) {
-      boolean hasConstant = expectedMap.fields().stream()
+      if (expectedMap != null) {
+        boolean hasConstant = expectedMap.fields().stream()
           .anyMatch(f -> idToConstant.containsKey(f.fieldId()));
-      if (hasConstant) {
-        throw new UnsupportedOperationException("constant column in map");
+        if (hasConstant) {
+          throw new UnsupportedOperationException("constant column in map");
+        }
       }
       GroupType repeated = map.getFields().get(0).asGroupType();
       Type originalKey = repeated.getType(0);


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/6723

The issue here is that we are iterating over the expected schema columns and comparing it to the actual.  In this case the actual contains an list column but we aren't selecting it, so the code here tries to dereference expected=null.

Its only using the expected column to check for constant columns so we can just skip the check when its null.

added test (without this fix will fail with null pointer exception) and manually ran with file I originally found issue with.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
