### PR TITLE
More cases support partition column pruning

### DIFF
--- a/integration_tests/src/main/python/prune_partition_column_test.py
+++ b/integration_tests/src/main/python/prune_partition_column_test.py
@@ -37,53 +37,19 @@ _enable_read_confs = {
 }
 
 
-@pytest.mark.parametrize('prune_part_enabled', [False, True])
-@pytest.mark.parametrize('file_format', file_formats)
-def test_prune_partition_column_when_project(spark_tmp_path, prune_part_enabled, file_format):
-    data_path = spark_tmp_path + '/PARTED_DATA/'
-    with_cpu_session(
-        lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
-            .partitionBy('b', 'c').format(file_format).save(data_path))
-
-    all_confs = copy_and_update(_enable_read_confs, {
-        'spark.sql.sources.useV1SourceList': file_format,
-        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.format(file_format).schema('a int, b int, c long') \
-            .load(data_path).select('a', 'c'),
-        conf=all_confs)
-
-
-@pytest.mark.parametrize('prune_part_enabled', [False, True])
-@pytest.mark.parametrize('file_format', file_formats)
-@pytest.mark.parametrize('filter_col', ['a', 'b', 'c'])
-def test_prune_partition_column_when_project_filter(spark_tmp_path, prune_part_enabled, filter_col, file_format):
-    data_path = spark_tmp_path + '/PARTED_DATA/'
-    with_cpu_session(
-        lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
-            .partitionBy('b', 'c').format(file_format).save(data_path))
-
-    all_confs = copy_and_update(_enable_read_confs, {
-        'spark.sql.sources.useV1SourceList': file_format,
-        'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark: spark.read.format(file_format).schema('a int, b int, c long').load(data_path) \
-            .filter('{} > 0'.format(filter_col)) \
-            .select('a', 'c'),
-        conf=all_confs)
-
-
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('prune_part_enabled', [False, True])
 @pytest.mark.parametrize('file_format', file_formats)
-def test_prune_partition_column_when_cpu_project(spark_tmp_path, prune_part_enabled, file_format):
+@pytest.mark.parametrize('gpu_project_enabled', [True, False])
+def test_prune_partition_column_when_project(spark_tmp_path, prune_part_enabled,
+                                             file_format, gpu_project_enabled):
     data_path = spark_tmp_path + '/PARTED_DATA/'
     with_cpu_session(
         lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
             .partitionBy('b', 'c').format(file_format).save(data_path))
 
     all_confs = copy_and_update(_enable_read_confs, {
-        'spark.rapids.sql.exec.ProjectExec': False,
+        'spark.rapids.sql.exec.ProjectExec': gpu_project_enabled,
         'spark.sql.sources.useV1SourceList': file_format,
         'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
     assert_gpu_and_cpu_are_equal_collect(
@@ -96,17 +62,18 @@ def test_prune_partition_column_when_cpu_project(spark_tmp_path, prune_part_enab
 @pytest.mark.parametrize('prune_part_enabled', [False, True])
 @pytest.mark.parametrize('file_format', file_formats)
 @pytest.mark.parametrize('filter_col', ['a', 'b', 'c'])
-@pytest.mark.parametrize('is_gpu_project,is_gpu_filter', [(True, False), (False, True), (False, False)])
-def test_prune_partition_column_when_cpu_project_filter(spark_tmp_path, prune_part_enabled, filter_col,
-                                                        file_format, is_gpu_project, is_gpu_filter):
+@pytest.mark.parametrize('gpu_project_enabled', [True, False])
+@pytest.mark.parametrize('gpu_filter_enabled', [True, False])
+def test_prune_partition_column_when_project_filter(spark_tmp_path, prune_part_enabled, filter_col,
+                                                    file_format, gpu_project_enabled, gpu_filter_enabled):
     data_path = spark_tmp_path + '/PARTED_DATA/'
     with_cpu_session(
         lambda spark: three_col_df(spark, int_gen, part1_gen, part2_gen).write \
             .partitionBy('b', 'c').format(file_format).save(data_path))
 
     all_confs = copy_and_update(_enable_read_confs, {
-        'spark.rapids.sql.exec.ProjectExec': is_gpu_project,
-        'spark.rapids.sql.exec.FilterExec': is_gpu_filter,
+        'spark.rapids.sql.exec.ProjectExec': gpu_project_enabled,
+        'spark.rapids.sql.exec.FilterExec': gpu_filter_enabled,
         'spark.sql.sources.useV1SourceList': file_format,
         'spark.rapids.sql.fileScanPrunePartition.enabled': prune_part_enabled})
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -399,32 +399,55 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
     fss.copy(requiredPartitionSchema = Some(prunedPartSchema))(fss.rapidsConf)
   }
 
+  private object GpuProjectWithFileScan {
+    def unapply(plan: SparkPlan): Option[(Seq[Expression], GpuFileSourceScanExec)] = plan match {
+      case p: GpuProjectExecLike if p.child.isInstanceOf[GpuFileSourceScanExec] =>
+        Some((p.projectList, p.child.asInstanceOf[GpuFileSourceScanExec]))
+      case _ => None
+    }
+  }
+
+  private object GpuProjectAndFilterWithFileScan {
+    def unapply(plan: SparkPlan):
+        Option[(Seq[Expression], GpuFilterExec, GpuFileSourceScanExec)] = plan match {
+      case p: GpuProjectExecLike =>
+        p.child match {
+          case f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec, _) =>
+            Some((p.projectList :+ condition, f, fss))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  private object GpuProjectAndCpuFilterWithFileScan {
+    def unapply(plan: SparkPlan): Option[(Seq[Expression], RowToColumnarExec, FilterExec,
+          ColumnarToRowExec, GpuFileSourceScanExec)] = plan match {
+      case p: GpuProjectExecLike =>
+        p.child match {
+          case rc @ RowToColumnarExec(
+              f @ FilterExec(condition, cr @ ColumnarToRowExec(fss: GpuFileSourceScanExec))) =>
+            Some((p.projectList :+ condition, rc, f, cr, fss))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
   // This tries to prune the partition schema for GpuFileSourceScanExec by leveraging
   // the project list of the first GpuProjectExec after a GpuFileSourceScanExec.
   private def prunePartitionForFileSourceScan(plan: SparkPlan): SparkPlan = plan match {
-    case p @ GpuProjectExec(projectList, fss: GpuFileSourceScanExec, _) =>
+    case p @ GpuProjectWithFileScan(projectList, fss) =>
       // A ProjectExec next to FileSourceScanExec, for cases like
       //   df.groupBy("b").agg(max($"a")), or
       //   df.select("b")
       p.withNewChildren(Seq(withPrunedPartSchema(fss, projectList)))
 
-    case p @ GpuProjectExec(
-        projectList,
-        f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec, _),
-        _) =>
+    case p @ GpuProjectAndFilterWithFileScan(refList, f, fss) =>
       // A FilterExec is between the ProjectExec and FileSourceScanExec, for cases like
       //   df.select("a").filter("a != 1")
       p.withNewChildren(Seq(
-        f.withNewChildren(Seq(withPrunedPartSchema(fss, projectList :+ condition)))))
-
-    case p @ GpuProjectAstExec(projectList, fss: GpuFileSourceScanExec) =>
-      p.withNewChildren(Seq(withPrunedPartSchema(fss, projectList)))
-
-    case p @ GpuProjectAstExec(
-        projectList,
-        f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec, _)) =>
-      p.withNewChildren(Seq(
-        f.withNewChildren(Seq(withPrunedPartSchema(fss, projectList :+ condition)))))
+        f.withNewChildren(Seq(withPrunedPartSchema(fss, refList)))))
 
     // Partial GPU plan cases.
     // This rule executes before rules override the ColumnarToRowExec, so the exec is the
@@ -450,25 +473,12 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
         f.withNewChildren(Seq(
           cr.withNewChildren(Seq(withPrunedPartSchema(fss, projectList :+ condition)))))))
 
-    case p @ GpuProjectExec(
-        projectList,
-        rc @ RowToColumnarExec(
-            f @ FilterExec(condition, cr @ ColumnarToRowExec(fss: GpuFileSourceScanExec))), _) =>
+    case p @ GpuProjectAndCpuFilterWithFileScan(refList, rc, f, cr, fss) =>
       // gpu project + cpu filter + gpu file scan
       p.withNewChildren(Seq(
         rc.withNewChildren(Seq(
           f.withNewChildren(Seq(
-            cr.withNewChildren(Seq(withPrunedPartSchema(fss, projectList :+ condition)))))))))
-
-    case p @ GpuProjectAstExec(
-        projectList,
-        rc @ RowToColumnarExec(
-            f @ FilterExec(condition, cr @ ColumnarToRowExec(fss: GpuFileSourceScanExec)))) =>
-      // gpu ast project + cpu filter + gpu file scan
-      p.withNewChildren(Seq(
-        rc.withNewChildren(Seq(
-          f.withNewChildren(Seq(
-            cr.withNewChildren(Seq(withPrunedPartSchema(fss, projectList :+ condition)))))))))
+            cr.withNewChildren(Seq(withPrunedPartSchema(fss, refList)))))))))
 
     case _ =>
       plan.withNewChildren(plan.children.map(prunePartitionForFileSourceScan))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -118,6 +118,14 @@ object GpuProjectExec extends Arm {
   }
 }
 
+object GpuProjectExecLike {
+  def unapply(plan: SparkPlan): Option[(Seq[Expression], SparkPlan)] = plan match {
+    case gpuProjectLike: GpuProjectExecLike =>
+      Some((gpuProjectLike.projectList, gpuProjectLike.child))
+    case _ => None
+  }
+}
+
 trait GpuProjectExecLike extends ShimUnaryExecNode with GpuExec {
 
   def projectList: Seq[Expression]


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/7436

This is a follow-up for PR #7428, to support partition column pruning for more cases when GPU file scan mixed with CPU project or filter.

Signed-off-by: Liangcai Li <liangcail@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
