### PR TITLE
Support Delta Lake UpdateCommand

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeltaProviderImpl.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeltaProviderImpl.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.delta
 
 import com.databricks.sql.transaction.tahoe.DeltaLog
-import com.databricks.sql.transaction.tahoe.commands.{DeleteCommand, DeleteCommandEdge, MergeIntoCommand, MergeIntoCommandEdge}
+import com.databricks.sql.transaction.tahoe.commands.{DeleteCommand, DeleteCommandEdge, MergeIntoCommand, MergeIntoCommandEdge, UpdateCommand, UpdateCommandEdge}
 import com.databricks.sql.transaction.tahoe.sources.DeltaDataSource
 import com.nvidia.spark.rapids._
 
@@ -61,7 +61,15 @@ object DeltaProviderImpl extends DeltaProviderImplBase {
       GpuOverrides.runnableCmd[MergeIntoCommandEdge](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandEdgeMeta(a, conf, p, r))
-          .disabledByDefault("Delta Lake merge support is experimental")
+          .disabledByDefault("Delta Lake merge support is experimental"),
+      GpuOverrides.runnableCmd[UpdateCommand](
+        "Update rows in a Delta Lake table",
+        (a, conf, p, r) => new UpdateCommandMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake update support is experimental"),
+      GpuOverrides.runnableCmd[UpdateCommandEdge](
+        "Update rows in a Delta Lake table",
+        (a, conf, p, r) => new UpdateCommandEdgeMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake update support is experimental")
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap
   }
 }

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import com.databricks.sql.transaction.tahoe.commands.{UpdateCommand, UpdateCommandEdge}
+import com.databricks.sql.transaction.tahoe.rapids.{GpuDeltaLog, GpuUpdateCommand}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class UpdateCommandMeta(
+    updateCmd: UpdateCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[UpdateCommand](updateCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
+      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuUpdateCommand(
+      new GpuDeltaLog(updateCmd.tahoeFileIndex.deltaLog, conf),
+      updateCmd.tahoeFileIndex,
+      updateCmd.target,
+      updateCmd.updateExpressions,
+      updateCmd.condition
+    )
+  }
+}
+
+class UpdateCommandEdgeMeta(
+    updateCmd: UpdateCommandEdge,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[UpdateCommandEdge](updateCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
+      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuUpdateCommand(
+      new GpuDeltaLog(updateCmd.tahoeFileIndex.deltaLog, conf),
+      updateCmd.tahoeFileIndex,
+      updateCmd.target,
+      updateCmd.updateExpressions,
+      updateCmd.condition
+    )
+  }
+}

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta20x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta20xProvider extends DeltaIOProvider {
@@ -34,7 +34,11 @@ object Delta20xProvider extends DeltaIOProvider {
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta Lake table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))
-          .disabledByDefault("Delta Lake merge support is experimental")
+          .disabledByDefault("Delta Lake merge support is experimental"),
+      GpuOverrides.runnableCmd[UpdateCommand](
+        "Update rows in a Delta Lake table",
+        (a, conf, p, r) => new UpdateCommandMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake update support is experimental")
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap
   }
 }

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/UpdateCommandMeta.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta20x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.delta.commands.UpdateCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta20x.GpuUpdateCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class UpdateCommandMeta(
+    updateCmd: UpdateCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[UpdateCommand](updateCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
+      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuUpdateCommand(
+      new GpuDeltaLog(updateCmd.tahoeFileIndex.deltaLog, conf),
+      updateCmd.tahoeFileIndex,
+      updateCmd.target,
+      updateCmd.updateExpressions,
+      updateCmd.condition
+    )
+  }
+}

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuUpdateCommand.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuUpdateCommand.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from UpdateCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta20x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeltaCommand, UpdateCommand, UpdateMetric}
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
+import org.apache.spark.sql.functions.{input_file_name, udf}
+
+case class GpuUpdateCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    tahoeFileIndex: TahoeFileIndex,
+    target: LogicalPlan,
+    updateExpressions: Seq[Expression],
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand {
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numUpdatedRows" -> createMetric(sc, "number of rows updated."),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied."),
+    "executionTimeMs" -> createMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" -> createMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" -> createMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched (copied + updated)")
+  )
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
+      val deltaLog = tahoeFileIndex.deltaLog
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        performUpdate(sparkSession, deltaLog, txn)
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+    Seq.empty[Row]
+  }
+
+  private def performUpdate(
+      sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
+    import sparkSession.implicits._
+
+    var numTouchedFiles: Long = 0
+    var numRewrittenFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var changeFileBytes: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = deltaLog.snapshot.numOfFiles
+
+    val updateCondition = condition.getOrElse(Literal.TrueLiteral)
+    val (metadataPredicates, dataPredicates) =
+      DeltaTableUtils.splitMetadataAndDataPredicates(
+        updateCondition, txn.metadata.partitionColumns, sparkSession)
+    val candidateFiles = txn.filterFiles(metadataPredicates ++ dataPredicates)
+    val nameToAddFile = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+    scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+    val filesToRewrite: Seq[AddFile] = if (candidateFiles.isEmpty) {
+      // Case 1: Do nothing if no row qualifies the partition predicates
+      // that are part of Update condition
+      Nil
+    } else if (dataPredicates.isEmpty) {
+      // Case 2: Update all the rows from the files that are in the specified partitions
+      // when the data filter is empty
+      candidateFiles
+    } else {
+      // Case 3: Find all the affected files using the user-specified condition
+      val fileIndex = new TahoeBatchFileIndex(
+        sparkSession, "update", candidateFiles, deltaLog, tahoeFileIndex.path, txn.snapshot)
+      // Keep everything from the resolved target except a new TahoeFileIndex
+      // that only involves the affected files instead of all files.
+      val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+      val data = Dataset.ofRows(sparkSession, newTarget)
+      val updatedRowCount = metrics("numUpdatedRows")
+      val updatedRowUdf = udf {
+        new GpuDeltaMetricUpdateUDF(updatedRowCount)
+      }.asNondeterministic()
+      val pathsToRewrite =
+        withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
+          data.filter(new Column(updateCondition))
+              .filter(updatedRowUdf())
+              .select(input_file_name())
+              .distinct()
+              .as[String]
+              .collect()
+        }
+
+      scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+      pathsToRewrite.map(getTouchedFile(deltaLog.dataPath, _, nameToAddFile)).toSeq
+    }
+
+    numTouchedFiles = filesToRewrite.length
+
+    val newActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Generate the new files containing the updated values
+      withStatusCode("DELTA", UpdateCommand.rewritingFilesMsg(filesToRewrite.size)) {
+        rewriteFiles(sparkSession, txn, tahoeFileIndex.path,
+          filesToRewrite.map(_.path), nameToAddFile, updateCondition)
+      }
+    }
+
+    rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+
+    val (changeActions, addActions) = newActions.partition(_.isInstanceOf[AddCDCFile])
+    numRewrittenFiles = addActions.size
+    numAddedChangeFiles = changeActions.size
+    changeFileBytes = changeActions.collect { case f: AddCDCFile => f.size }.sum
+
+    val totalActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Delete the old files and return those delete actions along with the new AddFile actions for
+      // files containing the updated values
+      val operationTimestamp = System.currentTimeMillis()
+      val deleteActions = filesToRewrite.map(_.removeWithTimestamp(operationTimestamp))
+
+      deleteActions ++ newActions
+    }
+
+    if (totalActions.nonEmpty) {
+      metrics("numAddedFiles").set(numRewrittenFiles)
+      metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+      metrics("changeFileBytes").set(changeFileBytes)
+      metrics("numRemovedFiles").set(numTouchedFiles)
+      metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
+      metrics("scanTimeMs").set(scanTimeMs)
+      metrics("rewriteTimeMs").set(rewriteTimeMs)
+      // In the case where the numUpdatedRows is not captured, we can siphon out the metrics from
+      // the BasicWriteStatsTracker. This is for case 2 where the update condition contains only
+      // metadata predicates and so the entire partition is re-written.
+      val outputRows = txn.getMetric("numOutputRows").map(_.value).getOrElse(-1L)
+      if (metrics("numUpdatedRows").value == 0 && outputRows != 0 &&
+          metrics("numCopiedRows").value == 0) {
+        // We know that numTouchedRows = numCopiedRows + numUpdatedRows.
+        // Since an entire partition was re-written, no rows were copied.
+        // So numTouchedRows == numUpdateRows
+        metrics("numUpdatedRows").set(metrics("numTouchedRows").value)
+      } else {
+        // This is for case 3 where the update condition contains both metadata and data predicates
+        // so relevant files will have some rows updated and some rows copied. We don't need to
+        // consider case 1 here, where no files match the update condition, as we know that
+        // `totalActions` is empty.
+        metrics("numCopiedRows").set(
+          metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
+      }
+      txn.registerSQLMetrics(sparkSession, metrics)
+      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
+      // This is needed to make the SQL metrics visible in the Spark UI
+      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+      SQLMetrics.postDriverMetricUpdates(
+        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    }
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.update.stats",
+      data = UpdateMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numTouchedFiles,
+        numRewrittenFiles,
+        numAddedChangeFiles,
+        changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+  }
+
+  /**
+   * Scan all the affected files and write out the updated files.
+   *
+   * When CDF is enabled, includes the generation of CDC preimage and postimage columns for
+   * changed rows.
+   *
+   * @return the list of [[AddFile]]s and [[AddCDCFile]]s that have been written.
+   */
+  private def rewriteFiles(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      rootPath: Path,
+      inputLeafFiles: Seq[String],
+      nameToAddFileMap: Map[String, AddFile],
+      condition: Expression): Seq[FileAction] = {
+    // Containing the map from the relative file path to AddFile
+    val baseRelation = buildBaseRelation(
+      spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val targetDf = Dataset.ofRows(spark, newTarget)
+
+    // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
+    // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    val updatedDataFrame = UpdateCommand.withUpdatedColumns(
+      target,
+      updateExpressions,
+      condition,
+      targetDf
+          .filter(numTouchedRowsUdf())
+          .withColumn(UpdateCommand.CONDITION_COLUMN_NAME, new Column(condition)),
+      UpdateCommand.shouldOutputCdc(txn))
+
+    txn.writeFiles(updatedDataFrame)
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta21x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta21xProvider extends DeltaIOProvider {
@@ -34,7 +34,11 @@ object Delta21xProvider extends DeltaIOProvider {
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))
-          .disabledByDefault("Delta Lake merge support is experimental")
+          .disabledByDefault("Delta Lake merge support is experimental"),
+      GpuOverrides.runnableCmd[UpdateCommand](
+        "Update rows in a Delta Lake table",
+        (a, conf, p, r) => new UpdateCommandMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake update support is experimental")
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap
   }
 }

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/UpdateCommandMeta.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta21x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.delta.commands.UpdateCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta21x.GpuUpdateCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class UpdateCommandMeta(
+    updateCmd: UpdateCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[UpdateCommand](updateCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
+      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuUpdateCommand(
+      new GpuDeltaLog(updateCmd.tahoeFileIndex.deltaLog, conf),
+      updateCmd.tahoeFileIndex,
+      updateCmd.target,
+      updateCmd.updateExpressions,
+      updateCmd.condition
+    )
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuUpdateCommand.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuUpdateCommand.scala
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from UpdateCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta21x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeltaCommand, UpdateCommand, UpdateMetric}
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.{input_file_name, udf}
+import org.apache.spark.sql.types.LongType
+
+case class GpuUpdateCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    tahoeFileIndex: TahoeFileIndex,
+    target: LogicalPlan,
+    updateExpressions: Seq[Expression],
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand {
+
+  override val output: Seq[Attribute] = {
+    Seq(AttributeReference("num_affected_rows", LongType)())
+  }
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numUpdatedRows" -> createMetric(sc, "number of rows updated."),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied."),
+    "executionTimeMs" ->
+        createTimingMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" ->
+        createTimingMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" ->
+        createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched (copied + updated)")
+  )
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
+      val deltaLog = tahoeFileIndex.deltaLog
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        performUpdate(sparkSession, deltaLog, txn)
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+    Seq(Row(metrics("numUpdatedRows").value))
+  }
+
+  private def performUpdate(
+      sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
+    import sparkSession.implicits._
+
+    var numTouchedFiles: Long = 0
+    var numRewrittenFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var changeFileBytes: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val updateCondition = condition.getOrElse(Literal.TrueLiteral)
+    val (metadataPredicates, dataPredicates) =
+      DeltaTableUtils.splitMetadataAndDataPredicates(
+        updateCondition, txn.metadata.partitionColumns, sparkSession)
+    val candidateFiles = txn.filterFiles(metadataPredicates ++ dataPredicates)
+    val nameToAddFile = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+    scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+    val filesToRewrite: Seq[AddFile] = if (candidateFiles.isEmpty) {
+      // Case 1: Do nothing if no row qualifies the partition predicates
+      // that are part of Update condition
+      Nil
+    } else if (dataPredicates.isEmpty) {
+      // Case 2: Update all the rows from the files that are in the specified partitions
+      // when the data filter is empty
+      candidateFiles
+    } else {
+      // Case 3: Find all the affected files using the user-specified condition
+      val fileIndex = new TahoeBatchFileIndex(
+        sparkSession, "update", candidateFiles, deltaLog, tahoeFileIndex.path, txn.snapshot)
+      // Keep everything from the resolved target except a new TahoeFileIndex
+      // that only involves the affected files instead of all files.
+      val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+      val data = Dataset.ofRows(sparkSession, newTarget)
+      val updatedRowCount = metrics("numUpdatedRows")
+      val updatedRowUdf = udf {
+        new GpuDeltaMetricUpdateUDF(updatedRowCount)
+      }.asNondeterministic()
+      val pathsToRewrite =
+        withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
+          data.filter(new Column(updateCondition))
+              .select(input_file_name())
+              .filter(updatedRowUdf())
+              .distinct()
+              .as[String]
+              .collect()
+        }
+
+      scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+      pathsToRewrite.map(getTouchedFile(deltaLog.dataPath, _, nameToAddFile)).toSeq
+    }
+
+    numTouchedFiles = filesToRewrite.length
+
+    val newActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Generate the new files containing the updated values
+      withStatusCode("DELTA", UpdateCommand.rewritingFilesMsg(filesToRewrite.size)) {
+        rewriteFiles(sparkSession, txn, tahoeFileIndex.path,
+          filesToRewrite.map(_.path), nameToAddFile, updateCondition)
+      }
+    }
+
+    rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+
+    val (changeActions, addActions) = newActions.partition(_.isInstanceOf[AddCDCFile])
+    numRewrittenFiles = addActions.size
+    numAddedChangeFiles = changeActions.size
+    changeFileBytes = changeActions.collect { case f: AddCDCFile => f.size }.sum
+
+    val totalActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Delete the old files and return those delete actions along with the new AddFile actions for
+      // files containing the updated values
+      val operationTimestamp = System.currentTimeMillis()
+      val deleteActions = filesToRewrite.map(_.removeWithTimestamp(operationTimestamp))
+
+      deleteActions ++ newActions
+    }
+
+    if (totalActions.nonEmpty) {
+      metrics("numAddedFiles").set(numRewrittenFiles)
+      metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+      metrics("changeFileBytes").set(changeFileBytes)
+      metrics("numRemovedFiles").set(numTouchedFiles)
+      metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
+      metrics("scanTimeMs").set(scanTimeMs)
+      metrics("rewriteTimeMs").set(rewriteTimeMs)
+      // In the case where the numUpdatedRows is not captured, we can siphon out the metrics from
+      // the BasicWriteStatsTracker. This is for case 2 where the update condition contains only
+      // metadata predicates and so the entire partition is re-written.
+      val outputRows = txn.getMetric("numOutputRows").map(_.value).getOrElse(-1L)
+      if (metrics("numUpdatedRows").value == 0 && outputRows != 0 &&
+          metrics("numCopiedRows").value == 0) {
+        // We know that numTouchedRows = numCopiedRows + numUpdatedRows.
+        // Since an entire partition was re-written, no rows were copied.
+        // So numTouchedRows == numUpdateRows
+        metrics("numUpdatedRows").set(metrics("numTouchedRows").value)
+      } else {
+        // This is for case 3 where the update condition contains both metadata and data predicates
+        // so relevant files will have some rows updated and some rows copied. We don't need to
+        // consider case 1 here, where no files match the update condition, as we know that
+        // `totalActions` is empty.
+        metrics("numCopiedRows").set(
+          metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
+      }
+      txn.registerSQLMetrics(sparkSession, metrics)
+      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
+      // This is needed to make the SQL metrics visible in the Spark UI
+      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+      SQLMetrics.postDriverMetricUpdates(
+        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    }
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.update.stats",
+      data = UpdateMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numTouchedFiles,
+        numRewrittenFiles,
+        numAddedChangeFiles,
+        changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+  }
+
+  /**
+   * Scan all the affected files and write out the updated files.
+   *
+   * When CDF is enabled, includes the generation of CDC preimage and postimage columns for
+   * changed rows.
+   *
+   * @return the list of [[AddFile]]s and [[AddCDCFile]]s that have been written.
+   */
+  private def rewriteFiles(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      rootPath: Path,
+      inputLeafFiles: Seq[String],
+      nameToAddFileMap: Map[String, AddFile],
+      condition: Expression): Seq[FileAction] = {
+    // Containing the map from the relative file path to AddFile
+    val baseRelation = buildBaseRelation(
+      spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val targetDf = Dataset.ofRows(spark, newTarget)
+
+    // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
+    // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    val updatedDataFrame = UpdateCommand.withUpdatedColumns(
+      target,
+      updateExpressions,
+      condition,
+      targetDf
+          .filter(numTouchedRowsUdf())
+          .withColumn(UpdateCommand.CONDITION_COLUMN_NAME, new Column(condition)),
+      UpdateCommand.shouldOutputCdc(txn))
+
+    txn.writeFiles(updatedDataFrame)
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.delta.delta22x
 import com.nvidia.spark.rapids.{GpuOverrides, RunnableCommandRule}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
-import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand}
+import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 object Delta22xProvider extends DeltaIOProvider {
@@ -34,7 +34,11 @@ object Delta22xProvider extends DeltaIOProvider {
       GpuOverrides.runnableCmd[MergeIntoCommand](
         "Merge of a source query/table into a Delta table",
         (a, conf, p, r) => new MergeIntoCommandMeta(a, conf, p, r))
-          .disabledByDefault("Delta Lake merge support is experimental")
+          .disabledByDefault("Delta Lake merge support is experimental"),
+      GpuOverrides.runnableCmd[UpdateCommand](
+        "Update rows in a Delta Lake table",
+        (a, conf, p, r) => new UpdateCommandMeta(a, conf, p, r))
+          .disabledByDefault("Delta Lake update support is experimental")
     ).map(r => (r.getClassFor.asSubclass(classOf[RunnableCommand]), r)).toMap
   }
 }

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/UpdateCommandMeta.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta22x
+
+import com.nvidia.spark.rapids.{DataFromReplacementRule, RapidsConf, RapidsMeta, RunnableCommandMeta}
+import com.nvidia.spark.rapids.delta.RapidsDeltaUtils
+
+import org.apache.spark.sql.delta.commands.UpdateCommand
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.rapids.delta22x.GpuUpdateCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+class UpdateCommandMeta(
+    updateCmd: UpdateCommand,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+    extends RunnableCommandMeta[UpdateCommand](updateCmd, conf, parent, rule) {
+
+  override def tagSelfForGpu(): Unit = {
+    if (!conf.isDeltaWriteEnabled) {
+      willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
+      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+  }
+
+  override def convertToGpu(): RunnableCommand = {
+    GpuUpdateCommand(
+      new GpuDeltaLog(updateCmd.tahoeFileIndex.deltaLog, conf),
+      updateCmd.tahoeFileIndex,
+      updateCmd.target,
+      updateCmd.updateExpressions,
+      updateCmd.condition
+    )
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuUpdateCommand.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuUpdateCommand.scala
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from UpdateCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta22x
+
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTableUtils, DeltaUDF, OptimisticTransaction}
+import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
+import org.apache.spark.sql.delta.commands.{DeltaCommand, UpdateCommand, UpdateMetric}
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.types.LongType
+
+case class GpuUpdateCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    tahoeFileIndex: TahoeFileIndex,
+    target: LogicalPlan,
+    updateExpressions: Seq[Expression],
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand {
+
+  override val output: Seq[Attribute] = {
+    Seq(AttributeReference("num_affected_rows", LongType)())
+  }
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numUpdatedRows" -> createMetric(sc, "number of rows updated."),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied."),
+    "executionTimeMs" ->
+        createTimingMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" ->
+        createTimingMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" ->
+        createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched (copied + updated)")
+  )
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
+      val deltaLog = tahoeFileIndex.deltaLog
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        performUpdate(sparkSession, deltaLog, txn)
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+    Seq(Row(metrics("numUpdatedRows").value))
+  }
+
+  private def performUpdate(
+      sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
+    import org.apache.spark.sql.delta.implicits._
+
+    var numTouchedFiles: Long = 0
+    var numRewrittenFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var changeFileBytes: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val updateCondition = condition.getOrElse(Literal.TrueLiteral)
+    val (metadataPredicates, dataPredicates) =
+      DeltaTableUtils.splitMetadataAndDataPredicates(
+        updateCondition, txn.metadata.partitionColumns, sparkSession)
+    val candidateFiles = txn.filterFiles(metadataPredicates ++ dataPredicates)
+    val nameToAddFile = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+    scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+    val filesToRewrite: Seq[AddFile] = if (candidateFiles.isEmpty) {
+      // Case 1: Do nothing if no row qualifies the partition predicates
+      // that are part of Update condition
+      Nil
+    } else if (dataPredicates.isEmpty) {
+      // Case 2: Update all the rows from the files that are in the specified partitions
+      // when the data filter is empty
+      candidateFiles
+    } else {
+      // Case 3: Find all the affected files using the user-specified condition
+      val fileIndex = new TahoeBatchFileIndex(
+        sparkSession, "update", candidateFiles, deltaLog, tahoeFileIndex.path, txn.snapshot)
+      // Keep everything from the resolved target except a new TahoeFileIndex
+      // that only involves the affected files instead of all files.
+      val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+      val data = Dataset.ofRows(sparkSession, newTarget)
+      val updatedRowCount = metrics("numUpdatedRows")
+      val updatedRowUdf = DeltaUDF.boolean {
+        new GpuDeltaMetricUpdateUDF(updatedRowCount)
+      }.asNondeterministic()
+      val pathsToRewrite =
+        withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
+          data.filter(new Column(updateCondition))
+              .select(input_file_name())
+              .filter(updatedRowUdf())
+              .distinct()
+              .as[String]
+              .collect()
+        }
+
+      scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+      pathsToRewrite.map(getTouchedFile(deltaLog.dataPath, _, nameToAddFile)).toSeq
+    }
+
+    numTouchedFiles = filesToRewrite.length
+
+    val newActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Generate the new files containing the updated values
+      withStatusCode("DELTA", UpdateCommand.rewritingFilesMsg(filesToRewrite.size)) {
+        rewriteFiles(sparkSession, txn, tahoeFileIndex.path,
+          filesToRewrite.map(_.path), nameToAddFile, updateCondition)
+      }
+    }
+
+    rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+
+    val (changeActions, addActions) = newActions.partition(_.isInstanceOf[AddCDCFile])
+    numRewrittenFiles = addActions.size
+    numAddedChangeFiles = changeActions.size
+    changeFileBytes = changeActions.collect { case f: AddCDCFile => f.size }.sum
+
+    val totalActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Delete the old files and return those delete actions along with the new AddFile actions for
+      // files containing the updated values
+      val operationTimestamp = System.currentTimeMillis()
+      val deleteActions = filesToRewrite.map(_.removeWithTimestamp(operationTimestamp))
+
+      deleteActions ++ newActions
+    }
+
+    if (totalActions.nonEmpty) {
+      metrics("numAddedFiles").set(numRewrittenFiles)
+      metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+      metrics("changeFileBytes").set(changeFileBytes)
+      metrics("numRemovedFiles").set(numTouchedFiles)
+      metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
+      metrics("scanTimeMs").set(scanTimeMs)
+      metrics("rewriteTimeMs").set(rewriteTimeMs)
+      // In the case where the numUpdatedRows is not captured, we can siphon out the metrics from
+      // the BasicWriteStatsTracker. This is for case 2 where the update condition contains only
+      // metadata predicates and so the entire partition is re-written.
+      val outputRows = txn.getMetric("numOutputRows").map(_.value).getOrElse(-1L)
+      if (metrics("numUpdatedRows").value == 0 && outputRows != 0 &&
+          metrics("numCopiedRows").value == 0) {
+        // We know that numTouchedRows = numCopiedRows + numUpdatedRows.
+        // Since an entire partition was re-written, no rows were copied.
+        // So numTouchedRows == numUpdateRows
+        metrics("numUpdatedRows").set(metrics("numTouchedRows").value)
+      } else {
+        // This is for case 3 where the update condition contains both metadata and data predicates
+        // so relevant files will have some rows updated and some rows copied. We don't need to
+        // consider case 1 here, where no files match the update condition, as we know that
+        // `totalActions` is empty.
+        metrics("numCopiedRows").set(
+          metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
+      }
+      txn.registerSQLMetrics(sparkSession, metrics)
+      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
+      // This is needed to make the SQL metrics visible in the Spark UI
+      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+      SQLMetrics.postDriverMetricUpdates(
+        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    }
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.update.stats",
+      data = UpdateMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numTouchedFiles,
+        numRewrittenFiles,
+        numAddedChangeFiles,
+        changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+  }
+
+  /**
+   * Scan all the affected files and write out the updated files.
+   *
+   * When CDF is enabled, includes the generation of CDC preimage and postimage columns for
+   * changed rows.
+   *
+   * @return the list of [[AddFile]]s and [[AddCDCFile]]s that have been written.
+   */
+  private def rewriteFiles(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      rootPath: Path,
+      inputLeafFiles: Seq[String],
+      nameToAddFileMap: Map[String, AddFile],
+      condition: Expression): Seq[FileAction] = {
+    // Containing the map from the relative file path to AddFile
+    val baseRelation = buildBaseRelation(
+      spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val targetDf = Dataset.ofRows(spark, newTarget)
+
+    // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
+    // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = DeltaUDF.boolean {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    val updatedDataFrame = UpdateCommand.withUpdatedColumns(
+      target,
+      updateExpressions,
+      condition,
+      targetDf
+          .filter(numTouchedRowsUdf())
+          .withColumn(UpdateCommand.CONDITION_COLUMN_NAME, new Column(condition)),
+      UpdateCommand.shouldOutputCdc(txn))
+
+    txn.writeFiles(updatedDataFrame)
+  }
+}

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuUpdateCommand.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuUpdateCommand.scala
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from UpdateCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import com.databricks.sql.transaction.tahoe.actions.{AddCDCFile, AddFile, FileAction}
+import com.databricks.sql.transaction.tahoe.commands.{DeltaCommand, UpdateCommandEdge, UpdateMetric}
+import com.databricks.sql.transaction.tahoe.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC, CDC_TYPE_UPDATE_POSTIMAGE, CDC_TYPE_UPDATE_PREIMAGE}
+import com.databricks.sql.transaction.tahoe.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, If, Literal}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.{array, col, explode, input_file_name, lit, struct, typedLit, udf}
+import org.apache.spark.sql.types.LongType
+
+case class GpuUpdateCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    tahoeFileIndex: TahoeFileIndex,
+    target: LogicalPlan,
+    updateExpressions: Seq[Expression],
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand {
+
+  override val output: Seq[Attribute] = {
+    Seq(AttributeReference("num_affected_rows", LongType)())
+  }
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numUpdatedRows" -> createMetric(sc, "number of rows updated."),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied."),
+    "executionTimeMs" ->
+        createTimingMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" ->
+        createTimingMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" ->
+        createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched (copied + updated)")
+  )
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
+      val deltaLog = tahoeFileIndex.deltaLog
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        performUpdate(sparkSession, deltaLog, txn)
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+    Seq(Row(metrics("numUpdatedRows").value))
+  }
+
+  private def performUpdate(
+      sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
+    import sparkSession.implicits._
+
+    var numTouchedFiles: Long = 0
+    var numRewrittenFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var changeFileBytes: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val updateCondition = condition.getOrElse(Literal.TrueLiteral)
+    val (metadataPredicates, dataPredicates) =
+      DeltaTableUtils.splitMetadataAndDataPredicates(
+        updateCondition, txn.metadata.partitionColumns, sparkSession)
+    val candidateFiles = txn.filterFiles(metadataPredicates ++ dataPredicates)
+    val nameToAddFile = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+    scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+    val filesToRewrite: Seq[AddFile] = if (candidateFiles.isEmpty) {
+      // Case 1: Do nothing if no row qualifies the partition predicates
+      // that are part of Update condition
+      Nil
+    } else if (dataPredicates.isEmpty) {
+      // Case 2: Update all the rows from the files that are in the specified partitions
+      // when the data filter is empty
+      candidateFiles
+    } else {
+      // Case 3: Find all the affected files using the user-specified condition
+      val fileIndex = new TahoeBatchFileIndex(
+        sparkSession, "update", candidateFiles, deltaLog, tahoeFileIndex.path, txn.snapshot)
+      // Keep everything from the resolved target except a new TahoeFileIndex
+      // that only involves the affected files instead of all files.
+      val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+      val data = Dataset.ofRows(sparkSession, newTarget)
+      val updatedRowCount = metrics("numUpdatedRows")
+      val updatedRowUdf = udf {
+        new GpuDeltaMetricUpdateUDF(updatedRowCount)
+      }.asNondeterministic()
+      val pathsToRewrite =
+        withStatusCode("DELTA", GpuUpdateCommand.FINDING_TOUCHED_FILES_MSG) {
+          data.filter(new Column(updateCondition))
+              .select(input_file_name())
+              .filter(updatedRowUdf())
+              .distinct()
+              .as[String]
+              .collect()
+        }
+
+      scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+      pathsToRewrite.map(getTouchedFile(deltaLog.dataPath, _, nameToAddFile)).toSeq
+    }
+
+    numTouchedFiles = filesToRewrite.length
+
+    val newActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Generate the new files containing the updated values
+      withStatusCode("DELTA", GpuUpdateCommand.rewritingFilesMsg(filesToRewrite.size)) {
+        rewriteFiles(sparkSession, txn, tahoeFileIndex.path,
+          filesToRewrite.map(_.path), nameToAddFile, updateCondition)
+      }
+    }
+
+    rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+
+    val (changeActions, addActions) = newActions.partition(_.isInstanceOf[AddCDCFile])
+    numRewrittenFiles = addActions.size
+    numAddedChangeFiles = changeActions.size
+    changeFileBytes = changeActions.collect { case f: AddCDCFile => f.size }.sum
+
+    val totalActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Delete the old files and return those delete actions along with the new AddFile actions for
+      // files containing the updated values
+      val operationTimestamp = System.currentTimeMillis()
+      val deleteActions = filesToRewrite.map(_.removeWithTimestamp(operationTimestamp))
+
+      deleteActions ++ newActions
+    }
+
+    if (totalActions.nonEmpty) {
+      metrics("numAddedFiles").set(numRewrittenFiles)
+      metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+      metrics("changeFileBytes").set(changeFileBytes)
+      metrics("numRemovedFiles").set(numTouchedFiles)
+      metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
+      metrics("scanTimeMs").set(scanTimeMs)
+      metrics("rewriteTimeMs").set(rewriteTimeMs)
+      // In the case where the numUpdatedRows is not captured, we can siphon out the metrics from
+      // the BasicWriteStatsTracker. This is for case 2 where the update condition contains only
+      // metadata predicates and so the entire partition is re-written.
+      val outputRows = txn.getMetric("numOutputRows").map(_.value).getOrElse(-1L)
+      if (metrics("numUpdatedRows").value == 0 && outputRows != 0 &&
+          metrics("numCopiedRows").value == 0) {
+        // We know that numTouchedRows = numCopiedRows + numUpdatedRows.
+        // Since an entire partition was re-written, no rows were copied.
+        // So numTouchedRows == numUpdateRows
+        metrics("numUpdatedRows").set(metrics("numTouchedRows").value)
+      } else {
+        // This is for case 3 where the update condition contains both metadata and data predicates
+        // so relevant files will have some rows updated and some rows copied. We don't need to
+        // consider case 1 here, where no files match the update condition, as we know that
+        // `totalActions` is empty.
+        metrics("numCopiedRows").set(
+          metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
+      }
+      txn.registerSQLMetrics(sparkSession, metrics)
+      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
+      // This is needed to make the SQL metrics visible in the Spark UI
+      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+      SQLMetrics.postDriverMetricUpdates(
+        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    }
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.update.stats",
+      data = UpdateMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numTouchedFiles,
+        numRewrittenFiles,
+        numAddedChangeFiles,
+        changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+  }
+
+  /**
+   * Scan all the affected files and write out the updated files.
+   *
+   * When CDF is enabled, includes the generation of CDC preimage and postimage columns for
+   * changed rows.
+   *
+   * @return the list of [[AddFile]]s and [[AddCDCFile]]s that have been written.
+   */
+  private def rewriteFiles(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      rootPath: Path,
+      inputLeafFiles: Seq[String],
+      nameToAddFileMap: Map[String, AddFile],
+      condition: Expression): Seq[FileAction] = {
+    // Containing the map from the relative file path to AddFile
+    val baseRelation = buildBaseRelation(
+      spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val targetDf = Dataset.ofRows(spark, newTarget)
+
+    // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
+    // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = udf {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    val updatedDataFrame = GpuUpdateCommand.withUpdatedColumns(
+      target,
+      updateExpressions,
+      condition,
+      targetDf
+          .filter(numTouchedRowsUdf())
+          .withColumn(GpuUpdateCommand.CONDITION_COLUMN_NAME, new Column(condition)),
+      GpuUpdateCommand.shouldOutputCdc(txn))
+
+    txn.writeFiles(updatedDataFrame)
+  }
+}
+
+object GpuUpdateCommand {
+  val CONDITION_COLUMN_NAME = UpdateCommandEdge.CONDITION_COLUMN_NAME
+  val FINDING_TOUCHED_FILES_MSG: String = "Finding files to rewrite for UPDATE operation"
+
+  def rewritingFilesMsg(numFilesToRewrite: Long): String =
+    s"Rewriting $numFilesToRewrite files for UPDATE operation"
+
+  /**
+   * Whether or not CDC is enabled on this table and, thus, if we should output CDC data during this
+   * UPDATE operation.
+   */
+  def shouldOutputCdc(txn: OptimisticTransaction): Boolean = {
+    DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(txn.metadata)
+  }
+
+  /**
+   * Build the new columns. If the condition matches, generate the new value using
+   * the corresponding UPDATE EXPRESSION; otherwise, keep the original column value.
+   *
+   * When CDC is enabled, includes the generation of CDC pre-image and post-image columns for
+   * changed rows.
+   *
+   * @param target                   target we are updating into
+   * @param updateExpressions        the update transformation to perform on the input DataFrame
+   * @param dfWithEvaluatedCondition source DataFrame on which we will apply the update expressions
+   *                                 with an additional column CONDITION_COLUMN_NAME which is the
+   *                                 true/false value of if the update condition is satisfied
+   * @param condition                update condition
+   * @param shouldOutputCdc          if we should output CDC data during this UPDATE operation.
+   * @return the updated DataFrame, with extra CDC columns if CDC is enabled
+   */
+  def withUpdatedColumns(
+      target: LogicalPlan,
+      updateExpressions: Seq[Expression],
+      condition: Expression,
+      dfWithEvaluatedCondition: DataFrame,
+      shouldOutputCdc: Boolean): DataFrame = {
+    val resultDf = if (shouldOutputCdc) {
+      val namedUpdateCols = updateExpressions.zip(target.output).map {
+        case (expr, targetCol) => new Column(expr).as(targetCol.name)
+      }
+
+      // Build an array of output rows to be unpacked later. If the condition is matched, we
+      // generate CDC pre and postimages in addition to the final output row; if the condition
+      // isn't matched, we just generate a rewritten no-op row without any CDC events.
+      val preimageCols = target.output.map(new Column(_)) :+
+          lit(CDC_TYPE_UPDATE_PREIMAGE).as(CDC_TYPE_COLUMN_NAME)
+      val postimageCols = namedUpdateCols :+
+          lit(CDC_TYPE_UPDATE_POSTIMAGE).as(CDC_TYPE_COLUMN_NAME)
+      val updatedDataCols = namedUpdateCols :+
+          typedLit[String](CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      val noopRewriteCols = target.output.map(new Column(_)) :+
+          typedLit[String](CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      val packedUpdates = array(
+        struct(preimageCols: _*),
+        struct(postimageCols: _*),
+        struct(updatedDataCols: _*)
+      ).expr
+
+      val packedData = if (condition == Literal.TrueLiteral) {
+        packedUpdates
+      } else {
+        If(
+          UnresolvedAttribute(CONDITION_COLUMN_NAME),
+          packedUpdates, // if it should be updated, then use `packagedUpdates`
+          array(struct(noopRewriteCols: _*)).expr) // else, this is a noop rewrite
+      }
+
+      // Explode the packed array, and project back out the final data columns.
+      val finalColNames = target.output.map(_.name) :+ CDC_TYPE_COLUMN_NAME
+      dfWithEvaluatedCondition
+          .select(explode(new Column(packedData)).as("packedData"))
+          .select(finalColNames.map { n => col(s"packedData.`$n`").as(s"$n") }: _*)
+    } else {
+      val finalCols = updateExpressions.zip(target.output).map { case (update, original) =>
+        val updated = if (condition == Literal.TrueLiteral) {
+          update
+        } else {
+          If(UnresolvedAttribute(CONDITION_COLUMN_NAME), update, original)
+        }
+        new Column(Alias(updated, original.name)())
+      }
+
+      dfWithEvaluatedCondition.select(finalCols: _*)
+    }
+
+    resultDf.drop(CONDITION_COLUMN_NAME)
+  }
+}

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuUpdateCommand.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuUpdateCommand.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from UpdateCommand.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe.{DeltaLog, DeltaOperations, DeltaTableUtils, DeltaUDF, OptimisticTransaction}
+import com.databricks.sql.transaction.tahoe.actions.{AddCDCFile, AddFile, FileAction}
+import com.databricks.sql.transaction.tahoe.commands.{DeltaCommand, UpdateCommand, UpdateMetric}
+import com.databricks.sql.transaction.tahoe.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import com.nvidia.spark.rapids.delta.GpuDeltaMetricUpdateUDF
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
+import org.apache.spark.sql.functions.input_file_name
+import org.apache.spark.sql.types.LongType
+
+case class GpuUpdateCommand(
+    gpuDeltaLog: GpuDeltaLog,
+    tahoeFileIndex: TahoeFileIndex,
+    target: LogicalPlan,
+    updateExpressions: Seq[Expression],
+    condition: Option[Expression])
+    extends LeafRunnableCommand with DeltaCommand {
+
+  override val output: Seq[Attribute] = {
+    Seq(AttributeReference("num_affected_rows", LongType)())
+  }
+
+  override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
+
+  @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
+
+  override lazy val metrics = Map[String, SQLMetric](
+    "numAddedFiles" -> createMetric(sc, "number of files added."),
+    "numRemovedFiles" -> createMetric(sc, "number of files removed."),
+    "numUpdatedRows" -> createMetric(sc, "number of rows updated."),
+    "numCopiedRows" -> createMetric(sc, "number of rows copied."),
+    "executionTimeMs" ->
+        createTimingMetric(sc, "time taken to execute the entire operation"),
+    "scanTimeMs" ->
+        createTimingMetric(sc, "time taken to scan the files for matches"),
+    "rewriteTimeMs" ->
+        createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numAddedChangeFiles" -> createMetric(sc, "number of change data capture files generated"),
+    "changeFileBytes" -> createMetric(sc, "total size of change data capture files generated"),
+    "numTouchedRows" -> createMetric(sc, "number of rows touched (copied + updated)")
+  )
+
+  final override def run(sparkSession: SparkSession): Seq[Row] = {
+    recordDeltaOperation(tahoeFileIndex.deltaLog, "delta.dml.update") {
+      val deltaLog = tahoeFileIndex.deltaLog
+      deltaLog.assertRemovable()
+      gpuDeltaLog.withNewTransaction { txn =>
+        performUpdate(sparkSession, deltaLog, txn)
+      }
+      // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
+      // this data source relation.
+      sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+    }
+    Seq(Row(metrics("numUpdatedRows").value))
+  }
+
+  private def performUpdate(
+      sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
+    import com.databricks.sql.transaction.tahoe.implicits._
+
+    var numTouchedFiles: Long = 0
+    var numRewrittenFiles: Long = 0
+    var numAddedChangeFiles: Long = 0
+    var changeFileBytes: Long = 0
+    var scanTimeMs: Long = 0
+    var rewriteTimeMs: Long = 0
+
+    val startTime = System.nanoTime()
+    val numFilesTotal = txn.snapshot.numOfFiles
+
+    val updateCondition = condition.getOrElse(Literal.TrueLiteral)
+    val (metadataPredicates, dataPredicates) =
+      DeltaTableUtils.splitMetadataAndDataPredicates(
+        updateCondition, txn.metadata.partitionColumns, sparkSession)
+    val candidateFiles = txn.filterFiles(metadataPredicates ++ dataPredicates)
+    val nameToAddFile = generateCandidateFileMap(deltaLog.dataPath, candidateFiles)
+
+    scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+    val filesToRewrite: Seq[AddFile] = if (candidateFiles.isEmpty) {
+      // Case 1: Do nothing if no row qualifies the partition predicates
+      // that are part of Update condition
+      Nil
+    } else if (dataPredicates.isEmpty) {
+      // Case 2: Update all the rows from the files that are in the specified partitions
+      // when the data filter is empty
+      candidateFiles
+    } else {
+      // Case 3: Find all the affected files using the user-specified condition
+      val fileIndex = new TahoeBatchFileIndex(
+        sparkSession, "update", candidateFiles, deltaLog, tahoeFileIndex.path, txn.snapshot)
+      // Keep everything from the resolved target except a new TahoeFileIndex
+      // that only involves the affected files instead of all files.
+      val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
+      val data = Dataset.ofRows(sparkSession, newTarget)
+      val updatedRowCount = metrics("numUpdatedRows")
+      val updatedRowUdf = DeltaUDF.boolean {
+        new GpuDeltaMetricUpdateUDF(updatedRowCount)
+      }.asNondeterministic()
+      val pathsToRewrite =
+        withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
+          data.filter(new Column(updateCondition))
+              .select(input_file_name())
+              .filter(updatedRowUdf())
+              .distinct()
+              .as[String]
+              .collect()
+        }
+
+      scanTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
+
+      pathsToRewrite.map(getTouchedFile(deltaLog.dataPath, _, nameToAddFile)).toSeq
+    }
+
+    numTouchedFiles = filesToRewrite.length
+
+    val newActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Generate the new files containing the updated values
+      withStatusCode("DELTA", UpdateCommand.rewritingFilesMsg(filesToRewrite.size)) {
+        rewriteFiles(sparkSession, txn, tahoeFileIndex.path,
+          filesToRewrite.map(_.path), nameToAddFile, updateCondition)
+      }
+    }
+
+    rewriteTimeMs = (System.nanoTime() - startTime) / 1000 / 1000 - scanTimeMs
+
+    val (changeActions, addActions) = newActions.partition(_.isInstanceOf[AddCDCFile])
+    numRewrittenFiles = addActions.size
+    numAddedChangeFiles = changeActions.size
+    changeFileBytes = changeActions.collect { case f: AddCDCFile => f.size }.sum
+
+    val totalActions = if (filesToRewrite.isEmpty) {
+      // Do nothing if no row qualifies the UPDATE condition
+      Nil
+    } else {
+      // Delete the old files and return those delete actions along with the new AddFile actions for
+      // files containing the updated values
+      val operationTimestamp = System.currentTimeMillis()
+      val deleteActions = filesToRewrite.map(_.removeWithTimestamp(operationTimestamp))
+
+      deleteActions ++ newActions
+    }
+
+    if (totalActions.nonEmpty) {
+      metrics("numAddedFiles").set(numRewrittenFiles)
+      metrics("numAddedChangeFiles").set(numAddedChangeFiles)
+      metrics("changeFileBytes").set(changeFileBytes)
+      metrics("numRemovedFiles").set(numTouchedFiles)
+      metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
+      metrics("scanTimeMs").set(scanTimeMs)
+      metrics("rewriteTimeMs").set(rewriteTimeMs)
+      // In the case where the numUpdatedRows is not captured, we can siphon out the metrics from
+      // the BasicWriteStatsTracker. This is for case 2 where the update condition contains only
+      // metadata predicates and so the entire partition is re-written.
+      val outputRows = txn.getMetric("numOutputRows").map(_.value).getOrElse(-1L)
+      if (metrics("numUpdatedRows").value == 0 && outputRows != 0 &&
+          metrics("numCopiedRows").value == 0) {
+        // We know that numTouchedRows = numCopiedRows + numUpdatedRows.
+        // Since an entire partition was re-written, no rows were copied.
+        // So numTouchedRows == numUpdateRows
+        metrics("numUpdatedRows").set(metrics("numTouchedRows").value)
+      } else {
+        // This is for case 3 where the update condition contains both metadata and data predicates
+        // so relevant files will have some rows updated and some rows copied. We don't need to
+        // consider case 1 here, where no files match the update condition, as we know that
+        // `totalActions` is empty.
+        metrics("numCopiedRows").set(
+          metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
+      }
+      txn.registerSQLMetrics(sparkSession, metrics)
+      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
+      // This is needed to make the SQL metrics visible in the Spark UI
+      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+      SQLMetrics.postDriverMetricUpdates(
+        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    }
+
+    recordDeltaEvent(
+      deltaLog,
+      "delta.dml.update.stats",
+      data = UpdateMetric(
+        condition = condition.map(_.sql).getOrElse("true"),
+        numFilesTotal,
+        numTouchedFiles,
+        numRewrittenFiles,
+        numAddedChangeFiles,
+        changeFileBytes,
+        scanTimeMs,
+        rewriteTimeMs)
+    )
+  }
+
+  /**
+   * Scan all the affected files and write out the updated files.
+   *
+   * When CDF is enabled, includes the generation of CDC preimage and postimage columns for
+   * changed rows.
+   *
+   * @return the list of [[AddFile]]s and [[AddCDCFile]]s that have been written.
+   */
+  private def rewriteFiles(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      rootPath: Path,
+      inputLeafFiles: Seq[String],
+      nameToAddFileMap: Map[String, AddFile],
+      condition: Expression): Seq[FileAction] = {
+    // Containing the map from the relative file path to AddFile
+    val baseRelation = buildBaseRelation(
+      spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val targetDf = Dataset.ofRows(spark, newTarget)
+
+    // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
+    // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
+    val numTouchedRows = metrics("numTouchedRows")
+    val numTouchedRowsUdf = DeltaUDF.boolean {
+      new GpuDeltaMetricUpdateUDF(numTouchedRows)
+    }.asNondeterministic()
+
+    val updatedDataFrame = UpdateCommand.withUpdatedColumns(
+      target,
+      updateExpressions,
+      condition,
+      targetDf
+          .filter(numTouchedRowsUdf())
+          .withColumn(UpdateCommand.CONDITION_COLUMN_NAME, new Column(condition)),
+      UpdateCommand.shouldOutputCdc(txn))
+
+    txn.writeFiles(updatedDataFrame)
+  }
+}

--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -97,3 +97,12 @@ spark.rapids.sql.command.DeleteCommandEdge=true on Databricks platforms.
 
 Deleting data from Delta Lake tables via the SQL `DELETE FROM` statement or via the DeltaTable
 `delete` API is supported.
+
+## Update Operations on Delta Lake Tables
+
+Delta Lake update acceleration is experimental and is disabled by default. To enable acceleration
+of Delta Lake update operations, set spark.rapids.sql.command.Updatecommand=true and also set
+spark.rapids.sql.command.UpdateCommandEdge=true on Databricks platforms.
+
+Updating data from Delta Lake tables via the SQL `UPDATE` statement or via the DeltaTable
+`update` API is supported.

--- a/integration_tests/src/main/python/delta_lake_update_test.py
+++ b/integration_tests/src/main/python/delta_lake_update_test.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_equal, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write
+from data_gen import *
+from delta_lake_write_test import assert_gpu_and_cpu_delta_logs_equivalent, delta_meta_allow, delta_writes_enabled_conf
+from delta_lake_merge_test import read_delta_path, read_delta_path_with_cdf, setup_dest_tables
+from marks import *
+from spark_session import is_before_spark_320, is_databricks_runtime, with_cpu_session, with_gpu_session
+
+delta_update_enabled_conf = copy_and_update(delta_writes_enabled_conf,
+                                            {"spark.rapids.sql.command.UpdateCommand": "true",
+                                             "spark.rapids.sql.command.UpdateCommandEdge": "true"})
+
+def delta_sql_update_test(spark_tmp_path, use_cdf, dest_table_func, update_sql,
+                          check_func, partition_columns=None):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_dest_tables(spark, data_path, dest_table_func, use_cdf, partition_columns)
+    def do_update(spark, path):
+        return spark.sql(update_sql.format(path=path))
+    with_cpu_session(setup_tables)
+    check_func(data_path, do_update)
+
+def assert_delta_sql_update_collect(spark_tmp_path, use_cdf, dest_table_func, update_sql,
+                                    partition_columns=None,
+                                    conf=delta_update_enabled_conf):
+    def read_data(spark, path):
+        read_func = read_delta_path_with_cdf if use_cdf else read_delta_path
+        df = read_func(spark, path)
+        return df.sort(df.columns)
+    def checker(data_path, do_update):
+        cpu_path = data_path + "/CPU"
+        gpu_path = data_path + "/GPU"
+        # compare resulting dataframe from the update operation (some older Spark versions return empty here)
+        cpu_result = with_cpu_session(lambda spark: do_update(spark, cpu_path).collect(), conf=conf)
+        gpu_result = with_gpu_session(lambda spark: do_update(spark, gpu_path).collect(), conf=conf)
+        assert_equal(cpu_result, gpu_result)
+        # compare table data results, read both via CPU to make sure GPU write can be read by CPU
+        cpu_result = with_cpu_session(lambda spark: read_data(spark, cpu_path).collect(), conf=conf)
+        gpu_result = with_cpu_session(lambda spark: read_data(spark, gpu_path).collect(), conf=conf)
+        assert_equal(cpu_result, gpu_result)
+        # Databricks not guaranteed to write the same number of files due to optimized write when
+        # using partitions
+        if not is_databricks_runtime() or not partition_columns:
+            with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
+    delta_sql_update_test(spark_tmp_path, use_cdf, dest_table_func, update_sql, checker,
+                          partition_columns)
+
+@allow_non_gpu("ExecutedCommandExec", *delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("disable_conf",
+                         [{"spark.rapids.sql.format.delta.write.enabled": "false"},
+                          {"spark.rapids.sql.format.parquet.write.enabled": "false"},
+                          {"spark.rapids.sql.command.UpdateCommand": "false"},
+                          delta_writes_enabled_conf  # Test disabled by default
+                          ], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_update_disabled_fallback(spark_tmp_path, disable_conf):
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    def setup_tables(spark):
+        setup_dest_tables(spark, data_path,
+                          dest_table_func=lambda spark: unary_op_df(spark, int_gen),
+                          use_cdf=False)
+    def write_func(spark, path):
+        update_sql="UPDATE delta.`{}` SET a = 0".format(path)
+        spark.sql(update_sql)
+    with_cpu_session(setup_tables)
+    assert_gpu_fallback_write(write_func, read_delta_path, data_path,
+                              "ExecutedCommandExec", disable_conf)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_update_entire_table(spark_tmp_path, use_cdf, partition_columns):
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen)
+    update_sql = "UPDATE delta.`{path}` SET a = 0"
+    assert_delta_sql_update_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    update_sql, partition_columns)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [["a"], ["a", "b"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_update_partitions(spark_tmp_path, use_cdf, partition_columns):
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen)
+    update_sql = "UPDATE delta.`{path}` SET a = 3 WHERE b < 'c'"
+    assert_delta_sql_update_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    update_sql, partition_columns)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_update_rows(spark_tmp_path, use_cdf, partition_columns):
+    # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
+    num_slices_to_test = 1 if is_databricks_runtime() else 10
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen, num_slices=num_slices_to_test)
+    update_sql = "UPDATE delta.`{path}` SET c = b WHERE b >= 'd'"
+    assert_delta_sql_update_collect(spark_tmp_path, use_cdf, generate_dest_data,
+                                    update_sql, partition_columns)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
+@pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+def test_delta_update_dataframe_api(spark_tmp_path, use_cdf, partition_columns):
+    from delta.tables import DeltaTable
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
+    num_slices_to_test = 1 if is_databricks_runtime() else 10
+    def generate_dest_data(spark):
+        return three_col_df(spark,
+                            SetValuesGen(IntegerType(), range(5)),
+                            SetValuesGen(StringType(), "abcdefg"),
+                            string_gen, num_slices=num_slices_to_test)
+    with_cpu_session(lambda spark: setup_dest_tables(spark, data_path, generate_dest_data, use_cdf, partition_columns))
+    def do_update(spark, path):
+        dest_table = DeltaTable.forPath(spark, path)
+        dest_table.update(condition="b > 'c'", set={"c": f.col("b"), "a": f.lit(1)})
+    read_func = read_delta_path_with_cdf if use_cdf else read_delta_path
+    assert_gpu_and_cpu_writes_are_equal_collect(do_update, read_func, data_path,
+                                                conf=delta_update_enabled_conf)
+    # Databricks not guaranteed to write the same number of files due to optimized write when
+    # using partitions
+    if not is_databricks_runtime() or not partition_columns:
+        with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -59,6 +59,7 @@ def fixup_operation_metrics(opm):
 
 TMP_TABLE_PATTERN=re.compile("tmp_table_\w+")
 TMP_TABLE_PATH_PATTERN=re.compile("delta.`[^`]*`")
+REF_ID_PATTERN=re.compile("#[0-9]+")
 
 def fixup_operation_parameters(opp):
     """Update the specified operationParameters node to facilitate log comparisons"""
@@ -66,7 +67,8 @@ def fixup_operation_parameters(opp):
         pred = opp.get(key)
         if pred:
             subbed = TMP_TABLE_PATTERN.sub("tmp_table", pred)
-            opp[key] = TMP_TABLE_PATH_PATTERN.sub("tmp_table", subbed)
+            subbed = TMP_TABLE_PATH_PATTERN.sub("tmp_table", subbed)
+            opp[key] = REF_ID_PATTERN.sub("#refid", subbed)
 
 def assert_delta_log_json_equivalent(filename, c_json, g_json):
     assert c_json.keys() == g_json.keys(), "Delta log {} has mismatched keys:\nCPU: {}\nGPU: {}".format(filename, c_json, g_json)
@@ -116,8 +118,9 @@ def decode_jsons(json_data):
     # reorder to produce a consistent output for comparison
     def json_to_sort_key(j):
         keys = sorted(j.keys())
+        stats = sorted([ v.get("stats", "") for v in j.values() ])
         paths = sorted([ v.get("path", "") for v in j.values() ])
-        return ','.join(keys + paths)
+        return ','.join(keys + stats + paths)
     jsons.sort(key=json_to_sort_key)
     return jsons
 


### PR DESCRIPTION
Fixes #7280.

This adds support for updating data in Delta Lake tables via the UpdateCommand physical plan node.  Code is derived from UpdateCommand.scala in the https://github.delta-io/delta project for the various versions we support, and adapted the same ode for Databricks based on visible semantics of the behavior.

This implementation is relatively straightforward, mostly using the same logic as the CPU with the followi changes:
- Creating a GpuOptimisticTransaction so the `writeFiles` call is leveraging a GPU columnar write rather than a CPU write.
- Leveraging equivalent RAPIDS accelerated UDFs for updating SQL metrics to avoid falling back to the CPU for the original CPU UDFs.