### PR TITLE
[Doc] remove xgboost demo from aws-emr doc due to nccl issue [skip ci]

### DIFF
--- a/docs/get-started/getting-started-aws-emr.md
+++ b/docs/get-started/getting-started-aws-emr.md
@@ -262,7 +262,7 @@ submitted. The mortgage examples we use are also available as a spark applicatio
 **spark shell** to run the scala code or **pyspark** to run the python code on master node through
 CLI.
 
-### Running GPU Accelerated Mortgage ETL and XGBoost Example using EMR Notebook
+### Running GPU Accelerated Mortgage ETL Example using EMR Notebook
 
 An EMR Notebook is a "serverless" Jupyter notebook. Unlike a traditional notebook, the contents of
 an EMR Notebook itself—the equations, visualizations, queries, models, code, and narrative text—are
@@ -271,8 +271,7 @@ with durable storage, efficient access, and flexibility.
 
 You can use the following step-by-step guide to run the example mortgage dataset using RAPIDS on
 Amazon EMR GPU clusters. For more examples, please refer to [NVIDIA/spark-rapids for
-ETL](https://github.com/NVIDIA/spark-rapids/tree/main/docs/demo) and [NVIDIA/spark-rapids for
-XGBoost](https://github.com/NVIDIA/spark-rapids-examples/tree/main/examples)
+ETL](https://github.com/NVIDIA/spark-rapids/tree/main/docs/demo)
 
 ![Create EMR Notebook](../img/AWS-EMR/EMR_notebook_2.png)
 
@@ -290,13 +289,7 @@ Download [the Mortgate ETL PySpark Notebook](../demo/AWS-EMR/Mortgage-ETL-GPU-EM
 to use PySpark as kernel. This example use 1 year (year 2000) data for a two node g4dn GPU
 cluster. You can adjust settings in the notebook for full mortgage dataset ETL.
 
-When executing the ETL code, you can also saw the Spark Job Progress within the notebook and the
+When executing the ETL code, you can also see the Spark Job Progress within the notebook and the
 code will also display how long it takes to run the query
 
 ![Create EMR Notebook](../img/AWS-EMR/EMR_notebook_3.png)
-
-#### Run Mortgage XGBoost Scala Notebook on EMR GPU Cluster 
-
-Please refer to this [quick start
-guide](https://github.com/NVIDIA/spark-xgboost-examples/blob/spark-2/getting-started-guides/csp/aws/Using_EMR_Notebook.md)
-to running GPU accelerated XGBoost on EMR Spark Cluster.


### PR DESCRIPTION
Signed-off-by: liyuan <yuali@nvidia.com>
remove xgboost demo from aws-emr getting started doc due to nccl [issue](https://github.com/dmlc/xgboost/issues/8746) 
