### PR TITLE
Fix regexp_replace integration test that should fallback when unicode is disabled

### DIFF
--- a/integration_tests/src/main/python/regexp_no_unicode_test.py
+++ b/integration_tests/src/main/python/regexp_no_unicode_test.py
@@ -35,7 +35,7 @@ def test_rlike_no_unicode_fallback():
     gen = mk_str_gen('[abcd]{1,3}')
     assert_gpu_fallback_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
-            'a rlike "ab"'),
+            'a rlike "ab+"'),
         'RLike',
         conf=_regexp_conf)
 
@@ -44,7 +44,7 @@ def test_re_replace_no_unicode_fallback():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
     assert_gpu_fallback_collect(
         lambda spark: unary_op_df(spark, gen).selectExpr(
-            'REGEXP_REPLACE(a, "TEST", "PROD")'),
+            'REGEXP_REPLACE(a, "[A-Z]+", "PROD")'),
         'RegExpReplace',
         conf=_regexp_conf)
 


### PR DESCRIPTION
Fixes #8030.

In #7967, one integration test did not get updated when the regexp_replace code was updated to support underlying stringReplace even when the charset is not UTF-8 (the plugin defaults to allowing for non-regexp optimizations even when the charset is not UTF-8 and/or regexp is disabled). This test is now updated.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
