### PR TITLE
Fix leak where RapidsShuffleIterator for a completed task was kept alive

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -463,5 +463,10 @@ class RapidsShuffleClient(
   def unregisterPeerErrorListener(handler: RapidsShuffleFetchHandler): Unit = {
     logDebug(s"Unregister $handler from client for ${connection.getPeerExecutorId}")
     liveHandlers.remove(handler)
+    // Make sure we remove the handler from the transport as well, otherwise
+    // we could have a host memory leak: https://github.com/NVIDIA/spark-rapids/issues/7997
+    // At this stage this should not cancel any requests because the task should have
+    // completed, but it will also remove `handler` from internal tracking in `transport`.
+    transport.cancelPending(handler)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,7 +348,7 @@ trait RapidsShuffleTransport extends AutoCloseable {
 
   /**
    * Cancel requests that are waiting in the queue (not in-flight) for a specific
-   * handler
+   * handler (if any), and unregister the handler.
    */
   def cancelPending(handler: RapidsShuffleFetchHandler): Unit
 


### PR DESCRIPTION
Relates to https://github.com/NVIDIA/spark-rapids/issues/7997.

This isn't closing #7997 yet as I am not 100% sure if this is the only host memory leak, but it is a bad one.

What is happening here is we getting OOM killed by yarn because an executor used more memory than allowed. When running heap `UCXShuffleTransport` class even after tasks complete, which is a bug. 

Because of this leak, the task's `TaskMemoryManager` is kept alive and it is keeping a pageTable of `org.apache.spark.unsafe.memory.MemoryBlock` alive with it, which depending on the tungsten allocation mode could be on heap or off heap. In this case it looks like we are using on heap. I saw it go up to 400MB in a heap dump. That said, I also see the collection within `UCXShuffleTransport` balloon all the way to 1.3GB worth of _retained_ memory. This is not a small leak by any means.

So this removes the handlers as tasks complete and I verified it fixes the leak locally. Note that the same is done when tasks fail and need to cancel UCX requests.