### PR TITLE
Add missing spark shim test suites 

### DIFF
--- a/sql-plugin/src/test/311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
@@ -16,11 +16,11 @@
 
 package com.nvidia.spark.rapids.shims.spark311;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 1))
   }

--- a/sql-plugin/src/test/311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark340;
+package com.nvidia.spark.rapids.shims.spark311;
 
 import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
-class Spark340ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 4, 0))
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 1))
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark340.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark311.RapidsShuffleManager].getCanonicalName)
   }
-
 }

--- a/sql-plugin/src/test/312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
@@ -16,11 +16,11 @@
 
 package com.nvidia.spark.rapids.shims.spark312;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 2))
   }

--- a/sql-plugin/src/test/312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark312;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+class SparkShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 2))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark312.RapidsShuffleManager].getCanonicalName)
+  }
+}

--- a/sql-plugin/src/test/313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark313;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+class SparkShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 3))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark313.RapidsShuffleManager].getCanonicalName)
+  }
+}

--- a/sql-plugin/src/test/313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
@@ -16,11 +16,11 @@
 
 package com.nvidia.spark.rapids.shims.spark313;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 1, 3))
   }

--- a/sql-plugin/src/test/320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark322;
+package com.nvidia.spark.rapids.shims.spark320;
 
 import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
@@ -22,17 +22,17 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark322ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 2))
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 0))
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark322.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark320.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig322") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark320;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 0))
   }

--- a/sql-plugin/src/test/321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark321;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
+
+class SparkShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 1))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark321.RapidsShuffleManager].getCanonicalName)
+  }
+
+  test("TypeSig") {
+    val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
+    assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
+    assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)
+  }
+
+}

--- a/sql-plugin/src/test/321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark321;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 1))
   }

--- a/sql-plugin/src/test/321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,24 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark321;
+package com.nvidia.spark.rapids.shims.spark321cdh;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
-import com.nvidia.spark.rapids.shims.SparkShimImpl
+import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark321ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 1))
+    assert(VersionUtils.cmpSparkVersion(3, 2, 1) === 0)
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark321.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark321cdh.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig321") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(VersionUtils.cmpSparkVersion(3, 2, 1) === 0)
   }

--- a/sql-plugin/src/test/322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark322;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 2))
   }

--- a/sql-plugin/src/test/322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark330;
+package com.nvidia.spark.rapids.shims.spark322;
 
 import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
@@ -22,17 +22,17 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark330ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 0))
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 2))
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark330.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark322.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig330") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark323;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 3))
   }

--- a/sql-plugin/src/test/323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark331;
+package com.nvidia.spark.rapids.shims.spark323;
 
 import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
@@ -22,17 +22,17 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark331ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 1))
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 3))
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark331.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark323.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig331") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark320;
+package com.nvidia.spark.rapids.shims.spark330;
 
 import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
 import com.nvidia.spark.rapids.shims.SparkShimImpl
@@ -22,17 +22,17 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark320ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 0))
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 0))
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark320.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark330.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig320") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark330;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 0))
   }

--- a/sql-plugin/src/test/330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
@@ -21,7 +21,7 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(VersionUtils.cmpSparkVersion(3, 3, 0) === 0)
   }

--- a/sql-plugin/src/test/330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,24 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.shims.spark323;
+package com.nvidia.spark.rapids.shims.spark330cdh;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
-import com.nvidia.spark.rapids.shims.SparkShimImpl
+import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class Spark323ShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite {
   test("spark shims version") {
-    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 2, 3))
+    assert(VersionUtils.cmpSparkVersion(3, 3, 0) === 0)
   }
 
   test("shuffle manager class") {
     assert(ShimLoader.getRapidsShuffleManagerClass ===
-      classOf[com.nvidia.spark.rapids.spark323.RapidsShuffleManager].getCanonicalName)
+      classOf[com.nvidia.spark.rapids.spark330cdh.RapidsShuffleManager].getCanonicalName)
   }
 
-  test("TypeSig323") {
+  test("TypeSig") {
     val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
     assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
     assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)

--- a/sql-plugin/src/test/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark331;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 1))
   }

--- a/sql-plugin/src/test/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark331;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
+
+class SparkShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 1))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark331.RapidsShuffleManager].getCanonicalName)
+  }
+
+  test("TypeSig") {
+    val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
+    assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
+    assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)
+  }
+
+}

--- a/sql-plugin/src/test/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
@@ -16,13 +16,13 @@
 
 package com.nvidia.spark.rapids.shims.spark332;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 2))
   }

--- a/sql-plugin/src/test/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark332;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion, TypeSig}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
+
+class SparkShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 3, 2))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark332.RapidsShuffleManager].getCanonicalName)
+  }
+
+  test("TypeSig") {
+    val check = TypeSig.DAYTIME + TypeSig.YEARMONTH
+    assert(check.isSupportedByPlugin(DayTimeIntervalType()) == true)
+    assert(check.isSupportedByPlugin(YearMonthIntervalType()) == true)
+  }
+
+}

--- a/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -20,8 +20,8 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
 
-class Spark340ShimsSuite extends FunSuite with FQSuiteName {
-  test("spark shims version") {
+class SparkShimsSuite extends FunSuite with FQSuiteName {
+  ignore("spark shims version - https://github.com/NVIDIA/spark-rapids/issues/7676") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 4, 0))
   }
 

--- a/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -16,11 +16,12 @@
 
 package com.nvidia.spark.rapids.shims.spark340;
 
-import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
+import com.nvidia.spark.rapids.FQSuiteName
 
-class Spark340ShimsSuite extends FunSuite {
+class Spark340ShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {
     assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 4, 0))
   }

--- a/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims.spark340;
+
+import com.nvidia.spark.rapids.{ShimLoader, SparkShimVersion}
+import com.nvidia.spark.rapids.shims.SparkShimImpl
+import org.scalatest.FunSuite
+
+class Spark340ShimsSuite extends FunSuite {
+  test("spark shims version") {
+    assert(SparkShimImpl.getSparkShimVersion === SparkShimVersion(3, 4, 0))
+  }
+
+  test("shuffle manager class") {
+    assert(ShimLoader.getRapidsShuffleManagerClass ===
+      classOf[com.nvidia.spark.rapids.spark340.RapidsShuffleManager].getCanonicalName)
+  }
+
+}

--- a/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.shims.spark340;
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.scalatest.FunSuite
-import com.nvidia.spark.rapids.FQSuiteName
 
 class Spark340ShimsSuite extends FunSuite with FQSuiteName {
   test("spark shims version") {

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/FQSuiteName.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/FQSuiteName.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+trait FQSuiteName extends org.scalatest.Suite {
+  override def suiteName: String = getClass().getName()
+}


### PR DESCRIPTION
- missing shim suites from Psnapshots profile,
- buildver in the package name is sufficient, use a uniform class name SparkShimsSuite for easier scripting
- add package with buildver as a decorator in a common base trait at runtime

reproduced and verified with 

```bash
printf '%s' $(mvn help:evaluate -Dexpression=included_buildvers -q -pl dist -Psnapshots -DforceStdout) ',340' \
   | tr -s ',' $'\n' \
   | xargs -t -n 1 bash -c 'mvn test -pl sql-plugin \
       -Dsuites=com.nvidia.spark.rapids.shims.spark$1.SparkShimsSuite \
       -Dbuildver=$1' '{}'
```

These  ScalaTests are not added for Databricks due #1320 

Contributes to #7487 


Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
