### PR TITLE
Fix CastBase issues not related to PromotePrecision and CheckOverflow

### DIFF
--- a/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/Spark31XShims.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/com/nvidia/spark/rapids/shims/Spark31XShims.scala
@@ -245,6 +245,14 @@ abstract class Spark31XShims extends SparkShims with Spark31Xuntil33XShims with 
         parent = p, rule = r, doFloatToIntCheck = true, stringToAnsiDate = false))
   }
 
+  override def ignoreTimeZone(e: Expression): Expression = e match {
+    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case c: GpuCast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case _ => e
+  }
+
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[Cast](
         "Convert a column of one type of data into another type",

--- a/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/Spark31XdbShims.scala
+++ b/sql-plugin/src/main/31xdb/scala/com/nvidia/spark/rapids/shims/Spark31XdbShims.scala
@@ -113,6 +113,14 @@ abstract class Spark31XdbShims extends Spark31XdbShimsBase with Logging {
         parent = p, rule = r, doFloatToIntCheck = true, stringToAnsiDate = true))
   }
 
+  override def ignoreTimeZone(e: Expression): Expression = e match {
+    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case c: GpuCast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case _ => e
+  }
+
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
     GpuOverrides.expr[Cast](
         "Convert a column of one type of data into another type",

--- a/sql-plugin/src/main/320until340-all/scala/com/nvidia/spark/rapids/shims/Spark320until340Shims.scala
+++ b/sql-plugin/src/main/320until340-all/scala/com/nvidia/spark/rapids/shims/Spark320until340Shims.scala
@@ -17,7 +17,7 @@ package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids._
 
-import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Expression}
+import org.apache.spark.sql.catalyst.expressions.{AnsiCast, CastBase, Expression}
 
 trait Spark320until340Shims extends SparkShims {
 
@@ -81,5 +81,13 @@ trait Spark320until340Shims extends SparkShims {
       },
       (cast, conf, p, r) => new CastExprMeta[AnsiCast](cast, ansiEnabled = true, conf = conf,
         parent = p, rule = r, doFloatToIntCheck = true, stringToAnsiDate = true))
+  }
+
+  override def ignoreTimeZone(e: Expression): Expression = e match {
+    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case c: GpuCast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case _ => e
   }
 }

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shims
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan}
 import org.apache.spark.sql.execution.exchange.ENSURE_REQUIREMENTS
