### PR TITLE
Rework for adding event log info for profiler output

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -18,7 +18,6 @@ package com.nvidia.spark.rapids.tool.profiling
 
 case class ApplicationSummaryInfo(
     val appInfo: Seq[AppInfoProfileResults],
-    val appEventLogPath: Seq[AppEventLogPath],
     val dsInfo: Seq[DataSourceProfileResult],
     val execInfo: Seq[ExecutorInfoProfileResult],
     val jobInfo: Seq[JobInfoProfileResult],
@@ -38,4 +37,5 @@ case class ApplicationSummaryInfo(
     val sparkProps: Seq[RapidsPropertyProfileResult],
     val sqlStageInfo: Seq[SQLStageInfoProfileResult],
     val wholeStage: Seq[WholeStageCodeGenResults],
-    val maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes])
+    val maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes],
+    val appLogPath: Seq[AppLogPathProfileResults])

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ClassWarehouse.scala
@@ -234,7 +234,7 @@ case class AppInfoProfileResults(appIndex: Int, appName: String,
   }
 }
 
-case class AppEventLogPath(appIndex: Int, appName: String,
+case class AppLogPathProfileResults(appIndex: Int, appName: String,
     appId: Option[String], eventLogPath: String)  extends ProfileResult {
   override val outputHeaders = Seq("appIndex", "appName", "appId",
     "eventLogPath")

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/CollectInformation.scala
@@ -46,11 +46,10 @@ class CollectInformation(apps: Seq[ApplicationInfo]) extends Logging {
     }
   }
 
-  def getAppEventLogPath: Seq[AppEventLogPath] = {
+  def getAppLogPath: Seq[AppLogPathProfileResults] = {
     val allRows = apps.map { app =>
       val a = app.appInfo
-      AppEventLogPath(app.index, a.appName, a.appId,
-        app.eventLogPath)
+      AppLogPathProfileResults(app.index, a.appName, a.appId, app.eventLogPath)
     }
     if (allRows.size > 0) {
       allRows.sortBy(cols => (cols.appIndex))

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -286,7 +286,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
 
     val collect = new CollectInformation(apps)
     val appInfo = collect.getAppInfo
-    val appEventLogPath = collect.getAppEventLogPath
+    val appLogPath = collect.getAppLogPath
     val dsInfo = collect.getDataSourceInfo
     val execInfo = collect.getExecutorInfo
     val jobInfo = collect.getJobInfo
@@ -354,10 +354,10 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
           s"to $outputDir in $duration second(s)\n")
       }
     }
-    (ApplicationSummaryInfo(appInfo, appEventLogPath, dsInfo, execInfo, jobInfo, rapidsProps, 
+    (ApplicationSummaryInfo(appInfo, dsInfo, execInfo, jobInfo, rapidsProps, 
       rapidsJar, sqlMetrics, jsMetAgg, sqlTaskAggMetrics, durAndCpuMet, skewInfo, failedTasks, 
       failedStages, failedJobs, removedBMs, removedExecutors, unsupportedOps, sparkProps, 
-      sqlStageInfo, wholeStage, maxTaskInputInfo), compareRes)
+      sqlStageInfo, wholeStage, maxTaskInputInfo, appLogPath), compareRes)
   }
 
   def writeOutput(profileOutputWriter: ProfileOutputWriter,
@@ -394,7 +394,6 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
       }
       val reduced = ApplicationSummaryInfo(
         appsSum.flatMap(_.appInfo).sortBy(_.appIndex),
-        appsSum.flatMap(_.appEventLogPath).sortBy(_.appIndex),
         appsSum.flatMap(_.dsInfo).sortBy(_.appIndex),
         appsSum.flatMap(_.execInfo).sortBy(_.appIndex),
         appsSum.flatMap(_.jobInfo).sortBy(_.appIndex),
@@ -414,7 +413,8 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
         combineProps(rapidsOnly=false, appsSum).sortBy(_.key),
         appsSum.flatMap(_.sqlStageInfo).sortBy(_.duration)(Ordering[Option[Long]].reverse),
         appsSum.flatMap(_.wholeStage).sortBy(_.appIndex),
-        appsSum.flatMap(_.maxTaskInputBytesRead).sortBy(_.appIndex)
+        appsSum.flatMap(_.maxTaskInputBytesRead).sortBy(_.appIndex),
+        appsSum.flatMap(_.appLogPath).sortBy(_.appIndex)
       )
       Seq(reduced)
     } else {
@@ -423,7 +423,7 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
     sums.foreach { app =>
       profileOutputWriter.writeText("### A. Information Collected ###")
       profileOutputWriter.write("Application Information", app.appInfo)
-      profileOutputWriter.write("Application Log Path Mapping", app.appEventLogPath)
+      profileOutputWriter.write("Application Log Path Mapping", app.appLogPath)
       profileOutputWriter.write("Data Source Information", app.dsInfo)
       profileOutputWriter.write("Executor Information", app.execInfo)
       profileOutputWriter.write("Job Information", app.jobInfo)

--- a/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
+++ b/tools/src/main/scala/org/apache/spark/sql/rapids/tool/profiling/ApplicationInfo.scala
@@ -205,7 +205,7 @@ class ApplicationInfo(
 
   var appInfo: ApplicationCase = null
   var appId: String = ""
-  var eventLogPath: String = eLogInfo.eventLog.toString
+  val eventLogPath: String = eLogInfo.eventLog.toString
   
   // physicalPlanDescription stores HashMap (sqlID <-> physicalPlanDescription)
   var physicalPlanDescription: mutable.HashMap[Long, String] = mutable.HashMap.empty[Long, String]

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -133,6 +133,8 @@ class ApplicationInfoSuite extends FunSuite with Logging {
     assert(rapidsJarResults.size === 2)
     assert(rapidsJarResults.filter(_.jar.contains("rapids-4-spark_2.12-0.5.0.jar")).size === 1)
     assert(rapidsJarResults.filter(_.jar.contains("cudf-0.19.2-cuda11.jar")).size === 1)
+
+    assert(apps.head.eventLogPath == (s"file:$logDir/rapids_join_eventlog.zstd"))
   }
 
   test("test sql and resourceprofile eventlog") {


### PR DESCRIPTION
Signed-off-by: Matt Ahrens <matthewahrens@gmail.com>

Closes #3160

Rework based on previous PR comments: https://github.com/NVIDIA/spark-rapids/pull/6706

Could not add comma in log path using TempDir/Trampoline utils, but tested manually that event log path with command is handled properly by profiler to output valid CSV (comma is converted to semicolon in output).