### PR TITLE
Add GPU support for EphemeralSubstring [databricks]

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -377,6 +377,12 @@ def test_substring_column():
             'SUBSTRING(\'abc\', b, NULL)',
             'SUBSTRING(\'abc\', b)',
             'SUBSTRING(a, b)'))
+
+def test_ephemeral_substring():
+    str_gen = mk_str_gen('.{0,30}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: three_col_df(spark, str_gen, int_gen, int_gen)\
+            .filter("substr(a, 1, 3) > 'mmm'"))
 
 def test_repeat_scalar_and_column():
     gen_s = StringGen(nullable=False)

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -22,7 +22,7 @@ from data_gen import *
 from marks import *
 from pyspark.sql.types import *
 import pyspark.sql.functions as f
-from spark_session import is_before_spark_320
+from spark_session import is_databricks104_or_later
 
 _regexp_conf = { 'spark.rapids.sql.regexp.enabled': 'true' }
 
@@ -378,6 +378,8 @@ def test_substring_column():
             'SUBSTRING(\'abc\', b)',
             'SUBSTRING(a, b)'))
 
+@pytest.mark.skipif(is_databricks_runtime() and not is_databricks104_or_later(),
+                    reason="https://github.com/NVIDIA/spark-rapids/issues/7463")
 def test_ephemeral_substring():
     str_gen = mk_str_gen('.{0,30}')
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Adds support for the EphemeralSubstring expression by translating these operations to the existing GpuSubstring expression.  Ephemeral substrings are simply a performance optimization for certain situations where substrings are generated and have no semantic differences from a regular substring.