### PR TITLE
Support Delta Lake optimized write on Databricks

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -24,15 +24,20 @@ package com.databricks.sql.transaction.tahoe.rapids
 import com.databricks.sql.transaction.tahoe._
 import com.databricks.sql.transaction.tahoe.actions.FileAction
 import com.databricks.sql.transaction.tahoe.constraints.{Constraint, DeltaInvariantCheckerExec}
+import com.databricks.sql.transaction.tahoe.files.TahoeBatchFileIndex
 import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
 import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
 import com.nvidia.spark.rapids._
 
-import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.rapids.GpuShuffleEnv
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
-import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.rapids.delta.{DeltaShufflePartitionsUtil, GpuOptimizeWriteExchangeExec, OptimizeWriteExchangeExec}
+import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Clock
 
 /**
@@ -128,6 +133,50 @@ abstract class GpuOptimisticTransactionBase
       inputData: Dataset[_],
       additionalConstraints: Seq[Constraint]): Seq[FileAction] = {
     writeFiles(inputData, None, additionalConstraints)
+  }
+
+  protected def applyOptimizeWriteIfNeeded(
+      spark: SparkSession,
+      physicalPlan: SparkPlan,
+      partitionSchema: StructType,
+      isOptimize: Boolean): SparkPlan = {
+    val optimizeWriteEnabled = !isOptimize &&
+        spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED)
+            .orElse(DeltaConfigs.OPTIMIZE_WRITE.fromMetaData(metadata)).getOrElse(false)
+    if (optimizeWriteEnabled) {
+      val planWithoutTopRepartition =
+        DeltaShufflePartitionsUtil.removeTopRepartition(physicalPlan)
+      val partitioning = DeltaShufflePartitionsUtil.partitioningForRebalance(
+        physicalPlan.output, partitionSchema, spark.sessionState.conf.numShufflePartitions)
+      planWithoutTopRepartition match {
+        case p: GpuExec =>
+          val partMeta = GpuOverrides.wrapPart(partitioning, rapidsConf, None)
+          partMeta.tagForGpu()
+          if (partMeta.canThisBeReplaced) {
+            val plan = GpuOptimizeWriteExchangeExec(partMeta.convertToGpu(), p)
+            if (GpuShuffleEnv.useGPUShuffle(rapidsConf)) {
+              GpuCoalesceBatches(plan, TargetSize(rapidsConf.gpuTargetBatchSizeBytes))
+            } else {
+              GpuShuffleCoalesceExec(plan, rapidsConf.gpuTargetBatchSizeBytes)
+            }
+          } else {
+            GpuColumnarToRowExec(OptimizeWriteExchangeExec(partitioning, p))
+          }
+        case p =>
+          OptimizeWriteExchangeExec(partitioning, p)
+      }
+    } else {
+      physicalPlan
+    }
+  }
+
+  protected def isOptimizeCommand(plan: LogicalPlan): Boolean = {
+    val leaves = plan.collectLeaves()
+    leaves.size == 1 && leaves.head.collect {
+      case LogicalRelation(HadoopFsRelation(
+      index: TahoeBatchFileIndex, _, _, _, _, _), _, _, _) =>
+        index.actionType.equals("Optimize")
+    }.headOption.getOrElse(false)
   }
 
   protected def convertToCpu(plan: SparkPlan): SparkPlan = plan match {

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaSQLConf.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaSQLConf.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaSQLConf.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta.
+ * (pending at https://github.com/delta-io/delta/pull/1198).
+*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta
+
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+
+/** Delta Lake related configs that are not yet provided by Delta Lake. */
+trait RapidsDeltaSQLConf {
+  val OPTIMIZE_WRITE_SMALL_PARTITION_FACTOR =
+    DeltaSQLConf.buildConf("optimizeWrite.smallPartitionFactor")
+        .internal()
+        .doc("Factor used to coalesce partitions for optimize write.")
+        .doubleConf
+        .createWithDefault(0.5)
+
+  val OPTIMIZE_WRITE_MERGED_PARTITION_FACTOR =
+    DeltaSQLConf.buildConf("optimizeWrite.mergedPartitionFactor")
+        .internal()
+        .doc("Factor used to rebalance partitions for optimize write.")
+        .doubleConf
+        .createWithDefault(1.2)
+}
+
+object RapidsDeltaSQLConf extends RapidsDeltaSQLConf

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids.delta
 
-import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOptions, DeltaParquetFileFormat}
+import com.databricks.sql.transaction.tahoe.{DeltaLog, DeltaParquetFileFormat}
 import com.nvidia.spark.rapids.{DeltaFormatType, FileFormatChecks, GpuParquetFileFormat, RapidsMeta, WriteFileOp}
 
 import org.apache.spark.sql.SparkSession
@@ -51,23 +51,6 @@ object RapidsDeltaUtils {
       } catch {
         case _: NoSuchElementException => None
       }
