### PR TITLE
Add RapidsDeltaWrite node to fix undesired transitions with AQE

### DIFF
--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -53,3 +53,12 @@ GPU accelerated. These operations will fallback to the CPU.
 [Automatic optimization](https://docs.databricks.com/optimizations/auto-optimize.html)
 during Delta Lake writes is not supported. Write operations that are configured to
 automatically optimize or automatically compact will fallback to the CPU.
+
+### RapidsDeltaWrite Node in Query Plans
+
+A side-effect of performing a GPU accelerated Delta Lake write is a new node will appear in the
+query plan, RapidsDeltaWrite. Normally the writing of Delta Lake files is not represented by a
+dedicated node in query plans, as it is implicitly covered by higher-level operations such as
+SaveIntoDataSourceCommand that wrap the entire query along with the write operation afterwards.
+The RAPIDS Accelerator places a node in the plan being written to mark the point at which the
+write occurs and adds statistics showing the time spent performing the low-level write operation.

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -663,3 +663,20 @@ def test_delta_write_auto_optimize_sql_conf_fallback(confkey, spark_tmp_path):
         data_path,
         "ExecutedCommandExec",
         conf=confs)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_write_aqe_join(spark_tmp_path):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    confs=copy_and_update(delta_writes_enabled_conf, {"spark.sql.adaptive.enabled": "true"})
+    def do_join(spark, path):
+        df = unary_op_df(spark, int_gen)
+        df.join(df, ["a"], "inner").write.format("delta").save(path)
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        do_join,
+        lambda spark, path: spark.read.format("delta").load(path),
+        data_path,
+        conf=confs)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))

--- a/sql-plugin/src/main/320+-nondb/scala/com/nvidia/spark/rapids/delta/shims/DeltaProviderImpl.scala
+++ b/sql-plugin/src/main/320+-nondb/scala/com/nvidia/spark/rapids/delta/shims/DeltaProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.delta.shims
 
 import com.nvidia.spark.rapids.{CreatableRelationProviderMeta, CreatableRelationProviderRule, DataFromReplacementRule, DeltaFormatType, FileFormatChecks, GpuCreatableRelationProvider, GpuParquetFileFormat, RapidsConf, RapidsMeta, WriteFileOp}
-import com.nvidia.spark.rapids.delta.DeltaProvider
+import com.nvidia.spark.rapids.delta.DeltaProviderImplBase
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOptions, DeltaParquetFileFormat}
@@ -27,7 +27,11 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.ExternalSource
 import org.apache.spark.sql.sources.CreatableRelationProvider
 
