### PR TITLE
Support tagging `Cast` for timezone conditionally

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -631,13 +631,9 @@ def test_cast_int_to_string_not_UTC():
         lambda spark: unary_op_df(spark, int_gen, 100).selectExpr("a", "CAST(a AS STRING) as str"),
         {"spark.sql.session.timeZone": "+08"})
 
-
-# The cases here should match "Cast.needsTimeZone(from, to)"
-valid_ts_str_gen = SetValuesGen(StringType(), ['2023-03-20 10:38:50', '2023-03-20 10:39:02'])
-valid_date_str_gen = SetValuesGen(StringType(), valid_values_string_to_date)
 not_utc_fallback_test_params = [(timestamp_gen, 'STRING'), (timestamp_gen, 'DATE'),
-                                (date_gen, 'STRING',), (date_gen, 'TIMESTAMP'),
-                                (valid_ts_str_gen, 'TIMESTAMP'), (valid_date_str_gen, 'DATE')]
+        (date_gen, 'TIMESTAMP'),
+        (SetValuesGen(StringType(), ['2023-03-20 10:38:50', '2023-03-20 10:39:02']), 'TIMESTAMP')]
 
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('from_gen, to_type', not_utc_fallback_test_params)

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -632,9 +632,12 @@ def test_cast_int_to_string_not_UTC():
         {"spark.sql.session.timeZone": "+08"})
 
 
-not_utc_fallback_test_params = [(timestamp_gen, 'STRING'), (date_gen, 'STRING'),
-        (SetValuesGen(StringType(), ['2023-03-20 10:38:50', '2023-03-20 10:39:02']), 'TIMESTAMP'),
-        (SetValuesGen(StringType(), valid_values_string_to_date), 'DATE')]
+# The cases here should match "Cast.needsTimeZone(from, to)"
+valid_ts_str_gen = SetValuesGen(StringType(), ['2023-03-20 10:38:50', '2023-03-20 10:39:02'])
+valid_date_str_gen = SetValuesGen(StringType(), valid_values_string_to_date)
+not_utc_fallback_test_params = [(timestamp_gen, 'STRING'), (timestamp_gen, 'DATE'),
+                                (date_gen, 'STRING',), (date_gen, 'TIMESTAMP'),
+                                (valid_ts_str_gen, 'TIMESTAMP'), (valid_date_str_gen, 'DATE')]
 
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('from_gen, to_type', not_utc_fallback_test_params)

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -625,3 +625,15 @@ def test_cast_day_time_to_integral_side_effect():
 
 def test_cast_binary_to_string():
     assert_gpu_and_cpu_are_equal_collect(lambda spark: unary_op_df(spark, binary_gen).selectExpr("a", "CAST(a AS STRING) as str"))
