### PR TITLE
Add reduced pom to dist jar in the packaging phase [databricks]

### DIFF
--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (c) 2021-2022, NVIDIA CORPORATION.
+  Copyright (c) 2021-2023, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@
         ${aggregatorDependencyRegex}
         </echo>
         <copy file="${project.basedir}/pom.xml"
-            tofile="${project.build.directory}/extra-resources/META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml"
+            tofile="${project.build.directory}/parallel-world/META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml"
             overwrite="true">
             <filterchain>
                 <replaceregex flags="gs" byline="false" replace=""

--- a/dist/maven-antrun/build-parallel-worlds.xml
+++ b/dist/maven-antrun/build-parallel-worlds.xml
@@ -199,7 +199,8 @@
             <fileset dir="${project.build.directory}/parallel-world/spark3xx-common"
                      includesfile="${project.basedir}/unshimmed-common-from-spark311.txt"/>
         </delete>
-
+    </target>
+    <target name="remove-dependencies-from-pom" depends="build-parallel-worlds">
         <echo level="info">Generating dependency-reduced-pom.xml</echo>
         <resources id="aggregatorDependencyRegexWithoutWhitespace">
             <string>&lt;dependency&gt;</string>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -439,7 +439,7 @@ root = ET.fromstring(pom_xml)
 # verify: either no child element dependencies or it is empty
 deps = root.findall('{%s}dependencies' % ns)
 assert len(deps) == 0 or len(deps) == 1 and len(deps[0]) == 0, \
-       "Dist pom must not have depepndencies"
+       "Dist pom must not have dependencies"
 self.log("... OK")
 ]]>
                                 </scriptdef>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -415,7 +415,7 @@
                                 <property name="included_buildvers" value="${included_buildvers}"/>
                                 <ant
                                     antfile="${project.basedir}/maven-antrun/build-parallel-worlds.xml"
-                                    target="build-parallel-worlds"
+                                    target="remove-dependencies-from-pom"
                                 />
                             </target>
                         </configuration>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -41,6 +41,7 @@
     <properties>
         <target.classifier/>
         <dist.jar.name>${project.build.directory}/${project.build.finalName}-${cuda.version}.jar</dist.jar.name>
+        <dist.jar.pom.url>jar:file:${dist.jar.name}!/META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml</dist.jar.pom.url>
     </properties>
     <profiles>
         <profile>
@@ -342,7 +343,7 @@
                         <id>default-resources</id>
                         <phase>process-resources</phase>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>>
+                            <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -368,10 +369,6 @@
                             <archive><compress>${dist.jar.compress}</compress></archive>
                             <classesDirectory>${project.build.directory}/parallel-world</classesDirectory>
                             <classifier>${cuda.version}</classifier>
-                            <excludes>
-                                <!-- get rid of all maven poms from shim builds -->
-                                <exclude>META-INF/maven/**</exclude>
-                            </excludes>
                         </configuration>
                     </execution>
                     <execution>
@@ -428,12 +425,28 @@
                         <goals>
                             <goal>run</goal>
                         </goals>
-                        <id>reduce-pom-deps-in-the-jar</id>
+                        <id>check-pom-dependencies-empty</id>
                         <configuration>
                             <target>
-                                <zip update="true" basedir="${project.build.directory}/extra-resources"
-                                    compress="${dist.jar.compress}"
-                                    destfile="${dist.jar.name}"/>
+                                <scriptdef name="validateReducedPom" language="jython">
+<![CDATA[
+import xml.etree.ElementTree as ET
+
+self.log("Verifying pom.xml in distribution jar has zero dependencies ...")
+pom_xml = project.getProperty("pomXmlInJar")
+ns = 'http://maven.apache.org/POM/4.0.0'
+root = ET.fromstring(pom_xml)
+# verify: either no child element dependencies or it is empty
+deps = root.findall('{%s}dependencies' % ns)
+assert len(deps) == 0 or len(deps) == 1 and len(deps[0]) == 0, \
+       "Dist pom must not have depepndencies"
+self.log("... OK")
+]]>
+                                </scriptdef>
+                                <loadresource property="pomXmlInJar">
+                                    <url url="${dist.jar.pom.url}"/>
+                                </loadresource>
+                                <validateReducedPom/>
                             </target>
                         </configuration>
                     </execution>
@@ -536,14 +549,14 @@
                                     <groupId>com.nvidia</groupId>
                                     <artifactId>spark-rapids-jni</artifactId>
                                     <classifier>${cuda.version}</classifier>
-                                    <excludes>META-INF</excludes>
+                                    <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.openucx</groupId>
                                     <artifactId>jucx</artifactId>
-                                    <excludes>META-INF</excludes>
+                                    <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
                                     <overWrite>true</overWrite>
                                 </artifactItem>

--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -1,7 +1,6 @@
 META-INF/DEPENDENCIES
 META-INF/LICENSE
 META-INF/NOTICE
-META-INF/maven/**
 com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin*
 com/nvidia/spark/GpuCachedBatchSerializer*
 com/nvidia/spark/ParquetCachedBatchSerializer*


### PR DESCRIPTION
Fixes #7826 

- Put the reduced pom directly to the final location META-INF/maven
- Convert previous expensive update of the jar to a verify check for pom.xml  exhibitting dependencies to detect future regressions
- Instead of excluding META-INF/maven in the final jar plugin invocation avoid producing unnecessary files when unpacking intermediate dependencies
- Fix META-INF excludes for spark-rapids-jni and jucx; it has been unnoticed previously due to the exclude in the jar creation
- Remove an extraneous '>' in dist/pom.xml

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
