### PR TITLE
Enable Dynamic FIle Pruning on [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -125,7 +125,7 @@ def test_delta_dfp_reuse_broadcast_exchange(spark_tmp_table_factory, s_index, aq
             .mode("overwrite") \
             .partitionBy("key", "skey") \
             .saveAsTable(fact_table)
-        spark.sql("OPTIMIZE {} ZORDER BY ex_key".format(fact_table))
+        spark.sql("OPTIMIZE {} ZORDER BY ex_key".format(fact_table)).show()
 
         df = gen_df(spark, [
             ('key', LongGen(nullable=False, min_val=0, max_val=9, special_cases=[])),

--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -156,6 +156,7 @@ def test_delta_dfp_reuse_broadcast_exchange(spark_tmp_table_factory, s_index, aq
         exist_classes,
         # Ensure Dynamic File Pruning kicks in by setting thresholds to 0
         conf=dict(_exchange_reuse_conf + [
+            ('spark.databricks.optimizer.dynamicFilePruning', 'true'),
             ('spark.databricks.optimizer.deltaTableSizeThreshold', '0'),
             ('spark.databricks.optimizer.deltaTableFilesThreshold', '0'),
             ('spark.sql.adaptive.enabled', aqe_enabled)]))

--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -14,10 +14,12 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect
 from data_gen import *
 from marks import allow_non_gpu, ignore_order, delta_lake
-from spark_session import is_databricks_runtime, with_cpu_session, with_gpu_session
+from spark_session import is_databricks_runtime, with_cpu_session, with_gpu_session, is_databricks104_or_later, is_databricks113_or_later
+
+from dpp_test import _exchange_reuse_conf
 
 # Almost all of this is the metadata query
 # the important part is to not have InterleaveBits or HilbertLongIndex and PartitionerExpr
@@ -48,3 +50,112 @@ def test_delta_zorder(spark_tmp_table_factory):
                   "spark.rapids.sql.castFloatToString.enabled": True,
                   "spark.rapids.sql.explain": "ALL"})
 
+_statements = [
+    # join on z-ordered column
+    '''
+    SELECT fact.ex_key, sum(fact.value)
+    FROM {0} fact
+    JOIN {1} dim
+    ON fact.ex_key = dim.ex_key
+    WHERE dim.filter = {2}
+    GROUP BY fact.ex_key
+    ''',
+    # join on 1 partitioned and 1 z-ordered column
+    '''
+    SELECT fact.key, fact.ex_key, sum(fact.value)
+    FROM {0} fact
+    JOIN {1} dim
+    ON fact.key = dim.key AND fact.ex_key = dim.ex_key
+    WHERE dim.filter = {2}
+    GROUP BY fact.key, fact.ex_key
+    ''',
+    # join on 2 partitioned and 1 z-ordered columns
+    '''
+    SELECT fact.key, fact.skey, fact.ex_key, sum(fact.value)
+    FROM {0} fact
+    JOIN {1} dim
+    ON fact.key = dim.key AND fact.skey = dim.skey AND fact.ex_key = dim.ex_key
+    WHERE dim.filter = {2}
+    GROUP BY fact.key, fact.skey, fact.ex_key
+    ''',
+    # reused subquery, join on z-ordered column
+    '''
+    SELECT ex_key, max(value)
+    FROM (
+        SELECT fact.ex_key as ex_key, fact.value as value
+        FROM {0} fact
+        JOIN {1} dim
+        ON fact.ex_key = dim.ex_key
+        WHERE dim.filter = {2}
+    UNION ALL
+        SELECT fact.ex_key as ex_key, fact.value as value
+        FROM {0} fact
+        JOIN {1} dim
+        ON fact.ex_key = dim.ex_key
+        WHERE dim.filter = {2}
+    )
+    GROUP BY ex_key
+    '''
+]
+
+# This tests Dynamic File Pruning, a feature in Databricks that is similar to Dynamic Partition Pruning 
+# except that it adds the DynamicPruningExpression for columns that are not partition columns but are still
+# optimized. In this case the DynamicPruningExpression should be added to the DataFilters in the scan.
+# This test is very similar to `test_dpp_reuse_broadcast_exchange` but it tests joining using a Z-ordered
+# column
+@delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(not is_databricks104_or_later(), reason="Dynamic File Pruning is only supported in Databricks 10.4+")
+@pytest.mark.parametrize('s_index', list(range(len(_statements))), ids=idfn)
+@pytest.mark.parametrize('aqe_enabled', ['false', 'true'])
+def test_delta_dfp_reuse_broadcast_exchange(spark_tmp_table_factory, s_index, aqe_enabled):
+    fact_table, dim_table = spark_tmp_table_factory.get(), spark_tmp_table_factory.get()
+
+    def build_and_optimize_tables(spark):
+        # Note that ex_key is a high-cardinality column, which makes it a good candidate for 
+        # for Z-ordering, which then means it can then be used in Dynamic File Pruning in joins
+        df = gen_df(spark, [
+            ('key', LongGen(nullable=False, min_val=0, max_val=9, special_cases=[])),
+            ('skey', LongGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
+            ('ex_key', LongGen(nullable=False, min_val=0, max_val=10000, special_cases=[])),
+            ('value', int_gen),
+        ], 10000)
+
+        df.write.format("delta") \
+            .mode("overwrite") \
+            .partitionBy("key", "skey") \
+            .saveAsTable(fact_table)
+        spark.sql("OPTIMIZE {} ZORDER BY ex_key".format(fact_table))
+
+        df = gen_df(spark, [
+            ('key', LongGen(nullable=False, min_val=0, max_val=9, special_cases=[])),
+            ('skey', LongGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
+            ('ex_key', LongGen(nullable=False, min_val=0, max_val=10000, special_cases=[])),
+            ('value', int_gen),
+            ('filter', RepeatSeqGen(
+                IntegerGen(min_val=0, max_val=2000, special_cases=[]), length=2000 // 20))
+        ], 2000)
+        df.write.format("delta") \
+            .mode("overwrite") \
+            .saveAsTable(dim_table)
+        return df.select('filter').first()[0]
+
+    filter_val = with_cpu_session(build_and_optimize_tables)
+
+    statement = _statements[s_index].format(fact_table, dim_table, filter_val)
+
+    if is_databricks113_or_later() and aqe_enabled == 'true':
+        # SubqueryBroadcastExec is unoptimized in Databricks 11.3 with EXECUTOR_BROADCAST
+        # See https://github.com/NVIDIA/spark-rapids/issues/7425
+        exist_classes='DynamicPruningExpression,SubqueryBroadcastExec,ReusedExchangeExec'
+    else:
+        exist_classes='DynamicPruningExpression,GpuSubqueryBroadcastExec,ReusedExchangeExec'
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: spark.sql(statement),
+        # The existence of GpuSubqueryBroadcastExec indicates the reuse works on the GPU
+        exist_classes,
+        # Ensure Dynamic File Pruning kicks in by setting thresholds to 0
+        conf=dict(_exchange_reuse_conf + [
+            ('spark.databricks.optimizer.deltaTableSizeThreshold', '0'),
+            ('spark.databricks.optimizer.deltaTableFilesThreshold', '0'),
+            ('spark.sql.adaptive.enabled', aqe_enabled)]))

--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
@@ -38,7 +38,8 @@ class FileSourceScanExecMeta(plan: FileSourceScanExec,
   // a new meta for SubqueryBroadcastExec. The reason is that the GPU replacement of
   // FileSourceScan is independent from the replacement of the partitionFilters. It is
   // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
-  // are on the GPU. And vice versa.
+  // are on the GPU. And vice versa. The same applies for dataFilters in the case of
+  // Dynamic File Pruning
   private def convertBroadcast(bc: SubqueryBroadcastExec):BaseSubqueryExec = {
     val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
     meta.tagForExplain()
@@ -81,6 +82,7 @@ class FileSourceScanExecMeta(plan: FileSourceScanExec,
   }
 
 
+  // Support partitionFilters in Dynamic Partition Pruning
   private lazy val partitionFilters = {
     wrapped.partitionFilters.map { filter =>
       filter.transformDown {
@@ -97,6 +99,7 @@ class FileSourceScanExecMeta(plan: FileSourceScanExec,
     }
   }
 
+  // Support dataFilters in Dynamic File Pruning
   private lazy val dataFilters = {
     wrapped.dataFilters.map { filter =>
       filter.transformDown {

--- a/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
+++ b/sql-plugin/src/main/321+-db/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ class FileSourceScanExecMeta(plan: FileSourceScanExec,
   // possible that the FileSourceScan is on the CPU, while the dynamic partitionFilters
   // are on the GPU. And vice versa. The same applies for dataFilters in the case of
   // Dynamic File Pruning
-  private def convertBroadcast(bc: SubqueryBroadcastExec):BaseSubqueryExec = {
+  private def convertBroadcast(bc: SubqueryBroadcastExec): BaseSubqueryExec = {
     val meta = GpuOverrides.wrapAndTagPlan(bc, conf)
     meta.tagForExplain()
     if (conf.shouldExplain) {


### PR DESCRIPTION
Fixes #7648. 

This PR enables [Dynamic File Pruning](https://docs.databricks.com/optimizations/dynamic-file-pruning.html) functionality in the plugin in Databricks environments. It does this by handling `DynamicPruningExpressions` that can show up in the `DataFilters` of a FileSourceScanExec in addition to `PartitionFilters`. This occurs when joining on a non-partition column in a Delta Table that is optimized.  In addition, an integration test is added that creates the optimized fact table and dim table and then tests several joins on the z-ordered column.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
