### PR TITLE
Use the static `withResource` in GpuProjectExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,6 +157,12 @@ trait Arm {
     }
   }
 }
+
+/**
+ * Use the utils as static methods will be better in some places. e.g. in a SparkPlan,
+ * it can avoid serializing the whole plan.
+ */
+object Arm extends Arm {}
 
 class CloseableHolder[T <: AutoCloseable](var t: T) {
   def setAndCloseOld(newT: T): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -162,7 +162,7 @@ trait Arm {
  * Use the utils as static methods will be better in some places. e.g. in a SparkPlan,
  * it can avoid serializing the whole plan.
  */
-object Arm extends Arm {}
+object Arm extends Arm
 
 class CloseableHolder[T <: AutoCloseable](var t: T) {
   def setAndCloseOld(newT: T): Unit = {


### PR DESCRIPTION
This can avoid serializing the whole plan.

The full fix targeting 23.06 is here https://github.com/NVIDIA/spark-rapids/pull/8108, so this fix is not needed by 23.06.

fixes #8095 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
