### PR TITLE
Fix Add and Subtract test failures in 330db and 340 shim [databricks]

### DIFF
--- a/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -31,13 +31,13 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
 case class GpuAdd(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuAddParent(left, right, failOnError)
+    failOnError: Boolean) extends GpuAddBase(left, right, failOnError)
 
 case class GpuSubtract(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends GpuSubtractParent(left, right, failOnError)
+    failOnError: Boolean) extends GpuSubtractBase(left, right, failOnError)
 
-case class GpuRemainder(left: Expression, right: Expression) extends GpuRemainderParent(left, right)
+case class GpuRemainder(left: Expression, right: Expression) extends GpuRemainderBase(left, right)
 
-case class GpuPmod(left: Expression, right: Expression) extends GpuPmodParent(left, right)
+case class GpuPmod(left: Expression, right: Expression) extends GpuPmodBase(left, right)

--- a/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import ai.rapids.cudf.BinaryOp
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerant {
+  override def dataType: DataType = left.dataType
+  // arithmetic operations can overflow and throw exceptions in ANSI mode
+  override def hasSideEffects: Boolean = super.hasSideEffects || SQLConf.get.ansiEnabled
+}
+
+case class GpuAdd(
+    left: Expression,
+    right: Expression,
+    failOnError: Boolean) extends GpuAddParent(left, right, failOnError)
+
+case class GpuSubtract(
+    left: Expression,
+    right: Expression,
+    failOnError: Boolean) extends GpuSubtractParent(left, right, failOnError)
+
+case class GpuRemainder(left: Expression, right: Expression) extends GpuRemainderParent(left, right)
+
+case class GpuPmod(left: Expression, right: Expression) extends GpuPmodParent(left, right)

--- a/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/311until340-non330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.rapids
 
-import ai.rapids.cudf.BinaryOp
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}

