### PR TITLE
Update UCX shuffle doc w/ memlock limit config [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -173,7 +173,7 @@ example, if two containers are trying to communicate and each have an isolated G
 these GPUs will not be optimal, forcing UCX to stage buffers to the host or use TCP.
 Additionally, if you want to use RoCE/Infiniband, the `/dev/infiniband` device should be exposed
 in the container. Also, to avoid potential `failed: Cannot allocate memory`,
-please specify `--ulimit memlock=-1` to make max locked memory as `unlimited` in container.
+please consider raising the `memlock` ulimit in the container via `--ulimit memlock=[maximum]`. Note that setting `--ulimit memlock=-1` disables the limit.
 
 If UCX will be used to communicate between containers, the IPC (`--ipc`) and
 PID namespaces (`--pid`) should also be shared.

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -172,7 +172,8 @@ want to take advantage of PCIe peer-to-peer or NVLink need to be visible within 
 example, if two containers are trying to communicate and each have an isolated GPU, the link between
 these GPUs will not be optimal, forcing UCX to stage buffers to the host or use TCP.
 Additionally, if you want to use RoCE/Infiniband, the `/dev/infiniband` device should be exposed
-in the container.
+in the container. Also, to avoid potential `failed: Cannot allocate memory`,
+please specify `--ulimit memlock=-1` to make max locked memory as `unlimited` in container.
 
 If UCX will be used to communicate between containers, the IPC (`--ipc`) and
 PID namespaces (`--pid`) should also be shared.


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

found in our regular doc verification CI. In RDMA test, the client side could fail intermittently,
```
ERROR mlx5_0: ibv_create_cq() failed: Cannot allocate memory.
```

set memlock to unlimited for container should resolve this issue