### PR TITLE
Fix ConditionalExpr parser in Qualification tool

### DIFF
--- a/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
+++ b/tools/src/main/scala/com/nvidia/spark/rapids/tool/planparser/SQLPlanParser.scala
@@ -587,72 +587,89 @@ object SQLPlanParser extends Logging {
     parseConditionalExpressions(exprStr)
   }
 
+  // The scope is to extract expressions from a conditional expression.
+  // Ideally, parsing conditional expressions needs to build a tree. The current implementation is
+  // a simplified version that does not accurately pickup the LHS and RHS of each predicate.
+  // Instead, it extracts function names, and expressions in best effort.
   def parseConditionalExpressions(exprStr: String): Array[String] = {
+    // Captures any word followed by '('
+    // isnotnull(, StringEndsWith(
+    val functionsRegEx = """((\w+))\(""".r
+    // Captures binary operators followed by '('
+    // AND(, OR(, NOT(, =(, <(, >(
+    val binaryOpsNoSpaceRegEx = """(^|\s+)((AND|OR|NOT|IN|=|<=>|<|>|>=|\++|-|\*+))(\(+)""".r
+    // Capture reserved words at the end of expression. Those should be considered literal
+    // and hence are ignored.
+    // Binary operators cannot be at the end of the string, or end of expression.
+    // For example we know that the following AND is a literal value, not the operator AND.
+    // So, we can filter that out from the results.
+    //     PushedFilters: [IsNotNull(c_customer_id), StringEndsWith(c_customer_id,AND)]
+    //     Filter (isnotnull(names#15) AND StartsWith(names#15, AND))
+    // AND), AND$
+    val nonBinaryOperatorsRegEx = """\s+((AND|OR|NOT|=|<=>|<|>|>=|\++|-|\*+))($|\)+)""".r
+    // Capture all "("
+    val parenthesisStartRegEx = """(\(+)""".r
+    // Capture all ")"
+    val parenthesisEndRegEx = """(\)+)""".r
+
     val parsedExpressions = ArrayBuffer[String]()
-    // split on AND/OR/NOT
-    val exprSepAND = if (exprStr.contains("AND")) {
-      exprStr.split(" AND ").map(_.trim)
-    } else {
-      Array(exprStr)
-    }
-    val exprSepOR = if (exprStr.contains(" OR ")) {
-      exprSepAND.flatMap(_.split(" OR ").map(_.trim))
-    } else {
-      exprSepAND
+    var processedExpr = exprStr
+    // Step-1: make sure that any binary operator won't mix up with functionNames
+    // For example AND(, isnotNull()
+    binaryOpsNoSpaceRegEx.findAllMatchIn(exprStr).foreach { m =>
+      // replace things like 'AND(' with 'AND ('
+      val str = s"${m.group(2)}\\(+"
+      processedExpr = str.r.replaceAllIn(processedExpr, s"${m.group(2)} \\(")
     }
 
-    val exprSplit = if (exprStr.contains("NOT ")) {
-      parsedExpressions += "Not"
-      exprSepOR.flatMap(_.split("NOT ").map(_.trim))
-    } else {
-      exprSepOR
+    // Step-2: Extract function names from the expression
+    val functionMatches = functionsRegEx.findAllMatchIn(processedExpr)
+    parsedExpressions ++=
+      functionMatches.map(_.group(1)).filter(_.toLowerCase() != "cast")
+    // remove all function calls. No need to keep them in the expression
+    processedExpr = functionsRegEx.replaceAllIn(processedExpr, " ")
+
+    // Step-3: remove literal variables so we do not treat them as Binary operators
+    // Simply replace them by white space.
+    processedExpr = nonBinaryOperatorsRegEx.replaceAllIn(processedExpr, " ")
+
+    // Step-4: remove remaining parentheses '(', ')' and commas if we had functionCalls
+    if (!functionMatches.isEmpty) {
+      // remove ","
+      processedExpr = processedExpr.replaceAll(",", " ")
     }
+    processedExpr = parenthesisStartRegEx.replaceAllIn(processedExpr, " ")
+    processedExpr = parenthesisEndRegEx.replaceAllIn(processedExpr, " ")
 
-    // Remove parentheses from the beginning and end to get only the expressions
-    val parenRemoved = exprSplit.map(_.replaceAll("""^\(+""", "").replaceAll("""\)\)$""", ")"))
-    val conditionalExprPattern = """([(\w# )]+) ([+=<>|]+) ([(\w# )]+)""".r
-
-    parenRemoved.foreach { case expr =>
-      if (expr.contains(" ")) {
-        // likely some conditional expression
-        // TODO - add in arithmetic stuff (- / * )
-        conditionalExprPattern.findFirstMatchIn(expr) match {
-          case Some(func) =>
-            logDebug(s" found expr: $func")
-            if (func.groupCount < 3) {
-              logError(s"found incomplete expression - $func")
-            }
-            val expressions = Array(func.group(1), func.group(3))
-            // Add function name to result
-            expressions.foreach { expr =>
-              val functionName = getFunctionName(functionPattern, expr)
-              functionName.foreach(parsedExpressions += _)
-            }
-            val predicate = func.group(2)
-            // check for variable
-            if (expressions.exists(_.contains("#"))) {
-              logDebug(s"expr contains # ${expressions(0)} or ${expressions(1)}")
-            }
-            val predStr = predicate match {
-              case "=" => "EqualTo"
-              case "<=>" => "EqualNullSafe"
-              case "<" => "LessThan"
-              case ">" => "GreaterThan"
-              case "<=" => "LessThanOrEqual"
-              case ">=" => "GreaterThanOrEqual"
-              case "+" => "Add"
-            }
-            logDebug(s"predicate string is $predStr")
-            parsedExpressions += predStr
-          // TODO - lookup function name
-          case None => logDebug(s"Incorrect expression - $expr")
-        }
-      } else {
-        // likely some function call, add function name to result
-        val functionName = getFunctionName(functionPattern, expr)
-        functionName.foreach(parsedExpressions += _)
+    // Step-5: now we should have a simplified expression that can be tokenized on white
+    // space delimiter
+    processedExpr.split("\\s+").foreach { token =>
+      token match {
+        case "NOT" => parsedExpressions += "Not"
+        case "=" => parsedExpressions += "EqualTo"
+        case "<=>" => parsedExpressions += "EqualNullSafe"
+        case "<" => parsedExpressions += "LessThan"
+        case ">" => parsedExpressions += "GreaterThan"
+        case "<=" => parsedExpressions += "LessThanOrEqual"
+        case ">=" => parsedExpressions += "GreaterThanOrEqual"
+        case "+" => parsedExpressions += "Add"
+        case "-" => parsedExpressions += "Subtract"
+        case "*" => parsedExpressions += "Multiply"
+        case "IN" => parsedExpressions += "In"
+        case "OR" | "||" =>
+          // Some Spark2.x eventlogs may have '||' instead of 'OR'
+          parsedExpressions += "Or"
+        case "&&" | "AND" =>
+          // Some Spark2.x eventlogs may have '&&' instead of 'AND'
+          parsedExpressions += "And"
+        case t if t.contains("#") =>
+          // This is a variable name. Ignore those ones.
+        case _ =>
+          // anything else could be a literal value or we do not handle yet. Ignore them for now.
+          logDebug(s"Unrecognized Token - $token")
       }
     }
+
     parsedExpressions.distinct.toArray
   }
 }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.tool.planparser
 
 import java.io.{File, PrintWriter}
 
+import scala.collection.mutable
 import scala.io.Source
 import scala.util.control.NonFatal
 
@@ -889,6 +890,50 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
       val execInfo = getAllExecsFromPlan(parsedPlans.toSeq)
       val hashAggregate = execInfo.filter(_.exec == "HashAggregate")
       assertSizeAndSupported(2, hashAggregate, 4.5)
+    }
+  }
+
+  test("Parsing Conditional Expressions") {
+    // scalastyle:off line.size.limit
+    val expressionsMap: mutable.HashMap[String, Array[String]] = mutable.HashMap(
+      "(((lower(partition_act#90) = moduleview) && (isnotnull(productarr#22) && NOT (productarr#22=[]))) || (lower(moduletype#13) = saveforlater))" ->
+        Array("lower", "isnotnull", "EqualTo", "And",  "Not", "Or"),
+      "(IsNotNull(c_customer_id))" ->
+        Array("IsNotNull"),
+      "(isnotnull(names#15) AND StartsWith(names#15, OR))" ->
+        Array("isnotnull", "And", "StartsWith"),
+      "((isnotnull(s_state#68) AND (s_state#68 = TN)) OR (hex(cast(value#0 as bigint)) = B))" ->
+        Array("isnotnull", "And", "Or", "hex", "EqualTo"),
+      // Test that AND followed by '(' without space can be parsed
+      "((isnotnull(s_state#68) AND(s_state#68 = TN)) OR (hex(cast(value#0 as bigint)) = B))" ->
+        Array("isnotnull", "And", "Or", "hex", "EqualTo"),
+      "(((isnotnull(d_year#498) AND isnotnull(d_moy#500)) AND (d_year#498 = 1998)) AND (d_moy#500 = 12))" ->
+        Array("isnotnull", "And", "EqualTo"),
+      "IsNotNull(d_year) AND IsNotNull(d_moy) AND EqualTo(d_year,1998) AND EqualTo(d_moy,12)" ->
+        Array("IsNotNull", "And", "EqualTo"),
+      // check that a predicate with a single variable name is fine
+      "flagVariable" ->
+        Array(),
+      // check that a predicate with a single function call
+      "isnotnull(c_customer_sk#412)" ->
+        Array("isnotnull"),
+      "((substr(ca_zip#457, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#456 IN (CA,WA,GA)) OR (cs_sales_price#20 > 500.00))" ->
+        Array("substr", "In", "Or", "GreaterThan"),
+      // test the operator is at the beginning of expression and not followed by space
+      "NOT(isnotnull(d_moy))" ->
+        Array("Not", "isnotnull"),
+      "NOT(isnotnull(d_moy))" ->
+        Array("Not", "isnotnull"),
+    )
+    // scalastyle:on line.size.limit
+    for ((condExpr, expectedExpression) <- expressionsMap) {
+      val parsedExpressionsMine = SQLPlanParser.parseConditionalExpressions(condExpr)
+      val currOutput = parsedExpressionsMine.sorted
+      val expectedOutput = expectedExpression.sorted
+      assert(currOutput sameElements expectedOutput,
+        s"The parsed expressions are not as expected. Expression: ${condExpr}, " +
+          s"Expected: ${expectedOutput.mkString}, " +
+          s"Output: ${currOutput.mkString}")
     }
   }
 }

--- a/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/tools/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -921,9 +921,7 @@ class SQLPlanParserSuite extends FunSuite with BeforeAndAfterEach with Logging {
         Array("substr", "In", "Or", "GreaterThan"),
       // test the operator is at the beginning of expression and not followed by space
       "NOT(isnotnull(d_moy))" ->
-        Array("Not", "isnotnull"),
-      "NOT(isnotnull(d_moy))" ->
-        Array("Not", "isnotnull"),
+        Array("Not", "isnotnull")
     )
     // scalastyle:on line.size.limit
     for ((condExpr, expectedExpression) <- expressionsMap) {


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

fixes #7059 

This PR revisited the implementation of `SQLParserPlan.parseConditionalExpressions`

- Added the following operators to the expressions:
  - `AND` / `&&`: the `&&` for backward compatibility with Spark2.x
  - `OR` / `||`: the `||` for backward compatibility with Spark2.x
  - `IN`,
  - Arithmetic "`-`, `*`"
- Unrecognized operators are being ignored for now.
- Added unit test to test parsing sample of condition expressions.

