### PR TITLE
Cuda.deviceSynchronize as a last resort if we cannot spill enough

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
@@ -65,7 +65,7 @@ class DeviceMemoryEventHandler(
           "First attempt. "
         }
         logInfo(s"Device allocation of $allocSize bytes failed, device store has " +
-            s"$storeSize bytes. $attemptMsg" +
+          s"$storeSize bytes. $attemptMsg" +
           s"Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes. ")
         if (storeSize == 0) {
           var syncAttempt = synchronizeAttempts.get()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
@@ -60,7 +60,7 @@ class DeviceMemoryEventHandler(
 
     def getRetriesSoFar: Int = synchronizeAttempts
 
-    def reset(): Unit = {
+    private def reset(): Unit = {
       synchronizeAttempts = 0
       retryCountLastSynced = 0
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
@@ -20,7 +20,7 @@ import java.io.File
 import java.lang.management.ManagementFactory
 import java.util.concurrent.atomic.AtomicLong
 
-import ai.rapids.cudf.{NvtxColor, NvtxRange, Rmm, RmmEventHandler}
+import ai.rapids.cudf.{Cuda, NvtxColor, NvtxRange, Rmm, RmmEventHandler}
 import com.sun.management.HotSpotDiagnosticMXBean
 
 import org.apache.spark.internal.Logging
@@ -30,53 +30,79 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
  * RMM event handler to trigger spilling from the device memory store.
  * @param store device memory store that will be triggered to spill
  * @param oomDumpDir local directory to create heap dumps on GPU OOM
+ * @param isGdsSpillEnabled true if GDS is enabled for device->disk spill
+ * @param maxFailedOOMRetries maximum number of retries for OOMs after
+ *                            depleting the device store
  */
 class DeviceMemoryEventHandler(
     store: RapidsDeviceMemoryStore,
     oomDumpDir: Option[String],
-    isGdsSpillEnabled: Boolean) extends RmmEventHandler with Logging {
+    isGdsSpillEnabled: Boolean,
+    maxFailedOOMRetries: Int) extends RmmEventHandler with Logging with Arm {
 
   // Flag that ensures we dump stack traces once and not for every allocation
   // failure. The assumption is that unhandled allocations will be fatal
   // to the process at this stage, so we only need this once before we exit.
   private var dumpStackTracesOnFailureToHandleOOM = true
 
+  // Thread local used to the number of times a sync has been attempted, when
+  // handling OOMs after depleting the device store.
+  private val synchronizeAttempts = ThreadLocal.withInitial[Int](() => 0)
+
   /**
    * Handles RMM allocation failures by spilling buffers from device memory.
    * @param allocSize the byte amount that RMM failed to allocate
+   * @param retryCount the number of times this allocation has been retried after failure
    * @return true if allocation should be reattempted or false if it should fail
    */
-  override def onAllocFailure(allocSize: Long): Boolean = {
+  override def onAllocFailure(allocSize: Long, retryCount: Int): Boolean = {
     try {
-      val nvtx = new NvtxRange("onAllocFailure", NvtxColor.RED)
-      try {
+      withResource(new NvtxRange("onAllocFailure", NvtxColor.RED)) { _ =>
         val storeSize = store.currentSize
-        logInfo(s"Device allocation of $allocSize bytes failed, device store has " +
-            s"$storeSize bytes. Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes.")
-        if (storeSize == 0) {
-          logWarning(s"Device store exhausted, unable to allocate $allocSize bytes. " +
-              s"Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes.")
-          synchronized {
-            if (dumpStackTracesOnFailureToHandleOOM) {
-              dumpStackTracesOnFailureToHandleOOM = false
-              GpuSemaphore.dumpActiveStackTracesToLog()
-            }
-          }
-          oomDumpDir.foreach(heapDump)
-          return false
-        }
-        val targetSize = Math.max(storeSize - allocSize, 0)
-        logDebug(s"Targeting device store size of $targetSize bytes")
-        val amountSpilled = store.synchronousSpill(targetSize)
-        logInfo(s"Spilled $amountSpilled bytes from the device store")
-        if (isGdsSpillEnabled) {
-          TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
+        val attemptMsg = if (retryCount > 0) {
+          s"Attempt ${retryCount}. "
         } else {
-          TrampolineUtil.incTaskMetricsMemoryBytesSpilled(amountSpilled)
+          "First attempt. "
         }
-        true
-      } finally {
-        nvtx.close()
+        logInfo(s"Device allocation of $allocSize bytes failed, device store has " +
+            s"$storeSize bytes. $attemptMsg" +
+          s"Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes. ")
+        if (storeSize == 0) {
+          var syncAttempt = synchronizeAttempts.get()
+          if (syncAttempt <= maxFailedOOMRetries) {
+            syncAttempt = syncAttempt + 1
+            synchronizeAttempts.set(syncAttempt)
+            Cuda.deviceSynchronize()
+            logWarning(s"[RETRY ${syncAttempt}] " +
+              s"Retrying allocation of $allocSize after a synchronize. " +
+              s"Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes.")
+            true
+          } else {
+            synchronizeAttempts.set(0)
+            logWarning(s"Device store exhausted, unable to allocate $allocSize bytes. " +
+              s"Total RMM allocated is ${Rmm.getTotalBytesAllocated} bytes.")
+            synchronized {
+              if (dumpStackTracesOnFailureToHandleOOM) {
+                dumpStackTracesOnFailureToHandleOOM = false
+                GpuSemaphore.dumpActiveStackTracesToLog()
+              }
+            }
+            oomDumpDir.foreach(heapDump)
+            false
+          }
+        } else {
+          synchronizeAttempts.set(0)
+          val targetSize = Math.max(storeSize - allocSize, 0)
+          logDebug(s"Targeting device store size of $targetSize bytes")
+          val amountSpilled = store.synchronousSpill(targetSize)
+          logInfo(s"Spilled $amountSpilled bytes from the device store")
+          if (isGdsSpillEnabled) {
+            TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
+          } else {
+            TrampolineUtil.incTaskMetricsMemoryBytesSpilled(amountSpilled)
+          }
+          true
+        }
       }
     } catch {
       case t: Throwable =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -202,7 +202,10 @@ object RapidsBufferCatalog extends Logging with Arm {
 
     logInfo("Installing GPU memory handler for spill")
     memoryEventHandler = new DeviceMemoryEventHandler(
-      deviceStorage, rapidsConf.gpuOomDumpDir, rapidsConf.isGdsSpillEnabled)
+      deviceStorage,
+      rapidsConf.gpuOomDumpDir,
+      rapidsConf.isGdsSpillEnabled,
+      rapidsConf.gpuOomMaxRetries)
     Rmm.setEventHandler(memoryEventHandler)
 
     _shouldUnspill = rapidsConf.isUnspillEnabled

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -339,6 +339,16 @@ object RapidsConf {
     .stringConf
     .createOptional
 
+  val GPU_OOM_MAX_RETRIES =
+    conf("spark.rapids.memory.gpu.oomMaxRetries")
+      .doc("The number of times that an OOM will be re-attempted after the device store " +
+        "can't spill anymore. In practice, we can use Cuda.deviceSynchronize to allow temporary " +
+        "state in the allocator and in the various streams to catch up, in hopes we can satisfy " +
+        "an allocation which was failing due to the interim state of memory.")
+      .internal()
+      .integerConf
+      .createWithDefault(2)
+
   private val RMM_ALLOC_MAX_FRACTION_KEY = "spark.rapids.memory.gpu.maxAllocFraction"
   private val RMM_ALLOC_MIN_FRACTION_KEY = "spark.rapids.memory.gpu.minAllocFraction"
   private val RMM_ALLOC_RESERVE_KEY = "spark.rapids.memory.gpu.reserve"
@@ -1772,6 +1782,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val rmmDebugLocation: String = get(RMM_DEBUG)
 
   lazy val gpuOomDumpDir: Option[String] = get(GPU_OOM_DUMP_DIR)
+
+  lazy val gpuOomMaxRetries: Int = get(GPU_OOM_MAX_RETRIES)
 
   lazy val isUvmEnabled: Boolean = get(UVM_ENABLED)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandlerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandlerSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.FunSuite
+import org.scalatest.mockito.MockitoSugar
+
+class DeviceMemoryEventHandlerSuite extends FunSuite with MockitoSugar {
+
+  test("a failed allocation should be retried if we spilled enough") {
+    val mockStore = mock[RapidsDeviceMemoryStore]
+    when(mockStore.currentSize).thenReturn(1024)
+    when(mockStore.synchronousSpill(any())).thenReturn(1024)
+    val handler = new DeviceMemoryEventHandler(mockStore, None, false, 2)
+    assertResult(true)(handler.onAllocFailure(1024, 0))
+  }
+
+  test("when we deplete the store, retry up to max failed OOM retries") {
+    val mockStore = mock[RapidsDeviceMemoryStore]
+    when(mockStore.currentSize).thenReturn(0)
+    when(mockStore.synchronousSpill(any())).thenReturn(0)
+    val handler = new DeviceMemoryEventHandler(mockStore, None, false, 2)
+    assertResult(true)(handler.onAllocFailure(1024, 0)) // sync
+    assertResult(true)(handler.onAllocFailure(1024, 1)) // sync 2
+    assertResult(false)(handler.onAllocFailure(1024, 2)) // cuDF would OOM here
+  }
+
+  test("we reset our OOM state after a successful retry") {
+    val mockStore = mock[RapidsDeviceMemoryStore]
+    when(mockStore.currentSize).thenReturn(0)
+    when(mockStore.synchronousSpill(any())).thenReturn(0)
+    val handler = new DeviceMemoryEventHandler(mockStore, None, false, 2)
+    // with this call we sync, and we mark our attempts at 1, we store 0 as the last count
+    assertResult(true)(handler.onAllocFailure(1024, 0))
+    // this retryCount is still 0, we should be back at 1 for attempts
+    assertResult(true)(handler.onAllocFailure(1024, 0))
+    assertResult(true)(handler.onAllocFailure(1024, 1))
+    assertResult(false)(handler.onAllocFailure(1024, 2)) // cuDF would OOM here
+  }
+}


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/6768

This depends on: https://github.com/rapidsai/cudf/pull/11940

This PR adds `Cuda.deviceSynchronize` calls when the device store is empty. The idea is that these calls should allow GPU work to finish (like pending frees) and allow the async pool to resolve any temporary state (make available blocks that were recently freed for other streams to consume).

Adds an internal config `spark.rapids.memory.gpu.oomMaxRetries`. It is set to 2 retries by default.