-class DeltaProviderImpl extends DeltaProvider {
+/**
+ * Implements the DeltaProvider interface when Delta Lake is available at runtime.
+ * @note This is instantiated via reflection from ShimLoader.
+ */
+class DeltaProviderImpl extends DeltaProviderImplBase {
   override def getCreatableRelationRules: Map[Class[_ <: CreatableRelationProvider],
       CreatableRelationProviderRule[_ <: CreatableRelationProvider]] = {
     Seq(

--- a/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuDeltaInvariantCheckerExec.scala
+++ b/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuDeltaInvariantCheckerExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -32,7 +33,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * is left unchanged after validations.
  */
 case class GpuDeltaInvariantCheckerExec(
-    child: GpuExec,
+    child: SparkPlan,
     checks: Seq[GpuCheckDeltaInvariant]) extends ShimUnaryExecNode with GpuExec {
 
   override def output: Seq[Attribute] = child.output

--- a/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
+++ b/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
@@ -165,10 +165,12 @@ class GpuOptimisticTransaction
     // columns and rows when AQE is involved. Without this node in the plan, AdaptiveSparkPlanExec
     // could be the root node of the plan. In that case we do not have enough context to know
     // whether the AdaptiveSparkPlanExec should be columnar or not, since the GPU overrides do not
-    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node, the
-    // parent node is present and it will be planned accordingly. We could force the AQE node to be
-    // columnar by explicitly replacing the node, but that breaks the connection between the
-    // queryExecution and the AdaptiveSparkPlanExec node that will actually execute.
+    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node that
+    // appears to be a data writing node to AQE (it derives from V2CommandExec), the
+    // AdaptiveSparkPlanExec will be planned as a child of this new node. That provides enough
+    // context to plan the AQE sub-plan properly with respect to columnar and row transitions.
+    // We could force the AQE node to be columnar here by explicitly replacing the node, but that
+    // breaks the connection between the queryExecution and the node that will actually execute.
     val gpuWritePlan = Dataset.ofRows(spark, RapidsDeltaWrite(normalizedQueryExecution.logical))
     val queryExecution = gpuWritePlan.queryExecution
 

--- a/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
+++ b/sql-plugin/src/main/320+-nondb/scala/org/apache/spark/sql/delta/rapids/shims/GpuOptimisticTransaction.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.ListBuffer
 
 import ai.rapids.cudf.ColumnView
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.delta.{GpuDeltaJobStatisticsTracker, GpuStatisticsCollection}
+import com.nvidia.spark.rapids.delta.{GpuDeltaJobStatisticsTracker, GpuRapidsDeltaWriteExec, GpuStatisticsCollection, RapidsDeltaWrite}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
 
@@ -45,7 +45,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter}
 import org.apache.spark.sql.functions.to_json
-import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter}
+import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.{Clock, SerializableConfiguration}
@@ -88,16 +88,10 @@ class GpuOptimisticTransaction
       DeltaInvariantCheckerExec.buildInvariantChecks(plan.output, constraints, plan.session)
     GpuCheckDeltaInvariant.maybeConvertToGpu(cpuInvariants, rapidsConf) match {
       case Some(gpuInvariants) =>
-        val gpuPlan = plan match {
-          case g: GpuExec => g
-          case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
-        }
+        val gpuPlan = convertToGpu(plan)
         GpuDeltaInvariantCheckerExec(gpuPlan, gpuInvariants)
       case None =>
-        val cpuPlan = plan match {
-          case g: GpuExec => GpuColumnarToRowExec(g)
-          case p => p
-        }
+        val cpuPlan = convertToCpu(plan)
         DeltaInvariantCheckerExec(cpuPlan, constraints)
     }
   }
@@ -164,8 +158,20 @@ class GpuOptimisticTransaction
     val (data, partitionSchema) = performCDCPartition(inputData)
     val outputPath = deltaLog.dataPath
 
-    val (queryExecution, output, generatedColumnConstraints, _) =
+    val (normalizedQueryExecution, output, generatedColumnConstraints, _) =
       normalizeData(deltaLog, data)
+
+    // Build a new plan with a stub GpuDeltaWrite node to work around undesired transitions between
+    // columns and rows when AQE is involved. Without this node in the plan, AdaptiveSparkPlanExec
+    // could be the root node of the plan. In that case we do not have enough context to know
+    // whether the AdaptiveSparkPlanExec should be columnar or not, since the GPU overrides do not
+    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node, the
+    // parent node is present and it will be planned accordingly. We could force the AQE node to be
+    // columnar by explicitly replacing the node, but that breaks the connection between the
+    // queryExecution and the AdaptiveSparkPlanExec node that will actually execute.
+    val gpuWritePlan = Dataset.ofRows(spark, RapidsDeltaWrite(normalizedQueryExecution.logical))
+    val queryExecution = gpuWritePlan.queryExecution
+
     val partitioningColumns = getPartitioningColumns(partitionSchema, output)
 
     val committer = getCommitter(outputPath)
@@ -219,14 +225,15 @@ class GpuOptimisticTransaction
         case GpuColumnarToRowExec(child, _) => child
         case p => p
       }
+      val gpuRapidsWrite = queryPhysicalPlan match {
+        case g: GpuRapidsDeltaWriteExec => Some(g)
+        case _ => None
+      }
 
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val planWithInvariants = addInvariantChecks(empty2NullPlan, constraints)
-      val physicalPlan = planWithInvariants match {
-        case g: GpuExec => g
-        case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
-      }
+      val physicalPlan = convertToGpu(planWithInvariants)
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()
 
@@ -236,6 +243,11 @@ class GpuOptimisticTransaction
           BasicWriteJobStatsTracker.metrics)
         registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
         statsTrackers.append(basicWriteJobStatsTracker)
