### PR TITLE
[FEA] Support `reverse` for arrays

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -11569,7 +11569,7 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP</em></td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -11590,7 +11590,7 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td><em>PS<br/>UTC is only supported TZ for child TIMESTAMP</em></td>
 <td> </td>
 <td> </td>
 <td> </td>

--- a/integration_tests/src/main/python/collection_ops_test.py
+++ b/integration_tests/src/main/python/collection_ops_test.py
@@ -129,8 +129,8 @@ def test_size_of_map(data_gen, size_of_null):
             lambda spark: unary_op_df(spark, data_gen).selectExpr('size(a)'),
             conf={'spark.sql.legacy.sizeOfNull': size_of_null})
 
-@pytest.mark.parametrize('data_gen', [string_gen], ids=idfn)
-def test_reverse_strings(data_gen):
+@pytest.mark.parametrize('data_gen', array_gens_sample + [string_gen], ids=idfn)
+def test_reverse(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, data_gen).selectExpr('reverse(a)'))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3232,8 +3232,10 @@ object GpuOverrides extends Logging {
       }),
     expr[Reverse](
       "Returns a reversed string or an array with reverse order of elements",
-      ExprChecks.unaryProject(TypeSig.STRING, TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all),
-        TypeSig.STRING, TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all)),
+      ExprChecks.unaryProject(TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all), 
+        TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all),
+        TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all),
+        TypeSig.STRING + TypeSig.ARRAY.nested(TypeSig.all)),
       (a, conf, p, r) => new UnaryExprMeta[Reverse](a, conf, p, r) {
         override def convertToGpu(input: Expression): GpuExpression =
           GpuReverse(input)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -310,7 +310,7 @@ case class GpuSize(child: Expression, legacySizeOfNull: Boolean)
 }
 
 case class GpuReverse(child: Expression) extends GpuUnaryExpression {
-  require(child.dataType.isInstanceOf[StringType],
+  require(child.dataType.isInstanceOf[StringType] || child.dataType.isInstanceOf[ArrayType],
     s"The reverse function doesn't support the operand type ${child.dataType}")
 
   override def dataType: DataType = child.dataType

--- a/tools/generated_files/supportedExprs.csv
+++ b/tools/generated_files/supportedExprs.csv
@@ -416,8 +416,8 @@ Remainder,S,`%`; `mod`,None,project,rhs,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA
 Remainder,S,`%`; `mod`,None,project,result,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA
 ReplicateRows,S, ,None,project,input,S,S,S,S,S,S,S,S,PS,S,S,S,NS,NS,PS,NS,PS,NS
 ReplicateRows,S, ,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,PS,NA,NA,NA
-Reverse,S,`reverse`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NS,NA,NA,NA
-Reverse,S,`reverse`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NS,NA,NA,NA
+Reverse,S,`reverse`,None,project,input,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,PS,NA,NA,NA
+Reverse,S,`reverse`,None,project,result,NA,NA,NA,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,PS,NA,NA,NA
 Rint,S,`rint`,None,project,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Rint,S,`rint`,None,project,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Rint,S,`rint`,None,AST,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
This supports `reverse` function for arrays, part of solution for https://github.com/NVIDIA/spark-rapids/issues/6885.

For example,
```
scala> val df2 = Seq(Seq(1, 2, 3), Seq(4, 5, 6)).toDF("i")
df2: org.apache.spark.sql.DataFrame = [i: array<int>]

scala> df2.show
+---------+
|        i|
+---------+
|[1, 2, 3]|
|[4, 5, 6]|
+---------+


scala> df2.selectExpr("reverse(i)").show
+----------+
|reverse(i)|
+----------+
| [3, 2, 1]|
| [6, 5, 4]|
+----------+
```