### PR TITLE
Fix ExtractValue assertion with 330db shim

### DIFF
--- a/sql-plugin/src/main/311+-non330db/scala/com/nvidia/spark/rapids/shims/extractValueShims.scala
+++ b/sql-plugin/src/main/311+-non330db/scala/com/nvidia/spark/rapids/shims/extractValueShims.scala
@@ -18,4 +18,8 @@ package com.nvidia.spark.rapids.shims
 
 import org.apache.spark.sql.catalyst.expressions._
 
-trait ShimExtractValue extends ExtractValue
+trait ShimGetArrayStructFields extends ExtractValue
+
+trait ShimGetArrayItem extends ExtractValue
+
+trait ShimGetStructField extends ExtractValue

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -45,8 +45,16 @@ object SparkShimImpl extends Spark321PlusDBShims {
   }
 }
 
-trait ShimExtractValue extends ExtractValue {
-  override def nodePatternsInternal(): Seq[TreePattern] = Seq.empty
+trait ShimGetArrayStructFields extends ExtractValue {
+  override def nodePatternsInternal(): Seq[TreePattern] = Seq(EXTRACT_ARRAY_SUBFIELDS)
+}
+
+trait ShimGetArrayItem extends ExtractValue {
+  override def nodePatternsInternal(): Seq[TreePattern] = Seq(GET_ARRAY_ITEM)
+}
+
+trait ShimGetStructField extends ExtractValue {
+  override def nodePatternsInternal(): Seq[TreePattern] = Seq(GET_STRUCT_FIELD)
 }
 
 // Fallback to the default definition of `deterministic`

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[String] = None)
     extends ShimUnaryExpression
     with GpuExpression
-    with ShimExtractValue
+    with ShimGetStructField
     with NullIntolerant {
 
   lazy val childSchema: StructType = child.dataType.asInstanceOf[StructType]
@@ -84,7 +84,7 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
 case class GpuGetArrayItem(child: Expression, ordinal: Expression, failOnError: Boolean)
     extends GpuBinaryExpression
     with ExpectsInputTypes
-    with ShimExtractValue {
+    with ShimGetArrayItem {
 
   // We have done type checking for child in `ExtractValue`, so only need to check the `ordinal`.
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType, IntegralType)
@@ -333,7 +333,7 @@ case class GpuGetArrayStructFields(
     ordinal: Int,
     numFields: Int,
     containsNull: Boolean) extends GpuUnaryExpression
-    with ShimExtractValue
+    with ShimGetArrayStructFields
     with NullIntolerant {
 
   override def dataType: DataType = ArrayType(field.dataType, containsNull)


### PR DESCRIPTION
Fixes #7352.  Databricks 11.4's version of the ExtractValue trait mandates that derived classes override `nodePatternsInternal`.  This removes `ShimExtractValue` and replaces it with shim traits for the specific derivations we're using which can provide the required tree patterns in the 330db shim.