### PR TITLE
Handle caused-by retry exceptions in withRestoreOnRetry

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -230,13 +230,7 @@ object RmmRapidsRetryIterator extends Arm with Logging {
       case ex: Throwable =>
         // Only restore on retry exceptions
         val (topLevelIsRetry, _) = isRetryOrSplitAndRetry(ex)
-        val causedByRetry = topLevelIsRetry match {
-          case false =>
-            val (cbRetry, _) = causedByRetryOrSplit(ex)
-            cbRetry
-          case true => true
-        }
-        if (topLevelIsRetry || causedByRetry) {
+        if (topLevelIsRetry || causedByRetryOrSplit(ex)._1) {
           r.restore()
         }
         throw ex
@@ -263,13 +257,7 @@ object RmmRapidsRetryIterator extends Arm with Logging {
       case ex: Throwable =>
         // Only restore on retry exceptions
         val (topLevelIsRetry, _) = isRetryOrSplitAndRetry(ex)
-        val causedByRetry = topLevelIsRetry match {
-          case false =>
-            val (cbRetry, _) = causedByRetryOrSplit(ex)
-            cbRetry
-          case true => true
-        }
-        if (topLevelIsRetry || causedByRetry) {
+        if (topLevelIsRetry || causedByRetryOrSplit(ex)._1) {
           r.foreach(_.restore())
         }
         throw ex

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -181,6 +181,36 @@ object RmmRapidsRetryIterator extends Arm with Logging {
   }
 
   /**
+   * Returns a tuple of (shouldRetry, shouldSplit) depending the exception
+   * passed
+   */
+  private def isRetryOrSplitAndRetry(ex: Throwable): (Boolean, Boolean) = {
+    ex match {
+      case _: RetryOOM => (true, false)
+      case _: SplitAndRetryOOM => (true, true)
+      case _ => (false, false)
+    }
+  }
+
+  /**
+   * Returns a tuple of (causedByRetry, causedBySplit) depending the exception
+   * passed
+   */
+  private def causedByRetryOrSplit(ex: Throwable): (Boolean, Boolean) = {
+    var current = ex
+    var causedByRetry = false
+    var causedBySplit = false
+    // check if there is a hidden retry or split OOM
+    while (current != null && !causedByRetry) {
+      current = current.getCause()
+      val (isRetry, isSplit) = isRetryOrSplitAndRetry(current)
+      causedByRetry = isRetry
+      causedBySplit = causedBySplit || isSplit
+    }
+    (causedByRetry, causedBySplit)
+  }
+
+  /**
    * withRestoreOnRetry for CheckpointRestore. This helper function calls `fn` with no input and
    * returns the result. In the event of an OOM Retry exception, it calls the restore() method
    * of the input and then throws the oom exception.  This is intended to be used within the `fn`
@@ -197,12 +227,19 @@ object RmmRapidsRetryIterator extends Arm with Logging {
     try {
       fn
     } catch {
-      case t: RetryOOM =>
-        r.restore()
-        throw t
-      case t: SplitAndRetryOOM =>
-        r.restore()
-        throw t
+      case ex: Throwable =>
+        // Only restore on retry exceptions
+        val (topLevelIsRetry, _) = isRetryOrSplitAndRetry(ex)
+        val causedByRetry = topLevelIsRetry match {
+          case false =>
+            val (cbRetry, _) = causedByRetryOrSplit(ex)
+            cbRetry
+          case true => true
+        }
+        if (topLevelIsRetry || causedByRetry) {
+          r.restore()
+        }
+        throw ex
     }
   }
 
@@ -223,12 +260,19 @@ object RmmRapidsRetryIterator extends Arm with Logging {
     try {
       fn
     } catch {
-      case t: RetryOOM =>
-        r.foreach(_.restore())
-        throw t
-      case t: SplitAndRetryOOM =>
-        r.foreach(_.restore())
-        throw t
+      case ex: Throwable =>
+        // Only restore on retry exceptions
+        val (topLevelIsRetry, _) = isRetryOrSplitAndRetry(ex)
+        val causedByRetry = topLevelIsRetry match {
+          case false =>
+            val (cbRetry, _) = causedByRetryOrSplit(ex)
+            cbRetry
+          case true => true
+        }
+        if (topLevelIsRetry || causedByRetry) {
+          r.foreach(_.restore())
+        }
+        throw ex
     }
   }
 
@@ -470,18 +514,6 @@ object RmmRapidsRetryIterator extends Arm with Logging {
       }
     }
 
-    /**
-     * Returns a tuple of (shouldRetry, shouldSplit) depending the exception
-     * passed
-     */
-    private def isRetryOrSplitAndRetry(ex: Throwable): (Boolean, Boolean) = {
-      ex match {
-        case retryOOM: RetryOOM => (true, false)
-        case splitAndRetryOOM: SplitAndRetryOOM => (true, true)
-        case _ => (false, false)
-      }
-    }
-
     override def next(): K = {
       // this is set on the first exception, and we add suppressed if there are others
       // during the retry attempts
@@ -513,20 +545,15 @@ object RmmRapidsRetryIterator extends Arm with Logging {
         } catch {
           case ex: Throwable =>
             // handle a retry as the top-level exception
-            val (topLevelIsRetry, isSplitAndRetry) = isRetryOrSplitAndRetry(ex)
-            doSplit = isSplitAndRetry
+            val (topLevelIsRetry, topLevelIsSplit) = isRetryOrSplitAndRetry(ex)
+            doSplit = topLevelIsSplit
 
             // handle any retries that are wrapped in a different top-level exception
             var causedByRetry = false
             if (!topLevelIsRetry) {
-              var current = ex
-              // check if there is a hidden retry OOM
-              while (current != null && !causedByRetry) {
-                current = current.getCause()
-                val (isRetry, isSplit) = isRetryOrSplitAndRetry(current)
-                causedByRetry = isRetry
-                doSplit = doSplit || isSplit
-              }
+              val (cbRetry, cbSplit) = causedByRetryOrSplit(ex)
+              causedByRetry = cbRetry
+              doSplit = doSplit || cbSplit
             }
 
             clearInjectedOOMIfNeeded()


### PR DESCRIPTION
Closes #7971.

In `withRestoreOnRetry`, we should restore on exceptions that are caused by `RetryOOM` or `SplitAndRetryOOM`, in addition to checking the top-level exception.  This brings it in line with the handling in `RmmRapidsRetryIterator`.
This include a little refactoring to avoid some code duplication.