### PR TITLE
Restore pandas import check in db113 runtime

### DIFF
--- a/integration_tests/src/main/python/udf_cudf_test.py
+++ b/integration_tests/src/main/python/udf_cudf_test.py
@@ -15,12 +15,8 @@
 import pytest
 
 from conftest import is_at_least_precommit_run
-from spark_session import is_databricks113_or_later
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
-
-if is_databricks113_or_later():
-    pytest.skip('https://github.com/NVIDIA/spark-rapids/issues/7639', allow_module_level=True)
 
 try:
     require_minimum_pandas_version()

--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -15,12 +15,9 @@
 import pytest
 
 from conftest import is_at_least_precommit_run
-from spark_session import is_databricks91_or_later, is_before_spark_330, is_databricks113_or_later
+from spark_session import is_databricks91_or_later, is_before_spark_330
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
-
-if is_databricks113_or_later():
-    pytest.skip('https://github.com/NVIDIA/spark-rapids/issues/7639', allow_module_level=True)
 
 try:
     require_minimum_pandas_version()


### PR DESCRIPTION
To fix the issue : https://github.com/NVIDIA/spark-rapids/issues/7820

Restore pandas import check in db113 runtime, as PR https://github.com/NVIDIA/spark-rapids/pull/7789 fixed the `require_minimum_pandas_version()` check failure

