### PR TITLE
Fix resolution of GpuRapidsProcessDeltaMergeJoinExec expressions [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuMergeIntoCommand.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuMergeIntoCommand.scala
@@ -602,11 +602,14 @@ case class GpuMergeIntoCommand(
        """.stripMargin)
 
     // UDFs to update metrics
+    // Make UDFs that appear in the custom join processor node deterministic, as they always
+    // return true and update a metric. Catalyst precludes non-deterministic UDFs that are not
+    // allowed outside a very specific set of Catalyst nodes (Project, Filter, Window, Aggregate).
     val incrSourceRowCountExpr = makeMetricUpdateUDF("numSourceRowsInSecondScan")
-    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated")
-    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted")
-    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied")
-    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted")
+    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated", deterministic = true)
+    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted", deterministic = true)
+    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied", deterministic = true)
+    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted", deterministic = true)
 
     // Apply an outer join to find both, matches and non-matches. We are adding two boolean fields
     // with value `true`, one to each side of the join. Whether this field is null or not after
@@ -864,16 +867,17 @@ case class GpuMergeIntoCommand(
     }
 
     if (canReplace) {
-      val processedJoinPlan = RapidsProcessDeltaMergeJoin(joinedPlan, outputRowSchema.toAttributes,
-        RapidsProcessDeltaMergeJoinExpressions(
-          targetRowHasNoMatch = targetRowHasNoMatchMeta.convertToGpu(),
-          sourceRowHasNoMatch = sourceRowHasNoMatchMeta.convertToGpu(),
-          matchedConditions = matchedConditionsMetas.map(_.convertToGpu()),
-          matchedOutputs = matchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          notMatchedConditions = notMatchedConditionsMetas.map(_.convertToGpu()),
-          notMatchedOutputs = notMatchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          noopCopyOutput = noopCopyOutputMetas.map(_.convertToGpu()),
-          deleteRowOutput = deleteRowOutputMetas.map(_.convertToGpu())))
+      val processedJoinPlan = RapidsProcessDeltaMergeJoin(
+        joinedPlan,
+        outputRowSchema.toAttributes,
+        targetRowHasNoMatch = targetRowHasNoMatch,
+        sourceRowHasNoMatch = sourceRowHasNoMatch,
+        matchedConditions = matchedConditions,
+        matchedOutputs = matchedOutputs,
+        notMatchedConditions = notMatchedConditions,
+        notMatchedOutputs = notMatchedOutputs,
+        noopCopyOutput = noopCopyOutput,
+        deleteRowOutput = deleteRowOutput)
       Dataset.ofRows(spark, processedJoinPlan)
     } else {
       val joinedRowEncoder = RowEncoder(joinedPlan.schema)
@@ -965,10 +969,14 @@ case class GpuMergeIntoCommand(
   }
 
   /** Expressions to increment SQL metrics */
-  private def makeMetricUpdateUDF(name: String): Expression = {
+  private def makeMetricUpdateUDF(name: String, deterministic: Boolean = false): Expression = {
     // only capture the needed metric in a local variable
     val metric = metrics(name)
-    udf(new GpuDeltaMetricUpdateUDF(metric)).asNondeterministic().apply().expr
+    var u = udf(new GpuDeltaMetricUpdateUDF(metric))
+    if (!deterministic) {
+      u = u.asNondeterministic()
+    }
+    u.apply().expr
   }
 
   private def seqToString(exprs: Seq[Expression]): String = exprs.map(_.sql).mkString("\n\t")

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuMergeIntoCommand.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuMergeIntoCommand.scala
@@ -639,11 +639,14 @@ case class GpuMergeIntoCommand(
        """.stripMargin)
 
     // UDFs to update metrics
+    // Make UDFs that appear in the custom join processor node deterministic, as they always
+    // return true and update a metric. Catalyst precludes non-deterministic UDFs that are not
+    // allowed outside a very specific set of Catalyst nodes (Project, Filter, Window, Aggregate).
     val incrSourceRowCountExpr = makeMetricUpdateUDF("numSourceRowsInSecondScan")
-    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated")
-    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted")
-    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied")
-    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted")
+    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated", deterministic = true)
+    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted", deterministic = true)
+    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied", deterministic = true)
+    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted", deterministic = true)
 
     // Apply an outer join to find both, matches and non-matches. We are adding two boolean fields
     // with value `true`, one to each side of the join. Whether this field is null or not after
@@ -909,16 +912,17 @@ case class GpuMergeIntoCommand(
     }
 
     if (canReplace) {
-      val processedJoinPlan = RapidsProcessDeltaMergeJoin(joinedPlan, outputRowSchema.toAttributes,
-        RapidsProcessDeltaMergeJoinExpressions(
-          targetRowHasNoMatch = targetRowHasNoMatchMeta.convertToGpu(),
-          sourceRowHasNoMatch = sourceRowHasNoMatchMeta.convertToGpu(),
-          matchedConditions = matchedConditionsMetas.map(_.convertToGpu()),
-          matchedOutputs = matchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          notMatchedConditions = notMatchedConditionsMetas.map(_.convertToGpu()),
-          notMatchedOutputs = notMatchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          noopCopyOutput = noopCopyOutputMetas.map(_.convertToGpu()),
-          deleteRowOutput = deleteRowOutputMetas.map(_.convertToGpu())))
+      val processedJoinPlan = RapidsProcessDeltaMergeJoin(
+        joinedPlan,
+        outputRowSchema.toAttributes,
+        targetRowHasNoMatch = targetRowHasNoMatch,
+        sourceRowHasNoMatch = sourceRowHasNoMatch,
+        matchedConditions = matchedConditions,
+        matchedOutputs = matchedOutputs,
+        notMatchedConditions = notMatchedConditions,
+        notMatchedOutputs = notMatchedOutputs,
+        noopCopyOutput = noopCopyOutput,
+        deleteRowOutput = deleteRowOutput)
       Dataset.ofRows(spark, processedJoinPlan)
     } else {
       val joinedRowEncoder = RowEncoder(joinedPlan.schema)
@@ -1009,10 +1013,14 @@ case class GpuMergeIntoCommand(
   }
 
   /** Expressions to increment SQL metrics */
-  private def makeMetricUpdateUDF(name: String): Expression = {
+  private def makeMetricUpdateUDF(name: String, deterministic: Boolean = false): Expression = {
     // only capture the needed metric in a local variable
     val metric = metrics(name)
-    udf(new GpuDeltaMetricUpdateUDF(metric)).asNondeterministic().apply().expr
+    var u = udf(new GpuDeltaMetricUpdateUDF(metric))
+    if (!deterministic) {
+      u = u.asNondeterministic()
+    }
+    u.apply().expr
   }
 
   private def seqToString(exprs: Seq[Expression]): String = exprs.map(_.sql).mkString("\n\t")

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuMergeIntoCommand.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuMergeIntoCommand.scala
@@ -676,11 +676,14 @@ case class GpuMergeIntoCommand(
        """.stripMargin)
 
     // UDFs to update metrics
+    // Make UDFs that appear in the custom join processor node deterministic, as they always
+    // return true and update a metric. Catalyst precludes non-deterministic UDFs that are not
+    // allowed outside a very specific set of Catalyst nodes (Project, Filter, Window, Aggregate).
     val incrSourceRowCountExpr = makeMetricUpdateUDF("numSourceRowsInSecondScan")
-    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated")
-    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted")
-    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied")
-    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted")
+    val incrUpdatedCountExpr = makeMetricUpdateUDF("numTargetRowsUpdated", deterministic = true)
+    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted", deterministic = true)
+    val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied", deterministic = true)
+    val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted", deterministic = true)
 
     // Apply an outer join to find both, matches and non-matches. We are adding two boolean fields
     // with value `true`, one to each side of the join. Whether this field is null or not after
@@ -947,16 +950,17 @@ case class GpuMergeIntoCommand(
     }
 
     if (canReplace) {
-      val processedJoinPlan = RapidsProcessDeltaMergeJoin(joinedPlan, outputRowSchema.toAttributes,
-        RapidsProcessDeltaMergeJoinExpressions(
-          targetRowHasNoMatch = targetRowHasNoMatchMeta.convertToGpu(),
-          sourceRowHasNoMatch = sourceRowHasNoMatchMeta.convertToGpu(),
-          matchedConditions = matchedConditionsMetas.map(_.convertToGpu()),
-          matchedOutputs = matchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          notMatchedConditions = notMatchedConditionsMetas.map(_.convertToGpu()),
-          notMatchedOutputs = notMatchedOutputsMetas.map(_.map(_.map(_.convertToGpu()))),
-          noopCopyOutput = noopCopyOutputMetas.map(_.convertToGpu()),
-          deleteRowOutput = deleteRowOutputMetas.map(_.convertToGpu())))
+      val processedJoinPlan = RapidsProcessDeltaMergeJoin(
+        joinedPlan,
+        outputRowSchema.toAttributes,
+        targetRowHasNoMatch = targetRowHasNoMatch,
+        sourceRowHasNoMatch = sourceRowHasNoMatch,
+        matchedConditions = matchedConditions,
+        matchedOutputs = matchedOutputs,
+        notMatchedConditions = notMatchedConditions,
+        notMatchedOutputs = notMatchedOutputs,
+        noopCopyOutput = noopCopyOutput,
+        deleteRowOutput = deleteRowOutput)
       Dataset.ofRows(spark, processedJoinPlan)
     } else {
       val joinedRowEncoder = RowEncoder(joinedPlan.schema)
@@ -1047,10 +1051,14 @@ case class GpuMergeIntoCommand(
   }
 
   /** Expressions to increment SQL metrics */
-  private def makeMetricUpdateUDF(name: String): Expression = {
+  private def makeMetricUpdateUDF(name: String, deterministic: Boolean = false): Expression = {
     // only capture the needed metric in a local variable
     val metric = metrics(name)
-    DeltaUDF.boolean(new GpuDeltaMetricUpdateUDF(metric)).asNondeterministic().apply().expr
+    var u = DeltaUDF.boolean(new GpuDeltaMetricUpdateUDF(metric))
+    if (!deterministic) {
+      u = u.asNondeterministic()
+    }
+    u.apply().expr
   }
 
   private def getTargetOutputCols(txn: OptimisticTransaction): Seq[NamedExpression] = {


### PR DESCRIPTION
When performing a Delta Lake merge, the source or target dataframe could be generated by an aggregation.  Aggregations can rewrite the expressions of upstream nodes.  The custom RapidsProcessDeltaMergeJoin node used for GPU-accelerated Delta Lake merges was caching the original source and target dataframe attributes from the logical plan, and this could end up being incorrect once rewritten by an aggregation physical plan transformation.

This fixes the problem by pushing the original CPU expressions up to the "top-level" of the RapidsProcessDeltaMergeJoin so that Catalyst can rewrite the expressions when necessary during planning and optimization.