### PR TITLE
Sub-partitioning supports repartitioning the input data multiple times

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+
+import scala.reflect.ClassTag
 
 /** Implementation of the automatic-resource-management pattern */
 trait Arm {
@@ -132,6 +134,18 @@ trait Arm {
     } catch {
       case t: Throwable =>
         r.foreach(_.safeClose(t))
+        throw t
+    }
+  }
+
+  /** Executes the provided code block, closing the resources only if an exception occurs */
+  def closeOnExcept[T <: AutoCloseable, V](r: Array[ArrayBuffer[T]])
+      (block: Array[ArrayBuffer[T]] => V)(implicit ct: ClassTag[T]): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.filterNot(_ == null).flatten.safeClose(t)
         throw t
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -16,10 +16,9 @@
 package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
 
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-
-import scala.reflect.ClassTag
 
 /** Implementation of the automatic-resource-management pattern */
 trait Arm {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
 
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
@@ -133,18 +132,6 @@ trait Arm {
     } catch {
       case t: Throwable =>
         r.foreach(_.safeClose(t))
-        throw t
-    }
-  }
-
-  /** Executes the provided code block, closing the resources only if an exception occurs */
-  def closeOnExcept[T <: AutoCloseable, V](r: Array[ArrayBuffer[T]])
-      (block: Array[ArrayBuffer[T]] => V)(implicit ct: ClassTag[T]): V = {
-    try {
-      block(r)
-    } catch {
-      case t: Throwable =>
-        r.filterNot(_ == null).flatten.safeClose(t)
         throw t
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -441,6 +441,7 @@ class GpuSubPartitionPairIterator(
     // build partitioner
     val buildIt = GpuSubPartitionHashJoin.safeIteratorFromSeq(bigBuildBatches)
       .map(_.getColumnarBatch())
+    bigBuildBatches.clear()
     buildSubPartitioner.safeClose(new Exception())
     buildSubPartitioner = new GpuBatchSubPartitioner(buildIt, boundBuildKeys,
       realNumPartitions, hashSeed)
@@ -449,6 +450,7 @@ class GpuSubPartitionPairIterator(
     // stream partitioner
     val streamIt = GpuSubPartitionHashJoin.safeIteratorFromSeq(bigStreamBatches)
       .map(_.getColumnarBatch())
+    bigStreamBatches.clear()
     streamSubPartitioner.safeClose(new Exception())
     streamSubPartitioner = new GpuBatchSubPartitioner(streamIt, boundStreamKeys,
       realNumPartitions, hashSeed)
@@ -460,6 +462,9 @@ class GpuSubPartitionPairIterator(
     val requiredNum = Math.floorDiv(totalSize, realTargetSize).toInt + 1
     math.max(requiredNum, numPartitions)
   }
+
+  /** For test only */
+  def isRepartitioned: Boolean = repartitioned
 }
 
 /** Base class for joins by sub-partitioning algorithm */

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.ColumnVector
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, ExprId}
-import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuBatchSubPartitionIterator}
+import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuBatchSubPartitionIterator, GpuSubPartitionPairIterator}
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -36,7 +36,8 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
       val subPartitioner = new GpuBatchSubPartitioner(
         Iterator.empty,
         boundKeys,
-        numPartitions = 0)
+        numPartitions = 0,
+        hashSeed = 100)
 
       // at least two partitions even given 0
       assertResult(expected = 2)(subPartitioner.partitionsCount)
@@ -60,7 +61,8 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val subPartitioner = new GpuBatchSubPartitioner(
           Seq(emptyBatch).toIterator,
           boundKeys,
-          numPartitions = 5)
+          numPartitions = 5,
+          hashSeed = 100)
 
         assertResult(expected = 5)(subPartitioner.partitionsCount)
         // empty batch is skipped
