### PR TITLE
Make RapidsBufferHandle AutoCloseable to prevent extra attempts to remove buffers

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -192,11 +192,7 @@ class ShuffleBufferCatalog(
         // NOTE: Not synchronizing array buffer because this shuffle should be inactive.
         bufferIds.foreach { id =>
           tableMap.remove(id.tableId)
-          val didRemove = catalog.removeBuffer(bufferIdToHandle.get(id))
-          if (!didRemove) {
-            logWarning(s"Unable to remove $id from underlying storage when cleaning " +
-              s"shuffle blocks.")
-          }
+          bufferIdToHandle.get(id).close()
         }
       }
       info.blockMap.forEachValue(Long.MaxValue, bufferRemover)
@@ -316,7 +312,7 @@ class ShuffleBufferCatalog(
   def removeBuffer(handle: RapidsBufferHandle): Unit = {
     val id = handle.id
     tableMap.remove(id.tableId)
-    catalog.removeBuffer(handle)
+    handle.close()
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
@@ -131,7 +131,7 @@ class ShuffleReceivedBufferCatalog(
   def removeBuffer(handle: RapidsBufferHandle): Unit = {
     val id = handle.id
     tableMap.remove(id.tableId)
-    catalog.removeBuffer(handle)
+    handle.close()
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -79,8 +79,6 @@ class SpillableColumnarBatchImpl (
     sparkTypes: Array[DataType],
     semWait: GpuMetric)
     extends SpillableColumnarBatch with Arm {
-  private var closed = false
-
   /**
    * The number of rows stored in this batch.
    */
@@ -113,11 +111,8 @@ class SpillableColumnarBatchImpl (
    * Remove the `ColumnarBatch` from the cache.
    */
   override def close(): Unit = {
-    if (!closed) {
-      // closing my reference
-      RapidsBufferCatalog.removeBuffer(handle)
-      closed = true
-    }
+    // closing my reference
+    handle.close()
   }
 }
 
@@ -224,8 +219,6 @@ class SpillableBuffer(
     handle: RapidsBufferHandle,
     semWait: GpuMetric) extends AutoCloseable with Arm {
 
-  private var closed = false
-
   /**
    * Set a new spill priority.
    */
@@ -246,10 +239,7 @@ class SpillableBuffer(
    * Remove the buffer from the cache.
    */
   override def close(): Unit = {
-    if (!closed) {
-      RapidsBufferCatalog.removeBuffer(handle)
-      closed = true
-    }
+    handle.close()
   }
 }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
@@ -161,9 +161,9 @@ class RapidsDeviceMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
         }
         assertResult(bufferSizes.take(i+1).sum)(store.currentSize)
       }
-      catalog.removeBuffer(bufferHandles(0))
+      bufferHandles(0).close()
       assertResult(bufferSizes(1))(store.currentSize)
-      catalog.removeBuffer(bufferHandles(1))
+      bufferHandles(1).close()
       assertResult(0)(store.currentSize)
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -181,7 +181,7 @@ class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSuga
             devStore.synchronousSpill(0)
             hostStore.synchronousSpill(0)
             assert(bufferPath.exists)
-            catalog.removeBuffer(handle)
+            handle.close()
             if (canShareDiskPaths) {
               assert(bufferPath.exists())
             } else {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
@@ -96,9 +96,9 @@ class RapidsGdsStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar
          }
        }
 
-       catalog.removeBuffer(bufferHandles(0))
+       bufferHandles(0).close()
        assert(paths(0).exists)
-       catalog.removeBuffer(bufferHandles(1))
+       bufferHandles(1).close()
        assert(!paths(0).exists)
      }
    }
@@ -130,7 +130,7 @@ class RapidsGdsStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar
           assertResult(spillPriority)(buffer.getSpillPriority)
         }
 
-        catalog.removeBuffer(handle)
+        handle.close()
         if (canShareDiskPaths) {
           assert(path.exists())
         } else {


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This is follow on work from https://github.com/NVIDIA/spark-rapids/pull/7512 but the issue was there before my pr was merged because spillable columnar batch could be closed on a finalizer in the broadcast code, attempting to close some buffer that doesn't exist anymore (because this races with the catalog cleanup logic)

This centralizes the close to the `RapidsBufferHandle`. Note, I made no attempts to invalidate the `id` in the handle, or throw from the other methods for this handle. I figure we can add that if we see issues or reviewers find that we need to be really strict here and make the handle throw on use.