### PR TITLE
Support pruning partition columns for GpuFileSourceScan[databricks]

### DIFF
--- a/integration_tests/src/main/python/prune_partition_column_test.py
+++ b/integration_tests/src/main/python/prune_partition_column_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_are_equal_collect
+from data_gen import *
+from marks import *
+from spark_session import with_cpu_session
+
+
+@pytest.mark.parametrize('prune_part_enabled', [False, True])
+def test_prune_partition_column_when_project(spark_tmp_path, prune_part_enabled):
+    data_path = spark_tmp_path + '/PARQUET_DATA/'
+    for part_path in ['b=0/c=s1', 'b=0/c=s2', 'b=1/c=s1', 'b=1/c=s2']:
+        with_cpu_session(
+            lambda spark: unary_op_df(spark, int_gen).write.parquet(data_path + part_path))
+
+    all_confs = {
+        'spark.sql.sources.useV1SourceList': "parquet",
+        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled}
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.parquet(data_path).select('a', 'c'),
+        conf=all_confs)
+
+
+@pytest.mark.parametrize('prune_part_enabled', [False, True])
+def test_prune_partition_column_when_project_filter(spark_tmp_path, prune_part_enabled):
+    data_path = spark_tmp_path + '/PARQUET_DATA/'
+    for part_path in ['b=0/c=s1', 'b=0/c=s2', 'b=1/c=s1', 'b=1/c=s2']:
+        with_cpu_session(
+            lambda spark: unary_op_df(spark, int_gen).write.parquet(data_path + part_path))
+
+    all_confs = {
+        'spark.sql.sources.useV1SourceList': "parquet",
+        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled}
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.parquet(data_path) \
+            .filter('a > 0') \
+            .select('a', 'c'),
+        conf=all_confs)

--- a/integration_tests/src/main/python/prune_partition_column_test.py
+++ b/integration_tests/src/main/python/prune_partition_column_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
@@ -19,34 +20,53 @@ from data_gen import *
 from marks import *
 from spark_session import with_cpu_session
 
+# Several values to avoid generating too many folders for partitions.
+part1_gen = SetValuesGen(IntegerType(), [-10, -1, 0, 1, 10])
+part2_gen = SetValuesGen(LongType(), [-100, 0, 100])
+
+file_formats = ['parquet', 'orc', 'csv', 'json']
+if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'true':
+    file_formats = file_formats + ['avro']
+
+_enable_read_confs = {
+    'spark.rapids.sql.format.avro.enabled': 'true',
+    'spark.rapids.sql.format.avro.read.enabled': 'true',
+    'spark.rapids.sql.format.json.enabled': 'true',
+    'spark.rapids.sql.format.json.read.enabled': 'true',
+}
+
 
 @pytest.mark.parametrize('prune_part_enabled', [False, True])
-def test_prune_partition_column_when_project(spark_tmp_path, prune_part_enabled):
-    data_path = spark_tmp_path + '/PARQUET_DATA/'
-    for part_path in ['b=0/c=s1', 'b=0/c=s2', 'b=1/c=s1', 'b=1/c=s2']:
-        with_cpu_session(
-            lambda spark: unary_op_df(spark, int_gen).write.parquet(data_path + part_path))
+@pytest.mark.parametrize('file_format', file_formats)
+def test_prune_partition_column_when_project(spark_tmp_path, prune_part_enabled, file_format):
+    data_path = spark_tmp_path + '/PARTED_DATA/'
+    with_cpu_session(
+        lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
+            .partitionBy('b', 'c').format(file_format).save(data_path))
 