-    }
-
-    val optimizeWriteEnabled = {
-      val deltaOptions = new DeltaOptions(options, sqlConf)
-      deltaOptions.optimizeWrite.orElse {
-        getSQLConf("spark.databricks.delta.optimizeWrite.enabled").map(_.toBoolean).orElse {
-          val metadata = deltaLog.snapshot.metadata
-          DeltaConfigs.AUTO_OPTIMIZE.fromMetaData(metadata).orElse {
-            metadata.configuration.get("delta.autoOptimize.optimizeWrite").orElse {
-              getSQLConf("spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite")
-            }.map(_.toBoolean)
-          }
-        }
-      }.getOrElse(false)
-    }
-    if (optimizeWriteEnabled) {
-      meta.willNotWorkOnGpu("optimized write of Delta Lake tables is not supported")
     }
 
     val autoCompactEnabled =

--- a/delta-lake/common/src/main/databricks/scala/org/apache/spark/sql/rapids/delta/GpuOptimizeWriteExchangeExec.scala
+++ b/delta-lake/common/src/main/databricks/scala/org/apache/spark/sql/rapids/delta/GpuOptimizeWriteExchangeExec.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from OptimizeWriteExchange.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta
+ * (pending at https://github.com/delta-io/delta/pull/1198).
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.delta
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.{GpuColumnarBatchSerializer, GpuExec, GpuMetric, GpuPartitioning, GpuRoundRobinPartitioning}
+import com.nvidia.spark.rapids.delta.RapidsDeltaSQLConf
+
+import org.apache.spark.{MapOutputStatistics, ShuffleDependency}
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.execution.{CoalescedPartitionSpec, ShufflePartitionSpec, SparkPlan, SQLExecution}
+import org.apache.spark.sql.execution.exchange.Exchange
+import org.apache.spark.sql.execution.metric.{SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
+import org.apache.spark.sql.rapids.execution.{GpuShuffleExchangeExecBase, ShuffledBatchRDD}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Execution plan to repartition and rebalance the data for Optimize Write.
+ * The plan will be added on top of the query plan of each write job to avoid any interference
+ * from Adaptive Query Execution.
+ *
+ * @param partitioning Partitioning to use data exchange.
+ * @param child Input plan of write job.
+ */
+case class GpuOptimizeWriteExchangeExec(
+    partitioning: GpuPartitioning,
+    override val child: SparkPlan) extends Exchange with GpuExec {
+  import GpuMetric._
+
+  // Use 150% of target file size hint config considering parquet compression.
+  // Still the result file can be smaller/larger than the config due to data skew or
+  // variable compression ratio for each data type.
+  final val PARQUET_COMPRESSION_RATIO = 1.5
+
+  // Dummy partitioning because:
+  // 1) The exact output partitioning is determined at query runtime
+  // 2) optimizeWrite is always placed right after the top node(DeltaInvariantChecker),
+  //    there is no parent plan to refer to outputPartitioning
+  override def outputPartitioning: Partitioning = UnknownPartitioning(partitioning.numPartitions)
+
+  private lazy val writeMetrics =
+    SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
+  private[sql] lazy val readMetrics =
+    SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
+
+  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    "dataSize" -> createSizeMetric(ESSENTIAL_LEVEL, "data size"),
+    "dataReadSize" -> createSizeMetric(MODERATE_LEVEL, "data read size"),
+    "rapidsShuffleSerializationTime" ->
+        createNanoTimingMetric(DEBUG_LEVEL, "rs. serialization time"),
+    "rapidsShuffleDeserializationTime" ->
+        createNanoTimingMetric(DEBUG_LEVEL, "rs. deserialization time"),
+    "rapidsShuffleWriteTime" ->
+        createNanoTimingMetric(ESSENTIAL_LEVEL, "rs. shuffle write time"),
+    "rapidsShuffleCombineTime" ->
+        createNanoTimingMetric(DEBUG_LEVEL, "rs. shuffle combine time"),
+    "rapidsShuffleWriteIoTime" ->
+        createNanoTimingMetric(DEBUG_LEVEL, "rs. shuffle write io time"),
+    "rapidsShuffleReadTime" ->
+        createNanoTimingMetric(ESSENTIAL_LEVEL, "rs. shuffle read time")
+  ) ++ GpuMetric.wrap(readMetrics) ++ GpuMetric.wrap(writeMetrics)
+
+  override lazy val allMetrics: Map[String, GpuMetric] = {
+    Map(
+      PARTITION_SIZE -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_PARTITION_SIZE),
+      NUM_PARTITIONS -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_NUM_PARTITIONS),
+      NUM_OUTPUT_ROWS -> createMetric(ESSENTIAL_LEVEL, DESCRIPTION_NUM_OUTPUT_ROWS),
+      NUM_OUTPUT_BATCHES -> createMetric(MODERATE_LEVEL, DESCRIPTION_NUM_OUTPUT_BATCHES)
+    ) ++ additionalMetrics
+  }
+
+  private lazy val serializer: Serializer =
+    new GpuColumnarBatchSerializer(gpuLongMetric("dataSize"))
+
+  @transient lazy val inputRDD: RDD[ColumnarBatch] = child.executeColumnar()
+
+  @transient lazy val mapOutputStatisticsFuture: Future[MapOutputStatistics] = {
+    if (inputRDD.getNumPartitions == 0) {
+      Future.successful(null)
+    } else {
+      sparkContext.submitMapStage(shuffleDependency)
+    }
+  }
+
+
+  @transient lazy val shuffleDependency: ShuffleDependency[Int, ColumnarBatch, ColumnarBatch] = {
+    val dep = GpuShuffleExchangeExecBase.prepareBatchShuffleDependency(
+      inputRDD,
+      child.output,
+      partitioning,
+      child.output.map(_.dataType).toArray,
+      serializer,
+      useGPUShuffle=partitioning.usesGPUShuffle,
+      useMultiThreadedShuffle=partitioning.usesMultiThreadedShuffle,
+      metrics=allMetrics,
+      writeMetrics=writeMetrics,
+      additionalMetrics=additionalMetrics)
+    metrics("numPartitions").set(dep.partitioner.numPartitions)
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkContext, executionId, metrics("numPartitions") :: Nil)
+    dep
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    throw new IllegalStateException(s"Row-based execution should not occur for $this")
+  }
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    // Collect execution statistics, these will be used to adjust/decide how to split files
+    val stats = ThreadUtils.awaitResult(mapOutputStatisticsFuture, Duration.Inf)
+    if (stats == null) {
+      new ShuffledBatchRDD(shuffleDependency, metrics)
+    } else {
+      try {
+        val partitionSpecs = Some(rebalancePartitions(stats))
+        new ShuffledBatchRDD(shuffleDependency, metrics, partitionSpecs.get.toArray)
+      } catch {
+        case e: Throwable =>
+          logWarning("Failed to apply OptimizeWrite.", e)
+          new ShuffledBatchRDD(shuffleDependency, metrics)
+      }
+    }
+  }
+
+  private def rebalancePartitions(stats: MapOutputStatistics): Seq[ShufflePartitionSpec] = {
+    val binSize = ByteUnit.BYTE.convertFrom(
+      conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE), ByteUnit.MiB)
+    val smallPartitionFactor =
+      conf.getConf(RapidsDeltaSQLConf.OPTIMIZE_WRITE_SMALL_PARTITION_FACTOR)
+    val mergedPartitionFactor =
+      conf.getConf(RapidsDeltaSQLConf.OPTIMIZE_WRITE_MERGED_PARTITION_FACTOR)
+    val bytesByPartitionId = stats.bytesByPartitionId
+    val targetPartitionSize = (binSize * PARQUET_COMPRESSION_RATIO).toLong
+
+    val splitPartitions = if (partitioning.isInstanceOf[GpuRoundRobinPartitioning]) {
+      DeltaShufflePartitionsUtil.splitSizeListByTargetSize(
+        bytesByPartitionId,
+        targetPartitionSize,
+        smallPartitionFactor,
+        mergedPartitionFactor)
+    } else {
+      // For partitioned data, do not coalesce small partitions as it will hurt parallelism.
+      // Eg. a partition containing 100 partition keys => a task will write 100 files.
+      Seq.range(0, bytesByPartitionId.length).toArray
+    }
+
+    def optimizeSkewedPartition(reduceIndex: Int): Seq[ShufflePartitionSpec] = {
+      val partitionSize = bytesByPartitionId(reduceIndex)
+      if (partitionSize > targetPartitionSize) {
+        val shuffleId = shuffleDependency.shuffleId
+        val newPartitionSpec = DeltaShufflePartitionsUtil.createSkewPartitionSpecs(
+          shuffleId,
+          reduceIndex,
+          targetPartitionSize,
+          smallPartitionFactor,
+          mergedPartitionFactor)
+
+        if (newPartitionSpec.isEmpty) {
+          CoalescedPartitionSpec(reduceIndex, reduceIndex + 1) :: Nil
+        } else {
+          logDebug(s"[OptimizeWrite] Partition $reduceIndex is skew, " +
+              s"split it into ${newPartitionSpec.get.size} parts.")
+          newPartitionSpec.get
+        }
+      } else if (partitionSize > 0) {
+        CoalescedPartitionSpec(reduceIndex, reduceIndex + 1) :: Nil
+      } else {
+        Nil
+      }
+    }
+
+    // Transform the partitions to the ranges.
+    // e.g. [0, 3, 6, 7, 10] -> [[0, 3), [3, 6), [6, 7), [7, 10)]
+    (splitPartitions :+ stats.bytesByPartitionId.length).sliding(2).flatMap { k =>
+      if (k.head == k.last - 1) {
+        // If not a merged partition, split it if needed.
+        optimizeSkewedPartition(k.head)
+      } else {
+        CoalescedPartitionSpec(k.head, k.last) :: Nil
+      }
+    }.toList
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): GpuOptimizeWriteExchangeExec = {
+    copy(child = newChild)
+  }
+}

