### PR TITLE
Spark-3.4: Update DecimalArithmeticOverrides to object

### DIFF
--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.ExprRule
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-class DecimalArithmeticOverrides {
+object DecimalArithmeticOverrides {
   def exprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     // We don't override PromotePrecision or CheckOverflow for Spark 3.4
     Map.empty[Class[_ <: Expression], ExprRule[_ <: Expression]]


### PR DESCRIPTION
This is a small build error fix where DecimalArithmeticOverrides is updated to object. 
Also moved the file from 340/ directory to 340+/ directory as this change may apply to future Spark versions asl well.
Fixes below build error:

```
[INFO] Compiler bridge file: /home/nartal/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.12-1.3.1-bin_2.12.15__52.0-1.3.1_20191012T045515.jar
[INFO] Compiling 329 Scala sources and 59 Java sources to /home/nartal/workspace/spark-rapids/sql-plugin/target/spark340/classes ...
[ERROR] [Error] /home/nartal/workspace/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:3502: not found: value DecimalArithmeticOverrides
[ERROR] [Error] /home/nartal/workspace/spark-rapids/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala:27: Unused import
[ERROR] two errors found
```



<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
