### PR TITLE
Add OOM Retry handling for join gather next

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -90,6 +90,16 @@ trait JoinGatherer extends LazySpillable with Arm {
   def getFixedWidthBitSize: Option[Int]
 
   /**
+   * Save state so it can be restored.
+   */
+  def checkpoint: Unit
+
+  /**
+   * Restore state that was checkpointed
+   */
+  def restore: Unit
+
+  /**
    * Do a complete/expensive job to get the number of rows that can be gathered to get close
    * to the targetSize for the final output.
    *
@@ -503,6 +513,7 @@ class JoinGathererImpl(
 
   // How much of the gather map we have output so far
   private var gatheredUpTo: Long = 0
+  private var gatheredUpToCheckpoint: Long = 0
   private val totalRows: Long = gatherMap.getRowCount
   private val (fixedWidthRowSizeBits, nullRowSizeBits) = {
     val dts = data.dataTypes
@@ -510,6 +521,9 @@ class JoinGathererImpl(
     val nullVal = JoinGathererImpl.nullRowSizeBits(dts)
     (fw, nullVal)
   }
+
+  override def checkpoint: Unit = { gatheredUpToCheckpoint = gatheredUpTo }
+  override def restore: Unit = { gatheredUpTo = gatheredUpToCheckpoint }
 
   override def toString: String = {
     s"GATHERER $gatheredUpTo/$totalRows $gatherMap $data"
@@ -619,6 +633,15 @@ case class MultiJoinGather(left: JoinGatherer, right: JoinGatherer) extends Join
   override def isDone: Boolean = left.isDone
 
   override def numRowsLeft: Long = left.numRowsLeft
+
+  override def checkpoint: Unit = {
+    left.checkpoint
+    right.checkpoint
+  }
+  override def restore: Unit = {
+    left.restore
+    right.restore
+  }
 
   override def allowSpilling(): Unit = {
     left.allowSpilling()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -90,12 +90,12 @@ trait JoinGatherer extends LazySpillable with Arm {
   def getFixedWidthBitSize: Option[Int]
 
   /**
-   * Save state so it can be restored.
+   * Save state so it can be restored in case of an OOM Retry.
    */
   def checkpoint: Unit
 
   /**
-   * Restore state that was checkpointed
+   * Restore state that was checkpointed.
    */
   def restore: Unit
 


### PR DESCRIPTION
This adds oom retry handling for the join gatherNext part of gpu hash joins. It is part of the work described in https://github.com/NVIDIA/spark-rapids/issues/7255.

This uses the RmmRapidsRetryIterator framework to add retries nextCbFromGatherer.  This adds a simple checkpoint mechanism to the gatherer to allow retrying JoinGatherer.getRowsInNextBatch.

I am putting this up as a draft because I have not added unit tests yet, and I am still confirming that this change does not cause the double close issue that was encountered in #7902.

I also need to do a performance impact check.