### PR TITLE
Add in support for zorder operators on databricks [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -23,21 +23,21 @@ from spark_session import is_databricks_runtime, with_cpu_session, with_gpu_sess
 # the important part is to not have InterleaveBits or PartitionerExpr
 @allow_non_gpu("SerializeFromObjectExec", "MapElementsExec", "MapPartitionsExec", "DeserializeToObjectExec",
         "ProjectExec", "FilterExec", "SortExec", "ShuffleExchangeExec", "FileSourceScanExec",
-        "ObjectHashAggregateExec", "CollectLimitExec")
+        "ObjectHashAggregateExec", "CollectLimitExec", "CreateTableExec", "AppendDataExecV1")
 @delta_lake
-@pytest.mark.skipif(is_databricks_runtime(), reason='We do not support zorder for databricks yet')
 @ignore_order(local=True)
 def test_delta_zorder(spark_tmp_table_factory):
     table = spark_tmp_table_factory.get()
-    def setup_delta_table(spark):
+
+    def optimize_table(spark):
+        # We need to drop the table and rerun each time because in some
+        # versions delta will keep track if it has already been optimized or not
+        # and will not re-run if it has been optimized
         df = two_col_df(spark, long_gen, string_gen, length=4096)
         spark.sql("DROP TABLE IF EXISTS {}".format(table)).show()
         spark.sql("CREATE TABLE {} (a BIGINT, b STRING) USING DELTA".format(table)).show()
         df.write.insertInto(table)
 
-    with_cpu_session(setup_delta_table)
-
-    def optimize_table(spark):
         # The optimize returns stats and metadata about the operation, which is different
         # from one run to another, so we cannot just compare them...
         spark.sql("OPTIMIZE {} ZORDER BY a, b".format(table)).show()

--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -20,10 +20,10 @@ from marks import allow_non_gpu, ignore_order, delta_lake
 from spark_session import is_databricks_runtime, with_cpu_session, with_gpu_session
 
 # Almost all of this is the metadata query
-# the important part is to not have InterleaveBits or PartitionerExpr
-@allow_non_gpu("SerializeFromObjectExec", "MapElementsExec", "MapPartitionsExec", "DeserializeToObjectExec",
-        "ProjectExec", "FilterExec", "SortExec", "ShuffleExchangeExec", "FileSourceScanExec",
-        "ObjectHashAggregateExec", "CollectLimitExec", "CreateTableExec", "AppendDataExecV1")
+# the important part is to not have InterleaveBits or HilbertLongIndex and PartitionerExpr
+# but there is no good way to check for that so I filed https://github.com/NVIDIA/spark-rapids/issues/6875
+# Until then we allow anything to be on the CPU.
+@allow_non_gpu(any=True)
 @delta_lake
 @ignore_order(local=True)
 def test_delta_zorder(spark_tmp_table_factory):

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.zorder
+
+import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec}
+import com.nvidia.spark.rapids.jni.ZOrder
+import com.nvidia.spark.rapids.shims.ShimExpression
+
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Expression used to replace DataBrick's HilbertLongIndex operator for zorder. We don't know
+ * exactly what their code is doing, so this is a lot of guess work based off of the
+ * InterleaveBits implementation in open source.
+ */
+case class GpuHilbertLongIndex(numBits: Int, children: Seq[Expression])
+    extends GpuExpression with ShimExpression with ExpectsInputTypes {
+
+  private val n: Int = children.size
+
+  override def inputTypes: Seq[DataType] = Seq.fill(n)(IntegerType)
+
+  override def dataType: DataType = LongType
+
+  override def nullable: Boolean = false
+
+  override def columnarEval(batch: ColumnarBatch): Any = {
+    val ret = withResource(GpuProjectExec.project(batch, children)) { inputs =>
+      withResource(new NvtxRange("HILBERT INDEX", NvtxColor.PURPLE)) { _ =>
+        val bases = GpuColumnVector.extractBases(inputs)
+        // Null values are replaced with 0 as a part of interleaveBits to match what delta does,
+        // but null values should never show up in practice because this is fed by
+        // GpuPartitionerExpr, which is not nullable.
+        ZOrder.hilbertIndex(numBits, batch.numRows(), bases: _*)
+      }
+    }
+    GpuColumnVector.from(ret, dataType)
+  }
+}


### PR DESCRIPTION
This adds in support to accelerate the zorder optimization on databricks.  The implementation is different from open source deltalake.