-    all_confs = {
-        'spark.sql.sources.useV1SourceList': "parquet",
-        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled}
+    all_confs = copy_and_update(_enable_read_confs, {
+        'spark.sql.sources.useV1SourceList': file_format,
+        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.parquet(data_path).select('a', 'c'),
+        lambda spark: spark.read.format(file_format).schema('a int, b int, c long') \
+            .load(data_path).select('a', 'c'),
         conf=all_confs)
 
 
 @pytest.mark.parametrize('prune_part_enabled', [False, True])
-def test_prune_partition_column_when_project_filter(spark_tmp_path, prune_part_enabled):
-    data_path = spark_tmp_path + '/PARQUET_DATA/'
-    for part_path in ['b=0/c=s1', 'b=0/c=s2', 'b=1/c=s1', 'b=1/c=s2']:
-        with_cpu_session(
-            lambda spark: unary_op_df(spark, int_gen).write.parquet(data_path + part_path))
+@pytest.mark.parametrize('file_format', file_formats)
+@pytest.mark.parametrize('filter_col', ['a', 'b', 'c'])
+def test_prune_partition_column_when_project_filter(spark_tmp_path, prune_part_enabled, filter_col, file_format):
+    data_path = spark_tmp_path + '/PARTED_DATA/'
+    with_cpu_session(
+        lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
+            .partitionBy('b', 'c').format(file_format).save(data_path))
 
-    all_confs = {
-        'spark.sql.sources.useV1SourceList': "parquet",
-        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled}
+    all_confs = copy_and_update(_enable_read_confs, {
+        'spark.sql.sources.useV1SourceList': file_format,
+        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.parquet(data_path) \
-            .filter('a > 0') \
+        lambda spark: spark.read.format(file_format).schema('a int, b int, c long').load(data_path) \
+            .filter('{} > 0'.format(filter_col)) \
             .select('a', 'c'),
         conf=all_confs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -554,6 +554,16 @@ object RapidsConf {
       .booleanConf
       .createWithDefault(false)
 
+  val FILE_SCAN_PRUNE_PARTITION_ENABLED = conf("spark.rapids.sql.fileScanPrunePartition.enabled")
+    .doc("Enable or disable the partition column pruning for v1 file scan. Spark always asks " +
+        "for all the partition columns even a query doesn't need them at last. And the " +
+        "partition column generation is relatively expensive for GPU. Enabling this allows " +
+        "GPU to try to generate the only required partition columns to save the time and GPU " +
+        "memory.")
+    .internal()
+    .booleanConf
+    .createWithDefault(true)
+
   // METRICS
 
   val METRICS_LEVEL = conf("spark.rapids.sql.metrics.level")
@@ -1915,6 +1925,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shuffledHashJoinOptimizeShuffle: Boolean = get(SHUFFLED_HASH_JOIN_OPTIMIZE_SHUFFLE)
 
   lazy val stableSort: Boolean = get(STABLE_SORT)
+
+  lazy val isFileScanPrunePartitionEnabled: Boolean = get(FILE_SCAN_PRUNE_PARTITION_ENABLED)
 
   lazy val isIncompatEnabled: Boolean = get(INCOMPATIBLE_OPS)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -556,9 +556,9 @@ object RapidsConf {
 
   val FILE_SCAN_PRUNE_PARTITION_ENABLED = conf("spark.rapids.sql.fileScanPrunePartition.enabled")
     .doc("Enable or disable the partition column pruning for v1 file scan. Spark always asks " +
-        "for all the partition columns even a query doesn't need them at last. And the " +
-        "partition column generation is relatively expensive for GPU. Enabling this allows " +
-        "GPU to try to generate the only required partition columns to save the time and GPU " +
+        "for all the partition columns even a query doesn't need them. Generation of " +
+        "partition columns is relatively expensive for the GPU. Enabling this allows the " +
+        "GPU to generate only required partition columns to save time and GPU " +
         "memory.")
     .internal()
     .booleanConf

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -49,7 +49,8 @@ import org.apache.spark.util.collection.BitSet
  * GPU version of Spark's `FileSourceScanExec`
  *
  * @param relation The file-based relation to scan.
- * @param output Output attributes of the scan, including data attributes and partition attributes.
+ * @param originalOutput Output attributes of the scan, including data attributes and partition
+ *                       attributes.
  * @param requiredSchema Required schema of the underlying relation, excluding partition columns.
  * @param partitionFilters Predicates to use for partition pruning.
  * @param optionalBucketSet Bucket ids for bucket pruning.
@@ -65,7 +66,7 @@ import org.apache.spark.util.collection.BitSet
  */
 case class GpuFileSourceScanExec(
     @transient relation: HadoopFsRelation,
-    output: Seq[Attribute],
+    originalOutput: Seq[Attribute],
     requiredSchema: StructType,
     partitionFilters: Seq[Expression],
     optionalBucketSet: Option[BitSet],
@@ -74,9 +75,21 @@ case class GpuFileSourceScanExec(
     tableIdentifier: Option[TableIdentifier],
     disableBucketedScan: Boolean = false,
     queryUsesInputFile: Boolean = false,
-    alluxioPathsMap: Option[Map[String, String]])(@transient val rapidsConf: RapidsConf)
+    alluxioPathsMap: Option[Map[String, String]],
+    requiredPartitionSchema: Option[StructType] = None)(@transient val rapidsConf: RapidsConf)
     extends GpuDataSourceScanExec with GpuExec {
   import GpuMetric._
+
+  override val output: Seq[Attribute] = requiredPartitionSchema.map { requiredPartSchema =>
+    // output attrs = data attrs ++ partition attrs
+    val (dataOutAttrs, partOutAttrs) = originalOutput.splitAt(requiredSchema.length)
+    val prunedPartOutAttrs = requiredPartSchema.map { f =>
+      partOutAttrs(relation.partitionSchema.indexOf(f))
+    }
+    dataOutAttrs ++ prunedPartOutAttrs
+  }.getOrElse(originalOutput)
+
+  private val readPartitionSchema = requiredPartitionSchema.getOrElse(relation.partitionSchema)
 
   // this is set only when we either explicitly replaced a path for CONVERT_TIME
   // or when TASK_TIME if one of the paths will be replaced.
@@ -351,7 +364,7 @@ case class GpuFileSourceScanExec(
         val reader = fileFormat.buildReaderWithPartitionValuesAndMetrics(
           sparkSession = relation.sparkSession,
           dataSchema = relation.dataSchema,
-          partitionSchema = relation.partitionSchema,
+          partitionSchema = readPartitionSchema,
           requiredSchema = requiredSchema,
           filters = pushedDownFilters,
           options = relation.options,
@@ -574,15 +587,29 @@ case class GpuFileSourceScanExec(
       readFile: Option[(PartitionedFile) => Iterator[InternalRow]],
       partitions: Seq[FilePartition]): RDD[InternalRow] = {
 
+    // Prune the partition values for each partition
+    val prunedPartitions = requiredPartitionSchema.map { partSchema =>
+      val idsAndTypes = partSchema.map(f => (relation.partitionSchema.indexOf(f), f.dataType))
+      partitions.map { p =>
+        val partFiles = p.files.map { pf =>
+          val prunedPartValues = idsAndTypes.map { case (id, dType) =>
+            pf.partitionValues.get(id, dType)
+          }
+          pf.copy(partitionValues = InternalRow.fromSeq(prunedPartValues))
+        }
+        p.copy(files = partFiles)
+      }
+    }.getOrElse(partitions)
+
     if (isPerFileReadEnabled) {
       logInfo("Using the original per file reader")
-      SparkShimImpl.getFileScanRDD(relation.sparkSession, readFile.get, partitions,
+      SparkShimImpl.getFileScanRDD(relation.sparkSession, readFile.get, prunedPartitions,
         requiredSchema)
     } else {
       logDebug(s"Using Datasource RDD, files are: " +
-        s"${partitions.flatMap(_.files).mkString(",")}")
+        s"${prunedPartitions.flatMap(_.files).mkString(",")}")
       // note we use the v2 DataSourceRDD instead of FileScanRDD so we don't have to copy more code
-      GpuDataSourceRDD(relation.sparkSession.sparkContext, partitions, readerFactory)
+      GpuDataSourceRDD(relation.sparkSession.sparkContext, prunedPartitions, readerFactory)
     }
   }
 
@@ -602,7 +629,7 @@ case class GpuFileSourceScanExec(
           broadcastedHadoopConf,
           relation.dataSchema,
           requiredSchema,
-          relation.partitionSchema,
+          readPartitionSchema,
           pushedDownFilters.toArray,
           rapidsConf,
           allMetrics,
@@ -614,7 +641,7 @@ case class GpuFileSourceScanExec(
           broadcastedHadoopConf,
           relation.dataSchema,
           requiredSchema,
-          relation.partitionSchema,
+          readPartitionSchema,
           pushedDownFilters.toArray,
           rapidsConf,
           allMetrics,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.FileUtils.withTempPath
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
+
+class GpuFileScanPrunePartitionSuite extends SparkQueryCompareTestSuite with Arm {
+
+  private def testGpuFileScanOutput(
+      func: DataFrame => DataFrame,
+      exPartitionCols: String*): Unit = {
+    withTempPath { file =>
+      // Generate partitioned files.
+      withCpuSparkSession(spark => {
+        import spark.implicits._
+        Seq((1, 11, "s1"), (2, 22, "s2"), (3, 33, "s3"), (4, 44, "s4"), (5, 55, "s5"))
+          .toDF("a", "b", "c").write.partitionBy("b", "c").parquet(file.getCanonicalPath)
+      })
+
+      val confs = new SparkConf()
+        .set("spark.sql.sources.useV1SourceList", "parquet")
+      // Run the input function
+      val df = withGpuSparkSession(spark => func(spark.read.parquet(file.toString)), confs)
+
+      // check the output of GpuFileSourceScan
+      val plans = df.queryExecution.executedPlan.collect {
+        case plan: GpuFileSourceScanExec =>
+          // all the excluded partition columns should not exist in the output
+          exPartitionCols.foreach(colName =>
+            assert(!plan.output.exists(a => a.name == colName),
+              s"Partition column '$colName' is excluded, but found in the output of FileScan")
+          )
+          plan
+      }
+      assert(plans.nonEmpty, "GpuFileSourceScan is not found")
+    }
+  }
+
+  test("Prune Partition Columns when GpuProject(GpuFileSourceScan)") {
+    testGpuFileScanOutput(_.groupBy("b").max("a"), "c")
+    testGpuFileScanOutput(_.select("a"), "b", "c")
+    testGpuFileScanOutput(_.select("a", "c"), "b")
+  }
+
+  test("Prune Partition Columns when GpuProject(GpuFilter(GpuFileSourceScan))") {
+    testGpuFileScanOutput(_.select("a", "c").filter("a != 1"), "b")
+    testGpuFileScanOutput(_.select("a").filter("a != 1"), "b", "c")
+  }
+}


### PR DESCRIPTION
closes #7226

This PR is to add the support of pruning partition columns for `GpuFileSourceScanExec` for two sub plan patterns.(`Project(FileSourceScan)` and `Project(Filter(FileSourceScan))`).

The main idea is to leverage the `projectList` of the `ProjectExec` node to prune the partition columns in `GpuFileSourceScanExec`. Partition columns that are not included in the `projectList` will be skipped when generating the partition data on GPU. This can save the GPU memory and time.

Signed-off-by: Liangcai Li <liangcail@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
