### PR TITLE
Revert "Suffix artifactId with amd64/arm64 for the dist jars [skip ci]] (#7070)(#7120)"

### DIFF
--- a/api_validation/pom.xml
+++ b/api_validation/pom.xml
@@ -155,7 +155,7 @@
          </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-${cpu_arch}_${scala.binary.version}</artifactId>
+            <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>${cuda.version}</classifier>
             <scope>provided</scope>

--- a/build/buildall
+++ b/build/buildall
@@ -160,19 +160,8 @@ shift
 
 done
 
-arch=$(uname -m)
-case ${arch} in
-  x86_64|amd64)
-    cpu_arch='amd64';;
-  aarch64|arm64)
-    cpu_arch='arm64';;
-  *)
-    echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 # include options to mvn command
-export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 ${MVN_OPT} -Dcpu_arch=${cpu_arch}"
+export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 ${MVN_OPT}"
 
 DIST_PROFILE=${DIST_PROFILE:-"noSnapshots"}
 [[ "$MODULE" != "" ]] && MODULE_OPT="--projects $MODULE --also-make" || MODULE_OPT=""

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>rapids-4-spark-parent</artifactId>
         <version>22.12.0-SNAPSHOT</version>
     </parent>
-    <artifactId>rapids-4-spark-${cpu_arch}_2.12</artifactId>
+    <artifactId>rapids-4-spark_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Distribution</name>
     <description>Creates the distribution package of the RAPIDS plugin for Apache Spark</description>
     <version>22.12.0-SNAPSHOT</version>

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>
-            <artifactId>rapids-4-spark-${cpu_arch}_${scala.binary.version}</artifactId>
+            <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>${cuda.version}</classifier>
             <scope>provided</scope>

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -24,17 +24,6 @@ elif [[ -z "$SPARK_HOME" ]];
 then
     >&2 echo "SPARK_HOME IS NOT SET CANNOT RUN PYTHON INTEGRATION TESTS..."
 else
-    arch=$(uname -m)
-    case ${arch} in
-        x86_64|amd64)
-            cpu_arch='amd64';;
-        aarch64|arm64)
-            cpu_arch='arm64';;
-        *)
-          echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-    esac
-    echo "cpu_arch is ${cpu_arch}"
-
     echo "WILL RUN TESTS WITH SPARK_HOME: ${SPARK_HOME}"
     [[ ! -x "$(command -v zip)" ]] && { echo "fail to find zip command in $PATH"; exit 1; }
     # Spark 3.1.1 includes https://github.com/apache/spark/pull/31540
@@ -59,7 +48,7 @@ else
     # support alternate local jars NOT building from the source code
     if [ -d "$LOCAL_JAR_PATH" ]; then
         AVRO_JARS=$(echo "$LOCAL_JAR_PATH"/spark-avro*.jar)
-        PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark-${cpu_arch}_*.jar)
+        PLUGIN_JARS=$(echo "$LOCAL_JAR_PATH"/rapids-4-spark_*.jar)
         if [ -f $(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar) ]; then
             export INCLUDE_PARQUET_HADOOP_TEST_JAR=true
             PARQUET_HADOOP_TESTS=$(echo $LOCAL_JAR_PATH/parquet-hadoop*.jar)
@@ -82,7 +71,7 @@ else
         # Make sure we have Parquet version >= 1.12 in the dependency
         LOWEST_PARQUET_JAR=$(echo -e "$MIN_PARQUET_JAR\n$PARQUET_HADOOP_TESTS" | sort -V | head -1)
         export INCLUDE_PARQUET_HADOOP_TEST_JAR=$([[ "$LOWEST_PARQUET_JAR" == "$MIN_PARQUET_JAR" ]] && echo true || echo false)
