### PR TITLE
Get PROJECT_VERSION from version-def.sh [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -179,12 +179,7 @@ pipeline {
                         major_ver = versions[0].toInteger()
                         minor_ver = versions[1].toInteger()
 
-                        if (major_ver >= 22) {
-                            PREMERGE_CI_2_ARGUMENT = "ci_2"
-                        } else {
-                            error("Unsupported major version: $major_ver")
-                        }
-
+                        PREMERGE_CI_2_ARGUMENT = "ci_2"
                         echo PREMERGE_CI_2_ARGUMENT
                     }
                 }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -165,22 +165,28 @@ pipeline {
 
             steps {
                 script {
-                    // Retrieve PROJECT_VER from version-def.sh, e.g, '<major>.<minor>.<patch>-SNAPSHOT'
-                    PROJECT_VER = sh(returnStdout: true, script: "bash $JENKINS_ROOT/version-def.sh | cut -d ',' -f 3 | cut -d ' ' -f 3")
-                    PROJECT_VER = PROJECT_VER.split('-')[0] // Remove trailing '-SNAPSHOT'
-                    echo PROJECT_VER
+                    container('cpu') {
+                        // Retrieve PROJECT_VER from version-def.sh, e.g, '<major>.<minor>.<patch>-SNAPSHOT'
+                        PROJECT_VER = sh(returnStdout: true,
+                                        script: '''#!/bin/bash
+                                                source jenkins/version-def.sh >& /dev/null
+                                                echo $PROJECT_VER
+                                                ''').trim()
+                        PROJECT_VER = PROJECT_VER.split('-')[0] // Remove trailing '-SNAPSHOT'
+                        echo PROJECT_VER
 
-                    def versions = PROJECT_VER.split('\\.')
-                    major_ver = versions[0].toInteger()
-                    minor_ver = versions[1].toInteger()
+                        def versions = PROJECT_VER.split('\\.')
+                        major_ver = versions[0].toInteger()
+                        minor_ver = versions[1].toInteger()
 
-                    if (major_ver >= 22) {
-                        PREMERGE_CI_2_ARGUMENT = "ci_2"
-                    } else {
-                        error("Unsupported major version: $major_ver")
+                        if (major_ver >= 22) {
+                            PREMERGE_CI_2_ARGUMENT = "ci_2"
+                        } else {
+                            error("Unsupported major version: $major_ver")
+                        }
+
+                        echo PREMERGE_CI_2_ARGUMENT
                     }
-
-                    echo PREMERGE_CI_2_ARGUMENT
                 }
             }
         }


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids/issues/7140

`cut -d , ...` will fail to parse PROJECT_VERSION, if we change the echo output in version-def.sh

Change the way to get PROJECT_VERSION from version-def.sh

Run stage 'Determine Project Version' in docker container to fix "mvn: command not found"

Signed-off-by: Tim Liu <timl@nvidia.com>