### PR TITLE
Fixes issue where UCX compressed tables would be decompressed multiple times

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -775,9 +775,14 @@ class GpuCompressionAwareCoalesceIterator(
               val cv = compressedVecs(outputIndex)
               val batchIndex = compressedBatchIndices(outputIndex)
               val compressedBatch = wip(batchIndex)
-              wip(batchIndex) =
-                MetaUtils.getBatchFromMeta(outputBuffer, cv.getTableMeta, sparkTypes)
-              compressedBatch.close()
+              withResource(compressedBatch) { _ =>
+                // the decompressed batch should get a new meta without codec information
+                // so that future materializations of the batch don't get confused and attempt
+                // to use GpuCompressedColumnVector instead of GpuPackedTableColumn
+                wip(batchIndex) =
+                  MetaUtils.getBatchFromMeta(
+                    outputBuffer, MetaUtils.dropCodecs(cv.getTableMeta), sparkTypes)
+              }
             }
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -122,18 +122,15 @@ class ShuffleBufferCatalog(
     val bufferId = nextShuffleBufferId(blockId)
     // update the table metadata for the buffer ID generated above
     tableMeta.bufferMeta.mutateId(bufferId.tableId)
-    // when we call `addBuffer` the store will incRefCount
-    withResource(buffer) { _ =>
-      val handle = catalog.addBuffer(
-        bufferId,
-        buffer,
-        tableMeta,
-        initialSpillPriority,
-        defaultSpillCallback,
-        needsSync)
-      trackCachedHandle(bufferId, handle)
-      handle
-    }
+    val handle = catalog.addBuffer(
+      bufferId,
+      buffer,
+      tableMeta,
+      initialSpillPriority,
+      defaultSpillCallback,
+      needsSync)
+    trackCachedHandle(bufferId, handle)
+    handle
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7850

This PR fixes two issues: 

1. The refactor of the spill framework didn't take into account that shuffle batches written by the RapidsCachingWriter are closed by the iterator produced in `prepareBatchShuffleDependency` (as it owns the last batch sent to the writer). Therefore I was closing the buffer 1 too many times in the addBuffer call from the RapidsCachingWriter.

2. `GpuCompressionAwareCoalesceIterator` was producing `ColumnarBatch` using a `GpuColunVectorFromBuffer` but with `BufferMeta` that contained the codec. This would confused the spill framework code to get a columnar batch, since the metadata claims the buffer is compressed, but it really isn't. So I added a `MetaUtils.dropCodecs` method that handles this.

I tested this manually for leaks/double closes and don't see further issues.