### PR TITLE
Ubuntu build&test images default as 20.04

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -19,13 +19,13 @@
 # Build the image for rapids-plugin development environment
 #
 # Arguments:
-#    CUDA_VER=11.0+
-#    UBUNTU_VER=18.04 or 20.04
+#    CUDA_VER=11.X.Y
+#    UBUNTU_VER=20.04 or 22.04
 #    CUDF_VER=<cudf-py version>
 ###
 
-ARG CUDA_VER=11.0
-ARG UBUNTU_VER=18.04
+ARG CUDA_VER=11.8.0
+ARG UBUNTU_VER=20.04
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG CUDA_VER
 ARG CUDF_VER

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -41,7 +41,8 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget \
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
+
 # some python3-pip would install pip for OS default python3 version only
 # like for ubuntu 18.04, it would only install pip for python3.6
 # so we install pip for specific python version explicitly

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -32,7 +32,8 @@ ARG CUDF_VER
 ARG UBUNTU_VER
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
-RUN UB_VER=$(echo ${UBUNTU_VER} | tr -d '.') && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UB_VER}/x86_64/3bf863cc.pub
+RUN UB_VER=$(echo ${UBUNTU_VER} | tr -d '.') && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UB_VER}/x86_64/3bf863cc.pub || true
 # Install jdk-8, jdk-11, maven, docker image
 RUN apt-get update -y && \
     apt-get install -y software-properties-common rsync zip unzip
@@ -41,7 +42,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
     openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
-RUN python3.8 -m easy_install pip
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py
 
 # Set default jdk as 1.8.0
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -43,7 +43,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
     openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
 
-# some python3-pip would install pip for OS default python3 version only
+# apt python3-pip would install pip for OS default python3 version only
 # like for ubuntu 18.04, it would only install pip for python3.6
 # so we install pip for specific python version explicitly
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -41,7 +41,10 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git wget \
+# some python3-pip would install pip for OS default python3 version only
+# like for ubuntu 18.04, it would only install pip for python3.6
+# so we install pip for specific python version explicitly
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py
 
 # Set default jdk as 1.8.0

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -48,7 +48,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
     openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget
 
-# some python3-pip would install pip for OS default python3 version only
+# apt python3-pip would install pip for OS default python3 version only
 # like for ubuntu 18.04, it would only install pip for python3.6
 # so we install pip for specific python version explicitly
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -46,7 +46,10 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget \
+# some python3-pip would install pip for OS default python3 version only
+# like for ubuntu 18.04, it would only install pip for python3.6
+# so we install pip for specific python version explicitly
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py
 
 # Set default jdk as 1.8.0

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -46,7 +46,8 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget \
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget
+
 # some python3-pip would install pip for OS default python3 version only
 # like for ubuntu 18.04, it would only install pip for python3.6
 # so we install pip for specific python version explicitly

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -19,14 +19,14 @@
 # Build the image for rapids-plugin development environment
 #
 # Arguments:
-#       CUDA_VER=11.0+
-#       UBUNTU_VER=18.04 or 20.04
+#       CUDA_VER=11.X.Y
+#       UBUNTU_VER=20.04
 #       UCX_CUDA_VER=11 (major CUDA version)
 #       UCX_VER=1.13.1
 ###
 
-ARG CUDA_VER=11.0
-ARG UBUNTU_VER=18.04
+ARG CUDA_VER=11.0.3
+ARG UBUNTU_VER=20.04
 ARG UCX_VER=1.13.1
 ARG UCX_CUDA_VER=11
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -36,7 +36,8 @@ ARG UCX_VER
 ARG UCX_CUDA_VER
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
-RUN UB_VER=$(echo ${UBUNTU_VER} | tr -d '.') && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UB_VER}/x86_64/3bf863cc.pub
+RUN UB_VER=$(echo ${UBUNTU_VER} | tr -d '.') && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UB_VER}/x86_64/3bf863cc.pub || true
 
 # Install jdk-8, jdk-11, maven, docker image
 RUN apt-get update -y && \
@@ -45,8 +46,8 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip
-RUN python3.8 -m easy_install pip
+    openjdk-8-jdk openjdk-11-jdk python3.8 python3.8-distutils python3-setuptools tzdata git zip unzip wget
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py
 
 # Set default jdk as 1.8.0
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -30,7 +30,7 @@ import ipp.blossom.*
 
 def githubHelper // blossom github helper
 def TEMP_IMAGE_BUILD = true
-def CUDA_NAME = 'cuda11.0' // hardcode cuda version for docker build part
+def CUDA_NAME = 'cuda11.0.3' // hardcode cuda version for docker build part
 def PREMERGE_DOCKERFILE = 'jenkins/Dockerfile-blossom.ubuntu'
 def IMAGE_PREMERGE // temp image for premerge test
 def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks")
@@ -198,7 +198,7 @@ pipeline {
                         }
 
                         if (TEMP_IMAGE_BUILD) {
-                            IMAGE_TAG = "dev-ubuntu18-${CUDA_NAME}"
+                            IMAGE_TAG = "dev-ubuntu20-${CUDA_NAME}"
                             PREMERGE_TAG = "${IMAGE_TAG}-${BUILD_TAG}"
                             IMAGE_PREMERGE = "${ARTIFACTORY_NAME}/sw-spark-docker-local/plugin:${PREMERGE_TAG}"
                             def CUDA_VER = "$CUDA_NAME" - "cuda"
@@ -206,7 +206,7 @@ pipeline {
                             uploadDocker(IMAGE_PREMERGE)
                         } else {
                             // if no pre-merge dockerfile change, use nightly image
-                            IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu18-$CUDA_NAME-blossom-dev"
+                            IMAGE_PREMERGE = "$ARTIFACTORY_NAME/sw-spark-docker-local/plugin:dev-ubuntu20-$CUDA_NAME-blossom-dev"
                         }
                     }
                 }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

Use ubuntu 20.04 as default nightly images, 
for integrations tests, we will update all ubuntu images to 20.04 and 22.04 later