### PR TITLE
Remove 314 from dist build list

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,7 +54,6 @@
             330cdh
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            314,
             332
         </snapshot.buildvers>
         <databricks.buildvers>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

related to https://github.com/NVIDIA/spark-rapids/issues/7409

This PR is to firstly disable building 314, and internally we have disabled testing against spark 3.1.4-snapshot
we should clean up redundant code in the future
