### PR TITLE
Skip test_hash_groupby_collect_with_single_distinct [skip ci]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -731,7 +731,7 @@ def test_hash_reduction_collect_set_on_nested_array_type(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7104')
+@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/7092,7104')
 def test_hash_groupby_collect_with_single_distinct(data_gen):
     # test collect_ops with other distinct aggregations
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

following-up of https://github.com/NVIDIA/spark-rapids/pull/7102 
to mitigate https://github.com/NVIDIA/spark-rapids/issues/7092 as we found new intermittent failure unlike previous result mismatch one
