### PR TITLE
ColumnarToRowIterator should release the semaphore if parent is empty

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -20,8 +20,8 @@ import scala.annotation.tailrec
 import scala.collection.mutable.Queue
 
 import ai.rapids.cudf.{Cuda, HostColumnVector, NvtxColor, Table}
-import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD


### PR DESCRIPTION
This fixes a bug where the ColumnarToRowIterator was not releasing the GPU semaphore when it had an empty parent.

This was found with a pyspark test where holding on to the semaphore meant that the pyspark WriterThread also wanted to grab the semaphore later, and now with the thread/task association work from `RmmSpark`, it can cause an exception to show up and tasks to fail.