### PR TITLE
Add different codepoint for unicode 13.0

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.functions._
  * java 11 :  unicode 10.0
  * java 12 :  unicode 11.0    (unsupported)
  * java 13 :  unicode 12.1
- * java 17 :  unicode 13.0
+ * java 17 :  unicode 13.0    (unsupported)
  *
  */
 object SupportedUnicodeVersion extends Enumeration {
@@ -114,7 +114,7 @@ object CudfIncompatibleCodepoints {
  * java 11 :  unicode 10.0
  * java 12 :  unicode 11.0    (unsupported)
  * java 13 :  unicode 12.1
- * java 17 :  unicode 13.0
+ * java 17 :  unicode 13.0    (unsupported)
  *
  */
 object TestCodepoints {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -143,7 +143,7 @@ object TestCodepoints {
   }
   // print out a warning if we're on an unsupported version
   if (getActiveUnicodeVersion() == SupportedUnicodeVersion.UNICODE_UNSUPPORTED) {
-    printf("WARNING : Unsupported version of Java (%s). You may encounted unexpected " +
+    printf("WARNING : Unsupported version of Java (%s). You may encounter unexpected " +
       "test failures\n", System.getProperties().getProperty("java.specification.version"))
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -31,15 +31,17 @@ import org.apache.spark.sql.functions._
  * java 11 :  unicode 10.0
  * java 12 :  unicode 11.0    (unsupported)
  * java 13 :  unicode 12.1
+ * java 17 :  unicode 13.0
  *
  */
 object SupportedUnicodeVersion extends Enumeration {
   val UNICODE_6 = 0
   val UNICODE_10 = 1
-  val UNICODE_12 = 2  
-  
-  val NUM_UNICODE_VERSIONS = 3  
-  val UNICODE_UNSUPPORTED = 4
+  val UNICODE_12 = 2
+  val UNICODE_13 = 3
+
+  val NUM_UNICODE_VERSIONS = 4
+  val UNICODE_UNSUPPORTED = 5
 
   val currentSupportedVersion = UNICODE_12
 }
@@ -72,7 +74,10 @@ object CudfIncompatibleCodepoints {
                                         42900),
 
                                   // java 13, unicode 12
-                                  List())
+                                  List(),
+
+                                  // java 17, unicode 13
+                                  List(42952, 42954, 42998))
 
   val lowercaseIncompatible = Array[List[Int]](
                                   // Java 8 / unicode 6.2
@@ -92,7 +97,10 @@ object CudfIncompatibleCodepoints {
                                   List(),
 
                                   // java 13, unicode 12
-                                  List())
+                                  List(),
+
+                                  // java 17, unicode 13
+                                  List(42951, 42953, 42997))
 }
 
 /* 
@@ -106,6 +114,7 @@ object CudfIncompatibleCodepoints {
  * java 11 :  unicode 10.0
  * java 12 :  unicode 11.0    (unsupported)
  * java 13 :  unicode 12.1
+ * java 17 :  unicode 13.0
  *
  */
 object TestCodepoints {
@@ -128,6 +137,7 @@ object TestCodepoints {
     vp(0).toInt match {
       case 11 => SupportedUnicodeVersion.UNICODE_10
       case 13 => SupportedUnicodeVersion.UNICODE_12
+      case 17 => SupportedUnicodeVersion.UNICODE_13
       case _ => SupportedUnicodeVersion.UNICODE_UNSUPPORTED
     }    
   }


### PR DESCRIPTION
New codepoints are added in unicode 13.0, but not exist in unicode 12.1.
Close https://github.com/NVIDIA/spark-rapids/issues/6752
Signed-off-by: Gary Shen <gashen@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
