### PR TITLE
Fix buffer and Filter time with Parquet multithreaded combine reader

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -71,16 +71,20 @@ object SingleHMBAndMeta {
 trait HostMemoryBuffersWithMetaDataBase {
   // PartitionedFile to be read
   def partitionedFile: PartitionedFile
+
   // Original PartitionedFile if path was replaced with Alluxio
   def origPartitionedFile: Option[PartitionedFile] = None
+
   // An array of BlockChunk(HostMemoryBuffer and its data size) read from PartitionedFile
   def memBuffersAndSizes: Array[SingleHMBAndMeta]
+
   // Total bytes read
   def bytesRead: Long
-  // Percentage of time spent on filtering
-  private var _filterTimePct: Double = 0L
-  // Percentage of time spent on buffering
-  private var _bufferTimePct: Double = 0L
+
+  // Time spent on filtering
+  private var _filterTime: Long = 0L
+  // Time spent on buffering
+  private var _bufferTime: Long = 0L
 
   // The partition values which are needed if combining host memory buffers
   // after read by the multithreaded reader but before sending to GPU.
@@ -89,13 +93,22 @@ trait HostMemoryBuffersWithMetaDataBase {
   // Called by parquet/orc/avro scanners to set the amount of time (in nanoseconds)
   // that filtering and buffering incurred in one of the scan runners.
   def setMetrics(filterTime: Long, bufferTime: Long): Unit = {
-    val totalTime = filterTime + bufferTime
-    _filterTimePct = filterTime.toDouble / totalTime
-    _bufferTimePct = bufferTime.toDouble / totalTime
+    _bufferTime = bufferTime
+    _filterTime = filterTime
   }
 
-  def getBufferTimePct: Double = _bufferTimePct
-  def getFilterTimePct: Double = _filterTimePct
+  def getBufferTime: Long = _bufferTime
+  def getFilterTime: Long = _filterTime
+
+  def getBufferTimePct: Double = {
+    val totalTime = _filterTime + _bufferTime
+    _bufferTime.toDouble / totalTime
+  }
+
+  def getFilterTimePct: Double = {
+    val totalTime = _filterTime + _bufferTime
+    _filterTime.toDouble / totalTime
+  }
 }
 
 // This is a common trait for all kind of file formats

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -71,13 +71,10 @@ object SingleHMBAndMeta {
 trait HostMemoryBuffersWithMetaDataBase {
   // PartitionedFile to be read
   def partitionedFile: PartitionedFile
-
   // Original PartitionedFile if path was replaced with Alluxio
   def origPartitionedFile: Option[PartitionedFile] = None
-
   // An array of BlockChunk(HostMemoryBuffer and its data size) read from PartitionedFile
   def memBuffersAndSizes: Array[SingleHMBAndMeta]
-
   // Total bytes read
   def bytesRead: Long
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1931,7 +1931,7 @@ class MultiFileCloudParquetPartitionReader(
       }
       val newHmbBufferInfo = SingleHMBAndMeta(buf, offset,
         combinedMeta.allPartValues.map(_._1).sum, Seq.empty, schemaToUse)
-      HostMemoryBuffersWithMetaData(
+      val newHmbMeta = HostMemoryBuffersWithMetaData(
         metaToUse.partitionedFile,
         metaToUse.origPartitionedFile, // this doesn't matter since already read
         Array(newHmbBufferInfo),
@@ -1942,6 +1942,10 @@ class MultiFileCloudParquetPartitionReader(
         metaToUse.clippedSchema,
         metaToUse.readSchema,
         Some(combinedMeta.allPartValues))
+      val filterTime = combinedMeta.toCombine.map(_.getFilterTime).sum
+      val bufferTime = combinedMeta.toCombine.map(_.getBufferTime).sum
+      newHmbMeta.setMetrics(filterTime, bufferTime)
+      newHmbMeta
     }
     logDebug(s"Took ${(System.currentTimeMillis() - startCombineTime)} " +
       s"ms to do combine of ${toCombineHmbs.size} files, " +


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/7829

The metrics in the UI were showing 0 most of the time for buffer time when the combining reader is used looks like I missed combining the metrics into the new host memory buffer we create.

Tested this manually on customer job and its now showing reasonable values.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
