### PR TITLE
Initialize only sql-plugin  to prevent missing submodule artifacts in buildall [skip ci]

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -263,7 +263,11 @@ export -f build_single_shim
 time (
   # printf a single buildver array element per line
   if [[ "$SKIP_DIST_DEPS" != "1" ]]; then
-    $MVN initialize
+    # Excute init to download huge artifacts like spark-rapids-jni in a single thread
+    # --fail-nerver to ignore missing intermediate dependencies and because this step
+    # is optional, real persistent issues will still fail the build subsequently
+    $MVN --fail-never initialize
+
     printf "%s\n" "${SPARK_SHIM_VERSIONS[@]}" | \
       xargs -t -I% -P "$BUILD_PARALLEL" -n 1 \
       bash -c 'build_single_shim "$@"' _ %

--- a/build/buildall
+++ b/build/buildall
@@ -263,9 +263,11 @@ export -f build_single_shim
 time (
   # printf a single buildver array element per line
   if [[ "$SKIP_DIST_DEPS" != "1" ]]; then
-    # Excute init to download huge artifacts like spark-rapids-jni in a single thread
-    # --fail-nerver to ignore missing intermediate dependencies and because this step
-    # is optional, real persistent issues will still fail the build subsequently
+    # Execute initialize to download huge artifacts like spark-rapids-jni in a single thread to
+    # avoid repeating this work in parallel
+    # Use --fail-nerver to ignore missing intermediate dependencies and because this step
+    # is executed before a real build commences which will still catch real persistent issues
+    #
     $MVN --fail-never initialize
 
     printf "%s\n" "${SPARK_SHIM_VERSIONS[@]}" | \

--- a/build/buildall
+++ b/build/buildall
@@ -263,12 +263,11 @@ export -f build_single_shim
 time (
   # printf a single buildver array element per line
   if [[ "$SKIP_DIST_DEPS" != "1" ]]; then
-    # Execute initialize to download huge artifacts like spark-rapids-jni in a single thread to
+    # Execute initialize to download a massive jar for spark-rapids-jni in a single thread to
     # avoid repeating this work in parallel
-    # Use --fail-nerver to ignore missing intermediate dependencies and because this step
-    # is executed before a real build commences which will still catch real persistent issues
+    # Initialize sql-plugin only to avoid dealing with missing submodule dependencies
     #
-    $MVN --fail-never initialize
+    $MVN initialize -pl sql-plugin -am
 
     printf "%s\n" "${SPARK_SHIM_VERSIONS[@]}" | \
       xargs -t -I% -P "$BUILD_PARALLEL" -n 1 \


### PR DESCRIPTION
Prevents buildall from failing on empty m2 cache

Tested with:

```
rm -rf ~/.m2/repository/com/nvidia ; ./build/buildall
```

Follow-up to #7840 

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
