### PR TITLE
Update AQE tests to support Spark 3.4

### DIFF
--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -302,7 +302,10 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
         plan: SparkPlan,
         predicate: SparkPlan => Boolean,
         accum: ListBuffer[SparkPlan]): Seq[SparkPlan] = {
+
+      println(s"findOperators: ${plan.getClass.getSimpleName}")
       if (predicate(plan)) {
+        println("findOperators: isPredicate")
         accum += plan
       }
       plan match {
@@ -315,7 +318,11 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
       accum
     }
 
-    recurse(plan, predicate, new ListBuffer[SparkPlan]())
+    val x = recurse(plan, predicate, new ListBuffer[SparkPlan]())
+
+    println(s"findOperators: returning $x")
+
+    x
   }
 
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = plan match {

--- a/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/320+/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -302,10 +302,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
         plan: SparkPlan,
         predicate: SparkPlan => Boolean,
         accum: ListBuffer[SparkPlan]): Seq[SparkPlan] = {
-
-      println(s"findOperators: ${plan.getClass.getSimpleName}")
       if (predicate(plan)) {
-        println("findOperators: isPredicate")
         accum += plan
       }
       plan match {
@@ -318,11 +315,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
       accum
     }
 
-    val x = recurse(plan, predicate, new ListBuffer[SparkPlan]())
-
-    println(s"findOperators: returning $x")
-
-    x
+    recurse(plan, predicate, new ListBuffer[SparkPlan]())
   }
 
   override def skipAssertIsOnTheGpu(plan: SparkPlan): Boolean = plan match {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7054

Spark 3.4 has a slightly different plan for writes. The write is inside AdaptiveSparkPlan rather than the write having AdaptiveSparkPlan as a child. This PR updates the tests to change the expected result depending on Spark version.

## Spark 3.2.1

```
CommandResult <empty>
   +- GpuColumnarToRow false
      +- Execute GpuInsertIntoHadoopFsRelationCommand ...
         +- AdaptiveSparkPlan isFinalPlan=true
            +- == Final Plan ==
               GpuFileGpuScan parquet ...
            +- == Initial Plan ==
               FileScan parquet ...
```

## Spark 3.4.0

```
CommandResult <empty>
   +- AdaptiveSparkPlan isFinalPlan=true
      +- == Final Plan ==
         GpuColumnarToRow false
         +- Execute GpuInsertIntoHadoopFsRelationCommand ...
            +- GpuFileGpuScan parquet ...
      +- == Initial Plan ==
         Execute InsertIntoHadoopFsRelationCommand ...
           +- FileScan parquet ...
```
