### PR TITLE
Support Delta Lake DeleteCommand

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeleteCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeleteCommandMeta.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import com.databricks.sql.transaction.tahoe.commands.{DeleteCommand, DeleteCommandEdge}
+import com.databricks.sql.transaction.tahoe.rapids.{GpuDeleteCommand, GpuDeltaLog}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class DeleteCommandMeta(
+    deleteCmd: DeleteCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends RunnableCommandMeta[DeleteCommand](deleteCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+        s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+      Map.empty, SparkSession.active)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeleteCommand(
+      new GpuDeltaLog(deleteCmd.deltaLog, conf),
+      deleteCmd.target,
+      deleteCmd.condition)
+  }
+}
+
+class DeleteCommandEdgeMeta(
+    deleteCmd: DeleteCommandEdge,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends RunnableCommandMeta[DeleteCommandEdge](deleteCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+        s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+      Map.empty, SparkSession.active)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeleteCommand(
+      new GpuDeltaLog(deleteCmd.deltaLog, conf),
+      deleteCmd.target,
+      deleteCmd.condition)
+  }
+}

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeltaProviderImpl.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeltaProviderImpl.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.delta
 
 import com.databricks.sql.transaction.tahoe.DeltaLog
-import com.databricks.sql.transaction.tahoe.commands.{MergeIntoCommand, MergeIntoCommandEdge}
+import com.databricks.sql.transaction.tahoe.commands.{DeleteCommand, DeleteCommandEdge, MergeIntoCommand, MergeIntoCommandEdge}
 import com.databricks.sql.transaction.tahoe.sources.DeltaDataSource
 import com.nvidia.spark.rapids._
 
