### PR TITLE
Enable tiered projections for GpuProjectExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -757,7 +757,7 @@ object RapidsConf {
       .createWithDefault(false)
 
   val ENABLE_TIERED_PROJECT = conf("spark.rapids.sql.tiered.project.enabled")
-      .doc("Enable tiered project for aggregations.")
+      .doc("Enable tiered projections.")
       .internal()
       .booleanConf
       .createWithDefault(true)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -355,15 +355,12 @@ case class GpuProjectAstExec(
   }
 
   def tieredProjectAndClose(cb: ColumnarBatch, opTime: GpuMetric): ColumnarBatch = {
-    val nvtxRange = new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)
-    try {
-      tieredProject(cb)
-    } finally {
-      cb.close()
-      nvtxRange.close()
+    withResource(cb) { cb =>
+      withResource(new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)) { _ =>
+        tieredProject(cb)
+      }
     }
   }
-
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -61,7 +61,7 @@ class GpuProjectExecMeta(
         }
       }
     }
-    GpuProjectExec(gpuExprs, gpuChild)
+    GpuProjectExec(gpuExprs, gpuChild, conf.isTieredProjectEnabled)
   }
 }
 
@@ -128,7 +128,8 @@ case class GpuProjectExec(
    // serde: https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/
    //   immutable/List.scala#L516
    projectList: List[NamedExpression],
-   child: SparkPlan
+   child: SparkPlan,
+   useTieredProject : Boolean = false
  ) extends ShimUnaryExecNode with GpuExec {
 
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
@@ -147,12 +148,20 @@ case class GpuProjectExec(
     val numOutputRows = gpuLongMetric(NUM_OUTPUT_ROWS)
     val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
     val opTime = gpuLongMetric(OP_TIME)
-    val boundProjectList = GpuBindReferences.bindGpuReferences(projectList, child.output)
+    val (boundProjectList, boundProjectListTiered) = if (useTieredProject) {
+      (None, Some(GpuBindReferences.bindGpuReferencesTiered(projectList, child.output)))
+    } else {
+      (Some(GpuBindReferences.bindGpuReferences(projectList, child.output)), None)
+    }
     val rdd = child.executeColumnar()
     rdd.map { cb =>
       numOutputBatches += 1
       numOutputRows += cb.numRows()
-      GpuProjectExec.projectAndClose(cb, boundProjectList, opTime)
+      if (useTieredProject) {
+        boundProjectListTiered.get.tieredProjectAndClose(cb, opTime)
+      } else {
+        GpuProjectExec.projectAndClose(cb, boundProjectList.get, opTime)
+      }
     }
   }
 
@@ -344,6 +353,17 @@ case class GpuProjectAstExec(
     // Process tiers sequentially
     recurse(exprTiers, inputAttrTiers, batch, true)
   }
+
+  def tieredProjectAndClose(cb: ColumnarBatch, opTime: GpuMetric): ColumnarBatch = {
+    val nvtxRange = new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)
+    try {
+      tieredProject(cb)
+    } finally {
+      cb.close()
+      nvtxRange.close()
+    }
+  }
+
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Change `GpuProjectExec` to use tiered projections if `spark.rapids.sql.tiered.project.enabled=true`, which is the default setting.

In testing with NDS2 power run, there was no measurable performance improvement or degradation with this change.   But it is possible that some real-world queries may benefit, and this will also help to shake out any issues with tiered projections.

During the NDS2 power run at scale 100, I observed 21874 invocations of GpuProjectExec, of which only 43 resulted in more than one tier.  A projection with one tier is equivalent to just doing a normal non-tiered projection.
I also validated that the output was correct for the power run.
