### PR TITLE
Fix the failure of `test_array_element_at_zero_index_fail` on Spark3.4 [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -263,7 +263,7 @@ def test_array_element_at_ansi_not_fail_all_null_data():
 @pytest.mark.parametrize('index', [0, array_zero_index_gen], ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', [False, True], ids=idfn)
 def test_array_element_at_zero_index_fail(index, ansi_enabled):
-    message = "SQL array indices start at 1"
+    message = "SQL array indices start at 1" if is_before_spark_340() else "[ELEMENT_AT_BY_INDEX_ZERO]"
     if isinstance(index, int):
         test_func = lambda spark: unary_op_df(spark, ArrayGen(int_gen)).select(
             element_at(col('a'), index)).collect()

--- a/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/311until320-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -36,7 +36,7 @@ object RapidsErrorUtils {
     new NoSuchElementException(s"Key $key does not exist.")
   }
 
-  def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
     new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
   }
 

--- a/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/31xdb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -36,7 +36,7 @@ object RapidsErrorUtils {
     new NoSuchElementException(s"Key $key does not exist.")
   }
 
-  def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
     new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
   }
 

--- a/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/320until330-nondb/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -36,7 +36,7 @@ object RapidsErrorUtils {
     new NoSuchElementException(s"Key $key does not exist.")
   }
 
-  def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
     new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
   }
 

--- a/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/321db/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -39,7 +39,7 @@ object RapidsErrorUtils {
     QueryExecutionErrors.mapKeyNotExistError(key)
   }
 
-  def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
     new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
   }
 

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
@@ -22,10 +22,6 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 
 trait RapidsErrorUtilsFor330plus {
 
-  def sqlArrayIndexNotStartAtOneError(): ArrayIndexOutOfBoundsException = {
-    new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
-  }
-
   def divByZeroError(origin: Origin): ArithmeticException = {
     QueryExecutionErrors.divideByZeroError(origin.context)
   }

--- a/sql-plugin/src/main/330until340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/330until340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -68,4 +68,8 @@ object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
     val messageParameters = Array("DOUBLE", "TIMESTAMP", SQLConf.ANSI_ENABLED.key)
     new SparkDateTimeException(errorClass, Array(infOrNan) ++ messageParameters)
   }
+
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
+    new ArrayIndexOutOfBoundsException("SQL array indices start at 1")
+  }
 }

--- a/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -74,4 +74,8 @@ object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
       "targetType" -> "TIMESTAMP", "ansiConfig" -> SQLConf.ANSI_ENABLED.key)
     new SparkDateTimeException(errorClass, messageParameters, Array.empty, "")
   }
+
+  def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
+    QueryExecutionErrors.elementAtByIndexZeroError(context = null)
+  }
 }


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Closes #7066.

## Changes in the PR
Add `sqlArrayIndexNotStartAtOneError()` in the `RapidsErrorUitls` of Spark 3.4, which is a wrapper of the function `ElementAtByIndexZeroError`. 
Undate the return type of `sqlArrayIndexNotStartAtOneError` to be `RuntimeException`, so that we can unify the return type of `ElementAtByIndexZeroError`.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
