### PR TITLE
Temporarily xfail failing test_iceberg_parquet_read_round_trip test

### DIFF
--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -92,6 +92,7 @@ def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, dat
 
 @iceberg
 @ignore_order(local=True) # Iceberg plans with a thread pool and is not deterministic in file ordering
+@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6718')
 @pytest.mark.parametrize("data_gens", iceberg_gens_list, ids=idfn)
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
 def test_iceberg_parquet_read_round_trip(spark_tmp_table_factory, data_gens, reader_type):


### PR DESCRIPTION
related to https://github.com/NVIDIA/spark-rapids/issues/6718

xfail so we get the ci pipeline running the rest of the way.

Signed-off-by: Thomas Graves <tgraves@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
