### PR TITLE
[Doc]add a Contact Us page at the top-level menu[skip ci]

### DIFF
--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: Contact US
+title: Contact Us
 nav_order: 16
 ---
-# Contact US
+# Contact Us
 
 ## Technical Support
 If you need any help or have questions on this product, please contact us :

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -6,9 +6,8 @@ nav_order: 16
 # Contact US
 
 ## Technical Support
-If you need any help or have questions on this product, please contact us : 
-[spark-rapids-support@nvidia.com](mailto:spark-rapids-support@nvidia.com?subject=[GitHub]%20Source%20Han%20Sans)
-
+If you need any help or have questions on this product, please contact us :
+<a href="mailto:spark-rapids-support@nvidia.com">spark-rapids-support@nvidia.com</a>
 ## Issues and Discussions
 We use github to track bugs, feature requests, and answer questions. File an
 [issue](https://github.com/NVIDIA/spark-rapids/issues/new/choose) for a bug or feature request. Ask

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Contact US
+nav_order: 16
+---
+# Contact US
+
+## Technical Support
+If you need any help or have questions on this product, please contact us : 
+[spark-rapids-support@nvidia.com](mailto:spark-rapids-support@nvidia.com?subject=[GitHub]%20Source%20Han%20Sans)
+
+## Issues and Discussions
+We use github to track bugs, feature requests, and answer questions. File an
+[issue](https://github.com/NVIDIA/spark-rapids/issues/new/choose) for a bug or feature request. Ask
+or answer a question on the [discussion board](https://github.com/NVIDIA/spark-rapids/discussions).

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -6,7 +6,7 @@ nav_order: 16
 # Contact Us
 
 ## Technical Support
-If you need any help or have questions on this product, please contact us :
+If you need any help or have questions on this product, please contact us:
 <a href="mailto:spark-rapids-support@nvidia.com">spark-rapids-support@nvidia.com</a>
 
 ## Issues and Discussions

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -8,6 +8,7 @@ nav_order: 16
 ## Technical Support
 If you need any help or have questions on this product, please contact us :
 <a href="mailto:spark-rapids-support@nvidia.com">spark-rapids-support@nvidia.com</a>
+
 ## Issues and Discussions
 We use github to track bugs, feature requests, and answer questions. File an
 [issue](https://github.com/NVIDIA/spark-rapids/issues/new/choose) for a bug or feature request. Ask


### PR DESCRIPTION
This PR is to add a Contact Us page at the top-level menu for easier to find.
fix #6994 
Signed-off-by: liyuan <yuali@nvidia.com>