### PR TITLE
Support Spark 3.3.1

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -49,11 +49,11 @@
             321cdh,
             322,
             330,
+            331,
             330cdh
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            314,
-            331
+            314
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -293,6 +293,7 @@ In this section, we are using a docker container built using the sample dockerfi
    | 3.2.1 CDH       | com.nvidia.spark.rapids.spark321cdh.RapidsShuffleManager |
    | 3.2.2           | com.nvidia.spark.rapids.spark322.RapidsShuffleManager |
    | 3.3.0           | com.nvidia.spark.rapids.spark330.RapidsShuffleManager    |
+   | 3.3.1           | com.nvidia.spark.rapids.spark331.RapidsShuffleManager    |
    | Databricks 9.1  | com.nvidia.spark.rapids.spark312db.RapidsShuffleManager  |
    | Databricks 10.4 | com.nvidia.spark.rapids.spark321db.RapidsShuffleManager  |
 

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -160,7 +160,7 @@ nvidia-smi
 
 . jenkins/version-def.sh
 
-# controls whether we build snapshots for the Spark maintenance versions like 3.1.4 and 3.3.1
+# controls whether we build snapshots for the Spark maintenance versions like 3.1.4
 BUILD_MAINTENANCE_VERSION_SNAPSHOTS="false"
 # controls whether we build snapshots for the next Spark major or feature version like 3.4.0 or 4.0.0
 BUILD_FEATURE_VERSION_SNAPSHOTS="false"

--- a/pom.xml
+++ b/pom.xml
@@ -1105,7 +1105,7 @@
         <spark321db.version>3.2.1-databricks</spark321db.version>
         <spark322.version>3.2.2</spark322.version>
         <spark330.version>3.3.0</spark330.version>
-        <spark331.version>3.3.1-SNAPSHOT</spark331.version>
+        <spark331.version>3.3.1</spark331.version>
         <spark340.version>3.4.0-SNAPSHOT</spark340.version>
         <spark330cdh.version>3.3.0.3.3.7180.0-274</spark330cdh.version>
         <mockito.version>3.6.0</mockito.version>

--- a/sql-plugin/src/main/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimServiceProvider.scala
+++ b/sql-plugin/src/main/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimServiceProvider.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.SparkShimVersion
 
 object SparkShimServiceProvider {
   val VERSION = SparkShimVersion(3, 3, 1)
-  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+  val VERSIONNAMES = Seq(s"$VERSION")
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/LimitExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/LimitExecSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,30 +24,31 @@ class LimitExecSuite extends SparkQueryCompareTestSuite {
 
  /** CollectLimitExec is off by default, turn it on for tests */
   def enableCollectLimitExec(conf: SparkConf = new SparkConf()): SparkConf = {
-    enableCsvConf().set("spark.rapids.sql.exec.CollectLimitExec", "true")
+    enableCsvConf(conf).set("spark.rapids.sql.exec.CollectLimitExec", "true")
   }
 
-  testSparkResultsAreEqual("limit more than rows", intCsvDf,
+  IGNORE_ORDER_testSparkResultsAreEqual("limit more than rows", intCsvDf,
       conf = enableCollectLimitExec()) {
       frame => frame.limit(10).repartition(2)
   }
 
-  testSparkResultsAreEqual("limit less than rows equal to batchSize", intCsvDf,
+  IGNORE_ORDER_testSparkResultsAreEqual("limit less than rows equal to batchSize", intCsvDf,
     conf = enableCollectLimitExec(makeBatchedBytes(1))) {
     frame => frame.limit(1).repartition(2)
   }
 
-  testSparkResultsAreEqual("limit less than rows applied with batches pending", intCsvDf,
+  IGNORE_ORDER_testSparkResultsAreEqual("limit less than rows applied with batches pending",
+    intCsvDf,
     conf = enableCollectLimitExec(makeBatchedBytes(3))) {
     frame => frame.limit(2).repartition(2)
   }
 
-  testSparkResultsAreEqual("limit with no real columns", intCsvDf,
+  IGNORE_ORDER_testSparkResultsAreEqual("limit with no real columns", intCsvDf,
     conf = enableCollectLimitExec(makeBatchedBytes(3)), repart = 0) {
     frame => frame.limit(2).selectExpr("pi()")
   }
 
-  testSparkResultsAreEqual("collect with limit", testData,
+  IGNORE_ORDER_testSparkResultsAreEqual("collect with limit", testData,
     conf = enableCollectLimitExec()) {
     frame => {
       import frame.sparkSession.implicits._
@@ -56,7 +57,7 @@ class LimitExecSuite extends SparkQueryCompareTestSuite {
     }
   }
 
-  testSparkResultsAreEqual("collect with limit, repart=4", testData,
+  IGNORE_ORDER_testSparkResultsAreEqual("collect with limit, repart=4", intCsvDf,
     conf = enableCollectLimitExec(), repart = 4) {
     frame => {
       import frame.sparkSession.implicits._
@@ -69,7 +70,7 @@ class LimitExecSuite extends SparkQueryCompareTestSuite {
     FuzzerUtils.generateDataFrame(spark, FuzzerUtils.createSchema(Seq(DataTypes.IntegerType)), 100)
   }
 
-  testSparkResultsAreEqual("nested limit", testNested, conf = new SparkConf()
+  IGNORE_ORDER_testSparkResultsAreEqual("nested limit", testNested, conf = new SparkConf()
       .set("spark.sql.execution.sortBeforeRepartition", "false")) {
     frame => {
       frame.limit(2).repartition(2)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -148,8 +148,10 @@ object SparkSessionHolder extends Logging {
 trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   import SparkSessionHolder.withSparkSession
 
-  def enableCsvConf(): SparkConf = {
-    new SparkConf()
+  def enableCsvConf(): SparkConf = enableCsvConf(new SparkConf())
+
+  def enableCsvConf(conf: SparkConf): SparkConf = {
+    conf
       .set(RapidsConf.ENABLE_READ_CSV_FLOATS.key, "true")
       .set(RapidsConf.ENABLE_READ_CSV_DOUBLES.key, "true")
       .set(RapidsConf.ENABLE_READ_CSV_DECIMALS.key, "true")


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/6896
Spark 3.3.1 is released, so this PR updated the shim version from 3.3.1-SNAPSHOT to 3.3.1 accordingly.

This PR also updated some `LimitExec` related tests to ignore the result order, becasue we can not assume GPU will always output the data having same order with CPU for the `limit` operation.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
