### PR TITLE
Avoid any issues with scalar values returned by evalColumnar [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import com.nvidia.spark.rapids.GpuExpressionsUtils.columnarEvalToColumn
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 
@@ -194,7 +195,7 @@ case class GpuAtLeastNNonNulls(
         var notNanVector: ColumnVector = null
         var nanAndNullVector: ColumnVector = null
         try {
-          cv = expr.columnarEval(batch).asInstanceOf[GpuColumnVector].getBase
+          cv = columnarEvalToColumn(expr, batch).getBase
           notNullVector = cv.isNotNull
           if (cv.getType == DType.FLOAT32 || cv.getType == DType.FLOAT64) {
             notNanVector = cv.isNotNan


### PR DESCRIPTION
This fixes #6727

But we still have not been able to reproduce the original problem. In this patch I have adjusted all places in the code that I could find that do not check for a `Scalar` being returned by `columnarEval`.  I only found 4 places. 2 in hash aggregate that were simple to fix and made the code smaller, and 2 in a few other expressions that should be covered by the the conversion checks, but this makes us a little more robust.