### PR TITLE
Update plan capture listener to handle multiple plans per query.

### DIFF
--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -11,7 +11,6 @@ com/nvidia/spark/rapids/ColumnarRdd*
 com/nvidia/spark/rapids/GpuColumnVectorUtils*
 com/nvidia/spark/rapids/ClouderaShimVersion*
 com/nvidia/spark/rapids/DatabricksShimVersion*
-com/nvidia/spark/rapids/ExecutionPlanCaptureCallback*
 com/nvidia/spark/rapids/ExplainPlan.class
 com/nvidia/spark/rapids/ExplainPlan$.class
 com/nvidia/spark/rapids/ExplainPlanBase.class
@@ -28,6 +27,7 @@ com/nvidia/spark/rapids/SparkShimServiceProvider*
 com/nvidia/spark/rapids/SparkShimVersion*
 com/nvidia/spark/rapids/SparkShims*
 com/nvidia/spark/udf/Plugin*
+org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback*
 org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase*
 org/apache/spark/sql/rapids/execution/Unshimmed*
 org/apache/spark/sql/rapids/RapidsShuffleManagerLike*

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -330,12 +330,12 @@ def assert_gpu_fallback_write(write_func,
     cpu_end = time.time()
     print('### GPU RUN ###')
     jvm = spark_jvm()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.startCapture()
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.startCapture()
     gpu_start = time.time()
     gpu_path = base_path + '/GPU'
     with_gpu_session(lambda spark : write_func(spark, gpu_path), conf=conf)
     gpu_end = time.time()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name, 2000)
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name, 10000)
     print('### WRITE: GPU TOOK {} CPU TOOK {} ###'.format(
         gpu_end - gpu_start, cpu_end - cpu_start))
 
@@ -371,10 +371,10 @@ def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
     jvm = spark_jvm()
     if exist_classes:
         for clz in exist_classes.split(','):
-            jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertContains(gpu_df._jdf, clz)
+            jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertContains(gpu_df._jdf, clz)
     if non_exist_classes:
         for clz in non_exist_classes.split(','):
-            jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertNotContain(gpu_df._jdf, clz)
+            jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertNotContain(gpu_df._jdf, clz)
     print('### {}: GPU TOOK {} CPU TOOK {} ###'.format(collect_type,
         gpu_end - gpu_start, cpu_end - cpu_start))
     if should_sort_locally():
