### PR TITLE
Set Hive write test to ignore order on verification.

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -432,6 +432,7 @@ TableWriteMode = Enum('TableWriteMode', ['CTAS', 'CreateThenWrite'])
                     reason="Hive text is disabled on CDH, as per "
                            "https://github.com/NVIDIA/spark-rapids/pull/7628")
 @approximate_float
+@ignore_order(local=True)
 @pytest.mark.parametrize('mode', [TableWriteMode.CTAS, TableWriteMode.CreateThenWrite])
 @pytest.mark.parametrize('input_dir,schema,options', [
     ('hive-delim-text/simple-boolean-values', make_schema(BooleanType()),        {}),


### PR DESCRIPTION
Fixes #7703.

The Hive text write tests should ignore order when verifying the write output. If not, we might not get consistent reads between CPU and GPU, especially if the output splits between multiple files.