### PR TITLE
Skip the unit test `sorted_partitioned_write` on Spark 340.

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -86,10 +86,6 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("sorted partitioned write") {
-    // Skip this test for Spark 3.4.0+
-    // because there are several related bugs in Spark which haven't been fixed yet:
-    // https://issues.apache.org/jira/browse/SPARK-40588
-    // https://issues.apache.org/jira/browse/SPARK-40885
     assume(!isSpark340OrLater,
       "Skipping on Spark 3.4+ because of " +
       "https://issues.apache.org/jira/browse/SPARK-40588 and " +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -86,20 +86,26 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("sorted partitioned write") {
-    val conf = new SparkConf().set(RapidsConf.SQL_ENABLED.key, "true")
-    val tempFile = File.createTempFile("partitioned", ".parquet")
-    try {
-      SparkSessionHolder.withSparkSession(conf, spark => {
-        import spark.implicits._
-        val df = spark.sparkContext.parallelize((1L to 10000000L))
-            .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
-        df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
-            .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)
-        val firstRow = spark.read.parquet(tempFile.getAbsolutePath).head
-        assertResult("0000000001")(firstRow.getString(0))
-      })
-    } finally {
-      fullyDelete(tempFile)
+    // Skip this test for Spark 3.4.0+
+    // because there are several related bugs in Spark which haven't been fixed yet:
+    // https://issues.apache.org/jira/browse/SPARK-40588
+    // https://issues.apache.org/jira/browse/SPARK-40885
+    if (cmpSparkVersion(3, 4, 0) < 0) {
+      val conf = new SparkConf().set(RapidsConf.SQL_ENABLED.key, "true")
+      val tempFile = File.createTempFile("partitioned", ".parquet")
+      try {
+        SparkSessionHolder.withSparkSession(conf, spark => {
+          import spark.implicits._
+          val df = spark.sparkContext.parallelize((1L to 10000000L))
+              .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
+          df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
+              .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)
+          val firstRow = spark.read.parquet(tempFile.getAbsolutePath).head
+          assertResult("0000000001")(firstRow.getString(0))
+        })
+      } finally {
+        fullyDelete(tempFile)
+      }
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -90,22 +90,25 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
     // because there are several related bugs in Spark which haven't been fixed yet:
     // https://issues.apache.org/jira/browse/SPARK-40588
     // https://issues.apache.org/jira/browse/SPARK-40885
-    if (cmpSparkVersion(3, 4, 0) < 0) {
-      val conf = new SparkConf().set(RapidsConf.SQL_ENABLED.key, "true")
-      val tempFile = File.createTempFile("partitioned", ".parquet")
-      try {
-        SparkSessionHolder.withSparkSession(conf, spark => {
-          import spark.implicits._
-          val df = spark.sparkContext.parallelize((1L to 10000000L))
-              .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
-          df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
-              .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)
-          val firstRow = spark.read.parquet(tempFile.getAbsolutePath).head
-          assertResult("0000000001")(firstRow.getString(0))
-        })
-      } finally {
-        fullyDelete(tempFile)
-      }
+    assume(!isSpark340OrLater,
+      "Skipping on Spark 3.4+ because of " +
+      "https://issues.apache.org/jira/browse/SPARK-40588 and " +
+      "https://issues.apache.org/jira/browse/SPARK-40885")
+
+    val conf = new SparkConf().set(RapidsConf.SQL_ENABLED.key, "true")
+    val tempFile = File.createTempFile("partitioned", ".parquet")
+    try {
+      SparkSessionHolder.withSparkSession(conf, spark => {
+        import spark.implicits._
+        val df = spark.sparkContext.parallelize((1L to 10000000L))
+            .map{i => ("a", f"$i%010d", i)}.toDF("partkey", "val", "val2")
+        df.repartition(1, $"partkey").sortWithinPartitions($"partkey", $"val", $"val2")
+            .write.mode("overwrite").partitionBy("partkey").parquet(tempFile.getAbsolutePath)
+        val firstRow = spark.read.parquet(tempFile.getAbsolutePath).head
+        assertResult("0000000001")(firstRow.getString(0))
+      })
+    } finally {
+      fullyDelete(tempFile)
     }
   }
 


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Related to #7018.
We decide to skip this test for now on Spark 340 because there are related bugs in Spark which have not been fixed yet.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
