### PR TITLE
Follow on from recent regexp fixes to reject patterns that cuDF no longer rejects

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -32,15 +32,21 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
 
   test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged
-    // but we still reject them because we see failures in fuzz testing if we allow them
+    // but we still reject them because the behavior is not consistent with Java
+
+    // The test "AST fuzz test - regexp_replace" hangs if we stop rejecting these patterns
     for (pattern <- Seq("\t+|a", "(\t+|a)Dc$1", "\n[^\r\n]x*|^3x")) {
       assertUnsupported(pattern, RegexFindMode,
         "cuDF does not support repetition on one side of a choice")
     }
+
+    //The test "AST fuzz test - regexp_find" fails if we stop rejecting these patterns.
     for (pattern <- Seq("$|$[^\n]2]}|B")) {
       assertUnsupported(pattern, RegexFindMode,
         "End of line/string anchor is not supported in this context")
     }
+
+    // The test "AST fuzz test - regexp_replace" hangs if we stop rejecting these patterns
     for (pattern <- Seq("a^|b", "w$|b", "]*\\wWW$|zb", "(\\A|\\05)?")) {
       assertUnsupported(pattern, RegexFindMode,
         "cuDF does not support terms ending with line anchors on one side of a choice")


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/6518

This is a follow on from https://github.com/NVIDIA/spark-rapids/pull/6548 to confirm that we should still be rejecting certain regexp patterns even though cuDF no longer rejects them. We reject them because cuDF either hangs or produces results that are inconsistent with Java.

For the patterns that we reject with `End of line/string anchor is not supported in this context`, I didn't spend time trying to determine if we could transpile differently to try and support these patterns because it seems like an edge case to me that we are unlikely to encounter, so I suggest we only spend time on this if someone asks us to support it.