### PR TITLE
Revert 7737 workaround for cudf setup in databricks 11.3 runtime [skip ci]

### DIFF
--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -18,7 +18,7 @@
 # The initscript to set up environment for the cudf_udf tests on Databricks
 # Will be automatically pushed into the dbfs:/databricks/init_scripts once it is updated.
 
-set -ex
+set -x
 
 CUDF_VER=${CUDF_VER:-23.04}
 CUDA_VER=${CUDA_VER:-11.0}
@@ -26,9 +26,7 @@ CUDA_VER=${CUDA_VER:-11.0}
 # Need to explicitly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH
 # Set Python for the running instance
-# PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
-# TODO: revert this change after https://github.com/rapidsai/cudf/issues/12764 is resolved
-PYTHON_VERSION='3.8'
+PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
 
 base=$(conda info --base)
 # Create and activate 'cudf-udf' conda env for cudf-udf tests
@@ -38,8 +36,7 @@ conda create -y -n cudf-udf -c conda-forge python=$PYTHON_VERSION mamba && \
 
 # Use mamba to install cudf-udf packages to speed up conda resolve time
 conda install -y -c conda-forge mamba python=$PYTHON_VERSION
-# Do not error out "This operation will remove conda without replacing it with another version of conda." for now
-${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas || true
+${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas
 
 REQUIRED_PACKAGES=(
   cudatoolkit=$CUDA_VER


### PR DESCRIPTION
This reverts commit fae8ec563cb61b8bfaa6231fb89324a253e9b38b.

Signed-off-by: Peixin Li <pxli@nyu.edu>

fix #7739 

we found new issue after specify python version which would conflict w/ existing compatibility support.

lets revert previous workaround first, and reopen #[7639](https://github.com/NVIDIA/spark-rapids/issues/7639)