### PR TITLE
Only warn when hive scratch creation fails

### DIFF
--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -90,8 +90,11 @@ def create_tmp_hive():
     path = os.environ.get('PYSP_TEST_spark_hadoop_hive_exec_scratchdir', '/tmp/hive')
     mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
     logging.info(f"Creating directory {path} with permissions {oct(mode)}")
-    os.makedirs(path, mode, exist_ok=True)
-    os.chmod(path, mode)
+    try:
+        os.makedirs(path, mode, exist_ok=True)
+        os.chmod(path, mode)
+    except Exception as e:
+        logging.warn(f"Failed to setup the hive scratch dir {path}. Error {e}")
 
 def pytest_sessionstart(session):
     # initializations that must happen globally once before tests start


### PR DESCRIPTION
Fixes #6883. Make hive scratch dir creation best effort with a warning

Tested with 
```
$ sudo chown root:root /tmp/hive
$ sudo chmod og-w /tmp/hive
$ ~/dist/spark-3.1.1-bin-hadoop3.2/bin/spark-submit \
  --jars ./dist/target/rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar \
  ./integration_tests/runtests.py \
  -rootdir ./integration_tests \
  ./integration_tests/src/main/python -v -rfE '' \
  --std_input_path=./integration_tests/src/test/resources  \
   -k existence -s

2022-10-26 17:17:47 INFO     Executing global initialization tasks before test launches
2022-10-26 17:17:47 INFO     Creating directory /tmp/hive with permissions 0o777
2022-10-26 17:17:47 WARNING  Failed to setup the hive scratch dir /tmp/hive. Error [Errno 1] Operation not permitted: '/tmp/hive'
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