-        PLUGIN_JARS=$(echo "$SCRIPTPATH"/../dist/target/rapids-4-spark-${cpu_arch}_*.jar)
+        PLUGIN_JARS=$(echo "$SCRIPTPATH"/../dist/target/rapids-4-spark_*.jar)
         # the integration-test-spark3xx.jar, should not include the integration-test-spark3xxtest.jar
         TEST_JARS=$(echo "$SCRIPTPATH"/target/rapids-4-spark-integration-tests*-$INTEGRATION_TEST_VERSION.jar)
     fi

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -90,16 +90,7 @@ initialize()
     SPARK_PLUGIN_JAR_VERSION=$($MVN_CMD help:evaluate -q -pl dist -Dexpression=project.version -DforceStdout)
     SCALA_VERSION=$($MVN_CMD help:evaluate -q -pl dist -Dexpression=scala.binary.version -DforceStdout)
     CUDA_VERSION=$($MVN_CMD help:evaluate -q -pl dist -Dexpression=cuda.version -DforceStdout)
-    # set the architecture for the current build.
-    arch=$(uname -m)
-    case ${arch} in
-        x86_64|amd64)
-            cpu_arch='amd64';;
-        aarch64|arm64)
-            cpu_arch='arm64';;
-        *) echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-    esac
-    RAPIDS_BUILT_JAR=rapids-4-spark-${cpu_arch}_$SCALA_VERSION-$SPARK_PLUGIN_JAR_VERSION.jar
+    RAPIDS_BUILT_JAR=rapids-4-spark_$SCALA_VERSION-$SPARK_PLUGIN_JAR_VERSION.jar
     # If set to 1, skips installing dependencies into mvn repo.
     SKIP_DEP_INSTALL=${SKIP_DEP_INSTALL:-'0'}
     # export 'M2DIR' so that shims can get the correct Spark dependency info
@@ -116,7 +107,6 @@ initialize()
     echo "workspace                                     : ${WORKSPACE}"
     echo "Scala version                                 : ${SCALA_VERSION}"
     echo "CUDA version                                  : ${CUDA_VERSION}"
