### PR TITLE
Fix issue with dynamicpruning filters used in converted GPU scans when S3 paths are replaced with alluxio [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
@@ -521,20 +521,15 @@ object AlluxioUtils extends Logging with Arm {
       // We use this approach to handle all the file index types for all CSPs like Databricks.
       relation.location match {
         case cfi: CatalogFileIndex =>
-          logWarning("Handling CatalogFileIndex")
+          logDebug("Handling CatalogFileIndex")
           val memFI = cfi.filterPartitions(Nil)
           createNewFileIndexWithPathsReplaced(memFI.partitionSpec(), memFI.rootPaths)
         case _ =>
-          logWarning(s"Handling file index type: ${relation.location.getClass}")
+          logDebug(s"Handling file index type: ${relation.location.getClass}")
 
           // With the base Spark FileIndex type we don't know how to modify it to
           // just replace the paths so we have to try to recompute.
           def isDynamicPruningFilter(e: Expression): Boolean = {
-            // val ret = e.find(_.isInstanceOf[PlanExpression[_]]).isDefined
-            // logWarning(s"isDynamicPruningFilter: $e, ${e.getClass}," +
-            //   s"superclass: ${e.getClass.getSuperclass}, " +
-            //   s"interfaces: ${e.getClass.getInterfaces.toList.mkString("|")}, ret: $ret")
-            // ret
             e.isInstanceOf[DynamicPruning] || e.find(_.isInstanceOf[PlanExpression[_]]).isDefined
           }
 


### PR DESCRIPTION
Fixes #7933 

This handles the scenario where CONVERT_TIME is used as the Alluxio path replacement algorithm and one of the scans being converted has a dynamic pruning filter in its partitionFilters. In this scenario, on Databricks, the dynamicpruningexpression (of type `DynamicPruningSubquery`) actually doesn't have the same inheritance tree as in Apache Spark, so AlluxioUtils needs to check if it is of type `DynamicPruning` instead to ensure that it's skipped over in this logic.

Verifying DPP is working correctly here, for NDS query 7 (referenced in #7933), the scan that would contain the dynamicpruningexpression shows the following set of output rows in `store_sales` for each of the following scenarios:

| DPP          |  Alluxio Automount | Number of Output Rows |
| ----------|--------------------|-------------------------|
|  disabled  | disabled                  | 8,251,124,389                  | 
|  enabled  | disabled                  | 1,632,403,114                  |  
|  disabled  | enabled                  | 8,251,124,389                  | 
|  enabled  | enabled                   | 1,632,403,114                  | 

Alluxio has no effect on DPP reducing the number of output rows, so therefore it should work correctly with DPP now.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
