### PR TITLE
Temporarily skip `test_parquet_read_nano_as_longs_31x` on dataproc

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -25,7 +25,7 @@ from pyspark.sql.types import *
 from pyspark.sql.functions import *
 from spark_init_internal import spark_version
 from spark_session import with_cpu_session, with_gpu_session, is_before_spark_320, is_before_spark_330, is_spark_321cdh
-from conftest import is_databricks_runtime
+from conftest import is_databricks_runtime, is_dataproc_runtime
 
 
 def read_parquet_df(data_path):
@@ -781,6 +781,7 @@ def test_spark_32639(std_input_path):
         conf=original_parquet_file_reader_conf)
 
 @pytest.mark.skipif(not is_before_spark_320(), reason='Spark 3.1.x does not need special handling')
+@pytest.mark.skipif(is_dataproc_runtime(), reason='https://github.com/NVIDIA/spark-rapids/issues/8074')
 def test_parquet_read_nano_as_longs_31x(std_input_path):
     data_path = "%s/timestamp-nanos.parquet" % (std_input_path)
     # we correctly return timestamp_micros when running against Spark 3.1.x


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/8074

Temporarily skip `test_parquet_read_nano_as_longs_31x` on dataproc to unblock the nightly build.