### PR TITLE
Add in basic support for OOM retry for project and filter

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,12 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    * @param cb the batch to print out.
    */
   public static synchronized void debug(String name, ColumnarBatch cb) {
-    try (Table table = from(cb)) {
-      debug(name, table);
+    if (cb.numCols() <= 0) {
+      System.err.println("DEBUG " + name + " NO COLS " + cb.numRows() + " ROWS");
+    } else {
+      try (Table table = from(cb)) {
+        debug(name, table);
+      }
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import ai.rapids.cudf.ast
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression, ExprId, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression, SortOrder}
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuEquivalentExpressions
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -130,19 +130,40 @@ object GpuBindReferences extends Logging {
 
   /**
    * A helper function to bind given expressions to an input schema where the expressions are
-   * to be processed on the GPU, and the result type indicates this.  Common sub-expressions
-   * bound with their inputs are placed into a sequence of tiers in a GpuTieredProject object.
+   * to be processed on the GPU, and the result type indicates this. If runTiered is true
+   * Common sub-expressions will be factored out where possible to reduce the runtime and memory.
+   * If set to false a GpuTieredProject object will still be returned, but no common
+   * sub-expressions will be factored out.
    */
   def bindGpuReferencesTiered[A <: Expression](
       expressions: Seq[A],
-      input: AttributeSeq): GpuTieredProject = {
+      input: AttributeSeq,
+      runTiered: Boolean): GpuTieredProject = {
 
-    val exprTiers = GpuEquivalentExpressions.getExprTiers(expressions)
-    val inputTiers = GpuEquivalentExpressions.getInputTiers(exprTiers, input)
-    GpuTieredProject(exprTiers.zip(inputTiers).map {
-      case (es:Seq[Expression], is:AttributeSeq) =>
-        es.map(GpuBindReferences.bindGpuReference(_, is)).toList
-    }, inputTiers)
+    if (runTiered) {
+      val exprTiers = GpuEquivalentExpressions.getExprTiers(expressions)
+      val inputTiers = GpuEquivalentExpressions.getInputTiers(exprTiers, input)
+      // Update ExprTiers to include the columns that are pass through and drop unneeded columns
+      var atInput = 0
+      val newExprTiers = exprTiers.map { exprTier =>
+        atInput += 1
+        if (atInput < inputTiers.length) {
+          inputTiers(atInput).attrs.map { attr =>
+            exprTier.find { expr =>
+              expr.asInstanceOf[NamedExpression].toAttribute == attr
+            }.getOrElse(attr)
+          }
+        } else {
+          exprTier
+        }
+      }
+      GpuTieredProject(newExprTiers.zip(inputTiers).map {
+        case (es: Seq[Expression], is: AttributeSeq) =>
+          es.map(GpuBindReferences.bindGpuReference(_, is)).toList
+      })
+    } else {
+      GpuTieredProject(Seq(GpuBindReferences.bindGpuReferences(expressions, input)))
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
   override def withNewSeed(seed: Long): GpuRand = GpuRand(GpuLiteral(seed, LongType))
 
   def seedExpression: Expression = child
+
+  override lazy val deterministic: Boolean = false
 
   /**
    * Record ID within each partition. By being transient, the Random Number Generator is


### PR DESCRIPTION
This adds in basic support for retry for project and filter. It specifically adds that retry in for hash aggregate pre and post processing. The pre-processing can be quite memory intensive and in our testing is likely to be one of the places where GPU OOM errors often happen.

This is not 100% ready to go in. I am working on some unit tests for the code. I have manually tested it, but I would like some more automated tests.

There is still a lot of follow on work to do too.

