### PR TITLE
[Doc]fix broken links[skip ci]

### DIFF
--- a/docs/get-started/getting-started-workload-qualification.md
+++ b/docs/get-started/getting-started-workload-qualification.md
@@ -140,7 +140,7 @@ which is the same as the driver logs with `spark.rapids.sql.explain=all`.
 #### Requirements with Spark 2.4.X
 
 - A Spark 2.4.X CPU cluster
-- The `rapids-4-spark-sql-meta` [jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-sql-meta_2.11/22.10.0/rapids-4-spark-sql-meta_2.11-22.10.0.jar")
+- The `rapids-4-spark-sql-meta` [jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark-sql-meta_2.11/22.10.0/rapids-4-spark-sql-meta_2.11-22.10.0.jar)
 - Ability to modify the existing Spark application code
 - RAPIDS Accelerator for Apache Spark version 22.02 or newer
 


### PR DESCRIPTION
Signed-off-by: liyuan <yuali@nvidia.com>

the markdown failure is because the link has an additional `"`
fix the broken link in getting-started-workload-qualification.md