### PR TITLE
Stop using deprecated JDK API javax.xml.bind

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -622,7 +622,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
 
   override def toString: String = value match {
     case null => "null"
-    case binary: Array[Byte] => s"0x${ApacheHex.encodeHexString(binary, false)}"
+    case binary: Array[Byte] => s"0x${ApacheHex.encodeHex(binary, false).mkString}"
     case other => other.toString
   }
 
@@ -691,7 +691,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
       val formatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
       s"TIMESTAMP('${formatter.format(v)}')"
-    case (v: Array[Byte], BinaryType) => s"X'${ApacheHex.encodeHexString(v, false)}'"
+    case (v: Array[Byte], BinaryType) => s"X'${ApacheHex.encodeHex(v, false).mkString}'"
     case _ => value.toString
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -691,7 +691,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
       val formatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
       s"TIMESTAMP('${formatter.format(v)}')"
-    case (v: Array[Byte], BinaryType) => s"X'${ApacheHex.encodeHex(v, false)}'"
+    case (v: Array[Byte], BinaryType) => s"X'${ApacheHex.encodeHexString(v, false)}'"
     case _ => value.toString
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -622,7 +622,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
 
   override def toString: String = value match {
     case null => "null"
-    case binary: Array[Byte] => s"0x" + ApacheHex.encodeHex(binary, false)
+    case binary: Array[Byte] => s"0x${ApacheHex.encodeHexString(binary, false)}"
     case other => other.toString
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -20,7 +20,6 @@ import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float =
 import java.math.BigInteger
 import java.util
 import java.util.{List => JList, Objects}
-import javax.xml.bind.DatatypeConverter
 
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe.TypeTag
@@ -29,6 +28,7 @@ import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Scalar}
 import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, SparkShimImpl}
+import org.apache.commons.codec.binary.Hex
 import org.json4s.JsonAST.{JField, JNull, JString}
 
 import org.apache.spark.internal.Logging
@@ -622,7 +622,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
 
   override def toString: String = value match {
     case null => "null"
-    case binary: Array[Byte] => s"0x" + DatatypeConverter.printHexBinary(binary)
+    case binary: Array[Byte] => s"0x" + Hex.encodeHex(binary, false)
     case other => other.toString
   }
 
@@ -691,7 +691,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
       val formatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
       s"TIMESTAMP('${formatter.format(v)}')"
-    case (v: Array[Byte], BinaryType) => s"X'${DatatypeConverter.printHexBinary(v)}'"
+    case (v: Array[Byte], BinaryType) => s"X'${Hex.encodeHex(v, false)}'"
     case _ => value.toString
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -28,7 +28,7 @@ import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Scalar}
 import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, SparkShimImpl}
-import org.apache.commons.codec.binary.Hex
+import org.apache.commons.codec.binary.{Hex => ApacheHex}
 import org.json4s.JsonAST.{JField, JNull, JString}
 
 import org.apache.spark.internal.Logging
@@ -622,7 +622,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
 
   override def toString: String = value match {
     case null => "null"
-    case binary: Array[Byte] => s"0x" + Hex.encodeHex(binary, false)
+    case binary: Array[Byte] => s"0x" + ApacheHex.encodeHex(binary, false)
     case other => other.toString
   }
 
@@ -691,7 +691,7 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
       val formatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
       s"TIMESTAMP('${formatter.format(v)}')"
-    case (v: Array[Byte], BinaryType) => s"X'${Hex.encodeHex(v, false)}'"
+    case (v: Array[Byte], BinaryType) => s"X'${ApacheHex.encodeHex(v, false)}'"
     case _ => value.toString
   }
 


### PR DESCRIPTION
Replace DataTypeConverter.printHexBinary with Hex.encodeHex since 
- javax.xml.bind is removed in JDK11
as revealed by #6901
- and Spark 3.3.1 removed jaxb-api in apache/spark@e8e5785f02ae7d44e0553b82c742e1eba4ca2082

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
