### PR TITLE
Fix parquet test for nztimestamp on spark 3.4.0

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -2047,6 +2047,11 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
   def assumeSpark330orLater: Assertion =
     assume(isSpark330OrLater, "Spark version not 3.3.0+")
 
+  lazy val isSpark340OrLater: Boolean = cmpSparkVersion(3, 4, 0) >= 0
+
+  def assumeSpark340orLater: Assertion =
+    assume(isSpark340OrLater, "Spark version not 3.4.0+")
+
   def cmpSparkVersion(major: Int, minor: Int, bugfix: Int): Int = {
     val sparkShimVersion = SparkShimImpl.getSparkShimVersion
     val (sparkMajor, sparkMinor, sparkBugfix) = sparkShimVersion match {


### PR DESCRIPTION
This fixes #7039 