### PR TITLE
Init version 23.02.0 [databricks]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ To this end in a pre-production build you can set the Boolean property
 
 The time saved is more significant if you are merely changing
 the `aggregator` module, or the `dist` module, or just incorporating changes from
-[spark-rapids-jni](https://github.com/NVIDIA/spark-rapids-jni/blob/branch-22.12/CONTRIBUTING.md#local-testing-of-cross-repo-contributions-cudf-spark-rapids-jni-and-spark-rapids)
+[spark-rapids-jni](https://github.com/NVIDIA/spark-rapids-jni/blob/branch-23.02/CONTRIBUTING.md#local-testing-of-cross-repo-contributions-cudf-spark-rapids-jni-and-spark-rapids)
 
 For example, to quickly repackage `rapids-4-spark` after the
 initial `./build/buildall` you can iterate by invoking

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ as a `provided` dependency.
 <dependency>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark_2.12</artifactId>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-aggregator_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Aggregator</name>
     <description>Creates an aggregated shaded package of the RAPIDS plugin for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <properties>
         <!--

--- a/api_validation/pom.xml
+++ b/api_validation/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-api-validation</artifactId>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <profiles>
        <profile>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,13 +24,13 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rapids-4-spark-common_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Common</name>
     <description>Utility code that is common across the RAPIDS Accelerator projects</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Distribution</name>
     <description>Creates the distribution package of the RAPIDS plugin for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -410,7 +410,7 @@ There are multiple reasons why this a problematic configuration:
 
 Yes, but it requires support from the underlying cluster manager to isolate the MIG GPU instance
 for each executor (e.g.: by setting `CUDA_VISIBLE_DEVICES`,
-[YARN with docker isolation](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/MIG-Support)
+[YARN with docker isolation](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/MIG-Support)
 or other means).
 
 Note that MIG is not recommended for use with the RAPIDS Accelerator since it significantly

--- a/docs/additional-functionality/ml-integration.md
+++ b/docs/additional-functionality/ml-integration.md
@@ -40,7 +40,7 @@ access to any of the memory that RMM is holding.
 ## Spark ML Algorithms Supported by RAPIDS Accelerator
 
 The [spark-rapids-examples repository](https://github.com/NVIDIA/spark-rapids-examples) provides a
-[working example](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/ML+DL-Examples/Spark-cuML/pca)
+[working example](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/ML+DL-Examples/Spark-cuML/pca)
 of accelerating the `transform` API for
 [Principal Component Analysis (PCA)](https://spark.apache.org/docs/latest/mllib-dimensionality-reduction#principal-component-analysis-pca).
 The example leverages the [RAPIDS accelerated UDF interface](rapids-udfs.md) to provide a native

--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -135,7 +135,7 @@ type `DECIMAL64(scale=-2)`.
 ## RAPIDS Accelerated UDF Examples
 
 <!-- Note: should update the branch name to tag when releasing-->
-Source code for examples of RAPIDS accelerated UDFs is provided in the [udf-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/UDF-Examples/RAPIDS-accelerated-UDFs) project.
+Source code for examples of RAPIDS accelerated UDFs is provided in the [udf-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/UDF-Examples/RAPIDS-accelerated-UDFs) project.
 
 ## GPU Support for Pandas UDF
 

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -10,7 +10,7 @@ The following is the list of options that `rapids-plugin-4-spark` supports.
 On startup use: `--conf [conf key]=[conf value]`. For example:
 
 ```
-${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar \
+${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar \
 --conf spark.plugins=com.nvidia.spark.SQLPlugin \
 --conf spark.rapids.sql.concurrentGpuTasks=2
 ```

--- a/docs/demo/AWS-EMR/Mortgage-ETL-GPU-EMR.ipynb
+++ b/docs/demo/AWS-EMR/Mortgage-ETL-GPU-EMR.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "## Data Source\n",
     "\n",
-    "Dataset is from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html). Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset from the Fannie Mae website.\n",
+    "Dataset is from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html). Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset from the Fannie Mae website.\n",
     "\n",
     "## Prerequisite\n",
     "\n",

--- a/docs/demo/Databricks/Mortgage-ETL-db.ipynb
+++ b/docs/demo/Databricks/Mortgage-ETL-db.ipynb
@@ -12,7 +12,7 @@
    },
    "source": [
     "## Prerequirement\n",
-    "Dataset is derived from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html) with all rights reserved by Fannie Mae. Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset."
+    "Dataset is derived from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html) with all rights reserved by Fannie Mae. Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset."
    ]
   },
   {

--- a/docs/dev/shims.md
+++ b/docs/dev/shims.md
@@ -68,17 +68,17 @@ Using JarURLConnection URLs we create a Parallel World of the current version wi
 Spark 3.0.2's URLs:
 
 ```text
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark3xx-common/
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark302/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark3xx-common/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark302/
 ```
 
 Spark 3.2.0's URLs :
 
 ```text
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark3xx-common/
-jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark320/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark3xx-common/
+jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark320/
 ```
 
 ### Late Inheritance in Public Classes

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -158,7 +158,7 @@ cluster.
 
 ## Import the GPU Mortgage Example Notebook
 Import the example [notebook](../demo/Databricks/Mortgage-ETL-db.ipynb) from the repo into your
-workspace, then open the notebook. Please find this [instruction](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md)
+workspace, then open the notebook. Please find this [instruction](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples/dataset/mortgage.md)
 to download the dataset.
 
 ```bash

--- a/docs/get-started/getting-started-gcp.md
+++ b/docs/get-started/getting-started-gcp.md
@@ -360,7 +360,7 @@ Jupyter link. Download the sample [Mortgage ETL on GPU Jupyter
 Notebook](../demo/GCP/Mortgage-ETL.ipynb) and upload it to Jupyter.
 
 To get example data for the sample notebook, please refer to these
-[instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples/dataset/mortgage.md).
+[instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples/dataset/mortgage.md).
 Download the desired data, decompress it, and upload the csv files to a GCS bucket.
 
 ![Dataproc Web Interfaces](../img/GCP/dataproc-service.png)
@@ -379,7 +379,7 @@ Once the data is prepared, we use the [Mortgage XGBoost4j Scala
 Notebook](../demo/GCP/mortgage-xgboost4j-gpu-scala.ipynb) in Dataproc's jupyter notebook to execute
 the training job on GPUs. Scala based XGBoost examples use [DLMC
 XGBoost](https://github.com/dmlc/xgboost). For a PySpark based XGBoost example, please refer to
-[Spark-RAPIDS-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12) that use
+[Spark-RAPIDS-examples](https://github.com/NVIDIA/spark-rapids-examples/tree/main) that use
 [NVIDIA’s Spark XGBoost](https://repo1.maven.org/maven2/com/nvidia/xgboost4j-spark_3.0/1.4.2-0.3.0/).
 Precompiled [XGBoost4j](https://repo1.maven.org/maven2/ml/dmlc/xgboost4j-gpu_2.12/) and [XGBoost4j
 Spark](https://repo1.maven.org/maven2/ml/dmlc/xgboost4j-gpu_2.12/) libraries are available on
@@ -400,12 +400,12 @@ val (xgbClassificationModel, _) = benchmark("train") {
 ## Submit Spark jobs to a Dataproc Cluster Accelerated by GPUs
 Similar to spark-submit for on-prem clusters, Dataproc supports submitting Spark applications to
 Dataproc clusters.  The previous mortgage examples are also available as a [spark
-application](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/XGBoost-Examples).
+application](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/XGBoost-Examples).
 
 Follow these
-[instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples/building-sample-apps/scala.md)
+[instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples/building-sample-apps/scala.md)
 to Build the
-[xgboost-example](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples)
+[xgboost-example](https://github.com/NVIDIA/spark-rapids-examples/blob/main/docs/get-started/xgboost-examples)
 jars. Upload the `sample_xgboost_apps-${VERSION}-SNAPSHOT-jar-with-dependencies.jar` to a GCS
 bucket by dragging and dropping the jar file from your local machine into the GCS web console or by running:
 ```

--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -53,13 +53,13 @@ CUDA and will not run on other versions. The jars use a classifier to keep them 
 - CUDA 11.x => classifier cuda11
 
 For example, here is a sample version of the jar with CUDA 11.x support:
-- rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar
+- rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar
 
 For simplicity export the location to this jar. This example assumes the sample jar above has
 been placed in the `/opt/sparkRapidsPlugin` directory:
 ```shell 
 export SPARK_RAPIDS_DIR=/opt/sparkRapidsPlugin
-export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_DIR}/rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar
+export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_DIR}/rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar
 ```
 
 ## Install the GPU Discovery Script
@@ -299,7 +299,7 @@ are using.
 #### YARN version 3.3.0+
 YARN version 3.3.0 and newer support a pluggable device framework which allows adding support for
 MIG devices via a plugin. See
-[NVIDIA GPU Plugin for YARN with MIG support for YARN 3.3.0+](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/MIG-Support/device-plugins/gpu-mig).
+[NVIDIA GPU Plugin for YARN with MIG support for YARN 3.3.0+](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/MIG-Support/device-plugins/gpu-mig).
 If you are using that plugin with a Spark version older than 3.2.1 and/or specifying the resource
 as `nvidia/miggpu` you will also need to specify the config:
 
@@ -316,7 +316,7 @@ required.
 If you are using YARN version from 3.1.2 up until 3.3.0, it requires making modifications to YARN
 and deploying a version that adds support for MIG to the built-in YARN GPU resource plugin.
 
-See [NVIDIA Support for GPU for YARN with MIG support for YARN 3.1.2 until YARN 3.3.0](https://github.com/NVIDIA/spark-rapids-examples/tree/branch-22.12/examples/MIG-Support/resource-types/gpu-mig)
+See [NVIDIA Support for GPU for YARN with MIG support for YARN 3.1.2 until YARN 3.3.0](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples/MIG-Support/resource-types/gpu-mig)
 for details.
 
 ## Running on Kubernetes

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -255,7 +255,7 @@ individually, so you don't risk running unit tests along with the integration te
 http://www.scalatest.org/user_guide/using_the_scalatest_shell
 
 ```shell
-spark-shell --jars rapids-4-spark-tests_2.12-22.12.0-SNAPSHOT-tests.jar,rapids-4-spark-integration-tests_2.12-22.12.0-SNAPSHOT-tests.jar,scalatest_2.12-3.0.5.jar,scalactic_2.12-3.0.5.jar
+spark-shell --jars rapids-4-spark-tests_2.12-23.02.0-SNAPSHOT-tests.jar,rapids-4-spark-integration-tests_2.12-23.02.0-SNAPSHOT-tests.jar,scalatest_2.12-3.0.5.jar,scalactic_2.12-3.0.5.jar
 ```
 
 First you import the `scalatest_shell` and tell the tests where they can find the test files you
@@ -278,7 +278,7 @@ If you just want to verify the SQL replacement is working you will need to add t
 assumes CUDA 11.0 is being used.
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar" ./runtests.py
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar" ./runtests.py
 ```
 
 You don't have to enable the plugin for this to work, the test framework will do that for you.
@@ -377,7 +377,7 @@ To run cudf_udf tests, need following configuration changes:
 As an example, here is the `spark-submit` command with the cudf_udf parameter on CUDA 11.0:
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar,rapids-4-spark-tests_2.12-22.12.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar" ./runtests.py --cudf_udf
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar,rapids-4-spark-tests_2.12-23.02.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar" ./runtests.py --cudf_udf
 ```
 
 ### Enabling fuzz tests

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-integration-tests_2.12</artifactId>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
     <properties>
         <target.classifier/>
     </properties>

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -27,7 +27,7 @@ def main():
   workspace = 'https://dbc-9ff9942e-a9c4.cloud.databricks.com'
   token = ''
   sshkey = ''
-  cluster_name = 'CI-GPU-databricks-22.12.0-SNAPSHOT'
+  cluster_name = 'CI-GPU-databricks-23.02.0-SNAPSHOT'
   idletime = 240
   runtime = '7.0.x-gpu-ml-scala2.12'
   num_workers = 1

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -18,7 +18,7 @@
 # The initscript to set up environment for the cudf_udf tests on Databricks
 # Will be automatically pushed into the dbfs:/databricks/init_scripts once it is updated.
 
-CUDF_VER=${CUDF_VER:-22.12}
+CUDF_VER=${CUDF_VER:-22.12} # TODO: update to 23.02 when available
 
 # Need to explictly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -26,10 +26,10 @@ for VAR in $OVERWRITE_PARAMS; do
 done
 IFS=$PRE_IFS
 
-CUDF_VER=${CUDF_VER:-"22.12.0-SNAPSHOT"}
+CUDF_VER=${CUDF_VER:-"22.12.0-SNAPSHOT"} # TODO: update to 23.02.0-SNAPSHOT when available
 CUDA_CLASSIFIER=${CUDA_CLASSIFIER:-"cuda11"}
-PROJECT_VER=${PROJECT_VER:-"22.12.0-SNAPSHOT"}
-PROJECT_TEST_VER=${PROJECT_TEST_VER:-"22.12.0-SNAPSHOT"}
+PROJECT_VER=${PROJECT_VER:-"23.02.0-SNAPSHOT"}
+PROJECT_TEST_VER=${PROJECT_TEST_VER:-"23.02.0-SNAPSHOT"}
 SPARK_VER=${SPARK_VER:-"3.1.1"}
 # Make a best attempt to set the default value for the shuffle shim.
 # Note that SPARK_VER for non-Apache Spark flavors (i.e. databricks,

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>rapids-4-spark-parent</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Root Project</name>
     <description>The root project of the RAPIDS Accelerator for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>https://nvidia.github.io/spark-rapids/</url>
@@ -596,6 +596,7 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
+        <!--TODO: update to 23.02.0-SNAPSHOT when available-->
         <spark-rapids-jni.version>22.12.0-SNAPSHOT</spark-rapids-jni.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rapids-4-spark-shuffle_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Shuffle Plugin</name>
     <description>Accelerated shuffle plugin for the RAPIDS plugin for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/spark2-sql-plugin/pom.xml
+++ b/spark2-sql-plugin/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-sql-meta_2.11</artifactId>
     <name>RAPIDS Accelerator for Apache Spark SQL Plugin Base Meta</name>
     <description>The RAPIDS SQL plugin for Apache Spark Base Meta Information</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <properties>
         <scala.binary.version>2.11</scala.binary.version>

--- a/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/spark2-sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1633,7 +1633,7 @@ object RapidsConf {
         |On startup use: `--conf [conf key]=[conf value]`. For example:
         |
         |```
-        |$SPARK_HOME/bin/spark-shell --jars rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar \
+        |$SPARK_HOME/bin/spark-shell --jars rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar \
         |--conf spark.plugins=com.nvidia.spark.SQLPlugin \
         |--conf spark.rapids.sql.concurrentGpuTasks=2
         |```

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-sql_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark SQL Plugin</name>
     <description>The RAPIDS SQL plugin for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1707,7 +1707,7 @@ object RapidsConf {
         |On startup use: `--conf [conf key]=[conf value]`. For example:
         |
         |```
-        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-22.12.0-SNAPSHOT-cuda11.jar \
+        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.02.0-SNAPSHOT-cuda11.jar \
         |--conf spark.plugins=com.nvidia.spark.SQLPlugin \
         |--conf spark.rapids.sql.concurrentGpuTasks=2
         |```

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -56,13 +56,13 @@ import org.apache.spark.util.MutableURLClassLoader
 
     E.g., Spark 3.2.0 Shim will use
 
-    jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark3xx-common/
-    jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark320/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark3xx-common/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark320/
 
     Spark 3.1.1 will use
 
-    jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark3xx-common/
-    jar:file:/home/spark/rapids-4-spark_2.12-22.12.0.jar!/spark311/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark3xx-common/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.02.0.jar!/spark311/
 
     Using these Jar URL's allows referencing different bytecode produced from identical sources
     by incompatible Scala / Spark dependencies.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-tests_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Tests</name>
     <description>RAPIDS plugin for Apache Spark integration tests</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark-tools_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark tools</name>
     <description>RAPIDS Accelerator for Apache Spark tools</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>22.12.0-SNAPSHOT</version>
+        <version>23.02.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-udf_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Scala UDF Plugin</name>
     <description>The RAPIDS Scala UDF plugin for Apache Spark</description>
-    <version>22.12.0-SNAPSHOT</version>
+    <version>23.02.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Update version to 23.02.0-SNAPSHOT,
Also update example repo URL to target default main branch

NOTE: 
23.02 cudf is not ready yet, so we let JNI and cudf-py dependency version stay at 22.12 for now https://github.com/NVIDIA/spark-rapids/issues/7064