### PR TITLE
Allow `*`, `?`, and `{0,...}` variants in StringSplit in non-empty match situations

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -44,6 +44,9 @@ def test_split_re_negative_limit():
             'split(a, "[^o]", -1)',
             'split(a, "[o]{1,2}", -1)',
             'split(a, "[bf]", -1)',
+            'split(a, "b[o]+", -1)',
+            'split(a, "b[o]*", -1)',
+            'split(a, "b[o]?", -1)',
             'split(a, "[o]", -2)'),
             conf=_regexp_conf)
 
@@ -58,6 +61,9 @@ def test_split_re_zero_limit():
             'split(a, "[^o]", 0)',
             'split(a, "[o]{1,2}", 0)',
             'split(a, "[bf]", 0)',
+            'split(a, "f[o]+", 0)',
+            'split(a, "f[o]*", 0)',
+            'split(a, "f[o]?", 0)',
             'split(a, "[o]", 0)'),
         conf=_regexp_conf)
 
@@ -72,6 +78,9 @@ def test_split_re_one_limit():
             'split(a, "[^o]", 1)',
             'split(a, "[o]{1,2}", 1)',
             'split(a, "[bf]", 1)',
+            'split(a, "b[o]+", 1)',
+            'split(a, "b[o]*", 1)',
+            'split(a, "b[o]?", 1)',
             'split(a, "[o]", 1)'),
         conf=_regexp_conf)
 
@@ -86,6 +95,9 @@ def test_split_re_positive_limit():
             'split(a, "[^o]", 55)',
             'split(a, "[o]{1,2}", 999)',
             'split(a, "[bf]", 2)',
+            'split(a, "f[o]+", 2)',
+            'split(a, "f[o]*", 9)',
+            'split(a, "f[o]?", 5)',
             'split(a, "[o]", 5)'),
             conf=_regexp_conf)
 
@@ -103,6 +115,9 @@ def test_split_re_no_limit():
             'split(a, "[o]")',
             'split(a, "^(boo|foo):$")',
             'split(a, "[bf]$:")',
+            'split(a, "b[o]+")',
+            'split(a, "b[o]*")',
+            'split(a, "b[o]?")',
             'split(a, "b^")',
             'split(a, "^[o]")'),
             conf=_regexp_conf)
@@ -153,6 +168,18 @@ def test_split_optimized_no_re_combined():
             'split(a, "\\\\{Z")',
             'split(a, "\\\\}Z")'),
             conf=_regexp_conf)
+
+@allow_non_gpu('ProjectExec', 'StringSplit')
+def test_split_unsupported_fallback():
+    data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \
+        .with_special_case('boo:and:foo')
+    assert_gpu_sql_fallback_collect(
+        lambda spark : unary_op_df(spark, data_gen),
+        'StringSplit',
+        'string_split_table',
+        'select ' +
+        'split(a, "o*"),' +
+        'split(a, "o?") from string_split_table')
 
 def test_split_regexp_disabled_no_fallback():
     conf = { 'spark.rapids.sql.regexp.enabled': 'false' }

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -169,6 +169,7 @@ def test_split_optimized_no_re_combined():
             'split(a, "\\\\}Z")'),
             conf=_regexp_conf)
 
+# See https://github.com/NVIDIA/spark-rapids/issues/6958 for issue with zero-width match
 @allow_non_gpu('ProjectExec', 'StringSplit')
 def test_split_unsupported_fallback():
     data_gen = mk_str_gen('([bf]o{0,2}:){1,7}') \

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -657,6 +657,8 @@ object RegexFindMode extends RegexMode
 object RegexReplaceMode extends RegexMode
 object RegexSplitMode extends RegexMode
 
