### PR TITLE
WIP: Optimize regexp_replace with choice of two strings as pattern

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -243,6 +243,17 @@ def test_re_replace():
                 'REGEXP_REPLACE(a, "TEST", NULL)'),
         conf=_regexp_conf)
 
+def test_re_replace_choice_opt():
+    gen = mk_str_gen('[a-d]{3,9}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'REGEXP_REPLACE(a, "ab|bc", "")',
+                'REGEXP_REPLACE(a, "ab|bc", "x")',
+                'REGEXP_REPLACE(a, "ab|cd", "b")',
+                'REGEXP_REPLACE(a, "ab|cd", "c")',
+                'REGEXP_REPLACE(a, "ab|cd", "x")'),
+        conf=_regexp_conf)
+
 # We have shims to support empty strings for zero-repetition patterns
 # See https://github.com/NVIDIA/spark-rapids/issues/5456
 def test_re_replace_repetition():

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -244,10 +244,13 @@ def test_re_replace():
         conf=_regexp_conf)
 
 def test_re_replace_choice_opt():
-    gen = mk_str_gen('[a-d]{3,9}')
+    gen = mk_str_gen('[a-d]{1,2}') \
+        .with_special_case("cabd")
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'REGEXP_REPLACE(a, "ab|bc", "")',
+                'REGEXP_REPLACE(a, "ab|cd", "")',
+                'REGEXP_REPLACE(a, "ab|cd", "bc")',
                 'REGEXP_REPLACE(a, "ab|bc", "x")',
                 'REGEXP_REPLACE(a, "ab|cd", "b")',
                 'REGEXP_REPLACE(a, "ab|cd", "c")',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -572,6 +572,11 @@ object GpuOverrides extends Logging {
     lit.value == null
   }
 
