### PR TITLE
Suppress unknown RunnableCommand warnings by default

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1376,6 +1376,9 @@ final class RuleNotFoundRunnableCommandMeta[INPUT <: RunnableCommand](
     parent: Option[RapidsMeta[_, _, _]])
     extends RunnableCommandMeta[INPUT](cmd, conf, parent, new NoRuleDataFromReplacementRule) {
 
+  // Do not complain by default, as many commands are metadata-only.
+  override def suppressWillWorkOnGpuInfo: Boolean = true
+
   override def tagSelfForGpu(): Unit =
     willNotWorkOnGpu(s"GPU does not currently support the command ${cmd.getClass}")
 


### PR DESCRIPTION
Before #7288 ExecutableCommandExec was suppressed by default, as we never replaced any RunnableCommands before.  Now we will replace ExecutableCommandExec and it will only complain about ExecutableCommandExec if we recognize the underlying command and have the ability to replace it but for some reason cannot.  While we're suppressing the complaints about ExecutableCommandExec for unknown commands we're not suppressing the complaints about the underlying command itself.  This can result in warnings by default like this, which did not appear before #7288:
```
scala> spark.range(1).createOrReplaceTempView("a")
22/12/30 16:11:52 WARN GpuOverrides: 
  ! <CreateViewCommand> cannot run on GPU because GPU does not currently support the command class org.apache.spark.sql.execution.command.CreateViewCommand
```

This updates RuleNotFoundRunnableCommandMeta to suppress warnings about unknown commands by default.