### PR TITLE
Throw when onAllocFailure is invoked with  invalid arguments

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
@@ -107,6 +107,13 @@ class DeviceMemoryEventHandler(
    * @return true if allocation should be reattempted or false if it should fail
    */
   override def onAllocFailure(allocSize: Long, retryCount: Int): Boolean = {
+    // check arguments for good measure
+    require(allocSize >= 0, 
+      s"onAllocFailure invoked with invalid allocSize $allocSize")
+
+    require(retryCount >= 0, 
+      s"onAllocFailure invoked with invalid retryCount $retryCount")
+
     try {
       withResource(new NvtxRange("onAllocFailure", NvtxColor.RED)) { _ =>
         val storeSize = store.currentSize


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/6949

This checks the allocSize argument passed to `onAllocFailure` to prevent infinite invocations trying to spill. I am also checking the retryCount, just in case that had overflowed for some reason (very unlikely, but just in case).

I haven't tested it with the original query in NDSv2 but I will later on. I did add unit tests for this.