### PR TITLE
Enable snapshot builds as optional PR checks 

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -44,12 +44,12 @@ jobs:
         run: |
           set -x
           . jenkins/version-def.sh
-          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"false\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": true}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
@@ -61,7 +61,7 @@ jobs:
 
   package-aggregator:
     needs: get-shim-versions-from-dist
-    continue-on-error: ${{ matrix.isSnapshot }}
+    #continue-on-error: ${{ matrix.isSnapshot }}
     strategy:
       matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkTailVersions) }}
       fail-fast: false

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -105,7 +105,6 @@ jobs:
           java-version: 8
 
       - name: package aggregator check for snapshot builds
-        continue-on-error: true
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B package -pl aggregator -am
           -P 'individual,pre-merge'

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -44,18 +44,18 @@ jobs:
         run: |
           set -x
           . jenkins/version-def.sh
-          # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
-          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"false\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -99,13 +99,13 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        continue-on-error: true
         uses: actions/setup-java@v3
         with:
           distribution: adopt
           java-version: 8
 
       - name: package aggregator check for snapshot builds
+        continue-on-error: true
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B package -pl aggregator -am
           -P 'individual,pre-merge'

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -x
           . jenkins/version-def.sh
-          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY @]}")
+          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
           svArrBody=${svArrBody:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBody)
           echo "snapshotVersions=$svJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -44,25 +44,24 @@ jobs:
         run: |
           set -x
           . jenkins/version-def.sh
-          # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
 
   package-aggregator:
     needs: get-shim-versions-from-dist
-    #continue-on-error: ${{ matrix.isSnapshot }}
+    continue-on-error: ${{ matrix.isSnapshot }}
     strategy:
       matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkTailVersions) }}
       fail-fast: false

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -45,17 +45,17 @@ jobs:
           set -x
           . jenkins/version-def.sh
           # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
-          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"false\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\"}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\": \"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -30,6 +30,7 @@ jobs:
       sparkHeadVersion: ${{ steps.noSnapshotVersionsStep.outputs.headVersion }}
       sparkTailVersions: ${{ steps.noSnapshotVersionsStep.outputs.tailVersions }}
       sparkJDK11Versions: ${{ steps.noSnapshotVersionsStep.outputs.jdk11Versions }}
+      sparkSnapshotOnlyVersions: ${{ steps.snapshotVersionsStep.outputs.snapshotVersions }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -53,6 +54,16 @@ jobs:
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
+
+      - name: Snapshot versions only
+        id: snapshotVersionsStep
+        run: |
+          set -x
+          . jenkins/version-def.sh
+          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY @]}")
+          svArrBody=${svArrBody:1}
+          svJsonStr=$(printf {\"include\":[%s]} $svArrBody)
+          echo "snapshotVersions=$svJsonStr" >> $GITHUB_OUTPUT
 
   package-aggregator:
     needs: get-noSnapshot-versions-from-dist
@@ -78,6 +89,32 @@ jobs:
           -Dmaven.javadoc.skip
           -Dmaven.scalastyle.skip=true
           -Drat.skip=true
+          
+  package-snapshotsOnly-aggregator:
+    needs: get-noSnapshot-versions-from-dist
+    strategy:
+      matrix: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkSnapshotOnlyVersions) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
+
+      - name: Setup Java and Maven Env
+        continue-on-error: true
+        uses: actions/setup-java@v3
+        with:
+          distribution: adopt
+          java-version: 8
+
+      - name: package aggregator check for snapshot builds
+        run: >
+          mvn -Dmaven.wagon.http.retryHandler.count=3 -B package -pl aggregator -am
+          -P 'individual,pre-merge'
+          -Dbuildver=${{ matrix.spark-version }}
+          -DskipTests
+          -Dskip
+          -Dmaven.javadoc.skip
+          -Dmaven.scalastyle.skip=true
+          -Drat.skip=true        
 
   verify-all-modules-with-headSparkVersion:
     needs: get-noSnapshot-versions-from-dist

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -44,12 +44,13 @@ jobs:
         run: |
           set -x
           . jenkins/version-def.sh
-          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\": true}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\"}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -93,6 +93,7 @@ jobs:
   package-snapshotsOnly-aggregator:
     needs: get-all-versions-from-dist
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkSnapshotOnlyVersions) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-noSnapshot-versions-from-dist:
+  get-all-versions-from-dist:
     runs-on: ubuntu-latest
     outputs:
       sparkHeadVersion: ${{ steps.noSnapshotVersionsStep.outputs.headVersion }}
