### PR TITLE
Re-enable some tests in ParseDateTimeSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -60,8 +60,6 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("to_date yyyy-MM-dd",
       datesAsStrings,
-      assumeCondition = _ => (false,
-        "https://github.com/NVIDIA/spark-rapids/issues/7090"),
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
@@ -114,11 +112,8 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     df => df.withColumn("c1", to_date(col("c0"), "yyyy-MM-dd"))
   }
 
-
   testSparkResultsAreEqual("to_timestamp yyyy-MM-dd",
       timestampsAsStrings,
-    assumeCondition = _ => (false,
-      "https://github.com/NVIDIA/spark-rapids/issues/7090"),
       conf = CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", to_timestamp(col("c0"), "yyyy-MM-dd"))
   }
@@ -139,9 +134,7 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
 
   testSparkResultsAreEqual("unix_timestamp parse date",
       timestampsAsStrings,
-    assumeCondition = _ => (false,
-      "https://github.com/NVIDIA/spark-rapids/issues/7090"),
-    conf = CORRECTED_TIME_PARSER_POLICY) {
+      CORRECTED_TIME_PARSER_POLICY) {
     df => df.withColumn("c1", unix_timestamp(col("c0"), "yyyy-MM-dd"))
   }
 


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Part of https://github.com/NVIDIA/spark-rapids/issues/7090

We disabled a few tests in ParseDateTimeSuite recently due to a regression in cuDF. This regression was fixed in https://github.com/rapidsai/cudf/pull/12282 and this PR re-enables the tests.