### PR TITLE
Restore hash aggregate tests after cub segmented sort fix [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -731,7 +731,7 @@ def test_hash_reduction_collect_set_on_nested_array_type(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/7092,7104')
+@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7104')
 def test_hash_groupby_collect_with_single_distinct(data_gen):
     # test collect_ops with other distinct aggregations
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -731,7 +731,6 @@ def test_hash_reduction_collect_set_on_nested_array_type(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', _full_gen_data_for_collect_op, ids=idfn)
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7104')
 def test_hash_groupby_collect_with_single_distinct(data_gen):
     # test collect_ops with other distinct aggregations
     assert_gpu_and_cpu_are_equal_collect(
@@ -840,7 +839,6 @@ _replace_modes_single_distinct = [
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.parametrize('use_obj_hash_agg', ['false', 'true'], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
-@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/7092')
 def test_hash_groupby_collect_partial_replace_with_distinct_fallback(data_gen,
                                                                      replace_mode,
                                                                      aqe_enabled,


### PR DESCRIPTION
Fixes #7092.

Reinstates the tests disabled by #7102 after the fix for the cub segmented sort issue via rapidsai/cudf#12217.