### PR TITLE
Skip/xfail some regexp tests

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -122,6 +122,7 @@ def test_split_re_no_limit():
             'split(a, "^[o]")'),
             conf=_regexp_conf)
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_optimized_no_re():
     data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|{}]{1,2}){1,7}') \
         .with_special_case('boo.and.foo') \
@@ -148,6 +149,7 @@ def test_split_optimized_no_re():
             'split(a, "\\\\$\\\\|")'),
             conf=_regexp_conf)
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_optimized_no_re_combined():
     data_gen = mk_str_gen('([bf]o{0,2}[AZ.?+\\^$|{}]{1,2}){1,7}') \
         .with_special_case('booA.ZandA.Zfoo') \
@@ -182,6 +184,7 @@ def test_split_unsupported_fallback():
         'split(a, "o*"),' +
         'split(a, "o?") from string_split_table')
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_regexp_disabled_no_fallback():
     conf = { 'spark.rapids.sql.regexp.enabled': 'false' }
     data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|&_]{1,2}){1,7}') \

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -681,6 +681,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split - optimized") {
+    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", ",", ";", "cd", "c\\|d",
         "\\%", "\\;", "\\/")
     val data = Seq("abc.def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
@@ -755,6 +756,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split fuzz") {
+    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val (data, patterns) = generateDataAndPatterns(Some(REGEXP_LIMITED_CHARS_REPLACE),
       REGEXP_LIMITED_CHARS_REPLACE, RegexSplitMode)
     for (limit <- Seq(-2, -1, 2, 5)) {
@@ -763,6 +765,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split fuzz - anchor focused") {
+    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val (data, patterns) = generateDataAndPatterns(validDataChars = Some("\r\nabc"),
       validPatternChars = "^$\\AZz\r\n()", RegexSplitMode)
     doStringSplitTest(patterns, data, -1)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Skip tests that fail due to https://github.com/NVIDIA/spark-rapids/issues/7607 until we can revert or fix the underlying issue in cuDF

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
