### PR TITLE
Support released spark 3.3.2

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,10 @@ jobs:
           . jenkins/version-def.sh
           svArrBodyNoSnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":false}" "${SPARK_SHIM_VERSIONS_NOSNAPSHOTS_TAIL[@]}")
           svArrBodyNoSnapshot=${svArrBodyNoSnapshot:1}
-          svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          # do not add empty snapshot versions
+          if [ ${#SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]} -gt 0 ]; then
+            svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+          fi
 
           # add snapshot versions which are not in snapshot property in pom file
           svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" 340)

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -26,6 +26,7 @@ in our plugin:
 | 3.2.3           | com.nvidia.spark.rapids.spark323.RapidsShuffleManager    |
 | 3.3.0           | com.nvidia.spark.rapids.spark330.RapidsShuffleManager    |
 | 3.3.1           | com.nvidia.spark.rapids.spark331.RapidsShuffleManager    |
+| 3.3.2           | com.nvidia.spark.rapids.spark332.RapidsShuffleManager    |
 | Databricks 9.1  | com.nvidia.spark.rapids.spark312db.RapidsShuffleManager  |
 | Databricks 10.4 | com.nvidia.spark.rapids.spark321db.RapidsShuffleManager  |
 | Databricks 11.3 | com.nvidia.spark.rapids.spark330db.RapidsShuffleManager  |

--- a/pom.xml
+++ b/pom.xml
@@ -697,7 +697,7 @@
         <spark323.version>3.2.3</spark323.version>
         <spark330.version>3.3.0</spark330.version>
         <spark331.version>3.3.1</spark331.version>
-        <spark332.version>3.3.2-SNAPSHOT</spark332.version>
+        <spark332.version>3.3.2</spark332.version>
         <spark340.version>3.4.0-SNAPSHOT</spark340.version>
         <spark330cdh.version>3.3.0.3.3.7180.0-274</spark330cdh.version>
         <spark330db.version>3.3.0-databricks</spark330db.version>
@@ -736,10 +736,10 @@
             323,
             330,
             331,
+            332,
             330cdh
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            332
         </snapshot.buildvers>
         <databricks.buildvers>
             312db,

--- a/sql-plugin/src/main/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimServiceProvider.scala
+++ b/sql-plugin/src/main/332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimServiceProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.nvidia.spark.rapids.SparkShimVersion
 
 object SparkShimServiceProvider {
   val VERSION = SparkShimVersion(3, 3, 2)
-  val VERSIONNAMES = Seq(s"$VERSION", s"$VERSION-SNAPSHOT")
+  val VERSIONNAMES = Seq(s"$VERSION")
 }
 
 class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {


### PR DESCRIPTION
fix #7783 

Remove SNAPSHOT version and move spark 332 build to noSnapshot list.
Internal nightly CI has been switched to use released spark 3.3.2 bin