### PR TITLE
Fix the Spark340 build error related to `mapKeyNotExistError`

### DIFF
--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
@@ -19,16 +19,8 @@ package org.apache.spark.sql.rapids.shims
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.types.DataType
 
 trait RapidsErrorUtilsFor330plus {
-
-  def mapKeyNotExistError(
-      key: String,
-      keyType: DataType,
-      origin: Origin): NoSuchElementException = {
-    QueryExecutionErrors.mapKeyNotExistError(key, keyType, origin.context)
-  }
 
   def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
     new ArrayIndexOutOfBoundsException("SQL array indices start at 1")

--- a/sql-plugin/src/main/330until340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330until340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,10 +16,18 @@
 
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{Decimal, DecimalType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
+
+  def mapKeyNotExistError(
+      key: String,
+      keyType: DataType,
+      origin: Origin): NoSuchElementException = {
+    QueryExecutionErrors.mapKeyNotExistError(key, keyType, origin.context)
+  }
 
   def invalidArrayIndexError(index: Int, numElements: Int,
       isElementAtF: Boolean = false): ArrayIndexOutOfBoundsException = {

--- a/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -16,11 +16,20 @@
 
 package org.apache.spark.sql.rapids.shims
 
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.{Origin, SQLQueryContext}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.types.{Decimal, DecimalType}
+import org.apache.spark.sql.types.{DataType, Decimal, DecimalType}
 
 object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
+
+  def mapKeyNotExistError(
+      key: String,
+      keyType: DataType,
+      origin: Origin): NoSuchElementException = {
+    throw new UnsupportedOperationException(
+      "`mapKeyNotExistError` has been removed since Spark 3.4.0. "
+    )
+  }
 
   def invalidArrayIndexError(
       index: Int,


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Fix the build error in #6383.

## Changes in the PR
Update the implementation of `RapidsErrorUtils.mapKeyNotExistError` for spark 340+ to throw an `UnsupportedOperationException` directly because `mapKeyNotExistError` has been removed since Spark 3.4.0.

## Rationale of the PR
### branch 22.12
```
...
[ERROR] [Error] /home/remziy/working/rapids/spark-rapids/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala:30: value mapKeyNotExistError is not a member of object org.apache.spark.sql.errors.QueryExecutionErrors
...
[ERROR] 29 errors found
```

### this patch
```
...
[ERROR] 28 errors found
```
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
