### PR TITLE
Plugin fixes after cuDF removed INT8 for binary columns in parquet writer

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -88,7 +88,6 @@ parquet_ts_write_options = ['INT96', 'TIMESTAMP_MICROS', 'TIMESTAMP_MILLIS']
 
 @pytest.mark.order(1) # at the head of xdist worker queue if pytest-order is installed
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6865')
 def test_write_round_trip(spark_tmp_path, parquet_gens):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -197,7 +196,6 @@ def test_compress_write_round_trip(spark_tmp_path, compress):
 
 @pytest.mark.order(2)
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6865')
 def test_write_save_table(spark_tmp_path, parquet_gens, spark_tmp_table_factory):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -215,7 +213,6 @@ def write_parquet_sql_from(spark, df, data_path, write_to_table):
 
 @pytest.mark.order(2)
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6865')
 def test_write_sql_save_table(spark_tmp_path, parquet_gens, spark_tmp_table_factory):
     gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -441,7 +438,6 @@ def test_non_empty_ctas(spark_tmp_path, spark_tmp_table_factory, allow_non_empty
     with_gpu_session(test_it, conf)
 
 @pytest.mark.parametrize('parquet_gens', parquet_write_gens_list, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/6865')
 def test_write_empty_parquet_round_trip(spark_tmp_path, parquet_gens):
     def create_empty_df(spark, path):
         gen_list = [('_c' + str(i), gen) for i, gen in enumerate(parquet_gens)]

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -257,7 +257,8 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       }
       return new HostColumnVector.StructType(nullable, children);
     } else if (spark instanceof BinaryType) {
-      return new HostColumnVector.ListType(nullable, convertFrom(DataTypes.ByteType, false));
+      return new HostColumnVector.ListType(
+          nullable, new HostColumnVector.BasicType(nullable, DType.UINT8));
     } else {
       // Only works for basic types
       return new HostColumnVector.BasicType(nullable, getNonNestedRapidsType(spark));
@@ -489,6 +490,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     } else if (type instanceof StringType) {
       return DType.STRING;
     } else if (type instanceof BinaryType) {
+      // FIXME: this should not be here, we should be able remove or throw
       return DType.LIST;
     } else if (type instanceof NullType) {
       // INT8 is used for both in this case
@@ -718,7 +720,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       }
       try (ColumnView tmp = cv.getChildColumnView(0)) {
         DType tmpType = tmp.getType();
-        return tmpType.equals(DType.INT8) || tmpType.equals(DType.UINT8);
+        return tmpType.equals(DType.UINT8);
       }
     } else {
       // Unexpected type

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -258,7 +258,7 @@ public class GpuColumnVector extends GpuColumnVectorBase {
       return new HostColumnVector.StructType(nullable, children);
     } else if (spark instanceof BinaryType) {
       return new HostColumnVector.ListType(
-          nullable, new HostColumnVector.BasicType(nullable, DType.UINT8));
+          nullable, new HostColumnVector.BasicType(false, DType.UINT8));
     } else {
       // Only works for basic types
       return new HostColumnVector.BasicType(nullable, getNonNestedRapidsType(spark));

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -578,7 +578,7 @@ object ParquetSchemaUtils extends Arm {
       // as a list.
 
       val dataBuf = cv.getData
-      withResource(new ColumnView(DType.INT8, dataBuf.getLength, Optional.of(0L),
+      withResource(new ColumnView(DType.UINT8, dataBuf.getLength, Optional.of(0L),
         dataBuf, null)) { data =>
         withResource(new ColumnView(DType.LIST, cv.getRowCount,
           Optional.of[java.lang.Long](cv.getNullCount),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -242,7 +242,8 @@ object GpuScalar extends Arm with Logging {
           resolveElementType(StructType(
             Seq(StructField("key", keyType), StructField("value", valueType)))))
       case BinaryType =>
-        Scalar.listFromNull(GpuColumnVector.convertFrom(ByteType, false))
+        Scalar.listFromNull(
+          new HostColumnVector.BasicType(false, DType.UINT8))
       case _ => Scalar.fromNull(GpuColumnVector.getNonNestedRapidsType(nullType))
     }
     case decType: DecimalType =>
@@ -367,11 +368,12 @@ object GpuScalar extends Arm with Logging {
     }
     case BinaryType => v match {
       case data: Array[Byte] =>
-        withResource(columnVectorFromLiterals(data, ByteType)) { list =>
+        withResource(ColumnVector.fromUnsignedBytes(data: _*)) { list =>
           Scalar.listFromColumnView(list)
         }
+
       case _ => throw new IllegalArgumentException(s"'$v: ${v.getClass}' is not supported" +
-          s" for BinaryType, expecting Array[Byte]")
+        s" for BinaryType, expecting Array[Byte]")
     }
     case GpuUnsignedIntegerType => v match {
       case i: Int =>  Scalar.fromUnsignedInt(i)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/6865.

This fixes the plugin after `INT8` was removed from binary column support in cuDF parquet writer. Tests that were xfailed before passed for me locally with this patch.