### PR TITLE
Add documentation for runnable command enable configs

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -441,6 +441,12 @@ Name | Description | Default Value | Notes
 <a name="sql.exec.WindowExec"></a>spark.rapids.sql.exec.WindowExec|Window-operator backend|true|None|
 <a name="sql.exec.HiveTableScanExec"></a>spark.rapids.sql.exec.HiveTableScanExec|Scan Exec to read Hive delimited text tables|true|None|
 
+### Commands
+
+Name | Description | Default Value | Notes
+-----|-------------|---------------|------------------
+<a name="sql.command.SaveIntoDataSourceCommand"></a>spark.rapids.sql.command.SaveIntoDataSourceCommand|Write to a data source|true|None|
+
 ### Scans
 
 Name | Description | Default Value | Notes

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1870,6 +1870,10 @@ object RapidsConf {
     }
     GpuOverrides.execs.values.toSeq.sortBy(_.tag.toString).foreach(_.confHelp(asTable))
     if (asTable) {
+      printToggleHeader("Commands\n")
+    }
+    GpuOverrides.runnableCmds.values.toSeq.sortBy(_.tag.toString).foreach(_.confHelp(asTable))
+    if (asTable) {
       printToggleHeader("Scans\n")
     }
     GpuOverrides.scans.values.toSeq.sortBy(_.tag.toString).foreach(_.confHelp(asTable))


### PR DESCRIPTION
This updates the documentation for the RunnableCommand enable configs that were added as part of #7288.