### PR TITLE
Update RapidsUDF interface to support UDFs with no input parameters

### DIFF
--- a/docs/additional-functionality/rapids-udfs.md
+++ b/docs/additional-functionality/rapids-udfs.md
@@ -53,15 +53,19 @@ Other forms of Spark UDFs are not supported, such as:
 For supported UDFs, the RAPIDS Accelerator will detect a GPU implementation
 if the UDF class implements the
 [RapidsUDF](../../sql-plugin/src/main/java/com/nvidia/spark/RapidsUDF.java)
-interface. This interface requires implementing the following method:
+interface. Unlike the CPU UDF which processes data one row at a time, the
+GPU version processes a columnar batch of rows. This reduces invocation
+overhead and enables parallel processing of the data by the GPU.
+
+This interface requires implementing the following method:
 
 ```java
-  ai.rapids.cudf.ColumnVector evaluateColumnar(ai.rapids.cudf.ColumnVector... args);
+  ai.rapids.cudf.ColumnVector evaluateColumnar(int numRows, ai.rapids.cudf.ColumnVector... args);
 ```
 
-Unlike the CPU UDF which processes data one row at a time, the GPU version
-processes a columnar batch of rows. This reduces invocation overhead and
-enables parallel processing of the data by the GPU.
+The implementation of `evaluateColumnar` must return a column with the
+specified number of rows. All input columns will contain the same number
+of rows.
 
 ### Interpreting Inputs
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/RapidsUDF.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/RapidsUDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ public interface RapidsUDF {
    * implementation of the UDF (e.g.: INT32 for int, FLOAT64 for double,
    * STRING for String, etc) or a runtime exception will occur when the
    * results are marshalled into the expected Spark result type for the UDF.
+   * The number of rows of output must match the number of rows for the
+   * input arguments, which will all have the same row count.
    * <p/>
    * Note that the inputs should NOT be closed by this method, as they will
    * be closed by the caller. This method must close any intermediate cuDF
@@ -35,6 +37,34 @@ public interface RapidsUDF {
    * @param args columnar inputs to the UDF that will be closed by the caller
    *             and should not be closed within this method.
    * @return columnar output from the user-defined function
+   * @deprecated Use {@link #evaluateColumnar(int, ColumnVector...)}
    */
-  ColumnVector evaluateColumnar(ColumnVector... args);
+  @Deprecated
+  default ColumnVector evaluateColumnar(ColumnVector... args) {
+    throw new UnsupportedOperationException(
+        "Must override evaluateColumnar(int numRows, ColumnVector... args");
+  }
+
+  /**
+   * Evaluate a user-defined function with RAPIDS cuDF columnar inputs
+   * producing a cuDF column as output. The method must return a column of
+   * the appropriate type that corresponds to the type returned by the CPU
+   * implementation of the UDF (e.g.: INT32 for int, FLOAT64 for double,
+   * STRING for String, etc) or a runtime exception will occur when the
+   * results are marshalled into the expected Spark result type for the UDF.
+   * The number of rows of output must match the number of rows specified,
+   * and all input columns will have that same number of rows.
+   * <p/>
+   * Note that the inputs should NOT be closed by this method, as they will
+   * be closed by the caller. This method must close any intermediate cuDF
+   * results produced during the computation (e.g.: `Table`, `ColumnVector`
+   * or `Scalar` instances).
+   * @param numRows number of rows of output to return
+   * @param args columnar inputs to the UDF that will be closed by the caller
+   *             and should not be closed within this method.
+   * @return columnar output from the user-defined function
+   */
+  default ColumnVector evaluateColumnar(int numRows, ColumnVector... args) {
+    return evaluateColumnar(args);
+  }
 }

--- a/sql-plugin/src/main/java/com/nvidia/spark/RapidsUDF.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/RapidsUDF.java
@@ -53,7 +53,7 @@ public interface RapidsUDF {
    * STRING for String, etc) or a runtime exception will occur when the
    * results are marshalled into the expected Spark result type for the UDF.
    * The number of rows of output must match the number of rows specified,
-   * and all input columns will have that same number of rows.
+   * and all input columns must have that same number of rows.
    * <p/>
    * Note that the inputs should NOT be closed by this method, as they will
    * be closed by the caller. This method must close any intermediate cuDF

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
@@ -56,7 +56,8 @@ trait GpuUserDefinedFunction extends GpuExpression
       val funcInputs = exprResults.map(_.getBase()).toArray
       withResource(new NvtxRange(nvtxRangeName, NvtxColor.PURPLE)) { _ =>
         try {
-          closeOnExcept(function.evaluateColumnar(funcInputs: _*)) { resultColumn =>
+          val resultColumn = function.evaluateColumnar(batch.numRows(), funcInputs: _*)
+          closeOnExcept(resultColumn) { _ =>
             if (batch.numRows() != resultColumn.getRowCount) {
               throw new IllegalStateException("UDF returned a different row count than the " +
                   s"input, expected ${batch.numRows} found ${resultColumn.getRowCount}")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/KnownNotNullSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/KnownNotNullSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +56,11 @@ class KnownNotNullSuite extends SparkQueryCompareTestSuite {
  */
 trait PlusOne extends RapidsUDF with Serializable with Arm {
 
-  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     require(args.length == 1,
       s"Unexpected argument count: ${args.length}")
+    require(numRows == args.head.getRowCount,
+      s"Expected $numRows rows, received ${args.head.getRowCount}")
 
     withResource(Scalar.fromInt(1)) { sOne =>
       args.head.add(sOne, args.head.getType)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ScalaUDFSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ScalaUDFSuite.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import com.nvidia.spark.rapids.tests.udf.scala.{URLDecode, URLEncode}
+import com.nvidia.spark.rapids.tests.udf.scala.{AlwaysTrueUDF, URLDecode, URLEncode}
 
 import org.apache.spark.sql.functions.col
 
@@ -33,5 +33,12 @@ class ScalaUDFSuite extends SparkQueryCompareTestSuite {
     // exhaustive test of the specific UDF implementation itself.
     val urlencode = frame.sparkSession.udf.register("urlencode", new URLEncode())
     frame.select(urlencode(col("strings")))
+  }
+
+  testSparkResultsAreEqual("Scala always true", nullableStringsFromCsv) { frame =>
+    // This is a basic smoke-test of the Scala UDF framework, not an
+    // exhaustive test of the specific UDF implementation itself.
+    val udf = frame.sparkSession.udf.register("alwaystrue", new AlwaysTrueUDF())
+    frame.withColumn("alwaystrue", udf())
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/AlwaysTrueUDF.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/AlwaysTrueUDF.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tests.udf.scala
+
+import ai.rapids.cudf.{ColumnVector, Scalar}
+import com.nvidia.spark.RapidsUDF
+import com.nvidia.spark.rapids.Arm
+
+/**
+ * A Scala user-defined function (UDF) that always returns true.
+ * Used for testing RAPIDS accelerated UDFs with no inputs.
+ */
+class AlwaysTrueUDF extends (() => Boolean) with RapidsUDF with Arm with Serializable {
+  /** Row-by-row implementation that executes on the CPU */
+  override def apply(): Boolean = true
+
+  /** Columnar implementation that runs on the GPU */
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
+    require(args.isEmpty)
+    withResource(Scalar.fromBool(true)) { s =>
+      ColumnVector.fromScalar(s, numRows);
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/URLDecode.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/URLDecode.scala
@@ -40,11 +40,12 @@ class URLDecode extends Function[String, String] with RapidsUDF with Serializabl
   }
 
   /** Columnar implementation that runs on the GPU */
-  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     require(args.length == 1, s"Unexpected argument count: ${args.length}")
     val input = args.head
+    require(numRows == input.getRowCount, s"Expected $numRows rows, received ${input.getRowCount}")
     require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
 
     // The cudf urlDecode does not convert '+' to a space, so do that as a pre-pass first.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/URLEncode.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/URLEncode.scala
@@ -39,11 +39,12 @@ class URLEncode extends Function[String, String] with RapidsUDF with Serializabl
   }
 
   /** Columnar implementation that runs on the GPU */
-  override def evaluateColumnar(args: ColumnVector*): ColumnVector = {
+  override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     // The CPU implementation takes a single string argument, so similarly
     // there should only be one column argument of type STRING.
     require(args.length == 1, s"Unexpected argument count: ${args.length}")
     val input = args.head
+    require(numRows == input.getRowCount, s"Expected $numRows rows, received ${input.getRowCount}")
     require(input.getType == DType.STRING, s"Argument type is not a string: ${input.getType}")
     input.urlEncode()
   }


### PR DESCRIPTION
Fixes #7373 by deprecating the old interface and providing a new interface that passes the number of rows as the first argument.  The new method has a default implementation that calls the original, deprecated method for backwards compatibility, and I verified that UDFs compiled against the original interface before this change continue to work against the new interface at runtime.