### PR TITLE
Update the tests in `array_test.py` to adapt the removal of `strictIndexOperator` in Spark 3.4

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect
 from data_gen import *
 from marks import incompat
-from spark_session import is_before_spark_313, is_before_spark_330, is_spark_330_or_later, is_databricks104_or_later
+from spark_session import is_before_spark_313, is_before_spark_330, is_spark_330_or_later, is_databricks104_or_later, is_spark_340_or_later
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
 from pyspark.sql.functions import array_contains, col, element_at, lit
@@ -103,7 +103,7 @@ def test_array_item(data_gen):
 
 
 # No need to test this for multiple data types for array. Only one is enough
-@pytest.mark.skipif(is_before_spark_330(), reason="'strictIndexOperator' is introduced from Spark 3.3.0")
+@pytest.mark.skipif(is_before_spark_330() or is_spark_340_or_later(), reason="'strictIndexOperator' is introduced from Spark 3.3.0 and removed in Spark 3.4.0")
 @pytest.mark.parametrize('strict_index_enabled', [True, False])
 @pytest.mark.parametrize('index', [-2, 100, array_neg_index_gen, array_out_index_gen], ids=idfn)
 def test_array_item_with_strict_index(strict_index_enabled, index):
@@ -126,13 +126,12 @@ def test_array_item_with_strict_index(strict_index_enabled, index):
             test_df,
             conf=test_conf)
 
-
 # No need to test this for multiple data types for array. Only one is enough, but with two kinds of invalid index.
-@pytest.mark.skipif(not is_before_spark_330(),
-                    reason="Only in Spark [3.1.1, 3.3.0) with ANSI mode, it throws exceptions for invalid index")
+@pytest.mark.skipif(not (is_before_spark_330() or is_spark_340_or_later()),
+                    reason="In Spark [3.1.1, 3.3.0) U [3.4.0, +inf)  with ANSI mode, it throws exceptions for invalid index")
 @pytest.mark.parametrize('index', [-2, 100, array_neg_index_gen, array_out_index_gen], ids=idfn)
 def test_array_item_ansi_fail_invalid_index(index):
-    message = "SparkArrayIndexOutOfBoundsException" if is_databricks104_or_later() else "java.lang.ArrayIndexOutOfBoundsException"
+    message = "SparkArrayIndexOutOfBoundsException" if (is_databricks104_or_later() or is_spark_340_or_later()) else "java.lang.ArrayIndexOutOfBoundsException"
     if isinstance(index, int):
         test_func = lambda spark: unary_op_df(spark, ArrayGen(int_gen)).select(col('a')[index]).collect()
     else:
@@ -243,7 +242,8 @@ def test_array_element_at_ansi_fail_invalid_index(index):
         test_func = lambda spark: two_col_df(spark, ArrayGen(int_gen), index).selectExpr(
             'element_at(a, b)').collect()
     # For 3.3.0+ strictIndexOperator should not affect element_at
-    test_conf=copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': 'false'})
+    # Since 3.4.0, strictIndexOperator has been removed.
+    test_conf=copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': 'false'}) if is_before_spark_340() else ansi_enabled_conf
     assert_gpu_and_cpu_error(
         test_func,
         conf=test_conf,

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -127,11 +127,9 @@ def test_array_item_with_strict_index(strict_index_enabled, index):
             conf=test_conf)
 
 # No need to test this for multiple data types for array. Only one is enough, but with two kinds of invalid index.
-@pytest.mark.skipif(not (is_before_spark_330() or is_spark_340_or_later()),
-                    reason="In Spark [3.1.1, 3.3.0) U [3.4.0, +inf)  with ANSI mode, it throws exceptions for invalid index")
 @pytest.mark.parametrize('index', [-2, 100, array_neg_index_gen, array_out_index_gen], ids=idfn)
 def test_array_item_ansi_fail_invalid_index(index):
-    message = "SparkArrayIndexOutOfBoundsException" if (is_databricks104_or_later() or is_spark_340_or_later()) else "java.lang.ArrayIndexOutOfBoundsException"
+    message = "SparkArrayIndexOutOfBoundsException" if (is_databricks104_or_later() or is_spark_330_or_later()) else "java.lang.ArrayIndexOutOfBoundsException"
     if isinstance(index, int):
         test_func = lambda spark: unary_op_df(spark, ArrayGen(int_gen)).select(col('a')[index]).collect()
     else:

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -156,6 +156,9 @@ def is_before_spark_340():
 def is_spark_330_or_later():
     return spark_version() >= "3.3.0"
 
+def is_spark_340_or_later():
+    return spark_version() >= "3.4.0"
+
 def is_spark_321cdh():
     return "3.2.1.3.2.717" in spark_version()
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Closes #7065.

## Rationales of the PR
The configuration `strictIndexOperator` has been removed in Spark3.4, and it always throws exception when accessing array element using invalid indexes in ANSI mode.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
