### PR TITLE
Clean the code of `GpuMetrics`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -104,8 +104,8 @@ object GpuMetric extends Logging {
   val DESCRIPTION_WRITE_BUFFER_TIME = "time to write data to buffer"
 
   def unwrap(input: GpuMetric): SQLMetric = input match {
-      case w :WrappedGpuMetric => w.sqlMetric
-      case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
+    case w :WrappedGpuMetric => w.sqlMetric
+    case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
   }
 
   def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = input.collect {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -103,6 +103,11 @@ object GpuMetric extends Logging {
   val DESCRIPTION_READ_FS_TIME = "time to read fs data"
   val DESCRIPTION_WRITE_BUFFER_TIME = "time to write data to buffer"
 
+  def unwrap(input: GpuMetric): SQLMetric = input match {
+      case w :WrappedGpuMetric => w.sqlMetric
+      case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
+  }
+
   def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = input.collect {
     // remove the metrics that are not registered (NoopMetric)
     case (k, w: WrappedGpuMetric) => (k, w.sqlMetric)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -109,12 +109,14 @@ object GpuMetric extends Logging {
   }
 
   def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = input.collect {
-    // remove the metrics that are not registered (NoopMetric)
-    case (k, w: WrappedGpuMetric) => (k, w.sqlMetric)
+    // remove the metrics that are not registered
+    case (k, w) if w != NoopMetric => (k, unwrap(w))
   }
 
+  def wrap(input: SQLMetric): GpuMetric = WrappedGpuMetric(input)
+
   def wrap(input: Map[String, SQLMetric]): Map[String, GpuMetric] = input.map {
-    case (k, v) => (k, WrappedGpuMetric(v))
+    case (k, v) => (k, wrap(v))
   }
 
   object DEBUG_LEVEL extends MetricsLevel(0)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,25 +103,14 @@ object GpuMetric extends Logging {
   val DESCRIPTION_READ_FS_TIME = "time to read fs data"
   val DESCRIPTION_WRITE_BUFFER_TIME = "time to write data to buffer"
 
-  def unwrap(input: GpuMetric): SQLMetric = input match {
-    case w :WrappedGpuMetric => w.sqlMetric
-    case i => throw new IllegalArgumentException(s"found unsupported GpuMetric ${i.getClass}")
+  def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = input.collect {
+    // remove the metrics that are not registered (NoopMetric)
+    case (k, w: WrappedGpuMetric) => (k, w.sqlMetric)
   }
 
-  def unwrap(input: Map[String, GpuMetric]): Map[String, SQLMetric] = input.filter {
-    // remove the metrics that are not registered
-    case (_, NoopMetric) => false
-    case _ => true
-    // sadly mapValues produces a non-serializable result, so we have to hack it a bit to force
-    // it to be materialized
-  }.mapValues(unwrap).toArray.toMap
-
-  def wrap(input: SQLMetric): GpuMetric = WrappedGpuMetric(input)
-
-  def wrap(input: Map[String, SQLMetric]): Map[String, GpuMetric] =
-  // sadly mapValues produces a non-serializable result, so we have to hack it a bit to force
-  // it to be materialized
-    input.mapValues(wrap).toArray.toMap
+  def wrap(input: Map[String, SQLMetric]): Map[String, GpuMetric] = input.map {
+    case (k, v) => (k, WrappedGpuMetric(v))
+  }
 
   object DEBUG_LEVEL extends MetricsLevel(0)
   object MODERATE_LEVEL extends MetricsLevel(1)
@@ -160,7 +149,7 @@ sealed abstract class GpuMetric extends Serializable {
   def +=(v: Long): Unit
   def add(v: Long): Unit
 
-  def ns[T](f: => T): T = {
+  final def ns[T](f: => T): T = {
     val start = System.nanoTime()
     try {
       f
@@ -177,7 +166,7 @@ object NoopMetric extends GpuMetric {
   override def value: Long = 0
 }
 
-case class WrappedGpuMetric(sqlMetric: SQLMetric) extends GpuMetric {
+final case class WrappedGpuMetric(sqlMetric: SQLMetric) extends GpuMetric {
   def +=(v: Long): Unit = sqlMetric.add(v)
   def add(v: Long): Unit = sqlMetric.add(v)
   override def set(v: Long): Unit = sqlMetric.set(v)


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

## Changes in the PR
1. mark `WrappedGpuMetric` as `final`
2. remove the usage of `mapValues` because it is non-strict and has been deprecated (actually, it has been a method of `MapView`, not `Map`)
```
warning: method mapValues in trait MapOps is deprecated (since 2.13.0): Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).
```
3. Simplify the `wrap` and  `unwrap` function
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

4. Please ensure that you have written units tests for the changes made/features
   added.

5. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

6. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

7. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

8. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
