### PR TITLE
Revert "Skip/xfail some regexp tests (#7608)"

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -122,7 +122,6 @@ def test_split_re_no_limit():
             'split(a, "^[o]")'),
             conf=_regexp_conf)
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_optimized_no_re():
     data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|{}]{1,2}){1,7}') \
         .with_special_case('boo.and.foo') \
@@ -149,7 +148,6 @@ def test_split_optimized_no_re():
             'split(a, "\\\\$\\\\|")'),
             conf=_regexp_conf)
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_optimized_no_re_combined():
     data_gen = mk_str_gen('([bf]o{0,2}[AZ.?+\\^$|{}]{1,2}){1,7}') \
         .with_special_case('booA.ZandA.Zfoo') \
@@ -184,7 +182,6 @@ def test_split_unsupported_fallback():
         'split(a, "o*"),' +
         'split(a, "o?") from string_split_table')
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7607")
 def test_split_regexp_disabled_no_fallback():
     conf = { 'spark.rapids.sql.regexp.enabled': 'false' }
     data_gen = mk_str_gen('([bf]o{0,2}[.?+\\^$|&_]{1,2}){1,7}') \

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -681,7 +681,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split - optimized") {
-    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val patterns = Set("\\.", "\\$", "\\[", "\\(", "\\}", "\\+", "\\\\", ",", ";", "cd", "c\\|d",
         "\\%", "\\;", "\\/")
     val data = Seq("abc.def", "abc$def", "abc[def]", "abc(def)", "abc{def}", "abc+def", "abc\\def",
@@ -756,7 +755,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split fuzz") {
-    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val (data, patterns) = generateDataAndPatterns(Some(REGEXP_LIMITED_CHARS_REPLACE),
       REGEXP_LIMITED_CHARS_REPLACE, RegexSplitMode)
     for (limit <- Seq(-2, -1, 2, 5)) {
@@ -765,7 +763,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   }
 
   test("string split fuzz - anchor focused") {
-    assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7607")
     val (data, patterns) = generateDataAndPatterns(validDataChars = Some("\r\nabc"),
       validPatternChars = "^$\\AZz\r\n()", RegexSplitMode)
     doStringSplitTest(patterns, data, -1)


### PR DESCRIPTION
Fixes #7607

rapidsai/cudf#12639 has been merged so we can revert the xfail workarounds from #7608.
