### PR TITLE
[Doc]update a typo for iceberg readme[skip ci]

### DIFF
--- a/docs/additional-functionality/iceberg-support.md
+++ b/docs/additional-functionality/iceberg-support.md
@@ -60,7 +60,7 @@ The RAPIDS Accelerator does not support Apache Iceberg tables using the Avro dat
 ### Reader Split Size
 
 The maximum number of bytes to pack into a single partition when reading files on Spark is normally
-controlled by the config `spark.files.maxPartitionBytes`. But on Iceberg that doesn't apply.
+controlled by the config `spark.sql.files.maxPartitionBytes`. But on Iceberg that doesn't apply.
 Iceberg has its own configs to control the split size. See the read options in the
  [Iceberg Runtime Configuration](https://iceberg.apache.org/docs/latest/spark-configuration/#runtime-configuration)
 documentation for details. One example is to use the `split-size` reader option like:


### PR DESCRIPTION
Signed-off-by: liyuan <yuali@nvidia.com>
update a typo for iceberg readme as [comment](https://github.com/NVIDIA/spark-rapids/pull/6737#issuecomment-1283928994)

