### PR TITLE
Add Python requirements file for integration tests

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -105,12 +105,7 @@ For manual installation, you need to setup your environment:
 You can install all the dependencies using `pip` by running the following command:
 
   ```shell script
-  pip install pytest \
-              sre_yield \
-              pandas \
-              pyarrow \
-              pytest-xdist \
-              findspark
+  pip install -r requirements.txt
   ```
 
 ### Installing Spark

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,0 +1,6 @@
+pytest
+sre_yield
+pandas
+pyarrow
+pytest-xdist
+findspark

--- a/pom.xml
+++ b/pom.xml
@@ -1425,6 +1425,7 @@
                         default, but there are some projects that are conditionally included.  -->
                         <exclude>**/target/**/*</exclude>
                         <exclude>**/cufile.log</exclude>
+                        <exclude>**/requirements.txt</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is a minor usability improvement. It is standard to use [requirements files](https://pip.pypa.io/en/stable/reference/requirements-file-format/) to specify Python dependencies, and this PR adds a `requirements.txt` file and updates the README.

This just makes it easier for users familiar with Python to import dependencies without having to go look through the README to figure out which dependencies to install. I ran into this today because I reinstalled my operating system over the weekend.