@@ -86,7 +88,8 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val subPartitioner = new GpuBatchSubPartitioner(
           Seq(nonemptyBatch).toIterator,
           boundKeys,
-          numPartitions = 5)
+          numPartitions = 5,
+          hashSeed = 100)
 
         assertResult(expected = 5)(subPartitioner.partitionsCount)
         // nonempty batches exist
@@ -112,7 +115,8 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val subPartitioner = new GpuBatchSubPartitioner(
           Seq(emptyBatch).toIterator,
           boundKeys,
-          numPartitions = 5)
+          numPartitions = 5,
+          hashSeed = 100)
         val subIter = new GpuBatchSubPartitionIterator(
           subPartitioner,
           targetBatchSize = 12L)
@@ -142,7 +146,8 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val subPartitioner = new GpuBatchSubPartitioner(
           Seq(nonemptyBatch).toIterator,
           boundKeys,
-          numPartitions = 5)
+          numPartitions = 5,
+          hashSeed = 100)
         val subIter = new GpuBatchSubPartitionIterator(
           subPartitioner,
           targetBatchSize = 12L)
@@ -160,6 +165,78 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         }
         assertResult(nonemptyBatch.numRows())(actualRowNum)
         subPartitioner.close()
+      }
+    }
+  }
+
+  test("Sub-pair iterator repartition because of too big batch") {
+    withGpuSparkSession { _ =>
+      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
+      // generate a little large data for this test.
+      val largeData = 0 until 1024
+      closeOnExcept {
+        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
+        new ColumnarBatch(Array(col), col.getRowCount.toInt)
+      } { nonemptyBatch =>
+        val subPairIter = new GpuSubPartitionPairIterator(
+          Seq(nonemptyBatch).toIterator, boundKeys,
+          Iterator.empty, boundKeys,
+          numPartitions = 2, targetBatchSize = 1024)
+
+        var actualRowNum, partCount = 0
+        while (subPairIter.hasNext) {
+          withResource(subPairIter.next()) { pair =>
+            val (buildCb, streamCbs) = pair.get
+            assert(streamCbs.isEmpty)
+            buildCb.foreach { cb =>
+              // got nonempty partition, add its row number
+              actualRowNum += cb.numRows()
+            }
+            partCount += 1
+          }
+        }
+        assertResult(nonemptyBatch.numRows())(actualRowNum)
+        // The final partition number should be larger than the original one (2).
+        assert(partCount > 2)
+        // Repartitioning should happen.
+        assert(subPairIter.isRepartitioned)
+        subPairIter.close()
+      }
+    }
+  }
+
+  test("Sub-pair iterator repartition because of skewed data") {
+    withGpuSparkSession { _ =>
+      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
+      // generate a little large data for this test.
+      val largeData = (0 until 1000).map(_ => 1) ++ (0 until 24).map(_ => 2)
+      closeOnExcept {
+        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
+        new ColumnarBatch(Array(col), col.getRowCount.toInt)
+      } { nonemptyBatch =>
+        val subPairIter = new GpuSubPartitionPairIterator(
+          Seq(nonemptyBatch).toIterator, boundKeys,
+          Iterator.empty, boundKeys,
+          numPartitions = 10, targetBatchSize = 1024)
+
+        var actualRowNum, partCount = 0
+        while (subPairIter.hasNext) {
+          withResource(subPairIter.next()) { pair =>
+            val (buildCb, streamCbs) = pair.get
+            assert(streamCbs.isEmpty)
+            buildCb.foreach { cb =>
+              // got nonempty partition, add its row number
+              actualRowNum += cb.numRows()
+              partCount += 1
+            }
+          }
+        }
+        assertResult(nonemptyBatch.numRows())(actualRowNum)
+        // There should be two nonempty partitions, one for 1000 "1"s and one for 24 "2"s.
+        assert(partCount == 2)
+        // Repartitioning should happen.
+        assert(subPairIter.isRepartitioned)
+        subPairIter.close()
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.ColumnVector
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, ExprId}
-import org.apache.spark.sql.rapids.execution.{GpuBatchSizeAwareSubPartitioner, GpuBatchSubPartitioner, GpuBatchSubPartitionIterator}
+import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuBatchSubPartitionIterator}
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -33,13 +33,37 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
 
   test("Sub-partitioner with empty iterator") {
     withGpuSparkSession { _ =>
-      Seq(
-        new GpuBatchSubPartitioner(Iterator.empty, boundKeys, numPartitions = 0),
-        new GpuBatchSizeAwareSubPartitioner(Iterator.empty, boundKeys, numPartitions = 0,
-          targetBatchSize = 0L)
-      ).foreach { subPartitioner =>
-        // at least two partitions even given 0
-        assertResult(expected = 2)(subPartitioner.partitionsCount)
+      val subPartitioner = new GpuBatchSubPartitioner(
+        Iterator.empty,
+        boundKeys,
+        numPartitions = 0)
+
+      // at least two partitions even given 0
+      assertResult(expected = 2)(subPartitioner.partitionsCount)
+      assertResult(expected = 0)(subPartitioner.batchesCount)
+      val ids = 0 until subPartitioner.partitionsCount
+      // every partition is empty
+      assert(ids.forall(subPartitioner.getBatchesByPartition(_).isEmpty))
+      // every partition becomes null after being released
+      // no actual resource so no need to close
+      ids.foreach(subPartitioner.releaseBatchesByPartition)
+      assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
+      subPartitioner.close()
+      // repeated close should be ok
+      subPartitioner.close()
+    }
+  }
+
+  test("Sub-partitioner with nonempty iterator of one empty batch") {
+    withGpuSparkSession { _ =>
+      closeOnExcept(GpuColumnVector.emptyBatch(attrs)) { emptyBatch =>
+        val subPartitioner = new GpuBatchSubPartitioner(
+          Seq(emptyBatch).toIterator,
+          boundKeys,
+          numPartitions = 5)
+
+        assertResult(expected = 5)(subPartitioner.partitionsCount)
+        // empty batch is skipped
         assertResult(expected = 0)(subPartitioner.batchesCount)
         val ids = 0 until subPartitioner.partitionsCount
         // every partition is empty
@@ -49,34 +73,6 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         ids.foreach(subPartitioner.releaseBatchesByPartition)
         assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
         subPartitioner.close()
-        // repeated close should be ok
-        subPartitioner.close()
-      }
-    }
-  }
-
-  test("Sub-partitioner with nonempty iterator of one empty batch") {
-    withGpuSparkSession { _ =>
-      closeOnExcept(GpuColumnVector.emptyBatch(attrs)) { emptyBatch =>
-        Seq(
-          new GpuBatchSubPartitioner(Seq(emptyBatch).toIterator, boundKeys,
-            numPartitions = 5),
-          new GpuBatchSizeAwareSubPartitioner(
-            Seq(GpuColumnVector.incRefCounts(emptyBatch)).toIterator, boundKeys,
-            numPartitions = 5, targetBatchSize = 0)
-        ).foreach { subPartitioner =>
-          assertResult(expected = 5)(subPartitioner.partitionsCount)
-          // empty batch is skipped
-          assertResult(expected = 0)(subPartitioner.batchesCount)
-          val ids = 0 until subPartitioner.partitionsCount
-          // every partition is empty
-          assert(ids.forall(subPartitioner.getBatchesByPartition(_).isEmpty))
-          // every partition becomes null after being released.
-          // no actual resource so no need to close
-          ids.foreach(subPartitioner.releaseBatchesByPartition)
-          assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
-          subPartitioner.close()
-        }
       }
     }
   }
@@ -87,80 +83,12 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val col = GpuColumnVector.from(ColumnVector.fromInts(1,2,2,3,3,3), IntegerType)
         new ColumnarBatch(Array(col), col.getRowCount.toInt)
       } { nonemptyBatch =>
-        Seq(
-          new GpuBatchSubPartitioner(Seq(nonemptyBatch).toIterator, boundKeys,
-            numPartitions = 5),
-          new GpuBatchSizeAwareSubPartitioner(
-            Seq(GpuColumnVector.incRefCounts(nonemptyBatch)).toIterator, boundKeys,
-            numPartitions = 5, targetBatchSize = 1024)
-        ).foreach { subPartitioner =>
-          assertResult(expected = 5)(subPartitioner.partitionsCount)
-          // nonempty batches exist
-          assert(subPartitioner.batchesCount > 0)
-          val ids = 0 until subPartitioner.partitionsCount
-          var actualRowNum = 0
-          ids.foreach { id =>
-            withResource(subPartitioner.releaseBatchesByPartition(id)) { batches =>
-              actualRowNum += batches.map(_.numRows()).sum
-            }
-          }
-          assertResult(nonemptyBatch.numRows())(actualRowNum)
-          // every partition becomes null after being released
-          assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
-          subPartitioner.close()
-        }
-      }
-    }
-  }
+        val subPartitioner = new GpuBatchSubPartitioner(
+          Seq(nonemptyBatch).toIterator,
+          boundKeys,
+          numPartitions = 5)
 
