### PR TITLE
Fix cache test for Spark 3.3.2 [databricks]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -935,6 +935,7 @@
                                             <include name="311until320-noncdh/*"/>
                                             <include name="311until320-nondb/*"/>
                                             <include name="311until330-all/*"/>
+                                            <include name="311until332-all/*"/>
                                             <include name="311until330-nondb/*"/>
                                             <include name="311until340-all/*"/>
                                             <include name="311until340-non330db/*"/>
@@ -1035,7 +1036,9 @@
                                 <pathconvert property="spark332.sources" pathsep=",">
                                     <dirset dir="${project.basedir}/src/main" erroronmissingdir="false">
                                         <patternset refid="spark331+.pattern"/>
+                                        <exclude name="*until332*/*"/>
                                         <include name="332/*"/>
+                                        <include name="332+/*"/>
                                     </dirset>
                                 </pathconvert>
                                 <pathconvert property="spark340.sources" pathsep=",">

--- a/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.hadoop.conf.Configuration
+
+object ParquetLegacyNanoAsLongShims {
+  def setupLegacyParquetNanosAsLong(conf: Configuration): Unit = {
+    // Parquet Infer Timestamp NTZ is considered in Spark 3.3.2
+  }
+}

--- a/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/311until332-all/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.shims
 import org.apache.hadoop.conf.Configuration
 
 object ParquetLegacyNanoAsLongShims {
-  def setupLegacyParquetNanosAsLong(conf: Configuration): Unit = {
-    // Parquet Infer Timestamp NTZ is considered in Spark 3.3.2
+  def setupLegacyParquetNanosAsLongForPCBS(conf: Configuration): Unit = {
+    // LEGACY_PARQUET_NANOS_AS_LONG is only considered in Spark 3.3.2 and later
   }
 }

--- a/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.shims
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.spark.sql.internal.SQLConf
+
+object ParquetLegacyNanoAsLongShims {
+  def setupLegacyParquetNanosAsLong(conf: Configuration): Unit = {
+    conf.setBoolean(SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key, true)
+  }
+}

--- a/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/332+/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -21,7 +21,16 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.internal.SQLConf
 
 object ParquetLegacyNanoAsLongShims {
-  def setupLegacyParquetNanosAsLong(conf: Configuration): Unit = {
+  /**
+   * This method should strictly be used by ParquetCachedBatchSerializer(PCBS) as it is hard coding
+   * the value of LEGACY_PARQUET_NANOS_AS_LONG.
+   *
+   * As far as PCBS is concerned it really doesn't matter what we set it to as long as
+   * ParquetSchemaConverter doesn't see a "null" value.
+   *
+   * @param conf Hadoop conf
+   */
+  def setupLegacyParquetNanosAsLongForPCBS(conf: Configuration): Unit = {
     conf.setBoolean(SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key, true)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -1202,7 +1202,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
     ParquetFieldIdShims.setupParquetFieldIdWriteConfig(hadoopConf, sqlConf)
 
     // From 3.3.2, Spark schema converter needs this conf
-    ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLong(hadoopConf)
+    ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLongForPCBS(hadoopConf)
 
     hadoopConf
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -28,7 +28,7 @@ import ai.rapids.cudf.ParquetWriterOptions.StatisticsFrequency
 import com.nvidia.spark.GpuCachedBatchSerializer
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, ParquetLegacyNanoAsLongShims, SparkShimImpl}
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.RecordWriter
@@ -477,7 +477,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
           Table.readParquet(parquetOptions, parquetCB.buffer, 0, parquetCB.sizeInBytes)
         } catch {
           case e: Exception =>
-            throw new IOException("Error when processing file " + 
+            throw new IOException("Error when processing file " +
                 s"[range: 0-${parquetCB.sizeInBytes}]", e)
         }
         withResource(table) { table =>
@@ -557,7 +557,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
       })
       cbRdd.mapPartitions(iter => CloseableColumnBatchIterator(iter))
     } else {
-      val origSelectedAttributesWithUnambiguousNames = 
+      val origSelectedAttributesWithUnambiguousNames =
         sanitizeColumnNames(newSelectedAttributes, selectedSchemaWithNames)
       val broadcastedConf = SparkSession.active.sparkContext.broadcast(conf.getAllConfs)
       input.mapPartitions {
@@ -1200,6 +1200,9 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
 
     // From 3.3.0, Spark will check this filed ID config
     ParquetFieldIdShims.setupParquetFieldIdWriteConfig(hadoopConf, sqlConf)
+
+    // From 3.3.2, Schema converter
+    ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLong(hadoopConf)
 
     hadoopConf
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1201,7 +1201,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer wi
     // From 3.3.0, Spark will check this filed ID config
     ParquetFieldIdShims.setupParquetFieldIdWriteConfig(hadoopConf, sqlConf)
 
-    // From 3.3.2, Schema converter
+    // From 3.3.2, Spark schema converter needs this conf
     ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLong(hadoopConf)
 
     hadoopConf


### PR DESCRIPTION
There has been a change in Spark 3.3.2 in SparkSchemaConverter where it now uses the `LEGACY_PARQUET_NANOS_AS_LONG` to determine whether to use TimestampType(nano) or to use long which loses the Timezone awareness. For us this is fine as we don't support TZ anyways. 

As discussed in [SPARK-40819](https://github.com/apache/spark/pull/39905) Timestamp(nano, true) will result in an `AnalysisException`. I don't think we need to highlight this in our documentation but I would like to know what others think. 

fixes #7725 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
