### PR TITLE
Add patched Hive Metastore Client jar to Databricks deps.

### DIFF
--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -238,6 +238,8 @@ set_dep_jars()
     dep_jars[HIVESERDE]=${PREFIX_WS_SP_MVN_HADOOP}--org.apache.hive--hive-serde--org.apache.hive__hive-serde__${sw_versions[HIVE_FULL]}.jar
     artifacts[HIVESTORAGE]="-DgroupId=org.apache.hive -DartifactId=hive-storage-api"
     dep_jars[HIVESTORAGE]=${PREFIX_WS_SP_MVN_HADOOP}--org.apache.hive--hive-storage-api--org.apache.hive__hive-storage-api__${sw_versions[HIVESTORAGE_API]}.jar
+    artifacts[HIVEMETASTORECLIENTPATCHED]="-DgroupId=org.apache.hive -DartifactId=hive-metastore-client-patched"
+    dep_jars[HIVEMETASTORECLIENTPATCHED]=${PREFIX_SPARK}--patched-hive-with-glue--hive-12679-patch-${HIVE_VER_STRING}__hadoop-${sw_versions[HADOOP]}_${SCALA_VERSION}_deploy.jar
     artifacts[PARQUETHADOOP]="-DgroupId=org.apache.parquet -DartifactId=parquet-hadoop"
     dep_jars[PARQUETHADOOP]=${PREFIX_WS_SP_MVN_HADOOP}--org.apache.parquet--parquet-hadoop--org.apache.parquet__parquet-hadoop__${sw_versions[PARQUET]}-databricks${sw_versions[DB]}.jar
     artifacts[PARQUETCOMMON]="-DgroupId=org.apache.parquet -DartifactId=parquet-common"
@@ -293,6 +295,7 @@ set_dep_jars()
     if [[ $BASE_SPARK_VERSION == "3.1.2" ]]
     then
         dep_jars[HIVE]=${PREFIX_SPARK}--sql--hive--hive_${SCALA_VERSION}_deploy_shaded.jar
+        dep_jars[HIVEMETASTORECLIENTPATCHED]=${PREFIX_SPARK}--patched-hive-with-glue--hive-12679-patch_deploy.jar
         dep_jars[PARQUETFORMAT]=${PREFIX_WS_SP_MVN_HADOOP}--org.apache.parquet--parquet-format--org.apache.parquet__parquet-format__2.4.0.jar
         dep_jars[AVROSPARK]=${PREFIX_SPARK}--vendor--avro--avro_${SCALA_VERSION}_deploy_shaded.jar
         dep_jars[AVROMAPRED]=${PREFIX_WS_SP_MVN_HADOOP}--org.apache.avro--avro-mapred-hadoop2--org.apache.avro__avro-mapred-hadoop2__${sw_versions[AVRO]}.jar

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -261,6 +261,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-metastore-client-patched</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
                     <artifactId>hive-serde</artifactId>
                     <version>${spark.version}</version>
                     <scope>provided</scope>


### PR DESCRIPTION
Databricks Spark ships a custom Hive jar patched with [HIVE-12679](https://issues.apache.org/jira/browse/HIVE-12679), presumably to supply its own implementation of the IMetaStoreClient Thrift interface. This necessitates moving `HiveConf` out from `hive-common` to the patched jar (`*patched-hive-with-glue--hive-12679-patch*_deploy.jar`).

The new patched jar is not included in the Databricks dependencies, thus denying access to `HiveConf` from being used in other changes (e.g. #7556).

This commit modifies the Databricks build to register and link to the patched jar, so that `HiveConf` is available from `spark-rapids`.

Signed-off-by: MithunR <mythrocks@gmail.com>
