### PR TITLE
Fix Databricks version comparison in pytests [databricks]

### DIFF
--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -180,7 +180,9 @@ def is_databricks_version_or_later(major, minor):
     parts = version.split(".")
     if (len(parts) < 2):
         raise RuntimeError("Unable to determine Databricks version from version string: " + version)
-    return int(parts[0]) >= major and int(parts[1]) >= minor
+    db_major = int(parts[0])
+    db_minor = int(parts[1])
+    return db_minor >= minor if (db_major == major) else db_major >= major
 
 def is_databricks91_or_later():
     return is_databricks_version_or_later(9, 1)


### PR DESCRIPTION
Compare minor components only as a tie breaker if major components are equal

Fixes #7345

Fixes xfail for is_databricks104_or_later on 11.3

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
