### PR TITLE
Stop releasing semaphore in GpuUserDefinedFunction

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,10 @@ trait GpuRowBasedUserDefinedFunction extends GpuExpression
             NoopMetric,
             NoopMetric,
             NoopMetric,
-            nullSafe).foreach { row =>
+            nullSafe,
+            // ensure `releaseSemaphore` is false so we don't release the semaphore
+            // mid projection.
+            releaseSemaphore = false).foreach { row =>
           retRow.update(0, evaluateRow(row))
           retConverter.append(retRow, 0, builder)
         }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7729

This was found by a customer running a `GpuUserDefinedFunction` within a `GpuProjectExec`. GpuUserDefinedFunction is reusing an iterator (`ColumnarToRowIterator`) which releases the semaphore after it has converted columnar batches to internal rows. 

When a UDF is evaluated in a GPU projection we do not want to release the semaphore as things are currently written, so I added an option to tell `ColumnarToRowIterator` to not release, defaulting it to release=true (so I don't break other code)