+
+def test_cast_not_UTC_int_to_string():
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, int_gen, 100).selectExpr("a", "CAST(a AS STRING) as str"),
+        {"spark.sql.session.timeZone": "+08"})
+
+@allow_non_gpu('ProjectExec')
+def test_cast_not_UTC_timestamp_to_string_fallback():
+    assert_gpu_fallback_collect(
+        lambda spark: unary_op_df(spark, timestamp_gen, 100).selectExpr("a", "CAST(a AS STRING) as str"),
+        "Cast",
+        {"spark.sql.session.timeZone": "+08"})

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -158,8 +158,7 @@ final class CastExprMeta[INPUT <: UnaryExpression with TimeZoneAwareExpression w
     GpuCast(child, toType, ansiEnabled, cast.timeZoneId, legacyCastToString,
       stringToAnsiDate)
 
-  // The timezone tagging in type checks is enough for Cast, so always false.
-  override protected val needTimezoneTagging: Boolean = false
+  override protected def needTimezoneTagging: Boolean = Cast.needsTimeZone(fromType, toType)
 }
 
 object GpuCast extends Arm {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -158,7 +158,8 @@ final class CastExprMeta[INPUT <: UnaryExpression with TimeZoneAwareExpression w
     GpuCast(child, toType, ansiEnabled, cast.timeZoneId, legacyCastToString,
       stringToAnsiDate)
 
-  override protected def needTimezoneTagging: Boolean = Cast.needsTimeZone(fromType, toType)
+  // timezone tagging in type checks is good enough, so always false
+  override protected val needTimezoneTagging: Boolean = false
 }
 
 object GpuCast extends Arm {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -157,6 +157,9 @@ final class CastExprMeta[INPUT <: UnaryExpression with TimeZoneAwareExpression w
   override def convertToGpu(child: Expression): GpuExpression =
     GpuCast(child, toType, ansiEnabled, cast.timeZoneId, legacyCastToString,
       stringToAnsiDate)
+
+  // The timezone tagging in type checks is enough for Cast, so always false.
+  override protected val needTimezoneTagging: Boolean = false
 }
 
 object GpuCast extends Arm {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1059,7 +1059,7 @@ abstract class BaseExprMeta[INPUT <: Expression](
    * Whether to tag a TimeZoneAwareExpression for timezone after all the other tagging
    * is done.
    * By default a TimeZoneAwareExpression always requires the timezone tagging, but
-   * there is one exception sa far, 'Cast', who requires timezone tagging only when it
+   * there is one exception so far, 'Cast', who requires timezone tagging only when it
    * has timestamp/date type as input or output. Override it to match the special case.
    */
   protected def needTimezoneTagging: Boolean = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1061,10 +1061,6 @@ abstract class BaseExprMeta[INPUT <: Expression](
         s"$wrapped is foldable and operates on non literals")
     }
     rule.getChecks.foreach(_.tag(this))
-    wrapped match {
-      case tzAware: TimeZoneAwareExpression => checkTimeZoneId(tzAware.zoneId)
-      case _ => // do nothing
-    }
     tagExprForGpu()
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
 
 import com.nvidia.spark.rapids.shims.{DistributionUtil, SparkShimImpl}
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BinaryExpression, ComplexTypeMergingExpression, Expression, QuaternaryExpression, String2TrimExpression, TernaryExpression, TimeZoneAwareExpression, UnaryExpression, WindowExpression, WindowFunction}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BinaryExpression, ComplexTypeMergingExpression, Expression, QuaternaryExpression, String2TrimExpression, TernaryExpression, UnaryExpression, WindowExpression, WindowFunction}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, ImperativeAggregate, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1059,12 +1059,16 @@ abstract class BaseExprMeta[INPUT <: Expression](
    * Whether to tag a TimeZoneAwareExpression for timezone after all the other tagging
    * is done.
    * By default a TimeZoneAwareExpression always requires the timezone tagging, but
-   * there is one exception so far, 'Cast', who requires timezone tagging only when it
-   * has timezone sensitive type as input or output. Override it to match the special case.
+   * there are some exceptions, e.g. 'Cast', who requires timezone tagging only when it
+   * has timezone sensitive type as input or output.
+   *
+   * Override this to match special cases.
    */
   protected def needTimezoneTagging: Boolean = {
     // A TimeZoneAwareExpression with no timezone sensitive types as input/output will
     // escape from the timezone tagging in the prior type checks. So ask for tagging here.
+    // e.g. 'UnixTimestamp' with 'DateType' as the input, timezone will be taken into
+    // account when converting a Date to a Long.
     !(dataType +: childExprs.map(_.dataType)).exists(TypeChecks.isTimezoneSensitiveType)
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1065,7 +1065,7 @@ abstract class BaseExprMeta[INPUT <: Expression](
   protected def needTimezoneTagging: Boolean = {
     // A TimeZoneAwareExpression having no timestamp/date types as input/output will escape
     // from the timezone tagging in the prior type checks. So ask for tagging it here.
-    !(expr.dataType +: expr.children.map(_.dataType)).exists(TypeChecks.isTimezoneSensitiveType)
+    !(dataType +: childExprs.map(_.dataType)).exists(TypeChecks.isTimezoneSensitiveType)
   }
 
   final override def tagSelfForGpu(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1056,7 +1056,8 @@ abstract class BaseExprMeta[INPUT <: Expression](
   val isFoldableNonLitAllowed: Boolean = false
 
   /**
-   * This is a flag used for tagging a TimeZoneAwareExpression for timezone.
+   * This is a flag used for tagging a TimeZoneAwareExpression for timezone after all
+   * the other tagging is done.
    * By default a TimeZoneAwareExpression always requires the timezone tagging, but there
    * are some exceptions. e.g. Cast, which requires timezone tagging only when it has
    * timestamp/date type as input or output. Override this to match special cases.
@@ -1070,12 +1071,10 @@ abstract class BaseExprMeta[INPUT <: Expression](
     }
     rule.getChecks.foreach(_.tag(this))
     tagExprForGpu()
-    // Try to tag a TimeZoneAwareExpression for timezone when the expression is going to run
-    // on GPU and asks for additional timezone tagging. Because a TimeZoneAwareExpression
-    // having no timestamp/date types as input/output will escape from the timezone tagging
-    // during the above type checks.
+    // A TimeZoneAwareExpression having no timestamp/date types as input/output will escape
+    // from the timezone tagging in the above type checks.
     wrapped match {
-      case tzAware: TimeZoneAwareExpression if canThisBeReplaced && needTimezoneTagging =>
+      case tzAware: TimeZoneAwareExpression if needTimezoneTagging =>
         checkTimeZoneId(tzAware.zoneId)
       case _ => // do nothing
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1060,11 +1060,11 @@ abstract class BaseExprMeta[INPUT <: Expression](
    * is done.
    * By default a TimeZoneAwareExpression always requires the timezone tagging, but
    * there is one exception so far, 'Cast', who requires timezone tagging only when it
-   * has timestamp/date type as input or output. Override it to match the special case.
+   * has timezone sensitive type as input or output. Override it to match the special case.
    */
   protected def needTimezoneTagging: Boolean = {
-    // A TimeZoneAwareExpression having no timestamp/date types as input/output will escape
-    // from the timezone tagging in the prior type checks. So ask for tagging it here.
+    // A TimeZoneAwareExpression with no timezone sensitive types as input/output will
+    // escape from the timezone tagging in the prior type checks. So ask for tagging here.
     !(dataType +: childExprs.map(_.dataType)).exists(TypeChecks.isTimezoneSensitiveType)
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -406,7 +406,7 @@ final class TypeSig private(
         s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
         s" Set both of the timezones to UTC to enable $dataType support"))
     } else {
-      basicNotSupportedMessage(dataType, TypeEnum.DATE, check, isChild)
+      basicNotSupportedMessage(dataType, te, check, isChild)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -784,7 +784,7 @@ abstract class TypeChecks[RET] {
       unsupportedTypes: Map[DataType, Set[String]],
       meta: RapidsMeta[_, _, _]): Unit = {
     def checkTimestampType(dataType: DataType): Unit = dataType match {
-      case TimestampType =>
+      case TimestampType if !TypeChecks.areTimestampsSupported() =>
         meta.willNotWorkOnGpu(TypeChecks.timezoneNotSupportedString(dataType))
       case ArrayType(elementType, _) =>
         checkTimestampType(elementType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -358,8 +358,7 @@ final class TypeSig private(
       case LongType => check.contains(TypeEnum.LONG)
       case FloatType => check.contains(TypeEnum.FLOAT)
       case DoubleType => check.contains(TypeEnum.DOUBLE)
-      case DateType if check.contains(TypeEnum.DATE) =>
-          TypeChecks.areTimestampsSupported()
+      case DateType => check.contains(TypeEnum.DATE)
       case TimestampType if check.contains(TypeEnum.TIMESTAMP) =>
           TypeChecks.areTimestampsSupported()
       case StringType => check.contains(TypeEnum.STRING)
@@ -402,9 +401,7 @@ final class TypeSig private(
   private[this] def timezoneNotSupportedMessage(dataType: DataType,
       te: TypeEnum.Value, check: TypeEnum.ValueSet, isChild: Boolean): Seq[String] = {
     if (check.contains(te) && !TypeChecks.areTimestampsSupported()) {
-      Seq(withChild(isChild, s"$dataType is not supported with timezone settings: (JVM:" +
-        s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
-        s" Set both of the timezones to UTC to enable $dataType support"))
+      Seq(withChild(isChild, TypeChecks.timezoneNotSupportedString(dataType)))
     } else {
       basicNotSupportedMessage(dataType, te, check, isChild)
     }
@@ -430,7 +427,7 @@ final class TypeSig private(
       case DoubleType =>
         basicNotSupportedMessage(dataType, TypeEnum.DOUBLE, check, isChild)
       case DateType =>
-        timezoneNotSupportedMessage(dataType, TypeEnum.DATE, check, isChild)
+        basicNotSupportedMessage(dataType, TypeEnum.DATE, check, isChild)
       case TimestampType =>
         timezoneNotSupportedMessage(dataType, TypeEnum.TIMESTAMP, check, isChild)
       case StringType =>
@@ -784,22 +781,19 @@ abstract class TypeChecks[RET] {
    * here check again to add UTC info.
    */
   private def tagTimezoneInfoIfHasTimestampType(
-    unsupportedTypes: Map[DataType, Set[String]],
-    meta: RapidsMeta[_, _, _]
-    ): Unit = {
+      unsupportedTypes: Map[DataType, Set[String]],
+      meta: RapidsMeta[_, _, _]): Unit = {
     def checkTimestampType(dataType: DataType): Unit = dataType match {
-        case (TimestampType | DateType) if !TypeChecks.areTimestampsSupported() =>
-          meta.willNotWorkOnGpu(s"your timezone isn't in UTC (JVM:" +
-            s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
-            s" Set both of the timezones to UTC to enable TimestampType support")
-        case ArrayType(elementType, _) =>
-          checkTimestampType(elementType)
-        case MapType(keyType, valueType, _) =>
-          checkTimestampType(keyType)
-          checkTimestampType(valueType)
-        case StructType(fields) =>
-          fields.foreach(field => checkTimestampType(field.dataType))
-        case _ => // do nothing
+      case TimestampType =>
+        meta.willNotWorkOnGpu(TypeChecks.timezoneNotSupportedString(dataType))
+      case ArrayType(elementType, _) =>
+        checkTimestampType(elementType)
+      case MapType(keyType, valueType, _) =>
+        checkTimestampType(keyType)
+        checkTimestampType(valueType)
+      case StructType(fields) =>
+        fields.foreach(field => checkTimestampType(field.dataType))
+      case _ => // do nothing
     }
     unsupportedTypes.foreach { case (dataType, _) =>
       checkTimestampType(dataType)
@@ -844,7 +838,13 @@ object TypeChecks {
   }
 
   def isTimezoneSensitiveType(dataType: DataType): Boolean = {
-    dataType == DateType || dataType == TimestampType
+    dataType == TimestampType
+  }
+
+  def timezoneNotSupportedString(dataType: DataType): String = {
+    s"$dataType is not supported with timezone settings: (JVM:" +
+      s" ${ZoneId.systemDefault()}, session: ${SQLConf.get.sessionLocalTimeZone})." +
+      s" Set both of the timezones to UTC to enable $dataType support"
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -842,6 +842,10 @@ object TypeChecks {
     areTimestampsSupported(ZoneId.systemDefault()) &&
       areTimestampsSupported(SQLConf.get.sessionLocalTimeZone)
   }
+
+  def isTimezoneSensitiveType(dataType: DataType): Boolean = {
+    dataType == DateType || dataType == TimestampType
+  }
 }
 
 /**


### PR DESCRIPTION
fixes #7893 
fixes #6138

`Cast` is a special `TimeZoneAwareExpression` who requires tagging for timezone only when it has timetamp or date type as input or output. This PR adds in the support for this feature. 


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
