### PR TITLE
Support pruning partition columns for avro file scan

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
@@ -81,7 +81,7 @@ class AvroProviderImpl extends AvroProvider {
           broadcastedConf,
           fileScan.relation.dataSchema,
           fileScan.requiredSchema,
-          fileScan.relation.partitionSchema,
+          fileScan.readPartitionSchema,
           new AvroOptions(fileScan.relation.options, broadcastedConf.value.value),
           fileScan.allMetrics,
           pushedFilters,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -89,7 +89,8 @@ case class GpuFileSourceScanExec(
     dataOutAttrs ++ prunedPartOutAttrs
   }.getOrElse(originalOutput)
 
-  private val readPartitionSchema = requiredPartitionSchema.getOrElse(relation.partitionSchema)
+  private[rapids] val readPartitionSchema =
+    requiredPartitionSchema.getOrElse(relation.partitionSchema)
 
   // this is set only when we either explicitly replaced a path for CONVERT_TIME
   // or when TASK_TIME if one of the paths will be replaced.


### PR DESCRIPTION
fixes #7443 

This is a bug fix for PR #7428, by replacing the partition schema with the read partition schema which is pruned for the required partition columns for a query when creating the avro reader factory, the same as parquet and orc.

Signed-off-by: Liangcai Li <liangcail@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
