### PR TITLE
Adds RapidsBufferHandle as an indirection layer to RapidsBufferId

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -451,7 +451,10 @@ object RapidsBufferCatalog extends Logging with Arm {
   }
 
   /**
-   * Adds a contiguous table to the device storage, taking ownership of the table.
+   * Adds a contiguous table to the device storage. This does NOT take ownership of the
+   * contiguous table, so it is the responsibility of the caller to close it. The refcount of the
+   * underlying device buffer will be incremented so the contiguous table can be closed before
+   * this buffer is destroyed.
    * @param contigTable contiguous table to trackNewHandle in device storage
    * @param initialSpillPriority starting spill priority value for the buffer
    * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
@@ -468,7 +471,8 @@ object RapidsBufferCatalog extends Logging with Arm {
   }
 
   /**
-   * Adds a buffer to the device storage, taking ownership of the buffer.
+   * Adds a buffer to the device storage. This does NOT take ownership of the
+   * buffer, so it is the responsibility of the caller to close it.
    * @param buffer buffer that will be owned by the store
    * @param tableMeta metadata describing the buffer layout
    * @param initialSpillPriority starting spill priority value for the buffer

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -445,9 +445,7 @@ object RapidsBufferCatalog extends Logging with Arm {
       tableMeta: TableMeta,
       initialSpillPriority: Long,
       spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback): RapidsBufferHandle = {
-    val id =
-      deviceStorage.addTable(table, contigBuffer, tableMeta, initialSpillPriority)
-    singleton.makeNewHandle(id, initialSpillPriority, spillCallback)
+    deviceStorage.addTable(table, contigBuffer, tableMeta, initialSpillPriority)
   }
 
   /**
@@ -465,9 +463,7 @@ object RapidsBufferCatalog extends Logging with Arm {
       contigTable: ContiguousTable,
       initialSpillPriority: Long,
       spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback): RapidsBufferHandle = {
-      val id = deviceStorage.addContiguousTable(
-        contigTable, initialSpillPriority, spillCallback)
-      singleton.makeNewHandle(id, initialSpillPriority, spillCallback)
+      deviceStorage.addContiguousTable(contigTable, initialSpillPriority, spillCallback)
   }
 
   /**
@@ -485,9 +481,7 @@ object RapidsBufferCatalog extends Logging with Arm {
       tableMeta: TableMeta,
       initialSpillPriority: Long,
       spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback): RapidsBufferHandle = {
-    val id = deviceStorage.addBuffer(
-      buffer, tableMeta, initialSpillPriority, spillCallback)
-    singleton.makeNewHandle(id, initialSpillPriority, spillCallback)
+    deviceStorage.addBuffer(buffer, tableMeta, initialSpillPriority, spillCallback)
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, HostMemoryBuff
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 
+import org.apache.spark.sql.rapids.TempSpillBufferId
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -46,27 +47,40 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
         case b => throw new IllegalStateException(s"Unrecognized buffer: $b")
       }
     }
-    new RapidsDeviceMemoryBuffer(other.id, other.size, other.meta, None,
-      deviceBuffer, other.getSpillPriority, other.spillCallback)
+    new RapidsDeviceMemoryBuffer(
+      other.id,
+      other.size,
+      other.meta,
+      None,
+      deviceBuffer,
+      other.getSpillPriority,
+      other.getSpillCallback)
   }
 
   /**
    * Adds a contiguous table to the device storage, taking ownership of the table.
-   * @param id buffer ID to associate with this buffer
+   *
    * @param table cudf table based from the contiguous buffer
    * @param contigBuffer device memory buffer backing the table
    * @param tableMeta metadata describing the buffer layout
    * @param initialSpillPriority starting spill priority value for the buffer
    * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
    *                      It should never allocate GPU memory and really just be used for metrics.
+   * @return RapidsBufferId identifying this table
    */
   def addTable(
-      id: RapidsBufferId,
       table: Table,
       contigBuffer: DeviceMemoryBuffer,
       tableMeta: TableMeta,
       initialSpillPriority: Long,
-      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback): Unit = {
+      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback): RapidsBufferId = {
+    // We increment this because this rapids device memory has two pointers to the buffer:
+    // the actual contig buffer, and the table. When this `RapidsBuffer` releases its resources,
+    // it will decrement the ref count for the contig buffer (negating this incRefCount),
+    // it will also close the table being passed here, which together brings the ref count
+    // to 0.
+    contigBuffer.incRefCount()
+    val id = TempSpillBufferId()
     freeOnExcept(
       new RapidsDeviceMemoryBuffer(
         id,
@@ -77,8 +91,9 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
         initialSpillPriority,
         spillCallback)) { buffer =>
       logDebug(s"Adding table for: [id=$id, size=${buffer.size}, " +
-          s"meta_id=${buffer.meta.bufferMeta.id}, meta_size=${buffer.meta.bufferMeta.size}]")
+        s"meta_id=${buffer.meta.bufferMeta.id}, meta_size=${buffer.meta.bufferMeta.size}]")
       addDeviceBuffer(buffer, needsSync = true)
+      id
     }
   }
 
@@ -87,20 +102,52 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
    * contiguous table, so it is the responsibility of the caller to close it. The refcount of the
    * underlying device buffer will be incremented so the contiguous table can be closed before
    * this buffer is destroyed.
-   * @param id buffer ID to associate with this buffer
+   *
+   * This version of `addContiguousTable` creates a `TempSpillBufferId` to use
+   * to refer to this table.
+   *
    * @param contigTable contiguous table to track in storage
    * @param initialSpillPriority starting spill priority value for the buffer
    * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
    *                      It should never allocate GPU memory and really just be used for metrics.
    * @param needsSync whether the spill framework should stream synchronize while adding
    *                  this device buffer (defaults to true)
+   * @return RapidsBufferId identifying this table
+   */
+  def addContiguousTable(
+      contigTable: ContiguousTable,
+      initialSpillPriority: Long,
+      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback,
+      needsSync: Boolean = true): RapidsBufferId = {
+    addContiguousTable(
+      TempSpillBufferId(),
+      contigTable,
+      initialSpillPriority,
+      spillCallback,
+      needsSync)
+  }
+
+  /**
+   * Adds a contiguous table to the device storage. This does NOT take ownership of the
+   * contiguous table, so it is the responsibility of the caller to close it. The refcount of the
+   * underlying device buffer will be incremented so the contiguous table can be closed before
+   * this buffer is destroyed.
+   *
+   * @param id the RapidsBufferId to use for this buffer
+   * @param contigTable contiguous table to track in storage
+   * @param initialSpillPriority starting spill priority value for the buffer
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @param needsSync whether the spill framework should stream synchronize while adding
+   *                             this device buffer (defaults to true)
+   * @return RapidsBufferId identifying this table
    */
   def addContiguousTable(
       id: RapidsBufferId,
       contigTable: ContiguousTable,
       initialSpillPriority: Long,
-      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback,
-      needsSync: Boolean = true): Unit = {
+      spillCallback: SpillCallback,
+      needsSync: Boolean): RapidsBufferId = {
     val contigBuffer = contigTable.getBuffer
     val size = contigBuffer.getLength
     val meta = MetaUtils.buildTableMeta(id.tableId, contigTable)
@@ -115,15 +162,20 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
         initialSpillPriority,
         spillCallback)) { buffer =>
       logDebug(s"Adding table for: [id=$id, size=${buffer.size}, " +
-          s"uncompressed=${buffer.meta.bufferMeta.uncompressedSize}, " +
-          s"meta_id=${buffer.meta.bufferMeta.id}, meta_size=${buffer.meta.bufferMeta.size}]")
+        s"uncompressed=${buffer.meta.bufferMeta.uncompressedSize}, " +
+        s"meta_id=${buffer.meta.bufferMeta.id}, meta_size=${buffer.meta.bufferMeta.size}]")
       addDeviceBuffer(buffer, needsSync)
