### PR TITLE
MINOR: Improve assertion error in assert_py4j_exception

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -613,7 +613,7 @@ def assert_py4j_exception(func, error_message):
     with pytest.raises(Py4JJavaError) as py4jError:
         func()
     actual_error = str(py4jError.value.java_exception)
-    assert error_message in actual_error, f"Expected error '{error_message}'' did not appear in '{actual_error}'"
+    assert error_message in actual_error, f"Expected error '{error_message}' did not appear in '{actual_error}'"
 
 def assert_gpu_and_cpu_error(df_fun, conf, error_message):
     """

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -612,7 +612,8 @@ def assert_py4j_exception(func, error_message):
     """
     with pytest.raises(Py4JJavaError) as py4jError:
         func()
-    assert error_message in str(py4jError.value.java_exception)
+    actual_error = str(py4jError.value.java_exception)
+    assert error_message in actual_error, f"Expected error '{error_message}'' did not appear in '{actual_error}'"
 
 def assert_gpu_and_cpu_error(df_fun, conf, error_message):
     """


### PR DESCRIPTION
This is a small improvement to show a detailed error message if an integration test fails due to an exception not matching the expected exception, making it easier to debug a failure by looking at existing logs rather than adding debug print statements and running again.

## Before

```
E       AssertionError
```

## After

```
E       AssertionError: Expected error 'Found duplicante field(s)' did not appear in 'org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 5.0 failed 1 times, most recent failure: Lost task 0.0 in stage 5.0 (TID 11) (192.168.0.80 executor driver): java.lang.RuntimeException:  Found duplicate field(s) "1": [a, rand2] in id mapping mode 
```