+  def isSupportedStringReplacePattern(strLit: String): Boolean = {
+    // check for regex special characters, except for \u0000 which we can support
+    !regexList.filterNot(_ == "\u0000").exists(pattern => strLit.contains(pattern))
+  }
+
   def isSupportedStringReplacePattern(exp: Expression): Boolean = {
     extractLit(exp) match {
       case Some(Literal(null, _)) => false
@@ -580,8 +585,7 @@ object GpuOverrides extends Logging {
         if (strLit.isEmpty) {
           false
         } else {
-          // check for regex special characters, except for \u0000 which we can support
-          !regexList.filterNot(_ == "\u0000").exists(pattern => strLit.contains(pattern))
+          isSupportedStringReplacePattern(strLit)
         }
       case _ => false
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -20,6 +20,17 @@ import org.apache.spark.sql.rapids.{GpuRegExpReplace, GpuRegExpReplaceWithBackre
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.unsafe.types.UTF8String
 
+sealed trait GpuRegExpReplaceAction
+object ActionStringReplace extends GpuRegExpReplaceAction
+case class ActionStringReplaceMulti(patterns: Seq[String])
+  extends GpuRegExpReplaceAction
+case class ActionRegExpReplace(
+  javaPattern: String,
+  cudfPattern: String,
+  replacement: String,
+  containsBackref: Boolean
+) extends GpuRegExpReplaceAction
+
 class GpuRegExpReplaceMeta(
     expr: RegExpReplace,
     conf: RapidsConf,
@@ -27,39 +38,72 @@ class GpuRegExpReplaceMeta(
     rule: DataFromReplacementRule)
   extends QuaternaryExprMeta[RegExpReplace](expr, conf, parent, rule) {
 
-  private var javaPattern: Option[String] = None
-  private var cudfPattern: Option[String] = None
-  private var replacement: Option[String] = None
-  private var canUseGpuStringReplace = false
-  private var containsBackref: Boolean = false
+  private var action: Option[GpuRegExpReplaceAction] = None
 
   override def tagExprForGpu(): Unit = {
     GpuRegExpUtils.tagForRegExpEnabled(this)
-    replacement = expr.rep match {
-      case Literal(s: UTF8String, DataTypes.StringType) if s != null => Some(s.toString)
-      case _ => None
+    val replacement: String = expr.rep match {
+      case Literal(s: UTF8String, DataTypes.StringType) if s != null => s.toString
+      case _ =>
+        willNotWorkOnGpu(s"only non-null literal strings are supported on GPU")
+        return
     }
 
     expr.regexp match {
       case Literal(s: UTF8String, DataTypes.StringType) if s != null =>
-        if (GpuOverrides.isSupportedStringReplacePattern(expr.regexp)) {
-          canUseGpuStringReplace = true
-        } else {
-          try {
-            javaPattern = Some(s.toString())
-            val (pat, repl) = 
-                new CudfRegexTranspiler(RegexReplaceMode).getTranspiledAST(s.toString, replacement)
-            GpuRegExpUtils.validateRegExpComplexity(this, pat)
-            cudfPattern = Some(pat.toRegexString)
-            repl.map { r => GpuRegExpUtils.backrefConversion(r.toRegexString) }.foreach {
+        try {
+          val (pattern, repl) = new CudfRegexTranspiler(RegexReplaceMode)
+              .getTranspiledAST(s.toString, Some(replacement))
+          GpuRegExpUtils.validateRegExpComplexity(this, pattern)
+          val maybeBackref = repl.map { r => GpuRegExpUtils.backrefConversion(r.toRegexString) }
+          val hasBackRef = maybeBackref.exists(_._1)
+
+          pattern match {
+            case RegexChoice(a, b) if !hasBackRef =>
+              // special handling for "AB|CD" where we can use string replace instead of
+              // regexp replace for improved performance. We can only perform this optimization
+              // if the following conditions are met:
+              //
+              // - Both strings must be supported by string_replace, so cannot contain regexp chars
+              // - There must be no back-references
+              // - The second string must not overlap with the replacement string because this
+              //   could cause incorrect results. For example, if we replace "AB|CD" with "C" for
+              //   the input "ABD", we would first replace "AB" with "C", resulting in "CD", which
+              //   would now match the second string, and the original string would not have
+              //   matched.
+              val str1 = a.toRegexString
+              val str2 = b.toRegexString
+              //TODO this check is probably too broad at the moment and could be refined
+              val overlap = str2.contains(replacement)
+              if (GpuOverrides.isSupportedStringReplacePattern(str1) &&
+                  GpuOverrides.isSupportedStringReplacePattern(str2) &&
+                  !overlap) {
+                action = Some(ActionStringReplaceMulti(Seq(str1, str2)))
+              } else {
+                maybeBackref.foreach {
+                  case (hasBackref, convertedRep) =>
+                    action = Some(ActionRegExpReplace(s.toString,
+                      pattern.toRegexString,
+                      GpuRegExpUtils.unescapeReplaceString(convertedRep),
+                      hasBackref))
+                }
+              }
+
+            case _ if GpuOverrides.isSupportedStringReplacePattern(expr.regexp) =>
+              action = Some(ActionStringReplace)
+
+            case _ =>
+              maybeBackref.foreach {
                 case (hasBackref, convertedRep) =>
-                  containsBackref = hasBackref
-                  replacement = Some(GpuRegExpUtils.unescapeReplaceString(convertedRep))
-            }
-          } catch {
-            case e: RegexUnsupportedException =>
-              willNotWorkOnGpu(e.getMessage)
+                  action = Some(ActionRegExpReplace(s.toString,
+                    pattern.toRegexString,
+                    GpuRegExpUtils.unescapeReplaceString(convertedRep),
+                    hasBackref))
+              }
           }
+        } catch {
+          case e: RegexUnsupportedException =>
+            willNotWorkOnGpu(e.getMessage)
         }
 
       case _ =>
@@ -81,19 +125,21 @@ class GpuRegExpReplaceMeta(
     // ignore the pos expression which must be a literal 1 after tagging check
     require(childExprs.length == 4,
       s"Unexpected child count for RegExpReplace: ${childExprs.length}")
-    if (canUseGpuStringReplace) {
-      GpuStringReplace(lhs, regexp, rep)
-    } else {
-      (javaPattern, cudfPattern, replacement) match {
-        case (Some(javaPattern), Some(cudfPattern), Some(cudfReplacement)) =>
-          if (containsBackref) {
-            GpuRegExpReplaceWithBackref(lhs, cudfPattern, cudfReplacement)
-          } else {
-            GpuRegExpReplace(lhs, regexp, rep, javaPattern, cudfPattern, cudfReplacement)
-          }
-        case _ =>
-          throw new IllegalStateException("Expression has not been tagged correctly")
-      }
+
+    action match {
+      case Some(ActionStringReplace) =>
+        GpuStringReplace(lhs, regexp, rep)
+      case Some(ActionStringReplaceMulti(patterns)) =>
+        GpuStringReplace(
+          GpuStringReplace(lhs, GpuLiteral(patterns.head), rep), GpuLiteral(patterns(1)), rep)
+      case Some(ActionRegExpReplace(javaPattern, cudfPattern, cudfReplacement, containsBackref)) =>
+        if (containsBackref) {
+          GpuRegExpReplaceWithBackref(lhs, cudfPattern, cudfReplacement)
+        } else {
+          GpuRegExpReplace(lhs, regexp, rep, javaPattern, cudfPattern, cudfReplacement)
+        }
+      case _ =>
+        throw new IllegalStateException("Expression has not been tagged correctly")
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -745,7 +745,8 @@ case class GpuStringRepeat(input: Expression, repeatTimes: Expression)
 case class GpuStringReplace(
     srcExpr: Expression,
     searchExpr: Expression,
-    replaceExpr: Expression)
+    replaceExpr: Expression,
+    override val hasSideEffects: Boolean = false)
   extends GpuTernaryExpression with ImplicitCastInputTypes {
 
   override def dataType: DataType = srcExpr.dataType


### PR DESCRIPTION
This PR aimed to create a performance optimization to use string replace instead of regexp replace when replacing a pattern such as "string1|string2" consisting of a choice of two literal strings.

This turned out to be more complex than I realized when I started, and the solution is quite convoluted, so I don't know how much of an optimization this will be.

See the code comments in the PR for an explanation of the approach, but this PR replaces the original regexp_replace expression with the following:

```
if (INPUT gpurlike PLACEHOLDER) {
  gpuregexpreplace(INPUT, PATTERN, REPL) 
} else {
  gpustringreplace(
    gpustringreplace(
      gpustringreplace(INPUT, STR1, PLACEHOLDER), 
      STR2, REPL
    ), 
    PLACEHOLDER, REPL
  )
```
