### PR TITLE
Adjust assert for SparkShims: no longer a per-shim file [skip ci]

### DIFF
--- a/build/shimplify.py
+++ b/build/shimplify.py
@@ -522,7 +522,7 @@ def __add_new_shim_to_file_map(files2bv):
         bv_list = files2bv[shim_file]
         if __add_shim_base in bv_list:
             # adding a lookalike
-            # case 1) dedicated per-shim files with a spark${buldver} in the package path:
+            # case 1) dedicated per-shim files with a spark${buildver} in the package path:
             #         CLONE the file with modifications
             # case 2) otherwise simply add the new buildver to the files2bv[shimfile] mapping
             base_package = "spark%s" % __add_shim_base

--- a/build/shimplify.py
+++ b/build/shimplify.py
@@ -522,15 +522,13 @@ def __add_new_shim_to_file_map(files2bv):
         bv_list = files2bv[shim_file]
         if __add_shim_base in bv_list:
             # adding a lookalike
-            # case 1) dedicated per-shim files such as SparkShims.scala and anything with
-            #         a spark${buldver} in the package path: CLONE the file with modifications
+            # case 1) dedicated per-shim files with a spark${buldver} in the package path:
+            #         CLONE the file with modifications
             # case 2) otherwise simply add the new buildver to the files2bv[shimfile] mapping
             base_package = "spark%s" % __add_shim_base
-            shim_impl_file = 'com.nvidia.spark.rapids.shims.SparkShims'\
-                .replace('.', os.sep) + '.scala'
-            if (base_package in shim_file) or shim_file.endswith(shim_impl_file):
-                assert len(bv_list) == 1, "Per-shim file are expect to belong to a single "\
-                        "shim, actual number of shims: %s" % len(bv_list)
+            if base_package in shim_file:
+                assert len(bv_list) == 1, "Per-shim file %s is expected to belong to a single "\
+                        "shim, actual shims: %s" % (shim_file, bv_list)
                 new_shim_file = __git_rename_or_copy(shim_file, __add_shim_buildver,
                                                      from_shim=__add_shim_base)
                 # schedule new file for comment update


### PR DESCRIPTION
- fix the assert in the add-shim path, SparkShims is now shareable after recent unshimming #7857 
- improve corresponding error messsage

```
Per-shim file path/SparkShims.scala
is expected to belong to a single shim, actual shims: ['331', '332']
```

Fixes #7927

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
