### PR TITLE
Fix test failures resulting from change in Exceptions

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -334,9 +334,13 @@ def test_mod_pmod_by_zero(data_gen, overflow_exp):
 def test_cast_neg_to_decimal_err():
     # -12 cannot be represented as decimal(7,7)
     data_gen = _decimal_gen_7_7
-    exception_content = "Decimal(compact,-120000000,20,0}) cannot be represented as Decimal(7, 7)" \
-        if is_before_spark_314() or ((not is_before_spark_320()) and is_before_spark_322()) else \
-        "Decimal(compact, -120000000, 20, 0) cannot be represented as Decimal(7, 7)"
+    if is_before_spark_314() or ((not is_before_spark_320()) and is_before_spark_322()):
+        exception_content = "Decimal(compact,-120000000,20,0}) cannot be represented as Decimal(7, 7)"
+    elif not is_before_spark_340():
+        exception_content = "[NUMERIC_VALUE_OUT_OF_RANGE] -12 cannot be represented as Decimal(7, 7)"
+    else:
+        exception_content = "Decimal(compact, -120000000, 20, 0) cannot be represented as Decimal(7, 7)"
+
     exception_type = "java.lang.ArithmeticException: " if is_before_spark_330() \
         and not is_databricks104_or_later() else "org.apache.spark.SparkArithmeticException: "
 

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -1137,10 +1137,12 @@ def _get_overflow_df_2cols(spark, data_types, values, expr):
     (IntegerType(), [timedelta(microseconds=LONG_MIN), -1])
 ], ids=idfn)
 def test_day_time_interval_division_overflow(data_type, value_pair):
+    exception_message = "SparkArithmeticException: Overflow in integral divide." if is_before_spark_340() else \
+        "SparkArithmeticException: [ARITHMETIC_OVERFLOW] Overflow in integral divide."
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: _get_overflow_df_2cols(spark, [DayTimeIntervalType(), data_type], value_pair, 'a / b').collect(),
         conf={},
-        error_message='SparkArithmeticException: Overflow in integral divide.')
+        error_message=exception_message)
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_type,value_pair', [
@@ -1169,18 +1171,22 @@ def test_day_time_interval_division_round_overflow(data_type, value_pair):
     (DoubleType(), [timedelta(seconds=0), 0.0]),  # 0 / 0 = NaN
 ], ids=idfn)
 def test_day_time_interval_divided_by_zero(data_type, value_pair):
+    exception_message = "SparkArithmeticException: Division by zero." if is_before_spark_340() else \
+        "SparkArithmeticException: [INTERVAL_DIVIDED_BY_ZERO] Division by zero"
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: _get_overflow_df_2cols(spark, [DayTimeIntervalType(), data_type], value_pair, 'a / b').collect(),
         conf={},
-        error_message='SparkArithmeticException: Division by zero.')
+        error_message=exception_message)
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('zero_literal', ['0', '0.0f', '-0.0f'], ids=idfn)
 def test_day_time_interval_divided_by_zero_scalar(zero_literal):
+    exception_message = "SparkArithmeticException: Division by zero." if is_before_spark_340() else \
+        "SparkArithmeticException: [INTERVAL_DIVIDED_BY_ZERO] Division by zero."
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: _get_overflow_df_1col(spark, DayTimeIntervalType(), [timedelta(seconds=1)], 'a / ' + zero_literal).collect(),
         conf={},
-        error_message='SparkArithmeticException: Division by zero.')
+        error_message=exception_message)
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_type,value', [
@@ -1194,10 +1200,12 @@ def test_day_time_interval_divided_by_zero_scalar(zero_literal):
     (DoubleType(), -0.0),
 ], ids=idfn)
 def test_day_time_interval_scalar_divided_by_zero(data_type, value):
