### PR TITLE
Add regular expression support for `\d` inside character classes on the GPU

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -568,6 +568,8 @@ def test_regexp_replace_digit():
             'regexp_replace(a, "\\\\D", "x")',
             'regexp_replace(a, "[0-9]", "x")',
             'regexp_replace(a, "[^0-9]", "x")',
+            'regexp_replace(a, "[\\\\d]", "x")',
+            'regexp_replace(a, "[a\\\\d]{0,2}", "x")',
         ),
         conf=_regexp_conf)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -193,6 +193,8 @@ class RegexParser(pattern: String) {
           }
         case Some(ch) =>
           consumeExpected(ch) match {
+            // NOTE: Should switch to ASCII mode to simplify and expland this fix
+            case 'd' => RegexCharacterRange(RegexChar('0'), RegexChar('9'))
             // List of character literals with an escape from here, under "Characters"
             // https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html
             case 'n' => RegexChar('\n')

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -445,9 +445,9 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
   }
 
-  test("compare CPU and GPU: character range including escaped + and -") {
-    val patterns = Seq(raw"a[\-\+]", raw"a[\+\-]", raw"a[a-b\-]")
-    val inputs = Seq("a+", "a-", "a", "a-+", "a[a-b-]")
+  test("compare CPU and GPU: character range including escaped + and - and d") {
+    val patterns = Seq(raw"a[\-\+]", raw"a[\+\-]", raw"a[a-b\-]", raw"a[\d]", raw"a[\d\+]")
+    val inputs = Seq("a+", "a-", "a", "a-+", "a[a-b-]", "a0", "a0+")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
   }
 


### PR DESCRIPTION
Partial workaround for #6961.

This adds support for `[\d]` in regular expression on the GPU. Note this is not a permanent solution and does not add support for `[\w]`. Supporting that will involve adding support for cudf regex flags in the cudf Java API, and this will temporarily fix this very simple case. 


Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
