### PR TITLE
Update columnar stats tracker API to pass file path for new batches

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/BasicColumnarWriteStatsTracker.scala
@@ -153,7 +153,7 @@ class BasicColumnarWriteTaskStatsTracker(
     }
   }
 
-  override def newBatch(batch: ColumnarBatch): Unit = {
+  override def newBatch(filePath: String, batch: ColumnarBatch): Unit = {
     numRows += batch.numRows
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ColumnarWriteStatsTracker.scala
@@ -52,9 +52,10 @@ trait ColumnarWriteTaskStatsTracker {
   /**
    * Process a new column batch to update the tracked statistics accordingly.
    * The batch will be written to the most recently witnessed file (via `newFile`).
+   * @param filePath Path of the file which the batch is written to.
    * @param batch Current data batch to be processed.
    */
-  def newBatch(batch: ColumnarBatch): Unit
+  def newBatch(filePath: String, batch: ColumnarBatch): Unit
 
   /**
    * Returns the final statistics computed so far.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -168,7 +168,7 @@ class GpuSingleDirectoryDataWriter(
     val maxRecordsPerFile = description.maxRecordsPerFile
     if (!needSplitBatch(maxRecordsPerFile, recordsInFile, batch.numRows())) {
       closeOnExcept(batch) { _ =>
-        statsTrackers.foreach(_.newBatch(currentWriter.path, batch))
+        statsTrackers.foreach(_.newBatch(currentWriter.path(), batch))
         recordsInFile += batch.numRows()
       }
       currentWriter.writeAndClose(batch, statsTrackers)
@@ -195,7 +195,7 @@ class GpuSingleDirectoryDataWriter(
               withResource(b.getTable()) {tab =>
                 val bc = GpuColumnVector.from(tab, dataTypes)
                 closeOnExcept(bc) { _ =>
-                  statsTrackers.foreach(_.newBatch(currentWriter.path, bc))
+                  statsTrackers.foreach(_.newBatch(currentWriter.path(), bc))
                   recordsInFile += b.getRowCount()
                 }
                 currentWriter.writeAndClose(bc, statsTrackers)
@@ -536,7 +536,7 @@ class GpuDynamicPartitionDataSingleWriter(
           {
             val batch  = GpuColumnVector.from(concat, outDataTypes)
             closeOnExcept(batch) { _ =>
-              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, batch))
+              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path(), batch))
               currentWriterStatus.recordsInFile += batch.numRows()
             }
             currentWriterStatus.outputWriter.writeAndClose(batch, statsTrackers)
@@ -551,7 +551,7 @@ class GpuDynamicPartitionDataSingleWriter(
           {
             val batch = GpuColumnVector.from(table, outDataTypes)
             closeOnExcept(batch) { _ =>
-              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, batch))
+              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path(), batch))
               currentWriterStatus.recordsInFile += batch.numRows()
             }
             currentWriterStatus.outputWriter.writeAndClose(batch, statsTrackers)
@@ -627,7 +627,7 @@ class GpuDynamicPartitionDataSingleWriter(
         }
         val bc = GpuColumnVector.from(b.getTable(), outDataTypes)
         closeOnExcept(bc) { _ =>
-          statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, bc))
+          statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path(), bc))
           currentWriterStatus.recordsInFile += b.getRowCount()
         }
         currentWriterStatus.outputWriter.writeAndClose(bc, statsTrackers)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -167,8 +167,10 @@ class GpuSingleDirectoryDataWriter(
   override def write(batch: ColumnarBatch): Unit = {
     val maxRecordsPerFile = description.maxRecordsPerFile
     if (!needSplitBatch(maxRecordsPerFile, recordsInFile, batch.numRows())) {
-      statsTrackers.foreach(_.newBatch(batch))
-      recordsInFile += batch.numRows()
+      closeOnExcept(batch) { _ =>
+        statsTrackers.foreach(_.newBatch(currentWriter.path, batch))
+        recordsInFile += batch.numRows()
+      }
       currentWriter.writeAndClose(batch, statsTrackers)
     } else {
       withResource(batch) { batch =>
@@ -192,8 +194,10 @@ class GpuSingleDirectoryDataWriter(
               }
               withResource(b.getTable()) {tab =>
                 val bc = GpuColumnVector.from(tab, dataTypes)
-                statsTrackers.foreach(_.newBatch(bc))
-                recordsInFile += b.getRowCount()
+                closeOnExcept(bc) { _ =>
+                  statsTrackers.foreach(_.newBatch(currentWriter.path, bc))
+                  recordsInFile += b.getRowCount()
+                }
                 currentWriter.writeAndClose(bc, statsTrackers)
                 needNewWriter = true
               }
@@ -532,7 +536,7 @@ class GpuDynamicPartitionDataSingleWriter(
           {
             val batch  = GpuColumnVector.from(concat, outDataTypes)
             closeOnExcept(batch) { _ =>
-              statsTrackers.foreach(_.newBatch(batch))
+              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, batch))
               currentWriterStatus.recordsInFile += batch.numRows()
             }
             currentWriterStatus.outputWriter.writeAndClose(batch, statsTrackers)
@@ -547,7 +551,7 @@ class GpuDynamicPartitionDataSingleWriter(
           {
             val batch = GpuColumnVector.from(table, outDataTypes)
             closeOnExcept(batch) { _ =>
-              statsTrackers.foreach(_.newBatch(batch))
+              statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, batch))
               currentWriterStatus.recordsInFile += batch.numRows()
             }
             currentWriterStatus.outputWriter.writeAndClose(batch, statsTrackers)
@@ -623,7 +627,7 @@ class GpuDynamicPartitionDataSingleWriter(
         }
         val bc = GpuColumnVector.from(b.getTable(), outDataTypes)
         closeOnExcept(bc) { _ =>
-          statsTrackers.foreach(_.newBatch(bc))
+          statsTrackers.foreach(_.newBatch(currentWriterStatus.outputWriter.path, bc))
           currentWriterStatus.recordsInFile += b.getRowCount()
         }
         currentWriterStatus.outputWriter.writeAndClose(bc, statsTrackers)
@@ -963,7 +967,7 @@ class GpuDynamicPartitionDataConcurrentWriter(
     withResource(t) { _ =>
       val batch = GpuColumnVector.from(t, outDataTypes)
       if (!needSplitBatch(maxRecordsPerFile, status.writerStatus.recordsInFile, batch.numRows())) {
-        statsTrackers.foreach(_.newBatch(batch))
+        statsTrackers.foreach(_.newBatch(status.writerStatus.outputWriter.path(), batch))
         status.writerStatus.recordsInFile += batch.numRows()
         status.writerStatus.outputWriter.writeAndClose(batch, statsTrackers)
       } else {
@@ -995,7 +999,7 @@ class GpuDynamicPartitionDataConcurrentWriter(
                 val cb = withResource(b.getTable()) {tab =>
                   GpuColumnVector.from(tab, dataTypes)
                 }
-                statsTrackers.foreach(_.newBatch(cb))
+                statsTrackers.foreach(_.newBatch(status.writerStatus.outputWriter.path(), cb))
                 status.writerStatus.recordsInFile += b.getRowCount()
                 status.writerStatus.outputWriter.writeAndClose(cb, statsTrackers)
                 needNewWriter = true


### PR DESCRIPTION
This updates the columnar stats tracker `newBatch` API to pass the output file path the batch will be written to.  It's essentially the columnar form of the row-based task stats change as part of [SPARK-26164](https://issues.apache.org/jira/browse/SPARK-26164).

This also fixes some potential leaks that could occur if the `newBatch` callback on a stats tracker were to throw.