### PR TITLE
Use withRetryNoSplit in BasicWindowCalc

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -1117,7 +1117,7 @@ class GroupedAggregations extends Arm {
    * Do all of the aggregations and put them in the output columns. There may be extra processing
    * after this before you get to a final result.
    */
-  def doAggs(isRunningBatched: Boolean,
+  def doAggsAndClose(isRunningBatched: Boolean,
       boundOrderSpec: Seq[SortOrder],
       orderByPositions: Array[Int],
       partByPositions: Array[Int],
@@ -1250,8 +1250,14 @@ trait BasicWindowCalc extends Arm {
         SpillPriorities.ACTIVE_BATCHING_PRIORITY,
         spillCallback)
 
-      aggregations.doAggs(isRunningBatched, boundOrderSpec, orderByPositions,
-        partByPositions, inputSpillable, outputColumns)
+      // this takes ownership of `inputSpillable`
+      aggregations.doAggsAndClose(
+        isRunningBatched,
+        boundOrderSpec,
+        orderByPositions,
+        partByPositions,
+        inputSpillable,
+        outputColumns)
 
       // if the window aggregates were successful, lets splice the passThrough
       // columns

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -23,9 +23,9 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{AggregationOverWindow, DType, GroupByOptions, GroupByScanAggregation, NullPolicy, NvtxColor, ReplacePolicy, ReplacePolicyWithColumn, Scalar, ScanAggregation, ScanType, Table, WindowOptions}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
 import com.nvidia.spark.rapids.shims.{GpuWindowUtil, ShimUnaryExecNode}
-import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler}
+import com.nvidia.spark.rapids.jni.RmmSpark
+import org.scalatest.{BeforeAndAfterEach, FunSuite}
+
+import org.apache.spark.sql.SparkSession
+
+class RmmSparkRetrySuiteBase extends FunSuite with BeforeAndAfterEach {
+  private var rmmWasInitialized = false
+
+  override def beforeEach(): Unit = {
+    SparkSession.getActiveSession.foreach(_.stop())
+    SparkSession.clearActiveSession()
+    if (!Rmm.isInitialized) {
+      rmmWasInitialized = true
+      Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024)
+    }
+    val deviceStorage = new RapidsDeviceMemoryStore()
+    val catalog = new RapidsBufferCatalog(deviceStorage)
+    RapidsBufferCatalog.setCatalog(catalog)
+    val mockEventHandler = new BaseRmmEventHandler()
+    RmmSpark.setEventHandler(mockEventHandler)
+    RmmSpark.associateThreadWithTask(RmmSpark.getCurrentThreadId, 1)
+  }
+
+  override def afterEach(): Unit = {
+    RmmSpark.removeThreadAssociation(RmmSpark.getCurrentThreadId)
+    RmmSpark.clearEventHandler()
+    RapidsBufferCatalog.close()
+    if (rmmWasInitialized) {
+      Rmm.shutdown()
+    }
+  }
+
+  private class BaseRmmEventHandler extends RmmEventHandler {
+    override def getAllocThresholds: Array[Long] = null
+    override def getDeallocThresholds: Array[Long] = null
+    override def onAllocThreshold(totalAllocSize: Long): Unit = {}
+    override def onDeallocThreshold(totalAllocSize: Long): Unit = {}
+    override def onAllocFailure(sizeRequested: Long, retryCount: Int): Boolean = {
+      false
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
@@ -60,7 +60,7 @@ class WindowRetrySuite
       GpuSpecialFrameBoundary(UnboundedFollowing))
     val (groupAggs, outputColumns) = setupCountAgg(frame)
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
-    groupAggs.doAggs(
+    groupAggs.doAggsAndClose(
       false,
       Seq.empty[SortOrder],
       Array.empty,
@@ -89,7 +89,7 @@ class WindowRetrySuite
       GpuSpecialFrameBoundary(CurrentRow))
     val (groupAggs, outputColumns) = setupCountAgg(frame)
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
-    groupAggs.doAggs(
+    groupAggs.doAggsAndClose(
       false,
       Seq.empty[SortOrder],
       Array.empty,
@@ -120,7 +120,7 @@ class WindowRetrySuite
     val orderSpec = SortOrder(child, Ascending) :: Nil
     val (groupAggs, outputColumns) = setupCountAgg(frame, orderSpec = orderSpec)
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
-    groupAggs.doAggs(
+    groupAggs.doAggsAndClose(
       false,
       orderSpec,
       Array(0),
@@ -154,7 +154,7 @@ class WindowRetrySuite
     outputColumns(0) = theMock
     RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId, 1)
     assertThrows[java.lang.OutOfMemoryError] {
-      groupAggs.doAggs(
+      groupAggs.doAggsAndClose(
         false,
         Seq.empty[SortOrder],
         Array.empty,
@@ -178,7 +178,7 @@ class WindowRetrySuite
       GpuSpecialFrameBoundary(CurrentRow))
     val (groupAggs, outputColumns) = setupCountAgg(frame)
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
-    groupAggs.doAggs(
+    groupAggs.doAggsAndClose(
       false,
       Seq.empty[SortOrder],
       Array.empty,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf._
+import com.nvidia.spark.rapids.jni.RmmSpark
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+
+import org.apache.spark.sql.catalyst.expressions.{Ascending, CurrentRow, ExprId, RangeFrame, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
+import org.apache.spark.sql.rapids.GpuCount
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
+
+class WindowRetrySuite
+    extends RmmSparkRetrySuiteBase
+        with MockitoSugar
+        with Arm {
+  private def buildInputBatch() = {
+    val reductionTable = new Table.TestBuilder()
+      .column(1.asInstanceOf[java.lang.Integer], 1, 1, 1)
+      .column(5L, null.asInstanceOf[java.lang.Long], 3L, 3L)
+      .build()
+    withResource(reductionTable) { tbl =>
+      val cb = GpuColumnVector.from(tbl, Seq(IntegerType, LongType).toArray[DataType])
+      spy(SpillableColumnarBatch(cb, -1, RapidsBuffer.defaultSpillCallback))
+    }
+  }
+
+  def setupCountAgg(
+      frame: GpuSpecifiedWindowFrame,
+      orderSpec: Seq[SortOrder] = Seq.empty):
+  (GroupedAggregations, Array[ai.rapids.cudf.ColumnVector]) = {
+    val groupAggs = new GroupedAggregations()
+    val spec = GpuWindowSpecDefinition(Seq.empty, orderSpec, frame)
+    val count = GpuWindowExpression(GpuCount(Seq(GpuLiteral.create(1, IntegerType))), spec)
+    groupAggs.addAggregation(count, Array(0), 2)
+    val windowOptsLength = 3
+    (groupAggs, new Array[ai.rapids.cudf.ColumnVector](windowOptsLength))
+  }
+
+  test("row based window handles RetryOOM") {
+    val inputBatch = buildInputBatch()
+    val frame = GpuSpecifiedWindowFrame(
+      RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding),
+      GpuSpecialFrameBoundary(UnboundedFollowing))
+    val (groupAggs, outputColumns) = setupCountAgg(frame)
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
+    groupAggs.doAggs(
+      false,
+      Seq.empty[SortOrder],
+      Array.empty,
+      Array.empty,
+      inputBatch,
+      outputColumns)
+    withResource(outputColumns) { _ =>
+      var rowsLeftToCheck = 4
+      withResource(outputColumns(2).copyToHost()) { hostCol =>
+        (0 until hostCol.getRowCount.toInt).foreach { row =>
+          assertResult(4)(hostCol.getLong(row))
+          rowsLeftToCheck -= 1
+        }
+      }
+      assertResult(0)(rowsLeftToCheck)
+    }
+    verify(inputBatch, times(2)).getColumnarBatch()
+    verify(inputBatch, times(1)).close()
+  }
+
+  test("optimized-row based window handles RetryOOM") {
+    val inputBatch = buildInputBatch()
+    val frame = GpuSpecifiedWindowFrame(
+      RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding),
+      GpuSpecialFrameBoundary(CurrentRow))
+    val (groupAggs, outputColumns) = setupCountAgg(frame)
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
+    groupAggs.doAggs(
+      false,
+      Seq.empty[SortOrder],
+      Array.empty,
+      Array.empty,
+      inputBatch,
+      outputColumns)
+    withResource(outputColumns) { _ =>
+      var rowsLeftToCheck = 4
+      withResource(outputColumns(2).copyToHost()) { hostCol =>
+        (0 until hostCol.getRowCount.toInt).foreach { row =>
+          assertResult(row + 1)(hostCol.getLong(row))
+          rowsLeftToCheck -= 1
+        }
+      }
+      assertResult(0)(rowsLeftToCheck)
+    }
+    verify(inputBatch, times(2)).getColumnarBatch()
+    verify(inputBatch, times(1)).close()
+  }
+
+  test("ranged based window handles RetryOOM") {
+    val inputBatch = buildInputBatch()
+    val frame = GpuSpecifiedWindowFrame(
+      RangeFrame,
+      GpuLiteral.create(-1, IntegerType),
+      GpuSpecialFrameBoundary(CurrentRow))
+    val child = GpuBoundReference(0, IntegerType, nullable = false)(ExprId(0), "test")
+    val orderSpec = SortOrder(child, Ascending) :: Nil
+    val (groupAggs, outputColumns) = setupCountAgg(frame, orderSpec = orderSpec)
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
+    groupAggs.doAggs(
+      false,
+      orderSpec,
+      Array(0),
+      Array.empty,
+      inputBatch,
+      outputColumns)
+    withResource(outputColumns) { _ =>
+      var rowsLeftToCheck = 4
+      withResource(outputColumns(2).copyToHost()) { hostCol =>
+        (0 until hostCol.getRowCount.toInt).foreach { row =>
+          assertResult(4)(hostCol.getLong(row))
+          rowsLeftToCheck -= 1
+        }
+      }
+      assertResult(0)(rowsLeftToCheck)
+    }
+    verify(inputBatch, times(2)).getColumnarBatch()
+    verify(inputBatch, times(1)).close()
+  }
+
+  test("SplitAndRetryOOM is not handled in doAggs") {
+    val inputBatch = buildInputBatch()
+
+    val frame = GpuSpecifiedWindowFrame(
+      RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding),
+      GpuSpecialFrameBoundary(CurrentRow))
+    val (groupAggs, outputColumns) = setupCountAgg(frame)
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId, 1)
+    assertThrows[java.lang.OutOfMemoryError] {
+      groupAggs.doAggs(
+        false,
+        Seq.empty[SortOrder],
+        Array.empty,
+        Array.empty,
+        inputBatch,
+        outputColumns)
+    }
+    verify(inputBatch, times(1)).getColumnarBatch()
+    verify(inputBatch, times(1)).close()
+  }
+
+  test("row based group by window handles RetryOOM") {
+    val inputBatch = buildInputBatch()
+    val frame = GpuSpecifiedWindowFrame(
+      RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding),
+      GpuSpecialFrameBoundary(CurrentRow))
+    val (groupAggs, outputColumns) = setupCountAgg(frame)
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1)
+    groupAggs.doAggs(
+      false,
+      Seq.empty[SortOrder],
+      Array.empty,
+      Array(1),
+      inputBatch,
+      outputColumns)
+    withResource(outputColumns) { _ =>
+      var rowsLeftToCheck = 4
+      withResource(outputColumns(2).copyToHost()) { hostCol =>
+        (0 until hostCol.getRowCount.toInt).foreach { row =>
+          if (row == 0) { // 5
+            assertResult(1)(hostCol.getLong(row))
+            rowsLeftToCheck -= 1
+          } else if (row == 1) { // null
+            assertResult(1)(hostCol.getLong(row))
+            rowsLeftToCheck -= 1
+          } else if (row == 2) { // 3
+            assertResult(1)(hostCol.getLong(row))
+            rowsLeftToCheck -= 1
+          } else if (row == 3) { // 3
+            assertResult(2)(hostCol.getLong(row))
+            rowsLeftToCheck -= 1
+          }
+        }
+      }
+      assertResult(0)(rowsLeftToCheck)
+    }
+    verify(inputBatch, times(2)).getColumnarBatch()
+    verify(inputBatch, times(1)).close()
+  }
+}


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7254

This uses `withRetryNoSplit` in the basic window code. This allows us to handle `RetryOOM` exceptions. In the first cut we are not handling `SplitAndRetryOOM` in the window.

Note that this does NOT cover the rolling window fixup logic, that was put under this other issue: https://github.com/NVIDIA/spark-rapids/issues/7809.

I refactored the tests a bit, including the hash aggregate retry suite.