### PR TITLE
Parse out positive and negative lookahead explicitly to fallback to GPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexComplexityEstimator.scala
@@ -22,9 +22,9 @@ object RegexComplexityEstimator {
     regex match {
       case RegexSequence(parts) =>
         parts.map(countStates).sum
-      case RegexGroup(true, term) =>
+      case RegexGroup(true, term, _) =>
         1 + countStates(term)
-      case RegexGroup(false, term) =>
+      case RegexGroup(false, term, _) =>
         countStates(term)
       case RegexCharacterClass(_, _) =>
         1

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -870,7 +870,7 @@ object GpuRegExpUtils {
           case QuantifierVariableLength(0, _) => true
           case _ => false
         }
-        case RegexGroup(_, term) =>
+        case RegexGroup(_, term, _) =>
           isASTEmptyRepetition(term)
         case RegexSequence(parts) =>
           parts.forall(isASTEmptyRepetition)
@@ -889,7 +889,7 @@ object GpuRegExpUtils {
   def countGroups(pattern: String): Int = {
     def countGroups(regexp: RegexAST): Int = {
       regexp match {
-        case RegexGroup(_, term) => 1 + countGroups(term)
+        case RegexGroup(_, term, _) => 1 + countGroups(term)
         case other => other.children().map(countGroups).sum
       }
    }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -72,8 +72,8 @@ class RegularExpressionParserSuite extends FunSuite {
   test("group") {
       assert(parse("(a)(b)") ===
         RegexSequence(ListBuffer(
-          RegexGroup(capture = true, RegexSequence(ListBuffer(RegexChar('a')))),
-          RegexGroup(capture = true, RegexSequence(ListBuffer(RegexChar('b')))))))
+          RegexGroup(capture = true, RegexSequence(ListBuffer(RegexChar('a'))), None),
+          RegexGroup(capture = true, RegexSequence(ListBuffer(RegexChar('b'))), None))))
   }
 
   test("character class") {
@@ -123,7 +123,7 @@ class RegularExpressionParserSuite extends FunSuite {
                 RegexCharacterRange(RegexChar('A'), RegexChar('Z')))),
               SimpleQuantifier('+')
             )
-          ))
+          )), None
         ),
         RegexEscaped(']')
       ))
@@ -167,13 +167,13 @@ class RegularExpressionParserSuite extends FunSuite {
     assert(parse("(3?)+") ===
       RegexSequence(ListBuffer(RegexRepetition(RegexGroup(capture = true, 
           RegexSequence(ListBuffer(RegexRepetition(RegexChar('3'), 
-          SimpleQuantifier('?'))))),SimpleQuantifier('+')))))
+          SimpleQuantifier('?')))), None),SimpleQuantifier('+')))))
   }
 
   test("repetition with group containing escape character") {
     assert(parse(raw"(\A)+") ===
       RegexSequence(ListBuffer(RegexRepetition(RegexGroup(capture = true,
-          RegexSequence(ListBuffer(RegexEscaped('A')))),
+          RegexSequence(ListBuffer(RegexEscaped('A'))), None),
           SimpleQuantifier('+'))))
     )
   }
