### PR TITLE
[FEA] Switch to `regex_program` APIs

### DIFF
--- a/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
+++ b/sql-plugin/src/main/330+/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit.{DAYS, HOURS, MINUTES, SECONDS}
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, RegexProgram, Scalar}
 import com.nvidia.spark.rapids.{Arm, BoolUtils, CloseableHolder}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
@@ -167,21 +167,19 @@ object GpuIntervalUtils extends Arm {
    * @param t              day-time interval type
    * @return long column of micros
    */
- @scala.annotation.nowarn("msg=method extractRe in class ColumnView is deprecated")
   def castStringToDTInterval(cv: ColumnView, t: DT): ColumnVector = {
     (t.startField, t.endField) match {
-      case (DT.DAY, DT.DAY) => withResource(cv.extractRe(dayLiteralRegex)) {
-        groupsTable => {
+      case (DT.DAY, DT.DAY) =>
+        withResource(cv.extractRe(new RegexProgram(dayLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromDayToDay(sign,
               groupsTable.getColumn(2) // day
             )
           }
         }
-      }
 
-      case (DT.DAY, DT.HOUR) => withResource(cv.extractRe(dayHourLiteralRegex)) {
-        groupsTable => {
+      case (DT.DAY, DT.HOUR) =>
+        withResource(cv.extractRe(new RegexProgram(dayHourLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromDayToHour(sign,
               groupsTable.getColumn(2), // day
@@ -189,10 +187,9 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
-      case (DT.DAY, DT.MINUTE) => withResource(cv.extractRe(dayMinuteLiteralRegex)) {
-        groupsTable => {
+      case (DT.DAY, DT.MINUTE) =>
+        withResource(cv.extractRe(new RegexProgram(dayMinuteLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromDayToMinute(sign,
               groupsTable.getColumn(2), // day
@@ -201,10 +198,9 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
-      case (DT.DAY, DT.SECOND) => withResource(cv.extractRe(daySecondLiteralRegex)) {
-        groupsTable => {
+      case (DT.DAY, DT.SECOND) =>
+        withResource(cv.extractRe(new RegexProgram(daySecondLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromDayToSecond(sign,
               groupsTable.getColumn(2), // day
@@ -215,19 +211,18 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
-      case (DT.HOUR, DT.HOUR) => withResource(cv.extractRe(hourLiteralRegex)) { groupsTable => {
-        withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
-          addFromHourToHour(sign,
-            groupsTable.getColumn(2) // hour
-          )
+      case (DT.HOUR, DT.HOUR) =>
+        withResource(cv.extractRe(new RegexProgram(hourLiteralRegex))) { groupsTable =>
+          withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
+            addFromHourToHour(sign,
+              groupsTable.getColumn(2) // hour
+            )
+          }
         }
-      }
-      }
 
-      case (DT.HOUR, DT.MINUTE) => withResource(cv.extractRe(hourMinuteLiteralRegex)) {
-        groupsTable => {
+      case (DT.HOUR, DT.MINUTE) =>
+        withResource(cv.extractRe(new RegexProgram(hourMinuteLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromHourToMinute(sign,
               groupsTable.getColumn(2), // hour
@@ -235,34 +230,30 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
-      case (DT.HOUR, DT.SECOND) => withResource(cv.extractRe(hourSecondLiteralRegex)) {
-        groupsTable => {
-          withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) {
-            sign =>
-              addFromHourToSecond(sign,
-                groupsTable.getColumn(2), // hour
-                groupsTable.getColumn(3), // minute
-                groupsTable.getColumn(4), // second
-                groupsTable.getColumn(5) // micros
-              )
+      case (DT.HOUR, DT.SECOND) =>
+        withResource(cv.extractRe(new RegexProgram(hourSecondLiteralRegex))) { groupsTable =>
+          withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
+            addFromHourToSecond(sign,
+              groupsTable.getColumn(2), // hour
+              groupsTable.getColumn(3), // minute
+              groupsTable.getColumn(4), // second
+              groupsTable.getColumn(5) // micros
+            )
           }
         }
-      }
 
-      case (DT.MINUTE, DT.MINUTE) => withResource(cv.extractRe(minuteLiteralRegex)) {
-        groupsTable => {
+      case (DT.MINUTE, DT.MINUTE) =>
+        withResource(cv.extractRe(new RegexProgram(minuteLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromMinuteToMinute(sign,
               groupsTable.getColumn(2) // minute
             )
           }
         }
-      }
 
-      case (DT.MINUTE, DT.SECOND) => withResource(cv.extractRe(minuteSecondLiteralRegex)) {
-        groupsTable => {
+      case (DT.MINUTE, DT.SECOND) =>
+        withResource(cv.extractRe(new RegexProgram(minuteSecondLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromMinuteToSecond(sign,
               groupsTable.getColumn(2), // minute
@@ -271,10 +262,9 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
-      case (DT.SECOND, DT.SECOND) => withResource(cv.extractRe(secondLiteralRegex)) {
-        groupsTable => {
+      case (DT.SECOND, DT.SECOND) =>
+        withResource(cv.extractRe(new RegexProgram(secondLiteralRegex))) { groupsTable =>
           withResource(finalSign(groupsTable.getColumn(0), groupsTable.getColumn(1))) { sign =>
             addFromSecondToSecond(sign,
               groupsTable.getColumn(2), // second
@@ -282,7 +272,6 @@ object GpuIntervalUtils extends Arm {
             )
           }
         }
-      }
 
       case _ =>
         throw new RuntimeException(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -22,7 +22,7 @@ import java.util.Optional
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DecimalUtils, DType, Scalar}
+import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DecimalUtils, DType, RegexProgram, Scalar}
 import ai.rapids.cudf
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.CastStrings
@@ -971,13 +971,15 @@ object GpuCast extends Arm {
   }
 
   /** This method does not close the `input` ColumnVector. */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
+  // @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   def convertDateOrNull(
       input: ColumnVector,
       regex: String,
       cudfFormat: String): ColumnVector = {
 
-    val isValidDate = withResource(input.matchesRe(regex)) { isMatch =>
+    // val isValidDate = withResource(input.matchesRe(regex)) { isMatch =>
+    val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
+    val isValidDate = withResource(input.matchesRe(prog)) { isMatch =>
       withResource(input.isTimestamp(cudfFormat)) { isTimestamp =>
         isMatch.and(isTimestamp)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -971,13 +971,11 @@ object GpuCast extends Arm {
   }
 
   /** This method does not close the `input` ColumnVector. */
-  // @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   def convertDateOrNull(
       input: ColumnVector,
       regex: String,
       cudfFormat: String): ColumnVector = {
 
-    // val isValidDate = withResource(input.matchesRe(regex)) { isMatch =>
     val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
     val isValidDate = withResource(input.matchesRe(prog)) { isMatch =>
       withResource(input.isTimestamp(cudfFormat)) { isTimestamp =>
@@ -995,14 +993,14 @@ object GpuCast extends Arm {
   }
 
     /** This method does not close the `input` ColumnVector. */
-    @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
     def convertDateOr(
       input: ColumnVector,
       regex: String,
       cudfFormat: String,
       orElse: ColumnVector): ColumnVector = {
-
-    val isValidDate = withResource(input.matchesRe(regex)) { isMatch =>
+    
+    val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
+    val isValidDate = withResource(input.matchesRe(prog)) { isMatch =>
       withResource(input.isTimestamp(cudfFormat)) { isTimestamp =>
         isMatch.and(isTimestamp)
       }
@@ -1081,14 +1079,14 @@ object GpuCast extends Arm {
   }
 
   /** This method does not close the `input` ColumnVector. */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   private def convertTimestampOrNull(
       input: ColumnVector,
       regex: String,
       cudfFormat: String): ColumnVector = {
 
     withResource(Scalar.fromNull(DType.TIMESTAMP_MICROSECONDS)) { orElse =>
-      val isValidTimestamp = withResource(input.matchesRe(regex)) { isMatch =>
+      val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
+      val isValidTimestamp = withResource(input.matchesRe(prog)) { isMatch =>
         withResource(input.isTimestamp(cudfFormat)) { isTimestamp =>
           isMatch.and(isTimestamp)
         }
@@ -1102,7 +1100,6 @@ object GpuCast extends Arm {
   }
 
   /** This method does not close the `input` ColumnVector. */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   private def convertTimestampOr(
       input: ColumnVector,
       regex: String,
@@ -1110,7 +1107,8 @@ object GpuCast extends Arm {
       orElse: ColumnVector): ColumnVector = {
 
     withResource(orElse) { orElse =>
-      val isValidTimestamp = withResource(input.matchesRe(regex)) { isMatch =>
+      val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
+      val isValidTimestamp = withResource(input.matchesRe(prog)) { isMatch =>
         withResource(input.isTimestamp(cudfFormat)) { isTimestamp =>
           isMatch.and(isTimestamp)
         }
@@ -1124,7 +1122,6 @@ object GpuCast extends Arm {
   }
 
   /** This method does not close the `input` ColumnVector. */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   private def convertFullTimestampOr(
       input: ColumnVector,
       orElse: ColumnVector): ColumnVector = {
@@ -1150,7 +1147,8 @@ object GpuCast extends Arm {
       }
 
       val isValidTimestamp = withResource(isCudfMatch) { _ =>
-        withResource(input.matchesRe(TIMESTAMP_REGEX_FULL)) { isRegexMatch =>
+        val prog = new RegexProgram(TIMESTAMP_REGEX_FULL, CaptureGroups.NON_CAPTURE)
+        withResource(input.matchesRe(prog)) { isRegexMatch =>
           isCudfMatch.and(isRegexMatch)
         }
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -631,7 +631,6 @@ object GpuCast extends Arm {
     }
   }
 
-  @scala.annotation.nowarn("msg=method stringReplaceWithBackrefs in class ColumnView is deprecated")
   private def castTimestampToString(input: ColumnView): ColumnVector = {
     // the complexity in this function is due to Spark's rules for truncating
     // the fractional part of the timestamp string. Any trailing decimal place
@@ -654,7 +653,8 @@ object GpuCast extends Arm {
         // the decimal point and the last non-zero digit
         // the second group (non-capture) covers the remaining zeroes
         withResource(firstPass) { _ =>
-          firstPass.stringReplaceWithBackrefs("(\\.[0-9]*[1-9]+)(?:0+)?$", "\\1")
+          val prog = new RegexProgram("(\\.[0-9]*[1-9]+)(?:0+)?$")
+          firstPass.stringReplaceWithBackrefs(prog, "\\1")
         }
       }
     }
@@ -1163,7 +1163,6 @@ object GpuCast extends Arm {
     }
   }
 
-  @scala.annotation.nowarn("msg=method stringReplaceWithBackrefs in class ColumnView is deprecated")
   private def castStringToTimestamp(input: ColumnVector, ansiMode: Boolean): ColumnVector = {
 
     // special timestamps
@@ -1175,7 +1174,8 @@ object GpuCast extends Arm {
 
     // prepend today's date to timestamp formats without dates
     sanitizedInput = withResource(sanitizedInput) { _ =>
-      sanitizedInput.stringReplaceWithBackrefs(TIMESTAMP_REGEX_NO_DATE, s"${todayStr}T\\1")
+      val prog = new RegexProgram(TIMESTAMP_REGEX_NO_DATE)
+      sanitizedInput.stringReplaceWithBackrefs(prog, s"${todayStr}T\\1")
     }
 
     withResource(sanitizedInput) { sanitizedInput =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2358,6 +2358,7 @@ object GpuOverrides extends Logging {
       }),
     expr[StringSplit](
        "Splits `str` around occurrences that match `regex`",
+      // Java's split API produces different behaviors than cudf when splitting with empty pattern
       ExprChecks.projectOnly(TypeSig.ARRAY.nested(TypeSig.STRING),
         TypeSig.ARRAY.nested(TypeSig.STRING),
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
@@ -2505,6 +2506,7 @@ object GpuOverrides extends Logging {
       }),
     expr[StringToMap](
       "Creates a map after splitting the input string into pairs of key-value strings",
+      // Java's split API produces different behaviors than cudf when splitting with empty pattern
       ExprChecks.projectOnly(TypeSig.MAP.nested(TypeSig.STRING), TypeSig.MAP.nested(TypeSig.STRING),
         Seq(ParamCheck("str", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("pairDelim", TypeSig.lit(TypeEnum.STRING), TypeSig.lit(TypeEnum.STRING)),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
@@ -403,7 +403,6 @@ abstract class GpuTextBasedPartitionReader[BUFF <: LineBufferer, FACT <: LineBuf
     }
   }
 
-  @scala.annotation.nowarn("msg=in class ColumnView is deprecated")
   def castStringToTimestamp(
       lhs: ColumnVector,
       sparkFormat: String,
@@ -462,8 +461,8 @@ abstract class GpuTextBasedPartitionReader[BUFF <: LineBufferer, FACT <: LineBuf
       // `@` was chosen somewhat arbitrarily but should be safe since we do not support any
       // date/time formats that contain the `@` character
       val placeholder = "@"
-      withResource(regexpFiltered.stringReplaceWithBackrefs(
-        raw"(\.\d{3})(Z?)\Z", raw"\1$placeholder\2")) { tmp =>
+      val prog = new RegexProgram(raw"(\.\d{3})(Z?)\Z")
+      withResource(regexpFiltered.stringReplaceWithBackrefs(prog, raw"\1$placeholder\2")) { tmp =>
         withResource(Scalar.fromString(placeholder)) { from =>
           withResource(Scalar.fromString("000")) { to =>
             tmp.stringReplace(from, to)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.hive.rapids
 
-import ai.rapids.cudf.{ColumnVector, DType, Scalar, Schema, Table}
+import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.RebaseHelper.withResource
 import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, PartitionReaderIterator, PartitionReaderWithBytesRead, RapidsConf}
 import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, DEBUG_LEVEL, DESCRIPTION_BUFFER_TIME, DESCRIPTION_FILTER_TIME, DESCRIPTION_GPU_DECODE_TIME, DESCRIPTION_PEAK_DEVICE_MEMORY, ESSENTIAL_LEVEL, FILTER_TIME, GPU_DECODE_TIME, MODERATE_LEVEL, NUM_OUTPUT_ROWS, PEAK_DEVICE_MEMORY}
@@ -586,11 +586,11 @@ class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
    *   1. The input strings are not trimmed of whitespace.
    *   2. Invalid date strings do not cause exceptions.
    */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   override def castStringToDate(input: ColumnVector, dt: DType): ColumnVector = {
     // Filter out any dates that do not conform to the `yyyy-MM-dd` format.
     val supportedDateRegex = raw"\A\d{4}-\d{2}-\d{2}\Z"
-    val regexFiltered = withResource(input.matchesRe(supportedDateRegex)) { matchesRegex =>
+    val prog = new RegexProgram(supportedDateRegex, CaptureGroups.NON_CAPTURE)
+    val regexFiltered = withResource(input.matchesRe(prog)) { matchesRegex =>
       withResource(Scalar.fromNull(DType.STRING)) { nullString =>
         matchesRegex.ifElse(input, nullString)
       }
@@ -608,7 +608,6 @@ class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
     }
   }
 
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   override def castStringToTimestamp(lhs: ColumnVector, sparkFormat: String, dType: DType)
   : ColumnVector = {
     // Currently, only the following timestamp pattern is supported:
@@ -619,7 +618,8 @@ class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
     // Input strings that do not match this format strictly must be replaced with nulls.
     //                 yyyy-  MM -  dd    HH  :  mm  :  ss [SSS...     ]
     val regex = raw"\A\d{4}-\d{2}-\d{2} \d{2}\:\d{2}\:\d{2}(?:\.\d{1,9})?\Z"
-    val regexFiltered = withResource(lhs.matchesRe(regex)) { matchesRegex =>
+    val prog = new RegexProgram(regex, CaptureGroups.NON_CAPTURE)
+    val regexFiltered = withResource(lhs.matchesRe(prog)) { matchesRegex =>
       withResource(Scalar.fromNull(DType.STRING)) { nullString =>
         matchesRegex.ifElse(lhs, nullString)
       }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -482,7 +482,6 @@ case class GpuHiveTextPartitionReaderFactory(sqlConf: SQLConf,
 }
 
 // Reader that converts from chunked data buffers into cudf.Table.
-@scala.annotation.nowarn("msg=method stringSplit in class ColumnView is deprecated")
 class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
                                           csvOptions: CSVOptions,
                                           params: Map[String, String],
@@ -503,7 +502,7 @@ class GpuHiveDelimitedTextPartitionReader(conf: Configuration,
     // The delimiter is currently hard coded to ^A. This should be able to support any format
     //  but we don't want to test that yet
     val splitTable = withResource(dataBufferer.getColumnAndRelease) { cv =>
-      cv.stringSplit("\u0001", false)
+      cv.stringSplit("\u0001")
     }
 
     // inputFileCudfSchema       == Schema of the input file/buffer.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -551,7 +551,6 @@ object GpuToTimestamp extends Arm {
    * Parse string to timestamp when timeParserPolicy is LEGACY. This was the default behavior
    * prior to Spark 3.0
    */
-  @scala.annotation.nowarn("msg=in class ColumnView is deprecated")
   def parseStringAsTimestampWithLegacyParserPolicy(
       lhs: GpuColumnVector,
       sparkFormat: String,
@@ -580,7 +579,7 @@ object GpuToTimestamp extends Arm {
     val fixedUp = rulesWithSeparator
       .foldLeft(rejectLeadingNewlineThenStrip(lhs))((cv, regexRule) => {
         withResource(cv) {
-          _.stringReplaceWithBackrefs(regexRule.search, regexRule.replace)
+          _.stringReplaceWithBackrefs(new RegexProgram(regexRule.search), regexRule.replace)
         }
       })
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -599,7 +599,6 @@ object GpuToTimestamp extends Arm {
    * Filter out strings that have a newline before the first non-whitespace character
    * and then strip all leading and trailing whitespace.
    */
-  @scala.annotation.nowarn("msg=method matchesRe in class ColumnView is deprecated")
   private def rejectLeadingNewlineThenStrip(lhs: GpuColumnVector) = {
     val prog = new RegexProgram("\\A[ \\t]*[\\n]+", CaptureGroups.NON_CAPTURE)
     withResource(lhs.getBase.matchesRe(prog)) { hasLeadingNewline =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -21,7 +21,7 @@ import java.util.Optional
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{BinaryOp, BinaryOperable, ColumnVector, ColumnView, DType, PadSide, Scalar, Table}
+import ai.rapids.cudf.{BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, PadSide, RegexProgram, Scalar, Table}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{ShimExpression, SparkShimImpl}
@@ -1044,9 +1044,8 @@ case class GpuRLike(left: Expression, right: Expression, pattern: String)
     throw new IllegalStateException("Really should not be here, " +
       "Cannot have a scalar as left side operand in RLike")
 
-  @scala.annotation.nowarn("msg=method containsRe in class ColumnView is deprecated")
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
-    lhs.getBase.containsRe(pattern)
+    lhs.getBase.containsRe(new RegexProgram(pattern, CaptureGroups.NON_CAPTURE))
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1379,7 +1379,6 @@ case class GpuRegExpExtractAll(
 
   override def prettyName: String = "regexp_extract_all"
 
-  @scala.annotation.nowarn("msg=method extractAllRecord in class ColumnView is deprecated")
   override def doColumnar(
       str: GpuColumnVector,
       regexp: GpuScalar,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.ColumnVector
+import ai.rapids.cudf.{ColumnVector, RegexProgram}
 import java.sql.{Date, Timestamp}
 import org.scalatest.BeforeAndAfterEach
 import scala.collection.mutable.ListBuffer
@@ -279,11 +279,11 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     assert(res)
   }
 
-  @scala.annotation.nowarn("msg=method stringReplaceWithBackrefs in class ColumnView is deprecated")
   private def testRegex(rule: RegexReplace, values: Seq[String], expected: Seq[String]): Unit = {
     withResource(ColumnVector.fromStrings(values: _*)) { v =>
       withResource(ColumnVector.fromStrings(expected: _*)) { expected =>
-        withResource(v.stringReplaceWithBackrefs(rule.search, rule.replace)) { actual =>
+        val prog = new RegexProgram(rule.search)
+        withResource(v.stringReplaceWithBackrefs(prog, rule.replace)) { actual =>
           CudfTestHelper.assertColumnsAreEqual(expected, actual)
         }
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -942,7 +942,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         cv.stringReplaceWithBackrefs(cudfPattern, converted)
       } else {
         withResource(GpuScalar.from(converted, DataTypes.StringType)) { replace =>
-          cv.replaceRegex(cudfPattern, replace)
+          val prog = new RegexProgram(cudfPattern, CaptureGroups.NON_CAPTURE)
+          cv.replaceRegex(prog, replace)
         }
       }
       withResource(c) { c => 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -931,7 +931,6 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   private val REPLACE_STRING = "\\_\\RE\\\\P\\L\\A\\C\\E\\_"
 
   /** cuDF replaceRe helper */
-  @scala.annotation.nowarn("msg=in class ColumnView is deprecated")
   private def gpuReplace(cudfPattern: String, replaceString: String,
       input: Seq[String]): Array[String] = {
     val result = new Array[String](input.length)
@@ -939,7 +938,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     val (hasBackrefs, converted) = GpuRegExpUtils.backrefConversion(replace)
     withResource(ColumnVector.fromStrings(input: _*)) { cv =>
       val c = if (hasBackrefs) {
-        cv.stringReplaceWithBackrefs(cudfPattern, converted)
+        cv.stringReplaceWithBackrefs(new RegexProgram(cudfPattern), converted)
       } else {
         withResource(GpuScalar.from(converted, DataTypes.StringType)) { replace =>
           val prog = new RegexProgram(cudfPattern, CaptureGroups.NON_CAPTURE)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7295.

This is the Spark plugin side work for switching to `regex_program` APIs, moving all existing java API calls to the version that takes in a `regex_program`.

Currently we documented that Java's split API produces different behaviors than cudf when splitting with empty pattern (in expressions `StringSplit` and `StringToMap`). We filed a follow up issue https://github.com/NVIDIA/spark-rapids/issues/7785 to handle this in the future.