### PR TITLE
Update the integration tests  to fit the removed config ` spark.sql.ansi.strictIndexOperator` in DB11.3 and Spark 3.4 [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect
 from data_gen import *
 from marks import incompat
-from spark_session import is_before_spark_313, is_before_spark_330, is_spark_330_or_later, is_databricks104_or_later, is_spark_340_or_later, is_spark_330
+from spark_session import is_before_spark_313, is_before_spark_330, is_databricks113_or_later, is_spark_330_or_later, is_databricks104_or_later, is_spark_33X, is_spark_340_or_later, is_spark_330
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
 from pyspark.sql.functions import array_contains, col, element_at, lit
@@ -103,7 +103,7 @@ def test_array_item(data_gen):
 
 
 # No need to test this for multiple data types for array. Only one is enough
-@pytest.mark.skipif(is_before_spark_330() or is_spark_340_or_later(), reason="'strictIndexOperator' is introduced from Spark 3.3.0 and removed in Spark 3.4.0")
+@pytest.mark.skipif(not is_spark_33X(), reason="'strictIndexOperator' is introduced from Spark 3.3.0 and removed in Spark 3.4.0")
 @pytest.mark.parametrize('strict_index_enabled', [True, False])
 @pytest.mark.parametrize('index', [-2, 100, array_neg_index_gen, array_out_index_gen], ids=idfn)
 def test_array_item_with_strict_index(strict_index_enabled, index):
@@ -113,8 +113,9 @@ def test_array_item_with_strict_index(strict_index_enabled, index):
     else:
         test_df = lambda spark: two_col_df(spark, ArrayGen(int_gen), index).selectExpr('a[b]')
 
-    test_conf=copy_and_update(
-        ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': strict_index_enabled})
+    # `strictIndexOperator` has been removed in Spark3.4+ and Databricks11.3+
+    test_conf = ansi_enabled_conf if (is_spark_340_or_later() or is_databricks113_or_later()) else \
+        copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': strict_index_enabled})
 
     if strict_index_enabled:
         assert_gpu_and_cpu_error(
@@ -240,8 +241,9 @@ def test_array_element_at_ansi_fail_invalid_index(index):
         test_func = lambda spark: two_col_df(spark, ArrayGen(int_gen), index).selectExpr(
             'element_at(a, b)').collect()
     # For 3.3.0+ strictIndexOperator should not affect element_at
-    # Since 3.4.0, strictIndexOperator has been removed.
-    test_conf=copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': 'false'}) if is_before_spark_340() else ansi_enabled_conf
+    # `strictIndexOperator` has been removed in Spark3.4+ and Databricks11.3+
+    test_conf = ansi_enabled_conf if (is_spark_340_or_later() or is_databricks113_or_later()) else \
+        copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': 'false'})
     assert_gpu_and_cpu_error(
         test_func,
         conf=test_conf,

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -16,6 +16,7 @@ import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect
 from data_gen import *
+from conftest import is_databricks_runtime
 from marks import incompat
 from spark_session import is_before_spark_313, is_before_spark_330, is_databricks113_or_later, is_spark_330_or_later, is_databricks104_or_later, is_spark_33X, is_spark_340_or_later, is_spark_330
 from pyspark.sql.types import *
@@ -103,7 +104,7 @@ def test_array_item(data_gen):
 
 
 # No need to test this for multiple data types for array. Only one is enough
-@pytest.mark.skipif(not is_spark_33X(), reason="'strictIndexOperator' is introduced from Spark 3.3.0 and removed in Spark 3.4.0")
+@pytest.mark.skipif(not is_spark_33X() or is_databricks_runtime(), reason="'strictIndexOperator' is introduced from Spark 3.3.0 and removed in Spark 3.4.0 and DB11.3")
 @pytest.mark.parametrize('strict_index_enabled', [True, False])
 @pytest.mark.parametrize('index', [-2, 100, array_neg_index_gen, array_out_index_gen], ids=idfn)
 def test_array_item_with_strict_index(strict_index_enabled, index):

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -114,9 +114,7 @@ def test_array_item_with_strict_index(strict_index_enabled, index):
     else:
         test_df = lambda spark: two_col_df(spark, ArrayGen(int_gen), index).selectExpr('a[b]')
 
-    # `strictIndexOperator` has been removed in Spark3.4+ and Databricks11.3+
-    test_conf = ansi_enabled_conf if (is_spark_340_or_later() or is_databricks113_or_later()) else \
-        copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': strict_index_enabled})
+    test_conf = copy_and_update(ansi_enabled_conf, {'spark.sql.ansi.strictIndexOperator': strict_index_enabled})
 
     if strict_index_enabled:
         assert_gpu_and_cpu_error(

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -18,7 +18,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_err
     assert_gpu_fallback_collect
 from data_gen import *
 from marks import incompat, allow_non_gpu
-from spark_session import is_before_spark_330, is_databricks104_or_later
+from spark_session import is_before_spark_330, is_databricks104_or_later, is_databricks113_or_later, is_spark_33X, is_spark_340_or_later
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
 
@@ -323,8 +323,8 @@ def test_simple_get_map_value_ansi_fail(data_gen):
             error_message=message)
 
 
-@pytest.mark.skipif(is_before_spark_330(),
-                    reason="Only in Spark 3.3.0 + ANSI mode + Strict Index, map key throws on no such element")
+@pytest.mark.skipif(not is_spark_33X(),
+                    reason="Only in Spark 3.3.X + ANSI mode + Strict Index, map key throws on no such element")
 @pytest.mark.parametrize('strict_index', ['true', 'false'])
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
 def test_simple_get_map_value_with_strict_index(strict_index, data_gen):
@@ -409,6 +409,8 @@ def test_get_map_value_element_at_map_string_col_keys(data_gen):
 
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
+@pytest.mark.skipif(is_spark_340_or_later() or is_databricks113_or_later(),
+                    reason="Since Spark3.4 and DB11.3, null will always be returned on invalid access to map")
 def test_element_at_map_string_col_keys_ansi_fail(data_gen):
     keys = StringGen(pattern='NOT_FOUND')
     message = "org.apache.spark.SparkNoSuchElementException" if (not is_before_spark_330() or is_databricks104_or_later()) else "java.util.NoSuchElementException"
@@ -422,6 +424,8 @@ def test_element_at_map_string_col_keys_ansi_fail(data_gen):
 
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
+@pytest.mark.skipif(is_spark_340_or_later() or is_databricks113_or_later(),
+                    reason="Since Spark3.4 and DB11.3, null will always be returned on invalid access to map")
 def test_get_map_value_string_col_keys_ansi_fail(data_gen):
     keys = StringGen(pattern='NOT_FOUND')
     message = "org.apache.spark.SparkNoSuchElementException" if (not is_before_spark_330() or is_databricks104_or_later()) else "java.util.NoSuchElementException"
@@ -458,6 +462,8 @@ def test_element_at_map_timestamp_keys(data_gen):
 
 
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)
+@pytest.mark.skipif(is_spark_340_or_later() or is_databricks113_or_later(),
+                    reason="Since Spark3.4 and DB11.3, null will always be returned on invalid access to map")
 def test_map_element_at_ansi_fail(data_gen):
     message = "org.apache.spark.SparkNoSuchElementException" if (not is_before_spark_330() or is_databricks104_or_later()) else "java.util.NoSuchElementException"
     # For 3.3.0+ strictIndexOperator should not affect element_at

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -323,7 +323,7 @@ def test_simple_get_map_value_ansi_fail(data_gen):
             error_message=message)
 
 
-@pytest.mark.skipif(not is_spark_33X(),
+@pytest.mark.skipif(not is_spark_33X() or is_databricks113_or_later(),
                     reason="Only in Spark 3.3.X + ANSI mode + Strict Index, map key throws on no such element")
 @pytest.mark.parametrize('strict_index', ['true', 'false'])
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -17,6 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_error, \
     assert_gpu_fallback_collect
 from data_gen import *
+from conftest import is_databricks_runtime
 from marks import incompat, allow_non_gpu
 from spark_session import is_before_spark_330, is_databricks104_or_later, is_databricks113_or_later, is_spark_33X, is_spark_340_or_later
 from pyspark.sql.types import *
@@ -323,7 +324,7 @@ def test_simple_get_map_value_ansi_fail(data_gen):
             error_message=message)
 
 
-@pytest.mark.skipif(not is_spark_33X() or is_databricks113_or_later(),
+@pytest.mark.skipif(not is_spark_33X() or is_databricks_runtime(),
                     reason="Only in Spark 3.3.X + ANSI mode + Strict Index, map key throws on no such element")
 @pytest.mark.parametrize('strict_index', ['true', 'false'])
 @pytest.mark.parametrize('data_gen', [simple_string_to_string_map_gen], ids=idfn)

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -188,6 +188,9 @@ def is_databricks91_or_later():
 def is_databricks104_or_later():
     return is_databricks_version_or_later(10, 4)
 
+def is_databricks113_or_later():
+    return is_databricks_version_or_later(11, 3)
+
 def get_java_major_version():
     ver = _spark.sparkContext._jvm.System.getProperty("java.version")
     # Allow these formats:


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Closes #7347 

## Rationale of the change
1. the configuration `strictIndexOperator` has been removed in Spark 3.4 and DB11.3: https://issues.apache.org/jira/browse/SPARK-38967
2. Null will always be returned on invalid access to map in Spark3.4 and DB11.3: https://issues.apache.org/jira/browse/SPARK-40066 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
