### PR TITLE
Enabling decimal 38,2 casting

### DIFF
--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCastMeta.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCastMeta.scala
@@ -85,8 +85,6 @@ final class CastExprMeta[INPUT <: Cast](
             "converting floating point data types to strings and this can produce results that " +
             "differ from the default behavior in Spark.  To enable this operation on the GPU, set" +
             s" ${RapidsConf.ENABLE_CAST_FLOAT_TO_STRING} to true.")
-      case (_: StringType, dt: DecimalType) if dt.precision + 1 > DecimalType.MAX_PRECISION =>
-        willNotWorkOnGpu(s"Because of rounding requirements we cannot support $dt on the GPU")
       case (_: StringType, _: FloatType | _: DoubleType) if !conf.isCastStringToFloatEnabled =>
         willNotWorkOnGpu("Currently hex values aren't supported on the GPU. Also note " +
             "that casting from string to float types on the GPU returns incorrect results when " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -100,8 +100,6 @@ final class CastExprMeta[INPUT <: CastBase](
             "converting floating point data types to strings and this can produce results that " +
             "differ from the default behavior in Spark.  To enable this operation on the GPU, set" +
             s" ${RapidsConf.ENABLE_CAST_FLOAT_TO_STRING} to true.")
-      case (_: StringType, dt: DecimalType) if dt.precision + 1 > DecimalType.MAX_PRECISION =>
-        willNotWorkOnGpu(s"Because of rounding requirements we cannot support $dt on the GPU")
       case (_: StringType, _: FloatType | _: DoubleType) if !conf.isCastStringToFloatEnabled =>
         willNotWorkOnGpu("Currently hex values aren't supported on the GPU. Also note " +
             "that casting from string to float types on the GPU returns incorrect results when " +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -906,12 +906,9 @@ class CastOpSuite extends GpuExpressionTestSuite {
     }
   }
 
-  test("cast string to decimal (fail)") {
-    assertThrows[IllegalArgumentException](
-    List(-38, 38, 2, 32, 8).foreach { scale =>
-      testCastToDecimal(DataTypes.StringType, scale,
-        customRandGenerator = Some(new scala.util.Random(1234L)))
-    })
+  test("cast 38,2 string to decimal") {
+    testCastToDecimal(DataTypes.StringType, scale = 2, precision = 38,
+      customRandGenerator = Some(new scala.util.Random(1234L)))
   }
 
   test("cast string to decimal (include NaN/INF/-INF)") {


### PR DESCRIPTION
This change enables casting 38,2 decimals in the plugin.