@@ -66,9 +66,9 @@ jobs:
           echo "snapshotVersions=$svJsonStr" >> $GITHUB_OUTPUT
 
   package-aggregator:
-    needs: get-noSnapshot-versions-from-dist
+    needs: get-all-versions-from-dist
     strategy:
-      matrix: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkTailVersions) }}
+      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkTailVersions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
@@ -91,9 +91,9 @@ jobs:
           -Drat.skip=true
           
   package-snapshotsOnly-aggregator:
-    needs: get-noSnapshot-versions-from-dist
+    needs: get-all-versions-from-dist
     strategy:
-      matrix: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkSnapshotOnlyVersions) }}
+      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkSnapshotOnlyVersions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
@@ -116,7 +116,7 @@ jobs:
           -Drat.skip=true        
 
   verify-all-modules-with-headSparkVersion:
-    needs: get-noSnapshot-versions-from-dist
+    needs: get-all-versions-from-dist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
@@ -132,7 +132,7 @@ jobs:
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge'
-          -Dbuildver=${{ needs.get-noSnapshot-versions-from-dist.outputs.sparkHeadVersion }}
+          -Dbuildver=${{ needs.get-all-versions-from-dist.outputs.sparkHeadVersion }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip
@@ -141,7 +141,7 @@ jobs:
     needs: get-noSnapshot-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-noSnapshot-versions-from-dist.outputs.sparkJDK11Versions) }}
+      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkJDK11Versions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -138,7 +138,7 @@ jobs:
           -Dmaven.javadoc.skip
 
   verify-modules-with-jdk11:
-    needs: get-noSnapshot-versions-from-dist
+    needs: get-all-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkJDK11Versions) }}

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -45,17 +45,17 @@ jobs:
           set -x
           . jenkins/version-def.sh
           # svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
-          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
 
           # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" 340)
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" 340)
           svArrBodySnapshot=${svArrBodySnapshot:1}
           svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,13 +24,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-all-versions-from-dist:
+  get-shim-versions-from-dist:
     runs-on: ubuntu-latest
     outputs:
-      sparkHeadVersion: ${{ steps.noSnapshotVersionsStep.outputs.headVersion }}
-      sparkTailVersions: ${{ steps.noSnapshotVersionsStep.outputs.tailVersions }}
-      sparkJDK11Versions: ${{ steps.noSnapshotVersionsStep.outputs.jdk11Versions }}
-      sparkSnapshotOnlyVersions: ${{ steps.snapshotVersionsStep.outputs.snapshotVersions }}
+      sparkHeadVersion: ${{ steps.allShimVersionsStep.outputs.headVersion }}
+      sparkTailVersions: ${{ steps.allShimVersionsStep.outputs.tailVersions }}
+      sparkJDK11Versions: ${{ steps.allShimVersionsStep.outputs.jdk11Versions }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -40,14 +39,19 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      - name: all noSnapshot versions
-        id: noSnapshotVersionsStep
+      - name: all shim versions
+        id: allShimVersionsStep
         run: |
           set -x
           . jenkins/version-def.sh
-          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
-          svArrBody=${svArrBody:1}
-          svJsonStr=$(printf {\"include\":[%s]} $svArrBody)
+          svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"false\"}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
+          svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
+          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+
+          # add snapshot versions which are not in snapshot property in pom file
+          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":\"true\"}" 340)
+          svArrBodySnapshot=${svArrBodySnapshot:1}
+          svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
@@ -55,20 +59,12 @@ jobs:
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
 
-      - name: Snapshot versions only
-        id: snapshotVersionsStep
-        run: |
-          set -x
-          . jenkins/version-def.sh
-          svArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
-          svArrBody=${svArrBody:1}
-          svJsonStr=$(printf {\"include\":[%s]} $svArrBody)
-          echo "snapshotVersions=$svJsonStr" >> $GITHUB_OUTPUT
-
   package-aggregator:
-    needs: get-all-versions-from-dist
+    needs: get-shim-versions-from-dist
+    continue-on-error: ${{ matrix.isSnapshot }}
     strategy:
-      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkTailVersions) }}
+      matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkTailVersions) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
@@ -89,35 +85,10 @@ jobs:
           -Dmaven.javadoc.skip
           -Dmaven.scalastyle.skip=true
           -Drat.skip=true
