### PR TITLE
Add missing cleanup of shuffle data when using multi-threaded shuffle

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1336,10 +1336,9 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
           }
         }
       case _ if taskIdMapsForShuffle.size() > 0 =>
-        logError("unregisterShuffle called with " +
-          s"unexpected resolver ${shuffleBlockResolver} and ${taskIdMapsForShuffle.size()} " +
-          s"blocks data to clean!")
-        taskIdMapsForShuffle.clear()
+        throw new IllegalStateException(
+          "unregisterShuffle called with unexpected resolver " +
+          s"$shuffleBlockResolver and blocks left to be cleaned")
     }
     wrapped.unregisterShuffle(shuffleId)
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.rapids
 
 import java.io.{File, FileInputStream}
 import java.util.Optional
-import java.util.concurrent.{Callable, ExecutionException, Executors, Future, LinkedBlockingQueue}
+import java.util.concurrent.{Callable, ConcurrentHashMap, ExecutionException, Executors, Future, LinkedBlockingQueue}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 import scala.collection.mutable
@@ -44,7 +44,7 @@ import org.apache.spark.sql.rapids.shims.{GpuShuffleBlockResolver, RapidsShuffle
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.{RapidsShuffleBlockFetcherIterator, _}
 import org.apache.spark.util.{CompletionIterator, Utils}
-import org.apache.spark.util.collection.ExternalSorter
+import org.apache.spark.util.collection.{ExternalSorter, OpenHashSet}
 
 class GpuShuffleHandle[K, V](
     val wrapped: ShuffleHandle,
@@ -1013,7 +1013,7 @@ class RapidsCachingWriter[K, V](
  *       `ShuffleManager` and `SortShuffleManager` classes. When configuring
  *       Apache Spark to use the RAPIDS shuffle manager,
  */
-class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
+abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
     extends ShuffleManager with Arm with RapidsShuffleHeartbeatHandler with Logging {
 
   def getServerId: BlockManagerId = server.fold(blockManager.blockManagerId)(_.getId)
@@ -1167,6 +1167,20 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
     Some(executorComponents)
   }
 
+  /**
+   * A mapping from shuffle ids to the task ids of mappers producing output for those shuffles.
+   */
+  protected val taskIdMapsForShuffle = new ConcurrentHashMap[Int, OpenHashSet[Long]]()
+
+  private def trackMapTaskForCleanup(shuffleId: Int, mapId: Long): Unit = {
+    // this uses OpenHashSet as it is copied from Spark
+    val mapTaskIds = taskIdMapsForShuffle.computeIfAbsent(
+      shuffleId, _ => new OpenHashSet[Long](16))
+    mapTaskIds.synchronized {
+      mapTaskIds.add(mapId)
+    }
+  }
+
   override def getWriter[K, V](
       handle: ShuffleHandle, mapId: Long, context: TaskContext,
     metricsReporter: ShuffleWriteMetricsReporter): ShuffleWriter[K, V] = {
@@ -1194,6 +1208,8 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
               gpuDep.metrics,
               // cast the handle with specific generic types due to type-erasure
               gpuDep.asInstanceOf[GpuShuffleDependency[K, V, V]])
+            // we need to track this mapId so we can clean it up later on unregisterShuffle
+            trackMapTaskForCleanup(handle.shuffleId, context.taskAttemptId())
             new RapidsShuffleThreadedWriter[K, V](
               blockManager,
               handleWithMetrics,
@@ -1312,6 +1328,19 @@ class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
 
   override def unregisterShuffle(shuffleId: Int): Boolean = {
     unregisterGpuShuffle(shuffleId)
+    shuffleBlockResolver match {
+      case isbr: IndexShuffleBlockResolver =>
+        Option(taskIdMapsForShuffle.remove(shuffleId)).foreach { mapTaskIds =>
+          mapTaskIds.iterator.foreach { mapTaskId =>
+            isbr.removeDataByMap(shuffleId, mapTaskId)
+          }
+        }
+      case _ if taskIdMapsForShuffle.size() > 0 =>
+        logError("unregisterShuffle called with " +
+          s"unexpected resolver ${shuffleBlockResolver} and ${taskIdMapsForShuffle.size()} " +
+          s"blocks data to clean!")
+        taskIdMapsForShuffle.clear()
+    }
     wrapped.unregisterShuffle(shuffleId)
   }
 


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/7111.

This is missing data cleanup required when creating shuffle files with the multi threaded shuffle. This was missed when the feature was first merged.