### PR TITLE
Correct partition columns handling for coalesced and chunked read

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -17,6 +17,8 @@
 package com.nvidia.spark.rapids
 
 import org.apache.spark.TaskContext
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -74,6 +76,85 @@ class SingleGpuColumnarBatchIterator(private var batch: ColumnarBatch)
     if (batch != null) {
       batch.close()
       batch = null
+    }
+  }
+}
+
+/**
+ * An iterator that appends partition columns to each batch in the input iterator.
+ *
+ * This iterator will correctly handle multiple partition values for each partition column
+ * for a chunked read.
+ *
+ * @param inputIter the input iterator of GPU columnar batch
+ * @param partValues partition values collected from all the batches in the input iterator
+ * @param partRowNums row numbers collected from all the batches in the input iterator, it
+ *                    should have the same size with "partValues".
+ * @param partSchema the partition schema
+ */
+class GpuColumnarBatchWithPartitionValuesIterator(
+    inputIter: GpuColumnarBatchIterator,
+    partValues: Array[InternalRow],
+    partRowNums: Array[Long],
+    partSchema: StructType) extends Iterator[ColumnarBatch] with Arm {
+  assert(partValues.length == partRowNums.length)
+
+  private var leftValues: Array[InternalRow] = partValues
+  private var leftRowNums: Array[Long] = partRowNums
+
+  override def hasNext: Boolean = inputIter.hasNext
+
+  override def next(): ColumnarBatch = {
+    if (!hasNext) throw new NoSuchElementException()
+    val batch = inputIter.next()
+    val (readPartValues, readPartRows) = closeOnExcept(batch) { _ =>
+      computeValuesAndRowNumsForBatch(batch.numRows())
+    }
+    MultiFileReaderUtils.addMultiplePartitionValuesAndClose(batch, readPartValues,
+      readPartRows, partSchema)
+  }
+
+  private[this] def computeValuesAndRowNumsForBatch(batchRowNum: Int):
+      (Array[InternalRow], Array[Long]) = {
+    val leftTotalRowNum = leftRowNums.sum
+    if (leftTotalRowNum == batchRowNum) {
+      // case a) All is read
+      (leftValues, leftRowNums)
+    } else if (leftTotalRowNum > batchRowNum) {
+      // case b) Partial is read
+      var consumedRowNum = 0L
+      var pos = 0
+      // 1: Locate the position for the current read
+      while (consumedRowNum < batchRowNum) {
+        // Not test "pos < leftRowNums.length" here because this is ensured
+        // by "leftRowNum > readNum"
+        consumedRowNum += leftRowNums(pos)
+        pos += 1
+      }
+      // 2: Split the arrays of values and row numbers for the current read
+      val (readValues, remainValues) = leftValues.splitAt(pos)
+      val (readRowNums, remainRowNums) = leftRowNums.splitAt(pos)
+      if (consumedRowNum == batchRowNum) {
+        // Good luck! Just at the edge of a partition
+        leftValues = remainValues
+        leftRowNums = remainRowNums
+      } else { // consumedRowNum > readNum, and pos > 0
+        // A worse case, inside a partition, need to correct the splits.
+        // e.g.
+        //    Row numbers: [2, 3, 2]
+        //    Read row number: 4,
+        // The original split result is:  [2, 3] and [2]
+        // And the corrected output is: [2, 2] and [1, 2]
+        val remainRowNumForSplitPart = consumedRowNum - batchRowNum
+        leftRowNums = remainRowNumForSplitPart +: remainRowNums
+        readRowNums(pos - 1) = readRowNums(pos - 1) - remainRowNumForSplitPart
+        leftValues = readValues(pos - 1) +: remainValues
+      }
+      (readValues, readRowNums)
+    } else { // leftTotalRowNum < readNum
+      // This should not happen, so throw an exception
+      throw new IllegalStateException(s"Partition row number <$leftTotalRowNum> " +
+        s"does not match that of the read batch <$batchRowNum>.")
     }
   }
 }


### PR DESCRIPTION
fixes #7225

This PR introduces a new iterator named `GpuColumnarBatchWithPartitionValuesIterator` to support appending multiple partition values to the batches returned from a `GpuDataProducer`.

Besides, it exposes some APIs related to partition handling by moving them out from `MultiFileCoalescingPartitionReaderBase` to the Scala object `MultiFileReaderUtils`.

Signed-off-by: Firestarman <firestarmanllc@gmail.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
