### PR TITLE
[Doc]update download docs for v22.12 release[skip ci]

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -5,6 +5,66 @@ nav_order: 15
 ---
 Below are archived releases for RAPIDS Accelerator for Apache Spark.
 
+## Release v22.10.0
+Hardware Requirements:
+
+The plugin is tested on the following architectures:
+
+	GPU Models: NVIDIA P100, V100, T4 and A2/A10/A30/A100 GPUs
+
+Software Requirements:
+
+	OS: Ubuntu 18.04, Ubuntu 20.04 or CentOS 7, Rocky Linux 8
+
+	CUDA & NVIDIA Drivers*: 11.x & v450.80.02+
+
+	Apache Spark 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1, 3.2.2, 3.3.0, Databricks 9.1 ML LTS or 10.4 ML LTS Runtime and GCP Dataproc 2.0
+
+	Python 3.6+, Scala 2.12, Java 8
+
+*Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
+for your hardware's minimum driver version.
+
+*For Cloudera and EMR support, please refer to the
+[Distributions](./FAQ.md#which-distributions-are-supported) section of the FAQ.
+
+### Download v22.10.0
+* Download the [RAPIDS
+  Accelerator for Apache Spark 22.10.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
+
+This package is built against CUDA 11.5 and all CUDA 11.x versions are supported through [CUDA forward
+compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html). It is tested
+on V100, T4, A2, A10, A30 and A100 GPUs with CUDA 11.0-11.5.  For those using other types of GPUs which
+do not have CUDA forward compatibility (for example, GeForce), CUDA 11.5 or later is required. Users will
+need to ensure the minimum driver (450.80.02) and CUDA toolkit are installed on each Spark node.
+
+### Verify signature
+* Download the [RAPIDS Accelerator for Apache Spark 22.10.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
+  and [RAPIDS Accelerator for Apache Spark 22.10.0 jars.asc](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar.asc)
+* Download the [PUB_KEY](https://keys.openpgp.org/search?q=sw-spark@nvidia.com).
+* Import the public key: `gpg --import PUB_KEY`
+* Verify the signature: `gpg --verify rapids-4-spark_2.12-22.10.0.jar.asc rapids-4-spark_2.12-22.10.0.jar`
+
+The output if signature verify:
+
+	gpg: Good signature from "NVIDIA Spark (For the signature of spark-rapids release jars) <sw-spark@nvidia.com>"
+
+### Release Notes
+New functionality and performance improvements for this release include:
+* Dataproc qualification, profiling, bootstrap and diagnostic tool
+* Databricks custom docker container
+* AQE support on Databricks
+* MultiThreaded Shuffle feature
+* Binary write support for parquet
+* Cast binary to string  
+* Hive parquet table write support
+* Qualification and Profiling tool:
+  * Print Databricks cluster/job information
+  * AutoTuner for Profiling tool
+
+For a detailed list of changes, please refer to the
+[CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).
+
 ## Release v22.08.0
 Hardware Requirements:
 

--- a/docs/demo/AWS-EMR/Mortgage-ETL-GPU-EMR.ipynb
+++ b/docs/demo/AWS-EMR/Mortgage-ETL-GPU-EMR.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "## Data Source\n",
     "\n",
-    "Dataset is from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html). Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset from the Fannie Mae website.\n",
+    "Dataset is from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html). Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset from the Fannie Mae website.\n",
     "\n",
     "## Prerequisite\n",
     "\n",

--- a/docs/demo/Databricks/Mortgage-ETL-db.ipynb
+++ b/docs/demo/Databricks/Mortgage-ETL-db.ipynb
@@ -12,7 +12,7 @@
    },
    "source": [
     "## Prerequirement\n",
-    "Dataset is derived from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html) with all rights reserved by Fannie Mae. Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset."
+    "Dataset is derived from Fannie Mae’s [Single-Family Loan Performance Data](http://www.fanniemae.com/portal/funding-the-market/data/loan-performance-data.html) with all rights reserved by Fannie Mae. Refer to these [instructions](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples/dataset/mortgage.md) to download the dataset."
    ]
   },
   {

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -5,5 +5,5 @@ nav_order: 2
 parent: Developer Overview
 ---
 An overview of testing can be found within the repository at:
-* [Unit tests](https://github.com/NVIDIA/spark-rapids/tree/branch-22.10/tests#readme)
-* [Integration testing](https://github.com/NVIDIA/spark-rapids/tree/branch-22.10/integration_tests#readme)
+* [Unit tests](https://github.com/NVIDIA/spark-rapids/tree/branch-22.12/tests#readme)
+* [Integration testing](https://github.com/NVIDIA/spark-rapids/tree/branch-22.12/integration_tests#readme)

--- a/docs/download.md
+++ b/docs/download.md
@@ -18,7 +18,7 @@ cuDF jar, that is either preinstalled in the Spark classpath on all nodes or sub
 that uses the RAPIDS Accelerator For Apache Spark. See the [getting-started
 guide](https://nvidia.github.io/spark-rapids/Getting-Started/) for more details.
 
-## Release v22.10.0
+## Release v22.12.0
 Hardware Requirements:
 
 The plugin is tested on the following architectures:
@@ -31,7 +31,7 @@ Software Requirements:
 
 	CUDA & NVIDIA Drivers*: 11.x & v450.80.02+
 
-	Apache Spark 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1, 3.2.2, 3.3.0, Databricks 9.1 ML LTS or 10.4 ML LTS Runtime and GCP Dataproc 2.0
+	Apache Spark 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1, 3.2.2, 3.2.3, 3.3.0, 3.3.1, 3.3.2, 3.4.0 Databricks 9.1 ML LTS, 10.4 ML LTS or 11.3 ML LTS Runtime and GCP Dataproc 2.0
 
 	Python 3.6+, Scala 2.12, Java 8
 
@@ -41,9 +41,9 @@ for your hardware's minimum driver version.
 *For Cloudera and EMR support, please refer to the
 [Distributions](./FAQ.md#which-distributions-are-supported) section of the FAQ.
 
-### Download v22.10.0
+### Download v22.12.0
 * Download the [RAPIDS
-  Accelerator for Apache Spark 22.10.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
+  Accelerator for Apache Spark 22.12.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
 
 This package is built against CUDA 11.5 and all CUDA 11.x versions are supported through [CUDA forward
 compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html). It is tested
@@ -52,11 +52,11 @@ do not have CUDA forward compatibility (for example, GeForce), CUDA 11.5 or late
 need to ensure the minimum driver (450.80.02) and CUDA toolkit are installed on each Spark node.
 
 ### Verify signature
-* Download the [RAPIDS Accelerator for Apache Spark 22.10.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
-  and [RAPIDS Accelerator for Apache Spark 22.10.0 jars.asc](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar.asc)
+* Download the [RAPIDS Accelerator for Apache Spark 22.12.0 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
+  and [RAPIDS Accelerator for Apache Spark 22.12.0 jars.asc](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar.asc)
 * Download the [PUB_KEY](https://keys.openpgp.org/search?q=sw-spark@nvidia.com).
 * Import the public key: `gpg --import PUB_KEY`
-* Verify the signature: `gpg --verify rapids-4-spark_2.12-22.10.0.jar.asc rapids-4-spark_2.12-22.10.0.jar`
+* Verify the signature: `gpg --verify rapids-4-spark_2.12-22.12.0.jar.asc rapids-4-spark_2.12-22.12.0.jar`
 
 The output if signature verify:
 
@@ -64,16 +64,15 @@ The output if signature verify:
 
 ### Release Notes
 New functionality and performance improvements for this release include:
-* Dataproc qualification, profiling, bootstrap and diagnostic tool
-* Databricks custom docker container
-* AQE support on Databricks
-* MultiThreaded Shuffle feature
-* Binary write support for parquet
-* Cast binary to string  
-* Hive parquet table write support
+* Deliver z-ordering capability on Databricks
+* Enable DPP on Databricks 10.4
+* Improve robust for workloads which has high compression ratio input datasets
+* Support Delta Lake batch writes on Databricks
+* Partially support HiveTableScanExec on GPU
+* Support mapInArrow
+* Enable tiered projections for more expressions to optimize performance   
 * Qualification and Profiling tool:
-  * Print Databricks cluster/job information
-  * AutoTuner for Profiling tool
+  * Support cost estimations for Dataproc 1.5 and Dataproc2.x
 
 For a detailed list of changes, please refer to the
 [CHANGELOG](https://github.com/NVIDIA/spark-rapids/blob/main/CHANGELOG.md).

--- a/docs/get-started/getting-started-databricks.md
+++ b/docs/get-started/getting-started-databricks.md
@@ -137,7 +137,7 @@ cluster.
     ```bash
     spark.rapids.sql.python.gpu.enabled true
     spark.python.daemon.module rapids.daemon_databricks
-    spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-22.10.0.jar:/databricks/spark/python
+    spark.executorEnv.PYTHONPATH /databricks/jars/rapids-4-spark_2.12-22.12.0.jar:/databricks/spark/python
     ```
 
 7. Once you’ve added the Spark config, click “Confirm and Restart”.
@@ -153,7 +153,7 @@ for more details.
 
 ## Import the GPU Mortgage Example Notebook
 Import the example [notebook](../demo/Databricks/Mortgage-ETL-db.ipynb) from the repo into your
-workspace, then open the notebook. Please find this [instruction](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.10/docs/get-started/xgboost-examples/dataset/mortgage.md)
+workspace, then open the notebook. Please find this [instruction](https://github.com/NVIDIA/spark-rapids-examples/blob/branch-22.12/docs/get-started/xgboost-examples/dataset/mortgage.md)
 to download the dataset.
 
 ```bash

--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -257,7 +257,7 @@ pretty accurate.
 ### Requirements
 
 - A Spark 3.x GPU cluster
-- The `rapids-4-spark` [jar](../download.md)
+- The `rapids-4-spark` [jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-sql-meta_2.11/22.10.0/rapids-4-spark-sql-meta_2.11-22.10.0.jar)
 
 ### How to use
 

--- a/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
+++ b/docs/get-started/gpu_dataproc_packages_ubuntu_sample.sh
@@ -139,7 +139,7 @@ EOF
   systemctl start dataproc-cgroup-device-permissions
 }
 
-readonly DEFAULT_SPARK_RAPIDS_VERSION="22.10.0"
+readonly DEFAULT_SPARK_RAPIDS_VERSION="22.12.0"
 readonly DEFAULT_CUDA_VERSION="11.5"
 readonly DEFAULT_XGBOOST_VERSION="1.6.2"
 readonly SPARK_VERSION="3.0"


### PR DESCRIPTION
Signed-off-by: liyuan <yuali@nvidia.com>
update download docs and update versions.
The links in download.md and getting-started-workload-qualification.md and some notebooks are not updated to avoid markdown checker failure, will draft another pr to update the links.
Fix issue #7190 

