### PR TITLE
Add dynamic partitioning test for Parquet writer.

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -289,8 +289,9 @@ def assert_gpu_and_cpu_sql_writes_are_equal_collect(table_name_factory, write_sq
     cpu_table = table_name_factory.get()
     cpu_start = time.time()
     def do_write(spark, table_name):
-        sql_text_array = write_sql_func(spark, table_name)
-        for sql_text in sql_text_array:
+        sql_texts = write_sql_func(spark, table_name)
+        sql_text_list = [sql_texts] if isinstance(sql_texts, str) else sql_texts
+        for sql_text in sql_text_list:
             spark.sql(sql_text)
         return None
     with_cpu_session(lambda spark : do_write(spark, cpu_table), conf=conf)

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -289,8 +289,9 @@ def assert_gpu_and_cpu_sql_writes_are_equal_collect(table_name_factory, write_sq
     cpu_table = table_name_factory.get()
     cpu_start = time.time()
     def do_write(spark, table_name):
-        sql_text = write_sql_func(spark, table_name)
-        spark.sql(sql_text)
+        sql_text_array = write_sql_func(spark, table_name)
+        for sql_text in sql_text_array:
+            spark.sql(sql_text)
         return None
     with_cpu_session(lambda spark : do_write(spark, cpu_table), conf=conf)
     cpu_end = time.time()

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -51,13 +51,13 @@ _map_gens = [simple_string_to_string_map_gen] + [MapGen(f(nullable=False), f()) 
     lambda nullable=True: DecimalGen(precision=15, scale=1, nullable=nullable),
     lambda nullable=True: DecimalGen(precision=36, scale=5, nullable=nullable)]]
 
-_write_gens = [_basic_gens, _struct_gens, _array_gens, _map_gens]
+_write_gens = [_basic_gens]  # , _struct_gens, _array_gens, _map_gens]
 
 # There appears to be a race when computing tasks for writing, order can be different even on CPU
 @ignore_order(local=True)
 @pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", _write_gens, ids=idfn)
-@pytest.mark.parametrize("storage", ["PARQUET", "nativeorc", "hiveorc"])
+@pytest.mark.parametrize("storage", ["PARQUET"])  # , "nativeorc", "hiveorc"])
 def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
     data_table = spark_tmp_table_factory.get()
     gen_list = [('c' + str(i), gen) for i, gen in enumerate(gens)]
@@ -66,8 +66,8 @@ def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
         store_name = storage
         if storage.endswith("orc"):
             store_name = "ORC"
-        return "CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
-            table_name, store_name, data_table)
+        return ["CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
+            table_name, store_name, data_table)]
     conf = {
         "spark.sql.legacy.parquet.datetimeRebaseModeInWrite": "CORRECTED",
         "spark.sql.legacy.parquet.int96RebaseModeInWrite": "CORRECTED"

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -51,13 +51,13 @@ _map_gens = [simple_string_to_string_map_gen] + [MapGen(f(nullable=False), f()) 
     lambda nullable=True: DecimalGen(precision=15, scale=1, nullable=nullable),
     lambda nullable=True: DecimalGen(precision=36, scale=5, nullable=nullable)]]
 
-_write_gens = [_basic_gens]  # , _struct_gens, _array_gens, _map_gens]
+_write_gens = [_basic_gens, _struct_gens, _array_gens, _map_gens]
 
 # There appears to be a race when computing tasks for writing, order can be different even on CPU
 @ignore_order(local=True)
 @pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", _write_gens, ids=idfn)
-@pytest.mark.parametrize("storage", ["PARQUET"])  # , "nativeorc", "hiveorc"])
+@pytest.mark.parametrize("storage", ["PARQUET", "nativeorc", "hiveorc"])
 def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
     data_table = spark_tmp_table_factory.get()
     gen_list = [('c' + str(i), gen) for i, gen in enumerate(gens)]

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -66,8 +66,8 @@ def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
         store_name = storage
         if storage.endswith("orc"):
             store_name = "ORC"