-    echo "Architecture                                  : ${cpu_arch}"
     echo "Rapids build jar                              : ${RAPIDS_BUILT_JAR}"
     echo "Build Version                                 : ${BUILDVER}"
     echo "Skip Dependencies                             : ${SKIP_DEP_INSTALL}"

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -22,17 +22,6 @@ SPARK_CONF=${SPARK_CONF:-''}
 BASE_SPARK_VERSION=${BASE_SPARK_VERSION:-$(< /databricks/spark/VERSION)}
 [[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VERSION//.}db
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 # install required packages
 sudo apt -y install zip unzip
 
@@ -124,7 +113,7 @@ if [ -d "$LOCAL_JAR_PATH" ]; then
 
     if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
         ## Run cudf-udf tests
-        CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark-${cpu_arch}_*.jar | grep -v 'tests.jar'`"
+        CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls $LOCAL_JAR_PATH/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
         LOCAL_JAR_PATH=$LOCAL_JAR_PATH SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
             bash $LOCAL_JAR_PATH/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks" -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
     fi
@@ -148,7 +137,7 @@ else
 
     if [[ "$TEST_MODE" == "CUDF_UDF_ONLY" ]]; then
         ## Run cudf-udf tests
-        CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls /home/ubuntu/spark-rapids/dist/target/rapids-4-spark-${cpu_arch}_*.jar | grep -v 'tests.jar'`"
+        CUDF_UDF_TEST_ARGS="$CUDF_UDF_TEST_ARGS --conf spark.executorEnv.PYTHONPATH=`ls /home/ubuntu/spark-rapids/dist/target/rapids-4-spark_*.jar | grep -v 'tests.jar'`"
         SPARK_SUBMIT_FLAGS="$SPARK_CONF $CUDF_UDF_TEST_ARGS" TEST_PARALLEL=1 \
             bash /home/ubuntu/spark-rapids/integration_tests/run_pyspark_from_build.sh --runtime_env="databricks"  -m "cudf_udf" --cudf_udf --test_type=$TEST_TYPE
     fi

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -51,18 +51,7 @@ if [ "$DATABRICKS" == true ]; then
     cd spark-rapids
 fi
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
-ART_ID=`mvn help:evaluate -q -pl $DIST_PL -Dexpression=project.artifactId -DforceStdout -Dcpu_arch=$cpu_arch`
+ART_ID=`mvn help:evaluate -q -pl $DIST_PL -Dexpression=project.artifactId -DforceStdout`
 ART_VER=`mvn help:evaluate -q -pl $DIST_PL -Dexpression=project.version -DforceStdout`
 CUDA_CLASSIFIER=`mvn help:evaluate -q -pl $DIST_PL -Dexpression=cuda.version -DforceStdout`
 
@@ -80,9 +69,9 @@ if [ "$SIGN_FILE" == true ]; then
     SQL_ART_VER=`mvn help:evaluate -q -pl $SQL_PL -Dexpression=project.version -DforceStdout`
     JS_FPATH="${SQL_PL}/target/spark${FINAL_AGG_VERSION_TOBUILD}/${SQL_ART_ID}-${SQL_ART_VER}"
     SRC_DOC_JARS="-Dsources=${JS_FPATH}-sources.jar -Djavadoc=${JS_FPATH}-javadoc.jar"
-    DEPLOY_CMD="$MVN -B gpg:sign-and-deploy-file -s jenkins/settings.xml -Dgpg.passphrase=$GPG_PASSPHRASE -Dcpu_arch=${cpu_arch}"
+    DEPLOY_CMD="$MVN -B gpg:sign-and-deploy-file -s jenkins/settings.xml -Dgpg.passphrase=$GPG_PASSPHRASE"
 else
-    DEPLOY_CMD="$MVN -B deploy:deploy-file -s jenkins/settings.xml -Dcpu_arch=${cpu_arch}"
+    DEPLOY_CMD="$MVN -B deploy:deploy-file -s jenkins/settings.xml"
 fi
 
 echo "Deploy CMD: $DEPLOY_CMD"

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -22,19 +22,8 @@ set -ex
 ## export 'M2DIR' so that shims can get the correct Spark dependency info
 export M2DIR=${M2DIR:-"$WORKSPACE/.m2"}
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 ## MVN_OPT : maven options environment, e.g. MVN_OPT='-Dspark-rapids-jni.version=xxx' to specify spark-rapids-jni dependency's version.
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT} -Dcpu_arch=${cpu_arch}"
+MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT}"
 
 TOOL_PL=${TOOL_PL:-"tools"}
 DIST_PL="dist"

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -27,18 +27,7 @@ elif [[ $# -gt 1 ]]; then
     exit 1
 fi
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
-MVN_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3 -Dcpu_arch=${cpu_arch}"
+MVN_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3"
 MVN_BUILD_ARGS="-Drat.skip=true -Dmaven.javadoc.skip=true -Dskip -Dmaven.scalastyle.skip=true -Dcuda.version=$CUDA_CLASSIFIER"
 
 mvn_verify() {
@@ -90,7 +79,7 @@ mvn_verify() {
     # things we care about
     SPK_VER=${JACOCO_SPARK_VER:-"311"}
     mkdir -p target/jacoco_classes/
-    FILE=$(ls dist/target/rapids-4-spark-${cpu_arch}_2.12-*.jar | grep -v test | xargs readlink -f)
+    FILE=$(ls dist/target/rapids-4-spark_2.12-*.jar | grep -v test | xargs readlink -f)
     UDF_JAR=$(ls ./udf-compiler/target/spark${SPK_VER}/rapids-4-spark-udf_2.12-*-spark${SPK_VER}.jar | grep -v test | xargs readlink -f)
     pushd target/jacoco_classes/
     jar xf $FILE com org rapids spark3xx-common "spark${JACOCO_SPARK_VER:-311}/"
@@ -187,7 +176,7 @@ elif [[ ${PROJECT_VER} =~ ^23\.02\. ]]; then
 fi
 
 ARTF_ROOT="$WORKSPACE/.download"
-MVN_GET_CMD="$MVN_CMD org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B -Dcpu_arch=${cpu_arch} \
+MVN_GET_CMD="$MVN_CMD org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B \
     $MVN_URM_MIRROR -DremoteRepositories=$URM_URL \
     -Ddest=$ARTF_ROOT"
 

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -21,19 +21,8 @@ nvidia-smi
 
 . jenkins/version-def.sh
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 ARTF_ROOT="$WORKSPACE/jars"
-MVN_GET_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3 org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B -Dcpu_arch=${cpu_arch} \
+MVN_GET_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3 org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B \
     -Dmaven.repo.local=$WORKSPACE/.m2 \
     $MVN_URM_MIRROR -Ddest=$ARTF_ROOT"
 
@@ -45,12 +34,12 @@ $MVN_GET_CMD -DremoteRepositories=$PROJECT_TEST_REPO \
     -DgroupId=com.nvidia -DartifactId=rapids-4-spark-integration-tests_$SCALA_BINARY_VER -Dversion=$PROJECT_TEST_VER -Dclassifier=$SHUFFLE_SPARK_SHIM
 if [ "$CUDA_CLASSIFIER"x == x ];then
     $MVN_GET_CMD -DremoteRepositories=$PROJECT_REPO \
-        -DgroupId=com.nvidia -DartifactId=rapids-4-spark-${cpu_arch}_$SCALA_BINARY_VER -Dversion=$PROJECT_VER
-    export RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark-${cpu_arch}_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
+        -DgroupId=com.nvidia -DartifactId=rapids-4-spark_$SCALA_BINARY_VER -Dversion=$PROJECT_VER
+    export RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
 else
     $MVN_GET_CMD -DremoteRepositories=$PROJECT_REPO \
-        -DgroupId=com.nvidia -DartifactId=rapids-4-spark-${cpu_arch}_$SCALA_BINARY_VER -Dversion=$PROJECT_VER -Dclassifier=$CUDA_CLASSIFIER
-    export RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark-${cpu_arch}_${SCALA_BINARY_VER}-$PROJECT_VER-${CUDA_CLASSIFIER}.jar"
+        -DgroupId=com.nvidia -DartifactId=rapids-4-spark_$SCALA_BINARY_VER -Dversion=$PROJECT_VER -Dclassifier=$CUDA_CLASSIFIER
+    export RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark_${SCALA_BINARY_VER}-$PROJECT_VER-${CUDA_CLASSIFIER}.jar"
 fi
 RAPIDS_TEST_JAR="$ARTF_ROOT/rapids-4-spark-integration-tests_${SCALA_BINARY_VER}-$PROJECT_TEST_VER-$SHUFFLE_SPARK_SHIM.jar"
 

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -66,12 +66,11 @@ SPARK_SHIM_VERSIONS_NOSNAPSHOTS=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 set_env_var_SPARK_SHIM_VERSIONS_ARR -PsnapshotOnly
 SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY=("${SPARK_SHIM_VERSIONS_ARR[@]}")
 
+# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
+# regular: noSnapshots + snapshots
+# pre-release: noSnapshots only
+PHASE_TYPE=${PHASE_TYPE:-"regular"}
 case $PHASE_TYPE in
-    # Build noSnapshots without cdh shims on the arm CPU
-    arm-base)
-        SPARK_SHIM_VERSIONS=(`echo "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]/3*cdh/}"`)
-        ;;
-
     # SPARK_SHIM_VERSIONS will be used for nightly artifact build
     pre-release)
         SPARK_SHIM_VERSIONS=("${SPARK_SHIM_VERSIONS_NOSNAPSHOTS[@]}")

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -48,30 +48,11 @@ SPARK_REPO=${SPARK_REPO:-"$URM_URL"}
 echo "CUDF_VER: $CUDF_VER, CUDA_CLASSIFIER: $CUDA_CLASSIFIER, PROJECT_VER: $PROJECT_VER \
     SPARK_VER: $SPARK_VER, SCALA_BINARY_VER: $SCALA_BINARY_VER"
 
-# PHASE_TYPE: CICD phase at which the script is called, to specify Spark shim versions.
-# regular: noSnapshots + snapshots
-# pre-release: noSnapshots only
-# arm-base: noSnapshots without cdh shims
-PHASE_TYPE=${PHASE_TYPE:-"regular"}
-
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64'
-        PHASE_TYPE='arm-base'
-        ;;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 # Spark shim versions
 # get Spark shim versions from pom
 function set_env_var_SPARK_SHIM_VERSIONS_ARR() {
     PROFILE_OPT=$1
-    SPARK_SHIM_VERSIONS_STR=$(mvn -B help:evaluate -q -pl dist $PROFILE_OPT -Dexpression=included_buildvers -DforceStdout -Dcpu_arch=${cpu_arch})
+    SPARK_SHIM_VERSIONS_STR=$(mvn -B help:evaluate -q -pl dist $PROFILE_OPT -Dexpression=included_buildvers -DforceStdout)
     SPARK_SHIM_VERSIONS_STR=$(echo $SPARK_SHIM_VERSIONS_STR)
     IFS=", " <<< $SPARK_SHIM_VERSIONS_STR read -r -a SPARK_SHIM_VERSIONS_ARR
 }

--- a/pom.xml
+++ b/pom.xml
@@ -690,11 +690,6 @@
             with the ones deployed to a remote Maven repo
         -->
         <ignore.shim.revisions.check>false</ignore.shim.revisions.check>
-        <!--
-            Build on x86_64/amd64 hosts to aggregate rapids-4-spark dist jar with -Dcpu_arch=amd64
-            Build on arm64/aarch64 hosts to aggregate rapids-4-spark dist jar with -Dcpu_arch=arm64
-        -->
-        <cpu_arch>amd64</cpu_arch>
     </properties>
 
     <dependencyManagement>

--- a/scripts/prioritize-commits.sh
+++ b/scripts/prioritize-commits.sh
@@ -37,29 +37,18 @@ if [ -e ${AUDIT_PLUGIN_LOG}]; then
   rm ${AUDIT_PLUGIN_LOG}
 fi
 
-arch=$(uname -m)
-case ${arch} in
-    x86_64|amd64)
-        cpu_arch='amd64';;
-    aarch64|arm64)
-        cpu_arch='arm64';;
-    *)
-      echo "Unsupported CPU architecture: ${arch}"; exit 1;;
-esac
-echo "cpu_arch is ${cpu_arch}"
-
 #Get plugin jar
 ARTF_ROOT="$WORKSPACE/jars"
 MVN_GET_CMD="mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B \
-    -Dmaven.repo.local=$WORKSPACE/.m2 -Dcpu_arch=${cpu_arch} \
+    -Dmaven.repo.local=$WORKSPACE/.m2 \
     -DrepoUrl=https://urm.nvidia.com/artifactory/sw-spark-maven -Ddest=$ARTF_ROOT"
 
 rm -rf $ARTF_ROOT && mkdir -p $ARTF_ROOT
 # maven download SNAPSHOT jars: rapids-4-spark, spark3.0
 $MVN_GET_CMD -DremoteRepositories=$PROJECT_REPO \
-    -DgroupId=com.nvidia -DartifactId=rapids-4-spark-${cpu_arch}_$SCALA_BINARY_VER -Dversion=$PROJECT_VER
+    -DgroupId=com.nvidia -DartifactId=rapids-4-spark_$SCALA_BINARY_VER -Dversion=$PROJECT_VER
 
-RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark-${cpu_arch}_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
+RAPIDS_PLUGIN_JAR="$ARTF_ROOT/rapids-4-spark_${SCALA_BINARY_VER}-$PROJECT_VER.jar"
 # Use jdeps to find the dependencies of the rapids-4-spark jar
 DEPS=$(jdeps -include "(com\.nvidia\.spark.*|org\.apache\.spark.*)" -v -e org.apache.spark.* $RAPIDS_PLUGIN_JAR)
 


### PR DESCRIPTION
This reverts commits:

c7f87f4643ac402beb27f34908019b76f95a7ec5  Reverts https://github.com/NVIDIA/spark-rapids/pull/7070

b7a79d31a382b698b06c4f8e6aa5fbc52e13a505   Reverts https://github.com/NVIDIA/spark-rapids/pull/7120

Will move all arm64 build related changes to 23.02

Signed-off-by: Tim Liu <timl@nvidia.com>
