### PR TITLE
batched full join tracking batch does not need to be lazy

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -545,7 +545,7 @@ class HashFullJoinIterator(
   private val useLeftOuterJoin = (buildSide == GpuBuildRight)
   private val numBuiltRows = built.numRows
 
-  private[this] var builtSideTracker : Option[LazySpillableColumnarBatch] = None
+  private[this] var builtSideTracker : Option[SpillableColumnarBatch] = None
 
   private val nullEquality = if (compareNullsEqual) NullEquality.EQUAL else NullEquality.UNEQUAL
 
@@ -643,12 +643,14 @@ class HashFullJoinIterator(
       builtSideTracker match {
         case None => None
         case Some(tracker) => {
-          val filteredBatch = withResource(tracker.releaseBatch()) { trackerBatch =>
-            withResource(GpuColumnVector.from(trackerBatch)) { trackerTab =>
-              val batch = built.getBatch
-              withResource(GpuColumnVector.from(batch)) { builtTable =>
-                withResource(builtTable.filter(trackerTab.getColumn(0))) { filterTab =>
-                  GpuColumnVector.from(filterTab, GpuColumnVector.extractTypes(batch))
+          val filteredBatch = withResource(tracker) { scb =>
+            withResource(scb.getColumnarBatch()) { trackerBatch =>
+              withResource(GpuColumnVector.from(trackerBatch)) { trackerTab =>
+                val batch = built.getBatch
+                withResource(GpuColumnVector.from(batch)) { builtTable =>
+                  withResource(builtTable.filter(trackerTab.getColumn(0))) { filterTab =>
+                    GpuColumnVector.from(filterTab, GpuColumnVector.extractTypes(batch))
+                  }
                 }
               }
             }
@@ -715,7 +717,7 @@ class HashFullJoinIterator(
     val updatedTrackingTable = withResource(filteredGatherMap) { filteredMap =>
       // Get the current tracking table, or all true table to start with
       val builtTrackingTable = builtSideTracker.map { spillableBatch =>
-        withResource(spillableBatch.releaseBatch()) { trackingBatch =>
+        withResource(spillableBatch.getColumnarBatch()) { trackingBatch =>
           GpuColumnVector.from(trackingBatch)
         }
       }.getOrElse {
@@ -727,13 +729,14 @@ class HashFullJoinIterator(
         }
       }
     }
-    builtSideTracker = withResource(updatedTrackingTable) { newTab =>
-      withResource(GpuColumnVector.from(newTab, Array[DataType](DataTypes.BooleanType))) { cb =>
-        val lazyBatch = LazySpillableColumnarBatch(cb, spillCallback, "tracking_batch")
-        lazyBatch.allowSpilling()
-        Some(lazyBatch)
-      }
+    val newScb = withResource(updatedTrackingTable) { _ =>
+      SpillableColumnarBatch(
+        GpuColumnVector.from(updatedTrackingTable, Array[DataType](DataTypes.BooleanType)),
+        SpillPriorities.ACTIVE_ON_DECK_PRIORITY, spillCallback)
     }
+    // Close old spillable batch and replace with updated one.
+    builtSideTracker.foreach(_.close())
+    builtSideTracker = Some(newScb)
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Jim Brennan <jimb@nvidia.com>

The `builtSideTracker` for batched full join is currently using a `LazySpillableColumnarBatch`, but we always immediately call `allowSpilling`, so it doesn't really need to be lazy.  We can just use `SpillableColumnarBatch`.
The only thing we lose by doing this is the nvtx ranges that are added in the Lazy version around `getBatch` and `allowSpilling`, but we already have ranges around the functions that call these.