### PR TITLE
Reliability handling for hash joins

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -18,11 +18,13 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{GatherMap, NvtxColor, OutOfBoundsPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.{InnerLike, JoinType, LeftOuter, RightOuter}
+import org.apache.spark.sql.rapids.execution.GpuHashJoin
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 trait TaskAutoCloseableResource extends AutoCloseable {
@@ -181,16 +183,17 @@ abstract class SplittableJoinIterator(
   // If the join explodes this holds batches from the stream side split into smaller pieces.
   private val pendingSplits = scala.collection.mutable.Queue[SpillableColumnarBatch]()
 
-  protected def computeNumJoinRows(cb: ColumnarBatch): Long
+  protected def computeNumJoinRows(scb: SpillableColumnarBatch): Long
 
   /**
    * Create a join gatherer.
-   * @param cb next column batch from the streaming side of the join
+   * @param scb next column batch from the streaming side of the join
    * @param numJoinRows if present, the number of join output rows computed for this batch
    * @return some gatherer to use next or None if there is no next gatherer or the loop should try
    *         to build the gatherer again (e.g.: to skip a degenerate join result batch)
    */
-  protected def createGatherer(cb: ColumnarBatch, numJoinRows: Option[Long]): Option[JoinGatherer]
+  protected def createGatherer(scb: SpillableColumnarBatch,
+      numJoinRows:Option[Long]): Option[JoinGatherer]
 
   override def hasNextStreamBatch: Boolean = {
     isInitialJoin || pendingSplits.nonEmpty || stream.hasNext
@@ -200,50 +203,130 @@ abstract class SplittableJoinIterator(
     val wasInitialJoin = isInitialJoin
     isInitialJoin = false
     if (pendingSplits.nonEmpty || stream.hasNext) {
-      val cb = if (pendingSplits.nonEmpty) {
-        opTime.ns {
-          withResource(pendingSplits.dequeue()) {
-            _.getColumnarBatch()
-          }
-        }
+      val scb = if (pendingSplits.nonEmpty) {
+        pendingSplits.dequeue()
       } else {
         val batch = withResource(stream.next()) { lazyBatch =>
           opTime.ns {
-            lazyBatch.releaseBatch()
+            SpillableColumnarBatch(lazyBatch.releaseBatch(),
+              SpillPriorities.ACTIVE_ON_DECK_PRIORITY, spillCallback)
           }
         }
         batch
       }
       opTime.ns {
-        withResource(cb) { cb =>
-          val numJoinRows = computeNumJoinRows(cb)
+        withResource(scb) { _ =>
+          val numJoinRows = computeNumJoinRows(scb)
 
           // We want the gather maps size to be around the target size. There are two gather maps
           // that are made up of ints, so compute how many rows on the stream side will produce the
           // desired gather maps size.
           val maxJoinRows = Math.max(1, targetSize / (2 * Integer.BYTES))
-          if (numJoinRows > maxJoinRows && cb.numRows() > 1) {
+          if (numJoinRows > maxJoinRows && scb.numRows() > 1) {
             // Need to split the batch to reduce the gather maps size. This takes a simplistic
             // approach of assuming the data is uniformly distributed in the stream table.
-            val numSplits = Math.min(cb.numRows(),
+            val numSplits = Math.min(scb.numRows(),
               Math.ceil(numJoinRows.toDouble / maxJoinRows).toInt)
-            splitAndSave(cb, numSplits)
+            splitAndSave(scb, numSplits)
 
             // Return no gatherer so the outer loop will try again
             return None
           }
 
-          createGatherer(cb, Some(numJoinRows))
+          createGathererWithRetry(scb, Some(numJoinRows))
         }
       }
     } else {
       opTime.ns {
         assert(wasInitialJoin)
         import scala.collection.JavaConverters._
-        withResource(GpuColumnVector.emptyBatch(streamAttributes.asJava)) { cb =>
-          createGatherer(cb, None)
+        withResource(
+          SpillableColumnarBatch(GpuColumnVector.emptyBatch(streamAttributes.asJava),
+            SpillPriorities.ACTIVE_ON_DECK_PRIORITY, spillCallback)) { scb =>
+          createGathererWithRetry(scb, None)
         }
       }
+    }
+  }
+
+  protected def createGathererHandleSplit(scb: SpillableColumnarBatch,
+      except: Throwable): Option[JoinGatherer] = {
+    val oom = new OutOfMemoryError("Out of Memory - unable to split input data")
+    if (except != null) {
+      oom.addSuppressed(except)
+    }
+    throw oom
+  }
+
+  protected def createGathererWithRetry(
+      scb: SpillableColumnarBatch,
+      numJoinRows: Option[Long]): Option[JoinGatherer] = {
+    var numRetries = 0
+    var doSplit = false
+    var done = false
+    var fail = false
+    var retryExcept: Throwable = null
+    var result : Option[JoinGatherer] = None
+    // Temporary hack for testing
+    RmmSpark.associateCurrentThreadWithTask(1)
+    while (!done && !doSplit && !fail) {
+      // If we are retrying, block until we get the go ahead
+      if (numRetries > 0) {
+        RmmSpark.blockThreadUntilReady()
+      }
+      if (GpuHashJoin.retryOOMCount > 0) {
+        RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+        GpuHashJoin.retryOOMCount -= 1
+      } else if (GpuHashJoin.doSplitOOM) {
+        RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+        GpuHashJoin.doSplitOOM = false
+      }
+      try {
+        result = createGatherer(scb, numJoinRows)
+        done = true
+      } catch {
+        case retryOOM: RetryOOM =>
+          if (retryExcept == null) {
+            retryExcept = retryOOM
+          } else {
+            retryExcept.addSuppressed(retryOOM)
+          }
+          numRetries = numRetries + 1
+          println(s"Retrying, retries so far is ${numRetries}")
+        case splitAndRetryOOM: SplitAndRetryOOM => // we are the only thread
+          if (retryExcept == null) {
+            retryExcept = splitAndRetryOOM
+          } else {
+            retryExcept.addSuppressed(splitAndRetryOOM)
+          }
+          println(s"Split, retries so far is ${numRetries}")
+          doSplit = true
+        // Temporary: This case is here to keep current functionality
+        case outOfMem: OutOfMemoryError =>
+          if (retryExcept == null) {
+            retryExcept = outOfMem
+          } else {
+            retryExcept.addSuppressed(outOfMem)
+          }
+          println(s"Split, retries so far is ${numRetries}")
+          doSplit = true
+        case other: Throwable =>
+          if (retryExcept == null) {
+            retryExcept = other
+          } else {
+            retryExcept.addSuppressed(other)
+          }
+          fail = true
+      }
+    }
+    // Temporary for testing
+    RmmSpark.removeCurrentThreadAssociation()
+    if (done) {
+      result
+    } else if (doSplit) {
+      createGathererHandleSplit(scb, retryExcept)
+    } else { // fail case
+      throw retryExcept
     }
   }
 
@@ -259,36 +342,41 @@ abstract class SplittableJoinIterator(
   /**
    * Split a stream-side input batch, making all splits spillable, and replacing this batch with
    * the splits in the stream-side input
-   * @param cb stream-side input batch to split
+   * @param scb stream-side input batch to split
    * @param numBatches number of splits to produce with approximately the same number of rows each
-   * @param oom a prior OOM exception that this will try to recover from by splitting
+   * @param except a prior OOM exception that this will try to recover from by splitting
    */
   protected def splitAndSave(
-      cb: ColumnarBatch,
+      scb: SpillableColumnarBatch,
       numBatches: Int,
-      oom: Option[OutOfMemoryError] = None): Unit = {
-    val batchSize = cb.numRows() / numBatches
-    if (oom.isDefined && batchSize < 100) {
+      except: Option[Throwable] = None): Unit = {
+    val batchSize = scb.numRows() / numBatches
+    if (except.isDefined && batchSize < GpuHashJoin.minBatchSize) {
       // We just need some kind of cutoff to not get stuck in a loop if the batches get to be too
       // small but we want to at least give it a chance to work (mostly for tests where the
       // targetSize can be set really small)
-      throw oom.get
+      val oom = new OutOfMemoryError(
+        s"Out of Memory - reached split limit of ${GpuHashJoin.minBatchSize} rows")
+      oom.addSuppressed(except.get)
+      throw oom
     }
     val msg = s"Split stream batch into $numBatches batches of about $batchSize rows"
-    if (oom.isDefined) {
+    if (except.isDefined) {
       logWarning(s"OOM Encountered: $msg")
     } else {
       logInfo(msg)
     }
-    val splits = withResource(GpuColumnVector.from(cb)) { tab =>
-      val splitIndexes = (1 until numBatches).map(num => num * batchSize)
-      tab.contiguousSplit(splitIndexes: _*)
-    }
-    withResource(splits) { splits =>
-      val schema = GpuColumnVector.extractTypes(cb)
-      pendingSplits ++= splits.map { ct =>
-        SpillableColumnarBatch(ct, schema,
-          SpillPriorities.ACTIVE_ON_DECK_PRIORITY, spillCallback)
+    withResource(scb.getColumnarBatch()) { cb =>
+      val splits = withResource(GpuColumnVector.from(cb)) { tab =>
+        val splitIndexes = (1 until numBatches).map(num => num * batchSize)
+        tab.contiguousSplit(splitIndexes: _*)
+      }
+      withResource(splits) { splits =>
+        val schema = GpuColumnVector.extractTypes(cb)
+        pendingSplits ++= splits.map { ct =>
+          SpillableColumnarBatch(ct, schema,
+            SpillPriorities.ACTIVE_ON_DECK_PRIORITY, spillCallback)
+        }
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -90,6 +90,16 @@ trait JoinGatherer extends LazySpillable with Arm {
   def getFixedWidthBitSize: Option[Int]
 
   /**
+   * Save state so it can be restored.
+   */
+  def checkpoint: Unit
+
+  /**
+   * Restore state that was checkpointed
+   */
+  def restore: Unit
+
+  /**
    * Do a complete/expensive job to get the number of rows that can be gathered to get close
    * to the targetSize for the final output.
    *
@@ -503,6 +513,7 @@ class JoinGathererImpl(
 
   // How much of the gather map we have output so far
   private var gatheredUpTo: Long = 0
+  private var gatheredUpToCheckpoint: Long = 0
   private val totalRows: Long = gatherMap.getRowCount
   private val (fixedWidthRowSizeBits, nullRowSizeBits) = {
     val dts = data.dataTypes
@@ -510,6 +521,9 @@ class JoinGathererImpl(
     val nullVal = JoinGathererImpl.nullRowSizeBits(dts)
     (fw, nullVal)
   }
+
+  override def checkpoint: Unit = { gatheredUpToCheckpoint = gatheredUpTo }
+  override def restore: Unit = { gatheredUpTo = gatheredUpToCheckpoint }
 
   override def toString: String = {
     s"GATHERER $gatheredUpTo/$totalRows $gatherMap $data"
@@ -619,6 +633,15 @@ case class MultiJoinGather(left: JoinGatherer, right: JoinGatherer) extends Join
   override def isDone: Boolean = left.isDone
 
   override def numRowsLeft: Long = left.numRowsLeft
+
+  override def checkpoint: Unit = {
+    left.checkpoint
+    right.checkpoint
+  }
+  override def restore: Unit = {
+    left.restore
+    right.restore
+  }
 
   override def allowSpilling(): Unit = {
     left.allowSpilling()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -715,6 +715,14 @@ object RapidsBufferCatalog extends Logging with Arm {
     deviceStorage = rdms
   }
 
+  // For testing
+  def setCatalog(catalog: RapidsBufferCatalog): Unit = {
+    if (_singleton != null) {
+      _singleton.close()
+    }
+    _singleton = catalog
+  }
+
   def init(rapidsConf: RapidsConf): Unit = {
     // We are going to re-initialize so make sure all of the old things were closed...
     closeImpl()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -103,6 +103,8 @@ object GpuHashJoin extends Arm {
   // Temporary for testing
   var retryOOMCount = 0
   var doSplitOOM = false
+  var retryGatherCount = 0
+  var splitGatherCount = 0
   var minBatchSize = 100
 
   def tagJoin(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JoinsRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JoinsRetrySuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler}
+import com.nvidia.spark.rapids.jni.RmmSpark
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.rapids.execution.GpuHashJoin
+
+class JoinsRetrySuite
+    extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+
+    Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024)
+    val deviceStorage = new RapidsDeviceMemoryStore()
+    val catalog = new RapidsBufferCatalog(deviceStorage)
+    RapidsBufferCatalog.setCatalog(catalog)
+    val baseEventHandler = new BaseRmmEventHandler()
+    RmmSpark.setEventHandler(baseEventHandler)
+    RmmSpark.associateCurrentThreadWithTask(1)
+    GpuHashJoin.minBatchSize = 10
+  }
+
+  override def afterEach(): Unit = {
+    GpuHashJoin.doSplitOOM = false
+    GpuHashJoin.retryOOMCount = 0
+    RapidsBufferCatalog.close()
+    if (Rmm.isInitialized) {
+      Rmm.shutdown()
+    }
+  }
+
+  lazy val shuffledJoinConf = new SparkConf()
+      .set("spark.sql.autoBroadcastJoinThreshold", "160")
+      .set("spark.sql.join.preferSortMergeJoin", "false")
+      .set("spark.sql.shuffle.partitions", "2") // hack to try and work around bug in cudf
+
+  def testWithRetry(
+      numRetries: Integer,
+      doSplit: Boolean,
+      dfA: SparkSession => DataFrame,
+      dfB: SparkSession => DataFrame,
+      conf: SparkConf = new SparkConf()
+      ) (fun: (DataFrame, DataFrame) => DataFrame): Unit = {
+    GpuHashJoin.retryOOMCount = numRetries
+    GpuHashJoin.doSplitOOM = doSplit
+    val gpuResult = withGpuSparkSession(spark => {
+      val df1 = dfA(spark)
+      val df2 = dfB(spark)
+      fun(df1, df2).collect()
+    }, conf)
+    assert(GpuHashJoin.retryOOMCount == 0)
+    // Validate correct results.
+    val cpuResult = withCpuSparkSession(spark => {
+      val df1 = dfA(spark)
+      val df2 = dfB(spark)
+      fun(df1, df2).collect()
+    }, conf)
+    compareResults(true, 0.0, cpuResult, gpuResult)
+  }
+
+  test("Test hash join with retries") {
+    testWithRetry(numRetries = 3, doSplit = false,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"))
+    }
+  }
+  test("Test hash join with split") {
+    testWithRetry(numRetries = 0, doSplit = true,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"))
+    }
+  }
+  test("Test hash join with retries and split") {
+    testWithRetry(numRetries = 2, doSplit = true,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"))
+    }
+  }
+  test("Test hash semi join with retries") {
+    testWithRetry(numRetries = 2, doSplit = false,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"), "LeftSemi")
+    }
+  }
+  test("Test hash anti join with retries") {
+    testWithRetry(numRetries = 2, doSplit = false,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"), "LeftAnti")
+    }
+  }
+  test("Test hash right join with retries and split") {
+    testWithRetry(numRetries = 2, doSplit = true,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"), "Right")
+    }
+  }
+  test("Test hash full join with retries and split") {
+    testWithRetry(numRetries = 2, doSplit = true,
+      longsDf, biggerLongsDf, conf = shuffledJoinConf) {
+      (A, B) => A.join(B, A("longs") === B("longs"), "FullOuter")
+    }
+  }
+
+  class BaseRmmEventHandler extends RmmEventHandler {
+    override def getAllocThresholds: Array[Long] = null
+    override def getDeallocThresholds: Array[Long] = null
+    override def onAllocThreshold(l: Long): Unit = {}
+    override def onDeallocThreshold(l: Long): Unit = {}
+
+    override def onAllocFailure(size: Long, retryCount: Int): Boolean = {
+      false
+    }
+  }
+}


### PR DESCRIPTION
This is a draft PR to use the reliability OOM retry framework for joins.  This PR adds oom retry logic for `createGatherer`, and makes some additional changes to ensure `SpillableColumnarBatches` are used where needed for this.

This is a pretty rough first implementation.  We may wish to integrate this more with the RmmRapidsRetryIterator introduced in #7771.   I did not do this initially because in the case of `createGatherer`,  the output is a `Option[JoinGatherer]` rather than a `SpillableColumnarBatch`, and in the case of a split, we don't split-and-retry immediately but instead add the splits to a pending list that is processed by the `SplittableJoinIterator` and we return `None` from `createGatherer`.  We could add a `withRetry` with these semantics if we think that is the best approach.

I suspect there are other places in the join code where we need to handle OOM retries, but this seemed like a good place to start, since we already had a split-and-retry approach.

I added some unit tests for this.  These currently depend on some variables added to `GpuHashJoin` object and some in-line code to inject the fake ooms.   This is not ideal, but I wanted to be able to validate not only that the retries/splits were happening, but the result of the joins were correct as well.
