### PR TITLE
Update some integration tests so that they are compatible with Spark 3.4.0

### DIFF
--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -473,20 +473,8 @@ def test_input_meta_fallback(spark_tmp_path, v1_enabled_list, disable_conf):
                         'input_file_block_length()'),
             conf=updated_conf)
 
-@allow_non_gpu('DataWritingCommandExec')
-@pytest.mark.skipif(is_spark_340_or_later(), reason='Plan changes in 340')
-def test_csv_save_as_table_fallback(spark_tmp_path, spark_tmp_table_factory):
-    gen = TimestampGen()
-    data_path = spark_tmp_path + '/CSV_DATA'
-    assert_gpu_fallback_write(
-            lambda spark, path: unary_op_df(spark, gen).coalesce(1).write.format("csv").mode('overwrite').option("path", path).saveAsTable(spark_tmp_table_factory.get()),
-            lambda spark, path: spark.read.csv(path),
-            data_path,
-            'DataWritingCommandExec')
-
 @allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
-@pytest.mark.skipif(is_before_spark_340(), reason='Plan changes in 340')
-def test_csv_save_as_table_fallback_340(spark_tmp_path, spark_tmp_table_factory):
+def test_csv_save_as_table_fallback(spark_tmp_path, spark_tmp_table_factory):
     gen = TimestampGen()
     data_path = spark_tmp_path + '/CSV_DATA'
     assert_gpu_fallback_write(

--- a/integration_tests/src/main/python/datasourcev2_write_test.py
+++ b/integration_tests/src/main/python/datasourcev2_write_test.py
@@ -20,7 +20,7 @@ from pyspark.sql.types import *
 from spark_session import is_hive_available, is_spark_330_or_later, with_cpu_session
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.skipif(not (is_hive_available() and is_spark_330_or_later()), reason="Must have Hive on Spark 3.3+")
 @pytest.mark.parametrize('fileFormat', ['parquet', 'orc'])
 def test_write_hive_bucketed_table_fallback(spark_tmp_table_factory, fileFormat):

--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -78,7 +78,7 @@ def test_optimized_hive_ctas_basic(gens, storage, spark_tmp_table_factory):
         conf["spark.sql.orc.impl"] = "hive"
     assert_gpu_and_cpu_sql_writes_are_equal_collect(spark_tmp_table_factory, do_write, conf=conf)
 
-@allow_non_gpu("DataWritingCommandExec")
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage_with_confs", [
@@ -99,7 +99,7 @@ def test_optimized_hive_ctas_configs_fallback(gens, storage_with_confs, spark_tm
             spark_tmp_table_factory.get(), storage, data_table)),
         "DataWritingCommandExec", conf=confs)
 
-@allow_non_gpu("DataWritingCommandExec")
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.skipif(not is_hive_available(), reason="Hive is missing")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
 @pytest.mark.parametrize("storage_with_opts", [
@@ -117,7 +117,7 @@ def test_optimized_hive_ctas_options_fallback(gens, storage_with_opts, spark_tmp
             spark_tmp_table_factory.get(), opts_string, storage, data_table)),
         "DataWritingCommandExec")
 
-@allow_non_gpu("DataWritingCommandExec")
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.skipif(not (is_hive_available() and is_spark_33X()),
                     reason="Requires Hive and Spark 3.3.X to write bucketed Hive tables")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)

--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -598,7 +598,7 @@ def test_broadcast_join_mixed(join_type):
     assert_gpu_and_cpu_are_equal_collect(do_join)
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.xfail(condition=is_emr_runtime(),
     reason='https://github.com/NVIDIA/spark-rapids/issues/821')
 @pytest.mark.parametrize('repartition', ["true", "false"], ids=idfn)

--- a/integration_tests/src/main/python/orc_write_test.py
+++ b/integration_tests/src/main/python/orc_write_test.py
@@ -165,7 +165,7 @@ def test_write_sql_save_table(spark_tmp_path, orc_gens, ts_type, orc_impl, spark
             data_path,
             conf={'spark.sql.orc.impl': orc_impl, 'spark.rapids.sql.format.orc.write.enabled': True})
 
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize('codec', ['zlib', 'lzo'])
 def test_orc_write_compression_fallback(spark_tmp_path, codec, spark_tmp_table_factory):
     gen = TimestampGen()
