### PR TITLE
Fallback Delta Lake optimized writes if GPU cannot support partitioning

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
@@ -16,10 +16,11 @@
 
 package com.nvidia.spark.rapids.delta
 
-import com.databricks.sql.transaction.tahoe.{DeltaLog, DeltaParquetFileFormat}
-import com.nvidia.spark.rapids.{DeltaFormatType, FileFormatChecks, GpuParquetFileFormat, RapidsMeta, WriteFileOp}
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOptions, DeltaParquetFileFormat}
+import com.nvidia.spark.rapids.{DeltaFormatType, FileFormatChecks, GpuOverrides, GpuParquetFileFormat, RapidsMeta, TypeSig, WriteFileOp}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.DataSourceUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 
@@ -37,11 +38,12 @@ object RapidsDeltaUtils {
       case f =>
         meta.willNotWorkOnGpu(s"file format $f is not supported")
     }
-    checkIncompatibleConfs(meta, deltaLog, spark.sessionState.conf, options)
+    checkIncompatibleConfs(meta, schema, deltaLog, spark.sessionState.conf, options)
   }
 
   private def checkIncompatibleConfs(
       meta: RapidsMeta[_, _, _],
+      schema: StructType,
       deltaLog: DeltaLog,
       sqlConf: SQLConf,
       options: Map[String, String]): Unit = {
@@ -50,6 +52,42 @@ object RapidsDeltaUtils {
         Option(sqlConf.getConfString(key))
       } catch {
         case _: NoSuchElementException => None
+      }
+    }
+
+    // Optimized writes for non-partitioned tables involves a round-robin partitioning, and that
+    // can involve a sort on all columns. The GPU doesn't currently support sorting on all types,
+    // so we fallback if the GPU cannot support the round-robin partitioning.
+    if (sqlConf.sortBeforeRepartition) {
+      val orderableTypeSig = (GpuOverrides.pluginSupportedOrderableSig + TypeSig.DECIMAL_128
+          + TypeSig.STRUCT).nested()
+      val unorderableTypes = schema.map(_.dataType).filterNot { t =>
+        orderableTypeSig.isSupportedByPlugin(t)
+      }
+      if (unorderableTypes.nonEmpty) {
+        val metadata = deltaLog.snapshot.metadata
+        val hasPartitioning = metadata.partitionColumns.nonEmpty ||
+            options.get(DataSourceUtils.PARTITIONING_COLUMNS_KEY).exists(_.nonEmpty)
+        if (!hasPartitioning) {
+          val optimizeWriteEnabled = {
+            val deltaOptions = new DeltaOptions(options, sqlConf)
+            deltaOptions.optimizeWrite.orElse {
+              getSQLConf("spark.databricks.delta.optimizeWrite.enabled").map(_.toBoolean).orElse {
+                DeltaConfigs.AUTO_OPTIMIZE.fromMetaData(metadata).orElse {
+                  metadata.configuration.get("delta.autoOptimize.optimizeWrite").orElse {
+                    getSQLConf(
+                      "spark.databricks.delta.properties.defaults.autoOptimize.optimizeWrite")
+                  }.map(_.toBoolean)
+                }
+              }
+            }.getOrElse(false)
+          }
+          if (optimizeWriteEnabled) {
+            unorderableTypes.foreach { t =>
+              meta.willNotWorkOnGpu(s"round-robin partitioning cannot sort $t")
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #7799.

Updates the tagging of Delta Lake write operations to fallback to the CPU for optimized writes that will need to use a round-robin partitioning when the GPU cannot order one or more types in the schema.