### PR TITLE
Fix Parquet dynamic partition test for [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -20,7 +20,7 @@ from data_gen import *
 from enum import Enum
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320, is_databricks_runtime
 import pyspark.sql.functions as f
 import pyspark.sql.utils
 import random
@@ -573,9 +573,12 @@ def test_write_empty_data_single_writer(spark_tmp_path):
 PartitionWriteMode = Enum('PartitionWriteMode', ['Static', 'Dynamic'])
 
 
+@pytest.mark.skipif(is_databricks_runtime(),
+                    reason="On Databricks, Hive partitioned SQL writes are routed through InsertIntoHiveTable; "
+                           "GpuInsertIntoHiveTable does not support Parquet writes.")
 @ignore_order(local=True)
 @pytest.mark.parametrize('mode', [PartitionWriteMode.Static, PartitionWriteMode.Dynamic])
-def test_partitioned_parquet_write(mode, spark_tmp_table_factory):
+def test_partitioned_sql_parquet_write(mode, spark_tmp_table_factory):
 
     def create_input_table(spark):
         tmp_input = spark_tmp_table_factory.get()
@@ -625,4 +628,38 @@ def test_partitioned_parquet_write(mode, spark_tmp_table_factory):
     assert_gpu_and_cpu_sql_writes_are_equal_collect(
         spark_tmp_table_factory, write_partitions,
         conf={"hive.exec.dynamic.partition.mode": "nonstrict"}
+    )
+
+
+@ignore_order(local=True)
+def test_dynamic_partitioned_parquet_write(spark_tmp_table_factory, spark_tmp_path):
+
+    def create_input_table(spark):
+        tmp_input = spark_tmp_table_factory.get()
+        spark.sql("CREATE TABLE " + tmp_input +
+                  " (make STRING, model STRING, year INT, type STRING, comment STRING)" +
+                  " STORED AS PARQUET")
+        spark.sql("INSERT INTO TABLE " + tmp_input + " VALUES " +
+                  "('Ford',   'F-150',       2020, 'ICE',      'Popular' ),"
+                  "('GMC',    'Sierra 1500', 1997, 'ICE',      'Older'),"
+                  "('Chevy',  'D-Max',       2015, 'ICE',      'Isuzu?' ),"
+                  "('Tesla',  'CyberTruck',  2025, 'Electric', 'BladeRunner'),"
+                  "('Rivian', 'R1T',         2022, 'Electric', 'Heavy'),"
+                  "('Jeep',   'Gladiator',   2024, 'Hybrid',   'Upcoming')")
+        return tmp_input
+
+    input_table_name = with_cpu_session(create_input_table)
+    base_output_path = spark_tmp_path + "/PARQUET_DYN_WRITE"
+
+    def write_partitions(spark, table_path):
+        input_df = spark.sql("SELECT * FROM {}".format(input_table_name))
+        input_df.write.mode("overwrite").partitionBy("type").parquet(table_path)
+        # Second write triggers the actual overwrite.
+        input_df.write.mode("overwrite").partitionBy("type").parquet(table_path)
+
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        lambda spark, path: write_partitions(spark, path),
+        lambda spark, path: spark.read.parquet(path),
+        base_output_path,
+        conf={}
     )


### PR DESCRIPTION
Fixes #7679.
The Parquet dynamic partitioning test added in #7653 does not run on Databricks successfully.
It turns out that on Databricks, a SQL query that writes partitions dynamically to a Parquet table is routed through `InsertIntoHiveTable` instead of `InsertIntoHadoopFSRelationCommand` as on Apache Spark. 
For one, `InsertIntoHiveTable` is not currently supported on `spark-rapids` (at least until #7556 is merged).
For another, `GpuInsertIntoHiveTable` would not support serialization of Parquet tables anyway.

This commit skips the SQL dynamic partitioning test on Databricks, and replaces it with a Dataframes-based test. The new test is functional on both Databricks and Apache Spark.
