### PR TITLE
Inserting multiple times to HashedPriorityQueue should not corrupt the heap

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,14 +77,20 @@ public final class HashedPriorityQueue<T> extends AbstractQueue<T> {
 
   @Override
   public boolean offer(T obj) {
-    ensureCapacityToInsert();
-    // Start with the new object at the bottom of the heap and sift it up
-    // until heap properties are restored.
-    MutableInt location = new MutableInt(size);
-    locationMap.put(obj, location);
-    size += 1;
-    siftUp(obj, location);
-    return true;
+    if (!locationMap.containsKey(obj)) {
+      ensureCapacityToInsert();
+      // Start with the new object at the bottom of the heap and sift it up
+      // until heap properties are restored.
+      MutableInt location = new MutableInt(size);
+      locationMap.put(obj, location);
+      size += 1;
+      siftUp(obj, location);
+      return true;
+    } else {
+      // we return false in the case where the object is already
+      // in the locationMap
+      return false;
+    }
   }
 
   @Override

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
@@ -79,16 +79,14 @@ public final class HashedPriorityQueue<T> extends AbstractQueue<T> {
   public boolean offer(T obj) {
     ensureCapacityToInsert();
     MutableInt location = new MutableInt(size);
-    val old = locationMap.putIfAbsent(obj, location);
-    if (old == null) {
+    MutableInt oldLocation = locationMap.putIfAbsent(obj, location);
+    if (oldLocation == null) {
+      // Inserted a new object since we didn't have a prior location.
       // Start with the new object at the bottom of the heap and sift it up
       // until heap properties are restored.
       size += 1;
       siftUp(obj, location);
       return true;
-    } else {
-      return false;
-    }
     } else {
       // we return false in the case where the object is already
       // in the locationMap

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/HashedPriorityQueue.java
@@ -77,15 +77,18 @@ public final class HashedPriorityQueue<T> extends AbstractQueue<T> {
 
   @Override
   public boolean offer(T obj) {
-    if (!locationMap.containsKey(obj)) {
-      ensureCapacityToInsert();
+    ensureCapacityToInsert();
+    MutableInt location = new MutableInt(size);
+    val old = locationMap.putIfAbsent(obj, location);
+    if (old == null) {
       // Start with the new object at the bottom of the heap and sift it up
       // until heap properties are restored.
-      MutableInt location = new MutableInt(size);
-      locationMap.put(obj, location);
       size += 1;
       siftUp(obj, location);
       return true;
+    } else {
+      return false;
+    }
     } else {
       // we return false in the case where the object is already
       // in the locationMap

--- a/tests/src/test/java/com/nvidia/spark/rapids/TestHashedPriorityQueue.java
+++ b/tests/src/test/java/com/nvidia/spark/rapids/TestHashedPriorityQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,15 @@ public class TestHashedPriorityQueue {
     }
   }
 
+  private void insertIntoQueueAssertSizeDidntChange(
+      HashedPriorityQueue<TestObj> q, Iterator<TestObj> objs) {
+    final int originalSize = q.size();
+    while (objs.hasNext()) {
+      assertFalse(q.offer(objs.next()));
+    }
+    assertEquals(originalSize, q.size());
+  }
+
   private ArrayList<TestObj> drainQueue(HashedPriorityQueue<TestObj> q) {
     final int originalSize = q.size();
     ArrayList<TestObj> objs = new ArrayList<>(originalSize);
@@ -93,6 +102,17 @@ public class TestHashedPriorityQueue {
 
   @Test
   public void testHeapInsertInOrder() {
+    ArrayList<TestObj> objs = buildTestObjs(100);
+    HashedPriorityQueue<TestObj> q =
+        new HashedPriorityQueue<>(new TestObjPriorityComparator());
+    insertIntoQueue(q, objs.iterator());
+    insertIntoQueueAssertSizeDidntChange(q, objs.iterator());
+    ArrayList<TestObj> result = drainQueue(q);
+    assertEquals(objs, result);
+  }
+
+  @Test
+  public void testHeapInsertDuplicate() {
     ArrayList<TestObj> objs = buildTestObjs(100);
     HashedPriorityQueue<TestObj> q =
         new HashedPriorityQueue<>(new TestObjPriorityComparator());


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

Contributes to https://github.com/NVIDIA/spark-rapids/issues/6864

This is the first of a series PRs that I'll be putting up in the next few days. This one is a bug I found in the `HashedPriorityQueue` where we could corrupt the queue on a redundant insertion. In order to make a `RapidsBuffer` spillable or not spillable, I have been removing it and re-adding it to this queue. I have seen cases where a redundant add can be used to figure out if this `RapidsBuffer` is already spillable (e.g. we didn't add it, so it must be already spillable). This helps when updating the total amount of bytes that are currently spillable. 