+sealed class RegexRewriteFlags(val emptyRepetition: Boolean)
+
 /**
  * Transpile Java/Spark regular expression to a format that cuDF supports, or throw an exception
  * if this is not possible.
@@ -951,14 +953,34 @@ class CudfRegexTranspiler(mode: RegexMode) {
           // ignore
       }
     }
+    
+    def isEmptyRepetition(regex: RegexAST): Boolean = {
+      regex match {
+        case RegexRepetition(_, term) => term match {
+          case SimpleQuantifier('*') | SimpleQuantifier('?') => true
+          case QuantifierFixedLength(0) => true
+          case QuantifierVariableLength(0, _) => true
+          case _ => false
+        }
+        case RegexGroup(_, term) =>
+          isEmptyRepetition(term)
+        case RegexSequence(parts) =>
+          parts.forall(isEmptyRepetition)
+        // cuDF does not support repetitions adjacent to a choice (eg. "a*|a"), but if
+        // we did, we would need to add a `case RegexChoice()` here
+        case _ => false
+      }
+    }
 
     checkUnsupported(regex)
 
-    rewrite(regex, replacement, previous)
+    val flags = new RegexRewriteFlags(isEmptyRepetition(regex))
+
+    rewrite(regex, replacement, previous, flags)
   }
 
   private def rewrite(regex: RegexAST, replacement: Option[RegexReplacement],
-      previous: Option[RegexAST]): RegexAST = {
+      previous: Option[RegexAST], flags: RegexRewriteFlags): RegexAST = {
     regex match {
 
       case RegexChar(ch) => ch match {
@@ -1112,7 +1134,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
             case Some(RegexEscaped('Z')) =>
               RegexEmpty()
             case _ =>
-              rewrite(RegexChar('$'), replacement, previous)
+              rewrite(RegexChar('$'), replacement, previous, flags)
           }
         case 's' | 'S' =>
           // whitespace characters
@@ -1184,7 +1206,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
         val components: Seq[RegexCharacterClassComponent] = characters
           .map {
             case r @ RegexChar(ch) if "^$.".contains(ch) => r
-            case ch => rewrite(ch, replacement, None) match {
+            case ch => rewrite(ch, replacement, None, flags) match {
               case valid: RegexCharacterClassComponent => valid
               case _ =>
                 // this can happen when a character class contains a meta-sequence such as
@@ -1282,7 +1304,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
                   case RegexChar(ch) if "\r\u0085\u2028\u2029".contains(ch) =>
                     r(j) = RegexSequence(
                       ListBuffer(
-                        rewrite(part, replacement, None),
+                        rewrite(part, replacement, None, flags),
                         RegexSequence(ListBuffer(
                           RegexRepetition(lineTerminatorMatcher(Set(ch), true, false),
                             SimpleQuantifier('?')), RegexChar('$')))))
@@ -1295,10 +1317,10 @@ class CudfRegexTranspiler(mode: RegexMode) {
                     throw new RegexUnsupportedException(
                       "Regex sequences with \\b or \\B not supported around $", part.position)
                   case _ =>
-                    r.append(rewrite(part, replacement, last))
+                    r.append(rewrite(part, replacement, last, flags))
                 }
               case _ =>
-                r.append(rewrite(part, replacement, last))
+                r.append(rewrite(part, replacement, last, flags))
             }
             r.last match {
               case RegexEmpty() =>
@@ -1309,20 +1331,21 @@ class CudfRegexTranspiler(mode: RegexMode) {
         })._1)
 
       case RegexRepetition(base, quantifier) => (base, quantifier) match {
-        case (_, SimpleQuantifier(ch)) if mode == RegexSplitMode && "?*".contains(ch) =>
+        case (_, SimpleQuantifier(ch)) if mode == RegexSplitMode
+            && flags.emptyRepetition && "?*".contains(ch) =>
           // example: pattern " ?", input "] b[", replace with "X":
           // java: X]XXbX[X
           // cuDF: XXXX] b[
           // see https://github.com/NVIDIA/spark-rapids/issues/4884
           throw new RegexUnsupportedException(
-            "regexp_split on GPU does not support repetition with ? or * consistently with Spark", 
+            "regexp_split on GPU does not support empty match repetition consistently with Spark",
             quantifier.position)
 
-        case (_, QuantifierVariableLength(0, _)) if mode == RegexSplitMode =>
+        case (_, QuantifierVariableLength(0, _)) if mode == RegexSplitMode
+            && flags.emptyRepetition =>
           // see https://github.com/NVIDIA/spark-rapids/issues/4884
           throw new RegexUnsupportedException(
-            "regexp_split on GPU does not support repetition with {0,} or {0,n} " +
-            "consistently with Spark",
+            "regexp_split on GPU does not support empty match repetition consistently with Spark",
             quantifier.position)
 
         case (_, QuantifierVariableLength(0, Some(0))) if mode != RegexFindMode =>
@@ -1344,7 +1367,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A)+ can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(capture, rewrite(term, replacement, previous))
+              RegexGroup(capture, rewrite(term, replacement, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1362,7 +1385,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A){1,} can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(capture, rewrite(term, replacement, previous))
+              RegexGroup(capture, rewrite(term, replacement, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1380,7 +1403,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
               // (\A){1,} can be transpiled to (\A) (dropping the repetition)
               // we use rewrite(...) here to handle logic regarding modes
               // (\A is not supported in RegexSplitMode)
-              RegexGroup(capture, rewrite(term, replacement, previous))
+              RegexGroup(capture, rewrite(term, replacement, previous, flags))
             // NOTE: (\A)* can be transpiled to (\A)?
             // however, (\A)? is not supported in libcudf yet
             case _ =>
@@ -1394,25 +1417,25 @@ class CudfRegexTranspiler(mode: RegexMode) {
             throw new RegexUnsupportedException(
                 s"cuDF does not support repetition of: ${term.toRegexString}", term.position)
           }
-          RegexRepetition(rewrite(base, replacement, None), quantifier)
+          RegexRepetition(rewrite(base, replacement, None, flags), quantifier)
         case (RegexEscaped(ch), SimpleQuantifier('+')) if "AZ".contains(ch) =>
           // \A+ can be transpiled to \A (dropping the repetition)
           // \Z+ can be transpiled to \Z (dropping the repetition)
           // we use rewrite(...) here to handle logic regarding modes
           // (\A and \Z are not supported in RegexSplitMode)
-          rewrite(base, replacement, previous)
+          rewrite(base, replacement, previous, flags)
         // NOTE: \A* can be transpiled to \A?
         // however, \A? is not supported in libcudf yet
         case (RegexEscaped(ch), QuantifierFixedLength(n)) if n > 0 && "AZ".contains(ch) =>
           // \A{2} can be transpiled to \A (dropping the repetition)
           // \Z{2} can be transpiled to \Z (dropping the repetition)
-          rewrite(base, replacement, previous)
+          rewrite(base, replacement, previous, flags)
         case (RegexEscaped(ch), QuantifierVariableLength(n,_)) if n > 0 && "AZ".contains(ch) =>
           // \A{1,5} can be transpiled to \A (dropping the repetition)
           // \Z{1,} can be transpiled to \Z (dropping the repetition)
-          rewrite(base, replacement, previous)
+          rewrite(base, replacement, previous, flags)
         case _ if isSupportedRepetitionBase(base) =>
-          RegexRepetition(rewrite(base, replacement, None), quantifier)
+          RegexRepetition(rewrite(base, replacement, None, flags), quantifier)
         case (RegexRepetition(_, SimpleQuantifier('*')), SimpleQuantifier('+')) => 
           throw new RegexUnsupportedException("Possessive quantifier *+ not supported", 
             quantifier.position)
@@ -1426,8 +1449,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
       }
 
       case RegexChoice(l, r) =>
-        val ll = rewrite(l, replacement, None)
-        val rr = rewrite(r, replacement, None)
+        val ll = rewrite(l, replacement, None, flags)
+        val rr = rewrite(r, replacement, None, flags)
 
         // cuDF does not support repetition on one side of a choice, such as "a*|a"
         if (isRepetition(ll)) {
@@ -1488,9 +1511,9 @@ class CudfRegexTranspiler(mode: RegexMode) {
                 case _ =>
               }
             }
-            RegexGroup(capture, rewrite(term, replacement, None))
+            RegexGroup(capture, rewrite(term, replacement, None, flags))
           case _ =>
-            RegexGroup(capture, rewrite(term, replacement, None))
+            RegexGroup(capture, rewrite(term, replacement, None, flags))
         }
 
       case other =>


### PR DESCRIPTION
Fixes #4884.

This enables `*`, `?` as well as `{0,}` and `{0,n}` in regular expressions that used in StringSplit in most circumstances aside from zero-width match cases (covered by https://github.com/NVIDIA/spark-rapids/issues/6958) to run on the GPU. 

Because zero-width matches are a somewhat rare edge case that need to be handled on the output side, in favor of usability, this PR reduces that to be a separate edge case that can fallback on its own.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
