### PR TITLE
Remove postProjection from GpuColumnarToRowExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -211,7 +211,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
    *       not unusual.
    */
   def optimizeCoalesce(plan: SparkPlan): SparkPlan = plan match {
-    case c2r @ GpuColumnarToRowExec(gpuCoalesce: GpuCoalesceBatches, _, _)
+    case c2r @ GpuColumnarToRowExec(gpuCoalesce: GpuCoalesceBatches, _)
       if !isGpuShuffleLike(gpuCoalesce.child) =>
         // Don't build a batch if we are just going to go back to ROWS
         // and there isn't a GPU shuffle involved

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -133,12 +133,12 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       df.collect()
 
       gpuPlan match {
-        case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _, _)) =>
+        case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _)) =>
           assert(plan.children.head.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 
-        case GpuColumnarToRowExec(plan, _, _) => // Codegen disabled
+        case GpuColumnarToRowExec(plan, _) => // Codegen disabled
           assert(plan.children.head.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
@@ -174,13 +174,13 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
       df.collect()
 
       gpuPlan match {
-        case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _, _)) =>
+        case WholeStageCodegenExec(GpuColumnarToRowExec(plan, _)) =>
           assert(plan.children.head.isInstanceOf[GpuSortExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.find(_.isInstanceOf[GpuHashAggregateExec]).isDefined)
           assert(gpuPlan.children.forall(exec => exec.isInstanceOf[GpuExec]))
 
-        case GpuColumnarToRowExec(plan, _, _) => // codegen disabled
+        case GpuColumnarToRowExec(plan, _) => // codegen disabled
           assert(plan.isInstanceOf[GpuHashAggregateExec])
           assert(gpuPlan.find(_.isInstanceOf[SortAggregateExec]).isEmpty)
           assert(gpuPlan.find(_.isInstanceOf[GpuHashAggregateExec]).isDefined)


### PR DESCRIPTION
GpuColumnarToRowExec has an optional argument to apply projections after the conversion to rows.  This is currently unused and a bit dangerous if it were, as other parts of the code assume that this node simply performs a row conversion without changing any existing values or adding/removing values.

To avoid surprises in the future, this removes the post-projection functionality from GpuColumnarToRowExec.