--- a/delta-lake/common/src/main/databricks/scala/org/apache/spark/sql/rapids/delta/OptimizeWriteExchangeExec.scala
+++ b/delta-lake/common/src/main/databricks/scala/org/apache/spark/sql/rapids/delta/OptimizeWriteExchangeExec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from OptimizeWriteExchange.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta
+ * (pending at https://github.com/delta-io/delta/pull/1198).
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.delta
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.delta.RapidsDeltaSQLConf
+
+import org.apache.spark.{MapOutputStatistics, ShuffleDependency}
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.rdd.RDD
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, RoundRobinPartitioning, UnknownPartitioning}
+import org.apache.spark.sql.execution.{CoalescedPartitionSpec, ShuffledRowRDD, ShufflePartitionSpec, SparkPlan, SQLExecution, UnsafeRowSerializer}
+import org.apache.spark.sql.execution.exchange.{Exchange, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.metric.{SQLMetrics, SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Execution plan to repartition and rebalance the data for Optimize Write.
+ * The plan will be added on top of the query plan of each write job to avoid any interference
+ * from Adaptive Query Execution.
+ *
+ * @param partitioning Partitioning to use data exchange.
+ * @param child Input plan of write job.
+ */
+case class OptimizeWriteExchangeExec(
+    partitioning: Partitioning,
+    override val child: SparkPlan) extends Exchange {
+
+  // Use 150% of target file size hint config considering parquet compression.
+  // Still the result file can be smaller/larger than the config due to data skew or
+  // variable compression ratio for each data type.
+  final val PARQUET_COMPRESSION_RATIO = 1.5
+
+  // Dummy partitioning because:
+  // 1) The exact output partitioning is determined at query runtime
+  // 2) optimizeWrite is always placed right after the top node(DeltaInvariantChecker),
+  //    there is no parent plan to refer to outputPartitioning
+  override def outputPartitioning: Partitioning = UnknownPartitioning(partitioning.numPartitions)
+
+  private lazy val writeMetrics =
+    SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
+  private[sql] lazy val readMetrics =
+    SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
+  override lazy val metrics = Map(
+    "dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size"),
+    "numPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions")
+  ) ++ readMetrics ++ writeMetrics
+
+  private lazy val serializer: Serializer =
+    new UnsafeRowSerializer(child.output.size, longMetric("dataSize"))
+
+  @transient lazy val inputRDD: RDD[InternalRow] = child.execute()
+
+  @transient lazy val mapOutputStatisticsFuture: Future[MapOutputStatistics] = {
+    if (inputRDD.getNumPartitions == 0) {
+      Future.successful(null)
+    } else {
+      sparkContext.submitMapStage(shuffleDependency)
+    }
+  }
+
+
+  @transient lazy val shuffleDependency: ShuffleDependency[Int, InternalRow, InternalRow] = {
+    val dep = ShuffleExchangeExec.prepareShuffleDependency(
+      inputRDD,
+      child.output,
+      partitioning,
+      serializer,
+      writeMetrics)
+    metrics("numPartitions").set(dep.partitioner.numPartitions)
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkContext, executionId, metrics("numPartitions") :: Nil)
+    dep
+  }
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    // Collect execution statistics, these will be used to adjust/decide how to split files
+    val stats = ThreadUtils.awaitResult(mapOutputStatisticsFuture, Duration.Inf)
+    if (stats == null) {
+      new ShuffledRowRDD(shuffleDependency, readMetrics)
+    } else {
+      try {
+        val partitionSpecs = Some(rebalancePartitions(stats))
+        new ShuffledRowRDD(shuffleDependency, readMetrics, partitionSpecs.get.toArray)
+      } catch {
+        case e: Throwable =>
+          logWarning("Failed to apply OptimizeWrite.", e)
+          new ShuffledRowRDD(shuffleDependency, readMetrics)
+      }
+    }
+  }
+
+  private def rebalancePartitions(stats: MapOutputStatistics): Seq[ShufflePartitionSpec] = {
+    val binSize = ByteUnit.BYTE.convertFrom(
+      conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_BIN_SIZE), ByteUnit.MiB)
+    val smallPartitionFactor =
+      conf.getConf(RapidsDeltaSQLConf.OPTIMIZE_WRITE_SMALL_PARTITION_FACTOR)
+    val mergedPartitionFactor =
+      conf.getConf(RapidsDeltaSQLConf.OPTIMIZE_WRITE_MERGED_PARTITION_FACTOR)
+    val bytesByPartitionId = stats.bytesByPartitionId
+    val targetPartitionSize = (binSize * PARQUET_COMPRESSION_RATIO).toLong
+
+    val splitPartitions = if (partitioning.isInstanceOf[RoundRobinPartitioning]) {
+      DeltaShufflePartitionsUtil.splitSizeListByTargetSize(
+        bytesByPartitionId,
+        targetPartitionSize,
+        smallPartitionFactor,
+        mergedPartitionFactor)
+    } else {
+      // For partitioned data, do not coalesce small partitions as it will hurt parallelism.
+      // Eg. a partition containing 100 partition keys => a task will write 100 files.
+      Seq.range(0, bytesByPartitionId.length).toArray
+    }
+
+    def optimizeSkewedPartition(reduceIndex: Int): Seq[ShufflePartitionSpec] = {
+      val partitionSize = bytesByPartitionId(reduceIndex)
+      if (partitionSize > targetPartitionSize) {
+        val shuffleId = shuffleDependency.shuffleId
+        val newPartitionSpec = DeltaShufflePartitionsUtil.createSkewPartitionSpecs(
+          shuffleId,
+          reduceIndex,
+          targetPartitionSize,
+          smallPartitionFactor,
+          mergedPartitionFactor)
+
+        if (newPartitionSpec.isEmpty) {
+          CoalescedPartitionSpec(reduceIndex, reduceIndex + 1) :: Nil
+        } else {
+          logDebug(s"[OptimizeWrite] Partition $reduceIndex is skew, " +
+              s"split it into ${newPartitionSpec.get.size} parts.")
+          newPartitionSpec.get
+        }
+      } else if (partitionSize > 0) {
+        CoalescedPartitionSpec(reduceIndex, reduceIndex + 1) :: Nil
+      } else {
+        Nil
+      }
+    }
+
+    // Transform the partitions to the ranges.
+    // e.g. [0, 3, 6, 7, 10] -> [[0, 3), [3, 6), [6, 7), [7, 10)]
+    (splitPartitions :+ stats.bytesByPartitionId.length).sliding(2).flatMap { k =>
+      if (k.head == k.last - 1) {
+        // If not a merged partition, split it if needed.
+        optimizeSkewedPartition(k.head)
+      } else {
+        CoalescedPartitionSpec(k.head, k.last) :: Nil
+      }
+    }.toList
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): OptimizeWriteExchangeExec = {
+    copy(child = newChild)
+  }
+}

