### PR TITLE
Bump the Spark version from 3.4.0-SNAPSHOT to 3.4.0 release JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,9 @@
         <ignore.shim.revisions.check>false</ignore.shim.revisions.check>
 
         <spark.shim.dest>${project.basedir}/target/${spark.version.classifier}/generated/src</spark.shim.dest>
+        <!-- TODO: Add 340 to noSnapshot.buildvers when 3.4.0 shim is complete
+             See https://github.com/NVIDIA/spark-rapids/issues/5824
+        -->
         <noSnapshot.buildvers>
             311,
             312,

--- a/pom.xml
+++ b/pom.xml
@@ -628,7 +628,7 @@
         <spark331.version>3.3.1</spark331.version>
         <spark332.version>3.3.2</spark332.version>
         <spark333.version>3.3.3-SNAPSHOT</spark333.version>
-        <spark340.version>3.4.0-SNAPSHOT</spark340.version>
+        <spark340.version>3.4.0</spark340.version>
         <spark330cdh.version>3.3.0.3.3.7180.0-274</spark330cdh.version>
         <spark330db.version>3.3.0-databricks</spark330db.version>
         <mockito.version>3.6.0</mockito.version>


### PR DESCRIPTION
Now that Spark 3.4.0 artifacts are officially in Maven Central, the version for spark340 should be set to 3.4.0 to build against the released version of Spark

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
