### PR TITLE
Fix issue where GpuSemaphore can throw NPE when logDebug is on

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -130,7 +130,7 @@ private final class GpuSemaphore() extends Logging with Arm {
         } else {
           refs.numPermits
         }
-        logDebug(s"Task $taskAttemptId acquiring GPU with ${refs.numPermits} permits")
+        logDebug(s"Task $taskAttemptId acquiring GPU with $permits permits")
         semaphore.acquire(permits)
         if (refs != null) {
           refs.count.increment()


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This is a small bug introduced here https://github.com/NVIDIA/spark-rapids/pull/7527, but it means we can't run with DEBUG logging level today.