### PR TITLE
Fix a class casting error in concurrent writer when enabling AQE [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -524,8 +524,8 @@ def test_concurrent_writer(spark_tmp_path):
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="is only supported in Spark 320+")
 @allow_non_gpu(any=True)
-@pytest.mark.parametrize('enable_aqe', ["true", "false"])
-def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path, enable_aqe):
+@pytest.mark.parametrize('aqe_enabled', [True, False])
+def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path, aqe_enabled):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_writes_are_equal_collect(
         lambda spark, path: get_25_partitions_df(spark)  # df has 25 partitions for (c1, c2)
@@ -537,7 +537,7 @@ def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path, enable
             # 10 < 25, will fall back to single writer
             {"spark.sql.maxConcurrentOutputFileWriters": 10},
             {"spark.rapids.sql.concurrentWriterPartitionFlushSize": 64 * 1024 * 1024},
-            {"spark.sql.adaptive.enabled": enable_aqe},
+            {"spark.sql.adaptive.enabled": aqe_enabled},
         ))
 
 

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -523,7 +523,9 @@ def test_concurrent_writer(spark_tmp_path):
 
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="is only supported in Spark 320+")
-def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path):
+@allow_non_gpu(any=True)
+@pytest.mark.parametrize('enable_aqe', ["true", "false"])
+def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path, enable_aqe):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_and_cpu_writes_are_equal_collect(
         lambda spark, path: get_25_partitions_df(spark)  # df has 25 partitions for (c1, c2)
@@ -534,7 +536,8 @@ def test_fallback_to_single_writer_from_concurrent_writer(spark_tmp_path):
         copy_and_update(
             # 10 < 25, will fall back to single writer
             {"spark.sql.maxConcurrentOutputFileWriters": 10},
-            {"spark.rapids.sql.concurrentWriterPartitionFlushSize": 64 * 1024 * 1024}
+            {"spark.rapids.sql.concurrentWriterPartitionFlushSize": 64 * 1024 * 1024},
+            {"spark.sql.adaptive.enabled": enable_aqe},
         ))
 
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -69,10 +69,14 @@ class GpuSortMeta(
 
 object GpuSortExec {
   def targetSize(sqlConf: SQLConf): Long = {
+    val batchSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(sqlConf)
+    targetSize(batchSize)
+  }
+
+  def targetSize(batchSize: Long): Long = {
     // To avoid divide by zero errors, underflow and overflow issues in tests
     // that want the targetSize to be 0, we set it to something more reasonable
-    val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(sqlConf)
-    math.max(16 * 1024, targetSize)
+    math.max(16 * 1024, batchSize)
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -779,7 +779,7 @@ class GpuDynamicPartitionDataConcurrentWriter(
    */
   private def getSorted(iterator: Iterator[ColumnarBatch]): GpuOutOfCoreSortIterator = {
     val gpuSortOrder: Seq[SortOrder] = spec.sortOrder
-    val output: Seq[Attribute] = spec.exec.output
+    val output: Seq[Attribute] = spec.output
     val sorter = new GpuSorter(gpuSortOrder, output)
     val cpuOrd = new LazilyGeneratedOrdering(sorter.cpuOrdering)
 
@@ -795,7 +795,8 @@ class GpuDynamicPartitionDataConcurrentWriter(
 
       override def semaphoreWaitTime: GpuMetric = NoopMetric
     }
-    val targetSize = GpuSortExec.targetSize(spec.exec.conf)
+
+    val targetSize = GpuSortExec.targetSize(spec.batchSize)
     // out of core sort the entire iterator
     GpuOutOfCoreSortIterator(iterator, sorter, cpuOrd, targetSize,
       opTime, sortTime, outputBatch, outputRows,


### PR DESCRIPTION
Closes #6762 

See the description of this issue, the bug is caused by `asInstanceOf` casting.
In this PR:
- Remove this `asInstanceOf` casting. 
- Add a test for enabling AQE.

Signed-off-by: Chong Gao <res_life@163.com>

