### PR TITLE
Stop checking store size when spilling

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -488,13 +488,15 @@ class RapidsBufferCatalog(
     if (spillStore == null) {
       throw new OutOfMemoryError("Requested to spill without a spill store")
     }
-    targetTotalSize.map { tgt =>
-      require(tgt >= 0, s"Negative spill target size: $tgt")
-      logWarning(s"Targeting a ${store.name} size of $tgt. " +
+
+    targetTotalSize.orElse {
+      logWarning(s"Spilling from ${store.name} " +
           s"Current total ${store.currentSize}. " +
           s"Current spillable ${store.currentSpillableSize}")
-    }.getOrElse {
-      logWarning(s"Spilling from ${store.name} " +
+      None
+    }.foreach { tgt =>
+      require(tgt >= 0, s"Negative spill target size: $tgt")
+      logWarning(s"Targeting a ${store.name} size of $tgt. " +
           s"Current total ${store.currentSize}. " +
           s"Current spillable ${store.currentSpillableSize}")
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
@@ -267,7 +267,7 @@ class RapidsBufferCatalogSuite extends FunSuite with MockitoSugar with Arm {
           buff, meta, -1, RapidsBuffer.defaultSpillCallback)
       }
       withResource(handle) { _ =>
-        catalog.synchronousSpill(deviceStore, 0)
+        catalog.synchronousSpill(deviceStore, Some(0))
         val acquiredHostBuffer = catalog.acquireBuffer(handle)
         withResource(acquiredHostBuffer) { _ =>
           assertResult(HOST)(acquiredHostBuffer.storageTier)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
@@ -287,21 +287,21 @@ class RapidsDeviceMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
 
       // asking to spill 0 bytes should not spill
       val sizeBeforeSpill = store.currentSize
-      catalog.synchronousSpill(store, sizeBeforeSpill)
+      catalog.synchronousSpill(store, Some(sizeBeforeSpill))
       assert(spillStore.spilledBuffers.isEmpty)
       assertResult(sizeBeforeSpill)(store.currentSize)
-      catalog.synchronousSpill(store, sizeBeforeSpill + 1)
+      catalog.synchronousSpill(store, Some(sizeBeforeSpill + 1))
       assert(spillStore.spilledBuffers.isEmpty)
       assertResult(sizeBeforeSpill)(store.currentSize)
 
       // spilling 1 byte should force one buffer to spill in priority order
-      catalog.synchronousSpill(store, sizeBeforeSpill - 1)
+      catalog.synchronousSpill(store, Some(sizeBeforeSpill - 1))
       assertResult(1)(spillStore.spilledBuffers.length)
       assertResult(bufferSizes.drop(1).sum)(store.currentSize)
       assertResult(1)(spillStore.spilledBuffers(0).tableId)
 
       // spilling to zero should force all buffers to spill in priority order
-      catalog.synchronousSpill(store, 0)
+      catalog.synchronousSpill(store, Some(0))
       assertResult(3)(spillStore.spilledBuffers.length)
       assertResult(0)(store.currentSize)
       assertResult(0)(spillStore.spilledBuffers(1).tableId)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -56,8 +56,8 @@ class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSuga
               addTableToCatalog(catalog, bufferId, spillPriority)
             val path = handle.id.getDiskPath(null)
             assert(!path.exists())
-            catalog.synchronousSpill(devStore, 0)
-            catalog.synchronousSpill(hostStore, 0)
+            catalog.synchronousSpill(devStore, Some(0))
+            catalog.synchronousSpill(hostStore, Some(0))
             assertResult(0)(hostStore.currentSize)
             assertResult(bufferSize)(diskStore.currentSize)
             assert(path.exists)
@@ -105,8 +105,8 @@ class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSuga
               withResource(expectedTable) { _ =>
                 withResource(
                     GpuColumnVector.from(expectedTable.getTable, sparkTypes)) { expectedBatch =>
-                  catalog.synchronousSpill(devStore, 0)
-                  catalog.synchronousSpill(hostStore, 0)
+                  catalog.synchronousSpill(devStore, Some(0))
+                  catalog.synchronousSpill(hostStore, Some(0))
                   withResource(catalog.acquireBuffer(handle)) { buffer =>
                     assertResult(StorageTier.DISK)(buffer.storageTier)
                     withResource(buffer.getColumnarBatch(sparkTypes)) { actualBatch =>
@@ -145,8 +145,8 @@ class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSuga
               }
             }
             withResource(expectedBuffer) { expectedBuffer =>
-              catalog.synchronousSpill(devStore, 0)
-              catalog.synchronousSpill(hostStore, 0)
+              catalog.synchronousSpill(devStore, Some(0))
+              catalog.synchronousSpill(hostStore, Some(0))
               withResource(catalog.acquireBuffer(handle)) { buffer =>
                 assertResult(StorageTier.DISK)(buffer.storageTier)
                 withResource(buffer.getMemoryBuffer) { actualBuffer =>
@@ -185,8 +185,8 @@ class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSuga
             val (_, handle) = addTableToCatalog(catalog, bufferId, spillPriority)
             val bufferPath = handle.id.getDiskPath(null)
             assert(!bufferPath.exists())
-            catalog.synchronousSpill(devStore, 0)
-            catalog.synchronousSpill(hostStore, 0)
+            catalog.synchronousSpill(devStore, Some(0))
+            catalog.synchronousSpill(hostStore, Some(0))
             assert(bufferPath.exists)
             handle.close()
             if (canShareDiskPaths) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
@@ -71,7 +71,7 @@ class RapidsGdsStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar
 
        bufferIds.zipWithIndex.foreach { case(id, ix) =>
          val (size, handle) = addTableToCatalog(catalog, id, spillPriority)
-         catalog.synchronousSpill(devStore, 0)
+         catalog.synchronousSpill(devStore, Some(0))
          bufferSizes(ix) = size
          bufferHandles(ix) = handle
        }
@@ -116,7 +116,7 @@ class RapidsGdsStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar
         devStore.setSpillStore(gdsStore)
         assertResult(0)(gdsStore.currentSize)
         val (bufferSize, handle) = addTableToCatalog(catalog, bufferId, spillPriority)
-        catalog.synchronousSpill(devStore, 0)
+        catalog.synchronousSpill(devStore, Some(0))
         assertResult(bufferSize)(gdsStore.currentSize)
         assert(path.exists)
         assertResult(bufferSize)(path.length)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
@@ -77,7 +77,7 @@ class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
             (len, handle)
           }
 
-          catalog.synchronousSpill(devStore, 0)
+          catalog.synchronousSpill(devStore, Some(0))
           assertResult(bufferSize)(hostStore.currentSize)
           assertResult(hostStoreMaxSize - bufferSize)(hostStore.numBytesFree)
           verify(catalog, times(2)).registerNewBuffer(ArgumentMatchers.any[RapidsBuffer])
@@ -113,7 +113,7 @@ class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
               RapidsBuffer.defaultSpillCallback)
           }
           withResource(expectedBuffer) { _ =>
-            catalog.synchronousSpill(devStore, 0)
+            catalog.synchronousSpill(devStore, Some(0))
             withResource(catalog.acquireBuffer(handle)) { buffer =>
               withResource(buffer.getMemoryBuffer) { actualBuffer =>
                 assert(actualBuffer.isInstanceOf[HostMemoryBuffer])
@@ -152,7 +152,7 @@ class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
               RapidsBuffer.defaultSpillCallback)
           }
           withResource(expectedBatch) { _ =>
-            catalog.synchronousSpill(devStore, 0)
+            catalog.synchronousSpill(devStore, Some(0))
             withResource(catalog.acquireBuffer(handle)) { buffer =>
               assertResult(StorageTier.HOST)(buffer.storageTier)
               withResource(buffer.getColumnarBatch(sparkTypes)) { actualBatch =>
@@ -201,7 +201,7 @@ class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
                   RapidsBuffer.defaultSpillCallback)
               } // close the bigTable so it can be spilled
               bigTable = null
-              catalog.synchronousSpill(devStore, 0)
+              catalog.synchronousSpill(devStore, Some(0))
               verify(mockStore, never()).copyBuffer(ArgumentMatchers.any[RapidsBuffer],
                 ArgumentMatchers.any[MemoryBuffer],
                 ArgumentMatchers.any[Cuda.Stream])
@@ -218,7 +218,7 @@ class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
                 RapidsBuffer.defaultSpillCallback, false)
             } // close the smallTable so it can be spilled
             smallTable = null
-            catalog.synchronousSpill(devStore, 0)
+            catalog.synchronousSpill(devStore, Some(0))
             val rapidsBufferCaptor: ArgumentCaptor[RapidsBuffer] =
               ArgumentCaptor.forClass(classOf[RapidsBuffer])
             val memoryBufferCaptor: ArgumentCaptor[MemoryBuffer] =


### PR DESCRIPTION
Linked issue: https://github.com/NVIDIA/spark-rapids/issues/7706

Given this discussion during a prior PR on spill framework refactoring (https://github.com/NVIDIA/spark-rapids/pull/7572#discussion_r1100314872), we filed an issue to look at removing checks for current spillable store size, as these checks could cause us to stop spilling when anything spilled could be beneficial (e.g. freeing just one buffer could open up enough space for us to satisfy an OOMing allocation).

Opening as draft for now. I ran some tests on this, but I want to run more. I wanted to get some eyes on it.