### PR TITLE
Clean run directory before running tests in run_pyspark_from_build

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -175,7 +175,7 @@ else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
     fi
     RUN_DIR=${RUN_DIR-"$SCRIPTPATH"/target/run_dir}
-    mkdir -p "$RUN_DIR"
+    rm -rf "$RUN_DIR" && mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
 
     ## Under cloud environment, overwrite the '--rootdir' param to point to the working directory of each excutor


### PR DESCRIPTION
Implementation for removing contents of the run directory before running tests in run_pyspark_from_build.

The problem, quoted from #6495 is that
"I sometimes run the integration tests across multiple Spark versions. If I run the tests against something like Spark 3.3.0 and then try to run tests against Spark 3.1.x, it will often fail complaining about the metastore version being incompatible. This occurs because remnants from the first run are leaking into the second run via artifacts in the integration tests run directory."

Our solution, as suggested in #6495, is to remove the run directory before running tests in run_pyspark_from_build.