+      id
     }
   }
 
   /**
-   * Adds a buffer to the device storage, taking ownership of the buffer.
-   * @param id buffer ID to associate with this buffer
+   * Adds a buffer to the device storage. This does NOT take ownership of the
+   * buffer, so it is the responsibility of the caller to close it.
+   *
+   * This version of `addBuffer` creates a `TempSpillBufferId` to use to refer to
+   * this buffer.
+   *
    * @param buffer buffer that will be owned by the store
    * @param tableMeta metadata describing the buffer layout
    * @param initialSpillPriority starting spill priority value for the buffer
@@ -131,14 +183,45 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
    *                      It should never allocate GPU memory and really just be used for metrics.
    * @param needsSync whether the spill framework should stream synchronize while adding
    *                  this device buffer (defaults to true)
+   * @return RapidsBufferId identifying this buffer
+   */
+  def addBuffer(
+      buffer: DeviceMemoryBuffer,
+      tableMeta: TableMeta,
+      initialSpillPriority: Long,
+      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback,
+      needsSync: Boolean = true): RapidsBufferId = {
+    addBuffer(
+      TempSpillBufferId(),
+      buffer,
+      tableMeta,
+      initialSpillPriority,
+      spillCallback,
+      needsSync)
+  }
+
+  /**
+   * Adds a buffer to the device storage. This does NOT take ownership of the
+   * buffer, so it is the responsibility of the caller to close it.
+   *
+   * @param id the RapidsBufferId to use for this buffer
+   * @param buffer buffer that will be owned by the store
+   * @param tableMeta metadata describing the buffer layout
+   * @param initialSpillPriority starting spill priority value for the buffer
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @param needsSync whether the spill framework should stream synchronize while adding
+   *                  this device buffer (defaults to true)
+   * @return RapidsBufferId identifying this buffer
    */
   def addBuffer(
       id: RapidsBufferId,
       buffer: DeviceMemoryBuffer,
       tableMeta: TableMeta,
       initialSpillPriority: Long,
-      spillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback,
-      needsSync: Boolean = true): Unit = {
+      spillCallback: SpillCallback,
+      needsSync: Boolean): RapidsBufferId = {
+    buffer.incRefCount()
     freeOnExcept(
       new RapidsDeviceMemoryBuffer(
         id,
@@ -149,10 +232,11 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
         initialSpillPriority,
         spillCallback)) { buff =>
       logDebug(s"Adding receive side table for: [id=$id, size=${buffer.getLength}, " +
-          s"uncompressed=${buff.meta.bufferMeta.uncompressedSize}, " +
-          s"meta_id=${tableMeta.bufferMeta.id}, " +
-          s"meta_size=${tableMeta.bufferMeta.size}]")
+        s"uncompressed=${buff.meta.bufferMeta.uncompressedSize}, " +
+        s"meta_id=${tableMeta.bufferMeta.id}, " +
+        s"meta_size=${tableMeta.bufferMeta.size}]")
       addDeviceBuffer(buff, needsSync)
+      id
     }
   }
 
@@ -160,13 +244,16 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
    * Adds a device buffer to the spill framework, stream synchronizing with the producer
    * stream to ensure that the buffer is fully materialized, and can be safely copied
    * as part of the spill.
+   *
    * @param needsSync true if we should stream synchronize before adding the buffer
    */
