### PR TITLE
Handle two changes related to `FileFormatWriter` since Spark 340

### DIFF
--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_
 from data_gen import *
 from datetime import date, datetime, timezone
 from marks import *
-from spark_session import is_hive_available, is_spark_330_or_later, with_cpu_session
+from spark_session import is_hive_available, is_spark_33X, is_spark_340_or_later, with_cpu_session
 
 # Using timestamps from 1970 to work around a cudf ORC bug
 # https://github.com/NVIDIA/spark-rapids/issues/140.
@@ -118,11 +118,11 @@ def test_optimized_hive_ctas_options_fallback(gens, storage_with_opts, spark_tmp
         "DataWritingCommandExec")
 
 @allow_non_gpu("DataWritingCommandExec")
-@pytest.mark.skipif(not (is_hive_available() and is_spark_330_or_later()),
+@pytest.mark.skipif(not (is_hive_available() and is_spark_33X()),
                      reason="Requires Hive and Spark 3.3+ to write bucketed Hive tables")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage", ["PARQUET", "ORC"], ids=idfn)
-def test_optimized_hive_bucketed_fallback(gens, storage, spark_tmp_table_factory):
+def test_optimized_hive_bucketed_fallback_33X(gens, storage, spark_tmp_table_factory):
     in_table = spark_tmp_table_factory.get()
     with_cpu_session(lambda spark: three_col_df(spark, int_gen, int_gen, int_gen).createOrReplaceTempView(in_table))
     assert_gpu_fallback_collect(
@@ -131,3 +131,22 @@ def test_optimized_hive_bucketed_fallback(gens, storage, spark_tmp_table_factory
             CLUSTERED BY (b) INTO 3 BUCKETS
             AS SELECT * FROM {}""".format(spark_tmp_table_factory.get(), storage, in_table)),
         "DataWritingCommandExec")
+
+# Since Spark 3.4.0, the internal "SortExec" will be pulled out by default
+# from the FileFormatWriter. Then it is visible at the planning stage.
+@allow_non_gpu("DataWritingCommandExec", "SortExec", "HiveHash")
+@pytest.mark.skipif(not (is_hive_available() and is_spark_340_or_later()),
+                    reason="Requires Hive and Spark 3.3+ to write bucketed Hive tables")
+@pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
+@pytest.mark.parametrize("storage", ["PARQUET", "ORC"], ids=idfn)
+@pytest.mark.parametrize("planned_write", [True, False], ids=idfn)
+def test_optimized_hive_bucketed_fallback(gens, storage, planned_write, spark_tmp_table_factory):
+    in_table = spark_tmp_table_factory.get()
+    with_cpu_session(lambda spark: three_col_df(spark, int_gen, int_gen, int_gen).createOrReplaceTempView(in_table))
+    assert_gpu_fallback_collect(
+        lambda spark: spark.sql(
+            """CREATE TABLE {} STORED AS {}
+            CLUSTERED BY (b) INTO 3 BUCKETS
+            AS SELECT * FROM {}""".format(spark_tmp_table_factory.get(), storage, in_table)),
+        "DataWritingCommandExec",
+        {"spark.sql.optimizer.plannedWrite.enabled": planned_write})

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -119,7 +119,7 @@ def test_optimized_hive_ctas_options_fallback(gens, storage_with_opts, spark_tmp
 
 @allow_non_gpu("DataWritingCommandExec")
 @pytest.mark.skipif(not (is_hive_available() and is_spark_33X()),
-                     reason="Requires Hive and Spark 3.3+ to write bucketed Hive tables")
+                    reason="Requires Hive and Spark 3.3.X to write bucketed Hive tables")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage", ["PARQUET", "ORC"], ids=idfn)
 def test_optimized_hive_bucketed_fallback_33X(gens, storage, spark_tmp_table_factory):
@@ -133,10 +133,10 @@ def test_optimized_hive_bucketed_fallback_33X(gens, storage, spark_tmp_table_fac
         "DataWritingCommandExec")
 
 # Since Spark 3.4.0, the internal "SortExec" will be pulled out by default
-# from the FileFormatWriter. Then it is visible at the planning stage.
+# from the FileFormatWriter. Then it is visible in the planning stage.
 @allow_non_gpu("DataWritingCommandExec", "SortExec", "HiveHash")
 @pytest.mark.skipif(not (is_hive_available() and is_spark_340_or_later()),
-                    reason="Requires Hive and Spark 3.3+ to write bucketed Hive tables")
+                    reason="Requires Hive and Spark 3.4+ to write bucketed Hive tables with SortExec pulled out")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage", ["PARQUET", "ORC"], ids=idfn)
 @pytest.mark.parametrize("planned_write", [True, False], ids=idfn)

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -159,6 +159,9 @@ def is_spark_330_or_later():
 def is_spark_340_or_later():
     return spark_version() >= "3.4.0"
 
+def is_spark_33X():
+    return "3.3.0" <= spark_version() < "3.4.0"
+
 def is_spark_321cdh():
     return "3.2.1.3.2.717" in spark_version()
 

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
@@ -68,7 +68,7 @@ trait Spark340PlusShims extends Spark331PlusShims {
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     val shimExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
       // Empty2Null is pulled out of FileFormatWriter by default since Spark 3.4.0,
-      // so it is visible at the overriding stage.
+      // so it is visible in the overriding stage.
       GpuOverrides.expr[Empty2Null](
         "Converts the empty string to null for writing data",
         ExprChecks.unaryProjectInputMatchesOutput(

--- a/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
+++ b/sql-plugin/src/main/340+/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
+import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.V1WritesUtils.Empty2Null
+import org.apache.spark.sql.execution.exchange.ENSURE_REQUIREMENTS
+import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
+
+trait Spark340PlusShims extends Spark331PlusShims {
+
+  private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
+    GpuOverrides.exec[GlobalLimitExec](
+      "Limiting of results across partitions",
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
+          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+        TypeSig.all),
+      (globalLimit, conf, p, r) =>
+        new SparkPlanMeta[GlobalLimitExec](globalLimit, conf, p, r) {
+          override def convertToGpu(): GpuExec =
+            GpuGlobalLimitExec(
+              globalLimit.limit, childPlans.head.convertIfNeeded(), globalLimit.offset)
+        }),
+    GpuOverrides.exec[CollectLimitExec](
+      "Reduce to single partition and apply limit",
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
+          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+        TypeSig.all),
+      (collectLimit, conf, p, r) => new GpuCollectLimitMeta(collectLimit, conf, p, r) {
+        override def convertToGpu(): GpuExec =
+          GpuGlobalLimitExec(collectLimit.limit,
+            GpuShuffleExchangeExec(
+              GpuSinglePartitioning,
+              GpuLocalLimitExec(collectLimit.limit, childPlans.head.convertIfNeeded()),
+              ENSURE_REQUIREMENTS
+            )(SinglePartition), collectLimit.offset)
+      }
+    ).disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
+        "of rows in a batch it could help by limiting the number of rows transferred from " +
+        "GPU to CPU")
+  ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
+
+  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
+    super.getExecs ++ shimExecs
+
+  // AnsiCast is removed from Spark3.4.0
+  override def ansiCastRule: ExprRule[_ <: Expression] = null
+
+  override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
+    val shimExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
+      // Empty2Null is pulled out of FileFormatWriter by default since Spark 3.4.0,
+      // so it is visible at the overriding stage.
+      GpuOverrides.expr[Empty2Null](
+        "Converts the empty string to null for writing data",
+        ExprChecks.unaryProjectInputMatchesOutput(
+          TypeSig.STRING, TypeSig.STRING),
+        (a, conf, p, r) => new UnaryExprMeta[Empty2Null](a, conf, p, r) {
+          override def convertToGpu(child: Expression): GpuExpression = GpuEmpty2Null(child)
+        }
+      )
+    ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
+    super.getExprs ++ shimExprs
+  }
+}

--- a/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/340/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -16,52 +16,8 @@
 
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.{ShimLoader, ShimVersion}
 
-import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
-import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
-import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan}
-import org.apache.spark.sql.execution.exchange.ENSURE_REQUIREMENTS
-
-object SparkShimImpl extends Spark331PlusShims {
+object SparkShimImpl extends Spark340PlusShims {
   override def getSparkShimVersion: ShimVersion = ShimLoader.getShimVersion
-
-  private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
-    GpuOverrides.exec[GlobalLimitExec](
-      "Limiting of results across partitions",
-      ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
-          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
-        TypeSig.all),
-      (globalLimit, conf, p, r) =>
-        new SparkPlanMeta[GlobalLimitExec](globalLimit, conf, p, r) {
-          override def convertToGpu(): GpuExec =
-            GpuGlobalLimitExec(
-              globalLimit.limit, childPlans.head.convertIfNeeded(), globalLimit.offset)
-        }),
-    GpuOverrides.exec[CollectLimitExec](
-      "Reduce to single partition and apply limit",
-      ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
-          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
-        TypeSig.all),
-      (collectLimit, conf, p, r) => new GpuCollectLimitMeta(collectLimit, conf, p, r) {
-        override def convertToGpu(): GpuExec =
-          GpuGlobalLimitExec(collectLimit.limit,
-            GpuShuffleExchangeExec(
-              GpuSinglePartitioning,
-              GpuLocalLimitExec(collectLimit.limit, childPlans.head.convertIfNeeded()),
-              ENSURE_REQUIREMENTS
-            )(SinglePartition), collectLimit.offset)
-      }
-    ).disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
-        "of rows in a batch it could help by limiting the number of rows transferred from " +
-        "GPU to CPU")
-  ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
-
-  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
-    super.getExecs ++ shimExecs
-
-  // AnsiCast is removed from Spark3.4.0
-  override def ansiCastRule: ExprRule[_ <: Expression] = null
-
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -107,7 +107,7 @@ object GpuFileFormatWriter extends Logging {
     val hasGpuEmpty2Null = plan.find(p => GpuV1WriteUtils.hasGpuEmptyToNull(p.expressions))
       .isDefined
     val empty2NullPlan = if (hasGpuEmpty2Null) {
-      // Empty2Null has been inserted during logic planning.
+      // Empty2Null has been inserted during logic optimization.
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuV1WriteUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuV1WriteUtils.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.types.{DataType, StringType}
+
+object GpuV1WriteUtils extends Logging {
+
+  /** A function that converts the empty string to null for partition values. */
+  case class GpuEmpty2Null(child: Expression) extends GpuUnaryExpression {
+    override def nullable: Boolean = true
+
+    override def doColumnar(input: GpuColumnVector): ColumnVector = {
+      var from: ColumnVector = null
+      var to: ColumnVector = null
+      try {
+        from = ColumnVector.fromStrings("")
+        to = ColumnVector.fromStrings(null)
+        input.getBase.findAndReplaceAll(from, to)
+      } finally {
+        if (from != null) {
+          from.close()
+        }
+        if (to != null) {
+          to.close()
+        }
+      }
+    }
+
+    override def dataType: DataType = StringType
+  }
+
+  def convertGpuEmptyToNull(
+      output: Seq[Attribute],
+      partitionSet: AttributeSet): List[NamedExpression] = {
+    var needConvert = false
+    val projectList: List[NamedExpression] = output.map {
+      case p if partitionSet.contains(p) && p.dataType == StringType && p.nullable =>
+        needConvert = true
+        GpuAlias(GpuEmpty2Null(p), p.name)()
+      case other => other
+    }.toList // Force list to avoid recursive Java serialization of lazy list Seq implementation
+
+    if (needConvert) projectList else Nil
+  }
+
+  def hasGpuEmptyToNull(expressions: Seq[Expression]): Boolean = {
+    expressions.exists(_.find(_.isInstanceOf[GpuEmpty2Null]).isDefined)
+  }
+}


### PR DESCRIPTION
fixes #6074 
fixes #7144

No change is required in plugin for https://github.com/apache/spark/commit/256227477b, just updating the test is enough.
Since the new class `V1WriteCommand` is used only in the optimization stage. 

This PR also pulls out the `GpuEmpty2Null` from `GpuFileFormatWriter` similarly as what Spark has done in https://github.com/apache/spark/commit/f98f9f8566.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
