### PR TITLE
Move Rounding ops to shim for 330+

### DIFF
--- a/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RoundingShims.scala
+++ b/sql-plugin/src/main/330+/scala/org/apache/spark/sql/rapids/shims/RoundingShims.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import ai.rapids.cudf.DType
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.rapids._
+import org.apache.spark.sql.types.DecimalType
+
+trait RoundingShims extends SparkShims {
+  def roundingExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
+    GpuOverrides.expr[RoundCeil](
+      "Computes the ceiling of the given expression to d decimal places",
+      ExprChecks.binaryProject(
+        TypeSig.gpuNumeric, TypeSig.cpuNumeric,
+        ("value", TypeSig.gpuNumeric +
+            TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
+            TypeSig.psNote(TypeEnum.DOUBLE, "result may round slightly differently"),
+            TypeSig.cpuNumeric),
+        ("scale", TypeSig.lit(TypeEnum.INT), TypeSig.lit(TypeEnum.INT))),
+      (ceil, conf, p, r) => new BinaryExprMeta[RoundCeil](ceil, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          ceil.child.dataType match {
+            case dt: DecimalType =>
+              val precision = GpuFloorCeil.unboundedOutputPrecision(dt)
+              if (precision > DType.DECIMAL128_MAX_PRECISION) {
+                willNotWorkOnGpu(s"output precision $precision would require overflow " +
+                    s"checks, which are not supported yet")
+              }
+            case _ => // NOOP
+          }
+          GpuOverrides.extractLit(ceil.scale).foreach { scale =>
+            if (scale.value != null &&
+                scale.value.asInstanceOf[Integer] != 0) {
+              willNotWorkOnGpu("Scale other than 0 is not supported")
+            }
+          }
+        }
+
+        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
+          // use Spark `RoundCeil.dataType` to keep consistent between Spark versions.
+          GpuCeil(lhs, ceil.dataType)
+        }
+      }),
+    GpuOverrides.expr[RoundFloor](
+      "Computes the floor of the given expression to d decimal places",
+      ExprChecks.binaryProject(
+        TypeSig.gpuNumeric, TypeSig.cpuNumeric,
+        ("value", TypeSig.gpuNumeric +
+            TypeSig.psNote(TypeEnum.FLOAT, "result may round slightly differently") +
+            TypeSig.psNote(TypeEnum.DOUBLE, "result may round slightly differently"),
+            TypeSig.cpuNumeric),
+        ("scale", TypeSig.lit(TypeEnum.INT), TypeSig.lit(TypeEnum.INT))),
+      (floor, conf, p, r) => new BinaryExprMeta[RoundFloor](floor, conf, p, r) {
+        override def tagExprForGpu(): Unit = {
+          floor.child.dataType match {
+            case dt: DecimalType =>
+              val precision = GpuFloorCeil.unboundedOutputPrecision(dt)
+              if (precision > DType.DECIMAL128_MAX_PRECISION) {
+                willNotWorkOnGpu(s"output precision $precision would require overflow " +
+                    s"checks, which are not supported yet")
+              }
+            case _ => // NOOP
+          }
+          GpuOverrides.extractLit(floor.scale).foreach { scale =>
+            if (scale.value != null &&
+                scale.value.asInstanceOf[Integer] != 0) {
+              willNotWorkOnGpu("Scale other than 0 is not supported")
+            }
+          }
+        }
+
+        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression = {
+          // use Spark `RoundFloor.dataType` to keep consistent between Spark versions.
+          GpuFloor(lhs, floor.dataType)
+        }
+      })
+  ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
+}

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 
-object SparkShimImpl extends Spark321PlusDBShims {
+object SparkShimImpl extends Spark321PlusDBShims with RoundingShims {
   // AnsiCast is removed from Spark3.4.0
   override def ansiCastRule: ExprRule[_ <: Expression] = null
 
@@ -43,6 +43,9 @@ object SparkShimImpl extends Spark321PlusDBShims {
     new ParquetFilters(schema, pushDownDate, pushDownTimestamp, pushDownDecimal, pushDownStartWith,
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
   }
+
+    override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] =
+      super.getExprs ++ roundingExprs
 }
 
 trait ShimExtractValue extends ExtractValue {


### PR DESCRIPTION
Resolves #7326 

Shims the `RoundCeil` and `RoundFloor` overrides so they can be shared by 330+ DB and non-DB shims. There is no common 330 shim right now for the ideal implementation, though that change can/should be handled in a different PR.