### PR TITLE
WIP: Join Reorder POC #1

### DIFF
--- a/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/311+-nondb/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,16 +16,27 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
 object AQEUtils {
+  type RuleBuilder = SparkSession => Rule[LogicalPlan]
+
   /** Return a new QueryStageExec reuse instance with updated output attributes */
   def newReuseInstance(sqse: ShuffleQueryStageExec, newOutput: Seq[Attribute]): QueryStageExec = {
     sqse.newReuseInstance(sqse.id, newOutput)
   }
 
   def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = true
+
+  def injectRuntimeOptimizerRule(rule: RuleBuilder): Unit = {
+    throw new UnsupportedOperationException(
+      "This version of Spark does not support injecting runtime optimizations")
+  }
+
 }

--- a/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/312db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,13 +16,18 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
 object AQEUtils {
+  type RuleBuilder = SparkSession => Rule[LogicalPlan]
+
   /** Return a new QueryStageExec reuse instance with updated output attributes */
   def newReuseInstance(sqse: ShuffleQueryStageExec, newOutput: Seq[Attribute]): QueryStageExec = {
     val reusedExchange = ReusedExchangeExec(newOutput, sqse.shuffle)
@@ -30,4 +35,10 @@ object AQEUtils {
   }
 
   def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = true
+
+  def injectRuntimeOptimizerRule(rule: RuleBuilder): Unit = {
+    throw new UnsupportedOperationException(
+      "This version of Spark does not support injecting runtime optimizations")
+  }
+
 }

--- a/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/321db/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -16,13 +16,18 @@
 
 package com.nvidia.spark.rapids.shims
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.adaptive.{QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 
 /** Utility methods for manipulating Catalyst classes involved in Adaptive Query Execution */
 object AQEUtils {
+  type RuleBuilder = SparkSession => Rule[LogicalPlan]
+
   /** Return a new QueryStageExec reuse instance with updated output attributes */
   def newReuseInstance(sqse: ShuffleQueryStageExec, newOutput: Seq[Attribute]): QueryStageExec = {
     val reusedExchange = ReusedExchangeExec(newOutput, sqse.shuffle)
@@ -34,5 +39,10 @@ object AQEUtils {
   // that.
   def isAdaptiveExecutionSupportedInSparkVersion(conf: SQLConf): Boolean = {
     conf.getConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED)
+  }
+
+  def injectRuntimeOptimizerRule(rule: RuleBuilder): Unit = {
+    throw new UnsupportedOperationException(
+      "This version of Spark does not support injecting runtime optimizations")
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1533,10 +1533,10 @@ object RapidsConf {
 
   val AQE_CBO_JOIN_REORDERING = conf("spark.rapids.sql.cbo.joinReordering")
     .internal()
-    .doc("Enable join reordering based on statistics from completed query stages " +
-      "when AQE is enabled")
+    .doc("Enable join reordering based on estimated statistics from file sources and " +
+      "from completed query stages")
     .booleanConf
-    .createWithDefault(true)
+    .createWithDefault(false)
 
   val OPTIMIZER_ENABLED = conf("spark.rapids.sql.optimizer.enabled")
       .internal()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1531,6 +1531,13 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(true)
 
+  val AQE_CBO_JOIN_REORDERING = conf("spark.rapids.sql.cbo.joinReordering")
+    .internal()
+    .doc("Enable join reordering based on statistics from completed query stages " +
+      "when AQE is enabled")
+    .booleanConf
+    .createWithDefault(true)
+
   val OPTIMIZER_ENABLED = conf("spark.rapids.sql.optimizer.enabled")
       .internal()
       .doc("Enable cost-based optimizer that will attempt to avoid " +
@@ -2152,6 +2159,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
     DEFAULT_CLOUD_SCHEMES ++ get(CLOUD_SCHEMES).getOrElse(Seq.empty)
 
   lazy val optimizerEnabled: Boolean = get(OPTIMIZER_ENABLED)
+
+  lazy val aqeJoinReordering: Boolean = get(AQE_CBO_JOIN_REORDERING)
 
   lazy val optimizerExplain: String = get(OPTIMIZER_EXPLAIN)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SQLExecPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SQLExecPlugin.scala
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids
 
+import com.nvidia.spark.rapids.optimizer.GpuCostBasedJoinReorder
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -28,6 +30,13 @@ class SQLExecPlugin extends (SparkSessionExtensions => Unit) with Logging {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectColumnar(columnarOverrides)
     extensions.injectQueryStagePrepRule(queryStagePrepOverrides)
+
+    // apply join reordering during logical plan optimization
+    extensions.injectOptimizerRule(_ => GpuCostBasedJoinReorder)
+
+    // apply join reordering during AQE reoptimization
+    // TODO enable this in shim layer for 3.2.3, 3.3.2, 3.4.0
+    //extensions.injectRuntimeOptimizerRule(_ => GpuCostBasedJoinReorder)
   }
 
   private def columnarOverrides(sparkSession: SparkSession): ColumnarRule = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
@@ -36,7 +36,7 @@ object GpuAggregateEstimation {
    * column stats for aggregate expressions.
    */
   def estimate(agg: Aggregate): Option[Statistics] = {
-    val childStats = GpuStatsPlanVisitor.visit(agg.child)
+    val childStats = GpuStatsPlanVisitor.visitCached(agg.child)
     // Check if we have column stats for all group-by columns.
     val colStatsExist = agg.groupingExpressions.forall { e =>
       e.isInstanceOf[Attribute] &&

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
@@ -18,10 +18,16 @@
 package com.nvidia.spark.rapids.optimizer
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
-import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 
-
+/**
+ * Copied from Spark's AggregateEstimation.scala
+ *
+ * Modifications:
+ *
+ * - Call GpuStatsPlanVisitor to get stats for child, instead of calling child.stats
+ */
 object GpuAggregateEstimation {
   import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Statistics}
+
+
+object GpuAggregateEstimation {
+  import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
+
+  /**
+   * Estimate the number of output rows based on column stats of group-by columns, and propagate
+   * column stats for aggregate expressions.
+   */
+  def estimate(agg: Aggregate): Option[Statistics] = {
+    val childStats = GpuStatsPlanVisitor.visit(agg.child)
+    // Check if we have column stats for all group-by columns.
+    val colStatsExist = agg.groupingExpressions.forall { e =>
+      e.isInstanceOf[Attribute] &&
+        childStats.attributeStats.get(e.asInstanceOf[Attribute]).exists(_.hasCountStats)
+    }
+    if (rowCountsExist(agg.child) && colStatsExist) {
+      // Multiply distinct counts of group-by columns. This is an upper bound, which assumes
+      // the data contains all combinations of distinct values of group-by columns.
+      var outputRows: BigInt = agg.groupingExpressions.foldLeft(BigInt(1))(
+        (res, expr) => {
+          val columnStat = childStats.attributeStats(expr.asInstanceOf[Attribute])
+          val distinctCount = columnStat.distinctCount.get
+          val distinctValue: BigInt = if (columnStat.nullCount.get > 0) {
+            distinctCount + 1
+          } else {
+            distinctCount
+          }
+          res * distinctValue
+        })
+
+      outputRows = if (agg.groupingExpressions.isEmpty) {
+        // If there's no group-by columns, the output is a single row containing values of aggregate
+        // functions: aggregated results for non-empty input or initial values for empty input.
+        1
+      } else {
+        // Here we set another upper bound for the number of output rows: it must not be larger than
+        // child's number of rows.
+        outputRows.min(childStats.rowCount.get)
+      }
+
+      val aliasStats = EstimationUtils.getAliasStats(agg.expressions, childStats.attributeStats)
+
+      val outputAttrStats = getOutputMap(
+        AttributeMap(childStats.attributeStats.toSeq ++ aliasStats), agg.output)
+      Some(Statistics(
+        sizeInBytes = getOutputSize(agg.output, outputRows, outputAttrStats),
+        rowCount = Some(outputRows),
+        attributeStats = outputAttrStats))
+    } else {
+      None
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuAggregateEstimation.scala
@@ -36,7 +36,7 @@ object GpuAggregateEstimation {
    * column stats for aggregate expressions.
    */
   def estimate(agg: Aggregate): Option[Statistics] = {
-    val childStats = GpuStatsPlanVisitor.visitCached(agg.child)
+    val childStats = GpuStatsPlanVisitor.visit(agg.child)
     // Check if we have column stats for all group-by columns.
     val colStatsExist = agg.groupingExpressions.forall { e =>
       e.isInstanceOf[Attribute] &&

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -353,13 +353,14 @@ object JoinReorderDP extends PredicateHelper with Logging {
 
     /** Get the cost of the root node of this plan tree. */
     def rootCost(conf: SQLConf): Cost = {
-      if (itemIds.size > 1) {
-        val rootStats = GpuStatsPlanVisitor.visit(plan)
+      //TODO this was treating unions as leaf nodes and assigning zero cost
+      //if (itemIds.size > 1) {
+        val rootStats = GpuStatsPlanVisitor.visitCached(plan)
         Cost(rootStats.rowCount.get, rootStats.sizeInBytes)
-      } else {
-        // If the plan is a leaf item, it has zero cost.
-        Cost(0, 0)
-      }
+//      } else {
+//        // If the plan is a leaf item, it has zero cost.
+//        Cost(0, 0)
+//      }
     }
 
     /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -191,14 +191,10 @@ object JoinReorderDP extends PredicateHelper with Logging {
 
     // The last level must have one and only one plan, because all items are joinable.
     assert(foundPlans.size == items.length && foundPlans.last.size == 1)
+
+    // TODO this has been modified compared to Spark and needs more investigation
+    //  to make sure this is what we want
     foundPlans.last.head._2.plan match {
-      case p @ Project(projectList, _: Join) if projectList != output =>
-        // TODO some queries are failing here
-        if (topOutputSet != p.outputSet) {
-          throw new RuntimeException(s"topOutputSet = $topOutputSet, p.outputSet = ${p.outputSet}")
-        }
-        // Keep the same order of final output attributes.
-        p.copy(projectList = output)
       case finalPlan if !sameOutput(finalPlan, output) =>
         Project(output, finalPlan)
       case finalPlan =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -1,0 +1,524 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.optimizer
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, ExpressionSet, PredicateHelper}
+import org.apache.spark.sql.catalyst.optimizer.StarSchemaDetection
+import org.apache.spark.sql.catalyst.plans.{Inner, InnerLike, JoinType}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.INNER_LIKE_JOIN
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Cost-based join reorder.
+ * We may have several join reorder algorithms in the future. This class is the entry of these
+ * algorithms, and chooses which one to use.
+ */
+object GpuCostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
+
+  //TODO this is an ugly hack but not sure how we are supposed to inject our own rules and have
+  // them work with RuleIdCollection in Spark
+  override val ruleName: String = "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder"
+
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    println(s"GpuCostBasedJoinReorder.apply() $plan")
+    val conf = new RapidsConf(plan.conf)
+    if (!conf.aqeJoinReordering) {
+      println(s"GpuCostBasedJoinReorder disabled")
+      plan
+    } else {
+      val result = plan.transformDownWithPruning(_.containsPattern(INNER_LIKE_JOIN), ruleId) {
+        // Start reordering with a joinable item, which is an InnerLike join with conditions.
+        // Avoid reordering if a join hint is present.
+        case j @ Join(_, _, _: InnerLike, Some(cond), JoinHint.NONE) =>
+          reorder(j, j.output)
+        case p @ Project(projectList, Join(_, _, _: InnerLike, Some(cond), JoinHint.NONE))
+          if projectList.forall(_.isInstanceOf[Attribute]) =>
+          reorder(p, p.output)
+      }
+      // After reordering is finished, convert OrderedJoin back to Join.
+      result transform {
+        case OrderedJoin(left, right, jt, cond) => Join(left, right, jt, cond, JoinHint.NONE)
+      }
+    }
+  }
+
+  private def reorder(plan: LogicalPlan, output: Seq[Attribute]): LogicalPlan = {
+    val (items, conditions) = extractInnerJoins(plan)
+    val result =
+    // Do reordering if the number of items is appropriate and join conditions exist.
+    // We also need to check if costs of all items can be evaluated.
+      if (items.size > 2 && items.size <= conf.joinReorderDPThreshold && conditions.nonEmpty) {
+        JoinReorderDP.search(conf, items, conditions, output)
+      } else {
+        println("reorder() skip")
+        plan
+      }
+    // Set consecutive join nodes ordered.
+    replaceWithOrderedJoin(result)
+  }
+
+  /**
+   * Extracts items of consecutive inner joins and join conditions.
+   * This method works for bushy trees and left/right deep trees.
+   */
+  private def extractInnerJoins(plan: LogicalPlan): (Seq[LogicalPlan], ExpressionSet) = {
+    plan match {
+      case Join(left, right, _: InnerLike, Some(cond), JoinHint.NONE) =>
+        val (leftPlans, leftConditions) = extractInnerJoins(left)
+        val (rightPlans, rightConditions) = extractInnerJoins(right)
+        (leftPlans ++ rightPlans, leftConditions ++ rightConditions ++
+          splitConjunctivePredicates(cond))
+      case Project(projectList, j @ Join(_, _, _: InnerLike, Some(cond), JoinHint.NONE))
+        if projectList.forall(_.isInstanceOf[Attribute]) =>
+        extractInnerJoins(j)
+      case _ =>
+        (Seq(plan), ExpressionSet())
+    }
+  }
+
+  private def replaceWithOrderedJoin(plan: LogicalPlan): LogicalPlan = plan match {
+    case j @ Join(left, right, jt: InnerLike, Some(cond), JoinHint.NONE) =>
+      val replacedLeft = replaceWithOrderedJoin(left)
+      val replacedRight = replaceWithOrderedJoin(right)
+      OrderedJoin(replacedLeft, replacedRight, jt, Some(cond))
+    case p @ Project(projectList, j @ Join(_, _, _: InnerLike, Some(cond), JoinHint.NONE)) =>
+      p.copy(child = replaceWithOrderedJoin(j))
+    case _ =>
+      plan
+  }
+}
+
+/** This is a mimic class for a join node that has been ordered. */
+case class OrderedJoin(
+                        left: LogicalPlan,
+                        right: LogicalPlan,
+                        joinType: JoinType,
+                        condition: Option[Expression]) extends BinaryNode {
+  override def output: Seq[Attribute] = left.output ++ right.output
+  override protected def withNewChildrenInternal(
+      newLeft: LogicalPlan, newRight: LogicalPlan): OrderedJoin =
+    copy(left = newLeft, right = newRight)
+}
+
+/**
+ * Reorder the joins using a dynamic programming algorithm. This implementation is based on the
+ * paper: Access Path Selection in a Relational Database Management System.
+ * https://dl.acm.org/doi/10.1145/582095.582099
+ *
+ * First we put all items (basic joined nodes) into level 0, then we build all two-way joins
+ * at level 1 from plans at level 0 (single items), then build all 3-way joins from plans
+ * at previous levels (two-way joins and single items), then 4-way joins ... etc, until we
+ * build all n-way joins and pick the best plan among them.
+ *
+ * When building m-way joins, we only keep the best plan (with the lowest cost) for the same set
+ * of m items. E.g., for 3-way joins, we keep only the best plan for items {A, B, C} among
+ * plans (A J B) J C, (A J C) J B and (B J C) J A.
+ * We also prune cartesian product candidates when building a new plan if there exists no join
+ * condition involving references from both left and right. This pruning strategy significantly
+ * reduces the search space.
+ * E.g., given A J B J C J D with join conditions A.k1 = B.k1 and B.k2 = C.k2 and C.k3 = D.k3,
+ * plans maintained for each level are as follows:
+ * level 0: p({A}), p({B}), p({C}), p({D})
+ * level 1: p({A, B}), p({B, C}), p({C, D})
+ * level 2: p({A, B, C}), p({B, C, D})
+ * level 3: p({A, B, C, D})
+ * where p({A, B, C, D}) is the final output plan.
+ *
+ * For cost evaluation, since physical costs for operators are not available currently, we use
+ * cardinalities and sizes to compute costs.
+ */
+object JoinReorderDP extends PredicateHelper with Logging {
+
+  def search(
+              conf: SQLConf,
+              items: Seq[LogicalPlan],
+              conditions: ExpressionSet,
+              output: Seq[Attribute]): LogicalPlan = {
+
+    val startTime = System.nanoTime()
+    // Level i maintains all found plans for i + 1 items.
+    // Create the initial plans: each plan is a single item with zero cost.
+    val itemIndex = items.zipWithIndex
+    val foundPlans = mutable.Buffer[JoinPlanMap]({
+      // SPARK-32687: Change to use `LinkedHashMap` to make sure that items are
+      // inserted and iterated in the same order.
+      val joinPlanMap = new JoinPlanMap
+      itemIndex.foreach {
+        case (item, id) =>
+          joinPlanMap.put(Set(id), JoinPlan(Set(id), item, ExpressionSet(), Cost(0, 0)))
+      }
+      joinPlanMap
+    })
+
+    // Build filters from the join graph to be used by the search algorithm.
+    val filters = JoinReorderDPFilters.buildJoinGraphInfo(conf, items, conditions, itemIndex)
+
+    // Build plans for next levels until the last level has only one plan. This plan contains
+    // all items that can be joined, so there's no need to continue.
+    val topOutputSet = AttributeSet(output)
+    while (foundPlans.size < items.length) {
+      // Build plans for the next level.
+      foundPlans += searchLevel(foundPlans.toSeq, conf, conditions, topOutputSet, filters)
+    }
+
+    val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
+    println(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
+      s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
+
+    // The last level must have one and only one plan, because all items are joinable.
+    assert(foundPlans.size == items.length && foundPlans.last.size == 1)
+    foundPlans.last.head._2.plan match {
+      case p @ Project(projectList, j: Join) if projectList != output =>
+        assert(topOutputSet == p.outputSet)
+        // Keep the same order of final output attributes.
+        p.copy(projectList = output)
+      case finalPlan if !sameOutput(finalPlan, output) =>
+        Project(output, finalPlan)
+      case finalPlan =>
+        finalPlan
+    }
+  }
+
+  private def sameOutput(plan: LogicalPlan, expectedOutput: Seq[Attribute]): Boolean = {
+    val thisOutput = plan.output
+    thisOutput.length == expectedOutput.length && thisOutput.zip(expectedOutput).forall {
+      case (a1, a2) => a1.semanticEquals(a2)
+    }
+  }
+
+  /** Find all possible plans at the next level, based on existing levels. */
+  private def searchLevel(
+                           existingLevels: Seq[JoinPlanMap],
+                           conf: SQLConf,
+                           conditions: ExpressionSet,
+                           topOutput: AttributeSet,
+                           filters: Option[JoinGraphInfo]): JoinPlanMap = {
+
+    val nextLevel = new JoinPlanMap
+    var k = 0
+    val lev = existingLevels.length - 1
+    // Build plans for the next level from plans at level k (one side of the join) and level
+    // lev - k (the other side of the join).
+    // For the lower level k, we only need to search from 0 to lev - k, because when building
+    // a join from A and B, both A J B and B J A are handled.
+    while (k <= lev - k) {
+      val oneSideCandidates = existingLevels(k).values.toSeq
+      for (i <- oneSideCandidates.indices) {
+        val oneSidePlan = oneSideCandidates(i)
+        val otherSideCandidates = if (k == lev - k) {
+          // Both sides of a join are at the same level, no need to repeat for previous ones.
+          oneSideCandidates.drop(i)
+        } else {
+          existingLevels(lev - k).values.toSeq
+        }
+
+        otherSideCandidates.foreach { otherSidePlan =>
+          buildJoin(oneSidePlan, otherSidePlan, conf, conditions, topOutput, filters) match {
+            case Some(newJoinPlan) =>
+              // Check if it's the first plan for the item set, or it's a better plan than
+              // the existing one due to lower cost.
+              val existingPlan = nextLevel.get(newJoinPlan.itemIds)
+              if (existingPlan.isEmpty || newJoinPlan.betterThan(existingPlan.get, conf)) {
+                nextLevel.update(newJoinPlan.itemIds, newJoinPlan)
+              }
+            case None =>
+          }
+        }
+      }
+      k += 1
+    }
+    nextLevel
+  }
+
+  /**
+   * Builds a new JoinPlan if the following conditions hold:
+   * - the sets of items contained in left and right sides do not overlap.
+   * - there exists at least one join condition involving references from both sides.
+   * - if star-join filter is enabled, allow the following combinations:
+   *         1) (oneJoinPlan U otherJoinPlan) is a subset of star-join
+   *         2) star-join is a subset of (oneJoinPlan U otherJoinPlan)
+   *         3) (oneJoinPlan U otherJoinPlan) is a subset of non star-join
+   *
+   * @param oneJoinPlan One side JoinPlan for building a new JoinPlan.
+   * @param otherJoinPlan The other side JoinPlan for building a new join node.
+   * @param conf SQLConf for statistics computation.
+   * @param conditions The overall set of join conditions.
+   * @param topOutput The output attributes of the final plan.
+   * @param filters Join graph info to be used as filters by the search algorithm.
+   * @return Builds and returns a new JoinPlan if both conditions hold. Otherwise, returns None.
+   */
+  private def buildJoin(
+                         oneJoinPlan: JoinPlan,
+                         otherJoinPlan: JoinPlan,
+                         conf: SQLConf,
+                         conditions: ExpressionSet,
+                         topOutput: AttributeSet,
+                         filters: Option[JoinGraphInfo]): Option[JoinPlan] = {
+
+    if (oneJoinPlan.itemIds.intersect(otherJoinPlan.itemIds).nonEmpty) {
+      // Should not join two overlapping item sets.
+      return None
+    }
+
+    if (filters.isDefined) {
+      // Apply star-join filter, which ensures that tables in a star schema relationship
+      // are planned together. The star-filter will eliminate joins among star and non-star
+      // tables until the star joins are built. The following combinations are allowed:
+      // 1. (oneJoinPlan U otherJoinPlan) is a subset of star-join
+      // 2. star-join is a subset of (oneJoinPlan U otherJoinPlan)
+      // 3. (oneJoinPlan U otherJoinPlan) is a subset of non star-join
+      val isValidJoinCombination =
+      JoinReorderDPFilters.starJoinFilter(oneJoinPlan.itemIds, otherJoinPlan.itemIds,
+        filters.get)
+      if (!isValidJoinCombination) return None
+    }
+
+    val onePlan = oneJoinPlan.plan
+    val otherPlan = otherJoinPlan.plan
+    val joinConds = conditions
+      .filterNot(l => canEvaluate(l, onePlan))
+      .filterNot(r => canEvaluate(r, otherPlan))
+      .filter(e => e.references.subsetOf(onePlan.outputSet ++ otherPlan.outputSet))
+    if (joinConds.isEmpty) {
+      // Cartesian product is very expensive, so we exclude them from candidate plans.
+      // This also significantly reduces the search space.
+      return None
+    }
+
+    // Put the deeper side on the left, tend to build a left-deep tree.
+    val (left, right) = if (oneJoinPlan.itemIds.size >= otherJoinPlan.itemIds.size) {
+      (onePlan, otherPlan)
+    } else {
+      (otherPlan, onePlan)
+    }
+    val newJoin = Join(left, right, Inner, joinConds.reduceOption(And), JoinHint.NONE)
+    val collectedJoinConds = joinConds ++ oneJoinPlan.joinConds ++ otherJoinPlan.joinConds
+    val remainingConds = conditions -- collectedJoinConds
+    val neededAttr = AttributeSet(remainingConds.flatMap(_.references)) ++ topOutput
+    val neededFromNewJoin = newJoin.output.filter(neededAttr.contains)
+    val newPlan =
+      if ((newJoin.outputSet -- neededFromNewJoin).nonEmpty) {
+        Project(neededFromNewJoin, newJoin)
+      } else {
+        newJoin
+      }
+
+    val itemIds = oneJoinPlan.itemIds.union(otherJoinPlan.itemIds)
+    // Now the root node of onePlan/otherPlan becomes an intermediate join (if it's a non-leaf
+    // item), so the cost of the new join should also include its own cost.
+    val newPlanCost = oneJoinPlan.planCost + oneJoinPlan.rootCost(conf) +
+      otherJoinPlan.planCost + otherJoinPlan.rootCost(conf)
+    Some(JoinPlan(itemIds, newPlan, collectedJoinConds, newPlanCost))
+  }
+
+  /** Map[set of item ids, join plan for these items] */
+  type JoinPlanMap = mutable.LinkedHashMap[Set[Int], JoinPlan]
+
+  /**
+   * Partial join order in a specific level.
+   *
+   * @param itemIds Set of item ids participating in this partial plan.
+   * @param plan The plan tree with the lowest cost for these items found so far.
+   * @param joinConds Join conditions included in the plan.
+   * @param planCost The cost of this plan tree is the sum of costs of all intermediate joins.
+   */
+  case class JoinPlan(
+                       itemIds: Set[Int],
+                       plan: LogicalPlan,
+                       joinConds: ExpressionSet,
+                       planCost: Cost) {
+
+    /** Get the cost of the root node of this plan tree. */
+    def rootCost(conf: SQLConf): Cost = {
+      if (itemIds.size > 1) {
+        // BEGIN AQE JOIN REORDERING CHANGE
+        val rootStats = JoinReorderUtils.statsWithRowCount(plan)
+        // END AQE JOIN REORDERING CHANGE
+        // TODO the getOrElse(0) seems like a regression
+        Cost(rootStats.rowCount.getOrElse(0), rootStats.sizeInBytes)
+      } else {
+        // If the plan is a leaf item, it has zero cost.
+        Cost(0, 0)
+      }
+    }
+
+    /**
+     * To identify the plan with smaller computational cost,
+     * we use the weighted geometric mean of ratio of rows and the ratio of sizes in bytes.
+     *
+     * There are other ways to combine these values as a cost comparison function.
+     * Some of these, that we have experimented with, but have gotten worse result,
+     * than with the current one:
+     * 1) Weighted arithmetic mean of these two ratios - adding up fractions puts
+     * less emphasis on ratios between 0 and 1. Ratios 10 and 0.1 should be considered
+     * to be just as strong evidences in opposite directions. The arithmetic mean of these
+     * would be heavily biased towards the 10.
+     * 2) Absolute cost (cost = weight * rowCount + (1 - weight) * size) - when adding up
+     * two numeric measurements that have different units we can easily end up with one
+     * overwhelming the other.
+     */
+    def betterThan(other: JoinPlan, conf: SQLConf): Boolean = {
+      if (other.planCost.card == 0 || other.planCost.size == 0) {
+        false
+      } else {
+        val relativeRows = BigDecimal(this.planCost.card) / BigDecimal(other.planCost.card)
+        val relativeSize = BigDecimal(this.planCost.size) / BigDecimal(other.planCost.size)
+        Math.pow(relativeRows.doubleValue, conf.joinReorderCardWeight) *
+          Math.pow(relativeSize.doubleValue, 1 - conf.joinReorderCardWeight) < 1
+      }
+    }
+  }
+}
+
+/**
+ * This class defines the cost model for a plan.
+ * @param card Cardinality (number of rows).
+ * @param size Size in bytes.
+ */
+case class Cost(card: BigInt, size: BigInt) {
+  def +(other: Cost): Cost = Cost(this.card + other.card, this.size + other.size)
+}
+
+/**
+ * Implements optional filters to reduce the search space for join enumeration.
+ *
+ * 1) Star-join filters: Plan star-joins together since they are assumed
+ *    to have an optimal execution based on their RI relationship.
+ * 2) Cartesian products: Defer their planning later in the graph to avoid
+ *    large intermediate results (expanding joins, in general).
+ * 3) Composite inners: Don't generate "bushy tree" plans to avoid materializing
+ *   intermediate results.
+ *
+ * Filters (2) and (3) are not implemented.
+ */
+object JoinReorderDPFilters {
+  /**
+   * Builds join graph information to be used by the filtering strategies.
+   * Currently, it builds the sets of star/non-star joins.
+   * It can be extended with the sets of connected/unconnected joins, which
+   * can be used to filter Cartesian products.
+   */
+  def buildJoinGraphInfo(
+                          conf: SQLConf,
+                          items: Seq[LogicalPlan],
+                          conditions: ExpressionSet,
+                          itemIndex: Seq[(LogicalPlan, Int)]): Option[JoinGraphInfo] = {
+
+    if (conf.joinReorderDPStarFilter) {
+      // Compute the tables in a star-schema relationship.
+      val starJoin = StarSchemaDetection.findStarJoins(items, conditions.toSeq)
+      val nonStarJoin = items.filterNot(starJoin.contains(_))
+
+      if (starJoin.nonEmpty && nonStarJoin.nonEmpty) {
+        val itemMap = itemIndex.toMap
+        Some(JoinGraphInfo(starJoin.map(itemMap).toSet, nonStarJoin.map(itemMap).toSet))
+      } else {
+        // Nothing interesting to return.
+        None
+      }
+    } else {
+      // Star schema filter is not enabled.
+      None
+    }
+  }
+
+  /**
+   * Applies the star-join filter that eliminates join combinations among star
+   * and non-star tables until the star join is built.
+   *
+   * Given the oneSideJoinPlan/otherSideJoinPlan, which represent all the plan
+   * permutations generated by the DP join enumeration, and the star/non-star plans,
+   * the following plan combinations are allowed:
+   * 1. (oneSideJoinPlan U otherSideJoinPlan) is a subset of star-join
+   * 2. star-join is a subset of (oneSideJoinPlan U otherSideJoinPlan)
+   * 3. (oneSideJoinPlan U otherSideJoinPlan) is a subset of non star-join
+   *
+   * It assumes the sets are disjoint.
+   *
+   * Example query graph:
+   *
+   * t1   d1 - t2 - t3
+   *  \  /
+   *   f1
+   *   |
+   *   d2
+   *
+   * star: {d1, f1, d2}
+   * non-star: {t2, t1, t3}
+   *
+   * level 0: (f1 ), (d2 ), (t3 ), (d1 ), (t1 ), (t2 )
+   * level 1: {t3 t2 }, {f1 d2 }, {f1 d1 }
+   * level 2: {d2 f1 d1 }
+   * level 3: {t1 d1 f1 d2 }, {t2 d1 f1 d2 }
+   * level 4: {d1 t2 f1 t1 d2 }, {d1 t3 t2 f1 d2 }
+   * level 5: {d1 t3 t2 f1 t1 d2 }
+   *
+   * @param oneSideJoinPlan One side of the join represented as a set of plan ids.
+   * @param otherSideJoinPlan The other side of the join represented as a set of plan ids.
+   * @param filters Star and non-star plans represented as sets of plan ids
+   */
+  def starJoinFilter(
+                      oneSideJoinPlan: Set[Int],
+                      otherSideJoinPlan: Set[Int],
+                      filters: JoinGraphInfo) : Boolean = {
+    val starJoins = filters.starJoins
+    val nonStarJoins = filters.nonStarJoins
+    val join = oneSideJoinPlan.union(otherSideJoinPlan)
+
+    // Disjoint sets
+    oneSideJoinPlan.intersect(otherSideJoinPlan).isEmpty &&
+      // Either star or non-star is empty
+      (starJoins.isEmpty || nonStarJoins.isEmpty ||
+        // Join is a subset of the star-join
+        join.subsetOf(starJoins) ||
+        // Star-join is a subset of join
+        starJoins.subsetOf(join) ||
+        // Join is a subset of non-star
+        join.subsetOf(nonStarJoins))
+  }
+}
+
+/**
+ * Helper class that keeps information about the join graph as sets of item/plan ids.
+ * It currently stores the star/non-star plans. It can be
+ * extended with the set of connected/unconnected plans.
+ */
+case class JoinGraphInfo (starJoins: Set[Int], nonStarJoins: Set[Int])
+
+// BEGIN AQE JOIN REORDERING CHANGE
+object JoinReorderUtils {
+
+  def statsWithRowCount(plan: LogicalPlan): Statistics = {
+    // AQE POC change:
+    // JoinReordering requires row count statistics so we estimate the row count
+    // based on schema and data size
+//    plan.invalidateStatsCache()
+    val stats = GpuStatsPlanVisitor.visit(plan)
+    //println(s"statsWithRowCount() ${plan.simpleStringWithNodeId()} returning $stats")
+    stats // replaces BasicStatsPlanVisitor
+
+  }
+}
+// END AQE JOIN REORDERING CHANGE

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -191,10 +191,11 @@ object JoinReorderDP extends PredicateHelper with Logging {
 
     // The last level must have one and only one plan, because all items are joinable.
     assert(foundPlans.size == items.length && foundPlans.last.size == 1)
-
-    // TODO this has been modified compared to Spark and needs more investigation
-    //  to make sure this is what we want
     foundPlans.last.head._2.plan match {
+      case p@Project(projectList, j: Join) if projectList != output =>
+        assert(topOutputSet == p.outputSet)
+        // Keep the same order of final output attributes.
+        p.copy(projectList = output)
       case finalPlan if !sameOutput(finalPlan, output) =>
         Project(output, finalPlan)
       case finalPlan =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -42,10 +42,10 @@ object GpuCostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
   override val ruleName: String = "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder"
 
   def apply(plan: LogicalPlan): LogicalPlan = {
-    println(s"GpuCostBasedJoinReorder.apply() $plan")
+    logDebug(s"GpuCostBasedJoinReorder.apply() $plan")
     val conf = new RapidsConf(plan.conf)
     if (!conf.aqeJoinReordering) {
-      println(s"GpuCostBasedJoinReorder disabled")
+      logDebug(s"GpuCostBasedJoinReorder disabled")
       plan
     } else {
       val result = plan.transformDownWithPruning(_.containsPattern(INNER_LIKE_JOIN), ruleId) {
@@ -72,7 +72,6 @@ object GpuCostBasedJoinReorder extends Rule[LogicalPlan] with PredicateHelper {
       if (items.size > 2 && items.size <= conf.joinReorderDPThreshold && conditions.nonEmpty) {
         JoinReorderDP.search(conf, items, conditions, output)
       } else {
-        println("reorder() skip")
         plan
       }
     // Set consecutive join nodes ordered.
@@ -184,7 +183,7 @@ object JoinReorderDP extends PredicateHelper with Logging {
     }
 
     val durationInMs = (System.nanoTime() - startTime) / (1000 * 1000)
-    println(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
+    logDebug(s"Join reordering finished. Duration: $durationInMs ms, number of items: " +
       s"${items.length}, number of plans in memo: ${foundPlans.map(_.size).sum}")
 
     // The last level must have one and only one plan, because all items are joinable.
@@ -516,7 +515,7 @@ object JoinReorderUtils {
     // based on schema and data size
 //    plan.invalidateStatsCache()
     val stats = GpuStatsPlanVisitor.visit(plan)
-    //println(s"statsWithRowCount() ${plan.simpleStringWithNodeId()} returning $stats")
+    // logDebug(s"statsWithRowCount() ${plan.simpleStringWithNodeId()} returning $stats")
     stats // replaces BasicStatsPlanVisitor
 
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -373,7 +373,7 @@ object JoinReorderDP extends PredicateHelper with Logging {
     def rootCost(conf: SQLConf): Cost = {
       //TODO this was treating unions as leaf nodes and assigning zero cost
       //if (itemIds.size > 1) {
-        val rootStats = GpuStatsPlanVisitor.visitCached(plan)
+        val rootStats = GpuStatsPlanVisitor.visit(plan)
         Cost(rootStats.rowCount.get, rootStats.sizeInBytes)
 //      } else {
 //        // If the plan is a leaf item, it has zero cost.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -192,8 +192,8 @@ object JoinReorderDP extends PredicateHelper with Logging {
     // The last level must have one and only one plan, because all items are joinable.
     assert(foundPlans.size == items.length && foundPlans.last.size == 1)
     foundPlans.last.head._2.plan match {
-      case p@Project(projectList, j: Join) if projectList != output =>
-        assert(topOutputSet == p.outputSet)
+      case p@Project(projectList, j: Join)
+          if projectList != output && topOutputSet == p.outputSet =>
         // Keep the same order of final output attributes.
         p.copy(projectList = output)
       case finalPlan if !sameOutput(finalPlan, output) =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuCostBasedJoinReorder.scala
@@ -17,8 +17,12 @@
 
 package com.nvidia.spark.rapids.optimizer
 
+import java.util.concurrent.TimeUnit
+
 import scala.collection.mutable
+
 import com.nvidia.spark.rapids.RapidsConf
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, ExpressionSet, PredicateHelper}
 import org.apache.spark.sql.catalyst.optimizer.StarSchemaDetection
@@ -28,8 +32,6 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.catalyst.trees.TreePattern.INNER_LIKE_JOIN
 import org.apache.spark.sql.internal.SQLConf
-
-import java.util.concurrent.TimeUnit
 
 /**
  * Copied from Spark's CostBasedJoinReorder.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
@@ -1,0 +1,934 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.optimizer
+
+import scala.collection.immutable.HashSet
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.{EstimationUtils, NumericValueInterval, ValueInterval}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
+import org.apache.spark.sql.types._
+
+case class GpuFilterEstimation(plan: Filter) extends Logging {
+
+  private val childStats = GpuStatsPlanVisitor.visit(plan.child)
+
+  private val colStatsMap = ColumnStatsMap(childStats.attributeStats)
+
+  /**
+   * Returns an option of Statistics for a Filter logical plan node.
+   * For a given compound expression condition, this method computes filter selectivity
+   * (or the percentage of rows meeting the filter condition), which
+   * is used to compute row count, size in bytes, and the updated statistics after a given
+   * predicated is applied.
+   *
+   * @return Option[Statistics] When there is no statistics collected, it returns None.
+   */
+  def estimate: Option[Statistics] = {
+    if (childStats.rowCount.isEmpty) {
+      println("GpuFilterEstimation childStats.rowCount.isEmpty")
+      return None
+    }
+
+    // Estimate selectivity of this filter predicate, and update column stats if needed.
+    // For not-supported condition, set filter selectivity to a conservative estimate 100%
+    val filterSelectivity = calculateFilterSelectivity(plan.condition).getOrElse(1.0)
+    println(s"GpuFilterEstimation filterSelectivity = $filterSelectivity")
+
+    val filteredRowCount: BigInt = ceil(BigDecimal(childStats.rowCount.get) * filterSelectivity)
+    println(s"GpuFilterEstimation filteredRowCount = $filteredRowCount")
+
+    val newColStats = if (filteredRowCount == 0) {
+      // The output is empty, we don't need to keep column stats.
+      AttributeMap[ColumnStat](Nil)
+    } else {
+      colStatsMap.outputColumnStats(rowsBeforeFilter = childStats.rowCount.get,
+        rowsAfterFilter = filteredRowCount)
+    }
+    val filteredSizeInBytes: BigInt = getOutputSize(plan.output, filteredRowCount, newColStats)
+
+    Some(childStats.copy(sizeInBytes = filteredSizeInBytes, rowCount = Some(filteredRowCount),
+      attributeStats = newColStats))
+  }
+
+  /**
+   * Returns a percentage of rows meeting a condition in Filter node.
+   * If it's a single condition, we calculate the percentage directly.
+   * If it's a compound condition, it is decomposed into multiple single conditions linked with
+   * AND, OR, NOT.
+   * For logical AND conditions, we need to update stats after a condition estimation
+   * so that the stats will be more accurate for subsequent estimation.  This is needed for
+   * range condition such as (c > 40 AND c <= 50)
+   * For logical OR and NOT conditions, we do not update stats after a condition estimation.
+   *
+   * @param condition the compound logical expression
+   * @param update a boolean flag to specify if we need to update ColumnStat of a column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition.
+   *         It returns None if the condition is not supported.
+   */
+  def calculateFilterSelectivity(condition: Expression, update: Boolean = true): Option[Double] = {
+    condition match {
+      case And(cond1, cond2) =>
+        val percent1 = calculateFilterSelectivity(cond1, update).getOrElse(1.0)
+        val percent2 = calculateFilterSelectivity(cond2, update).getOrElse(1.0)
+        Some(percent1 * percent2)
+
+      case Or(cond1, cond2) =>
+        val percent1 = calculateFilterSelectivity(cond1, update = false).getOrElse(1.0)
+        val percent2 = calculateFilterSelectivity(cond2, update = false).getOrElse(1.0)
+        Some(percent1 + percent2 - (percent1 * percent2))
+
+      // Not-operator pushdown
+      case Not(And(cond1, cond2)) =>
+        calculateFilterSelectivity(Or(Not(cond1), Not(cond2)), update = false)
+
+      // Not-operator pushdown
+      case Not(Or(cond1, cond2)) =>
+        calculateFilterSelectivity(And(Not(cond1), Not(cond2)), update = false)
+
+      // Collapse two consecutive Not operators which could be generated after Not-operator pushdown
+      case Not(Not(cond)) =>
+        calculateFilterSelectivity(cond, update = false)
+
+      // The foldable Not has been processed in the ConstantFolding rule
+      // This is a top-down traversal. The Not could be pushed down by the above two cases.
+      case Not(l @ Literal(null, _)) =>
+        calculateSingleCondition(l, update = false).map(boundProbability(_))
+
+      case Not(cond) =>
+        calculateFilterSelectivity(cond, update = false) match {
+          case Some(percent) => Some(1.0 - percent)
+          case None => None
+        }
+
+      case _ =>
+        calculateSingleCondition(condition, update).map(boundProbability(_))
+    }
+  }
+
+  /**
+   * Returns a percentage of rows meeting a single condition in Filter node.
+   * Currently we only support binary predicates where one side is a column,
+   * and the other is a literal.
+   *
+   * @param condition a single logical expression
+   * @param update a boolean flag to specify if we need to update ColumnStat of a column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition.
+   *         It returns None if the condition is not supported.
+   */
+  def calculateSingleCondition(condition: Expression, update: Boolean): Option[Double] = {
+    condition match {
+      case l: Literal =>
+        evaluateLiteral(l)
+
+      // For evaluateBinary method, we assume the literal on the right side of an operator.
+      // So we will change the order if not.
+
+      // EqualTo/EqualNullSafe does not care about the order
+      case Equality(ar: Attribute, l: Literal) =>
+        evaluateEquality(ar, l, update)
+      case Equality(l: Literal, ar: Attribute) =>
+        evaluateEquality(ar, l, update)
+
+      case op @ LessThan(ar: Attribute, l: Literal) =>
+        evaluateBinary(op, ar, l, update)
+      case op @ LessThan(l: Literal, ar: Attribute) =>
+        evaluateBinary(GreaterThan(ar, l), ar, l, update)
+
+      case op @ LessThanOrEqual(ar: Attribute, l: Literal) =>
+        evaluateBinary(op, ar, l, update)
+      case op @ LessThanOrEqual(l: Literal, ar: Attribute) =>
+        evaluateBinary(GreaterThanOrEqual(ar, l), ar, l, update)
+
+      case op @ GreaterThan(ar: Attribute, l: Literal) =>
+        evaluateBinary(op, ar, l, update)
+      case op @ GreaterThan(l: Literal, ar: Attribute) =>
+        evaluateBinary(LessThan(ar, l), ar, l, update)
+
+      case op @ GreaterThanOrEqual(ar: Attribute, l: Literal) =>
+        evaluateBinary(op, ar, l, update)
+      case op @ GreaterThanOrEqual(l: Literal, ar: Attribute) =>
+        evaluateBinary(LessThanOrEqual(ar, l), ar, l, update)
+
+      case In(ar: Attribute, expList)
+        if expList.forall(e => e.isInstanceOf[Literal]) =>
+        // Expression [In (value, seq[Literal])] will be replaced with optimized version
+        // [InSet (value, HashSet[Literal])] in Optimizer, but only for list.size > 10.
+        // Here we convert In into InSet anyway, because they share the same processing logic.
+        val hSet = expList.map(e => e.eval())
+        evaluateInSet(ar, HashSet() ++ hSet, update)
+
+      case InSet(ar: Attribute, set) =>
+        evaluateInSet(ar, set, update)
+
+      // In current stage, we don't have advanced statistics such as sketches or histograms.
+      // As a result, some operator can't estimate `nullCount` accurately. E.g. left outer join
+      // estimation does not accurately update `nullCount` currently.
+      // So for IsNull and IsNotNull predicates, we only estimate them when the child is a leaf
+      // node, whose `nullCount` is accurate.
+      // This is a limitation due to lack of advanced stats. We should remove it in the future.
+      case IsNull(ar: Attribute) if plan.child.isInstanceOf[LeafNode] =>
+        evaluateNullCheck(ar, isNull = true, update)
+
+      case IsNotNull(ar: Attribute) if plan.child.isInstanceOf[LeafNode] =>
+        evaluateNullCheck(ar, isNull = false, update)
+
+      case op @ Equality(attrLeft: Attribute, attrRight: Attribute) =>
+        evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
+
+      case op @ LessThan(attrLeft: Attribute, attrRight: Attribute) =>
+        evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
+
+      case op @ LessThanOrEqual(attrLeft: Attribute, attrRight: Attribute) =>
+        evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
+
+      case op @ GreaterThan(attrLeft: Attribute, attrRight: Attribute) =>
+        evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
+
+      case op @ GreaterThanOrEqual(attrLeft: Attribute, attrRight: Attribute) =>
+        evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
+
+      case _ =>
+        // TODO: it's difficult to support string operators without advanced statistics.
+        // Hence, these string operators Like(_, _) | Contains(_, _) | StartsWith(_, _)
+        // | EndsWith(_, _) are not supported yet
+        logDebug("[CBO] Unsupported filter condition: " + condition)
+        None
+    }
+  }
+
+  /**
+   * Returns a percentage of rows meeting "IS NULL" or "IS NOT NULL" condition.
+   *
+   * @param attr an Attribute (or a column)
+   * @param isNull set to true for "IS NULL" condition.  set to false for "IS NOT NULL" condition
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   *         It returns None if no statistics collected for a given column.
+   */
+  def evaluateNullCheck(
+                         attr: Attribute,
+                         isNull: Boolean,
+                         update: Boolean): Option[Double] = {
+    if (!colStatsMap.contains(attr) || colStatsMap(attr).nullCount.isEmpty) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+    val colStat = colStatsMap(attr)
+    val rowCountValue = childStats.rowCount.get
+    val nullPercent: Double = if (rowCountValue == 0) {
+      0
+    } else if (colStat.nullCount.get > rowCountValue) {
+      1
+    } else {
+      (BigDecimal(colStat.nullCount.get) / BigDecimal(rowCountValue)).toDouble
+    }
+
+    if (update) {
+      val newStats = if (isNull) {
+        colStat.copy(distinctCount = Some(0), min = None, max = None)
+      } else {
+        colStat.copy(nullCount = Some(0))
+      }
+      colStatsMap.update(attr, newStats)
+    }
+
+    val percent = if (isNull) {
+      nullPercent
+    } else {
+      1.0 - nullPercent
+    }
+
+    Some(percent)
+  }
+
+  /**
+   * Returns a percentage of rows meeting a binary comparison expression.
+   *
+   * @param op a binary comparison operator such as =, <, <=, >, >=
+   * @param attr an Attribute (or a column)
+   * @param literal a literal value (or constant)
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   *         It returns None if no statistics exists for a given column or wrong value.
+   */
+  def evaluateBinary(
+                      op: BinaryComparison,
+                      attr: Attribute,
+                      literal: Literal,
+                      update: Boolean): Option[Double] = {
+    if (!colStatsMap.contains(attr)) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+
+    attr.dataType match {
+      case _: NumericType | DateType | TimestampType | BooleanType =>
+        evaluateBinaryForNumeric(op, attr, literal, update)
+      case StringType | BinaryType =>
+        // TODO: It is difficult to support other binary comparisons for String/Binary
+        // type without min/max and advanced statistics like histogram.
+        logDebug("[CBO] No range comparison statistics for String/Binary type " + attr)
+        None
+    }
+  }
+
+  /**
+   * Returns a percentage of rows meeting an equality (=) expression.
+   * This method evaluates the equality predicate for all data types.
+   *
+   * For EqualNullSafe (<=>), if the literal is not null, result will be the same as EqualTo;
+   * if the literal is null, the condition will be changed to IsNull after optimization.
+   * So we don't need specific logic for EqualNullSafe here.
+   *
+   * @param attr an Attribute (or a column)
+   * @param literal a literal value (or constant)
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   */
+  def evaluateEquality(
+                        attr: Attribute,
+                        literal: Literal,
+                        update: Boolean): Option[Double] = {
+    if (!colStatsMap.contains(attr)) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+    val colStat = colStatsMap(attr)
+
+    // decide if the value is in [min, max] of the column.
+    // We currently don't store min/max for binary/string type.
+    // Hence, we assume it is in boundary for binary/string type.
+    val statsInterval = ValueInterval(colStat.min, colStat.max, attr.dataType)
+    if (statsInterval.contains(literal)) {
+      if (update) {
+        // We update ColumnStat structure after apply this equality predicate:
+        // Set distinctCount to 1, nullCount to 0, and min/max values (if exist) to the literal
+        // value.
+        val newStats = attr.dataType match {
+          case StringType | BinaryType =>
+            colStat.copy(distinctCount = Some(1), nullCount = Some(0))
+          case _ =>
+            colStat.copy(distinctCount = Some(1), min = Some(literal.value),
+              max = Some(literal.value), nullCount = Some(0))
+        }
+        colStatsMap.update(attr, newStats)
+      }
+
+      if (colStat.histogram.isEmpty) {
+        if (!colStat.distinctCount.isEmpty) {
+          // returns 1/ndv if there is no histogram
+          Some(1.0 / colStat.distinctCount.get.toDouble)
+        } else {
+          None
+        }
+      } else {
+        Some(computeEqualityPossibilityByHistogram(literal, colStat))
+      }
+
+    } else {  // not in interval
+      Some(0.0)
+    }
+  }
+
+  /**
+   * Returns a percentage of rows meeting a Literal expression.
+   * This method evaluates all the possible literal cases in Filter.
+   *
+   * FalseLiteral and TrueLiteral should be eliminated by optimizer, but null literal might be added
+   * by optimizer rule NullPropagation. For safety, we handle all the cases here.
+   *
+   * @param literal a literal value (or constant)
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   */
+  def evaluateLiteral(literal: Literal): Option[Double] = {
+    literal match {
+      case Literal(null, _) => Some(0.0)
+      case FalseLiteral => Some(0.0)
+      case TrueLiteral => Some(1.0)
+      // Ideally, we should not hit the following branch
+      case _ => None
+    }
+  }
+
+  /**
+   * Returns a percentage of rows meeting "IN" operator expression.
+   * This method evaluates the equality predicate for all data types.
+   *
+   * @param attr an Attribute (or a column)
+   * @param hSet a set of literal values
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   *         It returns None if no statistics exists for a given column.
+   */
+
+  def evaluateInSet(
+                     attr: Attribute,
+                     hSet: Set[Any],
+                     update: Boolean): Option[Double] = {
+    if (!colStatsMap.hasDistinctCount(attr)) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+
+    val colStat = colStatsMap(attr)
+    val ndv = colStat.distinctCount.get
+    val dataType = attr.dataType
+    var newNdv = ndv
+
+    // use [min, max] to filter the original hSet
+    dataType match {
+      case _: NumericType | BooleanType | DateType | TimestampType =>
+        if (ndv.toDouble == 0 || colStat.min.isEmpty || colStat.max.isEmpty)  {
+          return Some(0.0)
+        }
+
+        val statsInterval =
+          ValueInterval(colStat.min, colStat.max, dataType).asInstanceOf[NumericValueInterval]
+        val validQuerySet = hSet.filter { v =>
+          v != null && statsInterval.contains(Literal(v, dataType))
+        }
+
+        if (validQuerySet.isEmpty) {
+          return Some(0.0)
+        }
+
+        val newMax = validQuerySet.maxBy(EstimationUtils.toDouble(_, dataType))
+        val newMin = validQuerySet.minBy(EstimationUtils.toDouble(_, dataType))
+        // newNdv should not be greater than the old ndv.  For example, column has only 2 values
+        // 1 and 6. The predicate column IN (1, 2, 3, 4, 5). validQuerySet.size is 5.
+        newNdv = ndv.min(BigInt(validQuerySet.size))
+        if (update) {
+          val newStats = colStat.copy(distinctCount = Some(newNdv), min = Some(newMin),
+            max = Some(newMax), nullCount = Some(0))
+          colStatsMap.update(attr, newStats)
+        }
+
+      // We assume the whole set since there is no min/max information for String/Binary type
+      case StringType | BinaryType =>
+        if (ndv.toDouble == 0)  {
+          return Some(0.0)
+        }
+
+        newNdv = ndv.min(BigInt(hSet.size))
+        if (update) {
+          val newStats = colStat.copy(distinctCount = Some(newNdv), nullCount = Some(0))
+          colStatsMap.update(attr, newStats)
+        }
+    }
+
+    // return the filter selectivity.  Without advanced statistics such as histograms,
+    // we have to assume uniform distribution.
+    Some(math.min(newNdv.toDouble / ndv.toDouble, 1.0))
+  }
+
+  /**
+   * Returns a percentage of rows meeting a binary comparison expression.
+   * This method evaluate expression for Numeric/Date/Timestamp/Boolean columns.
+   *
+   * @param op a binary comparison operator such as =, <, <=, >, >=
+   * @param attr an Attribute (or a column)
+   * @param literal a literal value (or constant)
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   */
+  def evaluateBinaryForNumeric(
+                                op: BinaryComparison,
+                                attr: Attribute,
+                                literal: Literal,
+                                update: Boolean): Option[Double] = {
+
+    if (!colStatsMap.hasMinMaxStats(attr) || !colStatsMap.hasDistinctCount(attr)) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+
+    val colStat = colStatsMap(attr)
+    val statsInterval =
+      ValueInterval(colStat.min, colStat.max, attr.dataType).asInstanceOf[NumericValueInterval]
+    val max = statsInterval.max
+    val min = statsInterval.min
+    val ndv = colStat.distinctCount.get.toDouble
+
+    // determine the overlapping degree between predicate interval and column's interval
+    val numericLiteral = EstimationUtils.toDouble(literal.value, literal.dataType)
+    val (noOverlap: Boolean, completeOverlap: Boolean) = op match {
+      case _: LessThan =>
+        (numericLiteral <= min, numericLiteral > max)
+      case _: LessThanOrEqual =>
+        (numericLiteral < min, numericLiteral >= max)
+      case _: GreaterThan =>
+        (numericLiteral >= max, numericLiteral < min)
+      case _: GreaterThanOrEqual =>
+        (numericLiteral > max, numericLiteral <= min)
+    }
+
+    var percent = 1.0
+    if (noOverlap) {
+      percent = 0.0
+    } else if (completeOverlap) {
+      percent = 1.0
+    } else {
+      // This is the partial overlap case:
+
+      if (colStat.histogram.isEmpty) {
+        // Without advanced statistics like histogram, we assume uniform data distribution.
+        // We just prorate the adjusted range over the initial range to compute filter selectivity.
+        assert(max > min)
+        percent = op match {
+          case _: LessThan =>
+            if (numericLiteral == max) {
+              // If the literal value is right on the boundary, we can minus the part of the
+              // boundary value (1/ndv).
+              1.0 - 1.0 / ndv
+            } else {
+              (numericLiteral - min) / (max - min)
+            }
+          case _: LessThanOrEqual =>
+            if (numericLiteral == min) {
+              // The boundary value is the only satisfying value.
+              1.0 / ndv
+            } else {
+              (numericLiteral - min) / (max - min)
+            }
+          case _: GreaterThan =>
+            if (numericLiteral == min) {
+              1.0 - 1.0 / ndv
+            } else {
+              (max - numericLiteral) / (max - min)
+            }
+          case _: GreaterThanOrEqual =>
+            if (numericLiteral == max) {
+              1.0 / ndv
+            } else {
+              (max - numericLiteral) / (max - min)
+            }
+        }
+      } else {
+        percent = computeComparisonPossibilityByHistogram(op, literal, colStat)
+      }
+
+      if (update) {
+        val newValue = Some(literal.value)
+        var newMax = colStat.max
+        var newMin = colStat.min
+
+        op match {
+          case _: GreaterThan | _: GreaterThanOrEqual =>
+            newMin = newValue
+          case _: LessThan | _: LessThanOrEqual =>
+            newMax = newValue
+        }
+
+        val newStats = colStat.copy(distinctCount = Some(ceil(ndv * percent)),
+          min = newMin, max = newMax, nullCount = Some(0))
+
+        colStatsMap.update(attr, newStats)
+      }
+    }
+
+    Some(percent)
+  }
+
+  /**
+   * Computes the possibility of an equality predicate using histogram.
+   */
+  private def computeEqualityPossibilityByHistogram(
+      literal: Literal, colStat: ColumnStat): Double = {
+    val datum = EstimationUtils.toDouble(literal.value, literal.dataType)
+    val histogram = colStat.histogram.get
+
+    // find bins where column's current min and max locate.  Note that a column's [min, max]
+    // range may change due to another condition applied earlier.
+    val min = EstimationUtils.toDouble(colStat.min.get, literal.dataType)
+    val max = EstimationUtils.toDouble(colStat.max.get, literal.dataType)
+
+    // compute how many bins the column's current valid range [min, max] occupies.
+    val numBinsHoldingEntireRange = EstimationUtils.numBinsHoldingRange(
+      upperBound = max,
+      upperBoundInclusive = true,
+      lowerBound = min,
+      lowerBoundInclusive = true,
+      histogram.bins)
+
+    val numBinsHoldingDatum = EstimationUtils.numBinsHoldingRange(
+      upperBound = datum,
+      upperBoundInclusive = true,
+      lowerBound = datum,
+      lowerBoundInclusive = true,
+      histogram.bins)
+
+    numBinsHoldingDatum / numBinsHoldingEntireRange
+  }
+
+  /**
+   * Computes the possibility of a comparison predicate using histogram.
+   */
+  private def computeComparisonPossibilityByHistogram(
+      op: BinaryComparison, literal: Literal, colStat: ColumnStat): Double = {
+    val datum = EstimationUtils.toDouble(literal.value, literal.dataType)
+    val histogram = colStat.histogram.get
+
+    // find bins where column's current min and max locate.  Note that a column's [min, max]
+    // range may change due to another condition applied earlier.
+    val min = EstimationUtils.toDouble(colStat.min.get, literal.dataType)
+    val max = EstimationUtils.toDouble(colStat.max.get, literal.dataType)
+
+    // compute how many bins the column's current valid range [min, max] occupies.
+    val numBinsHoldingEntireRange = EstimationUtils.numBinsHoldingRange(
+      max, upperBoundInclusive = true, min, lowerBoundInclusive = true, histogram.bins)
+
+    val numBinsHoldingRange = op match {
+      // LessThan and LessThanOrEqual share the same logic, the only difference is whether to
+      // include the upperBound in the range.
+      case _: LessThan =>
+        EstimationUtils.numBinsHoldingRange(
+          upperBound = datum,
+          upperBoundInclusive = false,
+          lowerBound = min,
+          lowerBoundInclusive = true,
+          histogram.bins)
+      case _: LessThanOrEqual =>
+        EstimationUtils.numBinsHoldingRange(
+          upperBound = datum,
+          upperBoundInclusive = true,
+          lowerBound = min,
+          lowerBoundInclusive = true,
+          histogram.bins)
+
+      // GreaterThan and GreaterThanOrEqual share the same logic, the only difference is whether to
+      // include the lowerBound in the range.
+      case _: GreaterThan =>
+        EstimationUtils.numBinsHoldingRange(
+          upperBound = max,
+          upperBoundInclusive = true,
+          lowerBound = datum,
+          lowerBoundInclusive = false,
+          histogram.bins)
+      case _: GreaterThanOrEqual =>
+        EstimationUtils.numBinsHoldingRange(
+          upperBound = max,
+          upperBoundInclusive = true,
+          lowerBound = datum,
+          lowerBoundInclusive = true,
+          histogram.bins)
+    }
+
+    numBinsHoldingRange / numBinsHoldingEntireRange
+  }
+
+  /**
+   * Returns a percentage of rows meeting a binary comparison expression containing two columns.
+   * In SQL queries, we also see predicate expressions involving two columns
+   * such as "column-1 (op) column-2" where column-1 and column-2 belong to same table.
+   * Note that, if column-1 and column-2 belong to different tables, then it is a join
+   * operator's work, NOT a filter operator's work.
+   *
+   * @param op a binary comparison operator, including =, <=>, <, <=, >, >=
+   * @param attrLeft the left Attribute (or a column)
+   * @param attrRight the right Attribute (or a column)
+   * @param update a boolean flag to specify if we need to update ColumnStat of the given columns
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition
+   */
+  def evaluateBinaryForTwoColumns(
+                                   op: BinaryComparison,
+                                   attrLeft: Attribute,
+                                   attrRight: Attribute,
+                                   update: Boolean): Option[Double] = {
+
+    if (!colStatsMap.hasCountStats(attrLeft)) {
+      logDebug("[CBO] No statistics for " + attrLeft)
+      return None
+    }
+    if (!colStatsMap.hasCountStats(attrRight)) {
+      logDebug("[CBO] No statistics for " + attrRight)
+      return None
+    }
+
+    attrLeft.dataType match {
+      case StringType | BinaryType =>
+        // TODO: It is difficult to support other binary comparisons for String/Binary
+        // type without min/max and advanced statistics like histogram.
+        logDebug("[CBO] No range comparison statistics for String/Binary type " + attrLeft)
+        return None
+      case _ =>
+        if (!colStatsMap.hasMinMaxStats(attrLeft)) {
+          logDebug("[CBO] No min/max statistics for " + attrLeft)
+          return None
+        }
+        if (!colStatsMap.hasMinMaxStats(attrRight)) {
+          logDebug("[CBO] No min/max statistics for " + attrRight)
+          return None
+        }
+    }
+
+    val colStatLeft = colStatsMap(attrLeft)
+    val statsIntervalLeft = ValueInterval(colStatLeft.min, colStatLeft.max, attrLeft.dataType)
+      .asInstanceOf[NumericValueInterval]
+    val maxLeft = statsIntervalLeft.max
+    val minLeft = statsIntervalLeft.min
+
+    val colStatRight = colStatsMap(attrRight)
+    val statsIntervalRight = ValueInterval(colStatRight.min, colStatRight.max, attrRight.dataType)
+      .asInstanceOf[NumericValueInterval]
+    val maxRight = statsIntervalRight.max
+    val minRight = statsIntervalRight.min
+
+    // determine the overlapping degree between predicate interval and column's interval
+    val allNotNull = (colStatLeft.nullCount.get == 0) && (colStatRight.nullCount.get == 0)
+    val (noOverlap: Boolean, completeOverlap: Boolean) = op match {
+      // Left < Right or Left <= Right
+      // - no overlap:
+      //      minRight           maxRight     minLeft       maxLeft
+      // --------+------------------+------------+-------------+------->
+      // - complete overlap: (If null values exists, we set it to partial overlap.)
+      //      minLeft            maxLeft      minRight      maxRight
+      // --------+------------------+------------+-------------+------->
+      case _: LessThan =>
+        (minLeft >= maxRight, (maxLeft < minRight) && allNotNull)
+      case _: LessThanOrEqual =>
+        (minLeft > maxRight, (maxLeft <= minRight) && allNotNull)
+
+      // Left > Right or Left >= Right
+      // - no overlap:
+      //      minLeft            maxLeft      minRight      maxRight
+      // --------+------------------+------------+-------------+------->
+      // - complete overlap: (If null values exists, we set it to partial overlap.)
+      //      minRight           maxRight     minLeft       maxLeft
+      // --------+------------------+------------+-------------+------->
+      case _: GreaterThan =>
+        (maxLeft <= minRight, (minLeft > maxRight) && allNotNull)
+      case _: GreaterThanOrEqual =>
+        (maxLeft < minRight, (minLeft >= maxRight) && allNotNull)
+
+      // Left = Right or Left <=> Right
+      // - no overlap:
+      //      minLeft            maxLeft      minRight      maxRight
+      // --------+------------------+------------+-------------+------->
+      //      minRight           maxRight     minLeft       maxLeft
+      // --------+------------------+------------+-------------+------->
+      // - complete overlap:
+      //      minLeft            maxLeft
+      //      minRight           maxRight
+      // --------+------------------+------->
+      case _: EqualTo =>
+        ((maxLeft < minRight) || (maxRight < minLeft),
+          (minLeft == minRight) && (maxLeft == maxRight) && allNotNull
+            && (colStatLeft.distinctCount.get == colStatRight.distinctCount.get)
+        )
+      case _: EqualNullSafe =>
+        // For null-safe equality, we use a very restrictive condition to evaluate its overlap.
+        // If null values exists, we set it to partial overlap.
+        (((maxLeft < minRight) || (maxRight < minLeft)) && allNotNull,
+          (minLeft == minRight) && (maxLeft == maxRight) && allNotNull
+            && (colStatLeft.distinctCount.get == colStatRight.distinctCount.get)
+        )
+    }
+
+    var percent = 1.0
+    if (noOverlap) {
+      percent = 0.0
+    } else if (completeOverlap) {
+      percent = 1.0
+    } else {
+      // For partial overlap, we use an empirical value 1/3 as suggested by the book
+      // "Database Systems, the complete book".
+      percent = 1.0 / 3.0
+
+      if (update) {
+        // Need to adjust new min/max after the filter condition is applied
+
+        val ndvLeft = BigDecimal(colStatLeft.distinctCount.get)
+        val newNdvLeft = ceil(ndvLeft * percent)
+        val ndvRight = BigDecimal(colStatRight.distinctCount.get)
+        val newNdvRight = ceil(ndvRight * percent)
+
+        var newMaxLeft = colStatLeft.max
+        var newMinLeft = colStatLeft.min
+        var newMaxRight = colStatRight.max
+        var newMinRight = colStatRight.min
+
+        op match {
+          case _: LessThan | _: LessThanOrEqual =>
+            // the left side should be less than the right side.
+            // If not, we need to adjust it to narrow the range.
+            // Left < Right or Left <= Right
+            //      minRight     <     minLeft
+            // --------+******************+------->
+            //              filtered      ^
+            //                            |
+            //                        newMinRight
+            //
+            //      maxRight     <     maxLeft
+            // --------+******************+------->
+            //         ^    filtered
+            //         |
+            //     newMaxLeft
+            if (minLeft > minRight) newMinRight = colStatLeft.min
+            if (maxLeft > maxRight) newMaxLeft = colStatRight.max
+
+          case _: GreaterThan | _: GreaterThanOrEqual =>
+            // the left side should be greater than the right side.
+            // If not, we need to adjust it to narrow the range.
+            // Left > Right or Left >= Right
+            //      minLeft     <      minRight
+            // --------+******************+------->
+            //              filtered      ^
+            //                            |
+            //                        newMinLeft
+            //
+            //      maxLeft     <      maxRight
+            // --------+******************+------->
+            //         ^    filtered
+            //         |
+            //     newMaxRight
+            if (minLeft < minRight) newMinLeft = colStatRight.min
+            if (maxLeft < maxRight) newMaxRight = colStatLeft.max
+
+          case _: EqualTo | _: EqualNullSafe =>
+            // need to set new min to the larger min value, and
+            // set the new max to the smaller max value.
+            // Left = Right or Left <=> Right
+            //      minLeft     <      minRight
+            // --------+******************+------->
+            //              filtered      ^
+            //                            |
+            //                        newMinLeft
+            //
+            //      minRight    <=     minLeft
+            // --------+******************+------->
+            //              filtered      ^
+            //                            |
+            //                        newMinRight
+            //
+            //      maxLeft     <      maxRight
+            // --------+******************+------->
+            //         ^    filtered
+            //         |
+            //     newMaxRight
+            //
+            //      maxRight    <=     maxLeft
+            // --------+******************+------->
+            //         ^    filtered
+            //         |
+            //     newMaxLeft
+            if (minLeft < minRight) {
+              newMinLeft = colStatRight.min
+            } else {
+              newMinRight = colStatLeft.min
+            }
+            if (maxLeft < maxRight) {
+              newMaxRight = colStatLeft.max
+            } else {
+              newMaxLeft = colStatRight.max
+            }
+        }
+
+        val newStatsLeft = colStatLeft.copy(distinctCount = Some(newNdvLeft), min = newMinLeft,
+          max = newMaxLeft)
+        colStatsMap(attrLeft) = newStatsLeft
+        val newStatsRight = colStatRight.copy(distinctCount = Some(newNdvRight), min = newMinRight,
+          max = newMaxRight)
+        colStatsMap(attrRight) = newStatsRight
+      }
+    }
+
+    Some(percent)
+  }
+
+  // Bound result in [0, 1]
+  private def boundProbability(p: Double): Double = {
+    Math.max(0.0, Math.min(1.0, p))
+  }
+}
+
+/**
+ * This class contains the original column stats from child, and maintains the updated column stats.
+ * We will update the corresponding ColumnStats for a column after we apply a predicate condition.
+ * For example, column c has [min, max] value as [0, 100].  In a range condition such as
+ * (c > 40 AND c <= 50), we need to set the column's [min, max] value to [40, 100] after we
+ * evaluate the first condition c > 40. We also need to set the column's [min, max] value to
+ * [40, 50] after we evaluate the second condition c <= 50.
+ *
+ * @param originalMap Original column stats from child.
+ */
+case class ColumnStatsMap(originalMap: AttributeMap[ColumnStat]) {
+
+  /** This map maintains the latest column stats. */
+  private val updatedMap: mutable.Map[ExprId, (Attribute, ColumnStat)] = mutable.HashMap.empty
+
+  def contains(a: Attribute): Boolean = updatedMap.contains(a.exprId) || originalMap.contains(a)
+
+  /**
+   * Gets an Option of column stat for the given attribute.
+   * Prefer the column stat in updatedMap than that in originalMap,
+   * because updatedMap has the latest (updated) column stats.
+   */
+  def get(a: Attribute): Option[ColumnStat] = {
+    if (updatedMap.contains(a.exprId)) {
+      updatedMap.get(a.exprId).map(_._2)
+    } else {
+      originalMap.get(a)
+    }
+  }
+
+  def hasCountStats(a: Attribute): Boolean =
+    get(a).exists(_.hasCountStats)
+
+  def hasDistinctCount(a: Attribute): Boolean =
+    get(a).exists(_.distinctCount.isDefined)
+
+  def hasMinMaxStats(a: Attribute): Boolean =
+    get(a).exists(_.hasMinMaxStats)
+
+  /**
+   * Gets column stat for the given attribute. Prefer the column stat in updatedMap than that in
+   * originalMap, because updatedMap has the latest (updated) column stats.
+   */
+  def apply(a: Attribute): ColumnStat = {
+    get(a).get
+  }
+
+  /** Updates column stats in updatedMap. */
+  def update(a: Attribute, stats: ColumnStat): Unit = updatedMap.update(a.exprId, a -> stats)
+
+  /**
+   * Collects updated column stats; scales down column count stats if the
+   * number of rows decreases after this Filter operator.
+   */
+  def outputColumnStats(rowsBeforeFilter: BigInt, rowsAfterFilter: BigInt)
+  : AttributeMap[ColumnStat] = {
+    val newColumnStats = originalMap.map { case (attr, oriColStat) =>
+      attr -> oriColStat.updateCountStats(
+        rowsBeforeFilter, rowsAfterFilter, updatedMap.get(attr.exprId).map(_._2))
+    }
+    AttributeMap(newColumnStats.toSeq)
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.types._
  */
 case class GpuFilterEstimation(plan: Filter) extends Logging {
 
-  private val childStats = GpuStatsPlanVisitor.visit(plan.child)
+  private val childStats = GpuStatsPlanVisitor.visitCached(plan.child)
 
   private val colStatsMap = ColumnStatsMap(childStats.attributeStats)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.types._
  */
 case class GpuFilterEstimation(plan: Filter) extends Logging {
 
-  private val childStats = GpuStatsPlanVisitor.visitCached(plan.child)
+  private val childStats = GpuStatsPlanVisitor.visit(plan.child)
 
   private val colStatsMap = ColumnStatsMap(childStats.attributeStats)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
@@ -28,6 +28,13 @@ import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.{EstimationUt
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 import org.apache.spark.sql.types._
 
+/**
+ * Copied from Spark's FilterEstimation.scala
+ *
+ * Modifications:
+ *
+ * - Call GpuStatsPlanVisitor to get stats for child, instead of calling child.stats
+ */
 case class GpuFilterEstimation(plan: Filter) extends Logging {
 
   private val childStats = GpuStatsPlanVisitor.visit(plan.child)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuFilterEstimation.scala
@@ -45,17 +45,17 @@ case class GpuFilterEstimation(plan: Filter) extends Logging {
    */
   def estimate: Option[Statistics] = {
     if (childStats.rowCount.isEmpty) {
-      println("GpuFilterEstimation childStats.rowCount.isEmpty")
+      logDebug("GpuFilterEstimation childStats.rowCount.isEmpty")
       return None
     }
 
     // Estimate selectivity of this filter predicate, and update column stats if needed.
     // For not-supported condition, set filter selectivity to a conservative estimate 100%
     val filterSelectivity = calculateFilterSelectivity(plan.condition).getOrElse(1.0)
-    println(s"GpuFilterEstimation filterSelectivity = $filterSelectivity")
+    logDebug(s"GpuFilterEstimation filterSelectivity = $filterSelectivity")
 
     val filteredRowCount: BigInt = ceil(BigDecimal(childStats.rowCount.get) * filterSelectivity)
-    println(s"GpuFilterEstimation filteredRowCount = $filteredRowCount")
+    logDebug(s"GpuFilterEstimation filteredRowCount = $filteredRowCount")
 
     val newColStats = if (filteredRowCount == 0) {
       // The output is empty, we don't need to keep column stats.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
@@ -23,8 +23,8 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRela
  */
 case class GpuJoinEstimation(join: Join) extends Logging {
 
-  private val leftStats = GpuStatsPlanVisitor.visitCached(join.left)
-  private val rightStats = GpuStatsPlanVisitor.visitCached(join.right)
+  private val leftStats = GpuStatsPlanVisitor.visit(join.left)
+  private val rightStats = GpuStatsPlanVisitor.visit(join.right)
 
   /**
    * Estimate statistics after join. Return `None` if the join type is not supported, or we don't
@@ -385,7 +385,7 @@ case class GpuJoinEstimation(join: Join) extends Logging {
     // column stats. Now we just propagate the statistics from left side. We should do more
     // accurate estimation when advanced stats (e.g. histograms) are available.
     if (rowCountsExist(join.left)) {
-      val leftStats = GpuStatsPlanVisitor.visitCached(join.left)
+      val leftStats = GpuStatsPlanVisitor.visit(join.left)
       // Propagate the original column stats for cartesian product
       val outputRows = leftStats.rowCount.get
       Some(Statistics(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
@@ -234,10 +234,10 @@ case class GpuJoinEstimation(join: Join) extends Logging {
 
   /** Returns join cardinality and the column stat for this pair of join keys. */
   private def computeByNdv(
-                            leftKey: AttributeReference,
-                            rightKey: AttributeReference,
-                            min: Option[Any],
-                            max: Option[Any]): (BigInt, ColumnStat) = {
+      leftKey: AttributeReference,
+      rightKey: AttributeReference,
+      min: Option[Any],
+      max: Option[Any]): (BigInt, ColumnStat) = {
     val leftKeyStat = leftStats.attributeStats(leftKey)
     val rightKeyStat = rightStats.attributeStats(rightKey)
     val maxNdv = leftKeyStat.distinctCount.get.max(rightKeyStat.distinctCount.get)
@@ -263,12 +263,12 @@ case class GpuJoinEstimation(join: Join) extends Logging {
 
   /** Compute join cardinality using equi-height histograms. */
   private def computeByHistogram(
-                                  leftKey: AttributeReference,
-                                  rightKey: AttributeReference,
-                                  leftHistogram: Histogram,
-                                  rightHistogram: Histogram,
-                                  newMin: Option[Any],
-                                  newMax: Option[Any]): (BigInt, ColumnStat) = {
+      leftKey: AttributeReference,
+      rightKey: AttributeReference,
+      leftHistogram: Histogram,
+      rightHistogram: Histogram,
+      newMin: Option[Any],
+      newMax: Option[Any]): (BigInt, ColumnStat) = {
     val overlappedRanges = getOverlappedRanges(
       leftHistogram = leftHistogram,
       rightHistogram = rightHistogram,
@@ -310,10 +310,10 @@ case class GpuJoinEstimation(join: Join) extends Logging {
    * Propagate or update column stats for output attributes.
    */
   private def updateOutputStats(
-                                 outputRows: BigInt,
-                                 output: Seq[Attribute],
-                                 oldAttrStats: AttributeMap[ColumnStat],
-                                 keyStatsAfterJoin: AttributeMap[ColumnStat]): Seq[(Attribute, ColumnStat)] = {
+      outputRows: BigInt,
+      output: Seq[Attribute],
+      oldAttrStats: AttributeMap[ColumnStat],
+      keyStatsAfterJoin: AttributeMap[ColumnStat]): Seq[(Attribute, ColumnStat)] = {
     val outputAttrStats = new ArrayBuffer[(Attribute, ColumnStat)]()
     val leftRows = leftStats.rowCount.get
     val rightRows = rightStats.rowCount.get
@@ -338,8 +338,8 @@ case class GpuJoinEstimation(join: Join) extends Logging {
   }
 
   private def extractJoinKeysWithColStats(
-                                           leftKeys: Seq[Expression],
-                                           rightKeys: Seq[Expression]): Seq[(AttributeReference, AttributeReference)] = {
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression]): Seq[(AttributeReference, AttributeReference)] = {
     leftKeys.zip(rightKeys).collect {
       // Currently we don't deal with equal joins like key1 = key2 + 5.
       // Note: join keys from EqualNullSafe also fall into this case (Coalesce), consider to

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
@@ -25,7 +25,7 @@ case class GpuJoinEstimation(join: Join) extends Logging {
       case Inner | LeftOuter | RightOuter | FullOuter =>
         estimateInnerOuterJoin()
       case Cross =>
-        println("GpuJoinEstimation.CrossJoin")
+        logDebug("GpuJoinEstimation.CrossJoin")
         estimateInnerOuterJoin().map(s => s.copy(rowCount = s.rowCount.map(r => r*r)))
       case LeftSemi | LeftAnti =>
         estimateLeftSemiAntiJoin()
@@ -44,11 +44,10 @@ case class GpuJoinEstimation(join: Join) extends Logging {
    */
   private def estimateInnerOuterJoin(): Option[Statistics] = {
 
-    println(s"=== GpuJoinEstimation.estimateInnerOuterJoin() ===\n$join")
-
     val x = join match {
+      //TODO reinstate this
 //      case _ if !rowCountsExist(join.left, join.right) =>
-//        println("GpuJoinEstimation.estimateInnerOuterJoin() no row counts")
+//        logDebug("GpuJoinEstimation.estimateInnerOuterJoin() no row counts")
 //        None
 
       // TODO shim ExtractEquiJoinKeys or just copy it into this repo
@@ -58,7 +57,7 @@ case class GpuJoinEstimation(join: Join) extends Logging {
 
         // spark 3.3
       //case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, _, _, _, _, _) =>
-        println("GpuJoinEstimation.estimateInnerOuterJoin() ExtractEquiJoinKeys")
+        logDebug("GpuJoinEstimation.estimateInnerOuterJoin() ExtractEquiJoinKeys")
 
         // 1. Compute join selectivity
         val joinKeyPairs = extractJoinKeysWithColStats(leftKeys, rightKeys)
@@ -147,7 +146,7 @@ case class GpuJoinEstimation(join: Join) extends Logging {
           attributeStats = outputAttrStats))
 
       case _ =>
-        println("GpuJoinEstimation.estimateInnerOuterJoin() cartesian product")
+        logDebug("GpuJoinEstimation.estimateInnerOuterJoin() cartesian product")
 
         // When there is no equi-join condition, we do estimation like cartesian product.
         val inputAttrStats = AttributeMap(
@@ -166,7 +165,7 @@ case class GpuJoinEstimation(join: Join) extends Logging {
           attributeStats = inputAttrStats))
     }
 
-    println(s"GpuJoinEstimation.estimateInnerOuterJoin() -> $x")
+    logDebug(s"GpuJoinEstimation.estimateInnerOuterJoin() -> $x")
 
     x
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuJoinEstimation.scala
@@ -1,0 +1,368 @@
+package com.nvidia.spark.rapids.optimizer
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Histogram, Join, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
+
+case class GpuJoinEstimation(join: Join) extends Logging {
+
+  private val leftStats = GpuStatsPlanVisitor.visit(join.left)
+  private val rightStats = GpuStatsPlanVisitor.visit(join.right)
+
+  /**
+   * Estimate statistics after join. Return `None` if the join type is not supported, or we don't
+   * have enough statistics for estimation.
+   */
+  def estimate: Option[Statistics] = {
+    join.joinType match {
+      case Inner | LeftOuter | RightOuter | FullOuter =>
+        estimateInnerOuterJoin()
+      case Cross =>
+        println("GpuJoinEstimation.CrossJoin")
+        estimateInnerOuterJoin().map(s => s.copy(rowCount = s.rowCount.map(r => r*r)))
+      case LeftSemi | LeftAnti =>
+        estimateLeftSemiAntiJoin()
+      case _ =>
+        logDebug(s"[CBO] Unsupported join type: ${join.joinType}")
+        None
+    }
+  }
+
+//  def rowCountsExist(plans: LogicalPlan*): Unit = {
+//    plans.forall(plan =>  .stats.rowCount.isDefined)
+//
+//  }
+  /**
+   * Estimate output size and number of rows after a join operator, and update output column stats.
+   */
+  private def estimateInnerOuterJoin(): Option[Statistics] = {
+
+    println(s"=== GpuJoinEstimation.estimateInnerOuterJoin() ===\n$join")
+
+    val x = join match {
+//      case _ if !rowCountsExist(join.left, join.right) =>
+//        println("GpuJoinEstimation.estimateInnerOuterJoin() no row counts")
+//        None
+
+      // TODO shim ExtractEquiJoinKeys or just copy it into this repo
+
+      // spark 3.2
+      case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, _, _, _, _) =>
+
+        // spark 3.3
+      //case ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, _, _, _, _, _) =>
+        println("GpuJoinEstimation.estimateInnerOuterJoin() ExtractEquiJoinKeys")
+
+        // 1. Compute join selectivity
+        val joinKeyPairs = extractJoinKeysWithColStats(leftKeys, rightKeys)
+        val (numInnerJoinedRows, keyStatsAfterJoin) = computeCardinalityAndStats(joinKeyPairs)
+
+        // 2. Estimate the number of output rows
+        val leftRows = leftStats.rowCount.get
+        val rightRows = rightStats.rowCount.get
+
+        // Make sure outputRows won't be too small based on join type.
+        val outputRows = joinType match {
+          case LeftOuter =>
+            // All rows from left side should be in the result.
+            leftRows.max(numInnerJoinedRows)
+          case RightOuter =>
+            // All rows from right side should be in the result.
+            rightRows.max(numInnerJoinedRows)
+          case FullOuter =>
+            // T(A FOJ B) = T(A LOJ B) + T(A ROJ B) - T(A IJ B)
+            leftRows.max(numInnerJoinedRows) + rightRows.max(numInnerJoinedRows) - numInnerJoinedRows
+          case _ =>
+            assert(joinType == Inner || joinType == Cross)
+            // Don't change for inner or cross join
+            numInnerJoinedRows
+        }
+
+        // 3. Update statistics based on the output of join
+        val inputAttrStats = AttributeMap(
+          leftStats.attributeStats.toSeq ++ rightStats.attributeStats.toSeq)
+        val attributesWithStat = join.output.filter(a =>
+          inputAttrStats.get(a).map(_.hasCountStats).getOrElse(false))
+        val (fromLeft, fromRight) = attributesWithStat.partition(join.left.outputSet.contains(_))
+
+        val outputStats: Seq[(Attribute, ColumnStat)] = if (outputRows == 0) {
+          // The output is empty, we don't need to keep column stats.
+          Nil
+        } else if (numInnerJoinedRows == 0) {
+          joinType match {
+            // For outer joins, if the join selectivity is 0, the number of output rows is the
+            // same as that of the outer side. And column stats of join keys from the outer side
+            // keep unchanged, while column stats of join keys from the other side should be updated
+            // based on added null values.
+            case LeftOuter =>
+              fromLeft.map(a => (a, inputAttrStats(a))) ++
+                fromRight.map(a => (a, nullColumnStat(a.dataType, leftRows)))
+            case RightOuter =>
+              fromRight.map(a => (a, inputAttrStats(a))) ++
+                fromLeft.map(a => (a, nullColumnStat(a.dataType, rightRows)))
+            case FullOuter =>
+              fromLeft.map { a =>
+                val oriColStat = inputAttrStats(a)
+                (a, oriColStat.copy(nullCount = Some(oriColStat.nullCount.get + rightRows)))
+              } ++ fromRight.map { a =>
+                val oriColStat = inputAttrStats(a)
+                (a, oriColStat.copy(nullCount = Some(oriColStat.nullCount.get + leftRows)))
+              }
+            case _ =>
+              assert(joinType == Inner || joinType == Cross)
+              Nil
+          }
+        } else if (numInnerJoinedRows == leftRows * rightRows) {
+          // Cartesian product, just propagate the original column stats
+          inputAttrStats.toSeq
+        } else {
+          join.joinType match {
+            // For outer joins, don't update column stats from the outer side.
+            case LeftOuter =>
+              fromLeft.map(a => (a, inputAttrStats(a))) ++
+                updateOutputStats(outputRows, fromRight, inputAttrStats, keyStatsAfterJoin)
+            case RightOuter =>
+              updateOutputStats(outputRows, fromLeft, inputAttrStats, keyStatsAfterJoin) ++
+                fromRight.map(a => (a, inputAttrStats(a)))
+            case FullOuter =>
+              inputAttrStats.toSeq
+            case _ =>
+              assert(joinType == Inner || joinType == Cross)
+              // Update column stats from both sides for inner or cross join.
+              updateOutputStats(outputRows, attributesWithStat, inputAttrStats, keyStatsAfterJoin)
+          }
+        }
+
+        val outputAttrStats = AttributeMap(outputStats)
+        Some(Statistics(
+          sizeInBytes = getOutputSize(join.output, outputRows, outputAttrStats),
+          rowCount = Some(outputRows),
+          attributeStats = outputAttrStats))
+
+      case _ =>
+        println("GpuJoinEstimation.estimateInnerOuterJoin() cartesian product")
+
+        // When there is no equi-join condition, we do estimation like cartesian product.
+        val inputAttrStats = AttributeMap(
+          leftStats.attributeStats.toSeq ++ rightStats.attributeStats.toSeq)
+        // Propagate the original column stats
+
+        // AQE POC change:
+        // we really want to discourage cartesian joins / nested loop joins so lets
+        // square the result here until we figure out a better solution
+        val cartesianProduct = leftStats.rowCount.get * rightStats.rowCount.get
+        val outputRows = cartesianProduct * cartesianProduct
+
+        Some(Statistics(
+          sizeInBytes = getOutputSize(join.output, outputRows, inputAttrStats),
+          rowCount = Some(outputRows),
+          attributeStats = inputAttrStats))
+    }
+
+    println(s"GpuJoinEstimation.estimateInnerOuterJoin() -> $x")
+
+    x
+  }
+
+  // scalastyle:off
+
+  /**
+   * The number of rows of A inner join B on A.k1 = B.k1 is estimated by this basic formula:
+   * T(A IJ B) = T(A) * T(B) / max(V(A.k1), V(B.k1)),
+   * where V is the number of distinct values (ndv) of that column. The underlying assumption for
+   * this formula is: each value of the smaller domain is included in the larger domain.
+   *
+   * Generally, inner join with multiple join keys can be estimated based on the above formula:
+   * T(A IJ B) = T(A) * T(B) / (max(V(A.k1), V(B.k1)) * max(V(A.k2), V(B.k2)) * ... * max(V(A.kn), V(B.kn)))
+   * However, the denominator can become very large and excessively reduce the result, so we use a
+   * conservative strategy to take only the largest max(V(A.ki), V(B.ki)) as the denominator.
+   *
+   * That is, join estimation is based on the most selective join keys. We follow this strategy
+   * when different types of column statistics are available. E.g., if card1 is the cardinality
+   * estimated by ndv of join key A.k1 and B.k1, card2 is the cardinality estimated by histograms
+   * of join key A.k2 and B.k2, then the result cardinality would be min(card1, card2).
+   *
+   * @param keyPairs pairs of join keys
+   * @return join cardinality, and column stats for join keys after the join
+   */
+  // scalastyle:on
+  private def computeCardinalityAndStats(keyPairs: Seq[(AttributeReference, AttributeReference)])
+  : (BigInt, AttributeMap[ColumnStat]) = {
+    // If there's no column stats available for join keys, estimate as cartesian product.
+    var joinCard: BigInt = leftStats.rowCount.get * rightStats.rowCount.get
+    val keyStatsAfterJoin = new mutable.HashMap[Attribute, ColumnStat]()
+    var i = 0
+    while (i < keyPairs.length && joinCard != 0) {
+      val (leftKey, rightKey) = keyPairs(i)
+      // Check if the two sides are disjoint
+      val leftKeyStat = leftStats.attributeStats(leftKey)
+      val rightKeyStat = rightStats.attributeStats(rightKey)
+      val lInterval = ValueInterval(leftKeyStat.min, leftKeyStat.max, leftKey.dataType)
+      val rInterval = ValueInterval(rightKeyStat.min, rightKeyStat.max, rightKey.dataType)
+      if (ValueInterval.isIntersected(lInterval, rInterval)) {
+        val (newMin, newMax) = ValueInterval.intersect(lInterval, rInterval, leftKey.dataType)
+        val (card, joinStat) = (leftKeyStat.histogram, rightKeyStat.histogram) match {
+          case (Some(l: Histogram), Some(r: Histogram)) =>
+            computeByHistogram(leftKey, rightKey, l, r, newMin, newMax)
+          case _ =>
+            computeByNdv(leftKey, rightKey, newMin, newMax)
+        }
+        keyStatsAfterJoin += (
+          // Histograms are propagated as unchanged. During future estimation, they should be
+          // truncated by the updated max/min. In this way, only pointers of the histograms are
+          // propagated and thus reduce memory consumption.
+          leftKey -> joinStat.copy(histogram = leftKeyStat.histogram),
+          rightKey -> joinStat.copy(histogram = rightKeyStat.histogram)
+        )
+        // Return cardinality estimated from the most selective join keys.
+        if (card < joinCard) joinCard = card
+      } else {
+        // One of the join key pairs is disjoint, thus the two sides of join is disjoint.
+        joinCard = 0
+      }
+      i += 1
+    }
+    (joinCard, AttributeMap(keyStatsAfterJoin.toSeq))
+  }
+
+  /** Returns join cardinality and the column stat for this pair of join keys. */
+  private def computeByNdv(
+                            leftKey: AttributeReference,
+                            rightKey: AttributeReference,
+                            min: Option[Any],
+                            max: Option[Any]): (BigInt, ColumnStat) = {
+    val leftKeyStat = leftStats.attributeStats(leftKey)
+    val rightKeyStat = rightStats.attributeStats(rightKey)
+    val maxNdv = leftKeyStat.distinctCount.get.max(rightKeyStat.distinctCount.get)
+    // Compute cardinality by the basic formula.
+    val card = BigDecimal(leftStats.rowCount.get * rightStats.rowCount.get) / BigDecimal(maxNdv)
+
+    // Get the intersected column stat.
+    val newNdv = Some(leftKeyStat.distinctCount.get.min(rightKeyStat.distinctCount.get))
+    val newMaxLen = if (leftKeyStat.maxLen.isDefined && rightKeyStat.maxLen.isDefined) {
+      Some(math.min(leftKeyStat.maxLen.get, rightKeyStat.maxLen.get))
+    } else {
+      None
+    }
+    val newAvgLen = if (leftKeyStat.avgLen.isDefined && rightKeyStat.avgLen.isDefined) {
+      Some((leftKeyStat.avgLen.get + rightKeyStat.avgLen.get) / 2)
+    } else {
+      None
+    }
+    val newStats = ColumnStat(newNdv, min, max, Some(0), newAvgLen, newMaxLen)
+
+    (ceil(card), newStats)
+  }
+
+  /** Compute join cardinality using equi-height histograms. */
+  private def computeByHistogram(
+                                  leftKey: AttributeReference,
+                                  rightKey: AttributeReference,
+                                  leftHistogram: Histogram,
+                                  rightHistogram: Histogram,
+                                  newMin: Option[Any],
+                                  newMax: Option[Any]): (BigInt, ColumnStat) = {
+    val overlappedRanges = getOverlappedRanges(
+      leftHistogram = leftHistogram,
+      rightHistogram = rightHistogram,
+      // Only numeric values have equi-height histograms.
+      lowerBound = newMin.get.toString.toDouble,
+      upperBound = newMax.get.toString.toDouble)
+
+    var card: BigDecimal = 0
+    var totalNdv: Double = 0
+    for (i <- overlappedRanges.indices) {
+      val range = overlappedRanges(i)
+      if (i == 0 || range.hi != overlappedRanges(i - 1).hi) {
+        // If range.hi == overlappedRanges(i - 1).hi, that means the current range has only one
+        // value, and this value is already counted in the previous range. So there is no need to
+        // count it in this range.
+        totalNdv += math.min(range.leftNdv, range.rightNdv)
+      }
+      // Apply the formula in this overlapped range.
+      card += range.leftNumRows * range.rightNumRows / math.max(range.leftNdv, range.rightNdv)
+    }
+
+    val leftKeyStat = leftStats.attributeStats(leftKey)
+    val rightKeyStat = rightStats.attributeStats(rightKey)
+    val newMaxLen = if (leftKeyStat.maxLen.isDefined && rightKeyStat.maxLen.isDefined) {
+      Some(math.min(leftKeyStat.maxLen.get, rightKeyStat.maxLen.get))
+    } else {
+      None
+    }
+    val newAvgLen = if (leftKeyStat.avgLen.isDefined && rightKeyStat.avgLen.isDefined) {
+      Some((leftKeyStat.avgLen.get + rightKeyStat.avgLen.get) / 2)
+    } else {
+      None
+    }
+    val newStats = ColumnStat(Some(ceil(totalNdv)), newMin, newMax, Some(0), newAvgLen, newMaxLen)
+    (ceil(card), newStats)
+  }
+
+  /**
+   * Propagate or update column stats for output attributes.
+   */
+  private def updateOutputStats(
+                                 outputRows: BigInt,
+                                 output: Seq[Attribute],
+                                 oldAttrStats: AttributeMap[ColumnStat],
+                                 keyStatsAfterJoin: AttributeMap[ColumnStat]): Seq[(Attribute, ColumnStat)] = {
+    val outputAttrStats = new ArrayBuffer[(Attribute, ColumnStat)]()
+    val leftRows = leftStats.rowCount.get
+    val rightRows = rightStats.rowCount.get
+
+    output.foreach { a =>
+      // check if this attribute is a join key
+      if (keyStatsAfterJoin.contains(a)) {
+        outputAttrStats += a -> keyStatsAfterJoin(a)
+      } else {
+        val oldColStat = oldAttrStats(a)
+        val oldNumRows = if (join.left.outputSet.contains(a)) {
+          leftRows
+        } else {
+          rightRows
+        }
+        val newColStat = oldColStat.updateCountStats(oldNumRows, outputRows)
+        // TODO: support nullCount updates for specific outer joins
+        outputAttrStats += a -> newColStat
+      }
+    }
+    outputAttrStats.toSeq
+  }
+
+  private def extractJoinKeysWithColStats(
+                                           leftKeys: Seq[Expression],
+                                           rightKeys: Seq[Expression]): Seq[(AttributeReference, AttributeReference)] = {
+    leftKeys.zip(rightKeys).collect {
+      // Currently we don't deal with equal joins like key1 = key2 + 5.
+      // Note: join keys from EqualNullSafe also fall into this case (Coalesce), consider to
+      // support it in the future by using `nullCount` in column stats.
+      case (lk: AttributeReference, rk: AttributeReference)
+        if columnStatsWithCountsExist((leftStats, lk), (rightStats, rk)) => (lk, rk)
+    }
+  }
+
+  private def estimateLeftSemiAntiJoin(): Option[Statistics] = {
+    // TODO: It's error-prone to estimate cardinalities for LeftSemi and LeftAnti based on basic
+    // column stats. Now we just propagate the statistics from left side. We should do more
+    // accurate estimation when advanced stats (e.g. histograms) are available.
+    if (rowCountsExist(join.left)) {
+      val leftStats = GpuStatsPlanVisitor.visit(join.left)
+      // Propagate the original column stats for cartesian product
+      val outputRows = leftStats.rowCount.get
+      Some(Statistics(
+        sizeInBytes = getOutputSize(join.output, outputRows, leftStats.attributeStats),
+        rowCount = Some(outputRows),
+        attributeStats = leftStats.attributeStats))
+    } else {
+      None
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
@@ -32,7 +32,7 @@ object GpuProjectEstimation {
   import EstimationUtils._
 
   def estimate(project: Project): Option[Statistics] = {
-    val childStats = GpuStatsPlanVisitor.visit(project.child)
+    val childStats = GpuStatsPlanVisitor.visitCached(project.child)
     val aliasStats = EstimationUtils.getAliasStats(project.expressions, childStats.attributeStats)
 
     val outputAttrStats =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
@@ -32,7 +32,7 @@ object GpuProjectEstimation {
   import EstimationUtils._
 
   def estimate(project: Project): Option[Statistics] = {
-    val childStats = GpuStatsPlanVisitor.visitCached(project.child)
+    val childStats = GpuStatsPlanVisitor.visit(project.child)
     val aliasStats = EstimationUtils.getAliasStats(project.expressions, childStats.attributeStats)
 
     val outputAttrStats =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
@@ -21,6 +21,13 @@ import org.apache.spark.sql.catalyst.expressions.AttributeMap
 import org.apache.spark.sql.catalyst.plans.logical.{Project, Statistics}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 
+/**
+ * Copied from Spark's ProjectEstimation.scala
+ *
+ * Modifications:
+ *
+ * - Call GpuStatsPlanVisitor to get stats for child, instead of calling child.stats
+ */
 object GpuProjectEstimation {
   import EstimationUtils._
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuProjectEstimation.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.AttributeMap
+import org.apache.spark.sql.catalyst.plans.logical.{Project, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
+
+object GpuProjectEstimation {
+  import EstimationUtils._
+
+  def estimate(project: Project): Option[Statistics] = {
+    val childStats = GpuStatsPlanVisitor.visit(project.child)
+    val aliasStats = EstimationUtils.getAliasStats(project.expressions, childStats.attributeStats)
+
+    val outputAttrStats =
+      getOutputMap(AttributeMap(childStats.attributeStats.toSeq ++ aliasStats), project.output)
+    Some(childStats.copy(
+      sizeInBytes = getOutputSize(project.output, childStats.rowCount.get, outputAttrStats),
+      attributeStats = outputAttrStats))
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
@@ -9,6 +9,8 @@ import org.apache.spark.sql.types.{DataTypes, StructType}
 
 /**
  * A [[LogicalPlanVisitor]] that computes the statistics for the cost-based optimizer.
+ *
+ * Copied from Spark's BasicStatsPlanVisitor and modified to call GPU versions of estimation logic.
  */
 object GpuStatsPlanVisitor extends LogicalPlanVisitor[Statistics] with Logging {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
@@ -1,0 +1,151 @@
+package com.nvidia.spark.rapids.optimizer
+
+import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.execution.adaptive.{LogicalQueryStage, QueryStageExec}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.types.{DataTypes, StructType}
+
+/**
+ * A [[LogicalPlanVisitor]] that computes the statistics for the cost-based optimizer.
+ */
+object GpuStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
+
+  private def fallback(p: LogicalPlan): Statistics = default(p)
+
+  override def default(p: LogicalPlan): Statistics = p match {
+    case LogicalQueryStage(logicalPlan, physicalPlan) => physicalPlan match {
+        case qs: QueryStageExec => qs.plan match {
+          case e: GpuShuffleExchangeExec =>
+            // access GPU stats directly
+            println(s"Using GPU stats for completed query stage: $physicalPlan")
+            e.runtimeStatistics
+          case _ =>
+            println(s"Falling back to Spark stats for completed query stage: $physicalPlan")
+            inferRowCount(logicalPlan.schema, logicalPlan.stats) // fallback to Spark stats
+        }
+        case _ =>
+          println(s"Falling back to Spark stats for completed query stage: $physicalPlan")
+          inferRowCount(logicalPlan.schema, logicalPlan.stats) // fallback to Spark stats
+    }
+    case p: LogicalRelation =>
+      val stats = inferRowCount(p.schema, p.computeStats())
+      val relation = p.relation.asInstanceOf[HadoopFsRelation]
+      println(s"GpuStatsPlanVisitor " +
+        s"rel=${relation.location.inputFiles.head} " +
+        s"rowCount=${stats.rowCount}")
+      stats
+    case p: LeafNode =>
+      inferRowCount(p.schema, p.computeStats())
+    case _: LogicalPlan =>
+      val stats = p.children.map(child => visit(child))
+      val rowCount = if (stats.exists(_.rowCount.isEmpty)) {
+        None
+      } else {
+        Some(stats.map(_.rowCount.get).filter(_ > 0L).product)
+      }
+      inferRowCount(p.schema, Statistics(sizeInBytes =
+        stats.map(_.sizeInBytes).filter(_ > 0L).product, rowCount = rowCount))
+  }
+
+  private def inferRowCount(schema: StructType, stats: Statistics): Statistics = {
+    if (stats.rowCount.isDefined) {
+      stats
+    } else {
+      var size = 0
+      for (field <- schema.fields) {
+        // estimate the size of one row based on schema
+        val fieldSize = field.dataType match {
+          case DataTypes.ByteType | DataTypes.BooleanType => 1
+          case DataTypes.ShortType => 2
+          case DataTypes.IntegerType | DataTypes.FloatType => 4
+          case DataTypes.LongType | DataTypes.DoubleType => 8
+          case DataTypes.StringType => 50
+          case DataTypes.DateType | DataTypes.TimestampType => 8
+          case _ => 20
+        }
+        size += fieldSize
+      }
+      val estimatedRowCount = Some(stats.sizeInBytes / size)
+      new Statistics(stats.sizeInBytes, estimatedRowCount)
+    }
+  }
+
+  override def visitAggregate(p: Aggregate): Statistics = {
+    GpuAggregateEstimation.estimate(p).getOrElse(fallback(p))
+  }
+
+  override def visitDistinct(p: Distinct): Statistics = {
+    val child = p.child
+    visitAggregate(Aggregate(child.output, child.output, child))
+  }
+
+  override def visitExcept(p: Except): Statistics = fallback(p)
+
+  override def visitExpand(p: Expand): Statistics = fallback(p)
+
+  override def visitFilter(p: Filter): Statistics = {
+    val stats = GpuFilterEstimation(p).estimate.getOrElse(fallback(p))
+    println(s"Filter: stats=$stats")
+    stats
+  }
+
+  override def visitGenerate(p: Generate): Statistics = default(p)
+
+  override def visitGlobalLimit(p: GlobalLimit): Statistics = fallback(p)
+
+  override def visitIntersect(p: Intersect): Statistics = {
+    val leftStats = default(p.left)
+    val rightStats = default(p.right)
+    val leftSize = leftStats.sizeInBytes
+    val rightSize = rightStats.sizeInBytes
+    if (leftSize < rightSize) {
+      Statistics(sizeInBytes = leftSize, rowCount = leftStats.rowCount)
+    } else {
+      Statistics(sizeInBytes = rightSize, rowCount = rightStats.rowCount)
+    }
+  }
+
+  override def visitJoin(p: Join): Statistics = {
+    val stats = GpuJoinEstimation(p).estimate.getOrElse(fallback(p))
+    println(s"Join: stats=$stats")
+    stats
+  }
+
+  override def visitLocalLimit(p: LocalLimit): Statistics = fallback(p)
+
+  override def visitPivot(p: Pivot): Statistics = default(p)
+
+  override def visitProject(p: Project): Statistics = {
+    val stats = GpuProjectEstimation.estimate(p).getOrElse(fallback(p))
+    println(s"Projection: stats=$stats")
+    stats
+  }
+
+  override def visitRepartition(p: Repartition): Statistics = fallback(p)
+
+  override def visitRepartitionByExpr(p: RepartitionByExpression): Statistics = fallback(p)
+
+  // TODO this does not exist until spark 3.3.x
+  //override def visitRebalancePartitions(p: RebalancePartitions): Statistics = fallback(p)
+
+  override def visitSample(p: Sample): Statistics = fallback(p)
+
+  override def visitScriptTransform(p: ScriptTransformation): Statistics = default(p)
+
+  override def visitUnion(p: Union): Statistics = {
+    GpuUnionEstimation.estimate(p).getOrElse(fallback(p))
+  }
+
+  override def visitWindow(p: Window): Statistics = fallback(p)
+
+  override def visitSort(p: Sort): Statistics = {
+    GpuStatsPlanVisitor.visit(p.child)
+  }
+
+  override def visitTail(p: Tail): Statistics = {
+    fallback(p)
+  }
+
+  override def visitWithCTE(p: WithCTE): Statistics = fallback(p)
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
@@ -17,12 +17,12 @@ object GpuStatsPlanVisitor extends LogicalPlanVisitor[Statistics] with Logging {
 
   private val statsTag = new TreeNodeTag[Statistics]("rapids.stats")
 
-  def visitCached(p: LogicalPlan): Statistics = {
+  override def visit(p: LogicalPlan): Statistics = {
     p.getTagValue(statsTag) match {
       case Some(stats) =>
         stats
       case _ =>
-        val stats = visit(p)
+        val stats = super.visit(p)
         p.setTagValue(statsTag, stats)
         stats
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuStatsPlanVisitor.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.nvidia.spark.rapids.optimizer
 
 import org.apache.spark.internal.Logging

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
@@ -17,6 +17,7 @@
 
 package com.nvidia.spark.rapids.optimizer
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Statistics, Union}
 import org.apache.spark.sql.types._
@@ -26,7 +27,7 @@ import org.apache.spark.sql.types._
  * and estimate min and max stats for each column by finding the overall min and max of that
  * column coming from its children.
  */
-object GpuUnionEstimation {
+object GpuUnionEstimation extends Logging {
 
   private def createStatComparator(dt: DataType): (Any, Any) => Boolean = dt match {
     case ByteType => (a: Any, b: Any) =>
@@ -67,7 +68,7 @@ object GpuUnionEstimation {
   }
 
   def estimate(union: Union): Option[Statistics] = {
-    println("GpuUnionEstimation.estimate() BEGIN")
+    logDebug("GpuUnionEstimation.estimate() BEGIN")
     val sizeInBytes = union.children.map(ch => JoinReorderUtils
       .statsWithRowCount(ch).sizeInBytes).sum
     val outputRows = //if (rowCountsExist(union.children: _*)) {
@@ -94,7 +95,7 @@ object GpuUnionEstimation {
         rowCount = outputRows,
         attributeStats = newAttrStats))
 
-    println(s"GpuUnionEstimation.estimate() END -> $x")
+    logDebug(s"GpuUnionEstimation.estimate() END -> $x")
 
     x
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, Statistics, Union}
+import org.apache.spark.sql.types._
+
+/**
+ * Estimate the number of output rows by doing the sum of output rows for each child of union,
+ * and estimate min and max stats for each column by finding the overall min and max of that
+ * column coming from its children.
+ */
+object GpuUnionEstimation {
+
+  private def createStatComparator(dt: DataType): (Any, Any) => Boolean = dt match {
+    case ByteType => (a: Any, b: Any) =>
+      implicitly[Ordering[Byte]].lt(a.asInstanceOf[Byte], b.asInstanceOf[Byte])
+    case ShortType => (a: Any, b: Any) =>
+      implicitly[Ordering[Short]].lt(a.asInstanceOf[Short], b.asInstanceOf[Short])
+    case IntegerType => (a: Any, b: Any) =>
+      implicitly[Ordering[Int]].lt(a.asInstanceOf[Int], b.asInstanceOf[Int])
+    case LongType => (a: Any, b: Any) =>
+      implicitly[Ordering[Long]].lt(a.asInstanceOf[Long], b.asInstanceOf[Long])
+    case FloatType => (a: Any, b: Any) =>
+      implicitly[Ordering[Float]].lt(a.asInstanceOf[Float], b.asInstanceOf[Float])
+    case DoubleType => (a: Any, b: Any) =>
+      implicitly[Ordering[Double]].lt(a.asInstanceOf[Double], b.asInstanceOf[Double])
+    case _: DecimalType => (a: Any, b: Any) =>
+      implicitly[Ordering[Decimal]].lt(a.asInstanceOf[Decimal], b.asInstanceOf[Decimal])
+    case DateType => (a: Any, b: Any) =>
+      implicitly[Ordering[Int]].lt(a.asInstanceOf[Int],
+        b.asInstanceOf[Int])
+    case TimestampType => (a: Any, b: Any) =>
+      implicitly[Ordering[Long]].lt(a.asInstanceOf[Long],
+        b.asInstanceOf[Long])
+//    case TimestampNTZType => (a: Any, b: Any) =>
+//      TimestampNTZType.ordering.lt(a.asInstanceOf[TimestampNTZType.InternalType],
+//        b.asInstanceOf[TimestampNTZType.InternalType])
+//    case i: AnsiIntervalType => (a: Any, b: Any) =>
+//      i.ordering.lt(a.asInstanceOf[i.InternalType], b.asInstanceOf[i.InternalType])
+    case _ =>
+      throw new IllegalStateException(s"Unsupported data type: ${dt.catalogString}")
+  }
+
+  private def isTypeSupported(dt: DataType): Boolean = dt match {
+    case ByteType | IntegerType | ShortType | FloatType | LongType |
+         DoubleType | DateType | _: DecimalType | TimestampType  => true
+    //TODO these are private
+//    case TimestampNTZType | _: AnsiIntervalType => true
+    case _ => false
+  }
+
+  def estimate(union: Union): Option[Statistics] = {
+    println("GpuUnionEstimation.estimate() BEGIN")
+    val sizeInBytes = union.children.map(ch => JoinReorderUtils
+      .statsWithRowCount(ch).sizeInBytes).sum
+    val outputRows = //if (rowCountsExist(union.children: _*)) {
+      Some(union.children.map(ch => JoinReorderUtils.statsWithRowCount(ch).rowCount.get).sum)
+//    } else {
+//      None
+//    }
+
+    val newMinMaxStats = computeMinMaxStats(union)
+    val newNullCountStats = computeNullCountStats(union)
+    val newAttrStats = {
+      val baseStats = AttributeMap(newMinMaxStats)
+      val overwriteStats = newNullCountStats.map { case attrStat@(attr, stat) =>
+        baseStats.get(attr).map { baseStat =>
+          attr -> baseStat.copy(nullCount = stat.nullCount)
+        }.getOrElse(attrStat)
+      }
+      AttributeMap(newMinMaxStats ++ overwriteStats)
+    }
+
+    val x = Some(
+      Statistics(
+        sizeInBytes = sizeInBytes,
+        rowCount = outputRows,
+        attributeStats = newAttrStats))
+
+    println(s"GpuUnionEstimation.estimate() END -> $x")
+
+    x
+  }
+
+  private def computeMinMaxStats(union: Union): Seq[(Attribute, ColumnStat)] = {
+    val unionOutput = union.output
+    val attrToComputeMinMaxStats = union.children.map(_.output).transpose.zipWithIndex.filter {
+      case (attrs, outputIndex) => isTypeSupported(unionOutput(outputIndex).dataType) &&
+        // checks if all the children has min/max stats for an attribute
+        attrs.zipWithIndex.forall {
+          case (attr, childIndex) =>
+            val attrStats = JoinReorderUtils.statsWithRowCount(union.children(childIndex))
+              .attributeStats
+            attrStats.get(attr).isDefined && attrStats(attr).hasMinMaxStats
+        }
+    }
+    attrToComputeMinMaxStats.map {
+      case (attrs, outputIndex) =>
+        val dataType = unionOutput(outputIndex).dataType
+        val statComparator = createStatComparator(dataType)
+        val minMaxValue = attrs.zipWithIndex.foldLeft[(Option[Any], Option[Any])]((None, None)) {
+          case ((minVal, maxVal), (attr, childIndex)) =>
+            val colStat = JoinReorderUtils.statsWithRowCount(union.children(childIndex))
+              .attributeStats(attr)
+            val min = if (minVal.isEmpty || statComparator(colStat.min.get, minVal.get)) {
+              colStat.min
+            } else {
+              minVal
+            }
+            val max = if (maxVal.isEmpty || statComparator(maxVal.get, colStat.max.get)) {
+              colStat.max
+            } else {
+              maxVal
+            }
+            (min, max)
+        }
+        val newStat = ColumnStat(min = minMaxValue._1, max = minMaxValue._2)
+        unionOutput(outputIndex) -> newStat
+    }
+  }
+
+  private def computeNullCountStats(union: Union): Seq[(Attribute, ColumnStat)] = {
+    val unionOutput = union.output
+    val attrToComputeNullCount = union.children.map(_.output).transpose.zipWithIndex.filter {
+      case (attrs, _) => attrs.zipWithIndex.forall {
+        case (attr, childIndex) =>
+          val attrStats = JoinReorderUtils.statsWithRowCount(union.children(childIndex))
+            .attributeStats
+          attrStats.get(attr).isDefined && attrStats(attr).nullCount.isDefined
+      }
+    }
+    attrToComputeNullCount.map {
+      case (attrs, outputIndex) =>
+        val firstStat = JoinReorderUtils.statsWithRowCount(union.children.head)
+          .attributeStats(attrs.head)
+        val firstNullCount = firstStat.nullCount.get
+        val colWithNullStatValues = attrs.zipWithIndex.tail.foldLeft[BigInt](firstNullCount) {
+          case (totalNullCount, (attr, childIndex)) =>
+            val colStat = JoinReorderUtils.statsWithRowCount(union.children(childIndex))
+              .attributeStats(attr)
+            totalNullCount + colStat.nullCount.get
+        }
+        val newStat = ColumnStat(nullCount = Some(colWithNullStatValues))
+        unionOutput(outputIndex) -> newStat
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/optimizer/GpuUnionEstimation.scala
@@ -73,8 +73,8 @@ object GpuUnionEstimation extends Logging {
 
   def estimate(union: Union): Option[Statistics] = {
     logDebug("GpuUnionEstimation.estimate() BEGIN")
-    val sizeInBytes = union.children.map(ch => GpuStatsPlanVisitor.visit(ch).sizeInBytes).sum
-    val outputRows = Some(union.children.map(ch => GpuStatsPlanVisitor.visit(ch).rowCount.get).sum)
+    val sizeInBytes = union.children.map(ch => GpuStatsPlanVisitor.visitCached(ch).sizeInBytes).sum
+    val outputRows = Some(union.children.map(ch => GpuStatsPlanVisitor.visitCached(ch).rowCount.get).sum)
 
     val newMinMaxStats = computeMinMaxStats(union)
     val newNullCountStats = computeNullCountStats(union)
@@ -106,7 +106,7 @@ object GpuUnionEstimation extends Logging {
         // checks if all the children has min/max stats for an attribute
         attrs.zipWithIndex.forall {
           case (attr, childIndex) =>
-            val attrStats = GpuStatsPlanVisitor.visit(union.children(childIndex))
+            val attrStats = GpuStatsPlanVisitor.visitCached(union.children(childIndex))
               .attributeStats
             attrStats.get(attr).isDefined && attrStats(attr).hasMinMaxStats
         }
@@ -117,7 +117,7 @@ object GpuUnionEstimation extends Logging {
         val statComparator = createStatComparator(dataType)
         val minMaxValue = attrs.zipWithIndex.foldLeft[(Option[Any], Option[Any])]((None, None)) {
           case ((minVal, maxVal), (attr, childIndex)) =>
-            val colStat = GpuStatsPlanVisitor.visit(union.children(childIndex))
+            val colStat = GpuStatsPlanVisitor.visitCached(union.children(childIndex))
               .attributeStats(attr)
             val min = if (minVal.isEmpty || statComparator(colStat.min.get, minVal.get)) {
               colStat.min
@@ -141,19 +141,19 @@ object GpuUnionEstimation extends Logging {
     val attrToComputeNullCount = union.children.map(_.output).transpose.zipWithIndex.filter {
       case (attrs, _) => attrs.zipWithIndex.forall {
         case (attr, childIndex) =>
-          val attrStats = GpuStatsPlanVisitor.visit(union.children(childIndex))
+          val attrStats = GpuStatsPlanVisitor.visitCached(union.children(childIndex))
             .attributeStats
           attrStats.get(attr).isDefined && attrStats(attr).nullCount.isDefined
       }
     }
     attrToComputeNullCount.map {
       case (attrs, outputIndex) =>
-        val firstStat = GpuStatsPlanVisitor.visit(union.children.head)
+        val firstStat = GpuStatsPlanVisitor.visitCached(union.children.head)
           .attributeStats(attrs.head)
         val firstNullCount = firstStat.nullCount.get
         val colWithNullStatValues = attrs.zipWithIndex.tail.foldLeft[BigInt](firstNullCount) {
           case (totalNullCount, (attr, childIndex)) =>
-            val colStat = GpuStatsPlanVisitor.visit(union.children(childIndex))
+            val colStat = GpuStatsPlanVisitor.visitCached(union.children(childIndex))
               .attributeStats(attr)
             totalNullCount + colStat.nullCount.get
         }


### PR DESCRIPTION
This POC is on hold for now and will likely be replaced by https://github.com/NVIDIA/spark-rapids/pull/7311

This is not even close to being ready for review but I wanted to start making this POC more accessible.

Status:

- Only works with Spark 3.2 (need to do some shim work to make it work with other versions)
- Join reordering during AQE is not enabled yet (requires shim work and will only work in 3.2.3+, 3.3.2+, 3.4.0+)
- No tests
- Stil uses some Spark CBO configs
- Need to use shimloader for plugin 

Future work not started yet (will file issues for these):

- Research providing column statistics and see if that improves cardinality estimates
- Research alternate algorithms such as DuckDB's join reordering, as discussed in https://www.youtube.com/watch?v=aNRoR0Z3SzU
- Take file format and compression type into account when estimating row counts