### PR TITLE
Init plugin version 23.06.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ as a `provided` dependency.
 <dependency>
     <groupId>com.nvidia</groupId>
     <artifactId>rapids-4-spark_2.12</artifactId>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-aggregator_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Aggregator</name>
     <description>Creates an aggregated shaded package of the RAPIDS plugin for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <properties>
         <!--
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
+            <version>${spark-rapids-private.version}</version>
             <classifier>${spark.version.classifier}</classifier>
         </dependency>
     </dependencies>

--- a/api_validation/pom.xml
+++ b/api_validation/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-api-validation</artifactId>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <profiles>
        <profile>

--- a/delta-lake/delta-20x/pom.xml
+++ b/delta-lake/delta-20x/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-20x_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Delta Lake 2.0.x Support</name>
     <description>Delta Lake 2.0.x support for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/delta-lake/delta-21x/pom.xml
+++ b/delta-lake/delta-21x/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-21x_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Delta Lake 2.1.x Support</name>
     <description>Delta Lake 2.1.x support for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/delta-lake/delta-22x/pom.xml
+++ b/delta-lake/delta-22x/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-22x_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Delta Lake 2.2.x Support</name>
     <description>Delta Lake 2.2.x support for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/delta-lake/delta-spark321db/pom.xml
+++ b/delta-lake/delta-spark321db/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-spark321db_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Databricks 10.4 Delta Lake Support</name>
     <description>Databricks 10.4 Delta Lake support for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/delta-lake/delta-spark330db/pom.xml
+++ b/delta-lake/delta-spark330db/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-spark330db_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Databricks 11.3 Delta Lake Support</name>
     <description>Databricks 11.3 Delta Lake support for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/delta-lake/delta-stub/pom.xml
+++ b/delta-lake/delta-stub/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>rapids-4-spark-delta-stub_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Delta Lake Stub</name>
     <description>Delta Lake stub for the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Distribution</name>
     <description>Creates the distribution package of the RAPIDS plugin for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>

--- a/docs/configs.md
+++ b/docs/configs.md
@@ -10,7 +10,7 @@ The following is the list of options that `rapids-plugin-4-spark` supports.
 On startup use: `--conf [conf key]=[conf value]`. For example:
 
 ```
-${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar \
+${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar \
 --conf spark.plugins=com.nvidia.spark.SQLPlugin \
 --conf spark.rapids.sql.concurrentGpuTasks=2
 ```

--- a/docs/dev/shims.md
+++ b/docs/dev/shims.md
@@ -68,17 +68,17 @@ Using JarURLConnection URLs we create a Parallel World of the current version wi
 Spark 3.0.2's URLs:
 
 ```text
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark3xx-common/
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark302/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark3xx-common/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark302/
 ```
 
 Spark 3.2.0's URLs :
 
 ```text
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark3xx-common/
-jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark320/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark3xx-common/
+jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark320/
 ```
 
 ### Late Inheritance in Public Classes

--- a/docs/get-started/getting-started-on-prem.md
+++ b/docs/get-started/getting-started-on-prem.md
@@ -53,13 +53,13 @@ CUDA and will not run on other versions. The jars use a classifier to keep them 
 - CUDA 11.x => classifier cuda11
 
 For example, here is a sample version of the jar with CUDA 11.x support:
-- rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar
+- rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar
 
 For simplicity export the location to this jar. This example assumes the sample jar above has
 been placed in the `/opt/sparkRapidsPlugin` directory:
 ```shell 
 export SPARK_RAPIDS_DIR=/opt/sparkRapidsPlugin
-export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_DIR}/rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar
+export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_DIR}/rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar
 ```
 
 ## Install the GPU Discovery Script

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -255,7 +255,7 @@ individually, so you don't risk running unit tests along with the integration te
 http://www.scalatest.org/user_guide/using_the_scalatest_shell
 
 ```shell
-spark-shell --jars rapids-4-spark-tests_2.12-23.04.0-SNAPSHOT-tests.jar,rapids-4-spark-integration-tests_2.12-23.04.0-SNAPSHOT-tests.jar,scalatest_2.12-3.0.5.jar,scalactic_2.12-3.0.5.jar
+spark-shell --jars rapids-4-spark-tests_2.12-23.06.0-SNAPSHOT-tests.jar,rapids-4-spark-integration-tests_2.12-23.06.0-SNAPSHOT-tests.jar,scalatest_2.12-3.0.5.jar,scalactic_2.12-3.0.5.jar
 ```
 
 First you import the `scalatest_shell` and tell the tests where they can find the test files you
@@ -278,7 +278,7 @@ If you just want to verify the SQL replacement is working you will need to add t
 assumes CUDA 11.0 is being used.
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar" ./runtests.py
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar" ./runtests.py
 ```
 
 You don't have to enable the plugin for this to work, the test framework will do that for you.
@@ -377,7 +377,7 @@ To run cudf_udf tests, need following configuration changes:
 As an example, here is the `spark-submit` command with the cudf_udf parameter on CUDA 11.0:
 
 ```
