### PR TITLE
Fix upcast of signed integral values when reading from Parquet

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -559,6 +559,14 @@ object ParquetSchemaUtils extends Arm {
     cv.getType.equals(DType.INT32) && Seq(ByteType, ShortType, DateType).contains(dt)
   }
 
+  private def needSignedUpcast(cv: ColumnView, dt: DataType): Boolean = {
+    cv.getType match {
+      case DType.INT8 => dt == ShortType || dt == IntegerType
+      case DType.INT16 => dt == IntegerType
+      case _ => false
+    }
+  }
+
   // Wrap up all required casts for Parquet schema evolution
   //
   // Note: The behavior of unsigned to signed is decided by the Spark,
@@ -568,9 +576,8 @@ object ParquetSchemaUtils extends Arm {
   private def evolveSchemaCasts(cv: ColumnView, dt: DataType): ColumnView = {
     if (needDecimalCast(cv, dt)) {
       cv.castTo(DecimalUtil.createCudfDecimal(dt.asInstanceOf[DecimalType]))
-    } else if (needUnsignedToSignedCast(cv, dt)) {
-      cv.castTo(DType.create(GpuColumnVector.getNonNestedRapidsType(dt).getTypeId))
-    } else if (needInt32Downcast(cv, dt)) {
+    } else if (needUnsignedToSignedCast(cv, dt) || needInt32Downcast(cv, dt) ||
+        needSignedUpcast(cv, dt)) {
       cv.castTo(DType.create(GpuColumnVector.getNonNestedRapidsType(dt).getTypeId))
     } else if (DType.STRING.equals(cv.getType) && dt == BinaryType) {
       // Ideally we would bitCast the STRING to a LIST, but that does not work.


### PR DESCRIPTION
Fixes #7914.  Adds checks for upcast of integral values.  Spark does not support upcasting to long, but it does support implicit upcasting from byte/short to int and from byte to short.