### PR TITLE
Fix regressions in parsing dates

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -486,12 +486,19 @@ object GpuToTimestamp extends Arm {
       case Some(fmt) =>
         // the cuDF `is_timestamp` function is less restrictive than Spark's behavior for UnixTime
         // and ToUnixTime and will support parsing a subset of a string so we check the length of
-        // the string as well which works well for fixed-length formats but if/when we want to
-        // support variable-length formats (such as timestamps with milliseconds) then we will need
-        // to use regex instead.
-        withResource(col.matchesRe(fmt.validRegex)) { matches =>
+        // the string as well as checking for a regex match
+        val isTimestamp = withResource(col.matchesRe(fmt.validRegex)) { matches =>
           withResource(col.isTimestamp(strfFormat)) { isTimestamp =>
             isTimestamp.and(matches)
+          }
+        }
+        withResource(isTimestamp) { _ =>
+          withResource(col.getCharLengths) { len =>
+            withResource(Scalar.fromInt(sparkFormat.length)) { expectedLen =>
+              withResource(len.equalTo(expectedLen)) { lenMatches =>
+                lenMatches.and(isTimestamp)
+              }
+            }
           }
         }
       case _ =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -60,8 +60,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
-      assumeCondition = _ => (false,
-        "https://github.com/NVIDIA/spark-rapids/issues/7090"),
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
@@ -117,8 +115,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
       timestampsAsStrings,
-    assumeCondition = _ => (false,
-      "https://github.com/NVIDIA/spark-rapids/issues/7090"),
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
   }
@@ -139,8 +135,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("unix_timestamp parse date",
       timestampsAsStrings,
-    assumeCondition = _ => (false,
-      "https://github.com/NVIDIA/spark-rapids/issues/7090"),
     conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
   }


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/7090

The behavior of `\Z` in cuDF regex has changed and it will now match before a final line-terminator in a string, so this PR adds an additional check when parsing dates, in order to reject strings that have trailing newlines.