### PR TITLE
Revert "Build noSnapshots without cdh shims on arm CPU [skip ci]"

### DIFF
--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -48,20 +48,12 @@ SPARK_REPO=${SPARK_REPO:-"$URM_URL"}
 echo "CUDF_VER: $CUDF_VER, CUDA_CLASSIFIER: $CUDA_CLASSIFIER, PROJECT_VER: $PROJECT_VER \
     SPARK_VER: $SPARK_VER, SCALA_BINARY_VER: $SCALA_BINARY_VER"
 
-# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
-# regular: noSnapshots + snapshots
-# pre-release: noSnapshots only
-# arm-base: noSnapshots without cdh shims
-PHASE_TYPE=${PHASE_TYPE:-"regular"}
-
 arch=$(uname -m)
 case ${arch} in
     x86_64|amd64)
         cpu_arch='amd64';;
     aarch64|arm64)
-        cpu_arch='arm64'
-        PHASE_TYPE='arm-base'
-        ;;
+        cpu_arch='arm64';;
     *)
       echo "Unsupported CPU architecture: ${arch}"; exit 1;;
 esac
@@ -85,12 +77,11 @@ SPARK_SHIM_VERSIONS_NOSNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 set_env_var_SPARK_SHIM_VERSIONS_ARR -PsnapshotOnly
 SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 
+# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
+# regular: noSnapshots + snapshots
+# pre-release: noSnapshots only
+PHASE_TYPE=${PHASE_TYPE:-"regular"}
 case $PHASE_TYPE in
-    # Build noSnapshots without cdh shims on the arm CPU
-    arm-base)
-        SPARK_SHIM_VERSIONS=(`echo "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]/3*cdh/}"`)
-        ;;
-
     # SPARK_SHIM_VERSIONS will be used for nightly artifact build
     pre-release)
         SPARK_SHIM_VERSIONS=("${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]}")


### PR DESCRIPTION
Reverts NVIDIA/spark-rapids#7120

Will move all arm64 build related changes to 23.02

Signed-off-by: Tim Liu <timl@nvidia.com>