### PR TITLE
Support hashing different types for sub-partitioning

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -911,3 +911,21 @@ def test_multi_table_hash_join(data_gen, aqe_enabled, join_reorder_enabled):
         'spark.rapids.sql.optimizer.joinReorder.enabled': join_reorder_enabled
     })
     assert_gpu_and_cpu_are_equal_collect(do_join, conf=conf)
+
+
+limited_integral_gens = [byte_gen, short_gen, IntegerGen(max_val=SHORT_MAX), LongGen(max_val=SHORT_MAX)]
+
+@validate_execs_in_gpu_plan('GpuShuffledHashJoinExec')
+@ignore_order(local=True)
+@pytest.mark.parametrize('left_gen', limited_integral_gens, ids=idfn)
+@pytest.mark.parametrize('right_gen', limited_integral_gens, ids=idfn)
+@pytest.mark.parametrize('join_type', all_join_types, ids=idfn)
+def test_hash_join_different_key_integral_types(left_gen, right_gen, join_type):
+    def do_join(spark):
+        left = unary_op_df(spark, left_gen, length=127)
+        right = unary_op_df(spark, right_gen, length=500)
+        return left.join(right, left.a == right.a, join_type)
+    _all_conf = copy_and_update(_hash_join_conf, {
+        "spark.rapids.sql.test.subPartitioning.enabled": True
+    })
+    assert_gpu_and_cpu_are_equal_collect(do_join, conf=_all_conf)


### PR DESCRIPTION
Relevant to https://github.com/rapidsai/cudf/issues/13000

This PR changes to leverage the Plugin way to partition batches instead of the cudf `hashPartition` in sub-partitioning. 
 
Because the left and right join keys with the name value but different integral types(e.g. `100.toInt` and `100.toByte`) will produce different hash values by cudf `hashPartition`, breaking the join by sub-partitioning algorithm.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
