### PR TITLE
Re-enable empty repetition near end-of-line anchor for rlike, regexp_extract and regexp_replace

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -427,21 +427,23 @@ def test_regexp_extract():
                 'regexp_extract(a, "([0-9]+)", 1)',
                 'regexp_extract(a, "([0-9])([abcd]+)", 1)',
                 'regexp_extract(a, "([0-9])([abcd]+)", 2)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 1)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 2)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)\\z", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)$", 1)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)$", 2)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)([a-d]*)$", 3)',
                 'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)", 3)',
-                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)", 3)'),
+                'regexp_extract(a, "^([a-d]*)([0-9]*)\\\\/([a-d]*)$", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)", 3)',
+                'regexp_extract(a, "^([a-d]*)([0-9]*)(\\\\/[a-d]*)$", 3)'),
         conf=_regexp_conf)
 
 def test_regexp_extract_no_match():
     gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
-                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)\\z", 0)',
-                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)\\z", 1)',
-                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)\\z", 2)',
-                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)\\z", 3)'),
+                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)$", 0)',
+                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)$", 1)',
+                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)$", 2)',
+                'regexp_extract(a, "^([0-9]+)([a-z]+)([0-9]+)$", 3)'),
         conf=_regexp_conf)
 
 # if we determine that the index is out of range we fall back to CPU and let
@@ -680,7 +682,9 @@ def test_rlike():
                 'a rlike "a{2}"',
                 'a rlike "a{1,3}"',
                 'a rlike "a{1,}"',
-                'a rlike "a[bc]d"'),
+                'a rlike "a[bc]d"',
+                'a rlike "a[bc]d"',
+                'a rlike "^[a-d]*$"'),
         conf=_regexp_conf)
 
 def test_rlike_embedded_null():

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -817,6 +817,7 @@ def test_regexp_replace_unicode_support():
             'REGEXP_REPLACE(a, "TEST䤫", "PROD")',
             'REGEXP_REPLACE(a, "TEST[䤫]", "PROD")',
             'REGEXP_REPLACE(a, "TEST.*\\\\d", "PROD")',
+            'REGEXP_REPLACE(a, "TEST[85]*$", "PROD")',
             'REGEXP_REPLACE(a, "TEST.+$", "PROD")',
         ),
         conf=_regexp_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -945,7 +945,8 @@ class CudfRegexTranspiler(mode: RegexMode) {
       if ((containsEndAnchor(r1) &&
           (containsNewline(r2) || containsEmpty(r2) || containsBeginAnchor(r2))) ||
         (containsEndAnchor(r2) &&
-          (containsNewline(r1) || containsEmpty(r1) || containsBeginAnchor(r1)))) {
+          // (containsNewline(r1) || containsEmpty(r1) || containsBeginAnchor(r1)))) {
+          (containsNewline(r1) || containsBeginAnchor(r1)))) {
         throw new RegexUnsupportedException(
           s"End of line/string anchor is not supported in this context: " +
             s"${toReadableString(r1.toRegexString)}" +

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -115,18 +115,10 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
       frame.selectExpr("regexp_replace(strings,'\\(foo\\)','D')")
   }
 
-  // https://github.com/NVIDIA/spark-rapids/issues/5659
-  // testGpuFallback("String regexp_extract regex 1",
-  //   "ProjectExec", extractStrings, conf = conf,
-  //   execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
   testSparkResultsAreEqual("String regexp_extract regex 1", extractStrings, conf = conf) {
     frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 1)")
   }
 
-  // https://github.com/NVIDIA/spark-rapids/issues/5659
-  // testGpuFallback("String regexp_extract regex 2",
-  //   "ProjectExec", extractStrings, conf = conf,
-  //   execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
   testSparkResultsAreEqual("String regexp_extract regex 2", extractStrings, conf = conf) {
     frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 2)")
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -116,16 +116,18 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
   }
 
   // https://github.com/NVIDIA/spark-rapids/issues/5659
-  testGpuFallback("String regexp_extract regex 1",
-    "ProjectExec", extractStrings, conf = conf,
-    execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+  // testGpuFallback("String regexp_extract regex 1",
+  //   "ProjectExec", extractStrings, conf = conf,
+  //   execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+  testSparkResultsAreEqual("String regexp_extract regex 1", extractStrings, conf = conf) {
     frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 1)")
   }
 
   // https://github.com/NVIDIA/spark-rapids/issues/5659