--- a/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import scala.math.max
+
+import ai.rapids.cudf._
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerant {
+
+  protected def allowPrecisionLoss = SQLConf.get.decimalOperationsAllowPrecisionLoss
+
+  // arithmetic operations can overflow and throw exceptions in ANSI mode
+  override def hasSideEffects: Boolean = super.hasSideEffects || SQLConf.get.ansiEnabled
+
+  override def dataType: DataType = (left.dataType, right.dataType) match {
+    case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
+      resultDecimalType(p1, s1, p2, s2)
+    case _ => left.dataType
+  }
+
+  protected def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
+    throw new IllegalStateException(
+      s"${getClass.getSimpleName} must override `resultDecimalType`.")
+  }
+
+  override def checkInputDataTypes(): TypeCheckResult = (left.dataType, right.dataType) match {
+    case (l: DecimalType, r: DecimalType) if inputType.acceptsType(l) && inputType.acceptsType(r) =>
+      // We allow decimal type inputs with different precision and scale, and use special formulas
+      // to calculate the result precision and scale.
+      TypeCheckResult.TypeCheckSuccess
+    case _ => super.checkInputDataTypes()
+  }
+}
+
+trait GpuAddSub extends CudfBinaryArithmetic {
+
+  override def outputTypeOverride: DType = GpuColumnVector.getNonNestedRapidsType(dataType)
+  val failOnError: Boolean
+
+  override def columnarEval(batch: ColumnarBatch): Any = {
+    if (dataType.isInstanceOf[DecimalType]) {
+      (left.dataType, right.dataType) match {
+        case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>
+          val resultType = resultDecimalType(p1, s1, p2, s2)
+          if (resultType.precision < 38) {
+            super.columnarEval(batch)
+          } else {
+            // call the kernel to add 128-bit numbers
+            prepareInputAndExecute(batch, resultType)
+          }
+        case _ => throw new IllegalStateException("Both operands should be Decimal")
+      }
+    } else {
+      super.columnarEval(batch)
+    }
+  }
+
+  protected def prepareInputAndExecute(
+      batch: ColumnarBatch,
+      resultType: DecimalType): Any = {
+    val castLhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
+      lhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, lhs.getBase.getType.getScale))
+    }
+    val retTab = withResource(castLhs) { castLhs =>
+      val castRhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(right, batch)) { rhs =>
+        rhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, rhs.getBase.getType.getScale))
+      }
+      withResource(castRhs) { castRhs =>
+        do128BitOperation(castLhs, castRhs, -resultType.scale)
+      }
+    }
+    val retCol = withResource(retTab) { retTab =>
+      val overflowed = retTab.getColumn(0)
+      val sum = retTab.getColumn(1)
+      if (failOnError) {
+        withResource(overflowed.any()) { anyOverflow =>
+          if (anyOverflow.isValid && anyOverflow.getBoolean) {
+            throw new ArithmeticException(GpuCast.INVALID_INPUT_MESSAGE)
+          }
+        }
+        sum.incRefCount()
+      } else {
+        withResource(GpuScalar.from(null, dataType)) { nullVal =>
+          overflowed.ifElse(nullVal, sum)
+        }
+      }
+    }
+    GpuColumnVector.from(retCol, dataType)
+  }
+
+  protected def do128BitOperation(
+      castLhs: ColumnView,
+      castRhs: ColumnView,
+      outputScale: Int): Table
+}
+
+case class GpuAdd(
+    left: Expression,
+    right: Expression,
+    override val failOnError: Boolean)
+    extends GpuAddParent(left, right, failOnError) with GpuAddSub {
+
+  def do128BitOperation(
+      castLhs: ColumnView,
+      castRhs: ColumnView,
+      outputScale: Int): Table = {
+    com.nvidia.spark.rapids.jni.DecimalUtils.add128(castLhs, castRhs, outputScale)
+  }
+
+  // scalastyle:off
+  // The formula follows Hive which is based on the SQL standard and MS SQL:
+  // https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
+  // https://msdn.microsoft.com/en-us/library/ms190476.aspx
+  // Result Precision: max(s1, s2) + max(p1-s1, p2-s2) + 1
+  // Result Scale:     max(s1, s2)
+  // scalastyle:on
+  override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
+    val resultScale = max(s1, s2)
+    val resultPrecision = max(p1 - s1, p2 - s2) + resultScale + 1
+    if (allowPrecisionLoss) {
+      DecimalType.adjustPrecisionScale(resultPrecision, resultScale)
+    } else {
+      DecimalType.bounded(resultPrecision, resultScale)
+    }
+  }
+}
+
+case class GpuSubtract(
+    left: Expression,
+    right: Expression,
+    override val failOnError: Boolean)
+    extends GpuSubtractParent(left, right, failOnError) with GpuAddSub {
+
+  def do128BitOperation(
+      castLhs: ColumnView,
+      castRhs: ColumnView,
+      outputScale: Int): Table = {
+    com.nvidia.spark.rapids.jni.DecimalUtils.subtract128(castLhs, castRhs, outputScale)
+  }
+
+  override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
+    val resultScale = max(s1, s2)
+    val resultPrecision = max(p1 - s1, p2 - s2) + resultScale + 1
+    if (allowPrecisionLoss) {
+      DecimalType.adjustPrecisionScale(resultPrecision, resultScale)
+    } else {
+      DecimalType.bounded(resultPrecision, resultScale)
+    }
+  }
+}
+
+case class GpuRemainder(left: Expression, right: Expression)
+    extends GpuRemainderParent(left, right) {
+  // scalastyle:off
+  // The formula follows Hive which is based on the SQL standard and MS SQL:
+  // https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
+  // https://msdn.microsoft.com/en-us/library/ms190476.aspx
+  // Result Precision: min(p1-s1, p2-s2) + max(s1, s2)
+  // Result Scale:     max(s1, s2)
+  // scalastyle:on
+  override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
+    val resultScale = max(s1, s2)
+    val resultPrecision = min(p1 - s1, p2 - s2) + resultScale
+    if (allowPrecisionLoss) {
+      DecimalType.adjustPrecisionScale(resultPrecision, resultScale)
+    } else {
+      DecimalType.bounded(resultPrecision, resultScale)
+    }
+  }
+}
+
+case class GpuPmod(
+    left: Expression,
+    right: Expression) extends GpuPmodParent(left, right) {
+  // This follows Remainder rule
+  override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
+    val resultScale = max(s1, s2)
+    val resultPrecision = min(p1 - s1, p2 - s2) + resultScale
+    if (allowPrecisionLoss) {
+      DecimalType.adjustPrecisionScale(resultPrecision, resultScale)
+    } else {
+      DecimalType.bounded(resultPrecision, resultScale)
+    }
+  }
+}