--- a/delta-lake/common/src/main/scala/org/apache/spark/sql/rapids/delta/DeltaShufflePartitionsUtil.scala
+++ b/delta-lake/common/src/main/scala/org/apache/spark/sql/rapids/delta/DeltaShufflePartitionsUtil.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaShufflePartitionUtil.scala
+ * in the Delta Lake project at https://github.com/delta-io/delta
+ * (pending at https://github.com/delta-io/delta/pull/1198).
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.delta
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{MapOutputTrackerMaster, SparkEnv}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RoundRobinPartitioning}
+import org.apache.spark.sql.execution.{CoalesceExec, PartialReducerPartitionSpec, SparkPlan}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Utility functions to rebalance shuffle partitions for OptimizeWrite.
+ */
+object DeltaShufflePartitionsUtil {
+
+  // scalastyle:off line.size.limit
+  /**
+   * Splits the skewed partition based on the map size and the target partition size
+   * after split, and create a list of `PartialMapperPartitionSpec`. Returns None if can't split.
+   *
+   * The function is copied from Spark 3.2:
+   *   https://github.com/apache/spark/blob/v3.2.1/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala#L376
+   * EDIT: Configurable smallPartitionFactor and mergedPartitionFactor.
+   *
+   * @param shuffleId Shuffle ID for retrieve partition info.
+   * @param reducerId Reducer ID (Partition ID) for retrieve partition info.
+   * @param targetSize Target bin size for splitting.
+   * @param smallPartitionFactor Threshold to avoid too small partition. If a partial partition is
+   *                       smaller than targetSize * smallPartitionFactor, merge it to an adjacent
+   *                       partition.
+   * @param mergedPartitionFactor Threshold to avoid too large partition. If a partial partition is
+   *                        larger than targetSize * mergedPartitionFactor, do not merge other
+   *                        adjacent partitions to it.
+   */
+  // scalastyle:on
+  def createSkewPartitionSpecs(
+      shuffleId: Int,
+      reducerId: Int,
+      targetSize: Long,
+      smallPartitionFactor: Double,
+      mergedPartitionFactor: Double): Option[Seq[PartialReducerPartitionSpec]] = {
+    val mapPartitionSizes = getMapSizesForReduceId(shuffleId, reducerId)
+    if (mapPartitionSizes.exists(_ < 0)) return None
+    val mapStartIndices = splitSizeListByTargetSize(
+      mapPartitionSizes,
+      targetSize,
+      smallPartitionFactor,
+      mergedPartitionFactor)
+    if (mapStartIndices.length > 1) {
+      Some(mapStartIndices.indices.map { i =>
+        val startMapIndex = mapStartIndices(i)
+        val endMapIndex = if (i == mapStartIndices.length - 1) {
+          mapPartitionSizes.length
+        } else {
+          mapStartIndices(i + 1)
+        }
+        val dataSize = startMapIndex.until(endMapIndex).map(mapPartitionSizes(_)).sum
+        PartialReducerPartitionSpec(reducerId, startMapIndex, endMapIndex, dataSize)
+      })
+    } else {
+      None
+    }
+  }
+
+  // scalastyle:off line.size.limit
+  /**
+   * Given a list of size, return an array of indices to split the list into multiple partitions,
+   * so that the size sum of each partition is close to the target size. Each index indicates the
+   * start of a partition.
+   *
+   * The function is copied from Spark 3.2:
+   *   https://github.com/apache/spark/blob/v3.2.1/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala#L319
+   * EDIT: Configurable smallPartitionFactor and mergedPartitionFactor.
+   *
+   *
+   * @param targetSize Target bin size for splitting.
+   * @param smallPartitionFactor Threshold to avoid too small partition. If a partial partition is
+   *                       smaller than targetSize * smallPartitionFactor, merge it to an adjacent
+   *                       partition.
+   * @param mergedPartitionFactor Threshold to avoid too large partition. If a partial partition is
+   *                        larger than targetSize * mergedPartitionFactor, do not merge other
+   *                        adjacent partitions to it.
+   */
+  // scalastyle:on
+  // Visible for testing
+  private[sql] def splitSizeListByTargetSize(
+      sizes: Seq[Long],
+      targetSize: Long,
+      smallPartitionFactor: Double,
+      mergedPartitionFactor: Double): Array[Int] = {
+    val partitionStartIndices = ArrayBuffer[Int]()
+    partitionStartIndices += 0
+    var i = 0
+    var currentPartitionSize = 0L
+    var lastPartitionSize = -1L
+
+    def tryMergePartitions() = {
+      // When we are going to start a new partition, it's possible that the current partition or
+      // the previous partition is very small and it's better to merge the current partition into
+      // the previous partition.
+      val shouldMergePartitions = lastPartitionSize > -1 &&
+          ((currentPartitionSize + lastPartitionSize) < targetSize * mergedPartitionFactor ||
+              (currentPartitionSize < targetSize * smallPartitionFactor ||
+                  lastPartitionSize < targetSize * smallPartitionFactor))
+      if (shouldMergePartitions) {
+        // We decide to merge the current partition into the previous one, so the start index of
+        // the current partition should be removed.
+        partitionStartIndices.remove(partitionStartIndices.length - 1)
+        lastPartitionSize += currentPartitionSize
+      } else {
+        lastPartitionSize = currentPartitionSize
+      }
+    }
+
+    while (i < sizes.length) {
+      // If including the next size in the current partition exceeds the target size, package the
+      // current partition and start a new partition.
+      if (i > 0 && currentPartitionSize + sizes(i) > targetSize) {
+        tryMergePartitions()
+        partitionStartIndices += i
+        currentPartitionSize = sizes(i)
+      } else {
+        currentPartitionSize += sizes(i)
+      }
+      i += 1
+    }
+    tryMergePartitions()
+    partitionStartIndices.toArray
+  }
+
+  // scalastyle:off line.size.limit
+  /**
+   * Get the map size of the specific shuffle and reduce ID. Note that, some map outputs can be
+   * missing due to issues like executor lost. The size will be -1 for missing map outputs and the
+   * caller side should take care of it.
+   *
+   * The function is copied from Spark 3.2:
+   *   https://github.com/apache/spark/blob/v3.2.1/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala#L365
+   */
+  // scalastyle:on
+  def getMapSizesForReduceId(shuffleId: Int, partitionId: Int): Array[Long] = {
+    val mapOutputTracker = SparkEnv.get.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+    mapOutputTracker.shuffleStatuses(shuffleId).withMapStatuses(_.map { stat =>
+      if (stat == null) -1 else stat.getSizeForBlock(partitionId)
+    })
+  }
+
+  def removeTopRepartition(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case p: AdaptiveSparkPlanExec =>
+        p.inputPlan match {
+          case s: ShuffleExchangeExec if s.shuffleOrigin.equals(ENSURE_REQUIREMENTS) =>
+            p.copy(inputPlan = s.child)
+          case c: CoalesceExec =>
+            c.child
+          case _ => p
+        }
+      case ShuffleExchangeExec(_, child, shuffleOrigin)
+        if !shuffleOrigin.equals(ENSURE_REQUIREMENTS) =>
+        child
+      case CoalesceExec(_, child) =>
+        child
+      case _ =>
+        plan
+    }
+  }
+
+  def partitioningForRebalance(
+      outputColumns: Seq[Attribute],
+      partitionSchema: StructType,
+      numShufflePartitions: Int): Partitioning = {
+    if (partitionSchema.fields.isEmpty) {
+      // Non-partitioned data.
+      RoundRobinPartitioning(numShufflePartitions)
+    } else {
+      // Partitioned data.
+      val partitionColumnsExpr = partitionSchema.fields.map { f =>
+        outputColumns.find(c => c.name.equals(f.name)).get
+      }
+      HashPartitioning(partitionColumnsExpr, numShufflePartitions)
+    }
+  }
+}

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -176,6 +176,8 @@ class GpuOptimisticTransaction(
     val constraints =
       Constraints.getAll(metadata, spark) ++ generatedColumnConstraints ++ additionalConstraints
 
+    val isOptimize = isOptimizeCommand(queryExecution.analyzed)
+
     SQLExecution.withNewExecutionId(queryExecution, Option("deltaTransactionalWrite")) {
       val outputSpec = FileFormatWriter.OutputSpec(
         outputPath.toString,
@@ -194,7 +196,9 @@ class GpuOptimisticTransaction(
 
       val empty2NullPlan = convertEmptyToNullIfNeeded(queryPhysicalPlan,
         partitioningColumns, constraints)
-      val planWithInvariants = addInvariantChecks(empty2NullPlan, constraints)
+      val optimizedPlan =
+        applyOptimizeWriteIfNeeded(spark, empty2NullPlan, partitionSchema, isOptimize)
+      val planWithInvariants = addInvariantChecks(optimizedPlan, constraints)
       val physicalPlan = convertToGpu(planWithInvariants)
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()

--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -50,9 +50,22 @@ operation which is typically triggered via the DataFrame `write` API, e.g.:
 Table creation from selection, table insertion from SQL, and table merges are not currently
 GPU accelerated. These operations will fallback to the CPU.
 
-[Automatic optimization](https://docs.databricks.com/optimizations/auto-optimize.html)
-during Delta Lake writes is not supported. Write operations that are configured to
-automatically optimize or automatically compact will fallback to the CPU.
+#### Automatic Optimization of Writes
+
+Delta Lake on Databricks has
+[automatic optimization](https://docs.databricks.com/optimizations/auto-optimize.html)
+features for optimized writes and automatic compaction.  Automatic compaction is not supported,
+and writes configured for automatic compaction will fallback to the CPU.
+
+Optimized writes are supported only on Databricks platforms. The algorithm used is similar but
+not identical to the Databricks version. The following table describes configuration settings
+that control the operation of the optimized write.
+
+| Configuration                                               | Default | Description                                                                                |
+|-------------------------------------------------------------|---------|--------------------------------------------------------------------------------------------|
+| spark.databricks.delta.optimizeWrite.binSize                | 512     | Target uncompressed partition size in megabytes                                            |
+| spark.databricks.delta.optimizeWrite.smallPartitionFactor   | 0.5     | Merge partitions smaller than this factor multiplied by the target partition size          |
+| spark.databricks.delta.optimizeWrite.mergedPartitionFactor  | 1.2     | Avoid combining partitions larger than this factor multiplied by the target partition size |
 
 ### RapidsDeltaWrite Node in Query Plans
 

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -57,9 +57,9 @@ def fixup_operation_metrics(opm):
     for k in "executionTimeMs", "numOutputBytes", "rewriteTimeMs", "scanTimeMs":
         opm.pop(k, None)
 
-TMP_TABLE_PATTERN=re.compile("tmp_table_\w+")
-TMP_TABLE_PATH_PATTERN=re.compile("delta.`[^`]*`")
-REF_ID_PATTERN=re.compile("#[0-9]+")
+TMP_TABLE_PATTERN=re.compile(r"tmp_table_\w+")
+TMP_TABLE_PATH_PATTERN=re.compile(r"delta.`[^`]*`")
+REF_ID_PATTERN=re.compile(r"#[0-9]+")
 
 def fixup_operation_parameters(opp):
     """Update the specified operationParameters node to facilitate log comparisons"""
@@ -138,6 +138,13 @@ def assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path):
         assert len(cpu_jsons) == len(gpu_jsons), "Different line counts in {}:\nCPU: {}\nGPU: {}".format(file, cpu_json_data, gpu_json_data)
         for cpu_json, gpu_json in zip(cpu_jsons, gpu_jsons):
             assert_delta_log_json_equivalent(file, cpu_json, gpu_json)
+
+def get_last_operation_metrics(path):
+    from delta.tables import DeltaTable
+    return with_cpu_session(lambda spark: DeltaTable.forPath(spark, path)\
+                            .history(1)\
+                            .selectExpr("operationMetrics")\
+                            .head()[0])
 
 @allow_non_gpu("ExecutedCommandExec", *delta_meta_allow)
 @delta_lake
@@ -639,8 +646,7 @@ def test_delta_write_multiple_identity_columns(spark_tmp_path):
 @ignore_order
 @pytest.mark.parametrize("confkey", ["optimizeWrite"], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(is_databricks_runtime() and is_before_spark_330(),
-                    reason="Databricks 10.4 does not properly handle options passed during DataFrame API write")
+@pytest.mark.skipif(is_databricks_runtime(), reason="Optimized write is supported on Databricks")
 def test_delta_write_auto_optimize_write_opts_fallback(confkey, spark_tmp_path):
     data_path = spark_tmp_path + "/DELTA_DATA"
     assert_gpu_fallback_write(
@@ -654,8 +660,10 @@ def test_delta_write_auto_optimize_write_opts_fallback(confkey, spark_tmp_path):
 @delta_lake
 @ignore_order
 @pytest.mark.parametrize("confkey", [
-    "delta.autoOptimize",
-    "delta.autoOptimize.optimizeWrite",
+    pytest.param("delta.autoOptimize", marks=pytest.mark.skipif(
+        is_databricks_runtime(), reason="Optimize write is supported on Databricks")),
+    pytest.param("delta.autoOptimize.optimizeWrite", marks=pytest.mark.skipif(
+        is_databricks_runtime(), reason="Optimize write is supported on Databricks")),
     "delta.autoOptimize.autoCompact" ], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.skipif(not is_databricks_runtime(), reason="Auto optimize only supported on Databricks")
@@ -676,8 +684,10 @@ def test_delta_write_auto_optimize_table_props_fallback(confkey, spark_tmp_path)
 @delta_lake
 @ignore_order
 @pytest.mark.parametrize("confkey", [
-    "spark.databricks.delta.optimizeWrite.enabled",
-    "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite",
+    pytest.param("spark.databricks.delta.optimizeWrite.enabled", marks=pytest.mark.skipif(
+        is_databricks_runtime(), reason="Optimize write is supported on Databricks")),
+    pytest.param("spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite", marks=pytest.mark.skipif(
+        is_databricks_runtime(), reason="Optimize write is supported on Databricks")),
     "spark.databricks.delta.properties.defaults.autoOptimize.autoCompact" ], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 def test_delta_write_auto_optimize_sql_conf_fallback(confkey, spark_tmp_path):
@@ -706,3 +716,109 @@ def test_delta_write_aqe_join(spark_tmp_path):
         data_path,
         conf=confs)
     with_cpu_session(lambda spark: assert_gpu_and_cpu_delta_logs_equivalent(spark, data_path))
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(not is_databricks_runtime(), reason="Delta Lake optimized writes are only supported on Databricks")
+@pytest.mark.parametrize("enable_conf_key", [
+    "spark.databricks.delta.optimizeWrite.enabled",
+    "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite"], ids=idfn)
+@pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
+def test_delta_write_optimized(spark_tmp_path, enable_conf_key, aqe_enabled):
+    from delta.tables import DeltaTable
+    num_chunks = 20
+    def do_write(data_path, is_optimize_write):
+        confs=copy_and_update(delta_writes_enabled_conf, {
+            enable_conf_key : str(is_optimize_write),
+            "spark.sql.adaptive.enabled" : str(aqe_enabled)
+        })
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            lambda spark, path: unary_op_df(spark, int_gen)\
+                .repartition(num_chunks).write.format("delta").save(path),
+            lambda spark, path: spark.read.format("delta").load(path),
+            data_path,
+            conf=confs)
+    data_path = spark_tmp_path + "/DELTA_DATA1"
+    do_write(data_path, is_optimize_write=False)
+    opmetrics = get_last_operation_metrics(data_path + "/GPU")
+    assert int(opmetrics["numFiles"]) == num_chunks
+    data_path = spark_tmp_path + "/DELTA_DATA2"
+    do_write(data_path, is_optimize_write=True)
+    opmetrics = get_last_operation_metrics(data_path + "/GPU")
+    assert int(opmetrics["numFiles"]) == 1
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(not is_databricks_runtime(), reason="Delta Lake optimized writes are only supported on Databricks")
+def test_delta_write_optimized_table_confs(spark_tmp_path):
+    from delta.tables import DeltaTable
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    gpu_data_path = data_path + "/GPU"
+    num_chunks = 20
+    def do_write(confs):
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            lambda spark, path: unary_op_df(spark, int_gen)\
+                .repartition(num_chunks).write.format("delta").mode("overwrite").save(path),
+            lambda spark, path: spark.read.format("delta").load(path),
+            data_path,
+            conf=confs)
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.databricks.delta.optimizeWrite.enabled" : "true"
+    })
+    do_write(confs)
+    opmetrics = get_last_operation_metrics(gpu_data_path)
+    assert int(opmetrics["numFiles"]) == 1
+    # Verify SQL conf takes precedence over table setting
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.databricks.delta.optimizeWrite.enabled" : "false"
+    })
+    do_write(confs)
+    opmetrics = get_last_operation_metrics(gpu_data_path)
+    assert int(opmetrics["numFiles"]) == num_chunks
+    # Verify default conf is not honored after table setting
+    def do_prop_update(spark):
+        spark.sql("ALTER TABLE delta.`{}`".format(gpu_data_path) +
+                  " SET TBLPROPERTIES (delta.autoOptimize.optimizeWrite = true)")
+    with_cpu_session(do_prop_update)
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite" : "false"
+    })
+    do_write(confs)
+    opmetrics = get_last_operation_metrics(gpu_data_path)
+    assert int(opmetrics["numFiles"]) == 1
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
+@ignore_order
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.skipif(not is_databricks_runtime(), reason="Delta Lake optimized writes are only supported on Databricks")
+def test_delta_write_optimized_partitioned(spark_tmp_path):
+    from delta.tables import DeltaTable
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    gpu_data_path = data_path + "/GPU"
+    num_chunks = 20
+    def do_write(confs):
+        assert_gpu_and_cpu_writes_are_equal_collect(
+            lambda spark, path: two_col_df(spark, int_gen, SetValuesGen(StringType(), ["x", "y"]))\
+                .repartition(num_chunks).write.format("delta")\
+                .mode("overwrite").partitionBy("b").save(path),
+            lambda spark, path: spark.read.format("delta").load(path),
+            data_path,
+            conf=confs)
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.databricks.delta.optimizeWrite.enabled" : "false"
+    })
+    do_write(confs)
+    opmetrics = get_last_operation_metrics(gpu_data_path)
+    assert int(opmetrics["numFiles"]) == 2 * num_chunks
+    # Verify SQL conf takes precedence over table setting
+    confs=copy_and_update(delta_writes_enabled_conf, {
+        "spark.databricks.delta.optimizeWrite.enabled" : "true"
+    })
+    do_write(confs)
+    opmetrics = get_last_operation_metrics(gpu_data_path)
+    assert int(opmetrics["numFiles"]) == 2


### PR DESCRIPTION
Fixes #7393.

Adds support for the Delta Lake optimized write algorithm as proposed in https://github.com/delta-io/delta/pull/1198.  This support is currently only available on Databricks platforms, as that is the only Delta Lake version where optimized writes are supported on the CPU.
