### PR TITLE
Update regular expression parser to handle escape character sequences

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -273,6 +273,23 @@ def test_re_replace_issue_5492():
         'RegExpReplace',
         conf=_regexp_conf)
 
+def test_re_replace_escaped_chars():
+    # https://github.com/NVIDIA/spark-rapids/issues/7892
+    gen = mk_str_gen('.{0,5}TEST[\n\r\t\f\a\b\u001b]{0,5}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'REGEXP_REPLACE(a, "\\\\t", " ")',
+            'REGEXP_REPLACE(a, "\\\\n", " ")',
+            'REGEXP_REPLACE(a, "TEST\\\\n", "PROD")',
+            'REGEXP_REPLACE(a, "TEST\\\\r", "PROD")',
+            'REGEXP_REPLACE(a, "TEST\\\\f", "PROD")',
+            'REGEXP_REPLACE(a, "TEST\\\\a", "PROD")',
+            'REGEXP_REPLACE(a, "TEST\\\\b", "PROD")',
+            'REGEXP_REPLACE(a, "TEST\\\\e", "PROD")',
+            'REGEXP_REPLACE(a, "TEST[\\\\r\\\\n]", "PROD")'),
+        conf=_regexp_conf)
+
+
 def test_re_replace_backrefs():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}TEST')
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Fixes #7892.

Handles escape sequences like `\t` and `\n` that can be used in some regular expressions. Sometimes when escaping tab, newlines, etc. in Spark SQL, these are turned into explicit escape sequences that have to be parsed. This enables the parser to properly parse those sequences into their character equivalents.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