@@ -46,6 +46,14 @@ object DeltaProviderImpl extends DeltaProviderImplBase {
   override def getRunnableCommandRules: Map[Class[_ <: RunnableCommand],
       RunnableCommandRule[_ <: RunnableCommand]] = {
     Seq(
+      GpuOverrides.runnableCmd[DeleteCommand](
+        "Delete rows from a Delta Lake table",
+        (a, conf, p, r) => new DeleteCommandMeta(a, conf, p, r))
+        .disabledByDefault("Delta Lake delete support is experimental"),
+      GpuOverrides.runnableCmd[DeleteCommandEdge](
+        "Delete rows from a Delta Lake table",
+        (a, conf, p, r) => new DeleteCommandEdgeMeta(a, conf, p, r))
+        .disabledByDefault("Delta Lake delete support is experimental"),
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/DeleteCommandMeta.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta20x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.commands.DeleteCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta20x.GpuDeleteCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class DeleteCommandMeta(
+    deleteCmd: DeleteCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[DeleteCommand](deleteCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+      Map.empty, SparkSession.active)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeleteCommand(
+      new GpuDeltaLog(deleteCmd.deltaLog, conf),
+      deleteCmd.target,
+      deleteCmd.condition)
+  }
+}

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta20x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.MergeIntoCommand
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta20xProvider extends DeltaIOProvider {
@@ -27,8 +27,12 @@ object Delta20xProvider extends DeltaIOProvider {
   override def getRunnableCommandRules: Map[Class[_ <: RunnableCommand],
       RunnableCommandRule[_ <: RunnableCommand]] = {
     Seq(
+      GpuOverrides.runnableCmd[DeleteCommand](
+        "Delete rows from a Delta Lake table",
+        (a, conf, p, r) => new DeleteCommandMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake delete support is experimental"),
       GpuOverrides.runnableCmd[MergeIntoCommand](
-        "Merge of a source query/table into a Delta table",
+        "Merge of a source query/table into a Delta Lake table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))
           .disabledByDefault("Delta Lake merge support is experimental")
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuDeleteCommand.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuDeleteCommand.scala
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeleteCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta20x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{EqualNullSafe, Expression, If, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeleteCommandMetrics, DeleteMetric, DeltaCommand}
+import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
+import org.apache.spark.sql.delta.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.functions.{input_file_name, lit, typedLit, udf}
+
+/**
+ * GPU version of Delta Lake DeleteCommand.
+ *
+ * Performs a Delete based on the search condition
+ *
+ * Algorithm:
+ *   1) Scan all the files and determine which files have
+ *      the rows that need to be deleted.
+ *   2) Traverse the affected files and rebuild the touched files.
+ *   3) Use the Delta protocol to atomically write the remaining rows to new files and remove
+ *      the affected files that are identified in step 1.
+ */
+case class GpuDeleteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    target: LogicalPlan,
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand with DeleteCommandMetrics {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  override lazy val metrics = createMetrics
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = gpuDeltaLog.deltaLog
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.dml.delete") {
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        val deleteActions = performDelete(sparkSession, deltaLog, txn)
+        if (deleteActions.nonEmpty) {
+          txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+
+    Seq.empty[Row]
+  }
+
+  def performDelete(
+      sparkSession: SparkSession,
+      deltaLog: DeltaLog,
+      txn: OptimisticTransaction): Seq[Action] = {
+    import sparkSession.implicits._
+
+    var numRemovedFiles: Long = 0
+    var numAddedFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+    var numBytesAdded: Long = 0
+    var changeFileBytes: Long = 0
+    var numBytesRemoved: Long = 0
+    var numFilesBeforeSkipping: Long = 0
+    var numBytesBeforeSkipping: Long = 0
+    var numFilesAfterSkipping: Long = 0
+    var numBytesAfterSkipping: Long = 0
+    var numPartitionsAfterSkipping: Option[Long] = None
+    var numPartitionsRemovedFrom: Option[Long] = None
+    var numPartitionsAddedTo: Option[Long] = None
+    var numDeletedRows: Option[Long] = None
+    var numCopiedRows: Option[Long] = None
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = deltaLog.snapshot.numOfFiles
+
+    val deleteActions: Seq[Action] = condition match {
+      case None =>
+        // Case 1: Delete the whole table if the condition is true
+        val allFiles = txn.filterFiles(Nil)
+
+        numRemovedFiles = allFiles.size
+        scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        val (numBytes, numPartitions) = totalBytesAndDistinctPartitionValues(allFiles)
+        numBytesRemoved = numBytes
+        numFilesBeforeSkipping = numRemovedFiles
+        numBytesBeforeSkipping = numBytes
+        numFilesAfterSkipping = numRemovedFiles
+        numBytesAfterSkipping = numBytes
+        if (txn.metadata.partitionColumns.nonEmpty) {
+          numPartitionsAfterSkipping = Some(numPartitions)
+          numPartitionsRemovedFrom = Some(numPartitions)
+          numPartitionsAddedTo = Some(0)
+        }
+        val operationTimestamp = System.currentTimeMillis()
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      case Some(cond) =>
+        val (metadataPredicates, otherPredicates) =
+          DeltaTableUtils.splitMetadataAndDataPredicates(
+            cond, txn.metadata.partitionColumns, sparkSession)
+
+        numFilesBeforeSkipping = txn.snapshot.numOfFiles
+        numBytesBeforeSkipping = txn.snapshot.sizeInBytes
+
+        if (otherPredicates.isEmpty) {
+          // Case 2: The condition can be evaluated using metadata only.
+          //         Delete a set of files without the need of scanning any data files.
+          val operationTimestamp = System.currentTimeMillis()
+          val candidateFiles = txn.filterFiles(metadataPredicates)
+
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          numRemovedFiles = candidateFiles.size
+          numBytesRemoved = candidateFiles.map(_.size).sum
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+            numPartitionsRemovedFrom = Some(numCandidatePartitions)
+            numPartitionsAddedTo = Some(0)
+          }
+          candidateFiles.map(_.removeWithTimestamp(operationTimestamp))
+        } else {
+          // Case 3: Delete the rows based on the condition.
+          val candidateFiles = txn.filterFiles(metadataPredicates ++ otherPredicates)
+
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+          }
+
+          val nameToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+          val fileIndex = new TahoeBatchFileIndex(
+            sparkSession, "delete", candidateFiles, deltaLog, deltaLog.dataPath, txn.snapshot)
+          // Keep everything from the resolved target except a new TahoeFileIndex
+          // that only involves the affected files instead of all files.
+          val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+          val data = Dataset.ofRows(sparkSession, newTarget)
+          val deletedRowCount = metrics("numDeletedRows")
+          val deletedRowUdf = udf {
+            new GpuDeltaMetricUpdateUDF(deletedRowCount)
+          }.asNondeterministic()
+          val filesToRewrite =
+            withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
+              if (candidateFiles.isEmpty) {
+                Array.empty[String]
+              } else {
+                data.filter(new Column(cond))
+                    .select(input_file_name())
+                    .filter(deletedRowUdf())
+                    .distinct()
+                    .as[String]
+                    .collect()
+              }
+            }
+
+          numRemovedFiles = filesToRewrite.length
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          if (filesToRewrite.isEmpty) {
+            // Case 3.1: no row matches and no delete will be triggered
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(0)
+              numPartitionsAddedTo = Some(0)
+            }
+            Nil
+          } else {
+            // Case 3.2: some files need an update to remove the deleted files
+            // Do the second pass and just read the affected files
+            val baseRelation = buildBaseRelation(
+              sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
+            // Keep everything from the resolved target except a new TahoeFileIndex
+            // that only involves the affected files instead of all files.
+            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val targetDF = Dataset.ofRows(sparkSession, newTarget)
+            val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+            val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
+            val (changeFiles, rewrittenFiles) = rewrittenActions
+                .partition(_.isInstanceOf[AddCDCFile])
+            numAddedFiles = rewrittenFiles.size
+            val removedFiles = filesToRewrite.map(f =>
+              getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
+            val (removedBytes, removedPartitions) =
+              totalBytesAndDistinctPartitionValues(removedFiles)
+            numBytesRemoved = removedBytes
+            val (rewrittenBytes, rewrittenPartitions) =
+              totalBytesAndDistinctPartitionValues(rewrittenFiles)
+            numBytesAdded = rewrittenBytes
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(removedPartitions)
+              numPartitionsAddedTo = Some(rewrittenPartitions)
+            }
+            numAddedChangeFiles = changeFiles.size
+            changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+            rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+            numDeletedRows = Some(metrics("numDeletedRows").value)
+            numCopiedRows = Some(metrics("numTouchedRows").value - metrics("numDeletedRows").value)
+
+            val operationTimestamp = System.currentTimeMillis()
+            removeFilesFromPaths(deltaLog, nameToAddFileMap, filesToRewrite, operationTimestamp) ++
+                rewrittenActions
+          }
+        }
+    }
+    metrics("numRemovedFiles").set(numRemovedFiles)
+    metrics("numAddedFiles").set(numAddedFiles)
+    val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+    metrics("executionTimeMs").set(executionTimeMs)
+    metrics("scanTimeMs").set(scanTimeMs)
+    metrics("rewriteTimeMs").set(rewriteTimeMs)
+    metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+    metrics("changeFileBytes").set(changeFileBytes)
+    metrics("numBytesAdded").set(numBytesAdded)
+    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
+    metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
+    metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
+    metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
+    numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
+    numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
+    numCopiedRows.foreach(metrics("numCopiedRows").set)
+    txn.registerSQLMetrics(sparkSession, metrics)
+    // This is needed to make the SQL metrics visible in the Spark UI
+    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.delete.stats",
+      data = DeleteMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numFilesAfterSkipping,
+        numAddedFiles,
+        numRemovedFiles,
+        numAddedFiles,
+        numAddedChangeFiles = numAddedChangeFiles,
+        numFilesBeforeSkipping,
+        numBytesBeforeSkipping,
+        numFilesAfterSkipping,
+        numBytesAfterSkipping,
+        numPartitionsAfterSkipping,
+        numPartitionsAddedTo,
+        numPartitionsRemovedFrom,
+        numCopiedRows,
+        numDeletedRows,
+        numBytesAdded,
+        numBytesRemoved,
+        changeFileBytes = changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+
+    deleteActions
+  }
+
+  /**
+   * Returns the list of `AddFile`s and `AddCDCFile`s that have been re-written.
+   */
+  private def rewriteFiles(
+      txn: OptimisticTransaction,
+      baseData: DataFrame,
+      filterCondition: Expression,
+      numFilesToRewrite: Long): Seq[FileAction] = {
+    val shouldWriteCdc = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+
+    // number of total rows that we have seen / are either copying or deleting (sum of both).
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    withStatusCode(
+      "DELTA", rewritingFilesMsg(numFilesToRewrite)) {
+      val dfToWrite = if (shouldWriteCdc) {
+        import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+        // The logic here ends up being surprisingly elegant, with all source rows ending up in
+        // the output. Recall that we flipped the user-provided delete condition earlier, before the
+        // call to `rewriteFiles`. All rows which match this latest `filterCondition` are retained
+        // as table data, while all rows which don't match are removed from the rewritten table data
+        // but do get included in the output as CDC events.
+        baseData
+            .filter(numTouchedRowsUdf())
+            .withColumn(
+              CDC_TYPE_COLUMN_NAME,
+              new Column(
+                If(filterCondition, typedLit[String](CDC_TYPE_NOT_CDC).expr,
+                  lit(CDC_TYPE_DELETE).expr)
+              )
+            )
+      } else {
+        baseData
+            .filter(numTouchedRowsUdf())
+            .filter(new Column(filterCondition))
+      }
+
+      txn.writeFiles(dfToWrite)
+    }
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/DeleteCommandMeta.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta21x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.commands.DeleteCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta21x.GpuDeleteCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class DeleteCommandMeta(
+    deleteCmd: DeleteCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[DeleteCommand](deleteCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+      Map.empty, SparkSession.active)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeleteCommand(
+      new GpuDeltaLog(deleteCmd.deltaLog, conf),
+      deleteCmd.target,
+      deleteCmd.condition)
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta21x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.MergeIntoCommand
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta21xProvider extends DeltaIOProvider {
@@ -27,6 +27,10 @@ object Delta21xProvider extends DeltaIOProvider {
   override def getRunnableCommandRules: Map[Class[_ <: RunnableCommand],
       RunnableCommandRule[_ <: RunnableCommand]] = {
     Seq(
+      GpuOverrides.runnableCmd[DeleteCommand](
+        "Delete rows from a Delta Lake table",
+        (a, conf, p, r) => new DeleteCommandMeta(a, conf, p, r))
+        .disabledByDefault("Delta Lake delete support is experimental"),
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuDeleteCommand.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuDeleteCommand.scala
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeleteCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta21x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeleteCommandMetrics, DeleteMetric, DeltaCommand}
+import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
+import org.apache.spark.sql.delta.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.functions.{input_file_name, lit, typedLit, udf}
+import org.apache.spark.sql.types.LongType
+
+/**
+ * GPU version of Delta Lake DeleteCommand.
+ *
+ * Performs a Delete based on the search condition
+ *
+ * Algorithm:
+ *   1) Scan all the files and determine which files have
+ *      the rows that need to be deleted.
+ *   2) Traverse the affected files and rebuild the touched files.
+ *   3) Use the Delta protocol to atomically write the remaining rows to new files and remove
+ *      the affected files that are identified in step 1.
+ */
+case class GpuDeleteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    target: LogicalPlan,
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand with DeleteCommandMetrics {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  override val output: Seq[Attribute] = Seq(AttributeReference("num_affected_rows", LongType)())
+
+  override lazy val metrics = createMetrics
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = gpuDeltaLog.deltaLog
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.dml.delete") {
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        val deleteActions = performDelete(sparkSession, deltaLog, txn)
+        if (deleteActions.nonEmpty) {
+          txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+
+    // Adjust for deletes at partition boundaries. Deletes at partition boundaries is a metadata
+    // operation, therefore we don't actually have any information around how many rows were deleted
+    // While this info may exist in the file statistics, it's not guaranteed that we have these
+    // statistics. To avoid any performance regressions, we currently just return a -1 in such cases
+    if (metrics("numRemovedFiles").value > 0 && metrics("numDeletedRows").value == 0) {
+      Seq(Row(-1L))
+    } else {
+      Seq(Row(metrics("numDeletedRows").value))
+    }
+  }
+
+  def performDelete(
+      sparkSession: SparkSession,
+      deltaLog: DeltaLog,
+      txn: OptimisticTransaction): Seq[Action] = {
+    import sparkSession.implicits._
+
+    var numRemovedFiles: Long = 0
+    var numAddedFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+    var numBytesAdded: Long = 0
+    var changeFileBytes: Long = 0
+    var numBytesRemoved: Long = 0
+    var numFilesBeforeSkipping: Long = 0
+    var numBytesBeforeSkipping: Long = 0
+    var numFilesAfterSkipping: Long = 0
+    var numBytesAfterSkipping: Long = 0
+    var numPartitionsAfterSkipping: Option[Long] = None
+    var numPartitionsRemovedFrom: Option[Long] = None
+    var numPartitionsAddedTo: Option[Long] = None
+    var numDeletedRows: Option[Long] = None
+    var numCopiedRows: Option[Long] = None
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val deleteActions: Seq[Action] = condition match {
+      case None =>
+        // Case 1: Delete the whole table if the condition is true
+        val allFiles = txn.filterFiles(Nil)
+
+        numRemovedFiles = allFiles.size
+        scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        val (numBytes, numPartitions) = totalBytesAndDistinctPartitionValues(allFiles)
+        numBytesRemoved = numBytes
+        numFilesBeforeSkipping = numRemovedFiles
+        numBytesBeforeSkipping = numBytes
+        numFilesAfterSkipping = numRemovedFiles
+        numBytesAfterSkipping = numBytes
+        if (txn.metadata.partitionColumns.nonEmpty) {
+          numPartitionsAfterSkipping = Some(numPartitions)
+          numPartitionsRemovedFrom = Some(numPartitions)
+          numPartitionsAddedTo = Some(0)
+        }
+        val operationTimestamp = System.currentTimeMillis()
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      case Some(cond) =>
+        val (metadataPredicates, otherPredicates) =
+          DeltaTableUtils.splitMetadataAndDataPredicates(
+            cond, txn.metadata.partitionColumns, sparkSession)
+
+        numFilesBeforeSkipping = txn.snapshot.numOfFiles
+        numBytesBeforeSkipping = txn.snapshot.sizeInBytes
+
+        if (otherPredicates.isEmpty) {
+          // Case 2: The condition can be evaluated using metadata only.
+          //         Delete a set of files without the need of scanning any data files.
+          val operationTimestamp = System.currentTimeMillis()
+          val candidateFiles = txn.filterFiles(metadataPredicates)
+
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          numRemovedFiles = candidateFiles.size
+          numBytesRemoved = candidateFiles.map(_.size).sum
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+            numPartitionsRemovedFrom = Some(numCandidatePartitions)
+            numPartitionsAddedTo = Some(0)
+          }
+          candidateFiles.map(_.removeWithTimestamp(operationTimestamp))
+        } else {
+          // Case 3: Delete the rows based on the condition.
+          val candidateFiles = txn.filterFiles(metadataPredicates ++ otherPredicates)
+
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+          }
+
+          val nameToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+          val fileIndex = new TahoeBatchFileIndex(
+            sparkSession, "delete", candidateFiles, deltaLog, deltaLog.dataPath, txn.snapshot)
+          // Keep everything from the resolved target except a new TahoeFileIndex
+          // that only involves the affected files instead of all files.
+          val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+          val data = Dataset.ofRows(sparkSession, newTarget)
+          val deletedRowCount = metrics("numDeletedRows")
+          val deletedRowUdf = udf {
+            new GpuDeltaMetricUpdateUDF(deletedRowCount)
+          }.asNondeterministic()
+          val filesToRewrite =
+            withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
+              if (candidateFiles.isEmpty) {
+                Array.empty[String]
+              } else {
+                data.filter(new Column(cond))
+                    .select(input_file_name())
+                    .filter(deletedRowUdf())
+                    .distinct()
+                    .as[String]
+                    .collect()
+              }
+            }
+
+          numRemovedFiles = filesToRewrite.length
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          if (filesToRewrite.isEmpty) {
+            // Case 3.1: no row matches and no delete will be triggered
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(0)
+              numPartitionsAddedTo = Some(0)
+            }
+            Nil
+          } else {
+            // Case 3.2: some files need an update to remove the deleted files
+            // Do the second pass and just read the affected files
+            val baseRelation = buildBaseRelation(
+              sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
+            // Keep everything from the resolved target except a new TahoeFileIndex
+            // that only involves the affected files instead of all files.
+            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val targetDF = Dataset.ofRows(sparkSession, newTarget)
+            val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+            val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
+            val (changeFiles, rewrittenFiles) = rewrittenActions
+                .partition(_.isInstanceOf[AddCDCFile])
+            numAddedFiles = rewrittenFiles.size
+            val removedFiles = filesToRewrite.map(f =>
+              getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
+            val (removedBytes, removedPartitions) =
+              totalBytesAndDistinctPartitionValues(removedFiles)
+            numBytesRemoved = removedBytes
+            val (rewrittenBytes, rewrittenPartitions) =
+              totalBytesAndDistinctPartitionValues(rewrittenFiles)
+            numBytesAdded = rewrittenBytes
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(removedPartitions)
+              numPartitionsAddedTo = Some(rewrittenPartitions)
+            }
+            numAddedChangeFiles = changeFiles.size
+            changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+            rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+            numDeletedRows = Some(metrics("numDeletedRows").value)
+            numCopiedRows = Some(metrics("numTouchedRows").value - metrics("numDeletedRows").value)
+
+            val operationTimestamp = System.currentTimeMillis()
+            removeFilesFromPaths(deltaLog, nameToAddFileMap, filesToRewrite, operationTimestamp) ++
+                rewrittenActions
+          }
+        }
+    }
+    metrics("numRemovedFiles").set(numRemovedFiles)
+    metrics("numAddedFiles").set(numAddedFiles)
+    val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+    metrics("executionTimeMs").set(executionTimeMs)
+    metrics("scanTimeMs").set(scanTimeMs)
+    metrics("rewriteTimeMs").set(rewriteTimeMs)
+    metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+    metrics("changeFileBytes").set(changeFileBytes)
+    metrics("numBytesAdded").set(numBytesAdded)
+    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
+    metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
+    metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
+    metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
+    numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
+    numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
+    numCopiedRows.foreach(metrics("numCopiedRows").set)
+    txn.registerSQLMetrics(sparkSession, metrics)
+    // This is needed to make the SQL metrics visible in the Spark UI
+    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.delete.stats",
+      data = DeleteMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numFilesAfterSkipping,
+        numAddedFiles,
+        numRemovedFiles,
+        numAddedFiles,
+        numAddedChangeFiles = numAddedChangeFiles,
+        numFilesBeforeSkipping,
+        numBytesBeforeSkipping,
+        numFilesAfterSkipping,
+        numBytesAfterSkipping,
+        numPartitionsAfterSkipping,
+        numPartitionsAddedTo,
+        numPartitionsRemovedFrom,
+        numCopiedRows,
+        numDeletedRows,
+        numBytesAdded,
+        numBytesRemoved,
+        changeFileBytes = changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+
+    deleteActions
+  }
+
+  /**
+   * Returns the list of `AddFile`s and `AddCDCFile`s that have been re-written.
+   */
+  private def rewriteFiles(
+      txn: OptimisticTransaction,
+      baseData: DataFrame,
+      filterCondition: Expression,
+      numFilesToRewrite: Long): Seq[FileAction] = {
+    val shouldWriteCdc = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+
+    // number of total rows that we have seen / are either copying or deleting (sum of both).
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    withStatusCode(
+      "DELTA", rewritingFilesMsg(numFilesToRewrite)) {
+      val dfToWrite = if (shouldWriteCdc) {
+        import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+        // The logic here ends up being surprisingly elegant, with all source rows ending up in
+        // the output. Recall that we flipped the user-provided delete condition earlier, before the
+        // call to `rewriteFiles`. All rows which match this latest `filterCondition` are retained
+        // as table data, while all rows which don't match are removed from the rewritten table data
+        // but do get included in the output as CDC events.
+        baseData
+            .filter(numTouchedRowsUdf())
+            .withColumn(
+              CDC_TYPE_COLUMN_NAME,
+              new Column(
+                If(filterCondition, typedLit[String](CDC_TYPE_NOT_CDC).expr,
+                  lit(CDC_TYPE_DELETE).expr)
+              )
+            )
+      } else {
+        baseData
+            .filter(numTouchedRowsUdf())
+            .filter(new Column(filterCondition))
+      }
+
+      txn.writeFiles(dfToWrite)
+    }
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/DeleteCommandMeta.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta22x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.commands.DeleteCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta22x.GpuDeleteCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class DeleteCommandMeta(
+    deleteCmd: DeleteCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends RunnableCommandMeta[DeleteCommand](deleteCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+        s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+      Map.empty, SparkSession.active)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuDeleteCommand(
+      new GpuDeltaLog(deleteCmd.deltaLog, conf),
+      deleteCmd.target,
+      deleteCmd.condition)
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta22x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.MergeIntoCommand
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta22xProvider extends DeltaIOProvider {
@@ -27,6 +27,10 @@ object Delta22xProvider extends DeltaIOProvider {
   override def getRunnableCommandRules: Map[Class[_ <: RunnableCommand],
       RunnableCommandRule[_ <: RunnableCommand]] = {
     Seq(
+      GpuOverrides.runnableCmd[DeleteCommand](
+        "Delete rows from a Delta Lake table",
+        (a, conf, p, r) => new DeleteCommandMeta(a, conf, p, r))
+        .disabledByDefault("Delta Lake delete support is experimental"),
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuDeleteCommand.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuDeleteCommand.scala
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeleteCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta22x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, DeltaUDF, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeleteCommandMetrics, DeleteMetric, DeltaCommand}
+import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
+import org.apache.spark.sql.delta.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.types.LongType
+
+/**
+ * GPU version of Delta Lake DeleteCommand.
+ *
+ * Performs a Delete based on the search condition
+ *
+ * Algorithm:
+ *   1) Scan all the files and determine which files have
+ *      the rows that need to be deleted.
+ *   2) Traverse the affected files and rebuild the touched files.
+ *   3) Use the Delta protocol to atomically write the remaining rows to new files and remove
+ *      the affected files that are identified in step 1.
+ */
+case class GpuDeleteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    target: LogicalPlan,
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand with DeleteCommandMetrics {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  override val output: Seq[Attribute] = Seq(AttributeReference("num_affected_rows", LongType)())
+
+  override lazy val metrics = createMetrics
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = gpuDeltaLog.deltaLog
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.dml.delete") {
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        val deleteActions = performDelete(sparkSession, deltaLog, txn)
+        if (deleteActions.nonEmpty) {
+          txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+
+    // Adjust for deletes at partition boundaries. Deletes at partition boundaries is a metadata
+    // operation, therefore we don't actually have any information around how many rows were deleted
+    // While this info may exist in the file statistics, it's not guaranteed that we have these
+    // statistics. To avoid any performance regressions, we currently just return a -1 in such cases
+    if (metrics("numRemovedFiles").value > 0 && metrics("numDeletedRows").value == 0) {
+      Seq(Row(-1L))
+    } else {
+      Seq(Row(metrics("numDeletedRows").value))
+    }
+  }
+
+  def performDelete(
+      sparkSession: SparkSession,
+      deltaLog: DeltaLog,
+      txn: OptimisticTransaction): Seq[Action] = {
+    import org.apache.spark.sql.delta.implicits._
+
+    var numRemovedFiles: Long = 0
+    var numAddedFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+    var numBytesAdded: Long = 0
+    var changeFileBytes: Long = 0
+    var numBytesRemoved: Long = 0
+    var numFilesBeforeSkipping: Long = 0
+    var numBytesBeforeSkipping: Long = 0
+    var numFilesAfterSkipping: Long = 0
+    var numBytesAfterSkipping: Long = 0
+    var numPartitionsAfterSkipping: Option[Long] = None
+    var numPartitionsRemovedFrom: Option[Long] = None
+    var numPartitionsAddedTo: Option[Long] = None
+    var numDeletedRows: Option[Long] = None
+    var numCopiedRows: Option[Long] = None
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val deleteActions: Seq[Action] = condition match {
+      case None =>
+        // Case 1: Delete the whole table if the condition is true
+        val reportRowLevelMetrics = conf.getConf(DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA)
+        val allFiles = txn.filterFiles(Nil, keepNumRecords = reportRowLevelMetrics)
+
+        numRemovedFiles = allFiles.size
+        scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        val (numBytes, numPartitions) = totalBytesAndDistinctPartitionValues(allFiles)
+        numBytesRemoved = numBytes
+        numFilesBeforeSkipping = numRemovedFiles
+        numBytesBeforeSkipping = numBytes
+        numFilesAfterSkipping = numRemovedFiles
+        numBytesAfterSkipping = numBytes
+        numDeletedRows = getDeletedRowsFromAddFilesAndUpdateMetrics(allFiles)
+
+        if (txn.metadata.partitionColumns.nonEmpty) {
+          numPartitionsAfterSkipping = Some(numPartitions)
+          numPartitionsRemovedFrom = Some(numPartitions)
+          numPartitionsAddedTo = Some(0)
+        }
+        val operationTimestamp = System.currentTimeMillis()
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      case Some(cond) =>
+        val (metadataPredicates, otherPredicates) =
+          DeltaTableUtils.splitMetadataAndDataPredicates(
+            cond, txn.metadata.partitionColumns, sparkSession)
+
+        numFilesBeforeSkipping = txn.snapshot.numOfFiles
+        numBytesBeforeSkipping = txn.snapshot.sizeInBytes
+
+        if (otherPredicates.isEmpty) {
+          // Case 2: The condition can be evaluated using metadata only.
+          //         Delete a set of files without the need of scanning any data files.
+          val operationTimestamp = System.currentTimeMillis()
+          val reportRowLevelMetrics = conf.getConf(DeltaSQLConf.DELTA_DML_METRICS_FROM_METADATA)
+          val candidateFiles =
+            txn.filterFiles(metadataPredicates, keepNumRecords = reportRowLevelMetrics)
+
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          numRemovedFiles = candidateFiles.size
+          numBytesRemoved = candidateFiles.map(_.size).sum
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          numDeletedRows = getDeletedRowsFromAddFilesAndUpdateMetrics(candidateFiles)
+
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+            numPartitionsRemovedFrom = Some(numCandidatePartitions)
+            numPartitionsAddedTo = Some(0)
+          }
+          candidateFiles.map(_.removeWithTimestamp(operationTimestamp))
+        } else {
+          // Case 3: Delete the rows based on the condition.
+          val candidateFiles = txn.filterFiles(metadataPredicates ++ otherPredicates)
+
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+          }
+
+          val nameToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+          val fileIndex = new TahoeBatchFileIndex(
+            sparkSession, "delete", candidateFiles, deltaLog, deltaLog.dataPath, txn.snapshot)
+          // Keep everything from the resolved target except a new TahoeFileIndex
+          // that only involves the affected files instead of all files.
+          val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+          val data = Dataset.ofRows(sparkSession, newTarget)
+          val deletedRowCount = metrics("numDeletedRows")
+          val deletedRowUdf = DeltaUDF.boolean {
+            new GpuDeltaMetricUpdateUDF(deletedRowCount)
+          }.asNondeterministic()
+          val filesToRewrite =
+            withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
+              if (candidateFiles.isEmpty) {
+                Array.empty[String]
+              } else {
+                data.filter(new Column(cond))
+                    .select(input_file_name())
+                    .filter(deletedRowUdf())
+                    .distinct()
+                    .as[String]
+                    .collect()
+              }
+            }
+
+          numRemovedFiles = filesToRewrite.length
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          if (filesToRewrite.isEmpty) {
+            // Case 3.1: no row matches and no delete will be triggered
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(0)
+              numPartitionsAddedTo = Some(0)
+            }
+            Nil
+          } else {
+            // Case 3.2: some files need an update to remove the deleted files
+            // Do the second pass and just read the affected files
+            val baseRelation = buildBaseRelation(
+              sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
+            // Keep everything from the resolved target except a new TahoeFileIndex
+            // that only involves the affected files instead of all files.
+            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val targetDF = Dataset.ofRows(sparkSession, newTarget)
+            val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+            val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
+            val (changeFiles, rewrittenFiles) = rewrittenActions
+                .partition(_.isInstanceOf[AddCDCFile])
+            numAddedFiles = rewrittenFiles.size
+            val removedFiles = filesToRewrite.map(f =>
+              getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
+            val (removedBytes, removedPartitions) =
+              totalBytesAndDistinctPartitionValues(removedFiles)
+            numBytesRemoved = removedBytes
+            val (rewrittenBytes, rewrittenPartitions) =
+              totalBytesAndDistinctPartitionValues(rewrittenFiles)
+            numBytesAdded = rewrittenBytes
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(removedPartitions)
+              numPartitionsAddedTo = Some(rewrittenPartitions)
+            }
+            numAddedChangeFiles = changeFiles.size
+            changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+            rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+            numDeletedRows = Some(metrics("numDeletedRows").value)
+            numCopiedRows = Some(metrics("numTouchedRows").value - metrics("numDeletedRows").value)
+
+            val operationTimestamp = System.currentTimeMillis()
+            removeFilesFromPaths(deltaLog, nameToAddFileMap, filesToRewrite, operationTimestamp) ++
+                rewrittenActions
+          }
+        }
+    }
+    metrics("numRemovedFiles").set(numRemovedFiles)
+    metrics("numAddedFiles").set(numAddedFiles)
+    val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+    metrics("executionTimeMs").set(executionTimeMs)
+    metrics("scanTimeMs").set(scanTimeMs)
+    metrics("rewriteTimeMs").set(rewriteTimeMs)
+    metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+    metrics("changeFileBytes").set(changeFileBytes)
+    metrics("numBytesAdded").set(numBytesAdded)
+    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
+    metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
+    metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
+    metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
+    numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
+    numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
+    numCopiedRows.foreach(metrics("numCopiedRows").set)
+    txn.registerSQLMetrics(sparkSession, metrics)
+    // This is needed to make the SQL metrics visible in the Spark UI
+    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.delete.stats",
+      data = DeleteMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numFilesAfterSkipping,
+        numAddedFiles,
+        numRemovedFiles,
+        numAddedFiles,
+        numAddedChangeFiles = numAddedChangeFiles,
+        numFilesBeforeSkipping,
+        numBytesBeforeSkipping,
+        numFilesAfterSkipping,
+        numBytesAfterSkipping,
+        numPartitionsAfterSkipping,
+        numPartitionsAddedTo,
+        numPartitionsRemovedFrom,
+        numCopiedRows,
+        numDeletedRows,
+        numBytesAdded,
+        numBytesRemoved,
+        changeFileBytes = changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+
+    deleteActions
+  }
+
+  /**
+   * Returns the list of `AddFile`s and `AddCDCFile`s that have been re-written.
+   */
+  private def rewriteFiles(
+      txn: OptimisticTransaction,
+      baseData: DataFrame,
+      filterCondition: Expression,
+      numFilesToRewrite: Long): Seq[FileAction] = {
+    val shouldWriteCdc = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+
+    // number of total rows that we have seen / are either copying or deleting (sum of both).
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = DeltaUDF.boolean {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    withStatusCode(
+      "DELTA", rewritingFilesMsg(numFilesToRewrite)) {
+      val dfToWrite = if (shouldWriteCdc) {
+        import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+        // The logic here ends up being surprisingly elegant, with all source rows ending up in
+        // the output. Recall that we flipped the user-provided delete condition earlier, before the
+        // call to `rewriteFiles`. All rows which match this latest `filterCondition` are retained
+        // as table data, while all rows which don't match are removed from the rewritten table data
+        // but do get included in the output as CDC events.
+        baseData
+            .filter(numTouchedRowsUdf())
+            .withColumn(
+              CDC_TYPE_COLUMN_NAME,
+              new Column(If(filterCondition, CDC_TYPE_NOT_CDC, CDC_TYPE_DELETE))
+            )
+      } else {
+        baseData
+            .filter(numTouchedRowsUdf())
+            .filter(new Column(filterCondition))
+      }
+
+      txn.writeFiles(dfToWrite)
+    }
+  }
+}

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeleteCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import com.databricks.sql.transaction.tahoe.actions.{Action, AddCDCFile, FileAction}
+import com.databricks.sql.transaction.tahoe.commands.{DeleteMetric, DeltaCommand}
+import com.databricks.sql.transaction.tahoe.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import com.databricks.sql.transaction.tahoe.files.TahoeBatchFileIndex
+import com.databricks.sql.transaction.tahoe.rapids.GpuDeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.{input_file_name, lit, typedLit, udf}
+import org.apache.spark.sql.types.LongType
+
+trait DeleteCommandMetrics { self: LeafRunnableCommand =>
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  def createMetrics: Map[String, SQLMetric] = Map[String, SQLMetric](
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numDeletedRows" -> createMetric(sc, "number of rows deleted."),
+    "numFilesBeforeSkipping" -> createMetric(sc, "number of files before skipping"),
+    "numBytesBeforeSkipping" -> createMetric(sc, "number of bytes before skipping"),
+    "numFilesAfterSkipping" -> createMetric(sc, "number of files after skipping"),
+    "numBytesAfterSkipping" -> createMetric(sc, "number of bytes after skipping"),
+    "numPartitionsAfterSkipping" -> createMetric(sc, "number of partitions after skipping"),
+    "numPartitionsAddedTo" -> createMetric(sc, "number of partitions added"),
+    "numPartitionsRemovedFrom" -> createMetric(sc, "number of partitions removed"),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied"),
+    "numBytesAdded" -> createMetric(sc, "number of bytes added"),
+    "numBytesRemoved" -> createMetric(sc, "number of bytes removed"),
+    "executionTimeMs" ->
+        createTimingMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" ->
+        createTimingMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" ->
+        createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched")
+  )
+}
+
+/**
+ * GPU version of Delta Lake DeleteCommand.
+ *
+ * Performs a Delete based on the search condition
+ *
+ * Algorithm:
+ *   1) Scan all the files and determine which files have
+ *      the rows that need to be deleted.
+ *   2) Traverse the affected files and rebuild the touched files.
+ *   3) Use the Delta protocol to atomically write the remaining rows to new files and remove
+ *      the affected files that are identified in step 1.
+ */
+case class GpuDeleteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    target: LogicalPlan,
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand with DeleteCommandMetrics {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  override val output: Seq[Attribute] = Seq(AttributeReference("num_affected_rows", LongType)())
+
+  override lazy val metrics = createMetrics
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = gpuDeltaLog.deltaLog
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.dml.delete") {
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        val deleteActions = performDelete(sparkSession, deltaLog, txn)
+        if (deleteActions.nonEmpty) {
+          txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+
+    // Adjust for deletes at partition boundaries. Deletes at partition boundaries is a metadata
+    // operation, therefore we don't actually have any information around how many rows were deleted
+    // While this info may exist in the file statistics, it's not guaranteed that we have these
+    // statistics. To avoid any performance regressions, we currently just return a -1 in such cases
+    if (metrics("numRemovedFiles").value > 0 && metrics("numDeletedRows").value == 0) {
+      Seq(Row(-1L))
+    } else {
+      Seq(Row(metrics("numDeletedRows").value))
+    }
+  }
+
+  def performDelete(
+      sparkSession: SparkSession,
+      deltaLog: DeltaLog,
+      txn: OptimisticTransaction): Seq[Action] = {
+    import sparkSession.implicits._
+
+    var numRemovedFiles: Long = 0
+    var numAddedFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+    var numBytesAdded: Long = 0
+    var changeFileBytes: Long = 0
+    var numBytesRemoved: Long = 0
+    var numFilesBeforeSkipping: Long = 0
+    var numBytesBeforeSkipping: Long = 0
+    var numFilesAfterSkipping: Long = 0
+    var numBytesAfterSkipping: Long = 0
+    var numPartitionsAfterSkipping: Option[Long] = None
+    var numPartitionsRemovedFrom: Option[Long] = None
+    var numPartitionsAddedTo: Option[Long] = None
+    var numDeletedRows: Option[Long] = None
+    var numCopiedRows: Option[Long] = None
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val deleteActions: Seq[Action] = condition match {
+      case None =>
+        // Case 1: Delete the whole table if the condition is true
+        val allFiles = txn.filterFiles(Nil)
+
+        numRemovedFiles = allFiles.size
+        scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        val (numBytes, numPartitions) = totalBytesAndDistinctPartitionValues(allFiles)
+        numBytesRemoved = numBytes
+        numFilesBeforeSkipping = numRemovedFiles
+        numBytesBeforeSkipping = numBytes
+        numFilesAfterSkipping = numRemovedFiles
+        numBytesAfterSkipping = numBytes
+        if (txn.metadata.partitionColumns.nonEmpty) {
+          numPartitionsAfterSkipping = Some(numPartitions)
+          numPartitionsRemovedFrom = Some(numPartitions)
+          numPartitionsAddedTo = Some(0)
+        }
+        val operationTimestamp = System.currentTimeMillis()
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      case Some(cond) =>
+        val (metadataPredicates, otherPredicates) =
+          DeltaTableUtils.splitMetadataAndDataPredicates(
+            cond, txn.metadata.partitionColumns, sparkSession)
+
+        numFilesBeforeSkipping = txn.snapshot.numOfFiles
+        numBytesBeforeSkipping = txn.snapshot.sizeInBytes
+
+        if (otherPredicates.isEmpty) {
+          // Case 2: The condition can be evaluated using metadata only.
+          //         Delete a set of files without the need of scanning any data files.
+          val operationTimestamp = System.currentTimeMillis()
+          val candidateFiles = txn.filterFiles(metadataPredicates)
+
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          numRemovedFiles = candidateFiles.size
+          numBytesRemoved = candidateFiles.map(_.size).sum
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+            numPartitionsRemovedFrom = Some(numCandidatePartitions)
+            numPartitionsAddedTo = Some(0)
+          }
+          candidateFiles.map(_.removeWithTimestamp(operationTimestamp))
+        } else {
+          // Case 3: Delete the rows based on the condition.
+          val candidateFiles = txn.filterFiles(metadataPredicates ++ otherPredicates)
+
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+          }
+
+          val nameToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+          val fileIndex = new TahoeBatchFileIndex(
+            sparkSession, "delete", candidateFiles, deltaLog, deltaLog.dataPath, txn.snapshot)
+          // Keep everything from the resolved target except a new TahoeFileIndex
+          // that only involves the affected files instead of all files.
+          val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+          val data = Dataset.ofRows(sparkSession, newTarget)
+          val deletedRowCount = metrics("numDeletedRows")
+          val deletedRowUdf = udf {
+            new GpuDeltaMetricUpdateUDF(deletedRowCount)
+          }.asNondeterministic()
+          val filesToRewrite =
+            withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
+              if (candidateFiles.isEmpty) {
+                Array.empty[String]
+              } else {
+                data.filter(new Column(cond))
+                    .select(input_file_name())
+                    .filter(deletedRowUdf())
+                    .distinct()
+                    .as[String]
+                    .collect()
+              }
+            }
+
+          numRemovedFiles = filesToRewrite.length
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          if (filesToRewrite.isEmpty) {
+            // Case 3.1: no row matches and no delete will be triggered
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(0)
+              numPartitionsAddedTo = Some(0)
+            }
+            Nil
+          } else {
+            // Case 3.2: some files need an update to remove the deleted files
+            // Do the second pass and just read the affected files
+            val baseRelation = buildBaseRelation(
+              sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
+            // Keep everything from the resolved target except a new TahoeFileIndex
+            // that only involves the affected files instead of all files.
+            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val targetDF = Dataset.ofRows(sparkSession, newTarget)
+            val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+            val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
+            val (changeFiles, rewrittenFiles) = rewrittenActions
+                .partition(_.isInstanceOf[AddCDCFile])
+            numAddedFiles = rewrittenFiles.size
+            val removedFiles = filesToRewrite.map(f =>
+              getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
+            val (removedBytes, removedPartitions) =
+              totalBytesAndDistinctPartitionValues(removedFiles)
+            numBytesRemoved = removedBytes
+            val (rewrittenBytes, rewrittenPartitions) =
+              totalBytesAndDistinctPartitionValues(rewrittenFiles)
+            numBytesAdded = rewrittenBytes
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(removedPartitions)
+              numPartitionsAddedTo = Some(rewrittenPartitions)
+            }
+            numAddedChangeFiles = changeFiles.size
+            changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+            rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+            numDeletedRows = Some(metrics("numDeletedRows").value)
+            numCopiedRows = Some(metrics("numTouchedRows").value - metrics("numDeletedRows").value)
+
+            val operationTimestamp = System.currentTimeMillis()
+            removeFilesFromPaths(deltaLog, nameToAddFileMap, filesToRewrite, operationTimestamp) ++
+                rewrittenActions
+          }
+        }
+    }
+    metrics("numRemovedFiles").set(numRemovedFiles)
+    metrics("numAddedFiles").set(numAddedFiles)
+    val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+    metrics("executionTimeMs").set(executionTimeMs)
+    metrics("scanTimeMs").set(scanTimeMs)
+    metrics("rewriteTimeMs").set(rewriteTimeMs)
+    metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+    metrics("changeFileBytes").set(changeFileBytes)
+    metrics("numBytesAdded").set(numBytesAdded)
+    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
+    metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
+    metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
+    metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
+    numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
+    numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
+    numCopiedRows.foreach(metrics("numCopiedRows").set)
+    txn.registerSQLMetrics(sparkSession, metrics)
+    // This is needed to make the SQL metrics visible in the Spark UI
+    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.delete.stats",
+      data = DeleteMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numFilesAfterSkipping,
+        numAddedFiles,
+        numRemovedFiles,
+        numAddedFiles,
+        numAddedChangeFiles = numAddedChangeFiles,
+        numFilesBeforeSkipping,
+        numBytesBeforeSkipping,
+        numFilesAfterSkipping,
+        numBytesAfterSkipping,
+        numPartitionsAfterSkipping,
+        numPartitionsAddedTo,
+        numPartitionsRemovedFrom,
+        numCopiedRows,
+        numDeletedRows,
+        numBytesAdded,
+        numBytesRemoved,
+        changeFileBytes = changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+
+    deleteActions
+  }
+
+  /**
+   * Returns the list of `AddFile`s and `AddCDCFile`s that have been re-written.
+   */
+  private def rewriteFiles(
+      txn: OptimisticTransaction,
+      baseData: DataFrame,
+      filterCondition: Expression,
+      numFilesToRewrite: Long): Seq[FileAction] = {
+    val shouldWriteCdc = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+
+    // number of total rows that we have seen / are either copying or deleting (sum of both).
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    withStatusCode(
+      "DELTA", rewritingFilesMsg(numFilesToRewrite)) {
+      val dfToWrite = if (shouldWriteCdc) {
+        import com.databricks.sql.transaction.tahoe.commands.cdc.CDCReader._
+        // The logic here ends up being surprisingly elegant, with all source rows ending up in
+        // the output. Recall that we flipped the user-provided delete condition earlier, before the
+        // call to `rewriteFiles`. All rows which match this latest `filterCondition` are retained
+        // as table data, while all rows which don't match are removed from the rewritten table data
+        // but do get included in the output as CDC events.
+        baseData
+            .filter(numTouchedRowsUdf())
+            .withColumn(
+              CDC_TYPE_COLUMN_NAME,
+              new Column(
+                If(filterCondition, typedLit[String](CDC_TYPE_NOT_CDC).expr,
+                  lit(CDC_TYPE_DELETE).expr)
+              )
+            )
+      } else {
+        baseData
+            .filter(numTouchedRowsUdf())
+            .filter(new Column(filterCondition))
+      }
+
+      txn.writeFiles(dfToWrite)
+    }
+  }
+}
+
+object GpuDeleteCommand {
+  val FINDING_TOUCHED_FILES_MSG: String = "Finding files to rewrite for DELETE operation"
+
+  def rewritingFilesMsg(numFilesToRewrite: Long): String =
+    s"Rewriting $numFilesToRewrite files for DELETE operation"
+}

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeleteCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, DeltaUDF, OptimisticTransaction}
+import com.databricks.sql.transaction.tahoe.actions.{Action, AddCDCFile, FileAction}
+import com.databricks.sql.transaction.tahoe.commands.{DeleteCommandMetrics, DeleteMetric, DeltaCommand}
+import com.databricks.sql.transaction.tahoe.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import com.databricks.sql.transaction.tahoe.files.TahoeBatchFileIndex
+import com.databricks.sql.transaction.tahoe.rapids.GpuDeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.types.LongType
+
+/**
+ * GPU version of Delta Lake DeleteCommand.
+ *
+ * Performs a Delete based on the search condition
+ *
+ * Algorithm:
+ *   1) Scan all the files and determine which files have
+ *      the rows that need to be deleted.
+ *   2) Traverse the affected files and rebuild the touched files.
+ *   3) Use the Delta protocol to atomically write the remaining rows to new files and remove
+ *      the affected files that are identified in step 1.
+ */
+case class GpuDeleteCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    target: LogicalPlan,
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand with DeleteCommandMetrics {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  override val output: Seq[Attribute] = Seq(AttributeReference("num_affected_rows", LongType)())
+
+  override lazy val metrics = createMetrics
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = gpuDeltaLog.deltaLog
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.dml.delete") {
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        val deleteActions = performDelete(sparkSession, deltaLog, txn)
+        if (deleteActions.nonEmpty) {
+          txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+
+    // Adjust for deletes at partition boundaries. Deletes at partition boundaries is a metadata
+    // operation, therefore we don't actually have any information around how many rows were deleted
+    // While this info may exist in the file statistics, it's not guaranteed that we have these
+    // statistics. To avoid any performance regressions, we currently just return a -1 in such cases
+    if (metrics("numRemovedFiles").value > 0 && metrics("numDeletedRows").value == 0) {
+      Seq(Row(-1L))
+    } else {
+      Seq(Row(metrics("numDeletedRows").value))
+    }
+  }
+
+  def performDelete(
+      sparkSession: SparkSession,
+      deltaLog: DeltaLog,
+      txn: OptimisticTransaction): Seq[Action] = {
+    import com.databricks.sql.transaction.tahoe.implicits._
+
+    var numRemovedFiles: Long = 0
+    var numAddedFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+    var numBytesAdded: Long = 0
+    var changeFileBytes: Long = 0
+    var numBytesRemoved: Long = 0
+    var numFilesBeforeSkipping: Long = 0
+    var numBytesBeforeSkipping: Long = 0
+    var numFilesAfterSkipping: Long = 0
+    var numBytesAfterSkipping: Long = 0
+    var numPartitionsAfterSkipping: Option[Long] = None
+    var numPartitionsRemovedFrom: Option[Long] = None
+    var numPartitionsAddedTo: Option[Long] = None
+    var numDeletedRows: Option[Long] = None
+    var numCopiedRows: Option[Long] = None
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val deleteActions: Seq[Action] = condition match {
+      case None =>
+        // Case 1: Delete the whole table if the condition is true
+        val allFiles = txn.filterFiles(Nil)
+
+        numRemovedFiles = allFiles.size
+        scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+        val (numBytes, numPartitions) = totalBytesAndDistinctPartitionValues(allFiles)
+        numBytesRemoved = numBytes
+        numFilesBeforeSkipping = numRemovedFiles
+        numBytesBeforeSkipping = numBytes
+        numFilesAfterSkipping = numRemovedFiles
+        numBytesAfterSkipping = numBytes
+        if (txn.metadata.partitionColumns.nonEmpty) {
+          numPartitionsAfterSkipping = Some(numPartitions)
+          numPartitionsRemovedFrom = Some(numPartitions)
+          numPartitionsAddedTo = Some(0)
+        }
+        val operationTimestamp = System.currentTimeMillis()
+        allFiles.map(_.removeWithTimestamp(operationTimestamp))
+      case Some(cond) =>
+        val (metadataPredicates, otherPredicates) =
+          DeltaTableUtils.splitMetadataAndDataPredicates(
+            cond, txn.metadata.partitionColumns, sparkSession)
+
+        numFilesBeforeSkipping = txn.snapshot.numOfFiles
+        numBytesBeforeSkipping = txn.snapshot.sizeInBytes
+
+        if (otherPredicates.isEmpty) {
+          // Case 2: The condition can be evaluated using metadata only.
+          //         Delete a set of files without the need of scanning any data files.
+          val operationTimestamp = System.currentTimeMillis()
+          val candidateFiles = txn.filterFiles(metadataPredicates)
+
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          numRemovedFiles = candidateFiles.size
+          numBytesRemoved = candidateFiles.map(_.size).sum
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+            numPartitionsRemovedFrom = Some(numCandidatePartitions)
+            numPartitionsAddedTo = Some(0)
+          }
+          candidateFiles.map(_.removeWithTimestamp(operationTimestamp))
+        } else {
+          // Case 3: Delete the rows based on the condition.
+          val candidateFiles = txn.filterFiles(metadataPredicates ++ otherPredicates)
+
+          numFilesAfterSkipping = candidateFiles.size
+          val (numCandidateBytes, numCandidatePartitions) =
+            totalBytesAndDistinctPartitionValues(candidateFiles)
+          numBytesAfterSkipping = numCandidateBytes
+          if (txn.metadata.partitionColumns.nonEmpty) {
+            numPartitionsAfterSkipping = Some(numCandidatePartitions)
+          }
+
+          val nameToAddFileMap = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+          val fileIndex = new TahoeBatchFileIndex(
+            sparkSession, "delete", candidateFiles, deltaLog, deltaLog.dataPath, txn.snapshot)
+          // Keep everything from the resolved target except a new TahoeFileIndex
+          // that only involves the affected files instead of all files.
+          val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+          val data = Dataset.ofRows(sparkSession, newTarget)
+          val deletedRowCount = metrics("numDeletedRows")
+          val deletedRowUdf = DeltaUDF.boolean {
+            new GpuDeltaMetricUpdateUDF(deletedRowCount)
+          }.asNondeterministic()
+          val filesToRewrite =
+            withStatusCode("DELTA", FINDING_TOUCHED_FILES_MSG) {
+              if (candidateFiles.isEmpty) {
+                Array.empty[String]
+              } else {
+                data.filter(new Column(cond))
+                    .select(input_file_name())
+                    .filter(deletedRowUdf())
+                    .distinct()
+                    .as[String]
+                    .collect()
+              }
+            }
+
+          numRemovedFiles = filesToRewrite.length
+          scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+          if (filesToRewrite.isEmpty) {
+            // Case 3.1: no row matches and no delete will be triggered
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(0)
+              numPartitionsAddedTo = Some(0)
+            }
+            Nil
+          } else {
+            // Case 3.2: some files need an update to remove the deleted files
+            // Do the second pass and just read the affected files
+            val baseRelation = buildBaseRelation(
+              sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
+            // Keep everything from the resolved target except a new TahoeFileIndex
+            // that only involves the affected files instead of all files.
+            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val targetDF = Dataset.ofRows(sparkSession, newTarget)
+            val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+            val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)
+            val (changeFiles, rewrittenFiles) = rewrittenActions
+                .partition(_.isInstanceOf[AddCDCFile])
+            numAddedFiles = rewrittenFiles.size
+            val removedFiles = filesToRewrite.map(f =>
+              getTouchedFile(deltaLog.dataPath, f, nameToAddFileMap))
+            val (removedBytes, removedPartitions) =
+              totalBytesAndDistinctPartitionValues(removedFiles)
+            numBytesRemoved = removedBytes
+            val (rewrittenBytes, rewrittenPartitions) =
+              totalBytesAndDistinctPartitionValues(rewrittenFiles)
+            numBytesAdded = rewrittenBytes
+            if (txn.metadata.partitionColumns.nonEmpty) {
+              numPartitionsRemovedFrom = Some(removedPartitions)
+              numPartitionsAddedTo = Some(rewrittenPartitions)
+            }
+            numAddedChangeFiles = changeFiles.size
+            changeFileBytes = changeFiles.collect { case f: AddCDCFile => f.size }.sum
+            rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+            numDeletedRows = Some(metrics("numDeletedRows").value)
+            numCopiedRows = Some(metrics("numTouchedRows").value - metrics("numDeletedRows").value)
+
+            val operationTimestamp = System.currentTimeMillis()
+            removeFilesFromPaths(deltaLog, nameToAddFileMap, filesToRewrite, operationTimestamp) ++
+                rewrittenActions
+          }
+        }
+    }
+    metrics("numRemovedFiles").set(numRemovedFiles)
+    metrics("numAddedFiles").set(numAddedFiles)
+    val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+    metrics("executionTimeMs").set(executionTimeMs)
+    metrics("scanTimeMs").set(scanTimeMs)
+    metrics("rewriteTimeMs").set(rewriteTimeMs)
+    metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+    metrics("changeFileBytes").set(changeFileBytes)
+    metrics("numBytesAdded").set(numBytesAdded)
+    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
+    metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
+    metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
+    metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
+    numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
+    numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
+    numCopiedRows.foreach(metrics("numCopiedRows").set)
+    txn.registerSQLMetrics(sparkSession, metrics)
+    // This is needed to make the SQL metrics visible in the Spark UI
+    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.delete.stats",
+      data = DeleteMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numFilesAfterSkipping,
+        numAddedFiles,
+        numRemovedFiles,
+        numAddedFiles,
+        numAddedChangeFiles = numAddedChangeFiles,
+        numFilesBeforeSkipping,
+        numBytesBeforeSkipping,
+        numFilesAfterSkipping,
+        numBytesAfterSkipping,
+        numPartitionsAfterSkipping,
+        numPartitionsAddedTo,
+        numPartitionsRemovedFrom,
+        numCopiedRows,
+        numDeletedRows,
+        numBytesAdded,
+        numBytesRemoved,
+        changeFileBytes = changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+
+    deleteActions
+  }
+
+  /**
+   * Returns the list of `AddFile`s and `AddCDCFile`s that have been re-written.
+   */
+  private def rewriteFiles(
+      txn: OptimisticTransaction,
+      baseData: DataFrame,
+      filterCondition: Expression,
+      numFilesToRewrite: Long): Seq[FileAction] = {
+    val shouldWriteCdc = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+
+    // number of total rows that we have seen / are either copying or deleting (sum of both).
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = DeltaUDF.boolean {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    withStatusCode(
+      "DELTA", rewritingFilesMsg(numFilesToRewrite)) {
+      val dfToWrite = if (shouldWriteCdc) {
+        import com.databricks.sql.transaction.tahoe.commands.cdc.CDCReader._
+        // The logic here ends up being surprisingly elegant, with all source rows ending up in
+        // the output. Recall that we flipped the user-provided delete condition earlier, before the
+        // call to `rewriteFiles`. All rows which match this latest `filterCondition` are retained
+        // as table data, while all rows which don't match are removed from the rewritten table data
+        // but do get included in the output as CDC events.
+        baseData
+            .filter(numTouchedRowsUdf())
+            .withColumn(
+              CDC_TYPE_COLUMN_NAME,
+              new Column(If(filterCondition, CDC_TYPE_NOT_CDC, CDC_TYPE_DELETE))
+            )
+      } else {
+        baseData
+            .filter(numTouchedRowsUdf())
+            .filter(new Column(filterCondition))
+      }
+
+      txn.writeFiles(dfToWrite)
+    }
+  }
+}
+
+object GpuDeleteCommand {
+  val FINDING_TOUCHED_FILES_MSG: String = "Finding files to rewrite for DELETE operation"
+
+  def rewritingFilesMsg(numFilesToRewrite: Long): String =
+    s"Rewriting $numFilesToRewrite files for DELETE operation"
+}

--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -88,3 +88,12 @@ A side-effect of performing GPU accelerated Delta Lake merge operations is a new
 in the query plan, RapidsProcessDeltaMergeJoin. Normally the Delta Lake merge is performed via
 a join and then post-processing of the join via a MapPartitions node. Instead the GPU performs
 the join post-processing via this new RapidsProcessDeltaMergeJoin node.
+
+## Delete Operations on Delta Lake Tables
+
+Delta Lake delete acceleration is experimental and is disabled by default. To enable acceleration
+of Delta Lake delete operations, set spark.rapids.sql.command.DeleteCommand=true and also set
+spark.rapids.sql.command.DeleteCommandEdge=true on Databricks platforms.
+
+Deleting data from Delta Lake tables via the SQL `DELETE FROM` statement or via the DeltaTable
+`delete` API is supported.

--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_equal, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write
+from data_gen import *
+from delta_lake_write_test import assert_gpu_and_cpu_delta_logs_equivalent, delta_meta_allow, delta_writes_enabled_conf
+from delta_lake_merge_test import read_delta_path, read_delta_path_with_cdf, setup_dest_tables
+from marks import *
+from spark_session import is_before_spark_320, is_databricks_runtime, with_cpu_session, with_gpu_session
+
+delta_delete_enabled_conf = copy_and_update(delta_writes_enabled_conf,
+                                            {"spark.rapids.sql.command.DeleteCommand": "true",
+                                             "spark.rapids.sql.command.DeleteCommandEdge": "true"})
+
+def delta_sql_delete_test(spark_tmp_path, use_cdf, dest_table_func, delete_sql,
+                          check_func, partition_columns=None):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_dest_tables(spark, data_path, dest_table_func, use_cdf, partition_columns)
+    def do_delete(spark, path):
+        return spark.sql(delete_sql.format(path=path))
+    with_cpu_session(setup_tables)
+    check_func(data_path, do_delete)
+
+def assert_delta_sql_delete_collect(spark_tmp_path, use_cdf, dest_table_func, delete_sql,
+                                    partition_columns=None,
+                                    conf=delta_delete_enabled_conf):
+    def read_data(spark, path):
+        read_func = read_delta_path_with_cdf if use_cdf else read_delta_path
+        df = read_func(spark, path)
+        return df.sort(df.columns)
+    def checker(data_path, do_delete):
+        cpu_path = data_path + "/CPU"
+        gpu_path = data_path + "/GPU"
+        # compare resulting dataframe from the delete operation (some older Spark versions return empty here)
+        cpu_result = with_cpu_session(lambda spark: do_delete(spark, cpu_path).collect(), conf=conf)
+        gpu_result = with_gpu_session(lambda spark: do_delete(spark, gpu_path).collect(), conf=conf)
+        assert_equal(cpu_result, gpu_result)
+        # compare table data results, read both via CPU to make sure GPU write can be read by CPU
+        cpu_result = with_cpu_session(lambda spark: read_data(spark, cpu_path).collect(), conf=conf)
+        gpu_result = with_cpu_session(lambda spark: read_data(spark, gpu_path).collect(), conf=conf)
+        assert_equal(cpu_result, gpu_result)
+        with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
+    delta_sql_delete_test(spark_tmp_path, use_cdf, dest_table_func, delete_sql, checker,
+                          partition_columns)
+
+@allow_non_gpu("ExecutedCommandExec", *delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("disable_conf",
+                          [{"spark.rapids.sql.format.delta.write.enabled": "false"},
+                           {"spark.rapids.sql.format.parquet.enabled": "false"},
+                           {"spark.rapids.sql.format.parquet.write.enabled": "false"},
+                           {"spark.rapids.sql.command.DeleteCommand": "false"},
+                           delta_writes_enabled_conf  # Test disabled by default
+                           ], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_delete_disabled_fallback(spark_tmp_path, disable_conf):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_dest_tables(spark, data_path,
+                          dest_table_func=lambda spark: unary_op_df(spark, int_gen),
+                          use_cdf=False)
+    def write_func(spark, path):
+        delete_sql="DELETE FROM delta.`{}`".format(path)
+        spark.sql(delete_sql)
+    with_cpu_session(setup_tables)
+    assert_gpu_fallback_write(write_func, read_delta_path, data_path,
+                              "ExecutedCommandExec", disable_conf)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_delete_entire_table(spark_tmp_path, use_cdf, partition_columns):
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen)
+    delete_sql = "DELETE FROM delta.`{path}`"
+    assert_delta_sql_delete_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    delete_sql, partition_columns)
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [["a"], ["a", "b"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_delete_partitions(spark_tmp_path, use_cdf, partition_columns):
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen)
+    delete_sql = "DELETE FROM delta.`{path}` WHERE a = 3"
+    assert_delta_sql_delete_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    delete_sql, partition_columns)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_delete_rows(spark_tmp_path, use_cdf, partition_columns):
+    # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
+    num_slices_to_test = 1 if is_databricks_runtime() else 10
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen, num_slices=num_slices_to_test)
+    delete_sql = "DELETE FROM delta.`{path}` WHERE b < 'd'"
+    assert_delta_sql_delete_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    delete_sql, partition_columns)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_delete_dataframe_api(spark_tmp_path, use_cdf, partition_columns):
+    from delta.tables import DeltaTable
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
+    num_slices_to_test = 1 if is_databricks_runtime() else 10
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen, num_slices=num_slices_to_test)
+    with_cpu_session(lambda spark: setup_dest_tables(spark, data_path, generate_dest_data, use_cdf, partition_columns))
+    def do_delete(spark, path):
+        dest_table = DeltaTable.forPath(spark, path)
+        dest_table.delete("b > 'c'")
+    read_func = read_delta_path_with_cdf if use_cdf else read_delta_path
+    assert_gpu_and_cpu_writes_are_equal_collect(do_delete, read_func, data_path,
+                                                conf=delta_delete_enabled_conf)
+    with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -58,13 +58,15 @@ def fixup_operation_metrics(opm):
         opm.pop(k, None)
 
 TMP_TABLE_PATTERN=re.compile("tmp_table_\w+")
+TMP_TABLE_PATH_PATTERN=re.compile("delta.`[^`]*`")
 
 def fixup_operation_parameters(opp):
     """Update the specified operationParameters node to facilitate log comparisons"""
     for key in ("predicate", "matchedPredicates", "notMatchedPredicates"):
         pred = opp.get(key)
         if pred:
-            opp[key] = TMP_TABLE_PATTERN.sub("tmp_table", pred)
+            subbed = TMP_TABLE_PATTERN.sub("tmp_table", pred)
+            opp[key] = TMP_TABLE_PATH_PATTERN.sub("tmp_table", subbed)
 
 def assert_delta_log_json_equivalent(filename, c_json, g_json):
     assert c_json.keys() == g_json.keys(), "Delta log {} has mismatched keys:\nCPU: {}\nGPU: {}".format(filename, c_json, g_json)


### PR DESCRIPTION
Fixes #7281.

This adds support for deleting data from Delta Lake tables via the DeleteCommand physical plan node.  Code is derived from DeleteCommand.scala in the https://github.com/delta-io/delta project for the various versions we support, and adapted the same code for Databricks based on visible semantics of the behavior.

This implementation is relatively straightforward, mostly using the same logic as the CPU with the following changes:
- Creating a GpuOptimisticTransaction so the `writeFiles` call is leveraging a GPU columnar write rather than a CPU write.
- Leveraging equivalent RAPIDS accelerated UDFs for updating SQL metrics to avoid falling back to the CPU for the original CPU UDFs.