### PR TITLE
Lazily unspill the stream batches for joins by sub-partitioning

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -520,8 +520,8 @@ trait GpuSubPartitionHashJoin extends Arm with Logging { self: GpuHashJoin =>
           val buildCb = build.map(_.getColumnarBatch())
             .getOrElse(GpuColumnVector.emptyBatch(buildSchema))
           val streamIter = closeOnExcept(buildCb) { _ =>
-            closeOnExcept(stream.safeMap(_.getColumnarBatch())) { streamCbs =>
-              GpuSubPartitionHashJoin.safeIteratorFromSeq(streamCbs)
+            GpuSubPartitionHashJoin.safeIteratorFromSeq(stream).map { spill =>
+              closeOnExcept(spill)(_.getColumnarBatch())
             }
           }
           // Leverage the original join iterators

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -311,9 +311,20 @@ class PartitionPair(
     (build, stream)
   }
 
+  /**
+   * Release the batches from two sides as a Tuple(build, stream).
+   * Callers should close the returned batches.
+   */
+  def release: (Option[SpillableColumnarBatch], Seq[SpillableColumnarBatch]) = {
+    val ret = (build, stream)
+    build = None
+    stream = Seq.empty
+    ret
+  }
+
   override def close(): Unit = {
     stream.safeClose()
-    stream = Seq.empty[SpillableColumnarBatch]
+    stream = Seq.empty
     build.foreach(_.safeClose())
     build = None
   }
@@ -516,12 +527,15 @@ trait GpuSubPartitionHashJoin extends Arm with Logging { self: GpuHashJoin =>
           // Skip it due to optimization
           None
         } else {
-          val (build, stream) = pair.get
-          val buildCb = build.map(_.getColumnarBatch())
-            .getOrElse(GpuColumnVector.emptyBatch(buildSchema))
+          val (build, stream) = pair.release
+          val buildCb = closeOnExcept(stream) { _ =>
+            withResource(build) { _ =>
+              build.map(_.getColumnarBatch()).getOrElse(GpuColumnVector.emptyBatch(buildSchema))
+            }
+          }
           val streamIter = closeOnExcept(buildCb) { _ =>
             GpuSubPartitionHashJoin.safeIteratorFromSeq(stream).map { spill =>
-              closeOnExcept(spill)(_.getColumnarBatch())
+              withResource(spill)(_.getColumnarBatch())
             }
           }
           // Leverage the original join iterators


### PR DESCRIPTION
This is a small improvement to unspill the stream batches lazily one by one, which is likely to save GPU peak memory for sub-partitioning joins.
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