@@ -179,7 +179,7 @@ def test_orc_write_compression_fallback(spark_tmp_path, codec, spark_tmp_table_f
             conf=all_confs)
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/ORC_DATA'
     assert_gpu_fallback_write(
@@ -191,7 +191,7 @@ def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
 
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_orc_write_bloom_filter_with_options_cpu_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/ORC_DATA'
     assert_gpu_fallback_write(
@@ -203,7 +203,7 @@ def test_orc_write_bloom_filter_with_options_cpu_fallback(spark_tmp_path, spark_
 
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_orc_write_bloom_filter_sql_cpu_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/ORC_DATA'
     base_table_name = spark_tmp_table_factory.get()

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -700,7 +700,7 @@ def createBucketedTableAndJoin(spark, tbl_1, tbl_2):
     return bucketed_4_10e4.join(bucketed_4_10e6, "id")
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize('reader_confs', reader_opt_confs)
 @pytest.mark.parametrize('v1_enabled_list', ["", "parquet"])
 # this test would be better if we could ensure exchanges didn't exist - ie used buckets

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -296,7 +296,7 @@ def test_ts_write_twice_fails_exception(spark_tmp_path, spark_tmp_table_factory)
     with_gpu_session(
             lambda spark : writeParquetNoOverwriteCatchException(spark, unary_op_df(spark, gen), data_path, table_name))
 
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize('ts_write', parquet_ts_write_options)
 @pytest.mark.parametrize('ts_rebase', ['LEGACY'])
 def test_parquet_write_legacy_fallback(spark_tmp_path, ts_write, ts_rebase, spark_tmp_table_factory):
@@ -312,7 +312,7 @@ def test_parquet_write_legacy_fallback(spark_tmp_path, ts_write, ts_rebase, spar
             'DataWritingCommandExec',
             conf=all_confs)
 
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize('write_options', [{"parquet.encryption.footer.key": "k1"},
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
@@ -330,7 +330,7 @@ def test_parquet_write_encryption_option_fallback(spark_tmp_path, spark_tmp_tabl
         data_path,
         'DataWritingCommandExec')
 
-@allow_non_gpu("DataWritingCommandExec")
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize("write_options", [{"parquet.encryption.footer.key": "k1"},
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
@@ -344,7 +344,7 @@ def test_parquet_write_encryption_runtimeconfig_fallback(spark_tmp_path, write_o
         "DataWritingCommandExec",
         conf=write_options)
 
-@allow_non_gpu("DataWritingCommandExec")
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 @pytest.mark.parametrize("write_options", [{"parquet.encryption.footer.key": "k1"},
                                            {"parquet.encryption.column.keys": "k2:a"},
                                            {"parquet.encryption.footer.key": "k1", "parquet.encryption.column.keys": "k2:a"}])
@@ -367,7 +367,7 @@ def test_parquet_write_encryption_hadoopconfig_fallback(spark_tmp_path, write_op
     finally:
         with_cpu_session(reset_hadoop_confs)
 
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 # note that others should fail as well but requires you to load the libraries for them
 # 'lzo', 'brotli', 'lz4', 'zstd' should all fallback
 @pytest.mark.parametrize('codec', ['gzip'])
@@ -382,7 +382,7 @@ def test_parquet_write_compression_fallback(spark_tmp_path, codec, spark_tmp_tab
             'DataWritingCommandExec',
             conf=all_confs)
 
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_parquet_writeLegacyFormat_fallback(spark_tmp_path, spark_tmp_table_factory):
     gen = IntegerGen()
     data_path = spark_tmp_path + '/PARQUET_DATA'
@@ -395,7 +395,7 @@ def test_parquet_writeLegacyFormat_fallback(spark_tmp_path, spark_tmp_table_fact
             conf=all_confs)
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_fallback_write(
@@ -406,7 +406,7 @@ def test_buckets_write_fallback(spark_tmp_path, spark_tmp_table_factory):
 
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_parquet_write_bloom_filter_with_options_cpu_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     assert_gpu_fallback_write(
@@ -419,7 +419,7 @@ def test_parquet_write_bloom_filter_with_options_cpu_fallback(spark_tmp_path, sp
 
 
 @ignore_order
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec,ExecutedCommandExec,WriteFilesExec')
 def test_parquet_write_bloom_filter_sql_cpu_fallback(spark_tmp_path, spark_tmp_table_factory):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     base_table_name = spark_tmp_table_factory.get()


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8012 but note that the issue originally reported that tests were failing due to `CreateDataSourceTableAsSelectCommand` not being supported and prior to this PR they are now failing with `Part of the plan is not columnar class org.apache.spark.sql.execution.command.ExecutedCommandExec`.

For these fallback tests to pass with Spark 3.4.0 we have to add `ExecutedCommandExec` and `WriteFilesExec` to the list of operators in the `allow_non_gpu` annotation.