### PR TITLE
Fixes closed RapidsShuffleHandleImpl leak in ShuffleBufferCatalog

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -177,7 +177,7 @@ class ShuffleBufferCatalog(
         // NOTE: Not synchronizing array buffer because this shuffle should be inactive.
         bufferIds.foreach { id =>
           tableMap.remove(id.tableId)
-          bufferIdToHandle.get(id).close()
+          bufferIdToHandle.remove(id).close()
         }
       }
       info.blockMap.forEachValue(Long.MaxValue, bufferRemover)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7997

Investigating whether all leaks were gone from the shuffle issue (https://github.com/NVIDIA/spark-rapids/issues/7997) I found a heap leak that is pretty small (it's a closed handle) but it's nonetheless a leak from our stuff.

With this fix, I do not see any other leaks from the shuffle plugin.