-  private def addDeviceBuffer(buffer: RapidsDeviceMemoryBuffer, needsSync: Boolean): Unit = {
+  private def addDeviceBuffer(
+      buffer: RapidsDeviceMemoryBuffer,
+      needsSync: Boolean): Unit = {
     if (needsSync) {
       Cuda.DEFAULT_STREAM.sync()
     }
-    addBuffer(buffer);
+    addBuffer(buffer)
   }
 
   class RapidsDeviceMemoryBuffer(
@@ -176,7 +263,7 @@ class RapidsDeviceMemoryStore(catalog: RapidsBufferCatalog = RapidsBufferCatalog
       table: Option[Table],
       contigBuffer: DeviceMemoryBuffer,
       spillPriority: Long,
-      override val spillCallback: SpillCallback)
+      spillCallback: SpillCallback)
       extends RapidsBufferBase(id, size, meta, spillPriority, spillCallback) {
     override val storageTier: StorageTier = StorageTier.DEVICE
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -56,8 +56,14 @@ class RapidsDiskStore(
         copyBufferToPath(hostBuffer, path, append = false)
       }
       logDebug(s"Spilled to $path $fileOffset:${incoming.size}")
-      new this.RapidsDiskBuffer(id, fileOffset, incoming.size, incoming.meta,
-        incoming.getSpillPriority, incoming.spillCallback, deviceStorage)
+      new RapidsDiskBuffer(
+        id,
+        fileOffset,
+        incoming.size,
+        incoming.meta,
+        incoming.getSpillPriority,
+        incoming.getSpillCallback,
+        deviceStorage)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class RapidsGdsStore(
       override val size: Long,
       override val meta: TableMeta,
       spillPriority: Long,
-      override val spillCallback: SpillCallback)
+      spillCallback: SpillCallback)
       extends RapidsBufferBase(id, size, meta, spillPriority, spillCallback) {
     override val storageTier: StorageTier = StorageTier.GDS
 
@@ -124,8 +124,14 @@ class RapidsGdsStore(
       0
     }
     logDebug(s"Spilled to $path $fileOffset:${other.size} via GDS")
-    new RapidsGdsSingleShotBuffer(id, path, fileOffset, other.size, other.meta,
-      other.getSpillPriority, other.spillCallback)
+    new RapidsGdsSingleShotBuffer(
+      id,
+      path,
+      fileOffset,
+      other.size,
+      other.meta,
+      other.getSpillPriority,
+      other.getSpillCallback)
   }
 
   class BatchSpiller() extends AutoCloseable {
@@ -161,8 +167,14 @@ class RapidsGdsStore(
 
         val id = other.id
         addBuffer(currentFile, id)
-        val gdsBuffer = new RapidsGdsBatchedBuffer(id, currentFile, currentOffset,
-          other.size, other.meta, other.getSpillPriority, other.spillCallback)
+        val gdsBuffer = new RapidsGdsBatchedBuffer(
+          id,
+          currentFile,
+          currentOffset,
+          other.size,
+          other.meta,
+          other.getSpillPriority,
+          other.getSpillCallback)
         currentOffset += alignUp(deviceBuffer.getLength)
         pendingBuffers += gdsBuffer
         gdsBuffer

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class RapidsHostMemoryStore(
         applyPriorityOffset(other.getSpillPriority, allocationMode.spillPriorityOffset),
         hostBuffer,
         allocationMode,
-        other.spillCallback,
+        other.getSpillCallback,
         deviceStorage)
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.function.{Consumer, IntUnaryOperator}
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.Cuda
+import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer}
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.SparkEnv
@@ -50,9 +50,117 @@ case class ShuffleBufferId(
 class ShuffleBufferCatalog(
     catalog: RapidsBufferCatalog,
     diskBlockManager: RapidsDiskBlockManager) extends Arm with Logging {
+
+  private val deviceStore = RapidsBufferCatalog.getDeviceStorage
+
+  private val bufferIdToHandle = new ConcurrentHashMap[RapidsBufferId, RapidsBufferHandle]()
+
+  private def trackCachedHandle(
+      bufferId: ShuffleBufferId,
+      bufferHandle: RapidsBufferHandle): Unit = {
+    bufferIdToHandle.put(bufferId, bufferHandle)
+  }
+
+  def removeCachedHandles(): Unit = {
+    bufferIdToHandle.forEach { case (_, handle) =>
+      removeBuffer(handle)
+    }
+  }
+
+  /**
+   * Adds a contiguous table shuffle table to the device storage. This does NOT take ownership of
+   * the contiguous table, so it is the responsibility of the caller to close it.
+   * The refcount of the underlying device buffer will be incremented so the contiguous table
+   * can be closed before this buffer is destroyed.
+   *
+   * @param blockId Spark's `ShuffleBlockId` that identifies this buffer
+   * @param contigTable contiguous table to track in storage
+   * @param initialSpillPriority starting spill priority value for the buffer
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @param needsSync whether the spill framework should stream synchronize while adding
+   *                  this device buffer (defaults to true)
+   * @return RapidsBufferId identifying this table
+   */
+  def addContiguousTable(
+      blockId: ShuffleBlockId,
+      contigTable: ContiguousTable,
+      initialSpillPriority: Long,
+      defaultSpillCallback: SpillCallback,
+      needsSync: Boolean): RapidsBufferHandle = {
+    val bufferId = nextShuffleBufferId(blockId)
+    withResource(contigTable) { _ =>
+      deviceStore.addContiguousTable(
+        bufferId,
+        contigTable,
+        initialSpillPriority,
+        defaultSpillCallback,
+        needsSync)
+      val handle = catalog.makeNewHandle(
+        bufferId, initialSpillPriority, defaultSpillCallback)
+      trackCachedHandle(bufferId, handle)
+      handle
+    }
+  }
+
+  /**
+   * Adds a buffer to the device storage, taking ownership of the buffer.
+   *
+   * @param blockId Spark's `ShuffleBlockId` that identifies this buffer
+   * @param buffer buffer that will be owned by the store
+   * @param tableMeta metadata describing the buffer layout
+   * @param initialSpillPriority starting spill priority value for the buffer
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @return RapidsBufferHandle associated with this buffer
+   */
+  def addBuffer(
+      blockId: ShuffleBlockId,
+      buffer: DeviceMemoryBuffer,
+      tableMeta: TableMeta,
+      initialSpillPriority: Long,
+      defaultSpillCallback: SpillCallback,
+      needsSync: Boolean): RapidsBufferHandle = {
+    val bufferId = nextShuffleBufferId(blockId)
+    // update the table metadata for the buffer ID generated above
+    tableMeta.bufferMeta.mutateId(bufferId.tableId)
+    // when we call `addBuffer` the store will incRefCount
+    withResource(buffer) { _ =>
+      deviceStore.addBuffer(
+        bufferId,
+        buffer,
+        tableMeta,
+        initialSpillPriority,
+        defaultSpillCallback,
+        needsSync)
+      val handle =
+        catalog.makeNewHandle(bufferId, initialSpillPriority, defaultSpillCallback)
+      trackCachedHandle(bufferId, handle)
+      handle
+    }
+  }
+
+  /**
+   * Register a new buffer with the catalog. An exception will be thrown if an
+   * existing buffer was registered with the same block ID (extremely unlikely)
+   */
+  def addDegenerateRapidsBuffer(
+      blockId: ShuffleBlockId,
+      meta: TableMeta,
+      spillCallback: SpillCallback): RapidsBufferHandle = {
+    val bufferId = nextShuffleBufferId(blockId)
+    val buffer = new DegenerateRapidsBuffer(bufferId, meta)
+    catalog.registerNewBuffer(buffer)
+    val handle =
+      catalog.makeNewHandle(buffer.id, buffer.getSpillPriority, spillCallback)
+    trackCachedHandle(bufferId, handle)
+    handle
+  }
+
   /**
    * Information stored for each active shuffle.
    * NOTE: ArrayBuffer in blockMap must be explicitly locked when using it!
+   *
    * @param blockMap mapping of block ID to array of buffers for the block
    */
   private case class ShuffleInfo(
@@ -88,7 +196,13 @@ class ShuffleBufferCatalog(
         // NOTE: Not synchronizing array buffer because this shuffle should be inactive.
         bufferIds.foreach { id =>
           tableMap.remove(id.tableId)
-          catalog.removeBuffer(id)
+          val didRemove = catalog.removeBuffer(bufferIdToHandle.get(id))
+          if (!didRemove) {
+            logWarning(s"Unable to remove from underlying storage ${id} when cleaning " +
+              s"shuffle blocks.")
+          } else {
+            logWarning(s"Did remove ${id}")
+          }
         }
       }
       info.blockMap.forEachValue(Long.MaxValue, bufferRemover)
@@ -126,6 +240,20 @@ class ShuffleBufferCatalog(
     }
   }
 
+  def blockIdToBufferHandles(blockId: ShuffleBlockId): Array[RapidsBufferHandle] = {
+    val info = activeShuffles.get(blockId.shuffleId)
+    if (info == null) {
+      throw new NoSuchElementException(s"unknown shuffle $blockId.shuffleId")
+    }
+    val entries = info.blockMap.get(blockId)
+    if (entries == null) {
+      throw new NoSuchElementException(s"unknown shuffle block $blockId")
+    }
+    entries.synchronized {
+      entries.map(bufferIdToHandle.get).toArray
+    }
+  }
+
   /** Get all the buffer metadata that correspond to a shuffle block identifier. */
   def blockIdToMetas(blockId: ShuffleBlockId): Seq[TableMeta] = {
     blockIdToBuffersIds(blockId).map(catalog.getBufferMeta)
@@ -151,76 +279,50 @@ class ShuffleBufferCatalog(
     blockBufferIds.synchronized {
       blockBufferIds.append(id)
     }
-
     id
   }
 
-  /** Allocate a new table identifier for a shuffle block and update the shuffle block mapping. */
-  def nextTableId(blockId: ShuffleBlockId): Int = {
-    val shuffleBufferId = nextShuffleBufferId(blockId)
-    shuffleBufferId.tableId
-  }
-
-  /** Lookup the shuffle buffer identifier that corresponds to the specified table identifier. */
-  def getShuffleBufferId(tableId: Int): ShuffleBufferId = {
+  /** Lookup the shuffle buffer handle that corresponds to the specified table identifier. */
+  def getShuffleBufferHandle(tableId: Int): RapidsBufferHandle = {
     val shuffleBufferId = tableMap.get(tableId)
     if (shuffleBufferId == null) {
       throw new NoSuchElementException(s"unknown table ID $tableId")
     }
-    shuffleBufferId
+    bufferIdToHandle.get(shuffleBufferId)
   }
-
-  /**
-   * Register a new buffer with the catalog. An exception will be thrown if an
-   * existing buffer was registered with the same buffer ID.
-   */
-  def registerNewBuffer(buffer: RapidsBuffer): Unit = catalog.registerNewBuffer(buffer)
 
   /**
    * Update the spill priority of a shuffle buffer that soon will be read locally.
-   * @param id shuffle buffer identifier of buffer to update
+   * @param handle shuffle buffer handle of buffer to update
    */
-  def updateSpillPriorityForLocalRead(id: ShuffleBufferId): Unit = {
-    withResource(catalog.acquireBuffer(id)) { buffer =>
-      buffer.setSpillPriority(SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
-    }
+  def updateSpillPriorityForLocalRead(handle: RapidsBufferHandle): Unit = {
+    handle.setSpillPriority(SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY)
   }
 
   /**
-   * Lookup the shuffle buffer that corresponds to the specified shuffle buffer ID and acquire it.
+   * Lookup the shuffle buffer that corresponds to the specified buffer handle and acquire it.
    * NOTE: It is the responsibility of the caller to close the buffer.
-   * @param id shuffle buffer identifier
+   * @param handle shuffle buffer handle
    * @return shuffle buffer that has been acquired
    */
-  def acquireBuffer(id: ShuffleBufferId): RapidsBuffer = {
-    val buffer = catalog.acquireBuffer(id)
+  def acquireBuffer(handle: RapidsBufferHandle): RapidsBuffer = {
+    val buffer = catalog.acquireBuffer(handle)
     // Shuffle buffers that have been read are less likely to be read again,
     // so update the spill priority based on this access
-    val spillPriority = SpillPriorities.getShuffleOutputBufferReadPriority
-    buffer.setSpillPriority(spillPriority)
+    handle.setSpillPriority(SpillPriorities.getShuffleOutputBufferReadPriority)
     buffer
   }
 
   /**
-   * Lookup the shuffle buffer that corresponds to the specified table ID and acquire it.
-   * NOTE: It is the responsibility of the caller to close the buffer.
-   * @param tableId table identifier
-   * @return shuffle buffer that has been acquired
-   */
-  def acquireBuffer(tableId: Int): RapidsBuffer = {
-    val shuffleBufferId = getShuffleBufferId(tableId)
-    acquireBuffer(shuffleBufferId)
-  }
-
-  /**
-   * Remove a buffer and table given a buffer ID
+   * Remove a buffer and table given a buffer handle
    * NOTE: This function is not thread safe! The caller should only invoke if
-   * the [[ShuffleBufferId]] being removed is not being utilized by another thread.
-   * @param id buffer identifier
+   * the handle being removed is not being utilized by another thread.
+   * @param handle buffer handle
    */
-  def removeBuffer(id: ShuffleBufferId): Unit = {
+  def removeBuffer(handle: RapidsBufferHandle): Unit = {
+    val id = handle.id
     tableMap.remove(id.tableId)
-    catalog.removeBuffer(id)
+    catalog.removeBuffer(handle)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -90,14 +90,12 @@ class ShuffleBufferCatalog(
       needsSync: Boolean): RapidsBufferHandle = {
     val bufferId = nextShuffleBufferId(blockId)
     withResource(contigTable) { _ =>
-      deviceStore.addContiguousTable(
+      val handle = deviceStore.addContiguousTable(
         bufferId,
         contigTable,
         initialSpillPriority,
         defaultSpillCallback,
         needsSync)
-      val handle = catalog.makeNewHandle(
-        bufferId, initialSpillPriority, defaultSpillCallback)
       trackCachedHandle(bufferId, handle)
       handle
     }
@@ -126,15 +124,13 @@ class ShuffleBufferCatalog(
     tableMeta.bufferMeta.mutateId(bufferId.tableId)
     // when we call `addBuffer` the store will incRefCount
     withResource(buffer) { _ =>
-      deviceStore.addBuffer(
+      val handle = deviceStore.addBuffer(
         bufferId,
         buffer,
         tableMeta,
         initialSpillPriority,
         defaultSpillCallback,
         needsSync)
-      val handle =
-        catalog.makeNewHandle(bufferId, initialSpillPriority, defaultSpillCallback)
       trackCachedHandle(bufferId, handle)
       handle
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -194,10 +194,8 @@ class ShuffleBufferCatalog(
           tableMap.remove(id.tableId)
           val didRemove = catalog.removeBuffer(bufferIdToHandle.get(id))
           if (!didRemove) {
-            logWarning(s"Unable to remove from underlying storage ${id} when cleaning " +
+            logWarning(s"Unable to remove $id from underlying storage when cleaning " +
               s"shuffle blocks.")
-          } else {
-            logWarning(s"Did remove ${id}")
           }
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
@@ -92,7 +92,6 @@ class ShuffleReceivedBufferCatalog(
         initialSpillPriority,
         defaultSpillCallback,
         needsSync)
-      catalog.makeNewHandle(bufferId, initialSpillPriority, defaultSpillCallback)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.IntUnaryOperator
 
+import ai.rapids.cudf.DeviceMemoryBuffer
+import com.nvidia.spark.rapids.format.TableMeta
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 
@@ -37,7 +40,10 @@ case class ShuffleReceivedBufferId(
 
 /** Catalog for lookup of shuffle buffers by block ID */
 class ShuffleReceivedBufferCatalog(
-    catalog: RapidsBufferCatalog) extends Logging {
+    catalog: RapidsBufferCatalog) extends Arm with Logging {
+
+  private val deviceStore = RapidsBufferCatalog.getDeviceStorage
+
   /** Mapping of table ID to shuffle buffer ID */
   private[this] val tableMap = new ConcurrentHashMap[Int, ShuffleReceivedBufferId]
 
@@ -45,7 +51,7 @@ class ShuffleReceivedBufferCatalog(
   private[this] val tableIdCounter = new AtomicInteger(0)
 
   /** Allocate a new shuffle buffer identifier and update the shuffle block mapping. */
-  def nextShuffleReceivedBufferId(): ShuffleReceivedBufferId = {
+  private def nextShuffleReceivedBufferId(): ShuffleReceivedBufferId = {
     val tableId = tableIdCounter.getAndUpdate(ShuffleReceivedBufferCatalog.TABLE_ID_UPDATER)
     val id = ShuffleReceivedBufferId(tableId)
     val prev = tableMap.put(tableId, id)
@@ -55,49 +61,78 @@ class ShuffleReceivedBufferCatalog(
     id
   }
 
-  /** Lookup the shuffle buffer identifier that corresponds to the specified table identifier. */
-  def getShuffleBufferId(tableId: Int): ShuffleReceivedBufferId = {
-    val shuffleBufferId = tableMap.get(tableId)
-    if (shuffleBufferId == null) {
-      throw new NoSuchElementException(s"unknown table ID $tableId")
+  /**
+   * Adds a buffer to the device storage, taking ownership of the buffer.
+   *
+   * This method associates a new `bufferId` which is tracked internally in this catalog.
+   *
+   * @param buffer buffer that will be owned by the store
+   * @param tableMeta metadata describing the buffer layout
+   * @param initialSpillPriority starting spill priority value for the buffer
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @param needsSync tells the store a synchronize in the current stream is required
+   *                  before storing this buffer
+   * @return RapidsBufferHandle associated with this buffer
+   */
+  def addBuffer(
+      buffer: DeviceMemoryBuffer,
+      tableMeta: TableMeta,
+      initialSpillPriority: Long,
+      defaultSpillCallback: SpillCallback = RapidsBuffer.defaultSpillCallback,
+      needsSync: Boolean): RapidsBufferHandle = {
+    val bufferId = nextShuffleReceivedBufferId()
+    tableMeta.bufferMeta.mutateId(bufferId.tableId)
+    // when we call `addBuffer` the store will incRefCount
+    withResource(buffer) { _ =>
+      deviceStore.addBuffer(
+        bufferId,
+        buffer,
+        tableMeta,
+        initialSpillPriority,
+        defaultSpillCallback,
+        needsSync)
+      catalog.makeNewHandle(bufferId, initialSpillPriority, defaultSpillCallback)
     }
-    shuffleBufferId
   }
 
   /**
-   * Register a new buffer with the catalog. An exception will be thrown if an
-   * existing buffer was registered with the same buffer ID.
+   * Adds a degenerate buffer (zero rows or columns)
+   *
+   * @param meta metadata describing the buffer layout
+   * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
+   *                      It should never allocate GPU memory and really just be used for metrics.
+   * @return RapidsBufferHandle associated with this buffer
    */
-  def registerNewBuffer(buffer: RapidsBuffer): Unit = catalog.registerNewBuffer(buffer)
-
-  /**
-   * Lookup the shuffle buffer that corresponds to the specified shuffle buffer ID and acquire it.
-   * NOTE: It is the responsibility of the caller to close the buffer.
-   * @param id shuffle buffer identifier
-   * @return shuffle buffer that has been acquired
-   */
-  def acquireBuffer(id: ShuffleReceivedBufferId): RapidsBuffer = catalog.acquireBuffer(id)
-
-  /**
-   * Lookup the shuffle buffer that corresponds to the specified table ID and acquire it.
-   * NOTE: It is the responsibility of the caller to close the buffer.
-   * @param tableId table identifier
-   * @return shuffle buffer that has been acquired
-   */
-  def acquireBuffer(tableId: Int): RapidsBuffer = {
-    val shuffleBufferId = getShuffleBufferId(tableId)
-    acquireBuffer(shuffleBufferId)
+  def addDegenerateRapidsBuffer(
+      meta: TableMeta,
+      spillCallback: SpillCallback): RapidsBufferHandle = {
+    val bufferId = nextShuffleReceivedBufferId()
+    val buffer = new DegenerateRapidsBuffer(bufferId, meta)
+    catalog.registerNewBuffer(buffer)
+    catalog.makeNewHandle(bufferId, -1, spillCallback)
   }
 
   /**
-   * Remove a buffer and table given a buffer ID
+   * Lookup the shuffle buffer that corresponds to the specified shuffle buffer
+   * handle and acquire it.
+   * NOTE: It is the responsibility of the caller to close the buffer.
+   *
+   * @param handle shuffle buffer handle
+   * @return shuffle buffer that has been acquired
+   */
+  def acquireBuffer(handle: RapidsBufferHandle): RapidsBuffer = catalog.acquireBuffer(handle)
+
+  /**
+   * Remove a buffer and table given a buffer handle
    * NOTE: This function is not thread safe! The caller should only invoke if
-   * the [[ShuffleReceivedBufferId]] being removed is not being utilized by another thread.
-   * @param id buffer identifier
+   * the handle being removed is not being utilized by another thread.
+   * @param handle buffer handle
    */
-  def removeBuffer(id: ShuffleReceivedBufferId): Unit = {
+  def removeBuffer(handle: RapidsBufferHandle): Unit = {
+    val id = handle.id
     tableMap.remove(id.tableId)
-    catalog.removeBuffer(id)
+    catalog.removeBuffer(handle)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer}
 
 import org.apache.spark.TaskContext
-import org.apache.spark.sql.rapids.TempSpillBufferId
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -54,15 +53,21 @@ trait SpillableColumnarBatch extends AutoCloseable {
  * spillable, even though in reality there is no backing buffer.  It does this by just keeping the
  * row count in memory, and not dealing with the catalog at all.
  */
-class JustRowsColumnarBatch(numRows: Int, semWait: GpuMetric) extends SpillableColumnarBatch {
+class JustRowsColumnarBatch(numRows: Int, semWait: GpuMetric)
+    extends SpillableColumnarBatch with Arm {
   override def numRows(): Int = numRows
   override def setSpillPriority(priority: Long): Unit = () // NOOP nothing to spill
-  override def getColumnarBatch(): ColumnarBatch = {
+
+  private def makeJustRowsBatch(): ColumnarBatch = {
     GpuSemaphore.acquireIfNecessary(TaskContext.get(), semWait)
     new ColumnarBatch(Array.empty, numRows)
   }
   override def close(): Unit = () // NOOP nothing to close
   override val sizeInBytes: Long = 0L
+
+  def getColumnarBatch(): ColumnarBatch = {
+    makeJustRowsBatch()
+  }
 }
 
 /**
@@ -71,11 +76,12 @@ class JustRowsColumnarBatch(numRows: Int, semWait: GpuMetric) extends SpillableC
  *       ownership of the life cycle of the batch.  So don't call this constructor directly please
  *       use `SpillableColumnarBatch.apply` instead.
  */
-class SpillableColumnarBatchImpl (id: TempSpillBufferId,
+class SpillableColumnarBatchImpl (
+    handle: RapidsBufferHandle,
     rowCount: Int,
     sparkTypes: Array[DataType],
     semWait: GpuMetric)
-    extends  SpillableColumnarBatch with Arm {
+    extends SpillableColumnarBatch with Arm {
   private var closed = false
 
   /**
@@ -83,35 +89,24 @@ class SpillableColumnarBatchImpl (id: TempSpillBufferId,
    */
   override def numRows(): Int = rowCount
 
-  /**
-   * The ID that this is stored under.
-   * @note Use with caution because if this has been closed the id is no longer valid.
-   */
-  def spillId: TempSpillBufferId = id
+  private def withRapidsBuffer[T](fn: RapidsBuffer => T): T = {
+    withResource(RapidsBufferCatalog.acquireBuffer(handle)) { rapidsBuffer =>
+      fn(rapidsBuffer)
+    }
+  }
 
   override lazy val sizeInBytes: Long =
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { buff =>
-      buff.size
-    }
+    withRapidsBuffer(_.size)
 
   /**
    * Set a new spill priority.
    */
   override def setSpillPriority(priority: Long): Unit = {
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { rapidsBuffer =>
-      rapidsBuffer.setSpillPriority(priority)
-    }
+    handle.setSpillPriority(priority)
   }
 
-  /**
-   * Get the columnar batch.
-   * @note It is the responsibility of the caller to close the batch.
-   * @note If the buffer is compressed data then the resulting batch will be built using
-   *       `GpuCompressedColumnVector`, and it is the responsibility of the caller to deal
-   *       with decompressing the data if necessary.
-   */
   override def getColumnarBatch(): ColumnarBatch = {
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { rapidsBuffer =>
+    withRapidsBuffer { rapidsBuffer =>
       GpuSemaphore.acquireIfNecessary(TaskContext.get(), semWait)
       rapidsBuffer.getColumnarBatch(sparkTypes)
     }
@@ -122,7 +117,8 @@ class SpillableColumnarBatchImpl (id: TempSpillBufferId,
    */
   override def close(): Unit = {
     if (!closed) {
-      RapidsBufferCatalog.removeBuffer(id)
+      // closing my reference
+      RapidsBufferCatalog.removeBuffer(handle)
       closed = true
     }
   }
@@ -131,9 +127,10 @@ class SpillableColumnarBatchImpl (id: TempSpillBufferId,
 object SpillableColumnarBatch extends Arm {
   /**
    * Create a new SpillableColumnarBatch.
+   *
    * @note This takes over ownership of batch, and batch should not be used after this.
-   * @param batch the batch to make spillable
-   * @param priority the initial spill priority of this batch
+   * @param batch         the batch to make spillable
+   * @param priority      the initial spill priority of this batch
    * @param spillCallback a callback when the buffer is spilled. This should be very light weight.
    *                      It should never allocate GPU memory and really just be used for metrics.
    */
@@ -146,10 +143,13 @@ object SpillableColumnarBatch extends Arm {
       batch.close()
       new JustRowsColumnarBatch(numRows, spillCallback.semaphoreWaitTime)
     } else {
-      val types =  GpuColumnVector.extractTypes(batch)
-      val id = TempSpillBufferId()
-      addBatch(id, batch, priority, spillCallback)
-      new SpillableColumnarBatchImpl(id, numRows, types, spillCallback.semaphoreWaitTime)
+      val types = GpuColumnVector.extractTypes(batch)
+      val handle = addBatch(batch, priority, spillCallback)
+      new SpillableColumnarBatchImpl(
+        handle,
+        numRows,
+        types,
+        spillCallback.semaphoreWaitTime)
     }
   }
 
@@ -167,85 +167,80 @@ object SpillableColumnarBatch extends Arm {
       sparkTypes: Array[DataType],
       priority: Long,
       spillCallback: SpillCallback): SpillableColumnarBatch = {
-    val id = TempSpillBufferId()
-    RapidsBufferCatalog.addContiguousTable(id, ct, priority, spillCallback)
-    new SpillableColumnarBatchImpl(id, ct.getRowCount.toInt, sparkTypes,
-      spillCallback.semaphoreWaitTime)
+    val handle = RapidsBufferCatalog.addContiguousTable(ct, priority, spillCallback)
+    withResource(RapidsBufferCatalog.acquireBuffer(handle)) { _ =>
+      new SpillableColumnarBatchImpl(
+        handle,
+        ct.getRowCount.toInt,
+        sparkTypes,
+        spillCallback.semaphoreWaitTime)
+    }
   }
 
   private[this] def addBatch(
-      id: RapidsBufferId,
       batch: ColumnarBatch,
       initialSpillPriority: Long,
-      spillCallback: SpillCallback): Unit = {
+      spillCallback: SpillCallback): RapidsBufferHandle = {
     withResource(batch) { batch =>
       val numColumns = batch.numCols()
       if (GpuCompressedColumnVector.isBatchCompressed(batch)) {
         val cv = batch.column(0).asInstanceOf[GpuCompressedColumnVector]
         val buff = cv.getTableBuffer
-        buff.incRefCount()
-        RapidsBufferCatalog.addBuffer(id, buff, cv.getTableMeta, initialSpillPriority,
+        RapidsBufferCatalog.addBuffer(buff, cv.getTableMeta, initialSpillPriority,
           spillCallback)
       } else if (GpuPackedTableColumn.isBatchPacked(batch)) {
         val cv = batch.column(0).asInstanceOf[GpuPackedTableColumn]
-        RapidsBufferCatalog.addContiguousTable(id, cv.getContiguousTable, initialSpillPriority,
+        RapidsBufferCatalog.addContiguousTable(
+          cv.getContiguousTable,
+          initialSpillPriority,
           spillCallback)
       } else if (numColumns > 0 &&
           (0 until numColumns)
               .forall(i => batch.column(i).isInstanceOf[GpuColumnVectorFromBuffer])) {
         val cv = batch.column(0).asInstanceOf[GpuColumnVectorFromBuffer]
-        val table = GpuColumnVector.from(batch)
         val buff = cv.getBuffer
-        buff.incRefCount()
-        RapidsBufferCatalog.addTable(id, table, buff, cv.getTableMeta, initialSpillPriority,
+        // note the table here is handed over to the catalog
+        val table = GpuColumnVector.from(batch)
+        RapidsBufferCatalog.addTable(table, buff, cv.getTableMeta, initialSpillPriority,
           spillCallback)
       } else {
         withResource(GpuColumnVector.from(batch)) { tmpTable =>
           withResource(tmpTable.contiguousSplit()) { contigTables =>
             require(contigTables.length == 1, "Unexpected number of contiguous spit tables")
-            RapidsBufferCatalog.addContiguousTable(id, contigTables.head, initialSpillPriority,
+            RapidsBufferCatalog.addContiguousTable(
+              contigTables.head,
+              initialSpillPriority,
               spillCallback)
           }
         }
       }
     }
   }
+
 }
 
 
 /**
  * Just like a SpillableColumnarBatch but for buffers.
  */
-class SpillableBuffer (id: TempSpillBufferId, semWait: GpuMetric) extends AutoCloseable with Arm {
+class SpillableBuffer(
+    handle: RapidsBufferHandle,
+    semWait: GpuMetric) extends AutoCloseable with Arm {
+
   private var closed = false
-
-  /**
-   * The ID that this is stored under.
-   * @note Use with caution because if this has been closed the id is no longer valid.
-   */
-  def spillId: TempSpillBufferId = id
-
-  lazy val sizeInBytes: Long =
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { buff =>
-      buff.size
-    }
 
   /**
    * Set a new spill priority.
    */
   def setSpillPriority(priority: Long): Unit = {
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { rapidsBuffer =>
-      rapidsBuffer.setSpillPriority(priority)
-    }
+    handle.setSpillPriority(priority)
   }
 
   /**
-   * Get the device buffer.
-   * @note It is the responsibility of the caller to close the buffer.
+   * Use the device buffer.
    */
   def getDeviceBuffer(): DeviceMemoryBuffer = {
-    withResource(RapidsBufferCatalog.acquireBuffer(id)) { rapidsBuffer =>
-      GpuSemaphore.acquireIfNecessary(TaskContext.get(), semWait)
+    withResource(RapidsBufferCatalog.acquireBuffer(handle)) { rapidsBuffer =>
       rapidsBuffer.getDeviceMemoryBuffer
     }
   }
@@ -255,7 +250,7 @@ class SpillableBuffer (id: TempSpillBufferId, semWait: GpuMetric) extends AutoCl
    */
   override def close(): Unit = {
     if (!closed) {
-      RapidsBufferCatalog.removeBuffer(id)
+      RapidsBufferCatalog.removeBuffer(handle)
       closed = true
     }
   }
@@ -274,9 +269,8 @@ object SpillableBuffer extends Arm {
   def apply(buffer: DeviceMemoryBuffer,
       priority: Long,
       spillCallback: SpillCallback): SpillableBuffer = {
-    val id = TempSpillBufferId()
     val meta = MetaUtils.getTableMetaNoTable(buffer)
-    RapidsBufferCatalog.addBuffer(id, buffer, meta, priority, spillCallback)
-    new SpillableBuffer(id, spillCallback.semaphoreWaitTime)
+    val handle = RapidsBufferCatalog.addBuffer(buffer, meta, priority, spillCallback)
+    new SpillableBuffer(handle, spillCallback.semaphoreWaitTime)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -270,7 +270,9 @@ object SpillableBuffer extends Arm {
       priority: Long,
       spillCallback: SpillCallback): SpillableBuffer = {
     val meta = MetaUtils.getTableMetaNoTable(buffer)
-    val handle = RapidsBufferCatalog.addBuffer(buffer, meta, priority, spillCallback)
+    val handle = withResource(buffer) { _ => 
+      RapidsBufferCatalog.addBuffer(buffer, meta, priority, spillCallback)
+    }
     new SpillableBuffer(handle, spillCallback.semaphoreWaitTime)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -58,16 +58,13 @@ class JustRowsColumnarBatch(numRows: Int, semWait: GpuMetric)
   override def numRows(): Int = numRows
   override def setSpillPriority(priority: Long): Unit = () // NOOP nothing to spill
 
-  private def makeJustRowsBatch(): ColumnarBatch = {
+  def getColumnarBatch(): ColumnarBatch = {
     GpuSemaphore.acquireIfNecessary(TaskContext.get(), semWait)
     new ColumnarBatch(Array.empty, numRows)
   }
+
   override def close(): Unit = () // NOOP nothing to close
   override val sizeInBytes: Long = 0L
-
-  def getColumnarBatch(): ColumnarBatch = {
-    makeJustRowsBatch()
-  }
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -428,16 +428,14 @@ class RapidsShuffleClient(
       buffer: DeviceMemoryBuffer, meta: TableMeta): RapidsBufferHandle = {
     if (buffer != null) {
       // add the buffer to the catalog so it is available for spill
-      withResource(buffer) { _ =>
-        catalog.addBuffer(
-          buffer,
-          meta,
-          SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY,
-          // set needsSync to false because we already have stream synchronized after
-          // consuming the bounce buffer, so we know these buffers are synchronized
-          // w.r.t. the CPU
-          needsSync = false)
-      }
+      catalog.addBuffer(
+        buffer,
+        meta,
+        SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY,
+        // set needsSync to false because we already have stream synchronized after
+        // consuming the bounce buffer, so we know these buffers are synchronized
+        // w.r.t. the CPU
+        needsSync = false)
     } else {
       // no device data, just tracking metadata
       catalog.addDegenerateRapidsBuffer(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -84,13 +84,13 @@ case class PendingTransferRequest(client: RapidsShuffleClient,
  * @param exec Executor used to handle tasks that take time, and should not be in the
  *             transport's thread
  * @param clientCopyExecutor Executors used to handle synchronous mem copies
+ * @param catalog catalog to use to track received shuffle blocks
  */
 class RapidsShuffleClient(
     val connection: ClientConnection,
     transport: RapidsShuffleTransport,
     exec: Executor,
     clientCopyExecutor: Executor,
-    devStorage: RapidsDeviceMemoryStore = RapidsBufferCatalog.getDeviceStorage,
     catalog: ShuffleReceivedBufferCatalog = GpuShuffleEnv.getReceivedCatalog)
       extends Logging with Arm with AutoCloseable {
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ trait RapidsShuffleFetchHandler {
    * @return a boolean that lets the caller know the batch was accepted (true), or
    *         rejected (false), in which case the caller should dispose of the batch.
    */
-  def batchReceived(bufferId: ShuffleReceivedBufferId): Boolean
+  def batchReceived(handle: RapidsBufferHandle): Boolean
 
   /**
    * Called when the transport layer is not able to handle a fetch error for metadata
@@ -336,7 +336,7 @@ class RapidsShuffleClient(
       } else {
         // Degenerate buffer (no device data) so no more data to request.
         // We need to trigger call in iterator, otherwise this batch is never handled.
-        handler.batchReceived(track(null, tableMeta).asInstanceOf[ShuffleReceivedBufferId])
+        handler.batchReceived(track(null, tableMeta))
       }
     }
 
@@ -379,9 +379,9 @@ class RapidsShuffleClient(
 
               // hand buffer off to the catalog
               buffMetas.foreach { consumed: ConsumedBatchFromBounceBuffer =>
-                val bId = track(consumed.contigBuffer, consumed.meta)
-                if (!consumed.handler.batchReceived(bId)) {
-                  catalog.removeBuffer(bId)
+                val handle = track(consumed.contigBuffer, consumed.meta)
+                if (!consumed.handler.batchReceived(handle)) {
+                  catalog.removeBuffer(handle)
                   numBatchesRejected += 1
                 }
                 transport.doneBytesInFlight(consumed.contigBuffer.getLength)
@@ -425,22 +425,26 @@ class RapidsShuffleClient(
    * @return the [[RapidsBufferId]] to be used to look up the buffer from catalog
    */
   private[shuffle] def track(
-      buffer: DeviceMemoryBuffer, meta: TableMeta): ShuffleReceivedBufferId = {
-    val id: ShuffleReceivedBufferId = catalog.nextShuffleReceivedBufferId()
-    logDebug(s"Adding buffer id ${id} to catalog")
+      buffer: DeviceMemoryBuffer, meta: TableMeta): RapidsBufferHandle = {
     if (buffer != null) {
       // add the buffer to the catalog so it is available for spill
-      devStorage.addBuffer(id, buffer, meta,
-        SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY,
-        // set needsSync to false because we already have stream synchronized after
-        // consuming the bounce buffer, so we know these buffers are synchronized
-        // w.r.t. the CPU
-        needsSync = false)
+      withResource(buffer) { _ =>
+        catalog.addBuffer(
+          buffer,
+          meta,
+          SpillPriorities.INPUT_FROM_SHUFFLE_PRIORITY,
+          // set needsSync to false because we already have stream synchronized after
+          // consuming the bounce buffer, so we know these buffers are synchronized
+          // w.r.t. the CPU
+          needsSync = false)
+      }
     } else {
       // no device data, just tracking metadata
-      catalog.registerNewBuffer(new DegenerateRapidsBuffer(id, meta))
+      catalog.addDegenerateRapidsBuffer(
+        meta,
+        RapidsBuffer.defaultSpillCallback)
+
     }
-    id
   }
 
   override def close(): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.concurrent.{Callable, ConcurrentHashMap, ExecutionException, Ex
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 import scala.collection.mutable
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ListBuffer
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
@@ -892,10 +892,13 @@ class RapidsCachingWriter[K, V](
     catalog: ShuffleBufferCatalog,
     shuffleStorage: RapidsDeviceMemoryStore,
     rapidsShuffleServer: Option[RapidsShuffleServer],
-    metrics: Map[String, SQLMetric]) extends ShuffleWriter[K, V] with Logging {
+    metrics: Map[String, SQLMetric])
+  extends ShuffleWriter[K, V]
+    with Logging
+    with Arm {
   private val numParts = handle.dependency.partitioner.numPartitions
   private val sizes = new Array[Long](numParts)
-  private val writtenBufferIds = new ArrayBuffer[ShuffleBufferId](numParts)
+
   private val uncompressedMetric: SQLMetric = metrics("dataSize")
 
   override def write(records: Iterator[Product2[K, V]]): Unit = {
@@ -913,45 +916,49 @@ class RapidsCachingWriter[K, V](
         recordsWritten = recordsWritten + batch.numRows()
         var partSize: Long = 0
         val blockId = ShuffleBlockId(handle.shuffleId, mapId, partId)
-        val bufferId = catalog.nextShuffleBufferId(blockId)
         if (batch.numRows > 0 && batch.numCols > 0) {
           // Add the table to the shuffle store
-          batch.column(0) match {
+          val handle = batch.column(0) match {
             case c: GpuPackedTableColumn =>
               val contigTable = c.getContiguousTable
               partSize = c.getTableBuffer.getLength
               uncompressedMetric += partSize
-              shuffleStorage.addContiguousTable(
-                bufferId,
+              catalog.addContiguousTable(
+                blockId,
                 contigTable,
                 SpillPriorities.OUTPUT_FOR_SHUFFLE_INITIAL_PRIORITY,
+                RapidsBuffer.defaultSpillCallback,
                 // we don't need to sync here, because we sync on the cuda
                 // stream after sliceInternalOnGpu (contiguous_split)
                 needsSync = false)
             case c: GpuCompressedColumnVector =>
               val buffer = c.getTableBuffer
-              buffer.incRefCount()
               partSize = buffer.getLength
               val tableMeta = c.getTableMeta
-              // update the table metadata for the buffer ID generated above
-              tableMeta.bufferMeta.mutateId(bufferId.tableId)
               uncompressedMetric += tableMeta.bufferMeta().uncompressedSize()
-              shuffleStorage.addBuffer(
-                bufferId,
+              catalog.addBuffer(
+                blockId,
                 buffer,
                 tableMeta,
                 SpillPriorities.OUTPUT_FOR_SHUFFLE_INITIAL_PRIORITY,
+                RapidsBuffer.defaultSpillCallback,
                 // we don't need to sync here, because we sync on the cuda
                 // stream after compression.
                 needsSync = false)
-            case c => throw new IllegalStateException(s"Unexpected column type: ${c.getClass}")
+            case c =>
+              throw new IllegalStateException(s"Unexpected column type: ${c.getClass}")
           }
           bytesWritten += partSize
           sizes(partId) += partSize
+          handle
         } else {
           // no device data, tracking only metadata
           val tableMeta = MetaUtils.buildDegenerateTableMeta(batch)
-          catalog.registerNewBuffer(new DegenerateRapidsBuffer(bufferId, tableMeta))
+          val handle =
+            catalog.addDegenerateRapidsBuffer(
+              blockId,
+              tableMeta,
+              RapidsBuffer.defaultSpillCallback)
 
           // The size of the data is really only used to tell if the data should be shuffled or not
           // a 0 indicates that we should not shuffle anything.  This is here for the special case
@@ -961,8 +968,8 @@ class RapidsCachingWriter[K, V](
           if (batch.numRows > 0) {
             sizes(partId) += 100
           }
+          handle
         }
-        writtenBufferIds.append(bufferId)
       }
       metricsReporter.incBytesWritten(bytesWritten)
       metricsReporter.incRecordsWritten(recordsWritten)
@@ -975,7 +982,7 @@ class RapidsCachingWriter[K, V](
    * Used to remove shuffle buffers when the writing task detects an error, calling `stop(false)`
    */
   private def cleanStorage(): Unit = {
-    writtenBufferIds.foreach(catalog.removeBuffer)
+    catalog.removeCachedHandles()
   }
 
   override def stop(success: Boolean): Option[MapStatus] = {
@@ -1129,8 +1136,8 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
       val catalog = getCatalogOrThrow
       val requestHandler = new RapidsShuffleRequestHandler() {
         override def acquireShuffleBuffer(tableId: Int): RapidsBuffer = {
-          val shuffleBufferId = catalog.getShuffleBufferId(tableId)
-          catalog.acquireBuffer(shuffleBufferId)
+          val handle = catalog.getShuffleBufferHandle(tableId)
+          catalog.acquireBuffer(handle)
         }
 
         override def getShuffleBufferMetas(sbbId: ShuffleBlockBatchId): Seq[TableMeta] = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -890,7 +890,6 @@ class RapidsCachingWriter[K, V](
     mapId: Long,
     metricsReporter: ShuffleWriteMetricsReporter,
     catalog: ShuffleBufferCatalog,
-    shuffleStorage: RapidsDeviceMemoryStore,
     rapidsShuffleServer: Option[RapidsShuffleServer],
     metrics: Map[String, SQLMetric])
   extends ShuffleWriter[K, V]
@@ -1207,7 +1206,6 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
           mapId,
           metricsReporter,
           getCatalogOrThrow,
-          RapidsBufferCatalog.getDeviceStorage,
           server,
           gpu.dependency.metrics)
       case bmssh: BypassMergeSortShuffleHandle[_, _] =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -226,7 +226,9 @@ class SerializeConcatHostBuffersDeserializeBatch(
 
   override def close(): Unit = this.synchronized {
     buffers.safeClose()
+    buffers = Array.empty
     Option(batchInternal).foreach(_.close())
+    batchInternal = null
   }
 
   @scala.annotation.nowarn("msg=method finalize in class Object is deprecated")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -195,10 +195,9 @@ class GpuPartitioningSuite extends FunSuite with Arm {
               if (GpuCompressedColumnVector.isBatchCompressed(partBatch)) {
                 val gccv = columns.head.asInstanceOf[GpuCompressedColumnVector]
                 val devBuffer = gccv.getTableBuffer
-                val handle = withResource(devBuffer) { _ =>
-                  val id = deviceStore.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
+                val id = deviceStore.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
+                val handle =
                   catalog.makeNewHandle(id, spillPriority, RapidsBuffer.defaultSpillCallback)
-                }
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
                   withResource(catalog.acquireBuffer(handle)) { buffer =>
                     withResource(buffer.getColumnarBatch(sparkTypes)) { batch =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -195,10 +195,9 @@ class GpuPartitioningSuite extends FunSuite with Arm {
               if (GpuCompressedColumnVector.isBatchCompressed(partBatch)) {
                 val gccv = columns.head.asInstanceOf[GpuCompressedColumnVector]
                 val devBuffer = gccv.getTableBuffer
-                // device store takes ownership of the buffer
-                devBuffer.incRefCount()
-                val handle =
+                val handle = withResource(devBuffer) { _ =>
                   RapidsBufferCatalog.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
+                }
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
                   withResource(catalog.acquireBuffer(handle)) { buffer =>
                     withResource(buffer.getColumnarBatch(sparkTypes)) { batch =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -195,9 +195,7 @@ class GpuPartitioningSuite extends FunSuite with Arm {
               if (GpuCompressedColumnVector.isBatchCompressed(partBatch)) {
                 val gccv = columns.head.asInstanceOf[GpuCompressedColumnVector]
                 val devBuffer = gccv.getTableBuffer
-                val id = deviceStore.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
-                val handle =
-                  catalog.makeNewHandle(id, spillPriority, RapidsBuffer.defaultSpillCallback)
+                val handle = deviceStore.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
                   withResource(catalog.acquireBuffer(handle)) { buffer =>
                     withResource(buffer.getColumnarBatch(sparkTypes)) { batch =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,13 +194,13 @@ class GpuPartitioningSuite extends FunSuite with Arm {
               }
               if (GpuCompressedColumnVector.isBatchCompressed(partBatch)) {
                 val gccv = columns.head.asInstanceOf[GpuCompressedColumnVector]
-                val bufferId = MockRapidsBufferId(partIndex)
                 val devBuffer = gccv.getTableBuffer
                 // device store takes ownership of the buffer
                 devBuffer.incRefCount()
-                deviceStore.addBuffer(bufferId, devBuffer, gccv.getTableMeta, spillPriority)
+                val handle =
+                  RapidsBufferCatalog.addBuffer(devBuffer, gccv.getTableMeta, spillPriority)
                 withResource(buildSubBatch(batch, startRow, endRow)) { expectedBatch =>
-                  withResource(catalog.acquireBuffer(bufferId)) { buffer =>
+                  withResource(catalog.acquireBuffer(handle)) { buffer =>
                     withResource(buffer.getColumnarBatch(sparkTypes)) { batch =>
                       compareBatches(expectedBatch, batch)
                     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -230,8 +230,8 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
         val tmCaptor = ArgumentCaptor.forClass(classOf[TableMeta])
         verify(client, times(1)).track(any[DeviceMemoryBuffer](), tmCaptor.capture())
         verifyTableMeta(tableMeta, tmCaptor.getValue.asInstanceOf[TableMeta])
-        verify(mockStorage, times(1))
-            .addBuffer(any(), dmbCaptor.capture(), any(), any(), any(), any())
+        verify(mockCatalog, times(1))
+            .addBuffer(dmbCaptor.capture(), any(), any(), any(), any())
 
         val receivedBuff = dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer]
         assertResult(tableMeta.bufferMeta().size())(receivedBuff.getLength)
@@ -281,8 +281,8 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
       val tmCaptor = ArgumentCaptor.forClass(classOf[TableMeta])
       verify(client, times(1)).track(any[DeviceMemoryBuffer](), tmCaptor.capture())
       verifyTableMeta(tableMeta, tmCaptor.getValue.asInstanceOf[TableMeta])
-      verify(mockStorage, times(1))
-          .addBuffer(any(), dmbCaptor.capture(), any(), any(), any(), any())
+      verify(mockCatalog, times(1))
+          .addBuffer(dmbCaptor.capture(), any(), any(), any(), any())
       verify(mockCatalog, times(1)).removeBuffer(any())
 
       val receivedBuff = dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer]
@@ -334,8 +334,8 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
         verifyTableMeta(tm, tmCaptor.getAllValues().get(ix).asInstanceOf[TableMeta])
       }
 
-      verify(mockStorage, times(5))
-          .addBuffer(any(), dmbCaptor.capture(), any(), any(), any(), any())
+      verify(mockCatalog, times(5))
+          .addBuffer(dmbCaptor.capture(), any(), any(), any(), any())
 
       assertResult(totalExpectedSize)(
         dmbCaptor.getAllValues().toArray().map(_.asInstanceOf[DeviceMemoryBuffer].getLength).sum)
@@ -387,8 +387,8 @@ class RapidsShuffleClientSuite extends RapidsShuffleTestHelper {
         verifyTableMeta(tm, tmCaptor.getAllValues().get(ix).asInstanceOf[TableMeta])
       }
 
-      verify(mockStorage, times(20))
-          .addBuffer(any(), dmbCaptor.capture(), any(), any(), any(), any())
+      verify(mockCatalog, times(20))
+          .addBuffer(dmbCaptor.capture(), any(), any(), any(), any())
 
       assertResult(totalExpectedSize)(
         dmbCaptor.getAllValues().toArray().map(_.asInstanceOf[DeviceMemoryBuffer].getLength).sum)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -18,7 +18,9 @@ package com.nvidia.spark.rapids.shuffle
 
 import java.nio.ByteBuffer
 import java.util.concurrent.Executor
+
 import scala.collection.mutable.ArrayBuffer
+
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, DeviceMemoryBuffer, HostMemoryBuffer}
 import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsBufferHandle, RapidsConf, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
 import com.nvidia.spark.rapids.format.TableMeta
@@ -27,6 +29,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, when}
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import org.scalatest.mockito.MockitoSugar
+
 import org.apache.spark.sql.rapids.ShuffleMetricsUpdater
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -143,9 +143,6 @@ class RapidsShuffleTestHelper extends FunSuite
     when(mockCatalog.addBuffer(dmbCaptor.capture(), any(), any(), any(), any()))
       .thenAnswer(_ => {
         val buffer = dmbCaptor.getValue.asInstanceOf[DeviceMemoryBuffer]
-        // when calling addBuffer it is the responsibility of the caller to call
-        // close on the original buffer
-        buffer.incRefCount()
         buffersToClose.append(buffer)
         mock[RapidsBufferHandle]
       })

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -300,6 +300,8 @@ class InternalColumnarRDDConverterSuite extends SparkQueryCompareTestSuite {
           case _: RapidsHostColumnVector => true
           case _ => false
         }
+        columns.foreach(_.close())
+        table.close()
         isRapidsHostColumnVector
       }).collect()
       assert(result.forall(_ == true))


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/6864

This PR adds a `RapidsBufferHandle` which is to be used outside of the spill framework. What I am going for here is that stores only work with `RapidsBufferId` and the catalogs only deal with `RapidsBufferHandle` and the mapping between them. The `RapidsBufferCatalog` owns these handles.

What this PR allows us to do but is not included here is the ability to have multiple handles to a buffer. In a subsequent PR, we will detect a collision and return a new handle, but keep the original `RapidsBuffer` and its id. 

I am posting this to run through CI mostly and to get some feedback. I need to a bit more manual testing.