### PR TITLE
Sort Delta log objects when comparing and avoid caching all logs

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -220,7 +220,8 @@ else
         export PYSP_TEST_spark_jars="${ALL_JARS//:/,}"
     fi
 
-    export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=UTC $COVERAGE_SUBMIT_FLAGS"
+    # Set the Delta log cache size to prevent the driver from caching every Delta log indefinitely
+    export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=UTC -Ddelta.log.cacheSize=10 $COVERAGE_SUBMIT_FLAGS"
     export PYSP_TEST_spark_executor_extraJavaOptions='-ea -Duser.timezone=UTC'
     export PYSP_TEST_spark_ui_showConsoleProgress='false'
     export PYSP_TEST_spark_sql_session_timeZone='UTC'

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -90,6 +90,12 @@ def decode_jsons(json_data):
         # Skip whitespace between records
         while idx < len(json_data) and json_data[idx].isspace():
             idx += 1
+    # reorder to produce a consistent output for comparison
+    def json_to_sort_key(j):
+        keys = sorted(j.keys())
+        paths = sorted([ v.get("path", "") for v in j.values() ])
+        return ','.join(keys + paths)
+    jsons.sort(key=json_to_sort_key)
     return jsons
 
 def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):


### PR DESCRIPTION
The order of JSON objects in the Delta log files is not guaranteed to be consistent between runs, so this makes the Delta log comparison logic a bit more robust by sorting by the primary key and any paths found in the top-level of those objects.

This also fixes a problem where the driver gets slower and slower as the Delta Lake tests run, as by default Delta Lake will cache all Delta logs seen by the application.  Setting a reasonable value for the `delta.log.cacheSize` system property prevents all logs from being cached indefinitely.