### PR TITLE
Fix the `with_hidden_metadata_fallback` test failures on DB11.3 [databricks]

### DIFF
--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
@@ -106,6 +106,10 @@ trait Spark321PlusDBShims extends SparkShims
     }
   }
 
+  def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
+    GpuFileSourceScanExec.tagSupport(meta)
+  }
+
   private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
     Seq(
       GpuOverrides.exec[SubqueryBroadcastExec](
@@ -194,6 +198,8 @@ trait Spark321PlusDBShims extends SparkShims
           override def convertToCpu(): SparkPlan = {
             wrapped.copy(partitionFilters = partitionFilters)
           }
+
+          override def tagPlanForGpu(): Unit = tagFileSourceScanExec(this)
 
           override def convertToGpu(): GpuExec = {
             val sparkSession = wrapped.relation.sparkSession

--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
@@ -106,10 +106,6 @@ trait Spark321PlusDBShims extends SparkShims
     }
   }
 
-  def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
-    GpuFileSourceScanExec.tagSupport(meta)
-  }
-
   private val shimExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
     Seq(
       GpuOverrides.exec[SubqueryBroadcastExec](

--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/Spark321PlusDBShims.scala
@@ -192,14 +192,12 @@ trait Spark321PlusDBShims extends SparkShims
               this.entirePlanWillNotWork("Plans that read Delta Index JSON files can not run " +
                   "any part of the plan on the GPU!")
             }
-            GpuFileSourceScanExec.tagSupport(this)
+            tagFileSourceScanExec(this)
           }
 
           override def convertToCpu(): SparkPlan = {
             wrapped.copy(partitionFilters = partitionFilters)
           }
-
-          override def tagPlanForGpu(): Unit = tagFileSourceScanExec(this)
 
           override def convertToGpu(): GpuExec = {
             val sparkSession = wrapped.relation.sparkSession

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -46,6 +46,7 @@ object SparkShimImpl extends Spark321PlusDBShims {
   }
 
   override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
+    println("hit the shim");
     if (meta.wrapped.expressions.exists {
       case FileSourceMetadataAttribute(_) => true
       case _ => false

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -46,7 +46,7 @@ object SparkShimImpl extends Spark321PlusDBShims {
   }
 
   override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
-    println("hit the shim");
+    throw new ArithmeticException("HIT THE SHIM OF DB113 !!!!!")
     if (meta.wrapped.expressions.exists {
       case FileSourceMetadataAttribute(_) => true
       case _ => false

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -45,6 +45,16 @@ object SparkShimImpl extends Spark321PlusDBShims {
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
   }
 
+  override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
+    if (meta.wrapped.expressions.exists {
+      case FileSourceMetadataAttribute(_) => true
+      case _ => false
+    }) {
+      meta.willNotWorkOnGpu("hidden metadata columns are not supported on GPU")
+    }
+    super.tagFileSourceScanExec(meta)
+  }
+
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] =
     super.getExprs ++ DayTimeIntervalShims.exprs ++ RoundingShims.exprs
 

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -21,7 +21,7 @@ import org.apache.parquet.schema.MessageType
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.trees.TreePattern._
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -45,7 +45,7 @@ object SparkShimImpl extends Spark321PlusDBShims {
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
   }
 
-  def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
+  override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     if (meta.wrapped.expressions.exists {
       case FileSourceMetadataAttribute(_) => true
       case _ => false

--- a/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/330db/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -45,8 +45,7 @@ object SparkShimImpl extends Spark321PlusDBShims {
       pushDownInFilterThreshold, caseSensitive, datetimeRebaseMode)
   }
 
-  override def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
-    throw new ArithmeticException("HIT THE SHIM OF DB113 !!!!!")
+  def tagFileSourceScanExec(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     if (meta.wrapped.expressions.exists {
       case FileSourceMetadataAttribute(_) => true
       case _ => false


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>
Closes #7368.

## Changes in the PR
1. update the method `tagPlanForGpu` of `SparkPlanMeta[FileSourceScanExec]` in Spark321PlusDbShims to use the method `tagFileSourceScanExec` of `SparkShims`.
2. override the method `tagFileSourceScanExec` of SparkShims in 330db to check whether useing hidden meta data. (same as #4686) 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
