### PR TITLE
Workaround for incompatible serialization for `Inf` floats in Hive text write

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -450,8 +450,7 @@ TableWriteMode = Enum('TableWriteMode', ['CTAS', 'CreateThenWrite'])
                  marks=pytest.mark.xfail(condition=is_spark_cdh(),
                                          reason="https://github.com/NVIDIA/spark-rapids/issues/7423")),
     # Floating Point.
-    pytest.param('hive-delim-text/simple-float-values',   make_schema(FloatType()),          {},
-                 marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/7686")),
+    ('hive-delim-text/simple-float-values',   make_schema(FloatType()),          {}),
     pytest.param('hive-delim-text/simple-float-values', make_schema(DecimalType(10, 3)), {},
                  marks=pytest.mark.xfail(condition=is_spark_cdh(),
                                          reason="https://github.com/NVIDIA/spark-rapids/issues/7423")),

--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -432,6 +432,7 @@ TableWriteMode = Enum('TableWriteMode', ['CTAS', 'CreateThenWrite'])
                     reason="Hive text is disabled on CDH, as per "
                            "https://github.com/NVIDIA/spark-rapids/pull/7628")
 @approximate_float
+@ignore_order(local=True)
 @pytest.mark.parametrize('mode', [TableWriteMode.CTAS, TableWriteMode.CreateThenWrite])
 @pytest.mark.parametrize('input_dir,schema,options', [
     ('hive-delim-text/simple-boolean-values', make_schema(BooleanType()),        {}),

--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -546,7 +546,7 @@ def test_partitioned_hive_text_write(mode, spark_tmp_table_factory):
                   "('Ford',   'F-150',       2020, 'ICE',      'Popular' ),"
                   "('GMC',    'Sierra 1500', 1997, 'ICE',      'Older'),"
                   "('Chevy',  'D-Max',       2015, 'ICE',      'Isuzu?' ),"
-                  "('Tesla',  'CyberTruck',  2025, 'Electric', 'Fictional'),"
+                  "('Tesla',  'CyberTruck',  2025, 'Electric', 'BladeRunner'),"
                   "('Rivian', 'R1T',         2022, 'Electric', 'Heavy'),"
                   "('Jeep',   'Gladiator',   2024, 'Hybrid',   'Upcoming')")
         return tmp_input

--- a/sql-plugin/src/main/311until340-all/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
+++ b/sql-plugin/src/main/311until340-all/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
@@ -16,12 +16,12 @@
 
 package org.apache.spark.sql.hive.rapids.shims
 
-import ai.rapids.cudf.{CSVWriterOptions, HostBufferConsumer, QuoteStyle, Scalar, Table, TableWriter => CudfTableWriter}
+import ai.rapids.cudf.{CSVWriterOptions, DType, HostBufferConsumer, QuoteStyle, Scalar, Table, TableWriter => CudfTableWriter}
 import com.google.common.base.Charsets
 import com.nvidia.spark.rapids.{ColumnarFileFormat, ColumnarOutputWriter, ColumnarOutputWriterFactory, FileFormatChecks, HiveDelimitedTextFormatType, RapidsConf, WriteFileOp}
+
 import java.nio.charset.Charset
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.rapids.GpuHiveTextFileUtils._
@@ -125,14 +125,19 @@ class GpuHiveTextWriter(override val path: String,
                         context: TaskAttemptContext)
   extends ColumnarOutputWriter(context, dataSchema, "HiveText") {
 
-  // This CSV writer reformats timestamps. By default, the CUDF CSV writer
-  // writes timestamps in the following format:
-  //   "2020-09-16T22:32:01.123456Z"
-  // Such a timestamp is incompatible with Hive's LazySimpleSerDe format:
-  //   "uuuu-MM-dd HH:mm:ss[.SSS...]"
-  // (Specifically, the `T` between `dd` and `HH`, and the `Z` at the end.)
-  class TimestampReformattingCSVWriter(writeOptions: CSVWriterOptions,
-                                       bufferConsumer: HostBufferConsumer)
+  /**
+   * This CSV writer reformats columns, to iron out inconsistencies between
+   * CUDF serialization results and the values expected by Apache Spark
+   * (and Apache Hive's) `LazySimpleSerDe`.
+   *
+   * This writer currently reformats timestamp and floating point
+   * columns.
+   *
+   * @param writeOptions CSVWriterOptions for serializing in CSV with CUDF
+   * @param bufferConsumer In-memory buffer for storing the written results
+   */
+  class ComplianceReformattingCSVWriter(writeOptions: CSVWriterOptions,
+                                        bufferConsumer: HostBufferConsumer)
     extends CudfTableWriter {
 
     val underlying: CudfTableWriter = Table.getCSVBufferWriter(writeOptions, bufferConsumer)
@@ -141,9 +146,26 @@ class GpuHiveTextWriter(override val path: String,
       val columns = for (i <- 0 until table.getNumberOfColumns) yield {
         table.getColumn(i) match {
           case c if c.getType.hasTimeResolution =>
+            // By default, the CUDF CSV writer writes timestamps in the following format:
+            //   "2020-09-16T22:32:01.123456Z"
+            // Hive's LazySimpleSerDe format expects timestamps to be formatted thus:
+            //   "uuuu-MM-dd HH:mm:ss[.SSS...]"
+            // (Specifically, no `T` between `dd` and `HH`, and no `Z` at the end.)
             withResource(c.asStrings("%Y-%m-%d %H:%M:%S.%f")) { asStrings =>
               withResource(Scalar.fromString("\\N")) { nullString =>
                 asStrings.replaceNulls(nullString)
+              }
+            }
+          case c if c.getType == DType.FLOAT32 || c.getType == DType.FLOAT64 =>
+            // By default, the CUDF CSV writer writes floats with value `Infinity`
+            // as `"Inf"`.
+            // Hive's LazySimplSerDe expects such values to be written as `"Infinity"`.
+            // All occurrences of `Inf` need to be replaced with `Infinity`.
+            withResource(c.castTo(DType.STRING)) { asStrings =>
+              withResource(Scalar.fromString("Inf")) { infString =>
+                withResource(Scalar.fromString("Infinity")) { infinityString =>
+                  asStrings.stringReplace(infString, infinityString)
+                }
               }
             }
           case c => c.incRefCount()
@@ -172,8 +194,8 @@ class GpuHiveTextWriter(override val path: String,
       .withNullValue("\\N")
       .withQuoteStyle(QuoteStyle.NONE)
 
-    new TimestampReformattingCSVWriter(writeOptions = writeOptions.build,
-                                            bufferConsumer = this)
+    new ComplianceReformattingCSVWriter(writeOptions = writeOptions.build,
+                                        bufferConsumer = this)
   }
 }
 

--- a/sql-plugin/src/main/311until340-all/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
+++ b/sql-plugin/src/main/311until340-all/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.hive.rapids.shims
 import ai.rapids.cudf.{CSVWriterOptions, DType, HostBufferConsumer, QuoteStyle, Scalar, Table, TableWriter => CudfTableWriter}
 import com.google.common.base.Charsets
 import com.nvidia.spark.rapids.{ColumnarFileFormat, ColumnarOutputWriter, ColumnarOutputWriterFactory, FileFormatChecks, HiveDelimitedTextFormatType, RapidsConf, WriteFileOp}
-
 import java.nio.charset.Charset
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.rapids.GpuHiveTextFileUtils._


### PR DESCRIPTION
Fixes #7686.
Depends on #7708.

The `GpuHiveTextFileFormat` is currently serializing Float(Infinity) as 'Inf' instead of
'Infinity'. (It boils down to the CUDF implementation using 'Inf'.)
    
Apache Spark (and Apache Hive) expect Infinity strings to be represented as 'Infinity'. 'Inf' is read as `NULL`.
    
This commit adds special handling for floating point, such that 'Inf' is replaced with
'Infinity' before serializing to the table.
    
Signed-off-by: MithunR <mythrocks@gmail.com>