### PR TITLE
Hardcode python 3.8 to be used in databricks runtime for cudf_udf ENV [databricks]

### DIFF
--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,13 @@
 import pytest
 
 from conftest import is_at_least_precommit_run
+from spark_session import is_databricks113_or_later
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
+
+if is_databricks113_or_later():
+    pytest.skip('https://github.com/NVIDIA/spark-rapids/issues/7639', allow_module_level=True)
+
 try:
     require_minimum_pandas_version()
 except Exception as e:

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,13 @@
 import pytest
 
 from conftest import is_at_least_precommit_run
-from spark_session import is_databricks91_or_later, is_before_spark_330
+from spark_session import is_databricks91_or_later, is_before_spark_330, is_databricks113_or_later
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
+
+if is_databricks113_or_later():
+    pytest.skip('https://github.com/NVIDIA/spark-rapids/issues/7639', allow_module_level=True)
+
 try:
     require_minimum_pandas_version()
 except Exception as e:

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -18,7 +18,7 @@
 # The initscript to set up environment for the cudf_udf tests on Databricks
 # Will be automatically pushed into the dbfs:/databricks/init_scripts once it is updated.
 
-set -x
+set -ex
 
 CUDF_VER=${CUDF_VER:-23.04}
 CUDA_VER=${CUDA_VER:-11.0}
@@ -26,7 +26,9 @@ CUDA_VER=${CUDA_VER:-11.0}
 # Need to explicitly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH
 # Set Python for the running instance
-PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+# PYTHON_VERSION=$(${PYSPARK_PYTHON} -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+# cudf 23.02+ do not support python 3.9. ref: https://docs.rapids.ai/notices/rsn0022/
+PYTHON_VERSION='3.8'
 
 base=$(conda info --base)
 # Create and activate 'cudf-udf' conda env for cudf-udf tests
@@ -36,7 +38,8 @@ conda create -y -n cudf-udf -c conda-forge python=$PYTHON_VERSION mamba && \
 
 # Use mamba to install cudf-udf packages to speed up conda resolve time
 conda install -y -c conda-forge mamba python=$PYTHON_VERSION
-${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas
+# Do not error out "This operation will remove conda without replacing it with another version of conda." for now
+${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas || true
 
 REQUIRED_PACKAGES=(
   cudatoolkit=$CUDA_VER

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -66,7 +66,9 @@ if [ -d "${CONDA_HOME}/envs/cudf-udf" ]; then
 fi
 
 # Get Python version (major.minor). i.e., python3.8 for DB10.4 and python3.9 for DB11.3
-sw_versions[PYTHON]=$(${PYSPARK_PYTHON} -c 'import sys; print("python{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+#sw_versions[PYTHON]=$(${PYSPARK_PYTHON} -c 'import sys; print("python{}.{}".format(sys.version_info.major, sys.version_info.minor))')
+# NOTE: cudf 23.02+ do not support python 3.9. ref: https://docs.rapids.ai/notices/rsn0022/
+sw_versions[PYTHON]='python3.8'
 
 # override incompatible versions between databricks and cudf
 if [ -d "${CONDA_HOME}/envs/cudf-udf" ]; then


### PR DESCRIPTION
per https://docs.rapids.ai/notices/rsn0022/, and related issue https://github.com/rapidsai/cudf/issues/12764

hardcode the databricks python ENV version to 3.8

workaround #7639 
followup fix for #7737 

also skip pandas import check in db113 runtime for now to avoid fail require_minimum_pandas_version() check 
```
incorrect pandas version during required testing partially initialized 
module 'pandas' has no attribute '__version__' 
(most likely due to a circular import)
```