-          
-  package-snapshotsOnly-aggregator:
-    needs: get-all-versions-from-dist
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkSnapshotOnlyVersions) }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
-      - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 8
-
-      - name: package aggregator check for snapshot builds
-        run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B package -pl aggregator -am
-          -P 'individual,pre-merge'
-          -Dbuildver=${{ matrix.spark-version }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
-          -Dmaven.scalastyle.skip=true
-          -Drat.skip=true        
 
   verify-all-modules-with-headSparkVersion:
-    needs: get-all-versions-from-dist
+    needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
@@ -133,16 +104,16 @@ jobs:
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge'
-          -Dbuildver=${{ needs.get-all-versions-from-dist.outputs.sparkHeadVersion }}
+          -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.sparkHeadVersion }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip
 
   verify-modules-with-jdk11:
-    needs: get-all-versions-from-dist
+    needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-all-versions-from-dist.outputs.sparkJDK11Versions) }}
+      matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,7 +54,8 @@
         </noSnapshot.buildvers>
         <snapshot.buildvers>
             314,
-            332
+            332,
+            340
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,
@@ -169,7 +170,7 @@
             </properties>
         </profile>
         <profile>
-            <id>snapshotsOnly</id>
+            <id>snapshotOnly</id>
             <properties>
                 <included_buildvers>
                     ${snapshot.buildvers}

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,7 +54,8 @@
         </noSnapshot.buildvers>
         <snapshot.buildvers>
             314,
-            332
+            332,
+            340
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -169,6 +169,14 @@
             </properties>
         </profile>
         <profile>
+            <id>snapshotsOnly</id>
+            <properties>
+                <included_buildvers>
+                    ${snapshot.buildvers}
+                </included_buildvers>
+            </properties>
+        </profile>
+        <profile>
             <id>snapshotsWithDatabricks</id>
             <properties>
                 <included_buildvers>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,8 +54,7 @@
         </noSnapshot.buildvers>
         <snapshot.buildvers>
             314,
-            332,
-            340
+            332
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -62,8 +62,8 @@ SPARK_SHIM_VERSIONS_SNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 # PnoSnapshots: noSnapshots only
 set_env_var_SPARK_SHIM_VERSIONS_ARR -PnoSnapshots
 SPARK_SHIM_VERSIONS_NOSNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
-# PsnapshotsOnly : snapshots only
-set_env_var_SPARK_SHIM_VERSIONS_ARR -PsnapshotsOnly
+# PsnapshotOnly : snapshots only
+set_env_var_SPARK_SHIM_VERSIONS_ARR -PsnapshotOnly
 SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 
 # PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -62,6 +62,9 @@ SPARK_SHIM_VERSIONS_SNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 # PnoSnapshots: noSnapshots only
 set_env_var_SPARK_SHIM_VERSIONS_ARR -PnoSnapshots
 SPARK_SHIM_VERSIONS_NOSNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
+# PsnapshotsOnly : snapshots only
+set_env_var_SPARK_SHIM_VERSIONS_ARR -PsnapshotsOnly
+SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 
 # PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
 # regular: noSnapshots + snapshots

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.ExprRule
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-class DecimalArithmeticOverrides {
+object DecimalArithmeticOverrides {
   def exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     // We don't override PromotePrecision or CheckOverflow for Spark 3.4
     Map.empty[Class[_ <: Expression], ExprRule[_ <: Expression]]

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.ExprRule
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-object DecimalArithmeticOverrides {
+class DecimalArithmeticOverrides {
   def exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     // We don't override PromotePrecision or CheckOverflow for Spark 3.4
     Map.empty[Class[_ <: Expression], ExprRule[_ <: Expression]]


### PR DESCRIPTION
This contributes to https://github.com/NVIDIA/spark-rapids/issues/5824 

This PR enables snapshot builds in premerge but keeping it as optional. i.e If the pre-merge CI fails only due to snapshot builds, then the author of the PR can still merge it  if the issue isn't related to the PR.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
