### PR TITLE
Revert "Temporarily xfail failing test_iceberg_parquet_read_round_trip test"

### DIFF
--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -92,7 +92,6 @@ def test_iceberg_parquet_read_round_trip_select_one(spark_tmp_table_factory, dat
 
 @iceberg
 @ignore_order(local=True) # Iceberg plans with a thread pool and is not deterministic in file ordering
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6718')
 @pytest.mark.parametrize("data_gens", iceberg_gens_list, ids=idfn)
 @pytest.mark.parametrize('reader_type', rapids_reader_types)
 def test_iceberg_parquet_read_round_trip(spark_tmp_table_factory, data_gens, reader_type):


### PR DESCRIPTION
Reverts NVIDIA/spark-rapids#6756

fixes https://github.com/NVIDIA/spark-rapids/issues/6718

CUDF fix went in so revert the xfail