### PR TITLE
Do not error out DB IT test script when pytest code 5 [skip ci]

### DIFF
--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -101,7 +101,7 @@ ret=$?
 set -e
 if [ "$ret" = 5 ]; then
   # avoid exit script w/ code 5 when the cases are skipped in specific test
-  echo "Do exit Exit code 5: No tests were collected"
+  echo "Suppress Exit code 5: No tests were collected"
   exit 0
 fi
 exit "$ret"

--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,5 +94,14 @@ if [[ -n "$LOCAL_JAR_PATH" ]]; then
     export LOCAL_JAR_PATH=$LOCAL_JAR_PATH
 fi
 
+set +e
 # Run integration testing
 ./integration_tests/run_pyspark_from_build.sh --runtime_env='databricks' --test_type=$TEST_TYPE
+ret=$?
+set -e
+if [ "$ret" = 5 ]; then
+  # avoid exit script w/ code 5 when the cases are skipped in specific test
+  echo "Do exit Exit code 5: No tests were collected"
+  exit 0
+fi
+exit "$ret"


### PR DESCRIPTION
related to #7773 

we skipped udf tests in databricks runtime, 
but in our nightly CSP testing, the run_it script take single test as input which fail skipped module w/ 
`Exit code 5: No tests were collected` https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
```
[2023-02-21T19:37:57.572Z] Exception: run command failed: 
CompletedProcess(args="ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=10 -p 2200 -i **** ubuntu@20.69.125.98 
'TEST=udf_cudf_test.py' 'TEST_TAGS=' 'DATABRICKS_PORT=15062' 'LOCAL_JAR_PATH=/home/ubuntu' './run_it.sh'", 
returncode=5)
```

In this case we should not error out the test run
```
[2023-02-22T04:36:09.744Z] ===================== 2 skipped, 17695 deselected in 5.86s =====================
[2023-02-22T04:36:10.665Z] + ret=5
[2023-02-22T04:36:10.665Z] + set -e
[2023-02-22T04:36:10.665Z] + '[' 5 = 5 ']'
[2023-02-22T04:36:10.665Z] + echo 'Suppress Exit code 5: No tests were collected'
[2023-02-22T04:36:10.665Z] + exit 0
```


As this change is only be used with internal csp-utils, and has been verified internally. We add `[skip ci]` here