### PR TITLE
Update UCX docs to call out Ubuntu 22.04 is not supported yet [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -50,6 +50,14 @@ pools is the number of cores in the system divided by the number of executors pe
 
 ## UCX Mode
 
+---
+**NOTE:**
+
+As of the spark-rapids 23.02 release, Ubuntu 22.04 UCX packages are not available. They
+will be available for future releases.
+
+---
+
 UCX mode (`spark.rapids.shuffle.mode=UCX`) has two components: a spillable cache, and a transport that can utilize 
 Remote Direct Memory Access (RDMA) and high-bandwidth transfers 
 within a node that has multiple GPUs. This is possible because this mode 


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This adds a `NOTE` to the UCX section of the rapids-shuffle docs to call out that Ubuntu 22.04 isn't supported as of spark-rapids 23.02, but will be in the future.
