### PR TITLE
Fix parsing of Delta Lake logs containing multi-line JSON records

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -79,6 +79,19 @@ def assert_delta_log_json_equivalent(filename, c_json, g_json):
             fixup_path(g_val)
         assert c_val == g_val, "Delta log {} is different at key '{}':\nCPU: {}\nGPU: {}".format(filename, key, c_val, g_val)
 
+def decode_jsons(json_data):
+    """Decode the JSON records in a string"""
+    jsons = []
+    idx = 0
+    decoder = json.JSONDecoder()
+    while idx < len(json_data):
+        js, idx = decoder.raw_decode(json_data, idx=idx)
+        jsons.append(js)
+        # Skip whitespace between records
+        while idx < len(json_data) and json_data[idx].isspace():
+            idx += 1
+    return jsons
+
 def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):
     cpu_log_data = spark.sparkContext.wholeTextFiles(data_path + "/CPU/_delta_log/*").collect()
     gpu_log_data = spark.sparkContext.wholeTextFiles(data_path + "/GPU/_delta_log/*").collect()
@@ -88,12 +101,10 @@ def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):
     for file, cpu_json_data in cpu_logs_data:
         gpu_json_data = gpu_logs_dict.get(file)
         assert gpu_json_data, "CPU Delta log file {} is missing from GPU Delta logs".format(file)
-        cpu_json_lines = cpu_json_data.splitlines()
-        gpu_json_lines = gpu_json_data.splitlines()
-        assert len(cpu_json_lines) == len(gpu_json_lines), "Different line counts in {}:\nCPU: {}\nGPU: {}".format(file, cpu_json_data, gpu_json_data)
-        for c_line, g_line in zip(cpu_json_lines, gpu_json_lines):
-            cpu_json = json.loads(c_line)
-            gpu_json = json.loads(g_line)
+        cpu_jsons = decode_jsons(cpu_json_data)
+        gpu_jsons = decode_jsons(gpu_json_data)
+        assert len(cpu_jsons) == len(gpu_jsons), "Different line counts in {}:\nCPU: {}\nGPU: {}".format(file, cpu_json_data, gpu_json_data)
+        for cpu_json, gpu_json in zip(cpu_jsons, gpu_jsons):
             assert_delta_log_json_equivalent(file, cpu_json, gpu_json)
 
 @allow_non_gpu("ExecutedCommandExec", *delta_meta_allow)


### PR DESCRIPTION
This fixes an issue with the tests parsing a Delta Lake log that could have a string containing newlines (i.e.: a multi-line JSON record).  The old approach assumed we could separate the records by splitting on newline, but that breaks for a multi-line JSON record.  This fixes it by leveraging JSONDecoder.raw_decode which will both decode a record from a string at a specified index and return the index at which the parsing stopped.