### PR TITLE
[auto-merge] branch-23.02 to branch-23.04 [skip ci] [bot]

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ jobs:
     name: Add new issues and pull requests to project
     runs-on: ubuntu-latest
     steps:
-      # TODO: update project version when new release supports node 16 instead of 12
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/NVIDIA/projects/4
           github-token: ${{ secrets.PROJECT_TOKEN }}
+


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-23.02` to create a PR keeping `branch-23.04` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.