### PR TITLE
Fix memory leak in GpuIntervalUtilsTest

### DIFF
--- a/tests/src/test/330+/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
+++ b/tests/src/test/330+/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/330+/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
+++ b/tests/src/test/330+/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
@@ -34,17 +34,19 @@ class GpuIntervalUtilsTest extends FunSuite with Arm {
     val caseName = s"testToDayTimeIntervalString for " +
         s"from ${DT.fieldToString(fromField)} to ${DT.fieldToString(endField)}"
     test(caseName) {
-      val micros = ColumnVector.fromLongs(testData.map(e => e._1): _*)
-      withResource(GpuIntervalUtils.toDayTimeIntervalString(micros, fromField, endField)) {
-        gpuRet =>
-          withResource(ColumnVector.fromStrings(testData.map(e => e._2): _*)) { expected =>
-            withResource(ColumnVector.fromStrings(testData.map(e =>
-              IntervalUtils.toDayTimeIntervalString(e._1, IntervalStringStyles.ANSI_STYLE,
-                fromField, endField)): _*)) { cpuRet =>
-              CudfTestHelper.assertColumnsAreEqual(expected, gpuRet)
-              CudfTestHelper.assertColumnsAreEqual(cpuRet, gpuRet)
+      withResource(ColumnVector.fromStrings(testData.map(e => e._2): _*)) { expected =>
+        withResource(ColumnVector.fromStrings(testData.map(e =>
+          IntervalUtils.toDayTimeIntervalString(e._1, IntervalStringStyles.ANSI_STYLE,
+            fromField, endField)): _*)) { cpuRet =>
+          withResource(ColumnVector.fromLongs(testData.map(e => e._1): _*)) { micros =>
+            withResource(
+              GpuIntervalUtils.toDayTimeIntervalString(micros, fromField, endField)
+            ) { gpuRet =>
+                  CudfTestHelper.assertColumnsAreEqual(expected, gpuRet)
+                  CudfTestHelper.assertColumnsAreEqual(cpuRet, gpuRet)
             }
           }
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #7603.

don't leak `micros` backing buffers 

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
