### PR TITLE
Disable GPU write for ORC and Parquet, if bloom-filters are enabled.

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,18 @@ object GpuParquetFileFormat {
     if (!meta.conf.isParquetWriteEnabled) {
       meta.willNotWorkOnGpu("Parquet output has been disabled. To enable set" +
         s"${RapidsConf.ENABLE_PARQUET_WRITE} to true")
+    }
+
+    // Check if bloom filter is enabled for any columns. If yes, then disable GPU write.
+    // For Parquet tables, bloom filters are enabled for column `col` by setting
+    // `parquet.bloom.filter.enabled#col` to `true` in `options` or table properties.
+    // Refer to https://spark.apache.org/docs/3.2.0/sql-data-sources-load-save-functions.html
+    // for further details.
+    options.foreach {
+      case (key, _) if key.startsWith("parquet.bloom.filter.enabled#") =>
+        meta.willNotWorkOnGpu(s"Bloom filter write for Parquet is not yet supported on GPU. " +
+          s"If bloom filter is not required, unset $key")
+      case _ =>
     }
 
     FileFormatChecks.tag(meta, schema, ParquetFormatType, WriteFileOp)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuOrcFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,18 @@ object GpuOrcFileFormat extends Logging {
     val encrypt = options.getOrElse("orc.encrypt", "")
     val mask = options.getOrElse("orc.mask", "")
 
-    if (!keyProvider.isEmpty || !keyProviderPath.isEmpty || !encrypt.isEmpty || !mask.isEmpty) {
+    if (keyProvider.nonEmpty || keyProviderPath.nonEmpty || encrypt.nonEmpty || mask.nonEmpty) {
       meta.willNotWorkOnGpu("Encryption is not yet supported on GPU. If encrypted ORC " +
           "writes are not required unset the \"hadoop.security.key.provider.path\" and " +
           "\"orc.key.provider\" and \"orc.encrypt\" and \"orc.mask\"")
+    }
+
+    // Check if bloom filter is enabled. If yes, then disable GPU.
+    // Refer to https://orc.apache.org/docs/spark-config.html for the description of ORC configs.
+    val bloomFilterColumns = options.getOrElse("orc.bloom.filter.columns", "")
+    if (bloomFilterColumns.nonEmpty) {
+      meta.willNotWorkOnGpu("Bloom filter write for ORC is not yet supported on GPU. " +
+        "If bloom filter is not required, unset \"orc.bloom.filter.columns\"")
     }
 
     FileFormatChecks.tag(meta, schema, OrcFormatType, WriteFileOp)


### PR DESCRIPTION
Fixes #7921.

ORC and Parquet file formats support writing bloom filters to the index sections of data files, to support filtering row groups based on bloom filters. This is not currently supported via `spark-rapids`.

This commit disables GPU writes for ORC and Parquet, if bloom filters are enabled.

References:

Options for enabling bloom filters are explained in the [Apache ORC documentation](https://orc.apache.org/docs/spark-config.html) and in the [Spark DataSource documentation](https://spark.apache.org/docs/3.2.0/sql-data-sources-load-save-functions.html).

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