-        return ["CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
-            table_name, store_name, data_table)]
+        return "CREATE TABLE {} STORED AS {} AS SELECT * FROM {}".format(
+            table_name, store_name, data_table)
     conf = {
         "spark.sql.legacy.parquet.datetimeRebaseModeInWrite": "CORRECTED",
         "spark.sql.legacy.parquet.int96RebaseModeInWrite": "CORRECTED"

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2022, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -17,6 +17,7 @@ import pytest
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write, assert_py4j_exception
 from datetime import date, datetime, timezone
 from data_gen import *
+from enum import Enum
 from marks import *
 from pyspark.sql.types import *
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320
@@ -567,3 +568,76 @@ def test_write_empty_data_single_writer(spark_tmp_path):
     with_gpu_session(lambda spark: spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
                      .write.mode("overwrite").partitionBy('c1', 'c2').parquet(data_path))
     with_cpu_session(lambda spark: spark.read.parquet(data_path).collect())
+
+
+PartitionWriteMode = Enum('PartitionWriteMode', ['Static', 'Dynamic'])
+
+
+def populate_partitioned_parquet_table(spark_tmp_table_factory, mode=PartitionWriteMode.Static):
+    """
+    Returns a function that does the following:
+        1. Creates an un-partitioned Hive table with data with the following schema:
+             1. make STRING
+             2. model STRING
+             3. year INT
+             4. type STRING (cardinality == 3)
+             5. comment STRING
+        2. Creates a partitioned Hive, with a similar schema to above, but partitioned on
+           the `type` column.
+        3. Populates the partitioned table using the un-partitioned table as input.
+             1. If the partition mode is dynamic, all the partitions are populated at once.
+             2. If the partition mode is static, the partitions are populated explicitly,
+                and sequentially.
+        4. Returns all the rows from 2 of the 3 partitions in the new table.
+    """
+
+    def create_input_table(spark):
+        tmp_input = spark_tmp_table_factory.get()
+        spark.sql("CREATE TABLE " + tmp_input +
+                  " (make STRING, model STRING, year INT, type STRING, comment STRING)" +
+                  " STORED AS PARQUET")
+        spark.sql("INSERT INTO TABLE " + tmp_input + " VALUES " +
+                  "('Ford',   'F-150',       2020, 'ICE',      'Popular' ),"
+                  "('GMC',    'Sierra 1500', 1997, 'ICE',      'Older'),"
+                  "('Chevy',  'D-Max',       2015, 'ICE',      'Isuzu?' ),"
+                  "('Tesla',  'CyberTruck',  2025, 'Electric', 'Fictional'),"
+                  "('Rivian', 'R1T',         2022, 'Electric', 'Heavy'),"
+                  "('Jeep',   'Gladiator',   2024, 'Hybrid',   'Upcoming')")
+        return tmp_input
+
+    def populate_partitions_static(spark):
+        input_table = create_input_table(spark)
+        output_table = spark_tmp_table_factory.get()
+        spark.sql("CREATE TABLE " + output_table +
+                  " (make STRING, model STRING, year INT, comment STRING)"
+                  " PARTITIONED BY (type STRING) STORED AS PARQUET")
+        spark.sql("INSERT INTO TABLE " + output_table + " PARTITION (type='ICE')" +
+                  " SELECT make, model, year, comment FROM " + input_table +
+                  " WHERE type='Electric'")
+        spark.sql("INSERT OVERWRITE TABLE " + output_table + " PARTITION (type='ICE')" +
+                  " SELECT make, model, year, comment FROM " + input_table +
+                  " WHERE type='Hybrid'")
+        return spark.sql("SELECT * FROM " + output_table +
+                         " WHERE type = 'ELECTRIC' or type = 'Hybrid'")
+
+    def populate_partitions_dynamic(spark):
+        input_table = create_input_table(spark)
+        output_table = spark_tmp_table_factory.get()
+        spark.sql("CREATE TABLE " + output_table +
+                  " (make STRING, model STRING, year INT, comment STRING)"
+                  " PARTITIONED BY (type STRING) STORED AS PARQUET")
+        spark.sql("INSERT OVERWRITE TABLE " + output_table +
+                  " SELECT make, model, year, comment, type FROM " + input_table)
+        return spark.sql("SELECT * FROM " + output_table +
+                         " WHERE type = 'ELECTRIC' or type = 'Hybrid'")
+
+    return populate_partitions_static if mode == PartitionWriteMode.Static else populate_partitions_dynamic
+
+
+@allow_non_gpu("EqualTo,IsNotNull,Literal,Or")  # Accounts for partition predicate.
+@pytest.mark.parametrize('mode', [PartitionWriteMode.Static, PartitionWriteMode.Dynamic])
+def test_partitioned_parquet_write(mode, spark_tmp_table_factory):
+    assert_gpu_and_cpu_are_equal_collect(
+        populate_partitioned_parquet_table(spark_tmp_table_factory, mode),
+        conf={"hive.exec.dynamic.partition.mode": "nonstrict"}
+    )


### PR DESCRIPTION
Fixes #7382, for Parquet.

This commit adds a test for the parquet writer to test partition writes, via static and dynamic partitioning.
