### PR TITLE
Fix a substring issue for a corner case

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -329,12 +329,21 @@ def test_substring():
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'SUBSTRING(a, 1, 5)',
+                'SUBSTRING(a, 5, 2147483647)',
+                'SUBSTRING(a, 5, -2147483648)',
                 'SUBSTRING(a, 1)',
                 'SUBSTRING(a, -3)',
                 'SUBSTRING(a, 3, -2)',
                 'SUBSTRING(a, 100)',
+                'SUBSTRING(a, -100)',
                 'SUBSTRING(a, NULL)',
                 'SUBSTRING(a, 1, NULL)',
+                'SUBSTRING(a, -5, 0)',
+                'SUBSTRING(a, -5, 4)',
+                'SUBSTRING(a, 10, 0)',
+                'SUBSTRING(a, -50, 10)',
+                'SUBSTRING(a, -10, -1)',
+                'SUBSTRING(a, 0, 10)',
                 'SUBSTRING(a, 0, 0)'))
 
 def test_repeat_scalar_and_column():


### PR DESCRIPTION
This fixes an issue that when `pos + len < 0 && len >= 0`, GPU substring returns different strings than CPU.

closes https://github.com/NVIDIA/spark-rapids/issues/7033

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