+    exception_message = "SparkArithmeticException: Division by zero." if is_before_spark_340() else \
+        "SparkArithmeticException: [INTERVAL_DIVIDED_BY_ZERO] Division by zero."
     assert_gpu_and_cpu_error(
         df_fun=lambda spark: _get_overflow_df_1col(spark, data_type, [value], 'INTERVAL 1 SECOND / a').collect(),
         conf={},
-        error_message='SparkArithmeticException: Division by zero.')
+        error_message=exception_message)
 
 @pytest.mark.skipif(is_before_spark_330(), reason='DayTimeInterval is not supported before Pyspark 3.3.0')
 @pytest.mark.parametrize('data_type,value_pair', [

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -322,8 +322,10 @@ def test_mod_pmod_by_zero(data_gen, overflow_exp):
         exception_str = 'java.lang.ArithmeticException: divide by zero'
     elif is_before_spark_330():
         exception_str = 'SparkArithmeticException: divide by zero'
-    else:
+    elif is_before_spark_340():
         exception_str = 'SparkArithmeticException: Division by zero'
+    else:
+        exception_str = 'SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero'
         
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
@@ -26,6 +26,10 @@ trait RapidsErrorUtilsFor330plus {
     QueryExecutionErrors.divideByZeroError(origin.context)
   }
 
+  def intervalDivByZeroError(origin: Origin): ArithmeticException = {
+    divByZeroError(origin)
+  }
+
   def divOverflowError(origin: Origin): ArithmeticException = {
     QueryExecutionErrors.overflowInIntegralDivideError(origin.context)
   }

--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
@@ -525,7 +525,7 @@ case class GpuDivideDTInterval(
   override def doColumnar(interval: GpuColumnVector, numScalar: GpuScalar): ColumnVector = {
     withResource(makeZeroScalar(numScalar.getBase.getType)) { zeroScalar =>
       if (numScalar.getBase.equals(zeroScalar)) {
-        throw RapidsErrorUtils.divByZeroError(origin)
+        throw RapidsErrorUtils.intervalDivByZeroError(origin)
       }
     }
     doColumnar(interval.getBase, numScalar.getBase, num.dataType)
@@ -534,7 +534,7 @@ case class GpuDivideDTInterval(
   override def doColumnar(interval: GpuColumnVector, num: GpuColumnVector): ColumnVector = {
     withResource(makeZeroScalar(num.getBase.getType)) { zeroScalar =>
       if (num.getBase.contains(zeroScalar)) {
-        throw RapidsErrorUtils.divByZeroError(origin)
+        throw RapidsErrorUtils.intervalDivByZeroError(origin)
       }
     }
     doColumnar(interval.getBase, num.getBase, num.dataType)
@@ -543,7 +543,7 @@ case class GpuDivideDTInterval(
   override def doColumnar(intervalScalar: GpuScalar, num: GpuColumnVector): ColumnVector = {
     withResource(makeZeroScalar(num.getBase.getType)) { zeroScalar =>
       if (num.getBase.contains(zeroScalar)) {
-        throw RapidsErrorUtils.divByZeroError(origin)
+        throw RapidsErrorUtils.intervalDivByZeroError(origin)
       }
     }
     doColumnar(intervalScalar.getBase, num.getBase, num.dataType)

--- a/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/340+/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -78,4 +78,8 @@ object RapidsErrorUtils extends RapidsErrorUtilsFor330plus {
   def sqlArrayIndexNotStartAtOneError(): RuntimeException = {
     QueryExecutionErrors.elementAtByIndexZeroError(context = null)
   }
+  
+  override def intervalDivByZeroError(origin: Origin): ArithmeticException = {
+    QueryExecutionErrors.intervalDividedByZeroError(origin.context)
+  }
 }


### PR DESCRIPTION
This PR addresses test failures in https://github.com/NVIDIA/spark-rapids/issues/6988

Before this PR running `arithmetic_ops_test` we have 

```
 284 failed, 517 passed, 14 skipped, 2 xfailed in 178.43s (0:02:58) 
```

After this PR we have 

```
236 failed, 565 passed, 14 skipped, 2 xfailed in 167.59s (0:02:47)
```

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
