### PR TITLE
Add ApplicationSummaryInfo wrapper to allow mock tests

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Analysis.scala
@@ -314,7 +314,7 @@ class Analysis(apps: Seq[ApplicationInfo]) {
 
   def getMaxTaskInputSizeBytes(): Seq[SQLMaxTaskInputSizes] = {
     apps.map { app =>
-      val maxOfSql = app.sqlIdToInfo.map { case (sqlId, _) =>
+      val maxOfSqls = app.sqlIdToInfo.map { case (sqlId, _) =>
         val jcs = app.jobIdToInfo.filter { case (_, jc) =>
           jc.sqlID.getOrElse(-1) == sqlId
         }
@@ -331,8 +331,13 @@ class Analysis(apps: Seq[ApplicationInfo]) {
             tasksInSQL.map(_.input_bytesRead).max
           }
         }
-      }.max
-      SQLMaxTaskInputSizes(app.index, app.appId, maxOfSql)
+      }
+      val maxVal = if (maxOfSqls.nonEmpty) {
+        maxOfSqls.max
+      } else {
+        0
+      }
+      SQLMaxTaskInputSizes(app.index, app.appId, maxVal)
     }
   }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -41,7 +41,6 @@ case class ApplicationSummaryInfo(
     val appLogPath: Seq[AppLogPathProfileResults])
 
 trait AppInfoPropertyGetter {
-  def isAppDefined: Boolean = true
   def getSparkProperty(propKey: String): Option[String]
   def getRapidsProperty(propKey: String): Option[String]
   def getProperty(propKey: String): Option[String]
@@ -57,20 +56,25 @@ trait AppInfoSQLMaxTaskInputSizes {
   def getMaxInput: Double
 }
 
-abstract class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
+/**
+ * A base class definition that provides an empty implementation of the profile results embedded in
+ * [[ApplicationSummaryInfo]].
+ */
+class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   with AppInfoSqlTaskAggMetricsVisitor
   with AppInfoSQLMaxTaskInputSizes {
   override def getSparkProperty(propKey: String): Option[String] = None
   override def getRapidsProperty(propKey: String): Option[String] = None
-  override def getProperty(propKey: String): Option[String]
-  override def getSparkVersion: Option[String]
-  override def getMaxInput: Double
-  override def getJvmGCFractions: Seq[Double]
-  override def getSpilledMetrics: Seq[Long]
+  override def getProperty(propKey: String): Option[String] = None
+  override def getSparkVersion: Option[String] = None
+  override def getMaxInput: Double = 0.0
+  override def getJvmGCFractions: Seq[Double] = Seq()
+  override def getSpilledMetrics: Seq[Long] = Seq()
 }
 
 /**
- * A wrapper class to process the information embedded in ApplicationSummaryInfo.
+ * A wrapper class to process the information embedded in a valid instance of
+ * [[ApplicationSummaryInfo]].
  * Note that this class does not handle combined mode and assume that the profiling results belong
  * to a single app.
  * @param app the object resulting from profiling a single app.
@@ -112,7 +116,7 @@ class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
     }
   }
 
-  def getSpilledMetrics: Seq[Long] = {
+  override def getSpilledMetrics: Seq[Long] = {
     app.sqlTaskAggMetrics.map { task =>
       task.diskBytesSpilledSum + task.memoryBytesSpilledSum
     }

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -39,3 +39,90 @@ case class ApplicationSummaryInfo(
     val wholeStage: Seq[WholeStageCodeGenResults],
     val maxTaskInputBytesRead: Seq[SQLMaxTaskInputSizes],
     val appLogPath: Seq[AppLogPathProfileResults])
+
+trait AppInfoPropertyGetter {
+  def isAppDefined: Boolean = true
+  def getSparkProperty(propKey: String): Option[String]
+  def getRapidsProperty(propKey: String): Option[String]
+  def getProperty(propKey: String): Option[String]
+  def getSparkVersion: Option[String]
+}
+
+trait AppInfoSqlTaskAggMetricsVisitor {
+  def getJvmGCFractions: Seq[Double]
+  def getSpilledMetrics: Seq[Long]
+}
+
+trait AppInfoSQLMaxTaskInputSizes {
+  def getMaxInput: Double
+}
+
+abstract class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
+  with AppInfoSqlTaskAggMetricsVisitor
+  with AppInfoSQLMaxTaskInputSizes {
+  override def getSparkProperty(propKey: String): Option[String] = None
+  override def getRapidsProperty(propKey: String): Option[String] = None
+  override def getProperty(propKey: String): Option[String]
+  override def getSparkVersion: Option[String]
+  override def getMaxInput: Double
+  override def getJvmGCFractions: Seq[Double]
+  override def getSpilledMetrics: Seq[Long]
+}
+
+/**
+ * A wrapper class to process the information embedded in ApplicationSummaryInfo.
+ * Note that this class does not handle combined mode and assume that the profiling results belong
+ * to a single app.
+ * @param app the object resulting from profiling a single app.
+ */
+class SingleAppSummaryInfoProvider(val app: ApplicationSummaryInfo)
+  extends AppSummaryInfoBaseProvider {
+  private def findPropertyInProfPropertyResults(
+      key: String,
+      props: Seq[RapidsPropertyProfileResult]): Option[String] = {
+    props.collectFirst {
+      case entry: RapidsPropertyProfileResult
+        if entry.key == key && entry.rows(1) != "null" => entry.rows(1)
+    }
+  }
+
+  override def getSparkProperty(propKey: String): Option[String] = {
+    findPropertyInProfPropertyResults(propKey, app.sparkProps)
+  }
+
+  override def getRapidsProperty(propKey: String): Option[String] = {
+    findPropertyInProfPropertyResults(propKey, app.rapidsProps)
+  }
+
+  override def getProperty(propKey: String): Option[String] = {
+    if (propKey.startsWith("spark.rapids")) {
+      getRapidsProperty(propKey)
+    } else {
+      getSparkProperty(propKey)
+    }
+  }
+
+  override def getSparkVersion: Option[String] = {
+    Option(app.appInfo.head.sparkVersion)
+  }
+
+  override def getJvmGCFractions: Seq[Double] = {
+    app.sqlTaskAggMetrics.map {
+      taskMetrics => taskMetrics.jvmGCTimeSum * 1.0 / taskMetrics.executorCpuTime
+    }
+  }
+
+  def getSpilledMetrics: Seq[Long] = {
+    app.sqlTaskAggMetrics.map { task =>
+      task.diskBytesSpilledSum + task.memoryBytesSpilledSum
+    }
+  }
+
+  override def getMaxInput: Double = {
+    if (app.maxTaskInputBytesRead.nonEmpty) {
+      app.maxTaskInputBytesRead.head.maxTaskInputBytesRead
+    } else {
+      0.0
+    }
+  }
+}

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -321,11 +321,11 @@ class RecommendationEntry(val name: String,
  *
  * @param clusterProps The cluster properties including cores, mem, GPU, and software
  *                     (see [[ClusterProperties]]).
- * @param appInfo the container holding the profiling result.
+ * @param appInfoProvider the container holding the profiling result.
  */
 class AutoTuner(
     val clusterProps: ClusterProperties,
-    val appInfo: Option[ApplicationSummaryInfo])  extends Logging {
+    val appInfoProvider: AppSummaryInfoBaseProvider)  extends Logging {
 
   import AutoTuner._
 
@@ -344,28 +344,28 @@ class AutoTuner(
     !limitedLogicRecommendations.contains(prop)
   }
 
-  private def findPropertyInProfPropertyResults(
-      key: String,
-      props: Seq[RapidsPropertyProfileResult]): Option[String] = {
-    props.collectFirst {
-      case entry: RapidsPropertyProfileResult
-        if entry.key == key && entry.rows(1) != "null" => entry.rows(1)
-    }
-  }
-  def getSparkPropertyFromProfile(propKey: String): Option[String] = {
-    appInfo match {
-      case None => None
-      case Some(profInfo) =>
-        val resFromProfSparkProps = findPropertyInProfPropertyResults(propKey, profInfo.sparkProps)
-        resFromProfSparkProps match {
-          case None => findPropertyInProfPropertyResults(propKey, profInfo.rapidsProps)
-          case Some(_) => resFromProfSparkProps
-        }
-    }
-  }
+//  private def findPropertyInProfPropertyResults(
+//      key: String,
+//      props: Seq[RapidsPropertyProfileResult]): Option[String] = {
+//    props.collectFirst {
+//      case entry: RapidsPropertyProfileResult
+//        if entry.key == key && entry.rows(1) != "null" => entry.rows(1)
+//    }
+//  }
+//  def getSparkPropertyFromProfile(propKey: String): Option[String] = {
+//    appInfo match {
+//      case None => None
+//      case Some(profInfo) =>
+//        val resFromProfSparkProps =findPropertyInProfPropertyResults(propKey, profInfo.sparkProps)
+//        resFromProfSparkProps match {
+//          case None => findPropertyInProfPropertyResults(propKey, profInfo.rapidsProps)
+//          case Some(_) => resFromProfSparkProps
+//        }
+//    }
+//  }
 
   def getPropertyValue(key: String): Option[String] = {
-    val fromProfile = getSparkPropertyFromProfile(key)
+    val fromProfile = appInfoProvider.getProperty(key)
     fromProfile match {
       case None => Option(clusterProps.softwareProperties.get(key))
       case Some(_) => fromProfile
@@ -523,13 +523,6 @@ class AutoTuner(
     (pinnedMem, executorMemOverhead)
   }
 
-  private def getSparkVersion: Option[String] = {
-    appInfo match {
-      case Some(app) => Option(app.appInfo.head.sparkVersion)
-      case None => None
-    }
-  }
-
   /**
    * Find the label of the memory.overhead based on the spark master configuration and the spark
    * version.
@@ -545,7 +538,7 @@ class AutoTuner(
         if (sparkMaster.contains("yarn")) {
           defaultLabel
         } else if (sparkMaster.contains("k8s")) {
-          getSparkVersion match {
+          appInfoProvider.getSparkVersion match {
             case Some(version) =>
               if (compareSparkVersion(version, "3.3.0") > 0) {
                 "spark.executor.memoryOverheadFactor"
@@ -637,15 +630,11 @@ class AutoTuner(
     if (aqeEnabled == "False") {
       appendComment(commentsForMissingProps("spark.sql.adaptive.enabled"))
     }
-    if (appInfo.isDefined) {
-      val jvmGCFraction = appInfo.get.sqlTaskAggMetrics.map {
-        taskMetrics => taskMetrics.jvmGCTimeSum * 1.0 / taskMetrics.executorCpuTime
-      }
-      if (jvmGCFraction.nonEmpty) { // avoid zero division
-        if ((jvmGCFraction.sum / jvmGCFraction.size) > MAX_JVM_GCTIME_FRACTION) {
-          appendComment("Average JVM GC time is very high. " +
-            "Other Garbage Collectors can be used for better performance.")
-        }
+    val jvmGCFraction = appInfoProvider.getJvmGCFractions
+    if (jvmGCFraction.nonEmpty) { // avoid zero division
+      if ((jvmGCFraction.sum / jvmGCFraction.size) > MAX_JVM_GCTIME_FRACTION) {
+        appendComment("Average JVM GC time is very high. " +
+          "Other Garbage Collectors can be used for better performance.")
       }
     }
   }
@@ -665,13 +654,8 @@ class AutoTuner(
    *     Output: newMaxPartitionBytes = 2g / (512m/128m) = 512m
    */
   private def calculateMaxPartitionBytes(maxPartitionBytes: String): String = {
-    val app = appInfo.get
     // Autotuner only supports a single app right now, so we get whatever value is here
-    val inputBytesMax = if (app.maxTaskInputBytesRead.nonEmpty) {
-      app.maxTaskInputBytesRead.head.maxTaskInputBytesRead / 1024 / 1024
-    } else {
-      0.0
-    }
+    val inputBytesMax = appInfoProvider.getMaxInput / 1024 / 1024
     val maxPartitionBytesNum = convertToMB(maxPartitionBytes)
     if (inputBytesMax == 0.0) {
       maxPartitionBytesNum.toString
@@ -708,11 +692,7 @@ class AutoTuner(
       getPropertyValue("spark.sql.files.maxPartitionBytes").getOrElse(MAX_PARTITION_BYTES)
     val recommended =
       if (isCalculationEnabled("spark.sql.files.maxPartitionBytes")) {
-        appInfo match {
-          case None => s"${convertToMB(maxPartitionProp)}"
-          case Some(_) =>
-            calculateMaxPartitionBytes(maxPartitionProp)
-        }
+        calculateMaxPartitionBytes(maxPartitionProp)
       } else {
         s"${convertToMB(maxPartitionProp)}"
       }
@@ -732,16 +712,12 @@ class AutoTuner(
       getPropertyValue(lookup).getOrElse(DEF_SHUFFLE_PARTITIONS).toInt
     // TODO: Need to look at other metrics for GPU spills (DEBUG mode), and batch sizes metric
     if (isCalculationEnabled(lookup)) {
-      appInfo.foreach { app =>
-        val totalSpilledMetrics = app.sqlTaskAggMetrics.map { task =>
-          task.diskBytesSpilledSum + task.memoryBytesSpilledSum
-        }.sum
-        if (totalSpilledMetrics > 0) {
-          shufflePartitions *= DEF_SHUFFLE_PARTITION_MULTIPLIER
-          // Could be memory instead of partitions
-          appendOptionalComment(lookup,
-            s"'$lookup' should be increased since spilling occurred.")
-        }
+      val totalSpilledMetrics = appInfoProvider.getSpilledMetrics.sum
+      if (totalSpilledMetrics > 0) {
+        shufflePartitions *= DEF_SHUFFLE_PARTITION_MULTIPLIER
+        // Could be memory instead of partitions
+        appendOptionalComment(lookup,
+          s"'$lookup' should be increased since spilling occurred.")
       }
     }
     appendRecommendation("spark.sql.shuffle.partitions", s"$shufflePartitions")
@@ -885,7 +861,7 @@ object AutoTuner extends Logging {
 
   private def handleException(
       ex: Exception,
-      appInfo: Option[ApplicationSummaryInfo]): AutoTuner = {
+      appInfo: AppSummaryInfoBaseProvider): AutoTuner = {
     logError("Exception: " + ex.getStackTrace.mkString("Array(", ", ", ")"))
     val tuning = new AutoTuner(new ClusterProperties(), appInfo)
     val msg = ex match {
@@ -929,25 +905,25 @@ object AutoTuner extends Logging {
    */
   def buildAutoTunerFromProps(
       clusterProps: String,
-      appInfo: Option[ApplicationSummaryInfo]): AutoTuner = {
+      singleAppProvider: AppSummaryInfoBaseProvider): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterPropertiesFromContent(clusterProps)
-      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), appInfo)
+      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider)
     } catch {
       case e: Exception =>
-        handleException(e, appInfo)
+        handleException(e, singleAppProvider)
     }
   }
 
   def buildAutoTuner(
       filePath: String,
-      appInfo: Option[ApplicationSummaryInfo]): AutoTuner = {
+      singleAppProvider: AppSummaryInfoBaseProvider): AutoTuner = {
     try {
       val clusterPropsOpt = loadClusterProps(filePath)
-      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), appInfo)
+      new AutoTuner(clusterPropsOpt.getOrElse(new ClusterProperties()), singleAppProvider)
     } catch {
       case e: Exception =>
-        handleException(e, appInfo)
+        handleException(e, singleAppProvider)
     }
   }
 

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -634,7 +634,7 @@ class AutoTuner(
    *     Output: newMaxPartitionBytes = 2g / (512m/128m) = 512m
    */
   private def calculateMaxPartitionBytes(maxPartitionBytes: String): String = {
-    // Autotuner only supports a single app right now, so we get whatever value is here
+    // AutoTuner only supports a single app right now, so we get whatever value is here
     val inputBytesMax = appInfoProvider.getMaxInput / 1024 / 1024
     val maxPartitionBytesNum = convertToMB(maxPartitionBytes)
     if (inputBytesMax == 0.0) {

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/AutoTuner.scala
@@ -344,26 +344,6 @@ class AutoTuner(
     !limitedLogicRecommendations.contains(prop)
   }
 
-//  private def findPropertyInProfPropertyResults(
-//      key: String,
-//      props: Seq[RapidsPropertyProfileResult]): Option[String] = {
-//    props.collectFirst {
-//      case entry: RapidsPropertyProfileResult
-//        if entry.key == key && entry.rows(1) != "null" => entry.rows(1)
-//    }
-//  }
-//  def getSparkPropertyFromProfile(propKey: String): Option[String] = {
-//    appInfo match {
-//      case None => None
-//      case Some(profInfo) =>
-//        val resFromProfSparkProps =findPropertyInProfPropertyResults(propKey, profInfo.sparkProps)
-//        resFromProfSparkProps match {
-//          case None => findPropertyInProfPropertyResults(propKey, profInfo.rapidsProps)
-//          case Some(_) => resFromProfSparkProps
-//        }
-//    }
-//  }
-
   def getPropertyValue(key: String): Option[String] = {
     val fromProfile = appInfoProvider.getProperty(key)
     fromProfile match {
@@ -900,7 +880,8 @@ object AutoTuner extends Logging {
    * existing file. This can be used in testing.
    *
    * @param clusterProps the cluster properties as string.
-   * @param appInfo Optional of the profiling container.
+   * @param singleAppProvider the wrapper implementation that accesses the properties of the profile
+   *                          results.
    * @return a new AutoTuner object.
    */
   def buildAutoTunerFromProps(

--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/profiling/Profiler.scala
@@ -466,7 +466,8 @@ class Profiler(hadoopConf: Configuration, appArgs: ProfileArgs) extends Logging 
 
       if (useAutoTuner) {
         val workerInfoPath = appArgs.workerInfo.getOrElse(AutoTuner.DEFAULT_WORKER_INFO_PATH)
-        val autoTuner: AutoTuner = AutoTuner.buildAutoTuner(workerInfoPath, Some(app))
+        val autoTuner: AutoTuner = AutoTuner.buildAutoTuner(workerInfoPath,
+          new SingleAppSummaryInfoProvider(app))
         // the autotuner allows skipping some properties
         // e.g. getRecommendedProperties(Some(Seq("spark.executor.instances"))) skips the
         // recommendation related to executor instances.

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -26,6 +26,20 @@ import org.yaml.snakeyaml.{DumperOptions, Yaml}
 
 import org.apache.spark.internal.Logging
 
+
+class AppInfoProviderMockTest(val maxInput: Double,
+    val spilledMetrics: Seq[Long],
+    val jvmGCFractions: Seq[Double],
+    val propsFromLog: mutable.Map[String, String],
+    val sparkVersion: Option[String]) extends AppSummaryInfoBaseProvider {
+  // max input of the app in bytes
+  override def getMaxInput: Double = maxInput
+  override def getSpilledMetrics: Seq[Long] = spilledMetrics
+  override def getJvmGCFractions: Seq[Double] = jvmGCFractions
+  override def getProperty(propKey: String): Option[String] = propsFromLog.get(propKey)
+  override def getSparkVersion: Option[String] = sparkVersion
+}
+
 class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   val defaultDataprocProps: mutable.Map[String, String] = {
@@ -78,8 +92,20 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     rawString.split("\n").drop(1).mkString("\n")
   }
 
+  private def getMockInfoProvider: AppInfoProviderMockTest = {
+    new AppInfoProviderMockTest(0.0, Seq(), Seq(), mutable.Map[String, String](), None)
+  }
+  private def getMockInfoProvider(maxInput: Double,
+      spilledMetrics: Seq[Long],
+      jvmGCFractions: Seq[Double],
+      propsFromLog: mutable.Map[String, String],
+      sparkVersion: Option[String]): AppInfoProviderMockTest = {
+    new AppInfoProviderMockTest(maxInput,spilledMetrics, jvmGCFractions, propsFromLog, sparkVersion)
+  }
+
   test("Load non-existing cluster properties") {
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTuner("non-existing.yaml", None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTuner("non-existing.yaml",
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -99,7 +125,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU cores 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -121,7 +148,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU memory missing") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -144,7 +172,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU memory 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("0m"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -166,7 +195,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with number of workers 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("122880MiB"), Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -211,7 +241,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -243,7 +274,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo =
       buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -271,7 +303,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0M"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -298,7 +331,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -327,7 +361,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), Some("GPU-X"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -361,7 +396,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -390,7 +426,8 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -423,9 +460,159 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.shuffle.partitions' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, None)
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    assert(expectedResults == autoTunerOutput)
+  }
+
+  test("test with app mock 001") {
+    val customProps = mutable.LinkedHashMap(
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "47222m",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2",
+      "spark.task.resource.gpu.amount" -> "0.0625")
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.sql.shuffle.partitions" -> "200",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.0625",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.rapids.sql.concurrentGpuTasks" -> "4")
+
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+        Some("3.1.1")))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=8
+          |--conf spark.executor.instances=20
+          |--conf spark.executor.memory=16384m
+          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.sql.files.maxPartitionBytes=4096m
+          |--conf spark.task.resource.gpu.amount=0.125
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    assert(expectedResults == autoTunerOutput)
+  }
+
+  test("test with app mock 002") {
+    val customProps = mutable.LinkedHashMap(
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "47222m",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2",
+      "spark.task.resource.gpu.amount" -> "0.0625")
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.sql.shuffle.partitions" -> "1000",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.25",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.rapids.sql.concurrentGpuTasks" -> "1")
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.01, 0.0), logEventsProps,
+        Some("3.1.1")))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=8
+          |--conf spark.executor.instances=20
+          |--conf spark.executor.memory=16384m
+          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.sql.files.maxPartitionBytes=3669m
+          |--conf spark.task.resource.gpu.amount=0.125
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |""".stripMargin
+    // scalastyle:on line.size.limit
+    assert(expectedResults == autoTunerOutput)
+  }
+
+  test("test with app mock 003 - GC Fraction appears in comments") {
+    val customProps = mutable.LinkedHashMap(
+      "spark.executor.cores" -> "8",
+      "spark.executor.memory" -> "47222m",
+      "spark.rapids.sql.concurrentGpuTasks" -> "2",
+      "spark.task.resource.gpu.amount" -> "0.0625")
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    // mock the properties loaded from eventLog
+    val logEventsProps: mutable.Map[String, String] =
+      mutable.LinkedHashMap[String, String](
+        "spark.executor.cores" -> "16",
+        "spark.executor.instances" -> "1",
+        "spark.executor.memory" -> "80g",
+        "spark.executor.resource.gpu.amount" -> "1",
+        "spark.executor.instances" -> "1",
+        "spark.sql.shuffle.partitions" -> "1000",
+        "spark.sql.files.maxPartitionBytes" -> "1g",
+        "spark.task.resource.gpu.amount" -> "0.25",
+        "spark.rapids.memory.pinnedPool.size" -> "5g",
+        "spark.rapids.sql.enabled" -> "true",
+        "spark.rapids.sql.concurrentGpuTasks" -> "1")
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+      getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.4, 0.4), logEventsProps,
+        Some("3.1.1")))
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
+    // scalastyle:off line.size.limit
+    val expectedResults =
+      s"""|
+          |Spark Properties:
+          |--conf spark.executor.cores=8
+          |--conf spark.executor.instances=20
+          |--conf spark.executor.memory=16384m
+          |--conf spark.executor.memoryOverhead=5734m
+          |--conf spark.rapids.memory.pinnedPool.size=4096m
+          |--conf spark.rapids.sql.concurrentGpuTasks=2
+          |--conf spark.sql.files.maxPartitionBytes=3669m
+          |--conf spark.task.resource.gpu.amount=0.125
+          |
+          |Comments:
+          |- 'spark.executor.memoryOverhead' was not set.
+          |- 'spark.executor.memoryOverhead' must be set if using 'spark.rapids.memory.pinnedPool.size
+          |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
+          |- Average JVM GC time is very high. Other Garbage Collectors can be used for better performance.
+          |""".stripMargin
+    // scalastyle:on line.size.limit
     assert(expectedResults == autoTunerOutput)
   }
 }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -92,8 +92,9 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
   }
 
   private def getUnusedProvider: AppSummaryInfoBaseProvider = {
-    new AppInfoProviderMockTest(0.0, Seq(), Seq(), mutable.Map[String, String](), None)
+    new AppSummaryInfoBaseProvider()
   }
+
   private def getMockInfoProvider(maxInput: Double,
       spilledMetrics: Seq[Long],
       jvmGCFractions: Seq[Double],

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/profiling/AutoTunerSuite.scala
@@ -32,7 +32,6 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val jvmGCFractions: Seq[Double],
     val propsFromLog: mutable.Map[String, String],
     val sparkVersion: Option[String]) extends AppSummaryInfoBaseProvider {
-  // max input of the app in bytes
   override def getMaxInput: Double = maxInput
   override def getSpilledMetrics: Seq[Long] = spilledMetrics
   override def getJvmGCFractions: Seq[Double] = jvmGCFractions
@@ -92,20 +91,20 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     rawString.split("\n").drop(1).mkString("\n")
   }
 
-  private def getMockInfoProvider: AppInfoProviderMockTest = {
+  private def getUnusedProvider: AppSummaryInfoBaseProvider = {
     new AppInfoProviderMockTest(0.0, Seq(), Seq(), mutable.Map[String, String](), None)
   }
   private def getMockInfoProvider(maxInput: Double,
       spilledMetrics: Seq[Long],
       jvmGCFractions: Seq[Double],
       propsFromLog: mutable.Map[String, String],
-      sparkVersion: Option[String]): AppInfoProviderMockTest = {
-    new AppInfoProviderMockTest(maxInput,spilledMetrics, jvmGCFractions, propsFromLog, sparkVersion)
+      sparkVersion: Option[String]): AppSummaryInfoBaseProvider = {
+    new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
+      sparkVersion)
   }
 
   test("Load non-existing cluster properties") {
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTuner("non-existing.yaml",
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTuner("non-existing.yaml", getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -125,8 +124,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU cores 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -148,8 +146,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with CPU memory missing") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -169,11 +166,9 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assert(expectedResults == autoTunerOutput)
   }
 
-
   test("Load cluster properties with CPU memory 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("0m"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -195,8 +190,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
 
   test("Load cluster properties with number of workers 0") {
     val dataprocWorkerInfo = buildWorkerInfoAsString(None, Some(32), Some("122880MiB"), Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -241,8 +235,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(0))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -274,8 +267,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo =
       buildWorkerInfoAsString(Some(sparkProps), Some(32), Some("122880MiB"), Some(4), Some(2), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -303,8 +295,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0M"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -331,8 +322,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), None)
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -361,8 +351,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     val sparkProps = defaultDataprocProps.++(customProps)
     val dataprocWorkerInfo = buildWorkerInfoAsString(Some(sparkProps), Some(32),
       Some("122880MiB"), Some(4), Some(2), Some("0MiB"), Some("GPU-X"))
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     val expectedResults =
@@ -396,8 +385,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -426,8 +414,7 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |Comments:
           |- 'spark.sql.shuffle.partitions' was not set.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
@@ -460,21 +447,22 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
           |- 'spark.sql.shuffle.partitions' was not set.
           |- 'spark.sql.adaptive.enabled' should be enabled for better performance.
           |""".stripMargin
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider)
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, getUnusedProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     assert(expectedResults == autoTunerOutput)
   }
 
-  test("test with app mock 001") {
+  // Test that the properties from the eventlogs will be used to calculate the recommendations.
+  // For example, the output should recommend "spark.executor.cores" -> 8. Although the cluster
+  // "spark.executor.cores" is the same as the recommended value, the property is set to 16 in
+  // the eventlogs.
+  test("AutoTuner gives precedence to properties from eventlogs") {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "8",
       "spark.executor.memory" -> "47222m",
       "spark.rapids.sql.concurrentGpuTasks" -> "2",
       "spark.task.resource.gpu.amount" -> "0.0625")
-    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
-      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
@@ -489,10 +477,11 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
         "spark.rapids.sql.concurrentGpuTasks" -> "4")
-
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
-        Some("3.1.1")))
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    val infoProvider = getMockInfoProvider(8126464.0, Seq(0), Seq(0.004), logEventsProps,
+      Some("3.1.1"))
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit
@@ -517,14 +506,14 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assert(expectedResults == autoTunerOutput)
   }
 
-  test("test with app mock 002") {
+  // Changing the maxInput of tasks should reflect on the maxPartitions recommendations.
+  // Values used in setting the properties are taken from sample eventlogs.
+  test("Recommendation of maxPartitions is calculated based on maxInput of tasks") {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "8",
       "spark.executor.memory" -> "47222m",
       "spark.rapids.sql.concurrentGpuTasks" -> "2",
       "spark.task.resource.gpu.amount" -> "0.0625")
-    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
-      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
@@ -539,7 +528,9 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
         "spark.rapids.sql.concurrentGpuTasks" -> "1")
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    val autoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
       getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.01, 0.0), logEventsProps,
         Some("3.1.1")))
     val (properties, comments) = autoTuner.getRecommendedProperties()
@@ -566,14 +557,16 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
     assert(expectedResults == autoTunerOutput)
   }
 
-  test("test with app mock 003 - GC Fraction appears in comments") {
+  // When GCFraction is higher AutoTuner.MAX_JVM_GCTIME_FRACTION, the output should contain
+  // a comment recommending to consider different GC algorithms.
+  // This test triggers that case by injecting a sequence of jvmGCFraction with average higher
+  // than the static threshold of 0.3.
+  test("Output contains GC comments when GC Fraction is higher than threshold") {
     val customProps = mutable.LinkedHashMap(
       "spark.executor.cores" -> "8",
       "spark.executor.memory" -> "47222m",
       "spark.rapids.sql.concurrentGpuTasks" -> "2",
       "spark.task.resource.gpu.amount" -> "0.0625")
-    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
-      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
     // mock the properties loaded from eventLog
     val logEventsProps: mutable.Map[String, String] =
       mutable.LinkedHashMap[String, String](
@@ -588,9 +581,11 @@ class AutoTunerSuite extends FunSuite with BeforeAndAfterEach with Logging {
         "spark.rapids.memory.pinnedPool.size" -> "5g",
         "spark.rapids.sql.enabled" -> "true",
         "spark.rapids.sql.concurrentGpuTasks" -> "1")
-    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo,
-      getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.4, 0.4), logEventsProps,
-        Some("3.1.1")))
+    val dataprocWorkerInfo = buildWorkerInfoAsString(Some(customProps), Some(32),
+      Some("212992MiB"), Some(5), Some(4), Some("15109MiB"), Some("Tesla T4"))
+    val infoProvider = getMockInfoProvider(3.7449728E7, Seq(0, 0), Seq(0.4, 0.4), logEventsProps,
+      Some("3.1.1"))
+    val autoTuner: AutoTuner = AutoTuner.buildAutoTunerFromProps(dataprocWorkerInfo, infoProvider)
     val (properties, comments) = autoTuner.getRecommendedProperties()
     val autoTunerOutput = Profiler.getAutoTunerResultsAsString(properties, comments)
     // scalastyle:off line.size.limit


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #6707, fixes #6895

**Changed made for 6707:**

The objective is to do smallest change that allows testing autotuner without loading entire eventlog.  

- Added new classes in ApplicationSummaryInfo.scala: `AppSummaryInfoBaseProvider`, and `SingleAppSummaryInfoProvider`
- Change the constructor of AutoTuner, and make necessary changes in the implementation to avoid direct access of `ApplicationSummaryInfo`.
- Added a couple of new unit tests. We should be able to build on top of those unit tests when we start evaluating the heuristics.


**Changed made for 6895:**

- check that the sequence is non empty before calling max in Analysis.scala
- if it is empty, return `getMaxTaskInputSizeBytes` returns 0.