-  test("Sub-partitioner repartition because of too big batch") {
-    withGpuSparkSession { _ =>
-      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
-      // generate a little large data for this test.
-      val largeData = 0 until 1024
-      closeOnExcept {
-        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
-        new ColumnarBatch(Array(col), col.getRowCount.toInt)
-      } { nonemptyBatch =>
-        val subPartitioner = new GpuBatchSizeAwareSubPartitioner(Seq(nonemptyBatch).toIterator,
-          boundKeys, numPartitions = 2, targetBatchSize = 1024)
-        // repartition to 5 partitions (4 * 1024 / 1024 + 1)
         assertResult(expected = 5)(subPartitioner.partitionsCount)
-        // It repartitioned only once.
-        assertResult(expected = 1)(subPartitioner.getRetryCount)
-        // nonempty batches exist
-        assert(subPartitioner.batchesCount > 0)
-        val ids = 0 until subPartitioner.partitionsCount
-        var actualRowNum = 0
-        ids.foreach { id =>
-          withResource(subPartitioner.releaseBatchesByPartition(id)) { batches =>
-            actualRowNum += batches.map(_.numRows()).sum
-          }
-        }
-        assertResult(nonemptyBatch.numRows())(actualRowNum)
-        // every partition becomes null after being released
-        assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
-        subPartitioner.close()
-      }
-    }
-  }
-
-  test("Sub-partitioner repartition because of highly skewed data") {
-    withGpuSparkSession { _ =>
-      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
-      // generate a little large data for this test.
-      val largeData = (0 until 1000).map(_ => 1) ++ (0 until 24)
-      closeOnExcept {
-        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
-        new ColumnarBatch(Array(col), col.getRowCount.toInt)
-      } { nonemptyBatch =>
-        val subPartitioner = new GpuBatchSizeAwareSubPartitioner(Seq(nonemptyBatch).toIterator,
-          boundKeys, numPartitions = 7, targetBatchSize = 1024)
-        // try to repartition to 5 partitions ( 4 * 1024 / 1024 + 1), but
-        // still keep 7 partitions because 5 < 7
-        assertResult(expected = 7)(subPartitioner.partitionsCount)
-        // It should try 3 times (the maximum number allowed)
-        assertResult(expected = 3)(subPartitioner.getRetryCount)
         // nonempty batches exist
         assert(subPartitioner.batchesCount > 0)
         val ids = 0 until subPartitioner.partitionsCount

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.ColumnVector
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, ExprId}
-import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuBatchSubPartitionIterator}
+import org.apache.spark.sql.rapids.execution.{GpuBatchSizeAwareSubPartitioner, GpuBatchSubPartitioner, GpuBatchSubPartitionIterator}
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -33,37 +33,13 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
 
   test("Sub-partitioner with empty iterator") {
     withGpuSparkSession { _ =>
-      val subPartitioner = new GpuBatchSubPartitioner(
-        Iterator.empty,
-        boundKeys,
-        numPartitions = 0)
-
-      // at least two partitions even given 0
-      assertResult(expected = 2)(subPartitioner.partitionsCount)
-      assertResult(expected = 0)(subPartitioner.batchesCount)
-      val ids = 0 until subPartitioner.partitionsCount
-      // every partition is empty
-      assert(ids.forall(subPartitioner.getBatchesByPartition(_).isEmpty))
-      // every partition becomes null after being released
-      // no actual resource so no need to close
-      ids.foreach(subPartitioner.releaseBatchesByPartition)
-      assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
-      subPartitioner.close()
-      // repeated close should be ok
-      subPartitioner.close()
-    }
-  }
-
-  test("Sub-partitioner with nonempty iterator of one empty batch") {
-    withGpuSparkSession { _ =>
-      closeOnExcept(GpuColumnVector.emptyBatch(attrs)) { emptyBatch =>
-        val subPartitioner = new GpuBatchSubPartitioner(
-          Seq(emptyBatch).toIterator,
-          boundKeys,
-          numPartitions = 5)
-
-        assertResult(expected = 5)(subPartitioner.partitionsCount)
-        // empty batch is skipped
+      Seq(
+        new GpuBatchSubPartitioner(Iterator.empty, boundKeys, numPartitions = 0),
+        new GpuBatchSizeAwareSubPartitioner(Iterator.empty, boundKeys, numPartitions = 0,
+          targetBatchSize = 0L)
+      ).foreach { subPartitioner =>
+        // at least two partitions even given 0
+        assertResult(expected = 2)(subPartitioner.partitionsCount)
         assertResult(expected = 0)(subPartitioner.batchesCount)
         val ids = 0 until subPartitioner.partitionsCount
         // every partition is empty
@@ -73,6 +49,34 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         ids.foreach(subPartitioner.releaseBatchesByPartition)
         assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
         subPartitioner.close()
+        // repeated close should be ok
+        subPartitioner.close()
+      }
+    }
+  }
+
+  test("Sub-partitioner with nonempty iterator of one empty batch") {
+    withGpuSparkSession { _ =>
+      closeOnExcept(GpuColumnVector.emptyBatch(attrs)) { emptyBatch =>
+        Seq(
+          new GpuBatchSubPartitioner(Seq(emptyBatch).toIterator, boundKeys,
+            numPartitions = 5),
+          new GpuBatchSizeAwareSubPartitioner(
+            Seq(GpuColumnVector.incRefCounts(emptyBatch)).toIterator, boundKeys,
+            numPartitions = 5, targetBatchSize = 0)
+        ).foreach { subPartitioner =>
+          assertResult(expected = 5)(subPartitioner.partitionsCount)
+          // empty batch is skipped
+          assertResult(expected = 0)(subPartitioner.batchesCount)
+          val ids = 0 until subPartitioner.partitionsCount
+          // every partition is empty
+          assert(ids.forall(subPartitioner.getBatchesByPartition(_).isEmpty))
+          // every partition becomes null after being released.
+          // no actual resource so no need to close
+          ids.foreach(subPartitioner.releaseBatchesByPartition)
+          assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
+          subPartitioner.close()
+        }
       }
     }
   }
@@ -83,12 +87,80 @@ class GpuSubPartitionSuite extends SparkQueryCompareTestSuite {
         val col = GpuColumnVector.from(ColumnVector.fromInts(1,2,2,3,3,3), IntegerType)
         new ColumnarBatch(Array(col), col.getRowCount.toInt)
       } { nonemptyBatch =>
-        val subPartitioner = new GpuBatchSubPartitioner(
-          Seq(nonemptyBatch).toIterator,
-          boundKeys,
-          numPartitions = 5)
+        Seq(
+          new GpuBatchSubPartitioner(Seq(nonemptyBatch).toIterator, boundKeys,
+            numPartitions = 5),
+          new GpuBatchSizeAwareSubPartitioner(
+            Seq(GpuColumnVector.incRefCounts(nonemptyBatch)).toIterator, boundKeys,
+            numPartitions = 5, targetBatchSize = 1024)
+        ).foreach { subPartitioner =>
+          assertResult(expected = 5)(subPartitioner.partitionsCount)
+          // nonempty batches exist
+          assert(subPartitioner.batchesCount > 0)
+          val ids = 0 until subPartitioner.partitionsCount
+          var actualRowNum = 0
+          ids.foreach { id =>
+            withResource(subPartitioner.releaseBatchesByPartition(id)) { batches =>
+              actualRowNum += batches.map(_.numRows()).sum
+            }
+          }
+          assertResult(nonemptyBatch.numRows())(actualRowNum)
+          // every partition becomes null after being released
+          assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
+          subPartitioner.close()
+        }
+      }
+    }
+  }
 