@@ -64,4 +64,11 @@ object SparkShimImpl extends Spark331PlusShims {
   // AnsiCast is removed from Spark3.4.0
   override def ansiCastRule: ExprRule[_ <: Expression] = null
 
+  override def ignoreTimeZone(e: Expression): Expression = e match {
+    case c: Cast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case c: GpuCast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+      c.withTimeZone(null)
+    case _ => e
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -29,7 +29,7 @@ import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{AnsiUtil, GpuIntervalUtils, GpuTypeShims, SparkShimImpl, YearParseUtil}
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.{Cast, CastBase, Expression, NullIntolerant, TimeZoneAwareExpression}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, NullIntolerant, TimeZoneAwareExpression, UnaryExpression}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MICROS_PER_SECOND
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuToTimestamp.replaceSpecialDates
@@ -37,7 +37,7 @@ import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 
 /** Meta-data for cast and ansi_cast. */
-final class CastExprMeta[INPUT <: CastBase](
+final class CastExprMeta[INPUT <: UnaryExpression with TimeZoneAwareExpression with NullIntolerant](
     cast: INPUT,
     val ansiEnabled: Boolean,
     conf: RapidsConf,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -170,6 +170,12 @@ trait SparkShims {
   def ansiCastRule: ExprRule[_ <: Expression]
 
   /**
+   * Remove TimeZoneId for Cast if needsTimeZone return false.
+   * CastBase was removed in Spark 3.4.0 so the type match needs to be handled separately
+   */
+  def ignoreTimeZone(cast: Expression): Expression
+
+  /**
    * Determine if the Spark version allows the supportsColumnar flag to be overridden
    * in AdaptiveSparkPlanExec. This feature was introduced in Spark 3.2 as part of
    * SPARK-35881.


### PR DESCRIPTION
Fixes build errors in Spark 3.4.0, but does not necessarily match the functionality in 3.4.0. As a result it is related to #5807 but does not resolve it.

Current error set w/o changes:
```
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:32: object CastBase is not a member of package org.apache.spark.sql.cat
alyst.expressions
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:40: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/320+/scala/org/apache/spark/sql/execution/datasources/rapids/DataSourceStrategyUtils.scala:26: value translateRunti
meFilter is not a member of object org.apache.spark.sql.execution.datasources.DataSourceStrategy
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/330+/scala/org/apache/spark/rapids/ShimTrampolineUtil.scala:23: not enough arguments for constructor SparkDateTimeE
xception: (errorClass: String, messageParameters: Map[String,String], context: Array[org.apache.spark.QueryContext], summary: String)org.apache.spark.SparkDateTimeException.
Unspecified value parameters context, summary.
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala:58: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala:58: value timeZoneId is not a member of org.apache.spark.sql.ca
talyst.expressions.Expression
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala:58: value needsTimeZone is not a member of org.apache.spark.sql
.catalyst.expressions.Expression
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala:59: value withTimeZone is not a member of org.apache.spark.sql.
catalyst.expressions.Expression
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:58: value child is not a member of type parameter INPUT
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:59: value dataType is not a member of type parameter INPUT
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:158: value timeZoneId is not a member of type parameter INPUT
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala:32: Unused import
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:753: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:999: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:1842: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:1956: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:899: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:903: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:935: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:936: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:936: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:2087: recursive value x$15 needs type
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:2596: value failOnError is not a member of org.apache.spark.sql.catalyst.expressions.GetMapValue
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala:1084: value checkForNumericExpr is not a member of object org.apache.spark.sql.catalyst.util.TypeUtils
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala:1575: value checkForNumericExpr is not a member of object org.apache.spark.sql.catalyst.util.TypeUtils
[ERROR] 28 errors found
```
28 errors with 5 direct `CastBase` errors and several related downstream errors.

Current error set w/ changes:
```
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/320+/scala/org/apache/spark/sql/execution/datasources/rapids/DataSourceStrategyUtils.scala:26: value translateRunti
meFilter is not a member of object org.apache.spark.sql.execution.datasources.DataSourceStrategy
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/330+/scala/org/apache/spark/rapids/ShimTrampolineUtil.scala:23: not enough arguments for constructor SparkDateTimeE
xception: (errorClass: String, messageParameters: Map[String,String], context: Array[org.apache.spark.QueryContext], summary: String)org.apache.spark.SparkDateTimeException.
Unspecified value parameters context, summary.
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:753: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:999: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:1842: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala:1956: overloaded method value writeTo with alternatives:
  (x$1: org.apache.orc.protobuf.CodedOutputStream)Unit <and>
  (x$1: java.io.OutputStream)Unit
 cannot be applied to (com.google.protobuf.CodedOutputStream)
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:899: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:903: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: not found: type PromotePrecision
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:934: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:935: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:936: value child is not a member of Any
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:936: not found: type CastBase
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:2087: recursive value x$15 needs type
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:2596: value failOnError is not a member of org.apache.spark.sql.catalyst.expressions.GetMapValue
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala:1084: value checkForNumericExpr is not a member of object org.apache.spark.sql.catalyst.util.TypeUtils
[ERROR] [Error] /home/ryanlee/spark-rapids/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala:1575: value checkForNumericExpr is not a member of object org.apache.spark.sql.catalyst.util.TypeUtils
[ERROR] 18 errors found
```
18 errors with 2 `CastBase` related errors found in `PromotePrecision` and `CheckOverflow` -- @razajafri is working on those changes as part of #5827 which should eliminate the `CastBase` references.

These changes should resolve 10 build errors related to 3.4.0