### PR TITLE
Fix integration builds failing with current directory not found

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -175,7 +175,7 @@ else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
     fi
     RUN_DIR=${RUN_DIR-"$SCRIPTPATH"/target/run_dir}
-    rm -rf "$RUN_DIR" && mkdir -p "$RUN_DIR"
+    mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
 
     ## Under cloud environment, overwrite the '--rootdir' param to point to the working directory of each excutor


### PR DESCRIPTION
This is reverting https://github.com/NVIDIA/spark-rapids/commit/6f5151a63c8082c2c5a010c5942cd6f71a611cc4 which I'm guessing is causing the integration test builds (dataproc and cloudera) fail due to not being able to find the current directory.  I'm guessing 2 processes must be in using that same run dir so when this was removing it, it caused problems.

Will reopen https://github.com/NVIDIA/spark-rapids/issues/6495 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
