### PR TITLE
[BUG] GpuPartitioning should close CVs before releasing semaphore

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -67,9 +67,7 @@ abstract class GpuHashPartitioningBase(expressions: Seq[Expression], numPartitio
           partitionInternalAndClose(batch)
         }
       }
-      val ret = withResource(partitionColumns) { partitionColumns =>
-        sliceInternalGpuOrCpu(numRows, partitionIndexes, partitionColumns)
-      }
+      val ret = sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
       // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -68,7 +68,6 @@ abstract class GpuHashPartitioningBase(expressions: Seq[Expression], numPartitio
         }
       }
       val ret = sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
-      // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -78,7 +78,6 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
       }
       val ret: Array[ColumnarBatch] =
         sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
-      // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)
     } finally {
       totalRange.close()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids
 import java.util.Random
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.TaskContext
@@ -78,8 +77,7 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
         }
       }
       val ret: Array[ColumnarBatch] =
-        sliceInternalGpuOrCpu(numRows, partitionIndexes, partitionColumns)
-      partitionColumns.safeClose()
+        sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
       // Close the partition columns we copied them as a part of the slice
       ret.zipWithIndex.filter(_._1 != null)
     } finally {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
@@ -42,15 +42,13 @@ case object GpuSinglePartitioning extends GpuExpression with ShimExpression
     if (batch.numCols == 0) {
       Array(batch).zipWithIndex
     } else {
-      withResource(batch) { batch =>
-        // Nothing needs to be sliced but a contiguous table is needed for GPU shuffle which
-        // slice will produce.
-        val sliced = sliceInternalGpuOrCpu(
-          batch.numRows,
-          Array(0),
-          GpuColumnVector.extractColumns(batch))
-        sliced.zipWithIndex.filter(_._1 != null)
-      }
+      // Nothing needs to be sliced but a contiguous table is needed for GPU shuffle which
+      // slice will produce.
+      val sliced = sliceInternalGpuOrCpuAndClose(
+        batch.numRows,
+        Array(0),
+        GpuColumnVector.extractColumns(batch))
+      sliced.zipWithIndex.filter(_._1 != null)
     }
   }
 


### PR DESCRIPTION
Contributes to #6746, found while investigating #6758.

This is probably big in some cases? Before this change we would have copied to host, released the GPU, and then close the source columns. In some scenarios I could see N concurrent tasks reach here and end up allowing N more before we close the GPU buffers. 

It is close in time, so I am not sure how much in practice we would see it.