### PR TITLE
Fix estimatedNumBatches in case of OOM for Full Outer Join

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -371,7 +371,7 @@ abstract class BaseHashJoinIterator(
   }
 
   private def estimatedNumBatches(cb: ColumnarBatch): Int = joinType match {
-    case _: InnerLike | LeftOuter | RightOuter =>
+    case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
       // We want the gather map size to be around the target size. There are two gather maps
       // that are made up of ints, so estimate how many rows per batch on the stream side
       // will produce the desired gather map size.


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

When we added support for batched full join, we changed the OOM handling code to apply for FullOuter join because it is now implemented as either a LeftOuter or a RightOuter join.  But we missed updating the function that estimates the number of batches.  It is still returning 1 for FullOuter joins.  It should return the same estimate for FullOuter as it is doing for LeftOuter and RightOuter.