+  test("Sub-partitioner repartition because of too big batch") {
+    withGpuSparkSession { _ =>
+      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
+      // generate a little large data for this test.
+      val largeData = 0 until 1024
+      closeOnExcept {
+        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
+        new ColumnarBatch(Array(col), col.getRowCount.toInt)
+      } { nonemptyBatch =>
+        val subPartitioner = new GpuBatchSizeAwareSubPartitioner(Seq(nonemptyBatch).toIterator,
+          boundKeys, numPartitions = 2, targetBatchSize = 1024)
+        // repartition to 5 partitions (4 * 1024 / 1024 + 1)
         assertResult(expected = 5)(subPartitioner.partitionsCount)
+        // It repartitioned only once.
+        assertResult(expected = 1)(subPartitioner.getRetryCount)
+        // nonempty batches exist
+        assert(subPartitioner.batchesCount > 0)
+        val ids = 0 until subPartitioner.partitionsCount
+        var actualRowNum = 0
+        ids.foreach { id =>
+          withResource(subPartitioner.releaseBatchesByPartition(id)) { batches =>
+            actualRowNum += batches.map(_.numRows()).sum
+          }
+        }
+        assertResult(nonemptyBatch.numRows())(actualRowNum)
+        // every partition becomes null after being released
+        assert(ids.forall(subPartitioner.getBatchesByPartition(_) == null))
+        subPartitioner.close()
+      }
+    }
+  }
+
+  test("Sub-partitioner repartition because of highly skewed data") {
+    withGpuSparkSession { _ =>
+      // cudf aligns output to 64 bytes for contiguous split used by the sub partitioner, so
+      // generate a little large data for this test.
+      val largeData = (0 until 1000).map(_ => 1) ++ (0 until 24)
+      closeOnExcept {
+        val col = GpuColumnVector.from(ColumnVector.fromInts(largeData: _*), IntegerType)
+        new ColumnarBatch(Array(col), col.getRowCount.toInt)
+      } { nonemptyBatch =>
+        val subPartitioner = new GpuBatchSizeAwareSubPartitioner(Seq(nonemptyBatch).toIterator,
+          boundKeys, numPartitions = 7, targetBatchSize = 1024)
+        // try to repartition to 5 partitions ( 4 * 1024 / 1024 + 1), but
+        // still keep 7 partitions because 5 < 7
+        assertResult(expected = 7)(subPartitioner.partitionsCount)
+        // It should try 3 times (the maximum number allowed)
+        assertResult(expected = 3)(subPartitioner.getRetryCount)
         // nonempty batches exist
         assert(subPartitioner.batchesCount > 0)
         val ids = 0 until subPartitioner.partitionsCount


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/7911

This adds in the support of repartitioning the input data multiple times with different hash seeds to sub-partitioning when the initial partition number is not big enough to over partition data. It will also calculate the actual partition number needed for the over partitioning.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
