### PR TITLE
Add Join Reordering Integration Test

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -122,11 +122,11 @@ def join_batch_size_test_params(*args):
 
 def test_join_reorder_enabled():
     join_reorder_enabled = with_cpu_session( \
-        lambda spark: spark.conf.get("spark.rapids.sql.optimizer.joinReorder.enabled"))
+        lambda spark: spark.conf.get("spark.rapids.sql.optimizer.joinReorder.enabled", "false"))
     if is_databricks_runtime or is_emr_runtime:
-        assert join_reorder_enabled == False
+        assert join_reorder_enabled == "false"
     else:
-        assert join_reorder_enabled
+        assert join_reorder_enabled == "true"
 
 
 @ignore_order(local=True)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -119,14 +119,28 @@ def join_batch_size_test_params(*args):
                 params += [ pytest.param(obj, batch_size) ]
     return params
 
+
+def test_join_reorder_enabled():
+    join_reorder_enabled = with_cpu_session( \
+        lambda spark: spark.conf.get("spark.rapids.sql.optimizer.joinReorder.enabled"))
+    if is_databricks_runtime or is_emr_runtime:
+        assert join_reorder_enabled == False
+    else:
+        assert join_reorder_enabled
+
+
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)
 @pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
-def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled):
+@pytest.mark.parametrize("join_reorder_enabled", ["true", "false"], ids=idfn)
+def test_right_broadcast_nested_loop_join_without_condition_empty(join_type, aqe_enabled, join_reorder_enabled):
     def do_join(spark):
         left, right = create_df(spark, long_gen, 50, 0)
         return left.join(broadcast(right), how=join_type)
-    assert_gpu_and_cpu_are_equal_collect(do_join, conf={ "spark.sql.adaptive.enabled": aqe_enabled })
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf={
+        "spark.sql.adaptive.enabled": aqe_enabled,
+        "spark.rapids.sql.optimizer.joinReorder.enabled": join_reorder_enabled
+    })
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('join_type', ['Left', 'Inner', 'LeftSemi', 'LeftAnti'], ids=idfn)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -893,11 +893,10 @@ def test_degenerate_broadcast_nested_loop_existence_join(spark_tmp_table_factory
     assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, capture_regexp,
                                                       conf={"spark.sql.adaptive.enabled": aqeEnabled})
 
-
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', [StringGen(), IntegerGen()], ids=idfn)
-@pytest.mark.parametrize("aqe_enabled", ["true", "false"], ids=idfn)
-@pytest.mark.parametrize("join_reorder_enabled", ["true", "false"], ids=idfn)
+@pytest.mark.parametrize("aqe_enabled", [True, False], ids=idfn)
+@pytest.mark.parametrize("join_reorder_enabled", [True, False], ids=idfn)
 def test_multi_table_hash_join(data_gen, aqe_enabled, join_reorder_enabled):
     def do_join(spark):
         t1 = binary_op_df(spark, data_gen, length=1000)


### PR DESCRIPTION
This PR updates some existing join tests to run with and without join reordering to make sure there are no regressions in functionality.