### PR TITLE
Fix PMD docs URL [skip ci]

### DIFF
--- a/docs/dev/shimplify.md
+++ b/docs/dev/shimplify.md
@@ -263,4 +263,4 @@ See [CPD user doc][7] for more details about the options you can pass inside `cp
 [4]: https://jsonlines.org/
 [5]: https://spark.apache.org/versioning-policy.html
 [6]: https://plugins.jetbrains.com/plugin/16429-idea-resolve-symlinks
-[7]: https://pmd.github.io/latest/pmd_userdocs_cpd.html
+[7]: https://docs.pmd-code.org/latest/pmd_userdocs_cpd.html


### PR DESCRIPTION
Updates the PMD documentation link to its current location.