### PR TITLE
Align CI test scripts with new init scripts for Databricks [skip ci]

### DIFF
--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -30,8 +30,34 @@ export SPARK_SHIM_VER=${SPARK_SHIM_VER:-spark${SPARK_VER//.}db}
 if [[ -z "$SPARK_HOME" ]]; then
     # Configure spark environment on Databricks
     export SPARK_HOME=$DB_HOME/spark
-    export PYTHONPATH=$SPARK_HOME/python
 fi
+
+CONDA_HOME=${CONDA_HOME:-"/databricks/conda"}
+
+# Try to use "cudf-udf" conda environment for the python cudf-udf tests.
+if [ -d "${CONDA_HOME}/envs/cudf-udf" ]; then
+    export PATH=${CONDA_HOME}/envs/cudf-udf/bin:${CONDA_HOME}/bin:$PATH
+    export PYSPARK_PYTHON=${CONDA_HOME}/envs/cudf-udf/bin/python
+fi
+
+# Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB11.3
+python_version=$(${PYSPARK_PYTHON} -c 'import sys; print("python{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+
+# override incompatible versions between databricks and cudf
+if [ -d "${CONDA_HOME}/envs/cudf-udf" ]; then
+    PATCH_PACKAGES_PATH="$PWD/package-overrides/${python_version}"
+fi
+
+# Get the correct py4j file.
+PY4J_FILE=$(find $SPARK_HOME/python/lib -type f -iname "py4j*.zip")
+# Set the path of python site-packages
+PYTHON_SITE_PACKAGES=/databricks/python3/lib/${python_version}/site-packages
+# Databricks Koalas can conflict with the actual Pandas version, so put site packages first.
+# Note that Koala is deprecated for DB10.4+ and it is recommended to use Pandas API on Spark instead.
+export PYTHONPATH=$PATCH_PACKAGES_PATH:$PYTHON_SITE_PACKAGES:$SPARK_HOME/python:$SPARK_HOME/python/pyspark/:$PY4J_FILE
+
+# Disable parallel test as multiple tests would be executed by leveraging external parallelism, e.g. Jenkins parallelism
+export TEST_PARALLEL=${TEST_PARALLEL:-0}
 
 if [[ "$TEST" == "cache_test" || "$TEST" == "cache_test.py" ]]; then
     export PYSP_TEST_spark_sql_cache_serializer='com.nvidia.spark.ParquetCachedBatchSerializer'


### PR DESCRIPTION
Signed-off-by: Alex Zhang <alexzhang@nvidia.com>

related PR: https://github.com/NVIDIA/spark-rapids/pull/7417

internal CI jobs passed with Databricks runtime: 11.3, 10.4 & 9.1