### PR TITLE
Workaround for cudf setup in databricks 11.3 runtime [databricks]

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -38,7 +38,8 @@ conda create -y -n cudf-udf -c conda-forge python=$PYTHON_VERSION mamba && \
 
 # Use mamba to install cudf-udf packages to speed up conda resolve time
 conda install -y -c conda-forge mamba python=$PYTHON_VERSION
-${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas
+# Do not error out "This operation will remove conda without replacing it with another version of conda." for now
+${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas || true
 
 REQUIRED_PACKAGES=(
   cudatoolkit=$CUDA_VER

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -18,7 +18,7 @@
 # The initscript to set up environment for the cudf_udf tests on Databricks
 # Will be automatically pushed into the dbfs:/databricks/init_scripts once it is updated.
 
-set -x
+set -ex
 
 CUDF_VER=${CUDF_VER:-23.04}
 CUDA_VER=${CUDA_VER:-11.0}
@@ -26,7 +26,9 @@ CUDA_VER=${CUDA_VER:-11.0}
 # Need to explicitly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH
 # Set Python for the running instance
-PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+# PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+# TODO: revert this change after https://github.com/rapidsai/cudf/issues/12764 is resolved
+PYTHON_VERSION='3.8'
 
 base=$(conda info --base)
 # Create and activate 'cudf-udf' conda env for cudf-udf tests


### PR DESCRIPTION
Signed-off-by: Peixin Li <pxli@nyu.edu>

fix https://github.com/NVIDIA/spark-rapids/issues/7639

root cause is https://github.com/rapidsai/cudf/issues/12764

also error out the script if fail execution during cluster creation by adding `-e`