### PR TITLE
Update jni version 22.12.0 [databricks]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>22.12.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-jni.version>22.12.0</spark-rapids-jni.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Update JNI dep version to released 22.12.0

I will trigger CI after we deploy JNI artifact to maven central