### PR TITLE
Make AlluxioUtilsSuite pass for 340

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioUtilsSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioUtilsSuite.scala
@@ -76,15 +76,15 @@ class AlluxioUtilsSuite extends FunSuite {
     val partitionedFiles = Array[PartitionedFile](
       PartitionedFileUtilsShim.newPartitionedFile(null, "s3a://bucket_1/a.file", 0, 0),
       PartitionedFileUtilsShim.newPartitionedFile(null, "s3a://bucket_2/b.file", 0, 0),
-      PartitionedFileUtilsShim.newPartitionedFile(null, "my_scheme://bucket_1/1.file", 0, 0)
+      PartitionedFileUtilsShim.newPartitionedFile(null, "myScheme://bucket_1/1.file", 0, 0)
     )
     val replaced = AlluxioUtils.updateFilesTaskTimeIfAlluxio(partitionedFiles, Option(replaceMap))
     assert(replaced.size == 3)
-    assert(replaced(0).toRead.filePath.equals("alluxio://localhost:19998/bucket_1/a.file"))
-    assert(replaced(0).original.get.filePath.equals("s3a://bucket_1/a.file"))
-    assert(replaced(1).toRead.filePath.equals("alluxio://localhost:19998/bucket_2/b.file"))
-    assert(replaced(1).original.get.filePath.equals("s3a://bucket_2/b.file"))
-    assert(replaced(2).toRead.filePath.equals("my_scheme://bucket_1/1.file"))
+    assert(replaced(0).toRead.filePath.toString === "alluxio://localhost:19998/bucket_1/a.file")
+    assert(replaced(0).original.get.filePath.toString === "s3a://bucket_1/a.file")
+    assert(replaced(1).toRead.filePath.toString === "alluxio://localhost:19998/bucket_2/b.file")
+    assert(replaced(1).original.get.filePath.toString === "s3a://bucket_2/b.file")
+    assert(replaced(2).toRead.filePath.toString === "myScheme://bucket_1/1.file")
     assert(replaced(2).original.isEmpty)
   }
 


### PR DESCRIPTION
Fixes #7779 

- remove underscore `_` from URI schemes
- call `toString` to deal with `SparkPath`
- use `===` for clearer failure messages

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
