### PR TITLE
Reverse normalizing `nan` in the GpuSortArray

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -407,25 +407,7 @@ case class GpuSortArray(base: Expression, ascendingOrder: Expression)
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): cudf.ColumnVector = {
     val isDescending = isDescendingOrder(rhs)
-    val base = lhs.getBase()
-    withResource(base.getChildColumnView(0)) {child =>
-      withResource(child.copyToColumnVector()) {child =>
-        // When the average length of array is > 100
-        // and there are `-Nan`s in the data, the sort ordering
-        // of `Nan`s is inconsistent. So we need to normalize the data
-        // before sorting. This workaround can be removed after
-        // solving https://github.com/rapidsai/cudf/issues/11630
-        val normalizedChild = ColumnCastUtil.deepTransform(child) {
-          case (cv, _) if cv.getType == cudf.DType.FLOAT32 || cv.getType == cudf.DType.FLOAT64 =>
-              cv.normalizeNANsAndZeros()
-        }
-        withResource(normalizedChild) {normalizedChild =>
-          withResource(base.replaceListChild(normalizedChild)) {normalizedList =>
-            normalizedList.listSortRows(isDescending, true)
-          }
-        }
-      }
-    }
+    lhs.getBase.listSortRows(isDescending, true)
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): cudf.ColumnVector = {


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Close #6588
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
