### PR TITLE
Use GpuAlias when handling Empty2Null in GpuOptimisticTransaction

### DIFF
--- a/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
+++ b/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.FileAction
@@ -122,7 +122,7 @@ class GpuOptimisticTransaction
     val projectList: Seq[NamedExpression] = plan.output.map {
       case p if partSet.contains(p) && p.dataType == StringType =>
         needConvert = true
-        Alias(GpuEmpty2Null(p), p.name)()
+        GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
     if (needConvert) GpuProjectExec(projectList.toList, plan) else plan

--- a/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.
@@ -40,7 +40,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeSet, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter}
@@ -124,7 +124,7 @@ abstract class GpuOptimisticTransactionBase
     val projectList: Seq[NamedExpression] = plan.output.map {
       case p if partSet.contains(p) && p.dataType == StringType =>
         needConvert = true
-        Alias(GpuEmpty2Null(p), p.name)()
+        GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
     if (needConvert) GpuProjectExec(projectList.toList, plan) else plan


### PR DESCRIPTION
When handling empty-to-null processing with the GPU version of Delta Lake constraints, it builds an explicit GpuProjectExec with an alias.  It should be a GpuAlias which is fixed here.