### PR TITLE
Create target folder before attempting to add unique RUN_DIR [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -175,7 +175,10 @@ else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
     fi
 
-    RUN_DIR=${RUN_DIR-$(mktemp -p "$SCRIPTPATH"/target -d run_dir-$(date +%Y%m%d%H%M%S)-XXXX)}
+    TARGET_DIR="$SCRIPTPATH"/target
+    mkdir -p "$TARGET_DIR"
+
+    RUN_DIR=${RUN_DIR-$(mktemp -p "$TARGET_DIR" -d run_dir-$(date +%Y%m%d%H%M%S)-XXXX)}
     mkdir -p "$RUN_DIR"
     cd "$RUN_DIR"
 

--- a/jenkins/databricks/run-tests.py
+++ b/jenkins/databricks/run-tests.py
@@ -47,7 +47,7 @@ def main():
         print("Copying test report tarball back")
         report_path_prefix = params.jar_path if params.jar_path else "/home/ubuntu/spark-rapids"
         rsync_command = "rsync -I -Pave \"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2200 -i %s\"" \
-            " ubuntu@%s:%s/integration_tests/target/run_dir/TEST-pytest-*.xml ./" % \
+            " ubuntu@%s:%s/integration_tests/target/run_dir*/TEST-pytest-*.xml ./" % \
             (params.private_key_file, master_addr, report_path_prefix)
         print("rsync command: %s" % rsync_command)
         subprocess.check_call(rsync_command, shell = True)


### PR DESCRIPTION
Signed-off-by: Sameer Raheja <sraheja@nvidia.com>

PR https://github.com/NVIDIA/spark-rapids/pull/6866 added a unique `RUN_DIR` with `mktemp`.  The `mktemp` command does not appear to have an option to create subdirectories if they do not exists as is the case with `mkdir -p`.  This PR breaks up the creation of `RUN_DIR` into two steps: 
1. Create the target directory folder with mkdir -p
2. Add the unique RUN_DIR folder with mktemp

This is to avoid situations as follows:
```
[2022-10-22T12:42:41.675Z] ++ mktemp -p /opt/sparkRapidsPlugin/spark-raplab-cicd/jenkins-rapids-it-environment-buildnumber/integration_tests/target -d run_dir-20221022124241-XXXX

[2022-10-22T12:42:41.675Z] mktemp: failed to create directory via template ‘/opt/sparkRapidsPlugin/spark-raplab-cicd/jenkins-rapids-it-environment-buildnumber/integration_tests/target/run_dir-20221022124241-XXXX’: No such file or directory

[2022-10-22T12:42:41.675Z] + RUN_DIR=
```

Alternative suggestions welcome!  