### PR TITLE
Make shim revision check opt-out

### DIFF
--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -172,7 +172,7 @@
                 <ac:if>
                     <istrue value="${ignore.shim.revisions.check}"/>
                     <ac:then>
-                        <echo>ignore.shim.revisions.check=${ignore.shim.revisions.check}: Igoring shim revision check failure ${checkShimRevisionsError}</echo>
+                        <echo>ignore.shim.revisions.check=${ignore.shim.revisions.check}: Ignoring shim revision check failure ${checkShimRevisionsError}</echo>
                     </ac:then>
                     <ac:else>
                         <fail>${checkShimRevisionsError}</fail>

--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -160,13 +160,26 @@
               failonerror="false">
             <arg value="${included_buildvers}"/>
         </exec>
-        <fail message="exec check-shims-revisions.sh failed, exit code is ${build-parallel-worlds.checkRevisionsExitCode}, error msg is ${build-parallel-worlds.checkRevisionsErrorMsg}">
-            <condition>
-                <not>
-                    <equals arg1="${build-parallel-worlds.checkRevisionsExitCode}" arg2="0"/>
-                </not>
-            </condition>
-        </fail>
+        <ac:if>
+            <not>
+                <equals arg1="${build-parallel-worlds.checkRevisionsExitCode}" arg2="0"/>
+            </not>
+            <ac:then>
+                <property
+                    name="checkShimRevisionsError"
+                    value="check-shims-revisions.sh failed: exitCode=${build-parallel-worlds.checkRevisionsExitCode} error=${build-parallel-worlds.checkRevisionsErrorMsg}"
+                />
+                <ac:if>
+                    <istrue value="${ignore.shim.revisions.check}"/>
+                    <ac:then>
+                        <echo>ignore.shim.revisions.check=${ignore.shim.revisions.check}: Igoring shim revision check failure ${checkShimRevisionsError}</echo>
+                    </ac:then>
+                    <ac:else>
+                        <fail>${checkShimRevisionsError}</fail>
+                    </ac:else>
+                </ac:if>
+            </ac:then>
+        </ac:if>
 
         <exec executable="${project.basedir}/scripts/binary-dedupe.sh"
               dir="${project.build.directory}"

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,14 @@
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
+
+        <!--
+            If true, disables verification that all Shims be built as of one and the same git
+            commit hash. Do not use for CI!
+
+            It is intended only for local builds of the dist module when combining locally-built shims
+            with the ones deployed to a remote Maven repo
+        -->
         <ignore.shim.revisions.check>false</ignore.shim.revisions.check>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,7 @@
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
+        <ignore.shim.revisions.check>false</ignore.shim.revisions.check>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Don't enforce shim revision check when just testing dist packaging, i.e. `mvn package -pl dist` vs `mvn package -pl dist -am`

Useful when bundling the locally built shim with the rest from CI

Or when pulling together all shims from remote whereas some [Databricks] are currently likely to be out of sync from the others.

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
