### PR TITLE
Enable line/string anchors in choice

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -517,6 +517,19 @@ def test_character_classes():
             ),
         conf=_regexp_conf)
 
+def test_regexp_choice():
+    gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'rlike(a, "[abcd]|[123]")',
+                'rlike(a, "[^\n\r]|abcd")',
+                'rlike(a, "abd1a$|^ab2a")',
+                'regexp_extract(a, "(abc1a$|^ab2ab|a3abc)", 1)',
+                'regexp_extract(a, "(abc1a$|ab2ab$)", 1)',
+                'regexp_replace(a, "[abcd]$|^abc", "@")'
+            ),
+        conf=_regexp_conf)
+
 def test_regexp_hexadecimal_digits():
     gen = mk_str_gen(
         '[abcd]\\\\x00\\\\x7f\\\\x80\\\\xff\\\\x{10ffff}\\\\x{00eeee}[\\\\xa0-\\\\xb0][abcd]')

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1506,18 +1506,6 @@ class CudfRegexTranspiler(mode: RegexMode) {
             "cuDF does not support repetition on one side of a choice", r.position)
         }
 
-        // cuDF does not support terms ending with line anchors on one side
-        // of a choice, such as "^|$"
-        if (endsWithLineAnchor(ll)) {
-          throw new RegexUnsupportedException(
-            "cuDF does not support terms ending with line anchors on one side of a choice",
-            l.position)
-        } else if (endsWithLineAnchor(rr)) {
-          throw new RegexUnsupportedException(
-            "cuDF does not support terms ending with line anchors on one side of a choice",
-            r.position)
-        }
-
         // cuDF does not support terms ending with word boundaries on one side
         // of a choice, such as "\\b|a"
         if (endsWithWordBoundary(ll)) {
@@ -1650,7 +1638,7 @@ class CudfRegexTranspiler(mode: RegexMode) {
     case RegexRepetition(term, _) => isBeginOrEndLineAnchor(term)
     case RegexChar(ch) => ch == '^' || ch == '$'
     case RegexEscaped(ch) if "zZ".contains(ch) => true // \z gets translated to $
-    case RegexEscaped(ch) if 'A' == ch && mode == RegexSplitMode => true 
+    case RegexEscaped(ch) if 'A' == ch => true 
     case _ => false
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -239,14 +239,13 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   test("string anchor on one side of choice") {
     val patterns = Seq("a$|b", "^a|b", "\\Aa|b", "a\\Z|\\Ab")
     assertCpuGpuMatchesRegexpFind(patterns, Seq("", "testb", "atest", "testa",
-      "\ntesta", "btesta\n", "\ntestab\n"))
+      "\ntesta", "btesta\n", "\ntestab\n", "testa\r", "btesta\r\n"))
   }
 
   test("string anchor on both sides of choice") {
     val patterns = Seq("a$|b$", "^a|a$", "^a|b$", "\\Aa|a\\Z", "\\Aa|b\\Z")
-    //  val patterns = Seq(",\u000b\u000b$$|,\u000bz\f", "1|2$$", "a$\\Z|b", "a|b^^")
     assertCpuGpuMatchesRegexpFind(patterns, Seq("", "testb", "atest", "testa",
-      "\ntesta", "btesta\n", "\ntestab\n"))
+      "\ntesta", "btesta\n", "\ntestab\n", "testa\r", "btesta\r\n"))
   }
 
   test("string anchor \\A will fall back to CPU in some repetitions") {
@@ -530,37 +529,37 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
   test("line anchor find - unicode line separators 0085") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u0085", "aTEST\u0085\n", "aTEST\n\u0085")
-    assertCpuGpuMatchesRegexpFind(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpFind(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("line anchor find - unicode line separators 2028") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u2028", "aTEST\u2028\n", "aTEST\n\u2028")
-    assertCpuGpuMatchesRegexpFind(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpFind(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("line anchor find - unicode line separators 2029") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u2029", "aTEST\u2029\n", "aTEST\n\u2029")
-    assertCpuGpuMatchesRegexpFind(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpFind(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("line anchor replace - unicode line separators 0085") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u0085", "aTEST\u0085\n", "aTEST\n\u0085")
-    assertCpuGpuMatchesRegexpReplace(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpReplace(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("line anchor replace - unicode line separators 2028") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u2028", "aTEST\u2028\n", "aTEST\n\u2028")
-    assertCpuGpuMatchesRegexpReplace(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpReplace(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("line anchor replace - unicode line separators 2029") {
     assume(false, "https://github.com/NVIDIA/spark-rapids/issues/7585")
     val inputs = Seq("aTEST\u2029", "aTEST\u2029\n", "aTEST\n\u2029")
-    assertCpuGpuMatchesRegexpReplace(Seq("TEST$"), inputs)
+    assertCpuGpuMatchesRegexpReplace(Seq("TEST$", "^a|T$"), inputs)
   }
 
   test("cuDF does not support some uses of line anchors in regexp_replace") {


### PR DESCRIPTION
Fixes #6882.

This enables support for line and string anchors in regular expression choice syntax (e.g. `a$|^b`). This cleans up the unit tests for support this new feature, and adds an integration test for regular expression choice.  

In this case, many of the checks were removed, and the functionality had started working. This most likely became possible due to the work done in https://github.com/rapidsai/cudf/pull/11654 to fix choice and https://github.com/rapidsai/cudf/pull/12181 to fix EOL anchors. Issue #7585 remains unresolved.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
