### PR TITLE
Fix nested loop joins when there's no build-side columns

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -864,3 +864,27 @@ def test_existence_join_in_broadcast_nested_loop_join(spark_tmp_table_factory, a
     capture_regexp = r"GpuBroadcastNestedLoopJoin ExistenceJoin\(exists#[0-9]+\),"
     assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, capture_regexp,
                                                       conf={"spark.sql.adaptive.enabled": aqeEnabled})
+
+@ignore_order
+@pytest.mark.parametrize('aqeEnabled', [True, False], ids=['aqe:on', 'aqe:off'])
+def test_degenerate_broadcast_nested_loop_existence_join(spark_tmp_table_factory, aqeEnabled):
+    left_table_name = spark_tmp_table_factory.get()
+    right_table_name = spark_tmp_table_factory.get()
+
+    def do_join(spark):
+        gen = LongGen(min_val=0, max_val=5)
+
+        left_df = binary_op_df(spark, gen)
+        left_df.createOrReplaceTempView(left_table_name)
+        right_df = binary_op_df(spark, gen)
+        right_df.createOrReplaceTempView(right_table_name)
+
+        return spark.sql(("select * "
+                          "from {} as l "
+                          "where l.a >= 3 "
+                          "   or exists (select * from {} as r where l.b < l.a)"
+                          ).format(left_table_name, right_table_name))
+
+    capture_regexp = r"GpuBroadcastNestedLoopJoin ExistenceJoin\(exists#[0-9]+\),"
+    assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, capture_regexp,
+                                                      conf={"spark.sql.adaptive.enabled": aqeEnabled})


### PR DESCRIPTION
This fixes a problem in existence joins where a degenerate existence join that has conditions only on the stream-side columns can result in the plugin trying to construct a cudf Table from a rows-only batch (i.e.: no columns in the batch, just a row count).  In this case, we don't need to do the full join with gather maps, scattering to the existence column etc.   Since there are no columns in the build-side batch, the condition only relies on the stream-side batch.  That means for existence, we can simply evaluate the condition directly on the stream side batch if the build-side has any rows at all.  If the build-side has no rows, that means the existence column is false for all rows.