@@ -417,7 +417,7 @@ def assert_gpu_fallback_collect(func,
     from_gpu, gpu_df = with_gpu_session(bring_back, conf=conf)
     gpu_end = time.time()
     jvm = spark_jvm()
-    jvm.com.nvidia.spark.rapids.ExecutionPlanCaptureCallback.assertDidFallBack(gpu_df._jdf, cpu_fallback_class_name)
+    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertDidFallBack(gpu_df._jdf, cpu_fallback_class_name)
     print('### {}: GPU TOOK {} CPU TOOK {} ###'.format(collect_type,
         gpu_end - gpu_start, cpu_end - cpu_start))
     if should_sort_locally():

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -106,7 +106,6 @@ def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):
                           {}  # verify disabled by default
                           ], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_disabled_fallback(spark_tmp_path, disable_conf):
     data_path = spark_tmp_path + "/DELTA_DATA"
     assert_gpu_fallback_write(
@@ -278,7 +277,6 @@ def test_delta_write_round_trip_cdf_table_prop(spark_tmp_path):
 @ignore_order
 @pytest.mark.parametrize("ts_write", ["INT96", "TIMESTAMP_MICROS", "TIMESTAMP_MILLIS"], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_legacy_timestamp_fallback(spark_tmp_path, ts_write):
     gen = TimestampGen(start=datetime(1590, 1, 1, tzinfo=timezone.utc))
     data_path = spark_tmp_path + "/DELTA_DATA"
@@ -301,7 +299,6 @@ def test_delta_write_legacy_timestamp_fallback(spark_tmp_path, ts_write):
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_encryption_option_fallback(spark_tmp_path, write_options):
     def write_func(spark, path):
         writer = unary_op_df(spark, int_gen).coalesce(1).write.format("delta")
@@ -323,7 +320,6 @@ def test_delta_write_encryption_option_fallback(spark_tmp_path, write_options):
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_encryption_runtimeconfig_fallback(spark_tmp_path, write_options):
     data_path = spark_tmp_path + "/DELTA_DATA"
     assert_gpu_fallback_write(
@@ -340,7 +336,6 @@ def test_delta_write_encryption_runtimeconfig_fallback(spark_tmp_path, write_opt
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_encryption_hadoopconfig_fallback(spark_tmp_path, write_options):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_hadoop_confs(spark):
@@ -365,7 +360,6 @@ def test_delta_write_encryption_hadoopconfig_fallback(spark_tmp_path, write_opti
 @ignore_order
 @pytest.mark.parametrize('codec', ['gzip'])
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_compression_fallback(spark_tmp_path, codec):
     data_path = spark_tmp_path + "/DELTA_DATA"
     confs=copy_and_update(delta_writes_enabled_conf, {"spark.sql.parquet.compression.codec": codec})
@@ -380,7 +374,6 @@ def test_delta_write_compression_fallback(spark_tmp_path, codec):
 @delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_legacy_format_fallback(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     confs=copy_and_update(delta_writes_enabled_conf, {"spark.sql.parquet.writeLegacyFormat": "true"})
@@ -467,7 +460,6 @@ def test_delta_write_constraint_check(spark_tmp_path):
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_constraint_check_fallback(spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     # create table with check constraint
@@ -608,7 +600,6 @@ def test_delta_write_multiple_identity_columns(spark_tmp_path):
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.skipif(is_databricks_runtime() and is_before_spark_330(),
                     reason="Databricks 10.4 does not properly handle options passed during DataFrame API write")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_auto_optimize_write_opts_fallback(confkey, spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     assert_gpu_fallback_write(
@@ -627,7 +618,6 @@ def test_delta_write_auto_optimize_write_opts_fallback(confkey, spark_tmp_path):
     "delta.autoOptimize.autoCompact" ], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.skipif(not is_databricks_runtime(), reason="Auto optimize only supported on Databricks")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_auto_optimize_table_props_fallback(confkey, spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     def setup_tables(spark):
@@ -649,7 +639,6 @@ def test_delta_write_auto_optimize_table_props_fallback(confkey, spark_tmp_path)
     "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite",
     "spark.databricks.delta.properties.defaults.autoOptimize.autoCompact" ], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7329')
 def test_delta_write_auto_optimize_sql_conf_fallback(confkey, spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     confs=copy_and_update(delta_writes_enabled_conf, {confkey: "true"})

--- a/integration_tests/src/main/python/spark_init_internal.py
+++ b/integration_tests/src/main/python/spark_init_internal.py
@@ -121,7 +121,7 @@ def pytest_sessionstart(session):
     _sb = pyspark.sql.SparkSession.builder
     _sb.config('spark.plugins', 'com.nvidia.spark.SQLPlugin') \
             .config("spark.sql.adaptive.enabled", "false") \
-            .config('spark.sql.queryExecutionListeners', 'com.nvidia.spark.rapids.ExecutionPlanCaptureCallback')
+            .config('spark.sql.queryExecutionListeners', 'org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback')
 
     for key, value in os.environ.items():
         if key.startswith(_CONF_ENV_PREFIX) and key != _DRIVER_ENV and key not in spark_jars_env:

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import scala.collection.mutable.{ArrayBuffer, Map => MutableMap}
+import scala.util.matching.Regex
+
+import com.nvidia.spark.rapids.{PlanShims, PlanUtils}
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.{ExecSubqueryExpression, QueryExecution, ReusedSubqueryExec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
+import org.apache.spark.sql.util.QueryExecutionListener
+
+object ExecutionPlanCaptureCallback {
+  private[this] var shouldCapture: Boolean = false
+  private[this] val execPlans: ArrayBuffer[SparkPlan] = ArrayBuffer.empty
+
+  private def captureIfNeeded(qe: QueryExecution): Unit = synchronized {
+    if (shouldCapture) {
+      execPlans.append(qe.executedPlan)
+    }
+  }
+
+  // Avoiding the use of default arguments since this is called from Python
+  def startCapture(): Unit = startCapture(10000)
+
+  def startCapture(timeoutMillis: Long): Unit = {
+    SparkSession.getActiveSession.foreach { spark =>
+      spark.sparkContext.listenerBus.waitUntilEmpty(timeoutMillis)
+    }
+    synchronized {
+      execPlans.clear()
+      shouldCapture = true
+    }
+  }
+
+  def getResultsWithTimeout(timeoutMs: Long = 10000): Array[SparkPlan] = {
+    try {
+      val spark = SparkSession.active
+      spark.sparkContext.listenerBus.waitUntilEmpty(timeoutMs)
+      synchronized {
+        execPlans.toArray
+      }
+    } finally {
+      synchronized {
+        shouldCapture = false
+        execPlans.clear()
+      }
+    }
+  }
+
+  def extractExecutedPlan(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case p: AdaptiveSparkPlanExec => p.executedPlan
+      case p => PlanShims.extractExecutedPlan(p)
+    }
+  }
+
+  def assertCapturedAndGpuFellBack(fallbackCpuClass: String, timeoutMs: Long = 2000): Unit = {
+    val gpuPlans = getResultsWithTimeout(timeoutMs = timeoutMs)
+    assert(gpuPlans.nonEmpty, "Did not capture a plan")
+    assertDidFallBack(gpuPlans, fallbackCpuClass)
+  }
+
+  def assertDidFallBack(gpuPlans: Array[SparkPlan], fallbackCpuClass: String): Unit = {
+    val executedPlans = gpuPlans.map(extractExecutedPlan)
+    // Verify at least one of the plans has the fallback class
+    val found = executedPlans.exists { executedPlan =>
+      executedPlan.find(didFallBack(_, fallbackCpuClass)).isDefined
+    }
+    assert(found, s"Could not find $fallbackCpuClass in the GPU plans:\n" +
+        executedPlans.mkString("\n"))
+  }
+
+  def assertDidFallBack(gpuPlan: SparkPlan, fallbackCpuClass: String): Unit = {
+    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(gpuPlan)
+    assert(executedPlan.find(didFallBack(_, fallbackCpuClass)).isDefined,
+      s"Could not find $fallbackCpuClass in the GPU plan\n$executedPlan")
+  }
+
+  def assertDidFallBack(df: DataFrame, fallbackCpuClass: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    assertDidFallBack(Array(executedPlan), fallbackCpuClass)
+  }
+
+  def assertContains(gpuPlan: SparkPlan, className: String): Unit = {
+    assert(containsPlan(gpuPlan, className),
+      s"Could not find $className in the Spark plan\n$gpuPlan")
+  }
+
+  def assertContains(df: DataFrame, gpuClass: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    assertContains(executedPlan, gpuClass)
+  }
+
+  def assertNotContain(gpuPlan: SparkPlan, className: String): Unit = {
+    assert(!containsPlan(gpuPlan, className),
+      s"We found $className in the Spark plan\n$gpuPlan")
+  }
+
+  def assertNotContain(df: DataFrame, gpuClass: String): Unit = {
+    val executedPlan = df.queryExecution.executedPlan
+    assertNotContain(executedPlan, gpuClass)
+  }
+
+  private def didFallBack(exp: Expression, fallbackCpuClass: String): Boolean = {
+    !exp.getClass.getCanonicalName.equals("com.nvidia.spark.rapids.GpuExpression") &&
+        PlanUtils.getBaseNameFromClass(exp.getClass.getName) == fallbackCpuClass ||
+        exp.children.exists(didFallBack(_, fallbackCpuClass))
+  }
+
+  private def didFallBack(plan: SparkPlan, fallbackCpuClass: String): Boolean = {
+    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(plan)
+    !executedPlan.getClass.getCanonicalName.equals("com.nvidia.spark.rapids.GpuExec") &&
+        PlanUtils.sameClass(executedPlan, fallbackCpuClass) ||
+        executedPlan.expressions.exists(didFallBack(_, fallbackCpuClass))
+  }
+
+  private def containsExpression(exp: Expression, className: String,
+      regexMap: MutableMap[String, Regex] // regex memoization
+  ): Boolean = exp.find {
+    case e if PlanUtils.getBaseNameFromClass(e.getClass.getName) == className => true
+    case e: ExecSubqueryExpression => containsPlan(e.plan, className, regexMap)
+    case _ => false
+  }.nonEmpty
+
+  private def containsPlan(plan: SparkPlan, className: String,
+      regexMap: MutableMap[String, Regex] = MutableMap.empty // regex memoization
+  ): Boolean = plan.find {
+    case p if PlanUtils.sameClass(p, className) =>
+      true
+    case p: AdaptiveSparkPlanExec =>
+      containsPlan(p.executedPlan, className, regexMap)
+    case p: QueryStageExec =>
+      containsPlan(p.plan, className, regexMap)
+    case p: ReusedSubqueryExec =>
+      containsPlan(p.child, className, regexMap)
+    case p: ReusedExchangeExec =>
+      containsPlan(p.child, className, regexMap)
+    case p if p.expressions.exists(containsExpression(_, className, regexMap)) =>
+      true
+    case p: SparkPlan =>
+      val sparkPlanStringForRegex = p.verboseStringWithSuffix(1000)
+      regexMap.getOrElseUpdate(className, className.r)
+          .findFirstIn(sparkPlanStringForRegex)
+          .nonEmpty
+  }.nonEmpty
+}
+
+/**
+ * Used as a part of testing to capture the executed query plan.
+ */
+class ExecutionPlanCaptureCallback extends QueryExecutionListener {
+  import ExecutionPlanCaptureCallback._
+
+  override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
+    captureIfNeeded(qe)
+
+  override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
+    captureIfNeeded(qe)
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.execution.{SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, BroadcastQueryStageExec, QueryStageExec, ShuffleQueryStageExec}
 import org.apache.spark.sql.execution.aggregate.SortAggregateExec
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 import org.apache.spark.sql.types.{DataType, DataTypes}
 
 class HashAggregatesSuite extends SparkQueryCompareTestSuite {
@@ -38,7 +39,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
   }
 
   private def checkExecPlan(plan: SparkPlan): Unit = {
-    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(Some(plan))
+    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(plan)
     if (executedPlan.conf.getAllConfs(RapidsConf.SQL_ENABLED.key).toBoolean) {
       val gpuAgg = executedPlan.find(_.isInstanceOf[GpuHashAggregateExec]) match {
         case Some(agg) => Some(agg)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashSortOptimizeSuite.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.TestUtils.{findOperator, getFinalPlan}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 
 /** Test plan modifications to add optimizing sorts after hash joins in the plan */
 class HashSortOptimizeSuite extends SparkQueryCompareTestSuite with FunSuiteWithTempDir {
@@ -51,7 +52,7 @@ class HashSortOptimizeSuite extends SparkQueryCompareTestSuite with FunSuiteWith
    * specified join node.
    **/
   private def validateOptimizeSort(queryPlan: SparkPlan, joinNode: SparkPlan): Unit = {
-    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(Some(queryPlan))
+    val executedPlan = ExecutionPlanCaptureCallback.extractExecutedPlan(queryPlan)
     val sortNode = findOperator(executedPlan, _.isInstanceOf[GpuSortExec])
     assert(sortNode.isDefined, "No sort node found")
     val gse = sortNode.get.asInstanceOf[GpuSortExec]

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 
@@ -80,7 +81,7 @@ object SparkSessionHolder extends Logging {
         .config("spark.rapids.sql.test.enabled", "false")
         .config("spark.plugins", "com.nvidia.spark.SQLPlugin")
         .config("spark.sql.queryExecutionListeners",
-          "com.nvidia.spark.rapids.ExecutionPlanCaptureCallback")
+          "org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback")
         .config("spark.sql.warehouse.dir", sparkWarehouseDir.getAbsolutePath)
         .appName("rapids spark plugin integration tests (scala)")
 
@@ -261,7 +262,7 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     // force a new session to avoid accidentally capturing a late callback from a previous query
     TrampolineUtil.cleanupAnyExistingSession()
     ExecutionPlanCaptureCallback.startCapture()
-    var cpuPlan: Option[SparkPlan] = null
+    var cpuPlans: Array[SparkPlan] = Array.empty
       try {
         withCpuSparkSession(session => {
           var data = df(session)
@@ -273,14 +274,13 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
           fun(data)
         }, conf)
       } finally {
-        cpuPlan = ExecutionPlanCaptureCallback.getResultWithTimeout()
+        cpuPlans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
       }
-    if (cpuPlan.isEmpty) {
-      throw new RuntimeException("Did not capture CPU plan")
-    }
+    assert(cpuPlans.nonEmpty, "Did not capture CPU plan")
+    assert(cpuPlans.length == 1, s"Captured more than one CPU plan: ${cpuPlans.mkString("\n")}")
 
     ExecutionPlanCaptureCallback.startCapture()
-    var gpuPlan: Option[SparkPlan] = null
+    var gpuPlans: Array[SparkPlan] = Array.empty
       try {
         withGpuSparkSession(session => {
           var data = df(session)
@@ -292,14 +292,12 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
           fun(data)
         }, conf)
       } finally {
-        gpuPlan = ExecutionPlanCaptureCallback.getResultWithTimeout()
+        gpuPlans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
       }
+    assert(gpuPlans.nonEmpty, "Did not capture GPU plan")
+    assert(gpuPlans.length == 1, s"Captured more than one GPU plan: ${gpuPlans.mkString("\n")}")
 
-    if (gpuPlan.isEmpty) {
-      throw new RuntimeException("Did not capture GPU plan")
-    }
-
-    (cpuPlan.get, gpuPlan.get)
+    (cpuPlans.head, gpuPlans.head)
   }
 
   def runOnCpuAndGpuWithCapture(df: SparkSession => DataFrame,
@@ -312,7 +310,7 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
     // force a new session to avoid accidentally capturing a late callback from a previous query
     TrampolineUtil.cleanupAnyExistingSession()
     ExecutionPlanCaptureCallback.startCapture()
-    var cpuPlan: Option[SparkPlan] = null
+    var cpuPlans: Array[SparkPlan] = Array.empty
     val fromCpu =
       try {
         withCpuSparkSession(session => {
@@ -325,14 +323,13 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
           fun(data).collect()
         }, conf)
       } finally {
-        cpuPlan = ExecutionPlanCaptureCallback.getResultWithTimeout()
+        cpuPlans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
       }
-    if (cpuPlan.isEmpty) {
-      throw new RuntimeException("Did not capture CPU plan")
-    }
+    assert(cpuPlans.nonEmpty, "Did not capture CPU plan")
+    assert(cpuPlans.length == 1, s"Captured more than one CPU plan: ${cpuPlans.mkString("\n")}")
 
     ExecutionPlanCaptureCallback.startCapture()
-    var gpuPlan: Option[SparkPlan] = null
+    var gpuPlans: Array[SparkPlan] = Array.empty
     val fromGpu =
       try {
         withGpuSparkSession(session => {
@@ -345,14 +342,12 @@ trait SparkQueryCompareTestSuite extends FunSuite with Arm {
           fun(data).collect()
         }, conf)
       } finally {
-        gpuPlan = ExecutionPlanCaptureCallback.getResultWithTimeout()
+        gpuPlans = ExecutionPlanCaptureCallback.getResultsWithTimeout()
       }
+    assert(gpuPlans.nonEmpty, "Did not capture GPU plan")
+    assert(gpuPlans.length == 1, s"Captured more than one GPU plan: ${gpuPlans.mkString("\n")}")
 
-    if (gpuPlan.isEmpty) {
-      throw new RuntimeException("Did not capture GPU plan")
-    }
-
-    (fromCpu, cpuPlan.get, fromGpu, gpuPlan.get)
+    (fromCpu, cpuPlans.head, fromGpu, gpuPlans.head)
   }
 
   def testGpuWriteFallback(testName: String,


### PR DESCRIPTION
Fixes #7329 by updating the plan capture framework to handle the possibility that multiple plans could be captured.  For now, the fallback checks will pass if _any_ plan that was captured has the fallback class.  It also updates the plan listener to use the listener bus APIs to wait until the event traffic drains to help avoid extraneous or missed plans when capturing.