### PR TITLE
Fix loading extra jar [databricks]

### DIFF
--- a/api_validation/src/main/scala/com/nvidia/spark/rapids/api/ApiValidation.scala
+++ b/api_validation/src/main/scala/com/nvidia/spark/rapids/api/ApiValidation.scala
@@ -101,7 +101,7 @@ object ApiValidation extends Logging {
         }
 
         // TODO: Add error handling if Type is not present
-        val gpuTypes = classToTypeTag(ShimLoader.loadClass(gpu))
+        val gpuTypes = classToTypeTag(ShimReflectionUtils.loadClass(gpu))
 
         val sparkToGpuExecMap = Map(
           "org.apache.spark.sql.catalyst.expressions.Expression" ->

--- a/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
+++ b/delta-lake/common/src/main/delta-io/scala/com/nvidia/spark/rapids/delta/DeltaIOProvider.scala
@@ -86,7 +86,7 @@ class DeltaProbeImpl extends DeltaProbe {
   override def getDeltaProvider: DeltaProvider = {
     val cpuClassName = "org.apache.spark.sql.delta.sources.DeltaDataSource"
     val hasDeltaJar = UnshimmedTrampolineUtil.classIsLoadable(cpuClassName) &&
-        Try(ShimLoader.loadClass(cpuClassName)).isSuccess
+        Try(ShimReflectionUtils.loadClass(cpuClassName)).isSuccess
     if (hasDeltaJar) {
       DeltaRuntimeShim.getDeltaProvider
     } else {

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShim.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShim.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.rapids
 
 import scala.util.Try
 
-import com.nvidia.spark.rapids.{RapidsConf, ShimLoader, VersionUtils}
+import com.nvidia.spark.rapids.{RapidsConf, ShimReflectionUtils, VersionUtils}
 import com.nvidia.spark.rapids.delta.DeltaProvider
 
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
@@ -52,7 +52,7 @@ object DeltaRuntimeShim {
 
   private lazy val shimInstance = {
     val shimClassName = getShimClassName
-    val shimClass = ShimLoader.loadClass(shimClassName)
+    val shimClass = ShimReflectionUtils.loadClass(shimClassName)
     shimClass.getConstructor().newInstance().asInstanceOf[DeltaRuntimeShim]
   }
 

--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -25,6 +25,7 @@ com/nvidia/spark/rapids/ShimVersion*
 com/nvidia/spark/rapids/SparkShimServiceProvider*
 com/nvidia/spark/rapids/SparkShimVersion*
 com/nvidia/spark/rapids/SparkShims*
+com/nvidia/spark/rapids/optimizer/SQLOptimizerPlugin*
 com/nvidia/spark/udf/Plugin*
 org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback*
 org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase*

--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -21,6 +21,7 @@ com/nvidia/spark/rapids/RapidsExecutorUpdateMsg*
 com/nvidia/spark/rapids/RapidsShuffleHeartbeatHandler*
 com/nvidia/spark/rapids/SQLExecPlugin*
 com/nvidia/spark/rapids/ShimLoader*
+com/nvidia/spark/rapids/ShimReflectionUtils*
 com/nvidia/spark/rapids/ShimVersion*
 com/nvidia/spark/rapids/SparkShimServiceProvider*
 com/nvidia/spark/rapids/SparkShimVersion*

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKryoRegistrator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKryoRegistrator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ class GpuKryoRegistrator extends KryoRegistrator {
       "org.apache.spark.sql.rapids.execution.SerializeConcatHostBuffersDeserializeBatch",
       "org.apache.spark.sql.rapids.execution.SerializeBatchDeserializeHostBuffer")
     allClassesToRegister.foreach { classToRegister =>
-      kryo.register(ShimLoader.loadClass(classToRegister), new KryoJavaSerializer())
+      kryo.register(ShimReflectionUtils.loadClass(classToRegister), new KryoJavaSerializer())
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -41,7 +41,7 @@ object HostColumnarToGpu extends Logging {
 
   // use reflection to get access to a private field in a class
   private def getClassFieldAccessible(className: String, fieldName: String) = {
-    val classObj = ShimLoader.loadClass(className)
+    val classObj = ShimReflectionUtils.loadClass(className)
     val fields = classObj.getDeclaredFields.toList
     val field = fields.filter( x => {
       x.getName.contains(fieldName)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PlanUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PlanUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ object PlanUtils {
     val execNameWithoutPackage = getBaseNameFromClass(planClass.getName)
     execNameWithoutPackage == fallbackCpuClass ||
       plan.getClass.getName == fallbackCpuClass ||
-      Try(ShimLoader.loadClass(fallbackCpuClass))
+      Try(ShimReflectionUtils.loadClass(fallbackCpuClass))
         .map(_.isAssignableFrom(planClass))
         .getOrElse(false)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -271,7 +271,8 @@ object ShimLoader extends Logging {
           ret
         }.getOrElse(shimClassLoader.loadClass(shimServiceProviderStr))
         Option(
-          (ShimReflectionUtils.instantiateClass(shimClass).asInstanceOf[SparkShimServiceProvider], shimURL)
+          (ShimReflectionUtils.instantiateClass(shimClass).asInstanceOf[SparkShimServiceProvider],
+            shimURL)
         )
       } catch {
         case cnf: ClassNotFoundException =>
@@ -368,7 +369,8 @@ object ShimLoader extends Logging {
   }
 
   def newInternalExclusiveModeGpuDiscoveryPlugin(): ResourceDiscoveryPlugin = {
-    ShimReflectionUtils.newInstanceOf("com.nvidia.spark.rapids.InternalExclusiveModeGpuDiscoveryPlugin")
+    ShimReflectionUtils.
+      newInstanceOf("com.nvidia.spark.rapids.InternalExclusiveModeGpuDiscoveryPlugin")
   }
 
   def newParquetCachedBatchSerializer(): GpuCachedBatchSerializer = {
@@ -376,7 +378,8 @@ object ShimLoader extends Logging {
   }
 
   def loadColumnarRDD(): Class[_] = {
-    ShimReflectionUtils.loadClass("org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter")
+    ShimReflectionUtils.
+      loadClass("org.apache.spark.sql.rapids.execution.InternalColumnarRddConverter")
   }
 
   def newExplainPlan(): ExplainPlanBase = {
@@ -384,7 +387,8 @@ object ShimLoader extends Logging {
   }
 
   def newHiveProvider(): HiveProvider= {
-    ShimReflectionUtils.newInstanceOf[HiveProvider]("org.apache.spark.sql.hive.rapids.HiveProviderImpl")
+    ShimReflectionUtils.
+      newInstanceOf[HiveProvider]("org.apache.spark.sql.hive.rapids.HiveProviderImpl")
   }
 
   def newAvroProvider(): AvroProvider = ShimReflectionUtils.newInstanceOf[AvroProvider](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimReflectionUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimReflectionUtils.scala
@@ -18,6 +18,11 @@ package com.nvidia.spark.rapids
 
 import org.apache.spark.internal.Logging
 
+/*
+ * This is specifically for functions dealing with loading classes via reflection. This
+ * class itself should not contain or import any shimmed/parallel world classes so that
+ * it can also be called via reflection, like calling getMethod on ShimReflectionUtils.
+ */
 object ShimReflectionUtils extends Logging {
 
   def loadClass(className: String): Class[_] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimReflectionUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimReflectionUtils.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.internal.Logging
+
+object ShimReflectionUtils extends Logging {
+
+  def loadClass(className: String): Class[_] = {
+    val loader = ShimLoader.getShimClassLoader()
+    logDebug(s"Loading $className using $loader with the parent loader ${loader.getParent}")
+    loader.loadClass(className)
+  }
+
+  def newInstanceOf[T](className: String): T = {
+    instantiateClass(ShimReflectionUtils.loadClass(className)).asInstanceOf[T]
+  }
+
+  // avoid cached constructors
+  def instantiateClass[T](cls: Class[T]): T = {
+    logDebug(s"Instantiate ${cls.getName} using classloader " + cls.getClassLoader)
+    cls.getClassLoader match {
+      case urcCl: java.net.URLClassLoader =>
+        logDebug("urls " + urcCl.getURLs.mkString("\n"))
+      case _ =>
+    }
+    val constructor = cls.getConstructor()
+    constructor.newInstance()
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.iceberg
 import scala.reflect.ClassTag
 import scala.util.{Failure, Try}
 
-import com.nvidia.spark.rapids.{FileFormatChecks, IcebergFormatType, RapidsConf, ReadFileOp, ScanMeta, ScanRule, ShimLoader, ShimReflectionUtils}
+import com.nvidia.spark.rapids.{FileFormatChecks, IcebergFormatType, RapidsConf, ReadFileOp, ScanMeta, ScanRule, ShimReflectionUtils}
 import com.nvidia.spark.rapids.iceberg.spark.source.GpuSparkBatchQueryScan
 
 import org.apache.spark.sql.connector.read.Scan

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids.iceberg
 import scala.reflect.ClassTag
 import scala.util.{Failure, Try}
 
-import com.nvidia.spark.rapids.{FileFormatChecks, IcebergFormatType, RapidsConf, ReadFileOp, ScanMeta, ScanRule, ShimLoader}
+import com.nvidia.spark.rapids.{FileFormatChecks, IcebergFormatType, RapidsConf, ReadFileOp, ScanMeta, ScanRule, ShimLoader, ShimReflectionUtils}
 import com.nvidia.spark.rapids.iceberg.spark.source.GpuSparkBatchQueryScan
 
 import org.apache.spark.sql.connector.read.Scan
@@ -28,7 +28,7 @@ class IcebergProviderImpl extends IcebergProvider {
   override def isSupportedScan(scan: Scan): Boolean = scan.isInstanceOf[GpuSparkBatchQueryScan]
 
   override def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = {
-    val cpuIcebergScanClass = ShimLoader.loadClass(IcebergProvider.cpuScanClassName)
+    val cpuIcebergScanClass = ShimReflectionUtils.loadClass(IcebergProvider.cpuScanClassName)
     Seq(new ScanRule[Scan](
       (a, conf, p, r) => new ScanMeta[Scan](a, conf, p, r) {
         private lazy val convertedScan: Try[GpuSparkBatchQueryScan] = Try {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 import ai.rapids.cudf.{MemoryBuffer, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{RapidsConf, ShimLoader, ShimReflectionUtils}
+import com.nvidia.spark.rapids.{RapidsConf, ShimReflectionUtils}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.storage.RapidsStorageUtils

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 import ai.rapids.cudf.{MemoryBuffer, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{RapidsConf, ShimLoader}
+import com.nvidia.spark.rapids.{RapidsConf, ShimLoader, ShimReflectionUtils}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.rapids.storage.RapidsStorageUtils
@@ -560,7 +560,7 @@ object RapidsShuffleTransport extends Logging {
   def makeTransport(shuffleServerId: BlockManagerId,
                     rapidsConf: RapidsConf): RapidsShuffleTransport = {
     val transportClass = try {
-      ShimLoader.loadClass(rapidsConf.shuffleTransportClassName)
+      ShimReflectionUtils.loadClass(rapidsConf.shuffleTransportClassName)
     } catch {
       case classNotFoundException: ClassNotFoundException =>
         logError(s"Unable to find RapidsShuffleTransport class " +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveOverrides.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveOverrides.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.hive.rapids
 
-import com.nvidia.spark.rapids.{DataWritingCommandRule, ExecRule, ExprRule, HiveProvider, RunnableCommandRule, ShimLoader}
+import com.nvidia.spark.rapids.{DataWritingCommandRule, ExecRule, ExprRule, HiveProvider, RunnableCommandRule, ShimLoader, ShimReflectionUtils}
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.SparkPlan
@@ -25,8 +25,8 @@ import org.apache.spark.sql.execution.command.{DataWritingCommand, RunnableComma
 object GpuHiveOverrides {
   val isSparkHiveAvailable: Boolean = {
     try {
-      ShimLoader.loadClass("org.apache.spark.sql.hive.HiveSessionStateBuilder")
-      ShimLoader.loadClass("org.apache.hadoop.hive.conf.HiveConf")
+      ShimReflectionUtils.loadClass("org.apache.spark.sql.hive.HiveSessionStateBuilder")
+      ShimReflectionUtils.loadClass("org.apache.hadoop.hive.conf.HiveConf")
       true
     } catch {
       case _: ClassNotFoundException | _: NoClassDefFoundError => false

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
@@ -43,7 +43,7 @@ object ExternalSource extends Logging {
     /** spark-avro is an optional package for Spark, so the RAPIDS Accelerator
      * must run successfully without it. */
     Utils.classIsLoadable(avroScanClassName) && {
-      Try(ShimLoader.loadClass(avroScanClassName)).map(_ => true)
+      Try(ShimReflectionUtils.loadClass(avroScanClassName)).map(_ => true)
         .getOrElse {
           logWarning("Avro library not found by the RAPIDS plugin. The Plugin jars are " +
               "likely deployed using a static classpath spark.driver/executor.extraClassPath. " +
@@ -57,7 +57,7 @@ object ExternalSource extends Logging {
 
   private lazy val hasIcebergJar = {
     Utils.classIsLoadable(IcebergProvider.cpuScanClassName) &&
-        Try(ShimLoader.loadClass(IcebergProvider.cpuScanClassName)).isSuccess
+        Try(ShimReflectionUtils.loadClass(IcebergProvider.cpuScanClassName)).isSuccess
   }
 
   private lazy val icebergProvider = IcebergProvider()

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.zorder
 
-import com.nvidia.spark.rapids.{ExprChecks, ExprMeta, ExprRule, GpuExpression, GpuRangePartitioner, GpuSorter, RepeatingParamCheck, ShimLoader, TypeSig, UnaryExprMeta}
+import com.nvidia.spark.rapids.{ExprChecks, ExprMeta, ExprRule, GpuExpression, GpuRangePartitioner, GpuSorter, RepeatingParamCheck, ShimLoader, ShimReflectionUtils, TypeSig, UnaryExprMeta}
 import com.nvidia.spark.rapids.GpuOverrides.{expr, pluginSupportedOrderableSig}
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -88,7 +88,7 @@ object ZOrderRules {
   def openSourceExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     try {
       val interleaveClazz =
-        ShimLoader.loadClass("org.apache.spark.sql.delta.expressions.InterleaveBits")
+        ShimReflectionUtils.loadClass("org.apache.spark.sql.delta.expressions.InterleaveBits")
             .asInstanceOf[Class[Expression]]
       val interleaveRule = expr[Expression](
         "Interleave bit as a part of deltalake zorder",
@@ -105,7 +105,7 @@ object ZOrderRules {
         })
 
       val partExprClass =
-        ShimLoader.loadClass("org.apache.spark.sql.delta.expressions.PartitionerExpr")
+        ShimReflectionUtils.loadClass("org.apache.spark.sql.delta.expressions.PartitionerExpr")
             .asInstanceOf[Class[Expression]]
       val partRule = partExprRule(partExprClass)
 
@@ -120,7 +120,7 @@ object ZOrderRules {
   def databricksExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     try {
       val hilbertClazz =
-        ShimLoader.loadClass("com.databricks.sql.expressions.HilbertLongIndex")
+        ShimReflectionUtils.loadClass("com.databricks.sql.expressions.HilbertLongIndex")
             .asInstanceOf[Class[Expression]]
       val hilbertRule = expr[Expression](
         "Hilbert long index as a part of Databrick's deltalake zorder",
@@ -141,7 +141,7 @@ object ZOrderRules {
         })
 
       val partExprClass =
-        ShimLoader.loadClass("com.databricks.sql.expressions.PartitionerExpr")
+        ShimReflectionUtils.loadClass("com.databricks.sql.expressions.PartitionerExpr")
             .asInstanceOf[Class[Expression]]
       val partRule = partExprRule(partExprClass)
       Map(hilbertClazz -> hilbertRule,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids.zorder
 
-import com.nvidia.spark.rapids.{ExprChecks, ExprMeta, ExprRule, GpuExpression, GpuRangePartitioner, GpuSorter, RepeatingParamCheck, ShimLoader, ShimReflectionUtils, TypeSig, UnaryExprMeta}
+import com.nvidia.spark.rapids.{ExprChecks, ExprMeta, ExprRule, GpuExpression, GpuRangePartitioner, GpuSorter, RepeatingParamCheck, ShimReflectionUtils, TypeSig, UnaryExprMeta}
 import com.nvidia.spark.rapids.GpuOverrides.{expr, pluginSupportedOrderableSig}
 
 import org.apache.spark.sql.catalyst.InternalRow


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/8067

We have to unshim com/nvidia/spark/rapids/optimizer/SQLOptimizerPlugin because its used by the spark sql extensions and here we have to move some functions out of ShimLoader in order to allow calling ShimLoader.newInstanceOf via reflection.  If we don't move those functions out and ShimLoader.newInstanceOf is called via reflection without the classloader having been modified then the reflection getMethod call will fail to load classes like com.nvidia.spark.rapids.Optimizer, which are in the parallel world jar layout.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
