### PR TITLE
[databricks] Fix `test_array_element_at_zero_index_fail` and `test_div_overflow_exception_when_ansi` DB 11.3 integration test failures

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -910,10 +910,11 @@ div_overflow_exprs = [
 @pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
 def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_enabled}
-    err_exp = 'java.lang.ArithmeticException' if is_before_spark_330() \
-        else 'org.apache.spark.SparkArithmeticException'
-    err_mess = ': Overflow in integral divide' if is_before_spark_340() \
-        else ': [ARITHMETIC_OVERFLOW] Overflow in integral divide'
+    err_exp = 'java.lang.ArithmeticException' if is_before_spark_330() else \
+        'org.apache.spark.SparkArithmeticException'
+    err_mess = ': Overflow in integral divide' \
+        if is_before_spark_340() and not is_databricks113_or_later() else \
+        ': [ARITHMETIC_OVERFLOW] Overflow in integral divide'
     if ansi_enabled == 'true':
         assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_div_overflow_df(spark, expr).collect(),

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -262,7 +262,10 @@ def test_array_element_at_ansi_not_fail_all_null_data():
 @pytest.mark.parametrize('index', [0, array_zero_index_gen], ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', [False, True], ids=idfn)
 def test_array_element_at_zero_index_fail(index, ansi_enabled):
-    message = "SQL array indices start at 1" if is_before_spark_340() else "[ELEMENT_AT_BY_INDEX_ZERO]"
+    message = "SQL array indices start at 1" \
+        if is_before_spark_340() and not is_databricks113_or_later() else \
+        "org.apache.spark.SparkRuntimeException: [ELEMENT_AT_BY_INDEX_ZERO] The index 0 is invalid"
+
     if isinstance(index, int):
         test_func = lambda spark: unary_op_df(spark, ArrayGen(int_gen)).select(
             element_at(col('a'), index)).collect()


### PR DESCRIPTION
Related to #7327

Resolves `test_array_element_at_zero_index_fail` and `test_div_overflow_exception_when_ansi` test failures in DB 11.3. Remaining test failures in 7327 are unrelated to error messages and exceptions, failing due to not being able to run on GPU.