### PR TITLE
Fix non-deterministic query in test_aqe_join_reused_exchange_inequality_condition [databricks]

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -178,7 +178,7 @@ def test_aqe_join_reused_exchange_inequality_condition(spark_tmp_path, join):
                 where salary in (
                     select salary from (select a.salary
                     from df2 a inner join (select max(date(ts)) as state_start from df2) b on date(a.ts) > b.state_start - 2
-                    limit 1))
+                    order by a.salary limit 1))
             """.format(join=join)
         )
 


### PR DESCRIPTION
Fixes #7168.

The query was using a `limit 1` without any specified order, so it was non-deterministic which value in the subquery was selected.  Fixed by adding an `order by` clause before the limit to make the subquery deterministic.  Verified that the new query fails without the fix from #7110 and passes afterwards, so the test's intention to trigger a GPU exchange reuse by the CPU is preserved.