### PR TITLE
[BUG] Enable managed memory only if async allocator is not used

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -280,8 +280,11 @@ object GpuDeviceManager extends Logging {
       }
 
       if (conf.isUvmEnabled) {
-        init = init | RmmAllocationMode.CUDA_MANAGED_MEMORY
         features += "UVM"
+        // Enable managed memory only if async allocator is not used.
+        if ((init | RmmAllocationMode.CUDA_ASYNC) == 0) {
+          init = init | RmmAllocationMode.CUDA_MANAGED_MEMORY
+        }
       }
 
       val logConf: Rmm.LogConf = conf.rmmDebugLocation match {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -280,10 +280,13 @@ object GpuDeviceManager extends Logging {
       }
 
       if (conf.isUvmEnabled) {
-        features += "UVM"
         // Enable managed memory only if async allocator is not used.
         if ((init | RmmAllocationMode.CUDA_ASYNC) == 0) {
+          features += "UVM"
           init = init | RmmAllocationMode.CUDA_MANAGED_MEMORY
+        } else {
+          throw new IllegalArgumentException(
+            "CUDA Unified Memory is not supported in CUDA_ASYNC allocation mode");
         }
       }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -297,7 +297,7 @@ object GpuDeviceManager extends Logging {
           Rmm.logToStdout()
         case c if "stderr".equalsIgnoreCase(c) =>
           features += "LOG: STDERR"
-          Rmm.logToStdout()
+          Rmm.logToStderr()
         case c =>
           logWarning(s"RMM logging set to '$c' is not supported and is being ignored.")
           null


### PR DESCRIPTION
Currently, the plugin code always tries to turn on managed memory whenever unified memory is enabled. As such, if async allocator is used with unified memory, this may cause a crash in the JNI layer because async allocator can't be used together with managed memory.

This fixes such conflict, turning on managed memory (if possible) only if async allocator is not used.