### PR TITLE
Disable Dynamic partitioning tests on CDH

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -531,6 +531,9 @@ def test_basic_hive_text_write(std_input_path, input_dir, schema, spark_tmp_tabl
 PartitionWriteMode = Enum('PartitionWriteMode', ['Static', 'Dynamic'])
 
 
+@pytest.mark.skipif(is_spark_cdh(),
+                    reason="Hive text is disabled on CDH, as per "
+                           "https://github.com/NVIDIA/spark-rapids/pull/7628")
 @ignore_order(local=True)
 @pytest.mark.parametrize('mode', [PartitionWriteMode.Static, PartitionWriteMode.Dynamic])
 def test_partitioned_hive_text_write(mode, spark_tmp_table_factory):

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -20,7 +20,7 @@ from data_gen import *
 from enum import Enum
 from marks import *
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320, is_databricks_runtime
+from spark_session import with_cpu_session, with_gpu_session, is_before_spark_330, is_before_spark_320, is_spark_cdh, is_databricks_runtime
 import pyspark.sql.functions as f
 import pyspark.sql.utils
 import random
@@ -573,8 +573,8 @@ def test_write_empty_data_single_writer(spark_tmp_path):
 PartitionWriteMode = Enum('PartitionWriteMode', ['Static', 'Dynamic'])
 
 
-@pytest.mark.skipif(is_databricks_runtime(),
-                    reason="On Databricks, Hive partitioned SQL writes are routed through InsertIntoHiveTable; "
+@pytest.mark.skipif(is_databricks_runtime() or is_spark_cdh(),
+                    reason="On Databricks and CDH, Hive partitioned SQL writes are routed through InsertIntoHiveTable; "
                            "GpuInsertIntoHiveTable does not support Parquet writes.")
 @ignore_order(local=True)
 @pytest.mark.parametrize('mode', [PartitionWriteMode.Static, PartitionWriteMode.Dynamic])


### PR DESCRIPTION
Fixes #7693.

This commit disables two (failing) tests on CDH.

1. `test_partitioned_sql_parquet_write()` fails on CDH just like it fails on Databricks. This is because SQL partition writes are routed through the `InsertIntoHiveTable` instead of `InsertIntoHadoopFSRelation` as on Apache Spark. `GpuInsertIntoHiveTable` only supports Hive text tables at the moment. Further, the exec is disabled even for Hive text tables on CDH. This test would be testing disabled functionality on CDH.

2. `test_partitioned_hive_text_write()` should have been disabled on CDH as part of #7556. This was an oversight. CDH does not currently support acceleration for reads or writes of Hive delimited text.

Signed-off-by: MithunR <mythrocks@gmail.com>