--- a/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
-import scala.math.max
+import scala.math.{max, min}
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._

--- a/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/340+-and-330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -120,7 +120,7 @@ case class GpuAdd(
     left: Expression,
     right: Expression,
     override val failOnError: Boolean)
-    extends GpuAddParent(left, right, failOnError) with GpuAddSub {
+    extends GpuAddBase(left, right, failOnError) with GpuAddSub {
 
   def do128BitOperation(
       castLhs: ColumnView,
@@ -151,7 +151,7 @@ case class GpuSubtract(
     left: Expression,
     right: Expression,
     override val failOnError: Boolean)
-    extends GpuSubtractParent(left, right, failOnError) with GpuAddSub {
+    extends GpuSubtractBase(left, right, failOnError) with GpuAddSub {
 
   def do128BitOperation(
       castLhs: ColumnView,
@@ -172,7 +172,7 @@ case class GpuSubtract(
 }
 
 case class GpuRemainder(left: Expression, right: Expression)
-    extends GpuRemainderParent(left, right) {
+    extends GpuRemainderBase(left, right) {
   // scalastyle:off
   // The formula follows Hive which is based on the SQL standard and MS SQL:
   // https://cwiki.apache.org/confluence/download/attachments/27362075/Hive_Decimal_Precision_Scale_Support.pdf
@@ -193,7 +193,7 @@ case class GpuRemainder(left: Expression, right: Expression)
 
 case class GpuPmod(
     left: Expression,
-    right: Expression) extends GpuPmodParent(left, right) {
+    right: Expression) extends GpuPmodBase(left, right) {
   // This follows Remainder rule
   override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
     val resultScale = max(s1, s2)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1747,68 +1747,6 @@ object GpuOverrides extends Logging {
           TypeSig.lit(TypeEnum.STRING))),
       (a, conf, p, r) => new FromUTCTimestampExprMeta(a, conf, p, r)
     ),
-    expr[Pmod](
-      "Pmod",
-      ExprChecks.binaryProject(TypeSig.gpuNumeric, TypeSig.cpuNumeric,
-        ("lhs", TypeSig.gpuNumeric.withPsNote(TypeEnum.DECIMAL,
-          s"decimals with precision ${DecimalType.MAX_PRECISION} are not supported"),
-            TypeSig.cpuNumeric),
-        ("rhs", TypeSig.gpuNumeric, TypeSig.cpuNumeric)),
-      (a, conf, p, r) => new BinaryExprMeta[Pmod](a, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          a.dataType match {
-            case dt: DecimalType if dt.precision == DecimalType.MAX_PRECISION =>
-              willNotWorkOnGpu("pmod at maximum decimal precision is not supported")
-            case _ =>
-          }
-        }
-        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuPmod(lhs, rhs)
-      }),
-    expr[Add](
-      "Addition",
-      ExprChecks.binaryProjectAndAst(
-        TypeSig.implicitCastsAstTypes,
-        TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-        TypeSig.numericAndInterval,
-        ("lhs", TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-            TypeSig.numericAndInterval),
-        ("rhs", TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-            TypeSig.numericAndInterval)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Add](a, conf, p, r) {
-        private val ansiEnabled = SQLConf.get.ansiEnabled
-
-        override def tagSelfForAst(): Unit = {
-          if (ansiEnabled && GpuAnsi.needBasicOpOverflowCheck(a.dataType)) {
-            willNotWorkInAst("AST Addition does not support ANSI mode.")
-          }
-        }
-
-        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuAdd(lhs, rhs, failOnError = ansiEnabled)
-      }),
-    expr[Subtract](
-      "Subtraction",
-      ExprChecks.binaryProjectAndAst(
-        TypeSig.implicitCastsAstTypes,
-        TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-        TypeSig.numericAndInterval,
-        ("lhs", TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-            TypeSig.numericAndInterval),
-        ("rhs", TypeSig.gpuNumeric + GpuTypeShims.additionalArithmeticSupportedTypes,
-            TypeSig.numericAndInterval)),
-      (a, conf, p, r) => new BinaryAstExprMeta[Subtract](a, conf, p, r) {
-        private val ansiEnabled = SQLConf.get.ansiEnabled
-
-        override def tagSelfForAst(): Unit = {
-          if (ansiEnabled && GpuAnsi.needBasicOpOverflowCheck(a.dataType)) {
-            willNotWorkInAst("AST Subtraction does not support ANSI mode.")
-          }
-        }
-
-        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuSubtract(lhs, rhs, ansiEnabled)
-      }),
     expr[Multiply](
       "Multiplication",
       ExprChecks.binaryProjectAndAst(
@@ -2055,16 +1993,6 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new BinaryExprMeta[IntegralDivide](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuIntegralDivide(lhs, rhs)
-      }),
-    expr[Remainder](
-      "Remainder or modulo",
-      ExprChecks.binaryProject(
-        TypeSig.gpuNumeric, TypeSig.cpuNumeric,
-        ("lhs", TypeSig.gpuNumeric, TypeSig.cpuNumeric),
-        ("rhs", TypeSig.gpuNumeric, TypeSig.cpuNumeric)),
-      (a, conf, p, r) => new BinaryExprMeta[Remainder](a, conf, p, r) {
-        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuRemainder(lhs, rhs)
       }),
     expr[AggregateExpression](
       "Aggregate expression",

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -32,6 +32,82 @@ import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+object AddOverflowChecks extends Arm {
+  def basicOpOverflowCheck(
+      lhs: BinaryOperable,
+      rhs: BinaryOperable,
+      ret: ColumnVector): Unit = {
+    // Check overflow. It is true when both arguments have the opposite sign of the result.
+    // Which is equal to "((x ^ r) & (y ^ r)) < 0" in the form of arithmetic.
+    val signCV = withResource(ret.bitXor(lhs)) { lXor =>
+      withResource(ret.bitXor(rhs)) { rXor =>
+        lXor.bitAnd(rXor)
+      }
+    }
+    val signDiffCV = withResource(signCV) { sign =>
+      withResource(Scalar.fromInt(0)) { zero =>
+        sign.lessThan(zero)
+      }
+    }
+    withResource(signDiffCV) { signDiff =>
+      withResource(signDiff.any()) { any =>
+        if (any.isValid && any.getBoolean) {
+          throw RapidsErrorUtils.arithmeticOverflowError(
+            "One or more rows overflow for Add operation."
+          )
+        }
+      }
+    }
+  }
+
+  def didDecimalOverflow(
+      lhs: BinaryOperable,
+      rhs: BinaryOperable,
+      ret: ColumnVector): ColumnVector = {
+    // We need a special overflow check for decimal because CUDF does not support INT128 so we
+    // cannot reuse the same code for the other types.
+    // Overflow happens if the arguments have the same signs and it is different from the sign of
+    // the result
+    val numRows = ret.getRowCount.toInt
+    val zero = BigDecimal(0).bigDecimal
+    withResource(DecimalUtils.lessThan(rhs, zero, numRows)) { rhsLz =>
+      val argsSignSame = withResource(DecimalUtils.lessThan(lhs, zero, numRows)) { lhsLz =>
+        lhsLz.equalTo(rhsLz)
+      }
+      withResource(argsSignSame) { argsSignSame =>
+        val resultAndRhsDifferentSign =
+          withResource(DecimalUtils.lessThan(ret, zero)) { resultLz =>
+            rhsLz.notEqualTo(resultLz)
+          }
+        withResource(resultAndRhsDifferentSign) { resultAndRhsDifferentSign =>
+          resultAndRhsDifferentSign.and(argsSignSame)
+        }
+      }
+    }
+  }
+
+  def decimalOpOverflowCheck(
+      lhs: BinaryOperable,
+      rhs: BinaryOperable,
+      ret: ColumnVector,
+      failOnError: Boolean): ColumnVector = {
+    withResource(didDecimalOverflow(lhs, rhs, ret)) { overflow =>
+      if (failOnError) {
+        withResource(overflow.any()) { any =>
+          if (any.isValid && any.getBoolean) {
+            throw new ArithmeticException("One or more rows overflow for Add operation.")
+          }
+        }
+        ret.incRefCount()
+      } else {
+        withResource(Scalar.fromNull(ret.getType)) { nullVal =>
+          overflow.ifElse(nullVal, ret)
+        }
+      }
+    }
+  }
+}
+
 object GpuAnsi extends Arm {
   def needBasicOpOverflowCheck(dt: DataType): Boolean =
     dt.isInstanceOf[IntegralType]
@@ -175,92 +251,10 @@ case class GpuAbs(child: Expression, failOnError: Boolean) extends CudfUnaryExpr
   }
 }
 
-abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolerant {
-  override def dataType: DataType = left.dataType
-  // arithmetic operations can overflow and throw exceptions in ANSI mode
-  override def hasSideEffects: Boolean = super.hasSideEffects || SQLConf.get.ansiEnabled
-}
-
-object GpuAdd extends Arm {
-  def basicOpOverflowCheck(
-      lhs: BinaryOperable,
-      rhs: BinaryOperable,
-      ret: ColumnVector): Unit = {
-    // Check overflow. It is true when both arguments have the opposite sign of the result.
-    // Which is equal to "((x ^ r) & (y ^ r)) < 0" in the form of arithmetic.
-    val signCV = withResource(ret.bitXor(lhs)) { lXor =>
-      withResource(ret.bitXor(rhs)) { rXor =>
-        lXor.bitAnd(rXor)
-      }
-    }
-    val signDiffCV = withResource(signCV) { sign =>
-      withResource(Scalar.fromInt(0)) { zero =>
-        sign.lessThan(zero)
-      }
-    }
-    withResource(signDiffCV) { signDiff =>
-      withResource(signDiff.any()) { any =>
-        if (any.isValid && any.getBoolean) {
-          throw RapidsErrorUtils.arithmeticOverflowError(
-            "One or more rows overflow for Add operation."
-          )
-        }
-      }
-    }
-  }
-
-  def didDecimalOverflow(
-      lhs: BinaryOperable,
-      rhs: BinaryOperable,
-      ret: ColumnVector): ColumnVector = {
-    // We need a special overflow check for decimal because CUDF does not support INT128 so we
-    // cannot reuse the same code for the other types.
-    // Overflow happens if the arguments have the same signs and it is different from the sign of
-    // the result
-    val numRows = ret.getRowCount.toInt
-    val zero = BigDecimal(0).bigDecimal
-    withResource(DecimalUtils.lessThan(rhs, zero, numRows)) { rhsLz =>
-      val argsSignSame = withResource(DecimalUtils.lessThan(lhs, zero, numRows)) { lhsLz =>
-        lhsLz.equalTo(rhsLz)
-      }
-      withResource(argsSignSame) { argsSignSame =>
-        val resultAndRhsDifferentSign =
-          withResource(DecimalUtils.lessThan(ret, zero)) { resultLz =>
-            rhsLz.notEqualTo(resultLz)
-          }
-        withResource(resultAndRhsDifferentSign) { resultAndRhsDifferentSign =>
-          resultAndRhsDifferentSign.and(argsSignSame)
-        }
-      }
-    }
-  }
-
-  def decimalOpOverflowCheck(
-      lhs: BinaryOperable,
-      rhs: BinaryOperable,
-      ret: ColumnVector,
-      failOnError: Boolean): ColumnVector = {
-    withResource(didDecimalOverflow(lhs, rhs, ret)) { overflow =>
-      if (failOnError) {
-        withResource(overflow.any()) { any =>
-          if (any.isValid && any.getBoolean) {
-            throw new ArithmeticException("One or more rows overflow for Add operation.")
-          }
-        }
-        ret.incRefCount()
-      } else {
-        withResource(Scalar.fromNull(ret.getType)) { nullVal =>
-          overflow.ifElse(nullVal, ret)
-        }
-      }
-    }
-  }
-}
-
-case class GpuAdd(
+abstract class GpuAddParent(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends CudfBinaryArithmetic {
+    failOnError: Boolean) extends CudfBinaryArithmetic with Serializable {
   override def inputType: AbstractDataType = TypeCollection.NumericAndInterval
 
   override def symbol: String = "+"
@@ -277,11 +271,11 @@ case class GpuAdd(
           GpuTypeShims.isSupportedYearMonthType(dataType)) {
         // For day time interval, Spark throws an exception when overflow,
         // regardless of whether `SQLConf.get.ansiEnabled` is true or false
-        GpuAdd.basicOpOverflowCheck(lhs, rhs, ret)
+        AddOverflowChecks.basicOpOverflowCheck(lhs, rhs, ret)
       }
 
       if (dataType.isInstanceOf[DecimalType]) {
-        GpuAdd.decimalOpOverflowCheck(lhs, rhs, ret, failOnError)
+        AddOverflowChecks.decimalOpOverflowCheck(lhs, rhs, ret, failOnError)
       } else {
         ret.incRefCount()
       }
@@ -289,10 +283,10 @@ case class GpuAdd(
   }
 }
 
-case class GpuSubtract(
+abstract class GpuSubtractParent(
     left: Expression,
     right: Expression,
-    failOnError: Boolean) extends CudfBinaryArithmetic {
+    failOnError: Boolean) extends CudfBinaryArithmetic with Serializable {
   override def inputType: AbstractDataType = TypeCollection.NumericAndInterval
 
   override def symbol: String = "-"
@@ -1055,7 +1049,8 @@ case class GpuIntegralDivide(left: Expression, right: Expression) extends GpuDiv
   override def sqlOperator: String = "div"
 }
 
-case class GpuRemainder(left: Expression, right: Expression) extends GpuDivModLike {
+abstract class GpuRemainderParent(left: Expression, right: Expression)
+    extends GpuDivModLike with Serializable {
   override def inputType: AbstractDataType = NumericType
 
   override def symbol: String = "%"
@@ -1063,8 +1058,8 @@ case class GpuRemainder(left: Expression, right: Expression) extends GpuDivModLi
   override def binaryOp: BinaryOp = BinaryOp.MOD
 }
 
-
-case class GpuPmod(left: Expression, right: Expression) extends GpuDivModLike {
+abstract class GpuPmodParent(left: Expression, right: Expression)
+    extends GpuDivModLike with Serializable {
   override def inputType: AbstractDataType = NumericType
 
   override def binaryOp: BinaryOp = BinaryOp.PMOD

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -251,7 +251,7 @@ case class GpuAbs(child: Expression, failOnError: Boolean) extends CudfUnaryExpr
   }
 }
 
-abstract class GpuAddParent(
+abstract class GpuAddBase(
     left: Expression,
     right: Expression,
     failOnError: Boolean) extends CudfBinaryArithmetic with Serializable {
@@ -283,7 +283,7 @@ abstract class GpuAddParent(
   }
 }
 
-abstract class GpuSubtractParent(
+abstract class GpuSubtractBase(
     left: Expression,
     right: Expression,
     failOnError: Boolean) extends CudfBinaryArithmetic with Serializable {
@@ -1049,7 +1049,7 @@ case class GpuIntegralDivide(left: Expression, right: Expression) extends GpuDiv
   override def sqlOperator: String = "div"
 }
 
-abstract class GpuRemainderParent(left: Expression, right: Expression)
+abstract class GpuRemainderBase(left: Expression, right: Expression)
     extends GpuDivModLike with Serializable {
   override def inputType: AbstractDataType = NumericType
 
@@ -1058,7 +1058,7 @@ abstract class GpuRemainderParent(left: Expression, right: Expression)
   override def binaryOp: BinaryOp = BinaryOp.MOD
 }
 
-abstract class GpuPmodParent(left: Expression, right: Expression)
+abstract class GpuPmodBase(left: Expression, right: Expression)
     extends GpuDivModLike with Serializable {
   override def inputType: AbstractDataType = NumericType
 


### PR DESCRIPTION
This PR addresses the overflow that can happen when adding subtracting large numbers before rescaling the number. 

GpuRemainder and GpuPmod extend respective base classes and also override the `resultDecimalType` method which is needed for Spark 3.4 and DB11.3

Before 
`338 failed, 464 passed, 14 skipped, 2 xfailed in 448.22s (0:07:28)` 

After
`316 failed, 486 passed, 14 skipped, 2 xfailed in 444.10s (0:07:24)`

Contributes towards #7348  

Signed-off-by: Raza Jafri <rjafri@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
