### PR TITLE
Work around column vectors reporting incorrect data type

### DIFF
--- a/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/311until330-all/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -56,11 +56,17 @@ object GpuTypeShims {
   /**
    * Copy a column for computing on GPU.
    * Better to check if the type is supported first by calling 'isColumnarCopySupportedForType'
+   *
+   * Data type is passed explicitly to allow overriding the reported type from the column vector.
+   * There are cases where the type reported by the column vector does not match the data.
+   * See https://github.com/apache/iceberg/issues/6116.
    */
-  def columnarCopy(cv: ColumnVector,
-      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder, rows: Int): Unit = {
-    val t = cv.dataType()
-    throw new UnsupportedOperationException(s"Converting to GPU for $t is not supported yet")
+  def columnarCopy(
+      cv: ColumnVector,
+      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder,
+      dataType: DataType,
+      rows: Int): Unit = {
+    throw new UnsupportedOperationException(s"Converting to GPU for $dataType is not supported yet")
   }
 
   def isParquetColumnarWriterSupportedForType(colType: DataType): Boolean = false

--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -113,9 +113,16 @@ object GpuTypeShims {
   /**
    * Copy a column for computing on GPU.
    * Better to check if the type is supported first by calling 'isColumnarCopySupportedForType'
+   *
+   * Data type is passed explicitly to allow overriding the reported type from the column vector.
+   * There are cases where the type reported by the column vector does not match the data.
+   * See https://github.com/apache/iceberg/issues/6116.
    */
-  def columnarCopy(cv: ColumnVector,
-      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder, rows: Int): Unit = cv.dataType() match {
+  def columnarCopy(
+      cv: ColumnVector,
+      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder,
+      dataType: DataType,
+      rows: Int): Unit = dataType match {
     case DayTimeIntervalType(_, _) =>
       ColumnarCopyHelper.longCopy(cv, b, rows)
     case YearMonthIntervalType(_, _) =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -107,9 +107,15 @@ object HostColumnarToGpu extends Logging {
     referenceManagers.result().asJava
   }
 
-  def columnarCopy(cv: ColumnVector,
-      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder, rows: Int): Unit = {
-    cv.dataType() match {
+  // Data type is passed explicitly to allow overriding the reported type from the column vector.
+  // There are cases where the type reported by the column vector does not match the data.
+  // See https://github.com/apache/iceberg/issues/6116.
+  def columnarCopy(
+      cv: ColumnVector,
+      b: ai.rapids.cudf.HostColumnVector.ColumnBuilder,
+      dataType: DataType,
+      rows: Int): Unit = {
+    dataType match {
       case NullType =>
         ColumnarCopyHelper.nullCopy(b, rows)
       case BooleanType if cv.isInstanceOf[ArrowColumnVector] =>
@@ -148,7 +154,7 @@ object HostColumnarToGpu extends Logging {
             }
         }
       case other if GpuTypeShims.isColumnarCopySupportedForType(other) =>
-        GpuTypeShims.columnarCopy(cv, b, rows)
+        GpuTypeShims.columnarCopy(cv, b, other, rows)
       case t =>
         throw new UnsupportedOperationException(
           s"Converting to GPU for $t is not currently supported")
@@ -243,7 +249,7 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     withResource(new MetricRange(copyBufTime)) { _ =>
       val rows = batch.numRows()
       for (i <- 0 until batch.numCols()) {
-        batchBuilder.copyColumnar(batch.column(i), i, schema.fields(i).nullable, rows)
+        batchBuilder.copyColumnar(batch.column(i), i, rows)
       }
       totalRows += rows
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -309,7 +309,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
           val numRows = batch.numRows()
           val gcbBuilder = new GpuColumnarBatchBuilder(structSchema, numRows)
           for (i <- 0 until batch.numCols()) {
-            gcbBuilder.copyColumnar(batch.column(i), i, structSchema(i).nullable, numRows)
+            gcbBuilder.copyColumnar(batch.column(i), i, numRows)
           }
           gcbBuilder.build(numRows)
         } else {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -201,7 +201,7 @@ class DecimalUnitTest extends GpuUnitTests {
         GpuColumnVector.getNonNestedRapidsType(cv.dataType()))
       withResource(new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)) { builder =>
         withResource(cv.copyToHost()) { hostCV =>
-          HostColumnarToGpu.columnarCopy(hostCV, builder, cv.getRowCount.toInt)
+          HostColumnarToGpu.columnarCopy(hostCV, builder, cv.dataType(), cv.getRowCount.toInt)
           withResource(builder.build()) { actual =>
             val expected = hostCV.getBase
             assertResult(expected.getType)(actual.getType)
@@ -225,7 +225,7 @@ class DecimalUnitTest extends GpuUnitTests {
         GpuColumnVector.getNonNestedRapidsType(cv.dataType()))
       withResource(new HostColumnVector.ColumnBuilder(dt, cv.getRowCount)) { builder =>
         withResource(cv.copyToHost()) { hostCV =>
-          HostColumnarToGpu.columnarCopy(hostCV, builder, cv.getRowCount.toInt)
+          HostColumnarToGpu.columnarCopy(hostCV, builder, cv.dataType(), cv.getRowCount.toInt)
           withResource(builder.build()) { actual =>
             val expected = hostCV.getBase
             assertResult(DType.create(DType.DTypeEnum.DECIMAL64, expected.getType.getScale)


### PR DESCRIPTION
This is a workaround for apache/iceberg#6116 where columns report a type that is incompatible with the underlying data type.  This changes host columnar to GPU conversions to leverage the Spark schema rather than the types reported by the columns in the ColumnarBatch instance.