### PR TITLE
Revert "Fix a minor potential issue when rebatching for GpuArrowEvalP…

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -150,7 +150,7 @@ class RebatchingRoundoffIterator(
 
     val rc: Long = combined.numRows()
 
-    if (rc <= targetRoundoff) {
+    if (rc % targetRoundoff == 0 || rc < targetRoundoff) {
       return combined
     }
 


### PR DESCRIPTION
The original code returns the N*batchSize which is correct, but my previous PR https://github.com/NVIDIA/spark-rapids/pull/5995 changed it. So just revert it.