+        gpuRapidsWrite.foreach { grw =>
+          val hadoopConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
+          val tracker = new GpuWriteJobStatsTracker(hadoopConf, grw.basicMetrics, grw.taskMetrics)
+          statsTrackers.append(tracker)
+        }
       }
 
       // Retain only a minimal selection of Spark writer options to avoid any potential
@@ -289,5 +301,17 @@ class GpuOptimisticTransaction
     }
 
     resultFiles.toSeq ++ committer.changeFiles
+  }
+
+  private def convertToCpu(plan: SparkPlan): SparkPlan = plan match {
+    case GpuRowToColumnarExec(p, _) => p
+    case p: GpuExec => GpuColumnarToRowExec(p)
+    case p => p
+  }
+
+  private def convertToGpu(plan: SparkPlan): SparkPlan = plan match {
+    case GpuColumnarToRowExec(p, _) => p
+    case p: GpuExec => p
+    case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
   }
 }

--- a/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuDeltaInvariantCheckerExec.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuDeltaInvariantCheckerExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
@@ -32,7 +33,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * is left unchanged after validations.
  */
 case class GpuDeltaInvariantCheckerExec(
-    child: GpuExec,
+    child: SparkPlan,
     checks: Seq[GpuCheckDeltaInvariant]) extends ShimUnaryExecNode with GpuExec {
 
   override def output: Seq[Attribute] = child.output

--- a/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
@@ -176,10 +176,12 @@ abstract class GpuOptimisticTransactionBase
     // columns and rows when AQE is involved. Without this node in the plan, AdaptiveSparkPlanExec
     // could be the root node of the plan. In that case we do not have enough context to know
     // whether the AdaptiveSparkPlanExec should be columnar or not, since the GPU overrides do not
-    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node, the
-    // parent node is present and it will be planned accordingly. We could force the AQE node to be
-    // columnar by explicitly replacing the node, but that breaks the connection between the
-    // queryExecution and the AdaptiveSparkPlanExec node that will actually execute.
+    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node that
+    // appears to be a data writing node to AQE (it derives from V2CommandExec), the
+    // AdaptiveSparkPlanExec will be planned as a child of this new node. That provides enough
+    // context to plan the AQE sub-plan properly with respect to columnar and row transitions.
+    // We could force the AQE node to be columnar here by explicitly replacing the node, but that
+    // breaks the connection between the queryExecution and the node that will actually execute.
     val gpuWritePlan = Dataset.ofRows(spark, RapidsDeltaWrite(normalizedQueryExecution.logical))
     val queryExecution = gpuWritePlan.queryExecution
 

--- a/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/databricks/sql/transaction/tahoe/rapids/shims/GpuOptimisticTransactionBase.scala
@@ -33,7 +33,7 @@ import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
 import com.databricks.sql.transaction.tahoe.schema.InvariantViolationException
 import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.delta.{GpuDeltaJobStatisticsTracker, GpuStatisticsCollection}
+import com.nvidia.spark.rapids.delta.{GpuDeltaJobStatisticsTracker, GpuRapidsDeltaWriteExec, GpuStatisticsCollection, RapidsDeltaWrite}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
 
@@ -45,7 +45,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter}
 import org.apache.spark.sql.functions.to_json
-import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter}
+import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
 import org.apache.spark.sql.rapids.delta.GpuIdentityColumn
 import org.apache.spark.sql.types.{StringType, StructType}
@@ -90,16 +90,10 @@ abstract class GpuOptimisticTransactionBase
       DeltaInvariantCheckerExec.buildInvariantChecks(plan.output, constraints, plan.session)
     GpuCheckDeltaInvariant.maybeConvertToGpu(cpuInvariants, rapidsConf) match {
       case Some(gpuInvariants) =>
-        val gpuPlan = plan match {
-          case g: GpuExec => g
-          case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
-        }
+        val gpuPlan = convertToGpu(plan)
         GpuDeltaInvariantCheckerExec(gpuPlan, gpuInvariants)
       case None =>
-        val cpuPlan = plan match {
-          case g: GpuExec => GpuColumnarToRowExec(g)
-          case p => p
-        }
+        val cpuPlan = convertToCpu(plan)
         DeltaInvariantCheckerExec(cpuPlan, constraints)
     }
   }