@@ -182,7 +182,7 @@ class RegularExpressionParserSuite extends FunSuite {
     assert(parse("(\t+|a)") == RegexSequence(ListBuffer(
       RegexGroup(capture = true, RegexChoice(RegexSequence(ListBuffer(
         RegexRepetition(RegexChar('\t'),SimpleQuantifier('+')))),
-        RegexSequence(ListBuffer(RegexChar('a'))))))))
+        RegexSequence(ListBuffer(RegexChar('a')))), None))))
   }
 
   test("group containing quantifier") {
@@ -193,7 +193,7 @@ class RegularExpressionParserSuite extends FunSuite {
 
     assert(parse("(?:a?)") === RegexSequence(ListBuffer(
       RegexGroup(capture = false, RegexSequence(ListBuffer(
-        RegexRepetition(RegexChar('a'), SimpleQuantifier('?'))))))))
+        RegexRepetition(RegexChar('a'), SimpleQuantifier('?')))), None))))
   }
 
   test("complex expression") {
@@ -225,7 +225,7 @@ class RegularExpressionParserSuite extends FunSuite {
               RegexGroup(capture = true, RegexSequence(ListBuffer(
                 RegexRepetition(RegexCharacterClass(negated = false, ListBuffer(
                   RegexCharacterRange(RegexChar('0'), RegexChar('9')))), 
-                SimpleQuantifier('+'))))))),
+                SimpleQuantifier('+')))), None))),
               RegexChoice(RegexSequence(ListBuffer(
                 RegexGroup(capture = true, RegexSequence(ListBuffer(
                   RegexRepetition(
@@ -235,7 +235,7 @@ class RegularExpressionParserSuite extends FunSuite {
                 RegexRepetition(
                     RegexCharacterClass(negated = false, ListBuffer(
                       RegexCharacterRange(RegexChar('0'), RegexChar('9')))),
-                    SimpleQuantifier('+'))))))), RegexSequence(ListBuffer(
+                    SimpleQuantifier('+')))), None))), RegexSequence(ListBuffer(
                 RegexGroup(capture = true, RegexSequence(ListBuffer(
                 RegexRepetition(
                     RegexCharacterClass(negated = false, ListBuffer(
@@ -243,7 +243,7 @@ class RegularExpressionParserSuite extends FunSuite {
                     SimpleQuantifier('+')), RegexEscaped('.'),
                 RegexRepetition(RegexCharacterClass(negated = false,
                     ListBuffer(RegexCharacterRange(RegexChar('0'), RegexChar('9')))),
-                    SimpleQuantifier('*')))))))))),
+                    SimpleQuantifier('*')))), None))))), None),
                   RegexRepetition(
               RegexGroup(capture = true, RegexSequence(ListBuffer(
                 RegexCharacterClass(negated = false, ListBuffer(RegexChar('e'), RegexChar('E'))),
@@ -251,10 +251,10 @@ class RegularExpressionParserSuite extends FunSuite {
                     ListBuffer(RegexChar('+'), RegexEscaped('-'))),SimpleQuantifier('?')),
                   RegexRepetition(RegexCharacterClass(negated = false,
                   ListBuffer(RegexCharacterRange(RegexChar('0'), RegexChar('9')))),
-                  SimpleQuantifier('+'))))), SimpleQuantifier('?')),
+                  SimpleQuantifier('+')))), None), SimpleQuantifier('?')),
             RegexRepetition(RegexCharacterClass(negated = false, ListBuffer(
               RegexChar('f'), RegexChar('F'), RegexChar('d'), RegexChar('D'))),
-              SimpleQuantifier('?'))))))),
+              SimpleQuantifier('?')))), None))),
           RegexChoice(RegexSequence(ListBuffer(
             RegexChar('I'), RegexChar('n'), RegexChar('f'))),
             RegexSequence(ListBuffer(
@@ -263,7 +263,7 @@ class RegularExpressionParserSuite extends FunSuite {
               RegexCharacterClass(negated = false,
                 ListBuffer(RegexChar('a'), RegexChar('A'))),
               RegexCharacterClass(negated = false,
-                ListBuffer(RegexChar('n'), RegexChar('N')))))))),
+                ListBuffer(RegexChar('n'), RegexChar('N'))))))), None),
     RegexChar('$'))))
   }
   

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -144,6 +144,20 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     )
   }
 
+  test("cuDF does not support positive or negative lookahead") {
+    val negPatterns = Seq("a(!b)", "a(!b)c?")
+    negPatterns.foreach(pattern =>
+      assertUnsupported(pattern, RegexFindMode,
+        "Negative lookahead groups are not supported")
+    )
+
+    val posPatterns = Seq("a(=b)", "a(=b)c?")
+    posPatterns.foreach(pattern =>
+      assertUnsupported(pattern, RegexFindMode,
+        "Positive lookahead groups are not supported")
+    )
+  }
+
   test("cuDF does not support empty sequence") {
     val patterns = Seq("", "a|", "()")
     patterns.foreach(pattern =>
@@ -1144,7 +1158,7 @@ class FuzzRegExp(suggestedChars: String, skipKnownIssues: Boolean = true,
   }
 
   private def group(depth: Int) = {
-    RegexGroup(capture = rr.nextBoolean(), generate(depth + 1))
+    RegexGroup(capture = rr.nextBoolean(), generate(depth + 1), None)
   }
 
   private def repetition(depth: Int) = {


### PR DESCRIPTION
In order to fallback properly to CPU for negative and positive lookahead, we still need to parse negative and positive lookahead in the regex parser and throw the appropriate unsupported exception. This PR adds support for that in RegexGroup.

Signed-off-by: Navin Kumar <navink@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
