### PR TITLE
Avoid shutting down RMM until all allocations have cleared

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -145,7 +145,12 @@ object GpuDeviceManager extends Logging {
     GpuShuffleEnv.shutdown()
     // try to avoid segfault on RMM shutdown
     val timeout = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
-    while(Rmm.getTotalBytesAllocated > 0 && System.nanoTime() < timeout) {
+    var isFirstTime = true
+    while (Rmm.getTotalBytesAllocated > 0 && System.nanoTime() < timeout) {
+      if (isFirstTime) {
+        logWarning("Waiting for outstanding RMM allocations to be released...")
+        isFirstTime = false
+      }
       Thread.sleep(10)
     }
     if (System.nanoTime() >= timeout) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import java.util.concurrent.ThreadFactory
+import java.util.concurrent.{ThreadFactory, TimeUnit}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
@@ -143,6 +143,17 @@ object GpuDeviceManager extends Logging {
     singletonMemoryInitialized = Errored
     RapidsBufferCatalog.close()
     GpuShuffleEnv.shutdown()
+    // try to avoid segfault on RMM shutdown
+    val timeout = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+    while(Rmm.getTotalBytesAllocated > 0 && System.nanoTime() < timeout) {
+      Thread.sleep(10)
+    }
+    if (System.nanoTime() >= timeout) {
+      val remaining = Rmm.getTotalBytesAllocated
+      if (remaining > 0) {
+        logWarning(s"Shutting down RMM even though there are outstanding allocations $remaining")
+      }
+    }
     Rmm.shutdown()
     singletonMemoryInitialized = Uninitialized
   }


### PR DESCRIPTION
Inside of RMM when shutting down it will wait until the pending java allocations have cleared. Sadly if we get an out of memory error when trying to read an input file no GPU memory has been allocated from java.  When that happens we can get a segfault because native code tries to allocate memory through RMM, but the memory allocation pointer was set to null. For this patch we try to avoid it by waiting for all of the RMM allocations to be released before shutting down RMM.