### PR TITLE
Fix PCBS integration tests for Spark-3.4

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -29,7 +29,7 @@ import com.nvidia.spark.GpuCachedBatchSerializer
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, ParquetLegacyNanoAsLongShims, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, ParquetLegacyNanoAsLongShims, ParquetTimestampNTZShims, SparkShimImpl}
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.RecordWriter
@@ -1201,6 +1201,9 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
     // From 3.3.0, Spark will check this filed ID config
     ParquetFieldIdShims.setupParquetFieldIdWriteConfig(hadoopConf, sqlConf)
+
+    // timestamp_NTZ flag is introduced in Spark 3.4.0
+    ParquetTimestampNTZShims.setupTimestampNTZConfig(hadoopConf, sqlConf)
 
     // From 3.3.2, Spark schema converter needs this conf
     ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLongForPCBS(hadoopConf)

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -31,6 +31,7 @@ import scala.collection.JavaConverters._
 
 import com.nvidia.spark.CurrentBatchIterator
 import com.nvidia.spark.rapids.ParquetCachedBatch
+import com.nvidia.spark.rapids.shims.ParquetTimestampNTZShims
 import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.ParquetReadOptions
@@ -80,6 +81,7 @@ class ShimCurrentBatchIterator(
   config.setBoolean(SQLConf.PARQUET_BINARY_AS_STRING.key, false)
   config.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, false)
   config.setBoolean(SQLConf.CASE_SENSITIVE.key, false)
+  ParquetTimestampNTZShims.setupTimestampNTZConfig(config, conf)
   val parquetColumn = new ParquetToSparkSchemaConverter(config)
       .convertParquetColumn(reqParquetSchemaInCacheOrder, Option.empty)
 


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/7216 .

Spark-3.4 added a new config flag to enable TIMESTAMP_NTZ and added that in `class ParquetToSparkSchemaConverter`
Updated the code such that Spark-3.4 shim takes that into consideration. With this fix, the PCBS tests pass in Spark-3.4.

```
========================================================= 580 passed, 81 warnings in 168.18s (0:02:48) =========================================================
Starting with OOM injection seed: 1681945885. Set env variable SPARK_RAPIDS_TEST_INJECT_OOM_SEED to override.
2023-04-19 16:11:25 INFO     Executing global initialization tasks before test launches
```
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
