### PR TITLE
Pass through escaped punctuation in Regular Expression Transpiler

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -127,6 +127,9 @@ def test_split_optimized_no_re():
             'split(a, "\\\\|")',
             'split(a, "\\\\{")',
             'split(a, "\\\\}")',
+            'split(a, "\\\\%")',
+            'split(a, "\\\\;")',
+            'split(a, "\\\\/")',
             'split(a, "\\\\$\\\\|")'),
             conf=_regexp_conf)
 
@@ -377,7 +380,7 @@ def test_regexp_replace_character_set_negated():
         conf=_regexp_conf)
 
 def test_regexp_extract():
-    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}')
+    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}/?[abcd]{1,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'regexp_extract(a, "([0-9]+)", 1)',
@@ -385,7 +388,9 @@ def test_regexp_extract():
                 'regexp_extract(a, "([0-9])([abcd]+)", 2)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 1)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 2)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 3)'),
+                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)", 3)'),
         conf=_regexp_conf)
 
 def test_regexp_extract_no_match():
@@ -650,10 +655,13 @@ def test_rlike_fallback_empty_group():
         conf=_regexp_conf)
 
 def test_rlike_escape():
-    gen = mk_str_gen('[ab]{0,2}[\\-\\+]{0,2}')
+    gen = mk_str_gen('[ab]{0,2};?[\\-\\+]{0,2}/?')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
-                'a rlike "a[\\\\-]"'),
+                'a rlike "a[\\\\-]"',
+                'a rlike "a\\\\;[\\\\-]"',
+                'a rlike "a[\\\\-]\\\\/"',
+                'a rlike "b\\\\;[\\\\-]\\\\/"'),
         conf=_regexp_conf)
 
 def test_rlike_multi_line():

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -648,9 +648,10 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split - optimized") {
-    val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", ",", ";", "cd", "c\\|d")
+    val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", ",", ";", "cd", "c\\|d",
+        "\\%", "\\;", "\\/")
     val data = Seq("abc.def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
-        "abc,def", "abc;def", "abcdef", "abc|def")
+        "abc,def", "abc;def", "abcdef", "abc|def", "abc%def")
     for (limit <- Seq(Integer.MIN_VALUE, -2, -1)) {
       assertTranspileToSplittableString(patterns)
       doStringSplitTest(patterns, data, limit)


### PR DESCRIPTION
Fixes #6880.

This passes through escaped punctuation to the transpiler which will then unescape the non-metacharacter punctuation, allowing more regular expressions to run on the GPU.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
