### PR TITLE
Update JNI version to released 23.02.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,7 +654,7 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>23.02.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-jni.version>23.02.0</spark-rapids-jni.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

JNI version to released 23.02.0.

I will retrigger CI once artifact is available at maven central