### PR TITLE
Remove inaccurate warnings about fallbacks when using multithreaded shuffle

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1076,7 +1076,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
     if (!rapidsConf.isMultiThreadedShuffleManagerMode && GpuShuffleEnv.isExternalShuffleEnabled) {
       fallThroughReasons += "External Shuffle Service is enabled"
     }
-    if (GpuShuffleEnv.isSparkAuthenticateEnabled) {
+    if (!rapidsConf.isMultiThreadedShuffleManagerMode && GpuShuffleEnv.isSparkAuthenticateEnabled) {
       fallThroughReasons += "Spark authentication is enabled"
     }
     if (rapidsConf.isSqlExplainOnlyEnabled) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1073,7 +1073,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
   protected lazy val blockManager = env.blockManager
   protected lazy val shouldFallThroughOnEverything = {
     val fallThroughReasons = new ListBuffer[String]()
-    if (GpuShuffleEnv.isExternalShuffleEnabled) {
+    if (!rapidsConf.isMultiThreadedShuffleManagerMode && GpuShuffleEnv.isExternalShuffleEnabled) {
       fallThroughReasons += "External Shuffle Service is enabled"
     }
     if (GpuShuffleEnv.isSparkAuthenticateEnabled) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1073,11 +1073,13 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
   protected lazy val blockManager = env.blockManager
   protected lazy val shouldFallThroughOnEverything = {
     val fallThroughReasons = new ListBuffer[String]()
-    if (!rapidsConf.isMultiThreadedShuffleManagerMode && GpuShuffleEnv.isExternalShuffleEnabled) {
-      fallThroughReasons += "External Shuffle Service is enabled"
-    }
-    if (!rapidsConf.isMultiThreadedShuffleManagerMode && GpuShuffleEnv.isSparkAuthenticateEnabled) {
-      fallThroughReasons += "Spark authentication is enabled"
+    if (!rapidsConf.isMultiThreadedShuffleManagerMode) {
+      if (GpuShuffleEnv.isExternalShuffleEnabled) {
+        fallThroughReasons += "External Shuffle Service is enabled"
+      }
+      if (GpuShuffleEnv.isSparkAuthenticateEnabled) {
+        fallThroughReasons += "Spark authentication is enabled"
+      }
     }
     if (rapidsConf.isSqlExplainOnlyEnabled) {
       fallThroughReasons += "Plugin is in explain only mode"


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

When running with multithreaded shuffle on dataproc, I saw these warnings in the logs:
```
driver.log:22/11/22 17:48:44 WARN org.apache.spark.sql.rapids.shims.spark312.RapidsShuffleInternalManager: Rapids Shuffle Plugin is falling back to SortShuffleManager because: External Shuffle Service is enabled
```

I checked with @abellina and he confirmed that this warning should not be printing when using mulitthreaded shuffle.