-  testGpuFallback("String regexp_extract regex 2",
-    "ProjectExec", extractStrings, conf = conf,
-    execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+  // testGpuFallback("String regexp_extract regex 2",
+  //   "ProjectExec", extractStrings, conf = conf,
+  //   execsAllowedNonGpu = Seq("ProjectExec", "ShuffleExchangeExec")) {
+  testSparkResultsAreEqual("String regexp_extract regex 2", extractStrings, conf = conf) {
     frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 2)")
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionSuite.scala
@@ -116,11 +116,15 @@ class RegularExpressionSuite extends SparkQueryCompareTestSuite {
   }
 
   testSparkResultsAreEqual("String regexp_extract regex 1", extractStrings, conf = conf) {
-    frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 1)")
+    frame => 
+      assume(isUnicodeEnabled())
+      frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 1)")
   }
 
   testSparkResultsAreEqual("String regexp_extract regex 2", extractStrings, conf = conf) {
-    frame => frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 2)")
+    frame => 
+      assume(isUnicodeEnabled())
+      frame.selectExpr("regexp_extract(strings, '^([a-z]*)([0-9]*)([a-z]*)$', 2)")
   }
 
   // note that regexp_extract with a literal string gets replaced with the literal result of

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -102,6 +102,12 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     )
   }
 
+  test("zero-length repetition near line anchor  - regexp_find") {
+    val patterns = Seq("\\00*[D$3]$", "\\00*[D$3]\\Z", "^([a-z]*)([0-9]*)([a-z]*)$")
+    val inputs = Seq("abcd", "abc012abc", "999abb", "\\00D", "D", "D\n", "\\00D\n\r")
+    assertCpuGpuMatchesRegexpFind(patterns, inputs)
+  }
+
   test("cuDF unsupported choice cases") {
     val patterns = Seq("c*|d*", "c*|dog", "[cat]{3}|dog")
     patterns.foreach(pattern => {
@@ -303,7 +309,8 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         "\n\u0085", "\n\u2028", "\n\u2029", "2+|+??wD\n", "a\r\nb")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
     val unsupportedPatterns = Seq("[\r\n]?$", "$\r", "\r$",
-      "\u0085$", "\u2028$", "\u2029$", "\n$", "\r\n$", "\\00*[D$3]$")
+      // "\u0085$", "\u2028$", "\u2029$", "\n$", "\r\n$", "[D$3]$")
+      "\u0085$", "\u2028$", "\u2029$", "\n$", "\r\n$")
     for (pattern <- unsupportedPatterns) {
       assertUnsupported(pattern, RegexFindMode,
         "End of line/string anchor is not supported in this context")
@@ -317,7 +324,7 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
         "\n\u0085", "\n\u2028", "\n\u2029", "2+|+??wD\n", "a\r\nb")
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
     val unsupportedPatterns = Seq("[\r\n]?\\Z", "\\Z\r", "\r\\Z",
-      "\u0085\\Z", "\u2028\\Z", "\u2029\\Z", "\n\\Z", "\r\n\\Z", "\\00*[D$3]\\Z")
+      "\u0085\\Z", "\u2028\\Z", "\u2029\\Z", "\n\\Z", "\r\n\\Z")
     for (pattern <- unsupportedPatterns) {
       assertUnsupported(pattern, RegexFindMode,
         "End of line/string anchor is not supported in this context")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -108,6 +108,20 @@ class RegularExpressionTranspilerSuite extends FunSuite with Arm {
     assertCpuGpuMatchesRegexpFind(patterns, inputs)
   }
 
+  test("zero-length repetition near line anchor  - regexp_replace") {
+    val patterns = Seq("\\00*[D$3]$", "\\00*[D$3]\\Z", "^([a-z]*)([0-9]*)([a-z]*)$")
+    val inputs = Seq("abcd", "abc012abc", "999abb", "\\00D", "D", "D\n", "\\00D\n\r")
+    assertCpuGpuMatchesRegexpReplace(patterns, inputs)
+  }
+
+  test("zero-length repetition near line anchor  - regexp_split") {
+    val patterns = Set("\\00*[D$3]$", "\\00*[D$3]\\Z", "^([a-z]*)([0-9]*)([a-z]*)$")
+    patterns.foreach(pattern => {
+      assertUnsupported(pattern, RegexSplitMode,
+      "End of line/string anchor is not supported in this context")
+    })
+  }
+
   test("cuDF unsupported choice cases") {
     val patterns = Seq("c*|d*", "c*|dog", "[cat]{3}|dog")
     patterns.foreach(pattern => {


### PR DESCRIPTION
Fixes #5659.

This enables regular expressions with empty repetitions adjacent to end-of-line anchors in every regular expression SQL function but `split()`, a use case that had been working before but had been excluded due to other edge cases that were not functioning.  This does this by modifying to checks to narrowly allow this particular case.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
