### PR TITLE
xfail array zip tests

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -417,6 +417,7 @@ array_zips_gen = array_gens_sample + [ArrayGen(map_string_string_gen[0], max_len
 
 
 @pytest.mark.parametrize('data_gen', array_zips_gen, ids=idfn)
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7469")
 def test_arrays_zip(data_gen):
     gen = StructGen(
         [('a', data_gen), ('b', data_gen), ('c', data_gen), ('d', data_gen)], nullable=False)
@@ -429,6 +430,7 @@ def test_arrays_zip(data_gen):
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7469")
 def test_arrays_zip_corner_cases():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, ArrayGen(int_gen), length=100).selectExpr(


### PR DESCRIPTION
Related to #7469.  Marking the array zip tests as xfail to unblock premerge CI.