### PR TITLE
Dump stack traces for tasks with the semaphore held when OOM goes unhandled

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -17,14 +17,16 @@
 package com.nvidia.spark.rapids
 
 import java.util.concurrent.{ConcurrentHashMap, Semaphore}
-
+import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import org.apache.commons.lang3.mutable.MutableInt
-
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 
+import scala.collection.mutable
+
 object GpuSemaphore {
+
   private val enabled = {
     val propstr = System.getProperty("com.nvidia.spark.rapids.semaphore.enabled")
     if (propstr != null) {
@@ -87,6 +89,17 @@ object GpuSemaphore {
   }
 
   /**
+   * Dumps the stack traces for any tasks that have accessed the GPU semaphore
+   * and have not completed. The output includes whether the task has the GPU semaphore
+   * held at the time of the stack trace.
+   */
+  def dumpActiveStackTracesToLog(): Unit = {
+    if (enabled) {
+      getInstance.dumpActiveStackTracesToLog()
+    }
+  }
+
+  /**
    * Uninitialize the GPU semaphore.
    * NOTE: This does not wait for active tasks to release!
    */
@@ -100,21 +113,25 @@ object GpuSemaphore {
 
 private final class GpuSemaphore(tasksPerGpu: Int) extends Logging with Arm {
   private val semaphore = new Semaphore(tasksPerGpu)
+
   // Map to track which tasks have acquired the semaphore.
-  private val activeTasks = new ConcurrentHashMap[Long, MutableInt]
+  case class TaskInfo(count: MutableInt, thread: Thread)
+  private val activeTasks = new ConcurrentHashMap[Long, TaskInfo]
 
   def acquireIfNecessary(context: TaskContext, waitMetric: GpuMetric): Unit = {
     withResource(new NvtxWithMetrics("Acquire GPU", NvtxColor.RED, waitMetric)) { _ =>
       val taskAttemptId = context.taskAttemptId()
       val refs = activeTasks.get(taskAttemptId)
-      if (refs == null || refs.getValue == 0) {
+      if (refs == null || refs.count.getValue == 0) {
         logDebug(s"Task $taskAttemptId acquiring GPU")
         semaphore.acquire()
         if (refs != null) {
-          refs.increment()
+          refs.count.increment()
         } else {
           // first time this task has been seen
-          activeTasks.put(taskAttemptId, new MutableInt(1))
+          activeTasks.put(
+            taskAttemptId,
+            TaskInfo(new MutableInt(1), Thread.currentThread()))
           context.addTaskCompletionListener[Unit](completeTask)
         }
         GpuDeviceManager.initializeFromTask()
@@ -127,8 +144,8 @@ private final class GpuSemaphore(tasksPerGpu: Int) extends Logging with Arm {
     try {
       val taskAttemptId = context.taskAttemptId()
       val refs = activeTasks.get(taskAttemptId)
-      if (refs != null && refs.getValue > 0) {
-        if (refs.decrementAndGet() == 0) {
+      if (refs != null && refs.count.getValue > 0) {
+        if (refs.count.decrementAndGet() == 0) {
           logDebug(s"Task $taskAttemptId releasing GPU")
           semaphore.release()
         }
@@ -144,9 +161,39 @@ private final class GpuSemaphore(tasksPerGpu: Int) extends Logging with Arm {
     if (refs == null) {
       throw new IllegalStateException(s"Completion of unknown task $taskAttemptId")
     }
-    if (refs.getValue > 0) {
+    if (refs.count.getValue > 0) {
       logDebug(s"Task $taskAttemptId releasing GPU")
       semaphore.release()
+    }
+  }
+
+  def dumpActiveStackTracesToLog(): Unit = {
+    try {
+      val stackTracesSemaphoreHeld = new ArrayBuffer[String]()
+      val otherStackTraces = new ArrayBuffer[String]()
+      activeTasks.forEach { (taskAttemptId, taskInfo) =>
+        val sb = new mutable.StringBuilder()
+        val semaphoreHeld = taskInfo.count.getValue > 0
+        taskInfo.thread.getStackTrace.foreach { stackTraceElement =>
+          sb.append("    " + stackTraceElement + "\n")
+        }
+        if (semaphoreHeld) {
+          stackTracesSemaphoreHeld.append(
+            s"Semaphore held. " +
+              s"Stack trace for task attempt id $taskAttemptId:\n${sb.toString()}")
+        } else {
+          otherStackTraces.append(
+            s"Semaphore not held. " +
+              s"Stack trace for task attempt id $taskAttemptId:\n${sb.toString()}")
+        }
+      }
+      logWarning(s"Dumping stack traces. The semaphore sees ${activeTasks.size()} tasks, " +
+        s"${stackTracesSemaphoreHeld.size} are holding onto the semaphore. " +
+        stackTracesSemaphoreHeld.mkString("\n", "\n", "\n") +
+        otherStackTraces.mkString("\n", "\n", "\n"))
+    } catch {
+      case t: Throwable =>
+        logWarning("Unable to obtain stack traces in the semaphore.", t)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -17,13 +17,14 @@
 package com.nvidia.spark.rapids
 
 import java.util.concurrent.{ConcurrentHashMap, Semaphore}
-import scala.collection.mutable.ArrayBuffer
-import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import org.apache.commons.lang3.mutable.MutableInt
-import org.apache.spark.TaskContext
-import org.apache.spark.internal.Logging
 
 import scala.collection.mutable
+
+import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import org.apache.commons.lang3.mutable.MutableInt
+
+import org.apache.spark.TaskContext
+import org.apache.spark.internal.Logging
 
 object GpuSemaphore {
 
@@ -169,8 +170,8 @@ private final class GpuSemaphore(tasksPerGpu: Int) extends Logging with Arm {
 
   def dumpActiveStackTracesToLog(): Unit = {
     try {
-      val stackTracesSemaphoreHeld = new ArrayBuffer[String]()
-      val otherStackTraces = new ArrayBuffer[String]()
+      val stackTracesSemaphoreHeld = new mutable.ArrayBuffer[String]()
+      val otherStackTraces = new mutable.ArrayBuffer[String]()
       activeTasks.forEach { (taskAttemptId, taskInfo) =>
         val sb = new mutable.StringBuilder()
         val semaphoreHeld = taskInfo.count.getValue > 0


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/6744

This change logs at WARN level the stack traces of all active tasks (those that have entered the semaphore but have not finished). It distinguishes the tasks that are holding onto the semaphore from those that are not, for ease of debugging. Users should be able to copy the stack traces, or at least refer to those holding the semaphore, to make it easier to find all the points that may be accumulating GPU memory.

The caller (`DeviceMemoryEventHandler`) protects against several threads dumping stack traces by only allowing this call once (right before failure on one of the threads going OOM).

Sample output for one of the threads:

```
Executor task launch worker for task 42.0 in stage 1.0 (TID 193) 22/10/14 18:38:50:915 WARN DeviceMemoryEventHandler: Device store exhausted, unable to allocate 2138051776 bytes. Total RMM allocated is 19548107264 bytes.
Executor task launch worker for task 42.0 in stage 1.0 (TID 193) 22/10/14 18:38:50:919 WARN GpuSemaphore: Dumping stack traces. The semaphore sees 12 tasks, 4 are holding onto the semaphore.
Semaphore held. Stack trace for task attempt id 193:
    java.lang.Thread.getStackTrace(Thread.java:1559)
    com.nvidia.spark.rapids.GpuSemaphore.$anonfun$dumpActiveStackTracesToLog$1(GpuSemaphore.scala:177)
    com.nvidia.spark.rapids.GpuSemaphore.$anonfun$dumpActiveStackTracesToLog$1$adapted(GpuSemaphore.scala:174)
    java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1597)
    com.nvidia.spark.rapids.GpuSemaphore.dumpActiveStackTracesToLog(GpuSemaphore.scala:174)
    com.nvidia.spark.rapids.GpuSemaphore$.dumpActiveStackTracesToLog(GpuSemaphore.scala:98)
    com.nvidia.spark.rapids.DeviceMemoryEventHandler.onAllocFailure(DeviceMemoryEventHandler.scala:62)
    ai.rapids.cudf.Rmm.allocInternal(Native Method)
    ai.rapids.cudf.Rmm.alloc(Rmm.java:246)
    ai.rapids.cudf.DeviceMemoryBuffer.allocate(DeviceMemoryBuffer.java:143)
    ai.rapids.cudf.DeviceMemoryBuffer.allocate(DeviceMemoryBuffer.java:133)
    com.nvidia.spark.rapids.RapidsBufferStore$RapidsBufferBase.$anonfun$getDeviceMemoryBuffer$6(RapidsBufferStore.scala:381)
    com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
    com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
    com.nvidia.spark.rapids.RapidsBufferStore$RapidsBufferBase.withResource(RapidsBufferStore.scala:269)
    com.nvidia.spark.rapids.RapidsBufferStore$RapidsBufferBase.getDeviceMemoryBuffer(RapidsBufferStore.scala:380)
    com.nvidia.spark.rapids.RapidsBufferStore$RapidsBufferBase.getColumnarBatch(RapidsBufferStore.scala:322)
    com.nvidia.spark.rapids.SpillableColumnarBatchImpl.$anonfun$getColumnarBatch$1(SpillableColumnarBatch.scala:116)
    com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
    com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
    com.nvidia.spark.rapids.SpillableColumnarBatchImpl.withResource(SpillableColumnarBatch.scala:74)
    com.nvidia.spark.rapids.SpillableColumnarBatchImpl.getColumnarBatch(SpillableColumnarBatch.scala:114)
    com.nvidia.spark.rapids.LazySpillableColumnarBatchImpl.$anonfun$getBatch$2(JoinGatherer.scala:277)
    scala.Option.map(Option.scala:230)
    com.nvidia.spark.rapids.LazySpillableColumnarBatchImpl.$anonfun$getBatch$1(JoinGatherer.scala:277)
    com.nvidia.spark.rapids.LazySpillableColumnarBatchImpl.$anonfun$getBatch$1$adapted(JoinGatherer.scala:276)
    com.nvidia.spark.rapids.Arm.withResource(Arm.scala:28)
    com.nvidia.spark.rapids.Arm.withResource$(Arm.scala:26)
    com.nvidia.spark.rapids.LazySpillableColumnarBatchImpl.withResource(JoinGatherer.scala:262)
    com.nvidia.spark.rapids.LazySpillableColumnarBatchImpl.getBatch(JoinGatherer.scala:276)
    com.nvidia.spark.rapids.GpuHashAggregateIterator$$anon$1.$anonfun$next$4(aggregate.scala:417)
```