### PR TITLE
Avoid coalescing files with mismatched schemas

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -589,7 +589,7 @@ trait DataBlockBase {
  * The sub-class should wrap the real schema for the specific file format
  */
 trait SchemaBase {
-  def fieldNames: Array[String]
+  def isEmpty: Boolean
 }
 
 /**
@@ -846,7 +846,7 @@ abstract class MultiFileCoalescingPartitionReaderBase(
   private def readBatch(): Option[ColumnarBatch] = {
     withResource(new NvtxRange(s"$getFileFormatShortName readBatch", NvtxColor.GREEN)) { _ =>
       val currentChunkMeta = populateCurrentBlockChunk()
-      val retBatch = if (currentChunkMeta.clippedSchema.fieldNames.isEmpty) {
+      val retBatch = if (currentChunkMeta.clippedSchema.isEmpty) {
         // not reading any data, so return a degenerate ColumnarBatch with the row count
         if (currentChunkMeta.numTotalRows == 0) {
           None

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1977,20 +1977,16 @@ class MultiFileOrcPartitionReader(
   override def checkIfNeedToSplitDataBlock(
       currentBlockInfo: SingleDataBlockInfo,
       nextBlockInfo: SingleDataBlockInfo): Boolean = {
-    val schemaNextFile =
-      nextBlockInfo.schema.getFieldNames.asScala
-    val schemaCurrentfile =
-      currentBlockInfo.schema.getFieldNames.asScala
-
-    if (!schemaNextFile.sameElements(schemaCurrentfile)) {
-      logInfo(s"Orc File schema for the next file ${nextBlockInfo.filePath}" +
-        s" doesn't match current ${currentBlockInfo.filePath}, splitting it into another batch!")
+    if (!nextBlockInfo.schema.equals(currentBlockInfo.schema)) {
+      logInfo(s"ORC schema for the next file ${nextBlockInfo.filePath}" +
+        s" schema ${nextBlockInfo.schema} doesn't match current ${currentBlockInfo.filePath}" +
+        s" schema ${currentBlockInfo.schema}, splitting it into another batch!")
       return true
     }
 
     if (currentBlockInfo.dataBlock.ctx.compressionKind !=
         nextBlockInfo.dataBlock.ctx.compressionKind) {
-      logInfo(s"Orc File compression for the next file ${nextBlockInfo.filePath}" +
+      logInfo(s"ORC File compression for the next file ${nextBlockInfo.filePath}" +
         s" doesn't match current ${currentBlockInfo.filePath}, splitting it into another batch!")
       return true
     }
@@ -2006,7 +2002,7 @@ class MultiFileOrcPartitionReader(
     }
 
     if (!ret) {
-      logInfo(s"Orc requested column ids for the next file ${nextBlockInfo.filePath}" +
+      logInfo(s"ORC requested column ids for the next file ${nextBlockInfo.filePath}" +
         s" doesn't match current ${currentBlockInfo.filePath}, splitting it into another batch!")
       return true
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1804,7 +1804,7 @@ trait OrcCodecWritingHelper extends Arm {
 // Orc schema wrapper
 private case class OrcSchemaWrapper(schema: TypeDescription) extends SchemaBase {
 
-  override def fieldNames: Array[String] = schema.getFieldNames.asScala.toArray
+  override def isEmpty: Boolean = schema.getFieldNames.isEmpty
 }
 
 case class OrcStripeWithMeta(stripe: OrcOutputStripe, ctx: OrcPartitionReaderContext)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1489,8 +1489,7 @@ trait ParquetPartitionReaderBase extends Logging with Arm with ScanWithMetrics
 
 // Parquet schema wrapper
 private case class ParquetSchemaWrapper(schema: MessageType) extends SchemaBase {
-
-  override def fieldNames: Array[String] = schema.getFields.asScala.map(_.getName).toArray
+  override def isEmpty: Boolean = schema.getFields.isEmpty
 }
 
 // Parquet BlockMetaData wrapper

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1623,14 +1623,10 @@ class MultiFileParquetPartitionReader(
       return true
     }
 
-    val schemaNextFile =
-      nextBlockInfo.schema.asGroupType().getFields.asScala.map(_.getName)
-    val schemaCurrentfile =
-      currentBlockInfo.schema.asGroupType().getFields.asScala.map(_.getName)
-
-    if (!schemaNextFile.sameElements(schemaCurrentfile)) {
+    if (!nextBlockInfo.schema.equals(currentBlockInfo.schema)) {
       logInfo(s"File schema for the next file ${nextBlockInfo.filePath}" +
-        s" doesn't match current ${currentBlockInfo.filePath}, splitting it into another batch!")
+        s" schema ${nextBlockInfo.schema} doesn't match current ${currentBlockInfo.filePath}" +
+        s" schema ${currentBlockInfo.schema}, splitting it into another batch!")
       return true
     }
     false

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import java.util.concurrent.{Callable, TimeUnit}
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters.{asScalaBufferConverter, mapAsScalaMapConverter}
+import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.collection.mutable.{ArrayBuffer, LinkedHashMap}
 import scala.language.implicitConversions
 import scala.math.max
@@ -1019,8 +1019,7 @@ case class AvroExtraInfo() extends ExtraInfo
 
 /** avro schema wrapper */
 case class AvroSchemaWrapper(schema: Schema) extends SchemaBase {
-
-  override def fieldNames: Array[String] = schema.getFields.asScala.map(_.name()).toArray
+  override def isEmpty: Boolean = schema.getFields.isEmpty
 }
 
 /** avro BlockInfo wrapper */


### PR DESCRIPTION
Relates to #6871, but still waiting for confirmation that it fixes it as I was unable to reproduce the same error locally.

Changes the logic for checking for Parquet and ORC file coalesces on reads to check for full equality on the filtered read schemas from the files rather than just checking the names of top-level columns.  This also simplifies the API for `SchemaBase` since no code actually needed the field names.  It's also a bit dangerous to only support returning top-level column names but no other column names, as it encourages invalid checks like the original code that work in practice for many situations but not all.