### PR TITLE
Change RegExpExtract to use isNull checks instead of contains_re

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1300,13 +1300,13 @@ case class GpuRegExpExtract(
     // | '1a1'  | ''    | NULL  |
 
     withResource(str.getBase.extractRe(extractPattern)) { extract =>
-      val outputNullAndInputNotNull =
-        withResource(extract.getColumn(groupIndex).isNull) { outputNull =>
-          withResource(str.getBase.isNotNull) { inputNotNull =>
-            outputNull.and(inputNotNull)
-          }
-        }
       withResource(GpuScalar.from("", DataTypes.StringType)) { emptyString =>
+        val outputNullAndInputNotNull =
+          withResource(extract.getColumn(groupIndex).isNull) { outputNull =>
+            withResource(str.getBase.isNotNull) { inputNotNull =>
+              outputNull.and(inputNotNull)
+            }
+          }
         withResource(outputNullAndInputNotNull) {
           _.ifElse(emptyString, extract.getColumn(groupIndex))
         }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/7196

Currently Regexp Extract uses contains_re to handle the case where cudf returns a NULL when there is a valid value but it doesn't match the regex but with java/Spark it needs to return an empty string. The contains_re is inefficient and about doubles the time of the extract.  instead of using that we can just use isNull and And.

The cases:
```
    // | Input  | Java  | cuDF  |
    // |--------|-------|-------|
    // | ''     | ''    | ''    |
    // | NULL   | NULL  | NULL  |
    // | 'a1a'  | '1'   | '1'   |
    // | '1a1'  | ''    | NULL  |

```

So here we can just check if the result from CUDF is NULL and the input is not null then we put in an empty string.  This PR has changed to use that logic.

Tested via integration tests and tested on customer query where this had good speed up. Query went form 3.3 minutes to 2.5 minutes.  Looked and nsys trace and the contains_re is gone. This was taking about 36ms per call and now this code takes about 3ms per call.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
