### PR TITLE
Add check for is_spark_330cdh and update orc test to skip zstd for cdh

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -19,7 +19,7 @@ from asserts import assert_cpu_and_gpu_are_equal_sql_with_capture, assert_gpu_an
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, is_before_spark_320, is_before_spark_330, is_spark_321cdh
+from spark_session import with_cpu_session, is_before_spark_320, is_before_spark_330, is_spark_cdh
 from parquet_test import _nested_pruning_schemas
 from conftest import is_databricks_runtime
 
@@ -183,7 +183,7 @@ def test_pred_push_round_trip(spark_tmp_path, orc_gen, read_func, v1_enabled_lis
 
 orc_compress_options = ['none', 'uncompressed', 'snappy', 'zlib']
 # zstd is available in spark 3.2.0 and later.
-if not is_before_spark_320() and not is_spark_321cdh():
+if not is_before_spark_320() and not is_spark_cdh():
     orc_compress_options.append('zstd')
 
 # The following need extra jars 'lzo'

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -159,6 +159,12 @@ def is_spark_330_or_later():
 def is_spark_321cdh():
     return "3.2.1.3.2.717" in spark_version()
 
+def is_spark_330cdh():
+    return "3.3.0.3.3.718" in spark_version()
+
+def is_spark_cdh():
+    return is_spark_321cdh() or is_spark_330cdh()
+
 def is_databricks_version_or_later(major, minor):
     spark = get_spark_i_know_what_i_am_doing()
     version = spark.conf.get("spark.databricks.clusterUsageTags.sparkVersion", "0.0")


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

When testing on the new CDH release in a Cloudera cluster, we hit this:
```
orc_test.py

[2022-10-18T09:48:20.142Z] E               pyspark.sql.utils.IllegalArgumentException: The value of spark.sql.orc.compression.codec should be one of uncompressed, lz4, lzo, snappy, zlib, none, but was zstd
```
In #6056, we disabled zstd compression for orc for 321cdh releases.  We need to do the same for 330cdh releases.
