### PR TITLE
Adjust to cudf removal of checks in scatter and repeat

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
@@ -116,7 +116,7 @@ abstract class ExistenceJoinIterator(
       val numExistsTrueRows = existsScatterMap.getRowCount.toInt
       withResource(existsScatterMap.toColumnView(0, numExistsTrueRows)) { existsView =>
         withResource(Scalar.fromBool(true)) { trueScalar =>
-          withResource(Table.scatter(Array(trueScalar), existsView, allFalseTable, false)) {
+          withResource(Table.scatter(Array(trueScalar), existsView, allFalseTable)) {
             _.getColumn(0).incRefCount()
           }
         }


### PR DESCRIPTION
rapidsai/cudf#11938 is removing the checking parameter on Table.scatter and Table.repeat.  This updates the RAPIDS Accelerator code to fix the build after this change.  The code was not requesting checks on Table.scatter, so that's a straightforward change.  Table.repeat was called with checking, but the code just above explicitly removes any invalid counts and thus the checks are not necessary.