### PR TITLE
Add supervisor(like systemd stuff) to auto restart Alluxio processes … [skip ci]

### DIFF
--- a/docker/databricks/Dockerfile
+++ b/docker/databricks/Dockerfile
@@ -52,7 +52,7 @@ RUN set -ex && \
                cuda-nvcc-${CUDA_PKG_VERSION} cuda-thrust-${CUDA_PKG_VERSION} cuda-toolkit-${CUDA_PKG_VERSION}-config-common cuda-toolkit-11-config-common \
                cuda-toolkit-config-common python3.8-dev libpq-dev libcairo2-dev build-essential unattended-upgrades cmake ccache \
                openmpi-bin linux-headers-5.4.0-117 linux-headers-5.4.0-117-generic linux-headers-generic libopenmpi-dev unixodbc-dev \
-               sysstat ssh tmux && \
+               sysstat ssh tmux supervisor && \
     apt-get install -y less vim && \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     # Initialize the default environment that Spark and notebooks will use


### PR DESCRIPTION
…in case of crashes for Databricks Docker container

Contributes to #6459

Add supervisor for Alluxio. Supports Alluxio processes automatically starting when encountering crashes.
Docker image by default does not support `systemd`, it's heavy to install and configure. Usually, docker uses supervisor instead of systemd.

Signed-off-by: Chong Gao <res_life@163.com>
