### PR TITLE
Fix for incorrect nested-unsigned test

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
@@ -177,7 +177,7 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
       fail("Did not receive an expected exception from cudf")
     } catch {
       case e: Exception =>
-        if(!exceptionContains(e, "Encountered malformed")){
+        if (!exceptionContains(e, "Encountered malformed")) {
           throw e
         }
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScanSuite.scala
@@ -165,7 +165,7 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
     frame => frame.select(col("*"))
   }
   
-   /**
+  /**
    * A malformed version of nested-unsigned.parquet is, which should throw.
    */
   test("Test Parquet nested unsigned int malformed: uint8, uint16, uint32"){
@@ -173,10 +173,13 @@ class ParquetScanSuite extends SparkQueryCompareTestSuite {
     try {
       withGpuSparkSession(spark => {
         frameFromParquet("nested-unsigned-malformed.parquet")(spark).collect
-      })      
+      })
+      fail("Did not receive an expected exception from cudf")
     } catch {
       case e: Exception =>
-        assert(exceptionContains(e, "Encountered malformed"))
+        if(!exceptionContains(e, "Encountered malformed")){
+          throw e
+        }
     }
   }
 


### PR DESCRIPTION

The previous PR (https://github.com/NVIDIA/spark-rapids/pull/7340) was not properly failing if cudf did _not_ throw the expected exception.  This fixes that.

Note:  this PR is dependent on a cudf PR  https://github.com/rapidsai/cudf/pull/12360 and should not be merged until it is (but should be merged immediately after).