### PR TITLE
Fix an unchecked conversion warning

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
@@ -362,7 +362,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     @Override
     protected FilePartitionReaderBase createRapidsReader(PartitionedFile[] pFiles,
         StructType partitionSchema) {
-      ArrayList<ParquetSingleDataBlockMeta> clippedBlocks = new ArrayList();
+      ArrayList<ParquetSingleDataBlockMeta> clippedBlocks = new ArrayList<>();
       files.values().forEach(fst -> {
         FilteredParquetFileInfo filteredInfo = filterParquetBlocks(fst);
         List<ParquetSingleDataBlockMeta> fileSingleMetas =


### PR DESCRIPTION
Fix Javac "unchecked conversion" warning 

```
[WARNING] [Warn] /path/NVIDIA/spark-rapids/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java:365: found raw type: java.util.ArrayList
  missing type arguments for generic class java.util.ArrayList<E>
[WARNING] [Warn] /path/NVIDIA/spark-rapids/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java:365: unchecked conversion
  required: java.util.ArrayList<com.nvidia.spark.rapids.ParquetSingleDataBlockMeta>
  found:    java.util.ArrayList
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
