### PR TITLE
Fix case where tracking batch is never updated in batched full join

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -487,7 +487,7 @@ def test_broadcast_join_left_table(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join)
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.shuffle.partitions': '200'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -483,13 +483,14 @@ def test_broadcast_nested_loop_with_conditionals_build_right_fallback(data_gen, 
 # Not all join types can be translated to a broadcast join, but this tests them to be sure we
 # can handle what spark is doing
 @pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
-def test_broadcast_join_left_table(data_gen, join_type):
+# Specify 200 shuffle partitions to test cases where streaming side is empty
+# as in https://github.com/NVIDIA/spark-rapids/issues/7516
+@pytest.mark.parametrize('shuffle_conf', [{}, {'spark.sql.shuffle.partitions': 200}], ids=idfn)
+def test_broadcast_join_left_table(data_gen, join_type, shuffle_conf):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
-    # Specify 200 shuffle partitions to test cases where streaming side is empty
-    # as in https://github.com/NVIDIA/spark-rapids/issues/7516
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.shuffle.partitions': '200'})
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=shuffle_conf)
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84
 # After 3.1.0 is the min spark version we can drop this

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -487,6 +487,8 @@ def test_broadcast_join_left_table(data_gen, join_type):
     def do_join(spark):
         left, right = create_df(spark, data_gen, 250, 500)
         return broadcast(left).join(right, left.a == right.r_a, join_type)
+    # Specify 200 shuffle partitions to test cases where streaming side is empty
+    # as in https://github.com/NVIDIA/spark-rapids/issues/7516
     assert_gpu_and_cpu_are_equal_collect(do_join, conf={'spark.sql.shuffle.partitions': '200'})
 
 # local sort because of https://github.com/NVIDIA/spark-rapids/issues/84

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -603,10 +603,8 @@ class HashFullJoinIterator(
         val lazyRightMap = LazySpillableGatherMap(maps(1), spillCallback, "right_map")
         withResource(new NvtxWithMetrics("update tracking mask",
           NvtxColor.ORANGE, joinTime)) { _ =>
-          closeOnExcept(lazyLeftMap) { lazyLeft =>
-            closeOnExcept(lazyRightMap) { lazyRight =>
-              updateTrackingMask(if (buildSide == GpuBuildRight) lazyRight else lazyLeft)
-            }
+          closeOnExcept(Seq(lazyLeftMap, lazyRightMap)) { _ =>
+            updateTrackingMask(if (buildSide == GpuBuildRight) lazyRightMap else lazyLeftMap)
           }
         }
         val (leftOutOfBoundsPolicy, rightOutOfBoundsPolicy) = {


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

Closes https://github.com/NVIDIA/spark-rapids/issues/7516.

As reported in https://github.com/NVIDIA/spark-rapids/issues/7516, some of our nightly build tests running on the yarn cluster were reporting failures for some full join test cases.

From examining the CPU vs GPU output for some of the tests, it appeared that the final batch (which represents rows on the build side that were not matched on the streaming side) was empty where it shouldn't be.  Once I was able to reproduce on the yarn cluster, I confirmed this with debug logging.

In cases where there was nothing on the stream side for a task, we were never updating the tracking mask to indicate which rows from the build side were needed for the final batch.

With this fix, the tests on the yarn cluster now pass, and all full join integration tests also pass for me locally.
