### PR TITLE
Xfail the test of pruning partition column for json read

### DIFF
--- a/integration_tests/src/main/python/prune_partition_column_test.py
+++ b/integration_tests/src/main/python/prune_partition_column_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ from spark_session import with_cpu_session
 part1_gen = SetValuesGen(IntegerType(), [-10, -1, 0, 1, 10])
 part2_gen = SetValuesGen(LongType(), [-100, 0, 100])
 
-file_formats = ['parquet', 'orc', 'csv', 'json']
+file_formats = ['parquet', 'orc', 'csv',
+    pytest.param('json', marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/7446'))]
 if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'true':
     file_formats = file_formats + ['avro']
 


### PR DESCRIPTION
Xfail the test of pruning partition column for json read due to https://github.com/NVIDIA/spark-rapids/issues/7446

Signed-off-by: Liangcai Li <liangcail@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
