### PR TITLE
Doc changes for new nested JSON reader [skip ci]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -296,38 +296,20 @@ The JSON format read is a very experimental feature which is expected to have so
 it by default. If you would like to test it, you need to enable `spark.rapids.sql.format.json.enabled` and 
 `spark.rapids.sql.format.json.read.enabled`.
 
-Currently, the GPU accelerated JSON reader doesn't support column pruning, which will likely make 
-this difficult to use or even test. The user must specify the full schema or just let Spark infer 
-the schema from the JSON file. eg,
-
-We have a `people.json` file with below content
-
+It will cause error on invalid data. For example, the following is valid:
 ``` console
-{"name":"Michael"}
 {"name":"Andy", "age":30}
 {"name":"Justin", "age":19}
 ```
 
-Both below ways will work
+The followings will cause error:
+```console
+{"name":"Andy", "age":30} ,,,,
+{"name":"Justin", "age":19}
+```
 
-- Inferring the schema
-
-  ``` scala
-  val df = spark.read.json("people.json")
-  ```
-
-- Specifying the full schema
-
-  ``` scala
-  val schema = StructType(Seq(StructField("name", StringType), StructField("age", IntegerType)))
-  val df = spark.read.schema(schema).json("people.json")
-  ```
-
-While the below code will not work in the current version,
-
-``` scala
-val schema = StructType(Seq(StructField("name", StringType)))
-val df = spark.read.schema(schema).json("people.json")
+```console
+{"name":  Justin", "age":19}
 ```
 
 ### JSON supporting types

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -296,13 +296,14 @@ The JSON format read is a very experimental feature which is expected to have so
 it by default. If you would like to test it, you need to enable `spark.rapids.sql.format.json.enabled` and 
 `spark.rapids.sql.format.json.read.enabled`.
 
-It will cause error on invalid data. For example, the following is valid:
+Reading input containing invalid JSON format (in any row) will throw runtime exception.
+An example of valid input is as following:
 ``` console
 {"name":"Andy", "age":30}
 {"name":"Justin", "age":19}
 ```
 
-The followings will cause error:
+The following input is invalid and will cause error:
 ```console
 {"name":"Andy", "age":30} ,,,,
 {"name":"Justin", "age":19}


### PR DESCRIPTION
Contributes to #7518 
Signed-off-by: Chong Gao <res_life@163.com>

Changes:
- Cause error on invalid data
- Remove the desc of does not support column pruning.

The following shows it supports column pruning now:
```
$ cat /tmp/people.json
{"name":"Michael"}
{"name":"Andy", "age":30}
{"name":"Justin", "age":19}
```

```
scala> import org.apache.spark.sql.types._
scala> spark.conf.set("spark.rapids.sql.format.json.read.enabled", "true")
scala> spark.conf.set("spark.rapids.sql.format.json.enabled", "true")
scala> val schema = StructType(Seq(StructField("name", StringType)))    // Only specify one column
scala> val df = spark.read.schema(schema).json("/tmp/people.json")
scala> df.show()
23/02/20 10:17:36 WARN GpuOverrides: 
!Exec <CollectLimitExec> cannot run on GPU because the Exec CollectLimitExec has been disabled, and is disabled by default because Collect Limit replacement can be slower on the GPU, if huge number of rows in a batch it could help by limiting the number of rows transferred from GPU to CPU. Set spark.rapids.sql.exec.CollectLimitExec to true if you wish to enable it
  @Partitioning <SinglePartition$> could run on GPU
  *Exec <FileSourceScanExec> will run on GPU

+-------+
|   name|
+-------+
|Michael|
|   Andy|
| Justin|
+-------+
```