### PR TITLE
Update JNI version to released 22.10.0 [databricks]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1067,7 +1067,7 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>22.10.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-jni.version>22.10.0</spark-rapids-jni.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.15</scala.version>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Seems inconsistent PR info within github, the github action cannot update check status correctly.

re-create PR to update JNI version