### PR TITLE
Move Databricks variables into blossom-lib [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -40,52 +40,6 @@ def db_build = false
 def sourcePattern = 'shuffle-plugin/src/main/scala/,udf-compiler/src/main/scala/,' +
     'sql-plugin/src/main/java/,sql-plugin/src/main/scala/'
 
-// constant parameters for aws and azure databricks cluster
-// CSP params
-ID_HOST = 0
-ID_TOKEN = 1
-ID_DRIVER = 2
-ID_WORKER = 3
-PARAM_MAP = [
-        'aws'  : [
-                "${common.AWS_DATABRICKS_URL}",
-                'SPARK_AWS_DATABRICKS_TOKEN',
-                'g4dn.2xlarge',
-                'g4dn.2xlarge'
-        ],
-        'azure': [
-                "${common.AZURE_DATABRICKS_URL}",
-                'SPARK_AZURE_DATABRICKS_TOKEN',
-                'Standard_NC6s_v3',
-                'Standard_NC6s_v3'
-        ]
-]
-// runtime params
-ID_RUNTIME = 0
-ID_SPARK = 1
-ID_INITSCRIPTS = 2
-ID_INSTALL = 3
-RUNTIME_MAP = [
-        '9.1': [
-                '9.1.x-gpu-ml-scala2.12',
-                '3.1.2',
-                'init_cudf_udf.sh',
-                '3.1.2'
-        ],
-        '10.4': [
-                '10.4.x-gpu-ml-scala2.12',
-                '3.2.1',
-                'init_cudf_udf.sh',
-                '3.2.1'
-        ],
-        '11.3': [
-                '11.3.x-gpu-ml-scala2.12',
-                '3.3.0',
-                'init_cudf_udf.sh',
-                '3.3.0'
-        ]
-]
-
 pipeline {
     agent {
         kubernetes {
@@ -125,11 +79,11 @@ pipeline {
         IDLE_TIMEOUT = '240' // 4 hours
         NUM_WORKERS = '0'
         DB_TYPE = getDbType()
-        DATABRICKS_HOST = "${PARAM_MAP["$DB_TYPE"][ID_HOST]}"
-        DATABRICKS_TOKEN = credentials("${PARAM_MAP["$DB_TYPE"][ID_TOKEN]}")
+        DATABRICKS_HOST = DbUtils.getHost("$DB_TYPE")
+        DATABRICKS_TOKEN = credentials("${DbUtils.getToken("$DB_TYPE")}")
         DATABRICKS_PUBKEY = credentials("SPARK_DATABRICKS_PUBKEY")
-        DATABRICKS_DRIVER = "${PARAM_MAP["$DB_TYPE"][ID_DRIVER]}"
-        DATABRICKS_WORKER = "${PARAM_MAP["$DB_TYPE"][ID_WORKER]}"
+        DATABRICKS_DRIVER = DbUtils.getDriver("$DB_TYPE")
+        DATABRICKS_WORKER = DbUtils.getWorker("$DB_TYPE")
         INIT_SCRIPTS_DIR = "dbfs:/databricks/init_scripts/${BUILD_TAG}"
     }
 
@@ -231,13 +185,6 @@ pipeline {
                 script {
                     githubHelper.updateCommitStatus("$BUILD_URL", "Running - includes databricks", GitHubCommitState.PENDING)
                     unstash "source_tree"
-                    container('cpu') {
-                        sh """
-                            bash -c 'dbfs mkdirs $INIT_SCRIPTS_DIR'
-                            bash -c 'dbfs cp --overwrite jenkins/databricks/init_cudf_udf.sh $INIT_SCRIPTS_DIR'
-                            bash -c 'dbfs cp --overwrite jenkins/databricks/init_cuda11_runtime.sh $INIT_SCRIPTS_DIR'
-                        """
-                    }
                 }
             }
         }
@@ -338,11 +285,10 @@ pipeline {
                     }
                     environment {
                         DB_RUNTIME = '9.1'
-                        DATABRICKS_RUNTIME = "${RUNTIME_MAP["$DB_RUNTIME"][ID_RUNTIME]}"
-                        BASE_SPARK_VERSION = "${RUNTIME_MAP["$DB_RUNTIME"][ID_SPARK]}"
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = "${RUNTIME_MAP["$DB_RUNTIME"][ID_INSTALL]}"
-                        INIT_SCRIPTS = getInitScripts("$INIT_SCRIPTS_DIR",
-                                "${RUNTIME_MAP["$DB_RUNTIME"][ID_INITSCRIPTS]}")
+                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
+                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
+                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
+                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
                     }
                     steps {
                         script {
@@ -371,11 +317,10 @@ pipeline {
                     }
                     environment {
                         DB_RUNTIME = '10.4'
-                        DATABRICKS_RUNTIME = "${RUNTIME_MAP["$DB_RUNTIME"][ID_RUNTIME]}"
-                        BASE_SPARK_VERSION = "${RUNTIME_MAP["$DB_RUNTIME"][ID_SPARK]}"
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = "${RUNTIME_MAP["$DB_RUNTIME"][ID_INSTALL]}"
-                        INIT_SCRIPTS = getInitScripts("$INIT_SCRIPTS_DIR",
-                                "${RUNTIME_MAP["$DB_RUNTIME"][ID_INITSCRIPTS]}")
+                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
+                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
+                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
+                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
                     }
                     steps {
                         script {
@@ -404,11 +349,10 @@ pipeline {
                     }
                     environment {
                         DB_RUNTIME = '11.3'
-                        DATABRICKS_RUNTIME = "${RUNTIME_MAP["$DB_RUNTIME"][ID_RUNTIME]}"
-                        BASE_SPARK_VERSION = "${RUNTIME_MAP["$DB_RUNTIME"][ID_SPARK]}"
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = "${RUNTIME_MAP["$DB_RUNTIME"][ID_INSTALL]}"
-                        INIT_SCRIPTS = getInitScripts("$INIT_SCRIPTS_DIR",
-                                "${RUNTIME_MAP["$DB_RUNTIME"][ID_INITSCRIPTS]}")
+                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
+                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
+                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
+                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
                     }
                     steps {
                         script {
@@ -450,12 +394,6 @@ pipeline {
                     }
                 }
 
-                if (db_build) {
-                    container('cpu') {
-                        sh "bash -c 'dbfs rm -r $INIT_SCRIPTS_DIR || true'"
-                    }
-                }
-
                 if (TEMP_IMAGE_BUILD) {
                     container('cpu') {
                         deleteDockerTempTag("${PREMERGE_TAG}") // clean premerge temp image
@@ -472,14 +410,10 @@ String getDbType() {
     return params.DATABRICKS_TYPE ? params.DATABRICKS_TYPE : 'aws'
 }
 
-// e.g. foo.sh,bar.sh --> /dbfs/path/foo.sh,/dbfs/path/bar.sh
-String getInitScripts(String rootDir, String files) {
-    return rootDir + '/' + files.replace(',', ',' + rootDir + '/')
-}
-
 void databricksBuild() {
     def CLUSTER_ID = ''
     def SPARK_MAJOR = BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS.replace('.', '')
+    def dbfs_path = "$INIT_SCRIPTS_DIR-$DB_TYPE"
     try {
         stage("Create $SPARK_MAJOR DB") {
             script {
@@ -488,7 +422,18 @@ void databricksBuild() {
                     sh "tar -zcf spark-rapids-ci.tgz *"
                     def CREATE_PARAMS = " -r $DATABRICKS_RUNTIME -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN" +
                             " -s $DB_TYPE -n CI-${BUILD_TAG}-${BASE_SPARK_VERSION} -k \"$DATABRICKS_PUBKEY\" -i $IDLE_TIMEOUT" +
-                            " -d $DATABRICKS_DRIVER -o $DATABRICKS_WORKER -e $NUM_WORKERS -f $INIT_SCRIPTS"
+                            " -d $DATABRICKS_DRIVER -o $DATABRICKS_WORKER -e $NUM_WORKERS"
+
+                    // handle init scripts if exist
+                    if ( env.INIT_SCRIPTS ){
+                        sh "bash -c 'dbfs mkdirs $dbfs_path'"
+                        env.INIT_SCRIPTS.split(',').each {
+                            sh "bash -c 'dbfs cp --overwrite jenkins/databricks/${it} $dbfs_path'"
+                        }
+                        // foo.sh,bar.sh --> dbfs:/path/foo.sh,dbfs:/path/bar.sh
+                        CREATE_PARAMS += " -f $dbfs_path/" + env.INIT_SCRIPTS.replace(',', ",$dbfs_path/")
+                    }
+
                     CLUSTER_ID = sh(script: "python3 ./jenkins/databricks/create.py $CREATE_PARAMS",
                             returnStdout: true).trim()
                     echo CLUSTER_ID
@@ -532,6 +477,9 @@ void databricksBuild() {
         if (CLUSTER_ID) {
             container('cpu') {
                 retry(3) {
+                    if ( env.INIT_SCRIPTS ){
+                        sh "bash -c 'dbfs rm -r $dbfs_path'"
+                    }
                     sh "python3 ./jenkins/databricks/shutdown.py -s $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -d"
                 }
             }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -425,7 +425,7 @@ void databricksBuild() {
                             " -d $DATABRICKS_DRIVER -o $DATABRICKS_WORKER -e $NUM_WORKERS"
 
                     // handle init scripts if exist
-                    if ( env.INIT_SCRIPTS ){
+                    if (env.INIT_SCRIPTS) {
                         sh "bash -c 'dbfs mkdirs $dbfs_path'"
                         env.INIT_SCRIPTS.split(',').each {
                             sh "bash -c 'dbfs cp --overwrite jenkins/databricks/${it} $dbfs_path'"
@@ -477,7 +477,7 @@ void databricksBuild() {
         if (CLUSTER_ID) {
             container('cpu') {
                 retry(3) {
-                    if ( env.INIT_SCRIPTS ){
+                    if (env.INIT_SCRIPTS) {
                         sh "bash -c 'dbfs rm -r $dbfs_path'"
                     }
                     sh "python3 ./jenkins/databricks/shutdown.py -s $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -d"


### PR DESCRIPTION
Move Databricks variables into blossom-lib to share the variables among Jenkins files.

Keep only one copy of the Databricks variables in blossom-lib to make it easy to maintain.

Signed-off-by: Tim Liu <timl@nvidia.com>