-$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar,rapids-4-spark-tests_2.12-23.04.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar" ./runtests.py --cudf_udf
+$SPARK_HOME/bin/spark-submit --jars "rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar,rapids-4-spark-tests_2.12-23.06.0-SNAPSHOT.jar" --conf spark.rapids.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.memory.gpu.allocFraction=0.3 --conf spark.rapids.python.concurrentPythonWorkers=2 --py-files "rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar" --conf spark.executorEnv.PYTHONPATH="rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar" ./runtests.py --cudf_udf
 ```
 
 ### Enabling fuzz tests

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-integration-tests_2.12</artifactId>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
     <properties>
         <target.classifier/>
     </properties>

--- a/jenkins/databricks/create.py
+++ b/jenkins/databricks/create.py
@@ -27,7 +27,7 @@ def main():
   workspace = 'https://dbc-9ff9942e-a9c4.cloud.databricks.com'
   token = ''
   sshkey = ''
-  cluster_name = 'CI-GPU-databricks-23.04.0-SNAPSHOT'
+  cluster_name = 'CI-GPU-databricks-23.06.0-SNAPSHOT'
   idletime = 240
   runtime = '7.0.x-gpu-ml-scala2.12'
   num_workers = 1

--- a/jenkins/version-def.sh
+++ b/jenkins/version-def.sh
@@ -26,10 +26,10 @@ for VAR in $OVERWRITE_PARAMS; do
 done
 IFS=$PRE_IFS
 
-CUDF_VER=${CUDF_VER:-"23.04.0-SNAPSHOT"}
+CUDF_VER=${CUDF_VER:-"23.04.0-SNAPSHOT"} # TODO: https://github.com/NVIDIA/spark-rapids/issues/7947
 CUDA_CLASSIFIER=${CUDA_CLASSIFIER:-"cuda11"}
-PROJECT_VER=${PROJECT_VER:-"23.04.0-SNAPSHOT"}
-PROJECT_TEST_VER=${PROJECT_TEST_VER:-"23.04.0-SNAPSHOT"}
+PROJECT_VER=${PROJECT_VER:-"23.06.0-SNAPSHOT"}
+PROJECT_TEST_VER=${PROJECT_TEST_VER:-"23.06.0-SNAPSHOT"}
 SPARK_VER=${SPARK_VER:-"3.1.1"}
 # Make a best attempt to set the default value for the shuffle shim.
 # Note that SPARK_VER for non-Apache Spark flavors (i.e. databricks,

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>rapids-4-spark-parent</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Root Project</name>
     <description>The root project of the RAPIDS Accelerator for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>https://nvidia.github.io/spark-rapids/</url>
@@ -586,7 +586,9 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
+        <!--TODO: https://github.com/NVIDIA/spark-rapids/issues/7947>-->
         <spark-rapids-jni.version>23.04.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>23.04.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rapids-4-spark-shuffle_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Shuffle Plugin</name>
     <description>Accelerated shuffle plugin for the RAPIDS plugin for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-sql_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark SQL Plugin</name>
     <description>The RAPIDS SQL plugin for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1855,7 +1855,7 @@ object RapidsConf {
         |On startup use: `--conf [conf key]=[conf value]`. For example:
         |
         |```
-        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.04.0-SNAPSHOT-cuda11.jar \
+        |${SPARK_HOME}/bin/spark-shell --jars rapids-4-spark_2.12-23.06.0-SNAPSHOT-cuda11.jar \
         |--conf spark.plugins=com.nvidia.spark.SQLPlugin \
         |--conf spark.rapids.sql.concurrentGpuTasks=2
         |```

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -58,13 +58,13 @@ import org.apache.spark.util.MutableURLClassLoader
 
     E.g., Spark 3.2.0 Shim will use
 
-    jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark3xx-common/
-    jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark320/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark3xx-common/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark320/
 
     Spark 3.1.1 will use
 
-    jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark3xx-common/
-    jar:file:/home/spark/rapids-4-spark_2.12-23.04.0.jar!/spark311/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark3xx-common/
+    jar:file:/home/spark/rapids-4-spark_2.12-23.06.0.jar!/spark311/
 
     Using these Jar URL's allows referencing different bytecode produced from identical sources
     by incompatible Scala / Spark dependencies.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-tests_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Tests</name>
     <description>RAPIDS plugin for Apache Spark integration tests</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>com.nvidia</groupId>
         <artifactId>rapids-4-spark-parent</artifactId>
-        <version>23.04.0-SNAPSHOT</version>
+        <version>23.06.0-SNAPSHOT</version>
     </parent>
     <artifactId>rapids-4-spark-udf_2.12</artifactId>
     <name>RAPIDS Accelerator for Apache Spark Scala UDF Plugin</name>
     <description>The RAPIDS Scala UDF plugin for Apache Spark</description>
-    <version>23.04.0-SNAPSHOT</version>
+    <version>23.06.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Update version to 23.06.0-SNAPSHOT in branch-23.06

Note: JNI, private, cudf-py version is still 23.04 (added TODOs)
we will deal w/ https://github.com/NVIDIA/spark-rapids/issues/7947 later to bump up dependency versions when available