### PR TITLE
Add scripts to run integration test on Databricks by leveraging Jenkins parallelism [skip ci]

### DIFF
--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Run integration testing individually by setting environment variable:
+#   TEST=xxx
+# or
+#   TEST_TAGS=xxx
+# More details please refer to './integration_tests/run_pyspark_from_build.sh'.
+# Note, 'setup.sh' should be executed first to setup proper environment.
 
 set -xe
 

--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -xe
+
+SPARK_VER=${SPARK_VER:-$(< /databricks/spark/VERSION)}
+export SPARK_SHIM_VER=${SPARK_SHIM_VER:-spark${SPARK_VER//.}db}
+
+# Setup SPARK_HOME if need
+if [[ -z "$SPARK_HOME" ]]; then
+    # Configure spark environment on Databricks
+    export SPARK_HOME=$DB_HOME/spark
+    export PYTHONPATH=$SPARK_HOME/python
+fi
+
+if [[ "$TEST" == "cache_test" || "$TEST" == "cache_test.py" ]]; then
+    export PYSP_TEST_spark_sql_cache_serializer='com.nvidia.spark.ParquetCachedBatchSerializer'
+fi
+
+if [[ "$TEST_TAGS" == "iceberg" ]]; then
+    ICEBERG_VERSION=${ICEBERG_VERSION:-0.13.2}
+    ICEBERG_SPARK_VER=$(echo $SPARK_VER | cut -d. -f1,2)
+
+    export SPARK_SUBMIT_FLAGS="$SPARK_SUBMIT_FLAGS \
+        --packages org.apache.iceberg:iceberg-spark-runtime-${ICEBERG_SPARK_VER}_2.12:${ICEBERG_VERSION} \
+        --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+        --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
+        --conf spark.sql.catalog.spark_catalog.type=hadoop \
+        --conf spark.sql.catalog.spark_catalog.warehouse=/tmp/spark-warehouse-$$ \
+        "
+fi
+
+TEST_TYPE=${TEST_TYPE:-"nightly"}
+
+# Run integration testing
+LOCAL_JAR_PATH=`pwd` ./integration_tests/run_pyspark_from_build.sh --runtime_env='databricks' --test_type=$TEST_TYPE

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -xe
+
+sudo apt-get update
+sudo apt-get install -y zip
+
+# Configure spark environment on Databricks
+export SPARK_HOME=$DB_HOME/spark
+
+# Workaround to support local spark job
+sudo ln -sf $DB_HOME/jars/ $SPARK_HOME/jars
+
+# Set $SPARK_LOCAL_DIRS writable for ordinary user
+if [ -f $SPARK_HOME/conf/spark-env.sh ]; then
+    # Sample output: export SPARK_LOCAL_DIRS='/local_disk0'
+    local_dir=`grep SPARK_LOCAL_DIRS $SPARK_HOME/conf/spark-env.sh`
+    local_dir=${local_dir##*=}
+
+    sudo chmod 777 `echo $local_dir | xargs`
+fi
+
+# Install Python modules for integration test
+sudo pip install pytest sre_yield pandas pyarrow

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Setup Spark local environment for integration testing with Databricks cluster
 
 set -xe
 


### PR DESCRIPTION
per comments from https://github.com/NVIDIA/spark-rapids/issues/6455 to be more reliable. The scripts will allow to run one test each time (TEST=xxx or TEST_TAGS=xxx) without parallel of pytest, which will be executed by Jenkins multiple number (configurable) of threads in parallel.

test pass with internal CI jobs

Signed-off-by: Alex Zhang <alexzhang@nvidia.com>

TODO:
- replace with new CI jobs for integration testing on Databricks
- cleanup old scripts