### PR TITLE
Spark-3.4 - Fix cast unit tests

### DIFF
--- a/sql-plugin/src/main/311until340-all/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
+++ b/sql-plugin/src/main/311until340-all/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
@@ -26,14 +26,6 @@ object CastingConfigShim {
     case _ => e
   }
 
-  def ansiEnabled(e: Expression): Boolean = {
-      // prior to Spark 3.4.0 we could use CastBase as argument type, but starting 3.4.0 the type is
-      // the case class Cast.
-      // prior to Spark 3.3.0 we could use toString to see if the name of
-      // the cast was "cast" or "ansi_cast" but now the name is always "cast"
-      // so we need to use reflection to access the protected field "ansiEnabled"
-      val m = e.getClass.getDeclaredField("ansiEnabled")
-      m.setAccessible(true)
-      m.getBoolean(e)
-  }
+  // Before 340 ansiEnabled is private, so return false
+  def publicAnsiEnabled(e: Expression): Boolean = false
 }

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
@@ -27,7 +27,5 @@ object CastingConfigShim {
   }
 
   // Use public member of Cast class rather than reflection
-  def ansiEnabled(e: Expression): Boolean = {
-    e.asInstanceOf[Cast].ansiEnabled
-  }
+  def publicAnsiEnabled(e: Expression): Boolean = e.asInstanceOf[Cast].ansiEnabled
 }

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
@@ -16,13 +16,18 @@
 
 package com.nvidia.spark.rapids.shims
 
-import org.apache.spark.sql.catalyst.expressions.{CastBase, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
 
-object CastIgnoreTimeZoneShim {
+object CastingConfigShim {
   /** Remove TimeZoneId for Cast if needsTimeZone return false. */
   def ignoreTimeZone(e: Expression): Expression = e match {
-    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
+    case c: Cast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
       c.withTimeZone(null)
     case _ => e
+  }
+
+  // Use public member of Cast class rather than reflection
+  def ansiEnabled(e: Expression): Boolean = {
+    e.asInstanceOf[Cast].ansiEnabled
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCanonicalize.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import com.nvidia.spark.rapids.shims.CastIgnoreTimeZoneShim
+import com.nvidia.spark.rapids.shims.CastingConfigShim
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.rapids._
@@ -59,7 +59,7 @@ object GpuCanonicalize {
   def ignoreTimeZoneInCast(e: Expression): Expression = e match {
     case c: GpuCast if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
       c.withTimeZone(null)
-    case _ => CastIgnoreTimeZoneShim.ignoreTimeZone(e)
+    case _ => CastingConfigShim.ignoreTimeZone(e)
   }
 
   /** Collects adjacent commutative operations. */

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -21,7 +21,7 @@ import java.time.DateTimeException
 
 import scala.util.Random
 
-import com.nvidia.spark.rapids.shims.{SparkShimImpl, CastingConfigShim}
+import com.nvidia.spark.rapids.shims.{CastingConfigShim, SparkShimImpl}
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -25,7 +25,7 @@ import com.nvidia.spark.rapids.shims.SparkShimImpl
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
@@ -833,14 +833,18 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
     }
 
     def isAnsiCast(c: Expression): Boolean = {
+      // prior to Spark 3.4.0 we could use CastBase as argument type, but starting 3.4.0 the type is
+      // the case class Cast.
+      // prior to Spark 3.3.0 we could use toString to see if the name of
+      // the cast was "cast" or "ansi_cast" but now the name is always "cast"
+      // so we need to use reflection to access the protected field "ansiEnabled"
       if (cmpSparkVersion(3, 4, 0) < 0) {
-        // prior to Spark 3.4.0 ansiEnabled is protected, so we need to use
-        // reflection to access the protected field "ansiEnabled"
         val m = c.getClass.getDeclaredField("ansiEnabled")
         m.setAccessible(true)
         m.getBoolean(c)
       } else {
-        c.asInstanceOf[Cast].ansiEnabled
+        val m = c.getClass.getField("ansiEnabled")
+        m.getBoolean(c)
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Ryan Lee <ryanlee@nvidia.com>

Resolves #7026

Fixes multiple`java.lang.NoSuchFieldException: ansiEnabled` unit test errors caused by reflection. Before 340 it will continue to use reflection and going forward use the now public `ansiEnabled` field.