@@ -174,9 +168,21 @@ abstract class GpuOptimisticTransactionBase
     val (data, partitionSchema) = shimPerformCDCPartition(inputData)
     val outputPath = deltaLog.dataPath
 
-    val (queryExecution, output, generatedColumnConstraints, dataHighWaterMarks) =
+    val (normalizedQueryExecution, output, generatedColumnConstraints, dataHighWaterMarks) =
       normalizeData(deltaLog, data)
     val highWaterMarks = trackHighWaterMarks.getOrElse(dataHighWaterMarks)
+
+    // Build a new plan with a stub GpuDeltaWrite node to work around undesired transitions between
+    // columns and rows when AQE is involved. Without this node in the plan, AdaptiveSparkPlanExec
+    // could be the root node of the plan. In that case we do not have enough context to know
+    // whether the AdaptiveSparkPlanExec should be columnar or not, since the GPU overrides do not
+    // see how the parent is using the AdaptiveSparkPlanExec outputs. By using this stub node, the
+    // parent node is present and it will be planned accordingly. We could force the AQE node to be
+    // columnar by explicitly replacing the node, but that breaks the connection between the
+    // queryExecution and the AdaptiveSparkPlanExec node that will actually execute.
+    val gpuWritePlan = Dataset.ofRows(spark, RapidsDeltaWrite(normalizedQueryExecution.logical))
+    val queryExecution = gpuWritePlan.queryExecution
+
     val partitioningColumns = getPartitioningColumns(partitionSchema, output)
 
     val committer = getCommitter(outputPath)
@@ -236,14 +242,15 @@ abstract class GpuOptimisticTransactionBase
         case GpuColumnarToRowExec(child, _) => child
         case p => p
       }
+      val gpuRapidsWrite = queryPhysicalPlan match {
+        case g: GpuRapidsDeltaWriteExec => Some(g)
+        case _ => None
+      }
 
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
       val planWithInvariants = addInvariantChecks(empty2NullPlan, constraints)
-      val physicalPlan = planWithInvariants match {
-        case g: GpuExec => g
-        case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
-      }
+      val physicalPlan = convertToGpu(planWithInvariants)
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()
 
@@ -253,6 +260,11 @@ abstract class GpuOptimisticTransactionBase
           BasicWriteJobStatsTracker.metrics)
         registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
         statsTrackers.append(basicWriteJobStatsTracker)
+        gpuRapidsWrite.foreach { grw =>
+          val hadoopConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
+          val tracker = new GpuWriteJobStatsTracker(hadoopConf, grw.basicMetrics, grw.taskMetrics)
+          statsTrackers.append(tracker)
+        }
       }
 
       val options = writeOptions match {
@@ -303,5 +315,17 @@ abstract class GpuOptimisticTransactionBase
       updatedIdentityHighWaterMarks.appendAll(tracker.highWaterMarks.toSeq)
     }
     resultFiles.toSeq ++ committer.changeFiles
+  }
+
+  private def convertToCpu(plan: SparkPlan): SparkPlan = plan match {
+    case GpuRowToColumnarExec(p, _) => p
+    case p: GpuExec => GpuColumnarToRowExec(p)
+    case p => p
+  }
+
+  private def convertToGpu(plan: SparkPlan): SparkPlan = plan match {
+    case GpuColumnarToRowExec(p, _) => p
+    case p: GpuExec => p
+    case p => GpuRowToColumnarExec(p, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
   }
 }

--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/delta/shims/DeltaProviderImpl.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/delta/shims/DeltaProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.shims
 import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOptions, DeltaParquetFileFormat}
 import com.databricks.sql.transaction.tahoe.sources.DeltaDataSource
 import com.nvidia.spark.rapids.{CreatableRelationProviderMeta, CreatableRelationProviderRule, DataFromReplacementRule, DeltaFormatType, FileFormatChecks, GpuCreatableRelationProvider, GpuParquetFileFormat, RapidsConf, RapidsMeta, WriteFileOp}
-import com.nvidia.spark.rapids.delta.DeltaProvider
+import com.nvidia.spark.rapids.delta.DeltaProviderImplBase
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand
@@ -27,7 +27,11 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.ExternalSource
 import org.apache.spark.sql.sources.CreatableRelationProvider
 
-class DeltaProviderImpl extends DeltaProvider {
+/**
+ * Implements the DeltaProvider interface when Delta Lake is available at runtime.
+ * @note This is instantiated via reflection from ShimLoader.
+ */
+class DeltaProviderImpl extends DeltaProviderImplBase {
   override def getCreatableRelationRules: Map[Class[_ <: CreatableRelationProvider],
       CreatableRelationProviderRule[_ <: CreatableRelationProvider]] = {
     Seq(

--- a/sql-plugin/src/main/delta-lake-common/scala/com/nvidia/spark/rapids/delta/DeltaProviderImplBase.scala
+++ b/sql-plugin/src/main/delta-lake-common/scala/com/nvidia/spark/rapids/delta/DeltaProviderImplBase.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import com.nvidia.spark.rapids.{ExecChecks, ExecRule, GpuOverrides}
+
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.execution.SparkPlan
+
+abstract class DeltaProviderImplBase extends DeltaProvider {
+
+  override def getExecRules: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
+    Seq(
+      GpuOverrides.exec[RapidsDeltaWriteExec](
+        "GPU write into a Delta Lake table",
+        ExecChecks.hiddenHack(),
+        (wrapped, conf, p, r) => new RapidsDeltaWriteExecMeta(wrapped, conf, p, r)).invisible()
+    ).collect { case r if r != null => (r.getClassFor.asSubclass(classOf[SparkPlan]), r) }.toMap
+  }
+
+  override def getStrategyRules: Seq[Strategy] = Seq(RapidsDeltaWriteStrategy)
+}

--- a/sql-plugin/src/main/delta-lake-common/scala/com/nvidia/spark/rapids/delta/RapidsDeltaWrite.scala
+++ b/sql-plugin/src/main/delta-lake-common/scala/com/nvidia/spark/rapids/delta/RapidsDeltaWrite.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import com.nvidia.spark.rapids.{BaseExprMeta, DataFromReplacementRule, DataWritingCommandMeta, GpuExec, GpuMetric, GpuOverrides, PartMeta, RapidsConf, RapidsMeta, ScanMeta, SparkPlanMeta}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy, UnaryExecNode}
+import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.rapids.GpuWriteJobStatsTracker
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/** Strategy rule to translate a logical RapidsDeltaWrite into a physical RapidsDeltaWriteExec */
+object RapidsDeltaWriteStrategy extends SparkStrategy {
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case p: RapidsDeltaWrite =>
+      Seq(RapidsDeltaWriteExec(planLater(p.child)))
+    case _ => Nil
+  }
+}
+
+/**
+ * This logical node is a placeholder in the plan for where, semantically, a Delta Lake
+ * write occurs. Normally Delta Lake writes are *not* visible in the SQL plan, but we
+ * use this as a workaround for undesired row transitions in the plan when adaptive
+ * execution is enabled. Without it, AdaptiveSparkPlanExec can become the root node
+ * of the physical plan to write into Delta. Without a parent node above
+ * AdaptiveSparkPlanExec, the GPU transition planning does not know whether to make
+ * the result of the adaptive plan GPU columnar or CPU row, so it ends up assuming CPU
+ * row and injecting a columnar-to-row transition at the end of the plan. The Delta
+ * write code cannot directly replace the AdaptiveSparkPlanExec to force it to be
+ * columnar, because it's tied to the QueryExecution which can only be created with
+ * logical plans. Thus our workaround is to inject a node in the logical plan for
+ * the write and ensure the physical node appears to Spark as a write so the
+ * AdaptiveSparkPlanExec node is a child of it rather than the parent. This provides
+ * the necessary parent node for the AdaptiveSparkPlanExec so the GPU transition
+ * planning code can correctly determine whether the AQE plan should be GPU columnar
+ * or CPU row.
+ */
+case class RapidsDeltaWrite(child: LogicalPlan) extends UnaryNode {
+  override def output: Seq[Attribute] = child.output
+
+  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
+    copy(child = newChild)
+  }
+}
+
+/**
+ * A stand-in physical node for a Delta write. This should *always* be replaced by
+ * a GpuRapidsDeltaWriteExec during GPU planning and should never be executed.
+ */
+case class RapidsDeltaWriteExec(child: SparkPlan) extends V2CommandExec with UnaryExecNode {
+  override def output: Seq[Attribute] = child.output
+
+  override def run(): Seq[InternalRow] = {
+    throw new IllegalStateException("Should have been replaced with a GPU node before execution")
+  }
+
+  override def withNewChildInternal(newChild: SparkPlan): SparkPlan = {
+    copy(child = newChild)
+  }
+}
+
+/**
+ * A stand-in physical node for a GPU Delta write. It needs to appear as a writing
+ * command or data source command so the AdaptiveSparkPlanExec does not appear at the
+ * root of the plan to write. See the description for RapidsDeltaWrite for details.
+ */
+case class GpuRapidsDeltaWriteExec(child: SparkPlan) extends V2CommandExec
+    with UnaryExecNode with GpuExec {
+  override def output: Seq[Attribute] = child.output
+
+  lazy val basicMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.basicMetrics
+  lazy val taskMetrics: Map[String, SQLMetric] = GpuWriteJobStatsTracker.taskMetrics
+
+  override lazy val allMetrics: Map[String, GpuMetric] =
+    GpuMetric.wrap(basicMetrics ++ taskMetrics)
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    // This is just a stub node for planning purposes and does not actually perform
+    // the write. See the documentation for RapidsDeltaWrite and its use in
+    // GpuOptimisticTransaction for details on how the write is handled.
+    // In the future it may make sense to move the write code here, although this will
+    // cause the writing code to deviate heavily from the Delta Lake source.
+    child.executeColumnar()
+  }
+
+  override protected def run(): Seq[InternalRow] = {
+    throw new IllegalStateException("ROW BASED PROCESSING IS NOT SUPPORTED")
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan = {
+    copy(child = newChild)
+  }
+}
+
+/** Metadata tagging and converting for the custom RapidsDeltaWriteExec node. */
+class RapidsDeltaWriteExecMeta(
+    plan: RapidsDeltaWriteExec,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends SparkPlanMeta[RapidsDeltaWriteExec](plan, conf, parent, rule) {
+  override val childPlans: Seq[SparkPlanMeta[SparkPlan]] =
+    Seq(GpuOverrides.wrapPlan(plan.child, conf, Some(this)))
+  override val childExprs: Seq[BaseExprMeta[_]] = Nil
+  override val childScans: Seq[ScanMeta[_]] = Nil
+  override val childParts: Seq[PartMeta[_]] = Nil
+  override val childDataWriteCmds: Seq[DataWritingCommandMeta[_]] = Nil
+
+  override def convertToGpu(): GpuExec = {
+    GpuRapidsDeltaWriteExec(childPlans.head.convertIfNeeded())
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4048,7 +4048,7 @@ object GpuOverrides extends Logging {
   ).collect { case r if r != null => (r.getClassFor.asSubclass(classOf[SparkPlan]), r) }.toMap
 
   lazy val execs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
-    commonExecs ++ GpuHiveOverrides.execs ++
+    commonExecs ++ GpuHiveOverrides.execs ++ ExternalSource.execRules ++
       SparkShimImpl.getExecs // Shim execs at the end; shims get the last word in substitutions.
 
   def getTimeParserPolicy: TimeParserPolicy = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SQLExecPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SQLExecPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions, Strategy}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 
@@ -25,9 +25,12 @@ import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
  * Extension point to enable GPU SQL processing.
  */
 class SQLExecPlugin extends (SparkSessionExtensions => Unit) with Logging {
+  private val strategyRules: Strategy = ShimLoader.newStrategyRules()
+
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectColumnar(columnarOverrides)
     extensions.injectQueryStagePrepRule(queryStagePrepOverrides)
+    extensions.injectPlannerStrategy(_ => strategyRules)
   }
 
   private def columnarOverrides(sparkSession: SparkSession): ColumnarRule = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.apache.spark.{SPARK_BRANCH, SPARK_BUILD_DATE, SPARK_BUILD_USER, SPARK
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin}
 import org.apache.spark.api.resource.ResourceDiscoveryPlugin
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
@@ -383,6 +384,10 @@ object ShimLoader extends Logging {
 
   def newUdfLogicalPlanRules(): Rule[LogicalPlan] = {
     newInstanceOf("com.nvidia.spark.udf.LogicalPlanRules")
+  }
+
+  def newStrategyRules(): Strategy = {
+    newInstanceOf("com.nvidia.spark.rapids.StrategyRules")
   }
 
   def newInternalExclusiveModeGpuDiscoveryPlugin(): ResourceDiscoveryPlugin = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/StrategyRules.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/StrategyRules.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.delta.DeltaProvider
+
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SparkPlan
+
+/**
+ * Provides a Strategy that can implement rules for translating
+ * custom logical plan nodes to physical plan nodes.
+ * @note This is instantiated via reflection from ShimLoader.
+ */
+class StrategyRules extends Strategy {
+
+  private lazy val strategies: Seq[Strategy] = {
+    // Currently we only have custom plan nodes that originate from
+    // DeltaLake, but if we add other custom plan nodes later
+    // their strategies can be appended here.
+    DeltaProvider().getStrategyRules
+  }
+
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+    val rapidsConf = new RapidsConf(plan.conf)
+    if (rapidsConf.isSqlEnabled && rapidsConf.isSqlExecuteOnGPU) {
+      // Using view since the strategies are first fit.
+      strategies.view.map(_(plan)).find(_.nonEmpty).getOrElse(Nil)
+    } else {
+      Nil
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,11 @@ package com.nvidia.spark.rapids.delta
 
 import scala.util.Try
 
-import com.nvidia.spark.rapids.{CreatableRelationProviderRule, ShimLoader}
+import com.nvidia.spark.rapids.{CreatableRelationProviderRule, ExecRule, ShimLoader}
 import com.nvidia.spark.rapids.delta.shims.DeltaProviderShims
 
+import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.rapids.execution.UnshimmedTrampolineUtil
 import org.apache.spark.sql.sources.CreatableRelationProvider
 
@@ -28,11 +30,19 @@ import org.apache.spark.sql.sources.CreatableRelationProvider
 trait DeltaProvider {
   def getCreatableRelationRules: Map[Class[_ <: CreatableRelationProvider],
       CreatableRelationProviderRule[_ <: CreatableRelationProvider]]
+
+  def getExecRules: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]]
+
+  def getStrategyRules: Seq[Strategy]
 }
 
 class NoDeltaProvider extends DeltaProvider {
   override def getCreatableRelationRules: Map[Class[_ <: CreatableRelationProvider],
       CreatableRelationProviderRule[_ <: CreatableRelationProvider]] = Map.empty
+
+  override def getExecRules: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Map.empty
+
+  override def getStrategyRules: Seq[Strategy] = Nil
 }
 
 object DeltaProvider {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.nvidia.spark.rapids.iceberg.IcebergProvider
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.{PartitionReaderFactory, Scan}
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.sources.{CreatableRelationProvider, Filter}
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -64,6 +64,9 @@ object ExternalSource extends Logging {
   private lazy val deltaProvider = DeltaProvider()
 
   private lazy val creatableRelations = deltaProvider.getCreatableRelationRules
+
+  lazy val execRules: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
+    deltaProvider.getExecRules
 
   /** If the file format is supported as an external source */
   def isSupportedFormat(format: FileFormat): Boolean = {


### PR DESCRIPTION
Fixes #7505.

This adds a new RapidsDeltaWrite logical node along with the Strategy to translate it into a RapidsDeltaWriteExec stub physical node.  That node in turn is translated into a GpuRapidsDeltaWriteExec node which derives from V2CommandExec to prevent AdaptiveSparkPlanExec from appearing before it in a plan.  This logical node is then used by the Delta Write code in GpuOptimisticTransaction.writeFiles to allow any AQE sub-plan in the query plan to write to be transformed properly by the GPU transition planning code (i.e.: without extraneous row transitions).

Unlike CPU plans, this new node does appear in the SQL plans for Delta Lake write operations.  However I think this is ultimately a good thing, as it makes it very clear the write was translated to the GPU and also provides a place to attach metrics specific to the write operation (i.e.: time spent writing files vs. other Delta Lake operations like merge join processing, etc.).