### PR TITLE
Make Arm methods static [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
@@ -25,6 +25,7 @@ import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.databricks.sql.transaction.tahoe.constraints.{CheckDeltaInvariant, Constraint}
 import com.databricks.sql.transaction.tahoe.constraints.Constraints.{Check, NotNull}
 import com.nvidia.spark.rapids.{DataFromReplacementRule, ExprChecks, GpuBindReferences, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuOverrides, RapidsConf, RapidsMeta, TypeSig, UnaryExprMeta}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.delta.shims.InvariantViolationExceptionShim
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 

--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaInvariantCheckerExec.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaInvariantCheckerExec.scala
@@ -16,6 +16,7 @@
 
 package com.databricks.sql.transaction.tahoe.rapids
 
+import com.nvidia.spark.rapids.Arm.closeOnExcept
 import com.nvidia.spark.rapids.GpuExec
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
@@ -23,6 +23,7 @@ package org.apache.spark.sql.delta.rapids
 
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 
 import org.apache.spark.internal.Logging

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaInvariantCheckerExec.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaInvariantCheckerExec.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.rapids
 
+import com.nvidia.spark.rapids.Arm.closeOnExcept
 import com.nvidia.spark.rapids.GpuExec
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaIdentityColumnStatsTracker.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaIdentityColumnStatsTracker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package com.nvidia.spark.rapids.delta
 import scala.collection.mutable
 
 import ai.rapids.cudf.ColumnView
-import com.nvidia.spark.rapids.{Arm, GpuScalar}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuScalar
 import com.nvidia.spark.rapids.delta.shims.ShimJsonUtils
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -56,7 +57,7 @@ class GpuDeltaIdentityColumnStatsTracker(
   }
 }
 
-object GpuDeltaIdentityColumnStatsTracker extends Arm {
+object GpuDeltaIdentityColumnStatsTracker {
   def batchStatsToRow(
       dataCols: Seq[Attribute],
       identityStatsExpr: Expression,

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{NvtxColor, Table}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -216,7 +217,7 @@ class GpuRapidsProcessDeltaMergeJoinIterator(
     noopCopyOutput: Seq[GpuExpression],
     deleteRowOutput: Seq[GpuExpression],
     metrics: Map[String, GpuMetric])
-    extends Iterator[ColumnarBatch] with AutoCloseable with Arm {
+    extends Iterator[ColumnarBatch] with AutoCloseable {
 
   Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
 

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuStatisticsCollection.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuStatisticsCollection.scala
@@ -24,8 +24,8 @@ package com.nvidia.spark.rapids.delta
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnView, DType}
-import com.nvidia.spark.RebaseHelper.withResource
-import com.nvidia.spark.rapids.{Arm, GpuScalar}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuScalar
 import com.nvidia.spark.rapids.delta.shims.{ShimDeltaColumnMapping, ShimDeltaUDF, ShimUsesMetadataFields}
 
 import org.apache.spark.sql.Column
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 /** GPU version of Delta Lake's StatisticsCollection. */
-trait GpuStatisticsCollection extends ShimUsesMetadataFields with Arm {
+trait GpuStatisticsCollection extends ShimUsesMetadataFields {
   def tableDataSchema: StructType
   def dataSchema: StructType
   val numIndexedCols: Int

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/deltaUDFs.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/deltaUDFs.scala
@@ -19,13 +19,13 @@ package com.nvidia.spark.rapids.delta
 import ai.rapids.cudf.{ColumnVector, Scalar, Table}
 import ai.rapids.cudf.Table.DuplicateKeepOption
 import com.nvidia.spark.RapidsUDF
-import com.nvidia.spark.rapids.Arm
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.util.AccumulatorV2
 
 class GpuDeltaRecordTouchedFileNameUDF(accum: AccumulatorV2[String, java.util.Set[String]])
-    extends Function[String, Int] with RapidsUDF with Arm with Serializable {
+    extends Function[String, Int] with RapidsUDF with Serializable {
 
   override def apply(fileName: String): Int = {
     accum.add(fileName)
@@ -58,7 +58,7 @@ class GpuDeltaRecordTouchedFileNameUDF(accum: AccumulatorV2[String, java.util.Se
 }
 
 class GpuDeltaMetricUpdateUDF(metric: SQLMetric)
-    extends Function0[Boolean] with RapidsUDF with Arm with Serializable {
+    extends Function0[Boolean] with RapidsUDF with Serializable {
 
   override def apply(): Boolean = {
     metric += 1

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCX.scala
@@ -25,7 +25,8 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, GpuDeviceManager, RapidsConf}
+import com.nvidia.spark.rapids.{GpuDeviceManager, RapidsConf}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ThreadFactoryBuilder
 import com.nvidia.spark.rapids.jni.RmmSpark
@@ -68,7 +69,7 @@ case class UCXActiveMessage(activeMessageId: Int, header: Long, forceRndv: Boole
  * @param rapidsConf rapids configuration
  */
 class UCX(transport: UCXShuffleTransport, executor: BlockManagerId, rapidsConf: RapidsConf)
-    extends AutoCloseable with Logging with Arm {
+    extends AutoCloseable with Logging {
 
   private[this] val context = {
     val contextParams = new UcpParams()

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXConnection.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 
 import ai.rapids.cudf.MemoryBuffer
-import com.nvidia.spark.rapids.Arm
 import com.nvidia.spark.rapids.shuffle._
 import org.openucx.jucx.UcxCallback
 import org.openucx.jucx.ucp.UcpRequest
@@ -46,7 +45,7 @@ private[ucx] abstract class UCXAmCallback {
 }
 
 class UCXServerConnection(ucx: UCX, transport: UCXShuffleTransport)
-  extends UCXConnection(ucx) with ServerConnection with Logging with Arm {
+  extends UCXConnection(ucx) with ServerConnection with Logging {
   override def startManagementPort(host: String): Int = {
     ucx.startListener(host)
   }
@@ -144,8 +143,7 @@ class UCXServerConnection(ucx: UCX, transport: UCXShuffleTransport)
 }
 
 class UCXClientConnection(peerExecutorId: Long, ucx: UCX, transport: UCXShuffleTransport)
-  extends UCXConnection(peerExecutorId, ucx) with Arm
-  with ClientConnection {
+  extends UCXConnection(peerExecutorId, ucx) with ClientConnection {
 
   override def toString: String = {
     s"UCXClientConnection(ucx=$ucx, " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/RebaseHelper.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/RebaseHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
 package com.nvidia.spark
 
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
-import com.nvidia.spark.rapids.Arm
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 
 import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-object RebaseHelper extends Arm {
+object RebaseHelper {
   private[this] def isDateRebaseNeeded(column: ColumnVector,
       startDay: Int): Boolean = {
     // TODO update this for nested column checks

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{GatherMap, NvtxColor, OutOfBoundsPolicy}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetryNoSplit}
 
@@ -56,9 +57,7 @@ abstract class AbstractGpuJoinIterator(
     targetSize: Long,
     val opTime: GpuMetric,
     joinTime: GpuMetric)
-    extends Iterator[ColumnarBatch]
-    with Arm
-    with TaskAutoCloseableResource {
+    extends Iterator[ColumnarBatch] with TaskAutoCloseableResource {
   private[this] var nextCb: Option[ColumnarBatch] = None
   private[this] var gathererStore: Option[JoinGatherer] = None
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioFS.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioFS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import scala.collection.mutable
 import alluxio.AlluxioURI
 import alluxio.conf.{AlluxioProperties, InstancedConfiguration, PropertyKey}
 import alluxio.grpc.MountPOptions
+import com.nvidia.spark.rapids.Arm.withResource
 
 /**
  * interfaces for Alluxio file system.
@@ -28,7 +29,7 @@ import alluxio.grpc.MountPOptions
  *   get mount points
  *   mount
  */
-class AlluxioFS extends Arm {
+class AlluxioFS {
   private var masterHost: String = _
   private var masterPort: Int = _
   private var masterHostAndPort: Option[String] = None

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AlluxioUtils.scala
@@ -71,7 +71,7 @@ import org.apache.spark.sql.execution.datasources.rapids.GpuPartitioningUtils
  * to replace paths and then we have the config that specifies direct paths to replace and
  * user has to manually mount those.
  */
-object AlluxioUtils extends Logging with Arm {
+object AlluxioUtils extends Logging {
   private val checkedAlluxioPath = scala.collection.mutable.HashSet[String]()
   private val ALLUXIO_SCHEME = "alluxio://"
   private val mountedBuckets: scala.collection.mutable.Map[String, String] =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Arm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 /** Implementation of the automatic-resource-management pattern */
-trait Arm {
+object Arm {
 
   /** Executes the provided code block and then closes the resource */
   def withResource[T <: AutoCloseable, V](r: T)(block: T => V): V = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ArrayIndexUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ArrayIndexUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 
-object ArrayIndexUtils extends Arm {
+object ArrayIndexUtils {
 
   /**
    * Return the first int value (should be valid) in 'indices' and 'numElements' as a pair

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroDataFileReader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.collection.mutable
 
+import com.nvidia.spark.rapids.Arm.closeOnExcept
 import org.apache.avro.Schema
 import org.apache.avro.file.DataFileConstants._
 import org.apache.avro.file.SeekableInput
@@ -456,7 +457,7 @@ class AvroDataFileReader(si: SeekableInput) extends AvroFileReader(si) {
 
 }
 
-object AvroFileReader extends Arm {
+object AvroFileReader {
 
   def openMetaReader(filePath: String, conf: Configuration): AvroMetaFileReader = {
     closeOnExcept(openFile(filePath, conf)) { si =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BoolUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BoolUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, DType}
+import com.nvidia.spark.rapids.Arm.withResource
 
-object BoolUtils extends Arm {
+object BoolUtils {
 
   /**
    * Whether all the valid rows in 'col' are true. An empty column will get true.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnCastUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnCastUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Optional
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder}
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.types.{ArrayType, BinaryType, ByteType, DataType, MapType, StructField, StructType}
 
@@ -30,7 +31,7 @@ import org.apache.spark.sql.types.{ArrayType, BinaryType, ByteType, DataType, Ma
  *
  * At this time this is strictly a place for casting methods
  */
-object ColumnCastUtil extends Arm {
+object ColumnCastUtil {
 
   /**
    * Transforms a ColumnView into a new ColumnView using a `PartialFunction` or returns None

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -21,6 +21,7 @@ import java.io.OutputStream
 import scala.collection.mutable
 
 import ai.rapids.cudf.{HostBufferConsumer, HostMemoryBuffer, NvtxColor, NvtxRange, Table, TableWriter}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.apache.hadoop.mapreduce.TaskAttemptContext
@@ -64,7 +65,7 @@ abstract class ColumnarOutputWriterFactory extends Serializable {
 abstract class ColumnarOutputWriter(context: TaskAttemptContext,
     dataSchema: StructType,
     rangeName: String,
-    includeRetry: Boolean) extends HostBufferConsumer with Arm {
+    includeRetry: Boolean) extends HostBufferConsumer {
 
   val tableWriter: TableWriter
   val conf = context.getConfiguration

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarPartitionReaderWithPartitionValues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.Scalar
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.sql.connector.read.PartitionReader
@@ -51,7 +52,7 @@ class ColumnarPartitionReaderWithPartitionValues(
   }
 }
 
-object ColumnarPartitionReaderWithPartitionValues extends Arm {
+object ColumnarPartitionReaderWithPartitionValues {
   def newReader(partFile: PartitionedFile,
       baseReader: PartitionReader[ColumnarBatch],
       partitionSchema: StructType): PartitionReader[ColumnarBatch] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CopyCompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer}
+import com.nvidia.spark.rapids.Arm.closeOnExcept
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, CodecType}
 
 /** A table compression codec used only for testing that copies the data. */
-class CopyCompressionCodec extends TableCompressionCodec with Arm {
+class CopyCompressionCodec extends TableCompressionCodec {
   override val name: String = "COPY"
   override val codecId: Byte = CodecType.COPY
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DecimalUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DecimalUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import ai.rapids.cudf.{DecimalUtils, DType}
 
 import org.apache.spark.sql.types._
 
-object DecimalUtil extends Arm {
+object DecimalUtil {
 
   def createCudfDecimal(dt: DecimalType): DType =
     DecimalUtils.createDecimalType(dt.precision, dt.scale)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandler.scala
@@ -40,7 +40,7 @@ class DeviceMemoryEventHandler(
     store: RapidsDeviceMemoryStore,
     oomDumpDir: Option[String],
     isGdsSpillEnabled: Boolean,
-    maxFailedOOMRetries: Int) extends RmmEventHandler with Logging with Arm {
+    maxFailedOOMRetries: Int) extends RmmEventHandler with Logging {
 
   // Flag that ensures we dump stack traces once and not for every allocation
   // failure. The assumption is that unhandled allocations will be fatal

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DumpUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,12 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf._
 import ai.rapids.cudf.ColumnWriterOptions._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object DumpUtils extends Logging with Arm {
+object DumpUtils extends Logging {
   /**
    * Debug utility to dump columnar batch to parquet file. <br>
    * It's running on GPU. Parquet column names are generated from columnar batch type info. <br>
@@ -93,7 +94,7 @@ object DumpUtils extends Logging with Arm {
 
 // parquet dumper
 class ParquetDumper(path: String, table: Table) extends HostBufferConsumer
-  with Arm with AutoCloseable {
+  with AutoCloseable {
   private[this] val outputStream = new FileOutputStream(path)
   private[this] val tempBuffer = new Array[Byte](128 * 1024)
   private[this] val buffers = mutable.Queue[(HostMemoryBuffer, Long)]()
@@ -138,7 +139,7 @@ private class ColumnIndex() {
   }
 }
 
-object ParquetDumper extends Arm {
+object ParquetDumper {
   val COMPRESS_TYPE = CompressionType.SNAPPY
 
   def parquetWriterOptionsFromTable[T <: NestedBuilder[_, _], V <: ColumnWriterOptions](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/FloatUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/FloatUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
+import com.nvidia.spark.rapids.Arm.withResource
 
-object FloatUtils extends Arm {
+object FloatUtils {
 
   def nanToZero(cv: ColumnView): ColumnVector = {
     if (cv.getType() != DType.FLOAT32 && cv.getType() != DType.FLOAT64) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GatherUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GatherUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object GatherUtils extends Arm {
+object GatherUtils {
   def gather(cb: ColumnarBatch, rows: ArrayBuffer[Int]): ColumnarBatch = {
     val colTypes = GpuColumnVector.extractTypes(cb)
     if (rows.isEmpty) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{DType, GroupByAggregation, ReductionAggregation}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuCast.doCast
 import com.nvidia.spark.rapids.shims.ShimExpression
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -23,6 +23,7 @@ import scala.collection.JavaConverters._
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{ColumnVector, DType, NvtxColor, Scalar, Schema, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.ShimFilePartitionReaderFactory
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -334,7 +335,7 @@ abstract class CSVPartitionReaderBase[BUFF <: LineBufferer, FACT <: LineBufferer
 }
 
 
-object CSVPartitionReader extends Arm {
+object CSVPartitionReader {
   def readToTable(
       dataBufferer: HostLineBufferer,
       cudfSchema: Schema,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DecimalUtils, DType, RegexProgram, Scalar}
 import ai.rapids.cudf
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{AnsiUtil, GpuIntervalUtils, GpuTypeShims, SparkShimImpl, YearParseUtil}
@@ -162,7 +163,7 @@ final class CastExprMeta[INPUT <: UnaryExpression with TimeZoneAwareExpression w
   override protected val needTimezoneTagging: Boolean = false
 }
 
-object GpuCast extends Arm {
+object GpuCast {
 
   private val DATE_REGEX_YYYY_MM_DD = "\\A\\d{4}\\-\\d{1,2}\\-\\d{1,2}([ T](:?[\\r\\n]|.)*)?\\Z"
   private val DATE_REGEX_YYYY_MM = "\\A\\d{4}\\-\\d{1,2}\\Z"

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{Cuda, NvtxColor, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.shims.{ShimExpression, ShimUnaryExecNode}
@@ -254,7 +255,7 @@ abstract class AbstractGpuCoalesceIterator(
     streamTime: GpuMetric,
     concatTime: GpuMetric,
     opTime: GpuMetric,
-    opName: String) extends Iterator[ColumnarBatch] with Arm with Logging {
+    opName: String) extends Iterator[ColumnarBatch] with Logging {
 
   private val iter = new CollectTimeIterator(s"$opName: collect", inputIter, streamTime)
 
@@ -643,7 +644,7 @@ class GpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     collectTime,
     concatTime,
     opTime,
-    opName) with Arm {
+    opName) {
 
   protected val batches: ArrayBuffer[SpillableColumnarBatch] = ArrayBuffer.empty
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.closeOnExcept
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
@@ -96,7 +98,7 @@ class GpuColumnarBatchWithPartitionValuesIterator(
     inputIter: GpuColumnarBatchIterator,
     partValues: Array[InternalRow],
     partRowNums: Array[Long],
-    partSchema: StructType) extends Iterator[ColumnarBatch] with Arm {
+    partSchema: StructType) extends Iterator[ColumnarBatch] {
   assert(partValues.length == partRowNums.length)
 
   private var leftValues: Array[InternalRow] = partValues

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import scala.reflect.ClassTag
 
 import ai.rapids.cudf.{HostColumnVector, HostMemoryBuffer, JCudfSerialization, NvtxColor, NvtxRange}
 import ai.rapids.cudf.JCudfSerialization.SerializedTableHeader
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -32,7 +33,7 @@ import org.apache.spark.sql.types.NullType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class SerializedBatchIterator(dIn: DataInputStream)
-  extends Iterator[(Int, ColumnarBatch)] with Arm {
+  extends Iterator[(Int, ColumnarBatch)] {
   private[this] var nextHeader: Option[SerializedTableHeader] = None
   private[this] var toBeReturned: Option[ColumnarBatch] = None
   private[this] var streamClosed: Boolean = false

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -20,6 +20,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable.Queue
 
 import ai.rapids.cudf.{Cuda, HostColumnVector, NvtxColor, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
@@ -42,7 +43,7 @@ class AcceleratedColumnarToRowIterator(
     numInputBatches: GpuMetric,
     numOutputRows: GpuMetric,
     opTime: GpuMetric,
-    streamTime: GpuMetric) extends Iterator[InternalRow] with Arm with Serializable {
+    streamTime: GpuMetric) extends Iterator[InternalRow] with Serializable {
   @transient private var pendingCvs: Queue[HostColumnVector] = Queue.empty
   // GPU batches read in must be closed by the receiver (us)
   @transient private var currentCv: Option[HostColumnVector] = None
@@ -200,7 +201,7 @@ class ColumnarToRowIterator(batches: Iterator[ColumnarBatch],
     opTime: GpuMetric,
     streamTime: GpuMetric,
     nullSafe: Boolean = false,
-    releaseSemaphore: Boolean = true) extends Iterator[InternalRow] with Arm {
+    releaseSemaphore: Boolean = true) extends Iterator[InternalRow] {
   // GPU batches read in must be closed by the receiver (us)
   @transient private var cb: ColumnarBatch = null
   private var it: java.util.Iterator[InternalRow] = null

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataProducer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDataProducer.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -113,7 +114,7 @@ class WrappedGpuDataProducer[T, U](
 object EmptyTableReader extends EmptyGpuDataProducer[Table]
 
 class CachedGpuBatchIterator private(pending: mutable.Queue[SpillableColumnarBatch])
-    extends GpuColumnarBatchIterator(true) with Arm {
+    extends GpuColumnarBatchIterator(true) {
 
   override def hasNext: Boolean = pending.nonEmpty
 
@@ -143,7 +144,7 @@ class CachedGpuBatchIterator private(pending: mutable.Queue[SpillableColumnarBat
  * held and will not be released before the first table is consumed. This is also fitting with
  * the semantics of how we use an Iterator[ColumnarBatch] pointing to GPU data.
  */
-object CachedGpuBatchIterator extends Arm {
+object CachedGpuBatchIterator {
   private[this] def makeSpillableAndClose(table: Table,
       dataTypes: Array[DataType]): SpillableColumnarBatch = {
     withResource(table) { _ =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.NvtxColor
-import com.nvidia.spark.RebaseHelper.withResource
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 
 import org.apache.spark.internal.Logging
@@ -175,7 +175,7 @@ object GpuExec {
   val TASK_METRICS_TAG = new TreeNodeTag[GpuTaskMetrics]("gpu_task_metrics")
 }
 
-trait GpuExec extends SparkPlan with Arm {
+trait GpuExec extends SparkPlan {
   import GpuMetric._
   def sparkSession: SparkSession = {
     SparkShimImpl.sessionFromPlan(this)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.NvtxColor
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
@@ -109,8 +110,7 @@ class GpuExpandIterator(
     boundProjections: Seq[Seq[GpuExpression]],
     metrics: Map[String, GpuMetric],
     it: Iterator[ColumnarBatch])
-  extends Iterator[ColumnarBatch]
-  with Arm {
+  extends Iterator[ColumnarBatch] {
 
   private var cb: ColumnarBatch = _
   private var projectionIndex = 0

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ast, BinaryOp, BinaryOperable, ColumnVector, DType, Scalar, UnaryOp}
+import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.GpuExpressionsUtils.columnarEvalToColumn
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{ShimBinaryExpression, ShimExpression, ShimTernaryExpression, ShimUnaryExpression}
@@ -28,7 +29,7 @@ import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.unsafe.types.UTF8String
 
-object GpuExpressionsUtils extends Arm {
+object GpuExpressionsUtils {
   def getTrimString(trimStr: Option[Expression]): String = trimStr match {
     case Some(GpuLiteral(data, StringType)) =>
       if (data == null) {
@@ -110,7 +111,7 @@ object GpuExpressionsUtils extends Arm {
  * An Expression that cannot be evaluated in the traditional row-by-row sense (hence Unevaluable)
  * but instead can be evaluated on an entire column batch at once.
  */
-trait GpuExpression extends Expression with Arm {
+trait GpuExpression extends Expression {
 
   // copied from Unevaluable to avoid inheriting  final foldable
   //

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, DType, NvtxColor, NvtxRange, OrderByArg, Scalar, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.{ShimExpression, ShimUnaryExecNode}
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{DataType, StringType}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{DType, NvtxColor, NvtxRange, PartitionedTable}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -61,7 +62,7 @@ abstract class GpuHashPartitioningBase(expressions: Seq[Expression], numPartitio
   }
 }
 
-object GpuHashPartitioningBase extends Arm {
+object GpuHashPartitioningBase {
 
   val DEFAULT_HASH_SEED: Int = 42
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuInSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, Predicate}
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.Scalar
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, NvtxColor, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
@@ -43,7 +44,7 @@ class GpuKeyBatchingIterator(
     concatTime: GpuMetric,
     opTime: GpuMetric,
     peakDevMemory: GpuMetric)
-    extends Iterator[ColumnarBatch] with Arm {
+    extends Iterator[ColumnarBatch] {
   private val pending = mutable.Queue[SpillableColumnarBatch]()
   private var pendingSize: Long = 0
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuListUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@ package com.nvidia.spark.rapids
 import java.util.Optional
 
 import ai.rapids.cudf.{ColumnView, DType}
+import com.nvidia.spark.rapids.Arm.withResource
 
 /**
  * Provide a set of APIs to manipulate array/list columns in common ways.
  */
-object GpuListUtils extends Arm {
+object GpuListUtils {
   /**
    * Replace the data column in a LIST column. This will keep the same offsets and validity
    * of the listColumn.  This returns a view so it is the responsibility of the caller to keep

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMapUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMapUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.util.Optional
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableColumn
 
 import org.apache.spark.sql.catalyst.trees.Origin
@@ -30,7 +31,7 @@ import org.apache.spark.sql.types.DataType
  * Provide a set of APIs to manipulate map columns in common ways. CUDF does not officially support
  * maps so we store it as a list of key/value structs.
  */
-object GpuMapUtils extends Arm {
+object GpuMapUtils {
   val KEY_INDEX: Int = 0
   val VALUE_INDEX: Int = 1
   private[this] def pullChildOutAsListView(input: ColumnView, index: Int): ColumnView = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 import scala.language.implicitConversions
 
 import ai.rapids.cudf.{ColumnVector, HostMemoryBuffer, NvtxColor, NvtxRange, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, FILTER_TIME, PEAK_DEVICE_MEMORY}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import org.apache.commons.io.IOUtils
@@ -109,7 +110,7 @@ trait HostMemoryBuffersWithMetaDataBase {
 }
 
 // This is a common trait for all kind of file formats
-trait MultiFileReaderFunctions extends Arm {
+trait MultiFileReaderFunctions {
 
   // Add partitioned columns into the batch
   protected def addPartitionValues(
@@ -165,7 +166,7 @@ object MultiFileReaderThreadPool extends Logging {
   }
 }
 
-object MultiFileReaderUtils extends Arm {
+object MultiFileReaderUtils {
 
   private implicit def toURI(path: String): URI = {
     try {
@@ -289,7 +290,7 @@ abstract class MultiFilePartitionReaderFactoryBase(
     broadcastedConf: Broadcast[SerializableConfiguration],
     @transient rapidsConf: RapidsConf,
     alluxioPathReplacementMap: Option[Map[String, String]] = None)
-  extends PartitionReaderFactory with Arm with Logging {
+  extends PartitionReaderFactory with Logging {
 
   protected val maxReadBatchSizeRows: Int = rapidsConf.maxReadBatchSizeRows
   protected val maxReadBatchSizeBytes: Long = rapidsConf.maxReadBatchSizeBytes
@@ -373,7 +374,7 @@ abstract class MultiFilePartitionReaderFactoryBase(
  * @param execMetrics metrics
  */
 abstract class FilePartitionReaderBase(conf: Configuration, execMetrics: Map[String, GpuMetric])
-    extends PartitionReader[ColumnarBatch] with Logging with ScanWithMetrics with Arm {
+    extends PartitionReader[ColumnarBatch] with Logging with ScanWithMetrics {
 
   metrics = execMetrics
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -31,6 +31,7 @@ import scala.language.implicitConversions
 import scala.math.max
 
 import ai.rapids.cudf._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.SchemaUtils._
@@ -120,7 +121,7 @@ case class GpuOrcScan(
     this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
 }
 
-object GpuOrcScan extends Arm {
+object GpuOrcScan {
 
   def tagSupport(scanMeta: ScanMeta[OrcScan]): Unit = {
     val scan = scanMeta.wrapped
@@ -599,7 +600,7 @@ case class GpuOrcPartitionReaderFactory(
     @transient rapidsConf: RapidsConf,
     metrics : Map[String, GpuMetric],
     @transient params: Map[String, String])
-  extends ShimFilePartitionReaderFactory(params) with Arm {
+  extends ShimFilePartitionReaderFactory(params) {
 
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val debugDumpPrefix = Option(rapidsConf.orcDebugDumpPrefix)
@@ -847,7 +848,7 @@ trait OrcCommonFunctions extends OrcCodecWritingHelper { self: FilePartitionRead
  * A base ORC partition reader which compose of some common methods
  */
 trait OrcPartitionReaderBase extends OrcCommonFunctions with Logging
-  with Arm with ScanWithMetrics { self: FilePartitionReaderBase =>
+  with ScanWithMetrics { self: FilePartitionReaderBase =>
 
   /**
    * Send a host buffer to GPU for ORC decoding, and return it as a ColumnarBatch.
@@ -1095,7 +1096,7 @@ class GpuOrcPartitionReader(
 
 }
 
-private object OrcTools extends Arm {
+private object OrcTools {
 
   /** Build an ORC data reader using OrcPartitionReaderContext */
   def buildDataReader(ctx: OrcPartitionReaderContext): DataReader = {
@@ -1151,7 +1152,7 @@ private case class GpuOrcFileFilterHandler(
     @transient sqlConf: SQLConf,
     broadcastedConf: Broadcast[SerializableConfiguration],
     pushedFilters: Array[Filter],
-    isOrcFloatTypesToStringEnable: Boolean) extends Arm {
+    isOrcFloatTypesToStringEnable: Boolean) {
 
   private[rapids] val isCaseSensitive = sqlConf.caseSensitiveAnalysis
 
@@ -1783,7 +1784,7 @@ class MultiFileCloudOrcPartitionReader(
 
 }
 
-trait OrcCodecWritingHelper extends Arm {
+trait OrcCodecWritingHelper {
 
   /** Executes the provided code block in the codec environment */
   def withCodecOutputStream[T](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf._
 import com.nvidia.spark.RebaseHelper
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, ParquetTimestampNTZShims, SparkShimImpl}
 import org.apache.hadoop.mapreduce.{Job, OutputCommitter, TaskAttemptContext}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, NvtxColor, NvtxRange, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -27,7 +28,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuShuffleEnv
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-trait GpuPartitioning extends Partitioning with Arm {
+trait GpuPartitioning extends Partitioning {
   private[this] val (maxCompressionBatchSize, _useGPUShuffle, _useMultiThreadedShuffle) = {
     val rapidsConf = new RapidsConf(SQLConf.get)
     (rapidsConf.shuffleCompressionMaxBatchMemory,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import scala.util.hashing.byteswap32
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.rdd.{PartitionPruningRDD, RDD}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.util.Random
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, ShimUnaryExecNode}
 
@@ -33,7 +34,7 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-private class GpuRowToColumnConverter(schema: StructType) extends Serializable with Arm {
+private class GpuRowToColumnConverter(schema: StructType) extends Serializable {
   private val converters = schema.fields.map {
     f => GpuRowToColumnConverter.getConverterForType(f.dataType, f.nullable)
   }
@@ -592,7 +593,7 @@ class RowToColumnarIterator(
     numOutputRows: GpuMetric = NoopMetric,
     numOutputBatches: GpuMetric = NoopMetric,
     streamTime: GpuMetric = NoopMetric,
-    opTime: GpuMetric = NoopMetric) extends Iterator[ColumnarBatch] with Arm {
+    opTime: GpuMetric = NoopMetric) extends Iterator[ColumnarBatch] {
 
   private val targetSizeBytes = localGoal.targetSizeBytes
   private var targetRows = 0

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -114,7 +114,7 @@ object GpuSemaphore {
   }
 }
 
-private final class GpuSemaphore() extends Logging with Arm {
+private final class GpuSemaphore() extends Logging {
   import GpuSemaphore._
   private val semaphore = new Semaphore(MAX_PERMITS)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -20,6 +20,7 @@ import java.util
 
 import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization, NvtxColor, NvtxRange}
 import ai.rapids.cudf.JCudfSerialization.{HostConcatResult, SerializedTableHeader}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
@@ -82,7 +83,7 @@ class HostShuffleCoalesceIterator(
     targetBatchByteSize: Long,
     dataTypes: Array[DataType],
     metricsMap: Map[String, GpuMetric])
-      extends Iterator[HostConcatResult] with Arm with AutoCloseable {
+      extends Iterator[HostConcatResult] with AutoCloseable {
   private[this] val concatTimeMetric = metricsMap(GpuMetric.CONCAT_TIME)
   private[this] val inputBatchesMetric = metricsMap(GpuMetric.NUM_INPUT_BATCHES)
   private[this] val inputRowsMetric = metricsMap(GpuMetric.NUM_INPUT_ROWS)
@@ -191,7 +192,7 @@ class HostShuffleCoalesceIterator(
 class GpuShuffleCoalesceIterator(iter: Iterator[HostConcatResult],
                                  dataTypes: Array[DataType],
                                  metricsMap: Map[String, GpuMetric])
-      extends Iterator[ColumnarBatch] with Arm {
+      extends Iterator[ColumnarBatch] {
   private[this] val opTimeMetric = metricsMap(GpuMetric.OP_TIME)
   private[this] val outputBatchesMetric = metricsMap(GpuMetric.NUM_OUTPUT_BATCHES)
   private[this] val outputRowsMetric = metricsMap(GpuMetric.NUM_OUTPUT_ROWS)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import ai.rapids.cudf.JCudfSerialization.HostConcatResult
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.{GpuHashPartitioning, ShimBinaryExecNode}
 
 import org.apache.spark.TaskContext
@@ -209,7 +210,7 @@ case class GpuShuffledHashJoinExec(
   }
 }
 
-object GpuShuffledHashJoinExec extends Arm {
+object GpuShuffledHashJoinExec {
   /**
    * Return the build data as a single ColumnarBatch when sub-partitioning is not enabled,
    * while as an iterator of ColumnarBatch when sub-partitioning is enabled.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -21,6 +21,7 @@ import java.util.{Comparator, LinkedList, PriorityQueue}
 import scala.collection.mutable.{ArrayBuffer, ArrayStack}
 
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, NvtxColor, NvtxRange, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
@@ -157,7 +158,7 @@ case class GpuSortEachBatchIterator(
     sortTime: GpuMetric = NoopMetric,
     outputBatches: GpuMetric = NoopMetric,
     outputRows: GpuMetric = NoopMetric,
-    peakDevMemory: GpuMetric = NoopMetric) extends Iterator[ColumnarBatch] with Arm {
+    peakDevMemory: GpuMetric = NoopMetric) extends Iterator[ColumnarBatch] {
   override def hasNext: Boolean = iter.hasNext
 
   override def next(): ColumnarBatch = {
@@ -246,7 +247,7 @@ case class GpuOutOfCoreSortIterator(
     outputBatches: GpuMetric,
     outputRows: GpuMetric,
     peakDevMemory: GpuMetric) extends Iterator[ColumnarBatch]
-    with Arm with AutoCloseable {
+    with AutoCloseable {
 
   // There are so many places where we might hit a new peak that it gets kind of complex
   // so we are picking a few places that are likely to increase the amount of memory used.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, Scalar}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.types.{DataType, IntegerType}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTextBasedPartitionReader.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ListBuffer
 import scala.math.max
 
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, HostColumnVector, HostColumnVectorCore, HostMemoryBuffer, NvtxColor, NvtxRange, RegexProgram, Scalar, Schema, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.DateUtils.{toStrf, TimestampFormatConversionException}
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.GpuTypeShims
@@ -73,7 +74,7 @@ object HostLineBuffererFactory extends LineBuffererFactory[HostLineBufferer] {
  * Buffer the lines in a single HostMemoryBuffer with the separator inserted inbetween each of
  * the lines.
  */
-class HostLineBufferer(size: Long, separator: Array[Byte]) extends LineBufferer with Arm {
+class HostLineBufferer(size: Long, separator: Array[Byte]) extends LineBufferer {
   private var buffer = HostMemoryBuffer.allocate(size)
   private var location: Long = 0
 
@@ -127,7 +128,7 @@ object HostStringColBuffererFactory extends LineBuffererFactory[HostStringColBuf
 /**
  * Buffer the lines as a HostColumnVector of strings, one per line.
  */
-class HostStringColBufferer(size: Long, separator: Array[Byte]) extends LineBufferer with Arm {
+class HostStringColBufferer(size: Long, separator: Array[Byte]) extends LineBufferer {
   // We had to jump through some hoops so that we could grow the string columns dynamically
   //  might be nice to have this in CUDF, but this works fine too.
   private var dataBuffer = HostMemoryBuffer.allocate(size)
@@ -210,7 +211,7 @@ abstract class GpuTextBasedPartitionReader[BUFF <: LineBufferer, FACT <: LineBuf
     maxBytesPerChunk: Long,
     execMetrics: Map[String, GpuMetric],
     bufferFactory: FACT)
-  extends PartitionReader[ColumnarBatch] with ScanWithMetrics with Arm {
+  extends PartitionReader[ColumnarBatch] with ScanWithMetrics {
   import GpuMetric._
 
   private var batch: Option[ColumnarBatch] = None

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{HostColumnVector, HostColumnVectorCore, NvtxColor, NvtxRange}
 import com.nvidia.spark.RapidsUDF
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, ShimUnaryExecNode}
 import org.apache.arrow.memory.{ArrowBuf, ReferenceManager}
 import org.apache.arrow.vector.ValueVector

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DeviceMemoryBuffer, DType, GatherMap, NvtxColor, NvtxRange, OrderByArg, OutOfBoundsPolicy, Scalar, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.types._
@@ -52,7 +53,7 @@ trait LazySpillable extends AutoCloseable with CheckpointRestore {
  *
  * This is a LazySpillable instance so the life cycle follows that too.
  */
-trait JoinGatherer extends LazySpillable with Arm {
+trait JoinGatherer extends LazySpillable {
   /**
    * Gather the next n rows from the join gather maps.
    *
@@ -136,7 +137,7 @@ trait JoinGatherer extends LazySpillable with Arm {
   }
 }
 
-object JoinGatherer extends Arm {
+object JoinGatherer {
   def apply(gatherMap: LazySpillableGatherMap,
       inputData: LazySpillableColumnarBatch,
       outOfBoundsPolicy: OutOfBoundsPolicy): JoinGatherer =
@@ -230,7 +231,7 @@ object LazySpillableColumnarBatch {
  * where the data itself needs to out live the JoinGatherer it is handed off to.
  */
 case class AllowSpillOnlyLazySpillableColumnarBatchImpl(wrapped: LazySpillableColumnarBatch)
-    extends LazySpillableColumnarBatch with Arm {
+    extends LazySpillableColumnarBatch {
   override def getBatch: ColumnarBatch =
     wrapped.getBatch
 
@@ -268,7 +269,7 @@ case class AllowSpillOnlyLazySpillableColumnarBatchImpl(wrapped: LazySpillableCo
  */
 class LazySpillableColumnarBatchImpl(
     cb: ColumnarBatch,
-    name: String) extends LazySpillableColumnarBatch with Arm {
+    name: String) extends LazySpillableColumnarBatch {
 
   private var cached: Option[ColumnarBatch] = Some(GpuColumnVector.incRefCounts(cb))
   private var spill: Option[SpillableColumnarBatch] = None
@@ -327,7 +328,7 @@ class LazySpillableColumnarBatchImpl(
   override def toString: String = s"SpillableBatch $name $numCols X $numRows"
 }
 
-trait LazySpillableGatherMap extends LazySpillable with Arm {
+trait LazySpillableGatherMap extends LazySpillable {
   /**
    * How many rows total are in this gather map
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf._
 import com.google.flatbuffers.FlatBufferBuilder
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format._
 
 import org.apache.spark.internal.Logging
@@ -29,7 +30,7 @@ import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.ShuffleBlockBatchId
 
-object MetaUtils extends Arm {
+object MetaUtils {
   // Used in cases where the `tableId` is not known at meta creation. 
   // We pick a non-zero integer since FlatBuffers prevent mutating the 
   // field if originally set to the default value as specified in the 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange}
 import ai.rapids.cudf.nvcomp.{BatchedLZ4Compressor, BatchedLZ4Decompressor}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, CodecType}
 
 /** A table compression codec that uses nvcomp's LZ4-GPU codec */
 class NvcompLZ4CompressionCodec(codecConfigs: TableCompressionCodecConfig)
-    extends TableCompressionCodec with Arm {
+    extends TableCompressionCodec {
   override val name: String = "nvcomp-LZ4"
   override val codecId: Byte = CodecType.NVCOMP_LZ4
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import ai.rapids.cudf._
 import ai.rapids.cudf.ParquetWriterOptions.StatisticsFrequency
 import com.nvidia.spark.GpuCachedBatchSerializer
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{ParquetFieldIdShims, ParquetLegacyNanoAsLongShims, SparkShimImpl}
@@ -257,7 +258,7 @@ private case class CloseableColumnBatchIterator(iter: Iterator[ColumnarBatch]) e
  * Note, this class should not be referenced directly in source code.
  * It should be loaded by reflection using ShimLoader.newInstanceOf, see ./docs/dev/shims.md
  */
-protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer with Arm {
+protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
   override def supportsColumnarInput(schema: Seq[Attribute]): Boolean = true
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetSchemaUtils.scala
@@ -21,6 +21,7 @@ import java.util.{Locale, Optional}
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf.{ColumnView, DType, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.ParquetSchemaClipShims
 import org.apache.parquet.schema._
 import org.apache.parquet.schema.Type.Repetition
@@ -29,7 +30,7 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 
-object ParquetSchemaUtils extends Arm {
+object ParquetSchemaUtils {
   // Copied from Spark
   private val SPARK_PARQUET_SCHEMA_NAME = "spark_schema"
   // Copied from Spark

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBuffer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBuffer.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.File
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, MemoryBuffer, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 
@@ -161,7 +162,7 @@ trait RapidsBuffer extends AutoCloseable {
  */
 sealed class DegenerateRapidsBuffer(
     override val id: RapidsBufferId,
-    override val meta: TableMeta) extends RapidsBuffer with Arm {
+    override val meta: TableMeta) extends RapidsBuffer {
   override val size: Long = 0L
   override val storageTier: StorageTier = StorageTier.DEVICE
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange, Rmm}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsBufferCatalog.getExistingRapidsBufferAndAcquire
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.StorageTier.StorageTier
@@ -60,7 +61,7 @@ trait RapidsBufferHandle extends AutoCloseable {
  */
 class RapidsBufferCatalog(
     deviceStorage: RapidsDeviceMemoryStore = RapidsBufferCatalog.deviceStorage)
-  extends AutoCloseable with Arm with Logging {
+  extends AutoCloseable with Logging {
 
   /** Map of buffer IDs to buffers sorted by storage tier */
   private[this] val bufferMap = new ConcurrentHashMap[RapidsBufferId, Seq[RapidsBuffer]]
@@ -643,7 +644,7 @@ class RapidsBufferCatalog(
   }
 }
 
-object RapidsBufferCatalog extends Logging with Arm {
+object RapidsBufferCatalog extends Logging {
 
   private val MAX_BUFFER_LOOKUP_ATTEMPTS = 100
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -21,6 +21,7 @@ import java.util.Comparator
 import scala.collection.mutable
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.StorageTier.{DEVICE, StorageTier}
 import com.nvidia.spark.rapids.format.TableMeta
@@ -37,7 +38,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * @param catalog catalog to register this store
  */
 abstract class RapidsBufferStore(val tier: StorageTier)
-    extends AutoCloseable with Logging with Arm {
+    extends AutoCloseable with Logging {
 
   val name: String = tier.toString
 
@@ -257,7 +258,7 @@ abstract class RapidsBufferStore(val tier: StorageTier)
       override val meta: TableMeta,
       initialSpillPriority: Long,
       catalog: RapidsBufferCatalog = RapidsBufferCatalog.singleton)
-      extends RapidsBuffer with Arm {
+      extends RapidsBuffer {
     private val MAX_UNSPILL_ATTEMPTS = 100
 
     // isValid and refcount must be used with the `RapidsBufferBase` lock held

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 
@@ -28,7 +29,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * @param catalog catalog to register this store
  */
 class RapidsDeviceMemoryStore
-  extends RapidsBufferStore(StorageTier.DEVICE) with Arm {
+  extends RapidsBufferStore(StorageTier.DEVICE) {
 
   // The RapidsDeviceMemoryStore handles spillability via ref counting
   override protected def spillableOnAdd: Boolean = false

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -21,6 +21,7 @@ import java.nio.channels.FileChannel.MapMode
 import java.util.concurrent.ConcurrentHashMap
 
 import ai.rapids.cudf.{Cuda, HostMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -23,6 +23,7 @@ import java.util.function.BiFunction
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
@@ -33,7 +34,7 @@ import org.apache.spark.sql.rapids.{RapidsDiskBlockManager, TempSpillBufferId}
 class RapidsGdsStore(
     diskBlockManager: RapidsDiskBlockManager,
     batchWriteBufferSize: Long)
-    extends RapidsBufferStore(StorageTier.GDS) with Arm {
+    extends RapidsBufferStore(StorageTier.GDS) {
   private[this] val batchSpiller = new BatchSpiller()
 
   override protected def createBuffer(other: RapidsBuffer, otherBuffer: MemoryBuffer,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, PinnedMemoryPool}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.SpillPriorities.{applyPriorityOffset, HOST_MEMORY_BUFFER_DIRECT_OFFSET, HOST_MEMORY_BUFFER_PAGEABLE_OFFSET, HOST_MEMORY_BUFFER_PINNED_OFFSET}
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable
 
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, RmmSparkThreadState, SplitAndRetryOOM}
 
@@ -25,7 +26,7 @@ import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.internal.SQLConf
 
-object RmmRapidsRetryIterator extends Arm with Logging {
+object RmmRapidsRetryIterator extends Logging {
 
   /**
    * withRetry for Iterator[T]. This helper calls a function `fn` as it takes
@@ -445,8 +446,7 @@ object RmmRapidsRetryIterator extends Arm with Logging {
    */
   class RmmRapidsRetryAutoCloseableIterator[T <: AutoCloseable, K](
       attemptIter: Spliterator[K])
-      extends RmmRapidsRetryIterator[T, K](attemptIter)
-        with Arm {
+      extends RmmRapidsRetryIterator[T, K](attemptIter) {
 
     override def hasNext: Boolean = super.hasNext
 
@@ -475,8 +475,7 @@ object RmmRapidsRetryIterator extends Arm with Logging {
    * @param attemptIter an iterator of T
    */
   class RmmRapidsRetryIterator[T, K](attemptIter: Spliterator[K])
-      extends Iterator[K]
-          with Arm {
+      extends Iterator[K] {
     // used to figure out if we should inject an OOM (only for tests)
     private val config = new RapidsConf(SQLConf.get)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SamplingUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SamplingUtils.scala
@@ -27,12 +27,13 @@ import scala.util.Random
 import scala.util.hashing.MurmurHash3
 
 import ai.rapids.cudf.{ColumnVector, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object SamplingUtils extends Arm {
+object SamplingUtils {
   private def selectWithoutReplacementFrom(count: Int, rand: Random, cb: ColumnarBatch): Table = {
     val rows = cb.numRows()
     assert(count <= rows)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SchemaUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import scala.language.implicitConversions
 
 import ai.rapids.cudf._
 import ai.rapids.cudf.ColumnWriterOptions._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import org.apache.orc.TypeDescription
 
@@ -32,7 +33,7 @@ import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types._
 
-object SchemaUtils extends Arm {
+object SchemaUtils {
   // Parquet field ID metadata key
   val FIELD_ID_METADATA_KEY = "parquet.field.id"
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleBufferCatalog.scala
@@ -24,6 +24,7 @@ import java.util.function.{Consumer, IntUnaryOperator}
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.SparkEnv
@@ -49,7 +50,7 @@ case class ShuffleBufferId(
 /** Catalog for lookup of shuffle buffers by block ID */
 class ShuffleBufferCatalog(
     catalog: RapidsBufferCatalog,
-    diskBlockManager: RapidsDiskBlockManager) extends Arm with Logging {
+    diskBlockManager: RapidsDiskBlockManager) extends Logging {
 
   private val deviceStore = RapidsBufferCatalog.getDeviceStorage
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShuffleReceivedBufferCatalog.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.IntUnaryOperator
 
 import ai.rapids.cudf.DeviceMemoryBuffer
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.internal.Logging
@@ -40,7 +41,7 @@ case class ShuffleReceivedBufferId(
 
 /** Catalog for lookup of shuffle buffers by block ID */
 class ShuffleReceivedBufferCatalog(
-    catalog: RapidsBufferCatalog) extends Arm with Logging {
+    catalog: RapidsBufferCatalog) extends Logging {
 
   private val deviceStore = RapidsBufferCatalog.getDeviceStorage
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, NvtxColor, OrderByArg, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, Expression, NullsFirst, NullsLast, SortOrder}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object SortUtils extends Arm {
+object SortUtils {
   @scala.annotation.tailrec
   def extractReference(exp: Expression): Option[GpuBoundReference] = exp match {
     case r: GpuBoundReference => Some(r)
@@ -64,7 +65,7 @@ object SortUtils extends Arm {
  */
 class GpuSorter(
     val sortOrder: Seq[SortOrder],
-    inputSchema: Array[Attribute]) extends Arm with Serializable {
+    inputSchema: Array[Attribute]) extends Serializable {
 
   /**
    * A class that provides convenience methods for sorting batches of data

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.types.DataType
@@ -56,7 +57,7 @@ trait SpillableColumnarBatch extends AutoCloseable {
  * row count in memory, and not dealing with the catalog at all.
  */
 class JustRowsColumnarBatch(numRows: Int)
-    extends SpillableColumnarBatch with Arm {
+    extends SpillableColumnarBatch {
   override def numRows(): Int = numRows
   override def setSpillPriority(priority: Long): Unit = () // NOOP nothing to spill
 
@@ -81,7 +82,7 @@ class SpillableColumnarBatchImpl (
     handle: RapidsBufferHandle,
     rowCount: Int,
     sparkTypes: Array[DataType])
-    extends SpillableColumnarBatch with Arm {
+    extends SpillableColumnarBatch {
 
   override def dataTypes: Array[DataType] = sparkTypes
   /**
@@ -121,7 +122,7 @@ class SpillableColumnarBatchImpl (
   }
 }
 
-object SpillableColumnarBatch extends Arm {
+object SpillableColumnarBatch {
   /**
    * Create a new SpillableColumnarBatch.
    *
@@ -224,7 +225,7 @@ object SpillableColumnarBatch extends Arm {
  * Just like a SpillableColumnarBatch but for buffers.
  */
 class SpillableBuffer(
-    handle: RapidsBufferHandle) extends AutoCloseable with Arm {
+    handle: RapidsBufferHandle) extends AutoCloseable {
 
   /**
    * Set a new spill priority.
@@ -250,7 +251,7 @@ class SpillableBuffer(
   }
 }
 
-object SpillableBuffer extends Arm {
+object SpillableBuffer {
 
   /**
    * Create a new SpillableBuffer.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, CodecType, TableMeta}
 
@@ -111,7 +112,7 @@ object TableCompressionCodec {
  * @param stream CUDA stream to use
  */
 abstract class BatchedTableCompressor(maxBatchMemorySize: Long, stream: Cuda.Stream)
-    extends AutoCloseable with Arm with Logging {
+    extends AutoCloseable with Logging {
   // The tables that need to be compressed in the next batch
   private[this] val tables = new ArrayBuffer[ContiguousTable]
 
@@ -256,7 +257,7 @@ abstract class BatchedTableCompressor(maxBatchMemorySize: Long, stream: Cuda.Str
  * @param stream CUDA stream to use
  */
 abstract class BatchedBufferDecompressor(maxBatchMemorySize: Long, stream: Cuda.Stream)
-    extends AutoCloseable with Arm with Logging {
+    extends AutoCloseable with Logging {
   // The buffers of compressed data that will be decompressed in the next batch
   private[this] val inputBuffers = new ArrayBuffer[BaseDeviceMemoryBuffer]
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuHashAggregateIterator.{computeAggregateAndClose, concatenateBatches, AggHelper}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -153,7 +154,7 @@ object AggregateModeInfo {
   }
 }
 
-object GpuHashAggregateIterator extends Arm with Logging {
+object GpuHashAggregateIterator extends Logging {
   /**
    * Internal class used in `computeAggregates` for the pre, agg, and post steps
    *
@@ -172,7 +173,7 @@ object GpuHashAggregateIterator extends Arm with Logging {
       aggregateExpressions: Seq[GpuAggregateExpression],
       forceMerge: Boolean,
       isSorted: Boolean = false,
-      useTieredProject : Boolean = true) extends Arm {
+      useTieredProject : Boolean = true) {
 
     // `CudfAggregate` instances to apply, either update or merge aggregates
     // package private for testing
@@ -505,7 +506,7 @@ class GpuHashAggregateIterator(
     metrics: GpuHashAggregateMetrics,
     configuredTargetBatchSize: Long,
     useTieredProject: Boolean)
-    extends Iterator[ColumnarBatch] with Arm with AutoCloseable with Logging {
+    extends Iterator[ColumnarBatch] with AutoCloseable with Logging {
 
   // Partial mode:
   //  1. boundInputReferences: picks column from raw input
@@ -1459,7 +1460,7 @@ case class GpuHashAggregateExec(
     resultExpressions: Seq[NamedExpression],
     child: SparkPlan,
     configuredTargetBatchSize: Long,
-    configuredTieredProjectEnabled: Boolean) extends ShimUnaryExecNode with GpuExec with Arm {
+    configuredTieredProjectEnabled: Boolean) extends ShimUnaryExecNode with GpuExec {
 
   // lifted directly from `BaseAggregateExec.inputAttributes`, edited comment.
   def inputAttributes: Seq[Attribute] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf
 import ai.rapids.cudf._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims._
@@ -65,7 +66,7 @@ class GpuProjectExecMeta(
   }
 }
 
-object GpuProjectExec extends Arm {
+object GpuProjectExec {
   def projectAndClose[A <: Expression](cb: ColumnarBatch, boundExprs: Seq[A],
       opTime: GpuMetric): ColumnarBatch = {
     val nvtxRange = new NvtxWithMetrics("ProjectExec", NvtxColor.CYAN, opTime)
@@ -333,7 +334,7 @@ case class GpuProjectAstExec(
  *   Input columns for tier 3: a, c, e, f, ref2, ref3
  *   Tier 3: (ref2 * e), (ref3 * f), (a + e), (c + f)
  */
- case class GpuTieredProject(exprTiers: Seq[Seq[GpuExpression]]) extends Arm {
+ case class GpuTieredProject(exprTiers: Seq[Seq[GpuExpression]]) {
 
   /**
    * Is everything deterministic. This can help with reliability in the common case.
@@ -403,7 +404,7 @@ case class GpuProjectAstExec(
 /**
  * Run a filter on a batch.  The batch will be consumed.
  */
-object GpuFilter extends Arm {
+object GpuFilter {
   def apply(
       batch: ColumnarBatch,
       boundCondition: Expression,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, DType, NullPolicy, Scalar, ScanAggregation, ScanType, Table, UnaryOp}
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 
@@ -25,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, 
 import org.apache.spark.sql.types.{BooleanType, DataType, DataTypes}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object GpuExpressionWithSideEffectUtils extends Arm {
+object GpuExpressionWithSideEffectUtils {
 
   /**
    * Returns true only if all rows are true. Nulls are considered false.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/cudf_utils/HostConcatResultUtil.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/cudf_utils/HostConcatResultUtil.scala
@@ -18,12 +18,13 @@ package com.nvidia.spark.rapids.cudf_utils
 
 import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization}
 import ai.rapids.cudf.JCudfSerialization.HostConcatResult
-import com.nvidia.spark.rapids.{Arm, GpuColumnVectorFromBuffer, RmmRapidsRetryIterator}
+import com.nvidia.spark.rapids.{GpuColumnVectorFromBuffer, RmmRapidsRetryIterator}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object HostConcatResultUtil extends Arm {
+object HostConcatResultUtil {
   /**
    * Create a rows-only `HostConcatResult`.
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/decimalExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{ColumnVector, DecimalUtils, DType, Scalar}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.{DataType, DecimalType, LongType}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import ai.rapids.cudf
 import ai.rapids.cudf.DType
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{NvtxColor, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
@@ -181,7 +182,7 @@ class GpuCollectLimitMeta(
       )(SinglePartition), 0)
 }
 
-object GpuTopN extends Arm {
+object GpuTopN {
   private[this] def concatAndClose(a: SpillableColumnarBatch,
       b: ColumnarBatch,
       concatTime: GpuMetric): ColumnarBatch = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Scalar}
 import ai.rapids.cudf.ast
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, SparkShimImpl}
 import org.apache.commons.codec.binary.{Hex => ApacheHex}
@@ -41,7 +42,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.unsafe.types.UTF8String
 
-object GpuScalar extends Arm with Logging {
+object GpuScalar extends Logging {
 
   // TODO Support interpreting the value to a Spark DataType
   def extract(v: Scalar): Any = {
@@ -481,7 +482,7 @@ object GpuScalar extends Arm with Logging {
 class GpuScalar private(
     private var scalar: Option[Scalar],
     private var value: Option[Any],
-    val dataType: DataType) extends Arm with AutoCloseable {
+    val dataType: DataType) extends AutoCloseable {
 
   private var refCount: Int = 0
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/nullExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuExpressionsUtils.columnarEvalToColumn
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
@@ -27,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{ComplexTypeMergingExpression, 
 import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object GpuNvl extends Arm {
+object GpuNvl {
   def apply(lhs: ColumnVector, rhs: ColumnVector): ColumnVector = {
     withResource(lhs.isNotNull) { isLhsNotNull =>
       isLhsNotNull.ifElse(lhs, rhs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferReceiveState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{BaseDeviceMemoryBuffer, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange, Rmm}
-import com.nvidia.spark.rapids.Arm
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.internal.Logging
@@ -57,7 +57,7 @@ class BufferReceiveState(
     requests: Seq[PendingTransferRequest],
     transportOnClose: () => Unit,
     stream: Cuda.Stream = Cuda.DEFAULT_STREAM)
-    extends AutoCloseable with Logging with Arm {
+    extends AutoCloseable with Logging {
 
   val transportBuffer = new CudfTransportBuffer(bounceBuffer.buffer)
   // we use this to keep a list (should be depth 1) of "requests for receives"

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/BufferSendState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package com.nvidia.spark.rapids.shuffle
 import java.io.IOException
 
 import ai.rapids.cudf.{Cuda, MemoryBuffer}
-import com.nvidia.spark.rapids.{Arm, RapidsBuffer, ShuffleMetadata, StorageTier}
+import com.nvidia.spark.rapids.{RapidsBuffer, ShuffleMetadata, StorageTier}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.format.{BufferMeta, BufferTransferRequest}
 
@@ -57,7 +58,7 @@ class BufferSendState(
     sendBounceBuffers: SendBounceBuffers,
     requestHandler: RapidsShuffleRequestHandler,
     serverStream: Cuda.Stream = Cuda.DEFAULT_STREAM)
-    extends AutoCloseable with Logging with Arm {
+    extends AutoCloseable with Logging {
 
   class SendBlock(val bufferId: Int, tableSize: Long) extends BlockWithSize {
     override def size: Long = tableSize

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClient.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{DeviceMemoryBuffer, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.{MetadataResponse, TableMeta, TransferState}
 
 import org.apache.spark.internal.Logging
@@ -92,7 +93,7 @@ class RapidsShuffleClient(
     exec: Executor,
     clientCopyExecutor: Executor,
     catalog: ShuffleReceivedBufferCatalog = GpuShuffleEnv.getReceivedCatalog)
-      extends Logging with Arm with AutoCloseable {
+      extends Logging with AutoCloseable {
 
   // these are handlers that are interested (live spark tasks) in peer failure handling
   private val liveHandlers =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -21,7 +21,8 @@ import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
 import scala.collection.mutable
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, GpuSemaphore, RapidsBuffer, RapidsBufferHandle, RapidsConf, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.{GpuSemaphore, RapidsBuffer, RapidsBufferHandle, RapidsConf, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.RmmSpark
 
 import org.apache.spark.TaskContext
@@ -57,7 +58,7 @@ class RapidsShuffleIterator(
     catalog: ShuffleReceivedBufferCatalog = GpuShuffleEnv.getReceivedCatalog,
     timeoutSeconds: Long = GpuShuffleEnv.shuffleFetchTimeoutSeconds)
   extends Iterator[ColumnarBatch]
-    with Logging with Arm {
+    with Logging {
 
   /**
    * General trait encapsulating either a buffer or an error. Used to hand off batches

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import java.util.concurrent.{ConcurrentLinkedQueue, Executor}
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{Cuda, MemoryBuffer, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, RapidsBuffer, RapidsConf, ShuffleMetadata}
+import com.nvidia.spark.rapids.{RapidsBuffer, RapidsConf, ShuffleMetadata}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.format.TableMeta
 
 import org.apache.spark.internal.Logging
@@ -73,7 +74,7 @@ class RapidsShuffleServer(transport: RapidsShuffleTransport,
                           requestHandler: RapidsShuffleRequestHandler,
                           exec: Executor,
                           bssExec: Executor,
-                          rapidsConf: RapidsConf) extends AutoCloseable with Logging with Arm {
+                          rapidsConf: RapidsConf) extends AutoCloseable with Logging {
 
   def getId: BlockManagerId = {
     // upon seeing this port, the other side will try to connect to the port

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ListBuffer
 import ai.rapids.cudf
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, NvtxColor, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.ShimFilePartitionReaderFactory
 import org.apache.hadoop.conf.Configuration
 
@@ -245,7 +246,7 @@ case class GpuJsonPartitionReaderFactory(
   }
 }
 
-object JsonPartitionReader extends Arm {
+object JsonPartitionReader {
   def readToTable(
       dataBufferer: HostLineBufferer,
       cudfSchema: Schema,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -17,8 +17,8 @@
 package org.apache.spark.sql.hive.rapids
 
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, NvtxColor, RegexProgram, Scalar, Schema, Table}
-import com.nvidia.spark.RebaseHelper.withResource
 import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, NvtxWithMetrics, PartitionReaderIterator, PartitionReaderWithBytesRead, RapidsConf}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, DEBUG_LEVEL, DESCRIPTION_BUFFER_TIME, DESCRIPTION_FILTER_TIME, DESCRIPTION_GPU_DECODE_TIME, DESCRIPTION_PEAK_DEVICE_MEMORY, ESSENTIAL_LEVEL, FILTER_TIME, GPU_DECODE_TIME, MODERATE_LEVEL, NUM_OUTPUT_ROWS, PEAK_DEVICE_MEMORY}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.CastStrings

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 import ai.rapids.cudf
 import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, ShimUnaryExpression, TypeUtilsShims}
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -307,7 +308,7 @@ class CudfCount(override val dataType: DataType) extends CudfAggregate {
   override val name: String = "CudfCount"
 }
 
-class CudfSum(override val dataType: DataType) extends CudfAggregate with Arm {
+class CudfSum(override val dataType: DataType) extends CudfAggregate {
   // Up to 3.1.1, analyzed plan widened the input column type before applying
   // aggregation. Thus even though we did not explicitly pass the output column type
   // we did not run into integer overflow issues:

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -28,6 +28,7 @@ import scala.math.max
 
 import ai.rapids.cudf.{AvroOptions => CudfAvroOptions, HostMemoryBuffer, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, FILTER_TIME, GPU_DECODE_TIME, NUM_OUTPUT_BATCHES, PEAK_DEVICE_MEMORY, READ_FS_TIME, WRITE_BUFFER_TIME}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimFilePartitionReaderFactory
@@ -296,7 +297,7 @@ case class GpuAvroMultiFilePartitionReaderFactory(
 }
 
 /** A trait collecting common methods across the 3 kinds of avro readers */
-trait GpuAvroReaderBase extends Arm with Logging { self: FilePartitionReaderBase =>
+trait GpuAvroReaderBase extends Logging { self: FilePartitionReaderBase =>
   private val avroFormat = Some("avro")
 
   def debugDumpPrefix: Option[String]
@@ -1014,7 +1015,7 @@ class GpuMultiFileAvroPartitionReader(
 /** A tool to filter Avro blocks */
 case class AvroFileFilterHandler(
     hadoopConf: Configuration,
-    @transient options: AvroOptions) extends Arm with Logging {
+    @transient options: AvroOptions) extends Logging {
 
   @scala.annotation.nowarn(
     "msg=value ignoreExtension in class AvroOptions is deprecated*"

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuCartesianProductExec.scala
@@ -21,7 +21,8 @@ import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 import scala.collection.mutable
 
 import ai.rapids.cudf.{JCudfSerialization, NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuExpression, GpuMetric, GpuSemaphore, LazySpillableColumnarBatch, MetricsLevel}
+import com.nvidia.spark.rapids.{GpuBindReferences, GpuBuildLeft, GpuColumnVector, GpuExec, GpuExpression, GpuMetric, GpuSemaphore, LazySpillableColumnarBatch, MetricsLevel}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimBinaryExecNode
 
@@ -38,7 +39,7 @@ import org.apache.spark.util.Utils
 
 @SerialVersionUID(100L)
 class GpuSerializableBatch(batch: ColumnarBatch)
-    extends Serializable with AutoCloseable with Arm {
+    extends Serializable with AutoCloseable {
 
   assert(batch != null)
   @transient private var internalBatch: ColumnarBatch = batch
@@ -125,8 +126,7 @@ class GpuCartesianRDD(
     numOutputBatches: GpuMetric,
     var rdd1: RDD[GpuSerializableBatch],
     var rdd2: RDD[GpuSerializableBatch])
-    extends RDD[ColumnarBatch](sc, Nil)
-        with Serializable with Arm {
+    extends RDD[ColumnarBatch](sc, Nil) with Serializable {
 
   private val numPartitionsInRdd2 = rdd2.partitions.length
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, OrderByArg, Table}
 import com.nvidia.spark.TimingUtils
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.TaskAttemptContext
@@ -135,7 +136,6 @@ class GpuSingleDirectoryDataWriter(
     taskAttemptContext: TaskAttemptContext,
     committer: FileCommitProtocol)
   extends GpuFileFormatDataWriter(description, taskAttemptContext, committer) 
-  with Arm 
   with WriterUtil {
   private var fileCounter: Int = _
   private var recordsInFile: Long = _
@@ -219,7 +219,6 @@ class GpuDynamicPartitionDataSingleWriter(
     taskAttemptContext: TaskAttemptContext,
     committer: FileCommitProtocol)
   extends GpuFileFormatDataWriter(description, taskAttemptContext, committer) 
-  with Arm 
   with WriterUtil{
 
   /** Wrapper class for status of a unique single output writer. */
@@ -692,7 +691,7 @@ class GpuDynamicPartitionDataConcurrentWriter(
     committer: FileCommitProtocol,
     spec: GpuConcurrentOutputWriterSpec)
     extends GpuDynamicPartitionDataSingleWriter(description, taskAttemptContext, committer)
-        with Arm with Logging {
+        with Logging {
 
   // Keep all the unclosed writers, key is partition directory string.
   // Note: if fall back to sort-based mode, also use the opened writers in the map.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuLeafExpression}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.rdd.InputFileBlockHolder
 import org.apache.spark.sql.types.{DataType, LongType, StringType}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuPoissonSampler.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuPoissonSampler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,15 @@ package org.apache.spark.sql.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.NvtxColor
-import com.nvidia.spark.rapids.{Arm, GatherUtils, GpuMetric, NvtxWithMetrics}
+import com.nvidia.spark.rapids.{GatherUtils, GpuMetric, NvtxWithMetrics}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.random.PoissonSampler
 
 class GpuPoissonSampler(fraction: Double, useGapSamplingIfPossible: Boolean,
                         numOutputRows: GpuMetric, numOutputBatches: GpuMetric, opTime: GpuMetric)
-  extends PoissonSampler[ColumnarBatch](fraction, useGapSamplingIfPossible) with Arm {
+  extends PoissonSampler[ColumnarBatch](fraction, useGapSamplingIfPossible) {
 
   override def clone: PoissonSampler[ColumnarBatch] =
     new GpuPoissonSampler(fraction, useGapSamplingIfPossible,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.Arm
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.RmmSpark
 import java.{lang => jl}
 
@@ -77,7 +77,7 @@ class NanoSecondAccumulator extends AccumulatorV2[jl.Long, NanoTime] {
   override def value: NanoTime = NanoTime(_sum)
 }
 
-class GpuTaskMetrics extends Arm with Serializable {
+class GpuTaskMetrics extends Serializable {
   private val semWaitTimeNs = new NanoSecondAccumulator
   private val spillBlockTimeNs = new NanoSecondAccumulator
   private val readSpillTimeNs = new NanoSecondAccumulator

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuV1WriteUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuV1WriteUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@ package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, NamedExpression}
 import org.apache.spark.sql.types.{DataType, StringType}
 
-object GpuV1WriteUtils extends Arm {
+object GpuV1WriteUtils {
 
   /** A function that converts the empty string to null for partition values. */
   case class GpuEmpty2Null(child: Expression) extends GpuUnaryExpression {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, GpuExpression, GpuProjectExec, GpuUnaryExpression}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec, GpuUnaryExpression}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{HashUtils, ShimExpression}
 
@@ -40,7 +41,7 @@ case class GpuMd5(child: Expression)
   }
 }
 
-object GpuMurmur3Hash extends Arm {
+object GpuMurmur3Hash {
   def compute(batch: ColumnarBatch,
       boundExpr: Seq[Expression],
       seed: Int = 42): ColumnVector = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shuffle.{RapidsShuffleIterator, RapidsShuffleTransport}
 
 import org.apache.spark.{InterruptibleIterator, TaskContext}
@@ -55,7 +56,7 @@ class RapidsCachingReader[K, C](
     transport: Option[RapidsShuffleTransport],
     catalog: ShuffleBufferCatalog,
     sparkTypes: Array[DataType])
-  extends ShuffleReader[K, C]  with Arm with Logging {
+  extends ShuffleReader[K, C] with Logging {
 
   override def read(): Iterator[Product2[K, C]] = {
     val readRange = new NvtxRange(s"RapidsCachingReader.read", NvtxColor.DARK_GREEN)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsPrivateUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsPrivateUtil.scala
@@ -17,11 +17,12 @@ package org.apache.spark.sql.rapids
 
 import scala.io.Source
 
-import com.nvidia.spark.rapids.{Arm, ConfEntry, ConfEntryWithDefault, OptionalConfEntry}
+import com.nvidia.spark.rapids.{ConfEntry, ConfEntryWithDefault, OptionalConfEntry}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.internal.config.ConfigEntry
 
-object RapidsPrivateUtil extends Arm {
+object RapidsPrivateUtil {
   def getPrivateConfigs(): Seq[ConfEntry[_]] = {
     withResource(Source.fromResource("spark-rapids-extra-configs-classes").bufferedReader()) { r =>
       val className = r.readLine().trim

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -26,6 +26,7 @@ import scala.collection.mutable.ListBuffer
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.TableMeta
 import com.nvidia.spark.rapids.shuffle.{RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport}
 
@@ -241,7 +242,6 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     numWriterThreads: Int)
       extends ShuffleWriter[K, V]
         with RapidsShuffleWriterShimHelper
-        with Arm
         with Logging {
   private var myMapStatus: Option[MapStatus] = None
   private val metrics = handle.metrics
@@ -517,7 +517,7 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
     mapOutputTracker: MapOutputTracker = SparkEnv.get.mapOutputTracker,
     canUseBatchFetch: Boolean = false,
     numReaderThreads: Int = 0)
-  extends ShuffleReader[K, C] with Logging with Arm {
+  extends ShuffleReader[K, C] with Logging {
 
   case class GetMapSizesResult(
       blocksByAddress: Iterator[(BlockManagerId, Seq[(BlockId, Long, Int)])],
@@ -603,7 +603,7 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
   class RapidsShuffleThreadedBlockIterator(
       fetcherIterator: RapidsShuffleBlockFetcherIterator,
       serializer: GpuColumnarBatchSerializer)
-    extends Iterator[(Any, Any)] with Arm {
+    extends Iterator[(Any, Any)] {
     private val queued = new LinkedBlockingQueue[(Any, Any)]
     private val futures = new mutable.Queue[Future[Option[BlockState]]]()
     private val serializerInstance = serializer.newInstance()
@@ -890,8 +890,7 @@ class RapidsCachingWriter[K, V](
     rapidsShuffleServer: Option[RapidsShuffleServer],
     metrics: Map[String, SQLMetric])
   extends ShuffleWriter[K, V]
-    with Logging
-    with Arm {
+    with Logging {
   private val numParts = handle.dependency.partitioner.numPartitions
   private val sizes = new Array[Long](numParts)
 
@@ -1019,7 +1018,7 @@ class RapidsCachingWriter[K, V](
  *       Apache Spark to use the RAPIDS shuffle manager,
  */
 abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: Boolean)
-    extends ShuffleManager with Arm with RapidsShuffleHeartbeatHandler with Logging {
+    extends ShuffleManager with RapidsShuffleHeartbeatHandler with Logging {
 
   def getServerId: BlockManagerId = server.fold(blockManager.blockManagerId)(_.getId)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeWindow.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/TimeWindow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuUnaryExpression}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{AbstractDataType, DataType}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -21,6 +21,7 @@ import java.math.BigInteger
 import ai.rapids.cudf._
 import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{GpuTypeShims, ShimExpression, SparkShimImpl}
 
@@ -32,7 +33,7 @@ import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object AddOverflowChecks extends Arm {
+object AddOverflowChecks {
   def basicOpOverflowCheck(
       lhs: BinaryOperable,
       rhs: BinaryOperable,
@@ -108,7 +109,7 @@ object AddOverflowChecks extends Arm {
   }
 }
 
-object GpuAnsi extends Arm {
+object GpuAnsi {
   def needBasicOpOverflowCheck(dt: DataType): Boolean =
     dt.isInstanceOf[IntegralType]
 
@@ -379,7 +380,7 @@ abstract class GpuSubtractBase(failOnError: Boolean)
   }
 }
 
-trait GpuDecimalMultiplyBase extends GpuExpression with Arm {
+trait GpuDecimalMultiplyBase extends GpuExpression {
 
   def dataType: DecimalType
   def failOnError: Boolean
@@ -480,7 +481,7 @@ trait GpuDecimalMultiplyBase extends GpuExpression with Arm {
   override def nullable: Boolean = left.nullable || right.nullable
 }
 
-object DecimalMultiplyChecks extends Arm {
+object DecimalMultiplyChecks {
   // For Spark the final desired output is
   // new_scale = lhs.scale + rhs.scale
   // new_precision = lhs.precision + rhs.precision + 1
@@ -607,7 +608,7 @@ object DecimalMultiplyChecks extends Arm {
   }
 }
 
-object GpuDivModLike extends Arm {
+object GpuDivModLike {
   def replaceZeroWithNull(v: ColumnVector): ColumnVector = {
     var zeroScalar: Scalar = null
     var nullScalar: Scalar = null

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/bitwise.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@ package org.apache.spark.sql.rapids
 import ai.rapids.cudf.{ast, BinaryOp, ColumnVector, DType, Scalar, UnaryOp}
 import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.types._
 
-object ShiftHelper extends Arm {
+object ShiftHelper {
   // From the java language specification for Java 8
   // If the promoted type of the left-hand operand is int, then only the five lowest-order bits of
   // the right-hand operand are used as the shift distance. It is as if the right-hand operand

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.catalyst.expressions
 
 import ai.rapids.cudf.{DType, HostColumnVector, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuLiteral}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -21,6 +21,7 @@ import java.util.Optional
 import ai.rapids.cudf
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DType, Scalar, SegmentedReductionAggregation, Table}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAllValidTrue
 import com.nvidia.spark.rapids.GpuExpressionsUtils.columnarEvalToColumn
@@ -1300,7 +1301,7 @@ class GpuSequenceMeta(
   }
 }
 
-object GpuSequenceUtil extends Arm {
+object GpuSequenceUtil {
 
   private def checkSequenceInputs(
       start: ColumnVector,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeCreator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuMapUtils}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuMapUtils}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.shims.ShimExpression
 
@@ -132,7 +133,7 @@ case class GpuCreateMap(
   }
 }
 
-object GpuCreateMap extends Arm {
+object GpuCreateMap {
   def apply(children: Seq[Expression]): GpuCreateMap = {
     new GpuCreateMap(children,
       SQLConf.get.getConf(SQLConf.LEGACY_CREATE_EMPTY_COLLECTION_USING_STRING_TYPE))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, DType, Scalar}
 import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuListUtils, GpuMapUtils, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, UnaryExprMeta}
+import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAnyValidTrue
 import com.nvidia.spark.rapids.RapidsPluginImplicits._

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -20,7 +20,8 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DType, RegexProgram, Scalar}
-import com.nvidia.spark.rapids.{Arm, BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
+import com.nvidia.spark.rapids.{BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimBinaryExpression
@@ -397,7 +398,7 @@ object LegacyTimeParserPolicy extends TimeParserPolicy
 object ExceptionTimeParserPolicy extends TimeParserPolicy
 object CorrectedTimeParserPolicy extends TimeParserPolicy
 
-object GpuToTimestamp extends Arm {
+object GpuToTimestamp {
   // We are compatible with Spark for these formats when the timeParserPolicy is CORRECTED
   // or EXCEPTION. It is possible that other formats may be supported but these are the only
   // ones that we have tests for.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/ExistenceJoin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package org.apache.spark.sql.rapids.execution
 
 import ai.rapids.cudf.{ColumnVector, GatherMap, NvtxColor, Scalar, Table}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, GpuMetric, LazySpillableColumnarBatch, NvtxWithMetrics, TaskAutoCloseableResource}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuMetric, LazySpillableColumnarBatch, NvtxWithMetrics, TaskAutoCloseableResource}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -47,7 +48,7 @@ abstract class ExistenceJoinIterator(
     opTime: GpuMetric,
     joinTime: GpuMetric
 ) extends Iterator[ColumnarBatch]()
-    with TaskAutoCloseableResource with Arm {
+    with TaskAutoCloseableResource {
 
   use(spillableBuiltBatch)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -28,6 +28,7 @@ import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization, NvtxColor, NvtxRang
 import ai.rapids.cudf.JCudfSerialization.SerializedTableHeader
 import com.google.common.collect.MapMaker
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{ShimBroadcastExchangeLike, ShimUnaryExecNode, SparkShimImpl}
@@ -50,7 +51,7 @@ import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
-object SerializedHostTableUtils extends Arm {
+object SerializedHostTableUtils {
   /**
    * Read in a cudf serialized table into host memory
    */
@@ -94,7 +95,7 @@ object SerializedHostTableUtils extends Arm {
 class SerializeConcatHostBuffersDeserializeBatch(
     data: Array[SerializeBatchDeserializeHostBuffer],
     output: Seq[Attribute])
-  extends Serializable with Arm with AutoCloseable with Logging {
+  extends Serializable with AutoCloseable with Logging {
   @transient private var dataTypes = output.map(_.dataType).toArray
   @transient private var headers = data.map(_.header)
   @transient private var buffers = data.map(_.buffer)
@@ -241,7 +242,7 @@ class SerializeConcatHostBuffersDeserializeBatch(
 
 @SerialVersionUID(100L)
 class SerializeBatchDeserializeHostBuffer(batch: ColumnarBatch)
-  extends Serializable with AutoCloseable with Arm {
+  extends Serializable with AutoCloseable {
   @transient private var columns = GpuColumnVector.extractBases(batch).map(_.copyToHost())
   @transient var header: JCudfSerialization.SerializedTableHeader = null
   @transient var buffer: HostMemoryBuffer = null

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.execution
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.{GpuBroadcastJoinMeta, ShimBinaryExecNode}
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,15 @@
 package org.apache.spark.sql.rapids.execution
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuColumnVector
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-object GpuBroadcastHelper extends Arm {
+object GpuBroadcastHelper {
   /**
    * Given a broadcast relation get a ColumnarBatch that can be used on the GPU.
    *

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -20,6 +20,7 @@ import ai.rapids.cudf
 import ai.rapids.cudf.{ast, GatherMap, NvtxColor, OutOfBoundsPolicy, Scalar, Table}
 import ai.rapids.cudf.ast.CompiledExpression
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.shims.{GpuBroadcastJoinMeta, ShimBinaryExecNode}
 
@@ -271,7 +272,7 @@ class ConditionalNestedLoopJoinIterator(
   }
 }
 
-object GpuBroadcastNestedLoopJoinExecBase extends Arm {
+object GpuBroadcastNestedLoopJoinExecBase {
   def nestedLoopJoin(
       joinType: JoinType,
       buildSide: GpuBuildSide,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.concurrent.ExecutionContext
 
 import com.nvidia.spark.rapids.{GpuExec, GpuMetric}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric.{COLLECT_TIME, DESCRIPTION_COLLECT_TIME, ESSENTIAL_LEVEL, NUM_OUTPUT_ROWS}
 import com.nvidia.spark.rapids.shims.{ShimBroadcastExchangeLike, ShimUnaryExecNode, SparkShimImpl}
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.execution
 import ai.rapids.cudf.{ColumnView, DType, GatherMap, GroupByAggregation, NullEquality, NullPolicy, NvtxColor, OutOfBoundsPolicy, ReductionAggregation, Scalar, Table}
 import ai.rapids.cudf.ast.CompiledExpression
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.GpuOOM
@@ -100,7 +101,7 @@ object JoinTypeChecks {
     Map(CONDITION -> condition.toSeq)
 }
 
-object GpuHashJoin extends Arm {
+object GpuHashJoin {
 
   def tagJoin(
       meta: SparkPlanMeta[_],

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
 import com.nvidia.spark.rapids.{BaseExprMeta, DataFromReplacementRule, GpuColumnarToRowExec, GpuExec, GpuMetric, RapidsConf, RapidsMeta, SparkPlanMeta, TargetSize}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric.{COLLECT_TIME, DESCRIPTION_COLLECT_TIME, ESSENTIAL_LEVEL}
 import com.nvidia.spark.rapids.shims.{ShimUnaryExecNode, SparkShimImpl}
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/BatchGroupUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/BatchGroupUtils.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import ai.rapids.cudf
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.TaskContext
@@ -49,7 +50,7 @@ case class GroupArgs(
  * It plays the similar role to the Spark 'PandasGroupUtils', but dealing with 'ColumnarBatch',
  * instead of 'InternalRow'.
  */
-private[python] object BatchGroupUtils extends Arm {
+private[python] object BatchGroupUtils {
 
   /**
    * It mainly does 2 things:
@@ -260,7 +261,7 @@ private[python] object BatchGroupUtils extends Arm {
 private[python] class BatchGroupedIterator private(
     input: Iterator[ColumnarBatch],
     inputAttributes: Seq[Attribute],
-    groupingIndices: Seq[Int]) extends Iterator[ColumnarBatch] with Arm {
+    groupingIndices: Seq[Int]) extends Iterator[ColumnarBatch] {
 
   private val batchesQueue: mutable.Queue[SpillableColumnarBatch] = mutable.Queue.empty
 
@@ -318,7 +319,7 @@ private[python] class BatchGroupedIterator private(
 
 }
 
-private[python] object BatchGroupedIterator extends Arm {
+private[python] object BatchGroupedIterator {
 
   /**
    * Create a `BatchGroupedIterator` instance
@@ -394,7 +395,7 @@ class CombiningIterator(
     pythonOutputIter: Iterator[ColumnarBatch],
     pythonArrowReader: GpuPythonArrowOutput,
     numOutputRows: GpuMetric,
-    numOutputBatches: GpuMetric) extends Iterator[ColumnarBatch] with Arm {
+    numOutputBatches: GpuMetric) extends Iterator[ColumnarBatch] {
 
   // For `hasNext` we are waiting on the queue to have something inserted into it
   // instead of waiting for a result to be ready from Python. The reason for this
@@ -440,7 +441,7 @@ class CoGroupedIterator(
     leftGroupOffsets: Seq[Int],
     rightGroupedIter: Iterator[ColumnarBatch],
     rightSchema: Seq[Attribute],
-    rightGroupOffsets: Seq[Int]) extends Iterator[(ColumnarBatch, ColumnarBatch)] with Arm {
+    rightGroupOffsets: Seq[Int]) extends Iterator[(ColumnarBatch, ColumnarBatch)] {
 
   // Same with CPU, use the left grouping key for comparison.
   private val groupSchema = leftGroupOffsets.map(leftSchema(_))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
@@ -51,7 +52,7 @@ class RebatchingRoundoffIterator(
     targetRoundoff: Int,
     inputRows: GpuMetric,
     inputBatches: GpuMetric)
-    extends Iterator[ColumnarBatch] with Arm {
+    extends Iterator[ColumnarBatch] {
   var pending: Option[SpillableColumnarBatch] = None
 
   TaskContext.get().addTaskCompletionListener[Unit]{ _ =>
@@ -171,7 +172,7 @@ class RebatchingRoundoffIterator(
  * A simple queue that holds the pending batches that need to line up with
  * and combined with batches coming back from python
  */
-class BatchQueue extends AutoCloseable with Arm {
+class BatchQueue extends AutoCloseable {
   private val queue: mutable.Queue[SpillableColumnarBatch] =
     mutable.Queue[SpillableColumnarBatch]()
   private var isSet = false

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python._
@@ -35,7 +36,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
 
-class BufferToStreamWriter(outputStream: DataOutputStream) extends HostBufferConsumer with Arm {
+class BufferToStreamWriter(outputStream: DataOutputStream) extends HostBufferConsumer {
   private[this] val tempBuffer = new Array[Byte](128 * 1024)
 
   override def handleBuffer(hostBuffer: HostMemoryBuffer, length: Long): Unit = {
@@ -79,7 +80,7 @@ class StreamToBufferProvider(inputStream: DataInputStream) extends HostBufferPro
  * A trait that can be mixed-in with `GpuPythonRunnerBase`. It implements the logic from
  * Python (Arrow) to GPU/JVM (ColumnarBatch).
  */
-trait GpuPythonArrowOutput extends Arm { _: GpuPythonRunnerBase[_] =>
+trait GpuPythonArrowOutput { _: GpuPythonRunnerBase[_] =>
 
   /**
    * Default to `Int.MaxValue` to try to read as many as possible.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuCoGroupedArrowPythonRunner.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuCoGroupedArrowPythonRunner.scala
@@ -21,6 +21,7 @@ import java.net.Socket
 
 import ai.rapids.cudf.{ArrowIPCWriterOptions, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuSemaphore}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python.{ChainedPythonFunctions, PythonRDD}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuMapInBatchExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuMapInBatchExec.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids.execution.python
 import ai.rapids.cudf
 import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf
 import ai.rapids.cudf.{GroupByAggregation, NullPolicy, OrderByArg}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
@@ -86,7 +87,7 @@ class GroupingIterator(
     wrapped: Iterator[ColumnarBatch],
     partitionSpec: Seq[Expression],
     inputRows: GpuMetric,
-    inputBatches: GpuMetric) extends Iterator[ColumnarBatch] with Arm {
+    inputBatches: GpuMetric) extends Iterator[ColumnarBatch] {
 
   // Currently do it in a somewhat ugly way. In the future cuDF will provide a dedicated API.
   // Current solution assumes one group data exists in only one batch, so just split the

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.Serializable
 import ai.rapids.cudf._
 import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes}
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
@@ -309,7 +310,7 @@ case class GpuLog(child: Expression) extends CudfUnaryMathExpression("LOG") {
   }
 }
 
-object GpuLogarithm extends Arm {
+object GpuLogarithm {
 
   /**
    * Replace negative values with nulls. Note that the caller is responsible for closing the
@@ -430,7 +431,7 @@ case class GpuCot(child: Expression) extends GpuUnaryMathExpression("COT") {
   }
 }
 
-object GpuHypot extends Arm {
+object GpuHypot {
   def chooseXandY(lhs: ColumnVector, rhs: ColumnVector): Seq[ColumnVector] = {
     withResource(lhs.abs) { lhsAbs =>
       withResource(rhs.abs) { rhsAbs =>
@@ -799,7 +800,7 @@ case class GpuRint(child: Expression) extends CudfUnaryMathExpression("ROUND") {
   override def outputTypeOverride: DType = DType.FLOAT64
 }
 
-private object RoundingErrorUtil extends Arm {
+private object RoundingErrorUtil {
   /**
    * Wrapper of the `cannotChangeDecimalPrecisionError` of RapidsErrorUtils.
    *

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/misc.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/misc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{ColumnVector}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, GpuUnaryExpression}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuUnaryExpression}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{AbstractDataType, DataType, NullType, StringType}
 
-case class GpuRaiseError(child: Expression) extends GpuUnaryExpression with ExpectsInputTypes
-  with Arm {
+case class GpuRaiseError(child: Expression) extends GpuUnaryExpression with ExpectsInputTypes {
 
   override def dataType: DataType = NullType
   override def inputTypes: Seq[AbstractDataType] = Seq(StringType)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids
 import ai.rapids.cudf._
 import ai.rapids.cudf.ast.BinaryOperator
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions._

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{BinaryOp, BinaryOperable, CaptureGroups, ColumnVector, ColumnView, DType, PadSide, RegexProgram, Scalar, Table}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{ShimExpression, SparkShimImpl}
 
@@ -742,7 +743,7 @@ case class GpuStringRepeat(input: Expression, repeatTimes: Expression)
 
 }
 
-trait HasGpuStringReplace extends Arm {
+trait HasGpuStringReplace {
   def doStringReplace(
       strExpr: GpuColumnVector,
       searchExpr: GpuScalar,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.zorder
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.ZOrder
 import com.nvidia.spark.rapids.shims.ShimExpression
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuInterleaveBits.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuInterleaveBits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.zorder
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.ZOrder
 import com.nvidia.spark.rapids.shims.ShimExpression
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuPartitionerExpr.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuPartitionerExpr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.spark.sql.rapids.zorder
 
 import ai.rapids.cudf.{ColumnVector, NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuRangePartitioner, GpuUnaryExpression}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types._

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
@@ -21,9 +21,8 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import ai.rapids.cudf
-import com.nvidia.spark.rapids.Arm
 
-object HashUtils extends Arm {
+object HashUtils {
   /**
    * In Spark 3.2.0+ -0.0 is normalized to 0.0, but for everyone else this is a noop
    * @param in the input to normalize

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/rapids/shims/api/python/ShimBasePythonRunner.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/rapids/shims/api/python/ShimBasePythonRunner.scala
@@ -25,8 +25,6 @@ import java.io.DataInputStream
 import java.net.Socket
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.nvidia.spark.rapids.Arm
-
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python.BasePythonRunner
 
@@ -34,8 +32,7 @@ import org.apache.spark.api.python.BasePythonRunner
 abstract class ShimBasePythonRunner[IN, OUT](
     funcs : scala.Seq[org.apache.spark.api.python.ChainedPythonFunctions],
     evalType : scala.Int, argOffsets : scala.Array[scala.Array[scala.Int]]
-) extends BasePythonRunner[IN, OUT](funcs, evalType, argOffsets)
-    with Arm {
+) extends BasePythonRunner[IN, OUT](funcs, evalType, argOffsets) {
   protected abstract class ShimReaderIterator(
     stream: DataInputStream,
     writerThread: WriterThread,

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/hive/rapids/shims/GpuHiveTextFileFormat.scala
@@ -36,6 +36,7 @@ package org.apache.spark.sql.hive.rapids.shims
 import ai.rapids.cudf.{CSVWriterOptions, DType, HostBufferConsumer, QuoteStyle, Scalar, Table, TableWriter => CudfTableWriter}
 import com.google.common.base.Charsets
 import com.nvidia.spark.rapids.{ColumnarFileFormat, ColumnarOutputWriter, ColumnarOutputWriterFactory, FileFormatChecks, HiveDelimitedTextFormatType, RapidsConf, WriteFileOp}
+import com.nvidia.spark.rapids.Arm.withResource
 import java.nio.charset.Charset
 import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
 

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
@@ -22,6 +22,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{MapOutputTracker, SparkEnv, TaskContext}
 import org.apache.spark.serializer.SerializerManager

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
@@ -31,9 +31,10 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import ai.rapids.cudf
-import com.nvidia.spark.rapids.{Arm, ColumnCastUtil}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.ColumnCastUtil
 
-object HashUtils extends Arm {
+object HashUtils {
   /**
    * In Spark 3.2.0+ -0.0 is normalized to 0.0
    * @param in the input to normalize

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/api/python/ShimBasePythonRunner.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/api/python/ShimBasePythonRunner.scala
@@ -35,16 +35,13 @@ import java.io.DataInputStream
 import java.net.Socket
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.nvidia.spark.rapids.Arm
-
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python.BasePythonRunner
 
 abstract class ShimBasePythonRunner[IN, OUT](
     funcs : scala.Seq[org.apache.spark.api.python.ChainedPythonFunctions],
     evalType : scala.Int, argOffsets : scala.Array[scala.Array[scala.Int]]
-) extends BasePythonRunner[IN, OUT](funcs, evalType, argOffsets)
-    with Arm {
+) extends BasePythonRunner[IN, OUT](funcs, evalType, argOffsets) {
   protected abstract class ShimReaderIterator(
     stream: DataInputStream,
     writerThread: WriterThread,

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
@@ -25,6 +25,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{MapOutputTracker, SparkEnv, TaskContext}
 import org.apache.spark.serializer.SerializerManager

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, BinaryOperable, ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuScalar}
+import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimBinaryExpression
 

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -23,6 +23,7 @@ package com.nvidia.spark.rapids.shims
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 
 import org.apache.spark.TaskContext

--- a/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuGroupUDFArrowPythonRunner.scala
+++ b/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuGroupUDFArrowPythonRunner.scala
@@ -28,6 +28,7 @@ import java.net.Socket
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python._

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/AnsiUtil.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/AnsiUtil.scala
@@ -26,13 +26,14 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
-import com.nvidia.spark.rapids.{Arm, BoolUtils, FloatUtils, GpuColumnVector}
+import com.nvidia.spark.rapids.{BoolUtils, FloatUtils, GpuColumnVector}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.RapidsErrorUtils
 import org.apache.spark.sql.types.DataType
 
-object AnsiUtil extends Arm {
+object AnsiUtil {
 
   /**
    * Spark 330+ supports Ansi cast from float/double to timestamp

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
@@ -30,7 +30,8 @@ import java.util.concurrent.TimeUnit.{DAYS, HOURS, MINUTES, SECONDS}
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DType, RegexProgram, Scalar}
-import com.nvidia.spark.rapids.{Arm, BoolUtils, CloseableHolder}
+import com.nvidia.spark.rapids.{BoolUtils, CloseableHolder}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND, MONTHS_PER_YEAR}
@@ -76,7 +77,7 @@ import org.apache.spark.sql.types.{DataType, DayTimeIntervalType => DT, YearMont
  * should update correspondingly if Spark fixes this issue
  *
  */
-object GpuIntervalUtils extends Arm {
+object GpuIntervalUtils {
   val MAX_DAY: Long = Long.MaxValue / DAYS.toMicros(1)
   val MAX_HOUR: Long = Long.MaxValue / HOURS.toMicros(1)
   val MAX_MINUTE: Long = Long.MaxValue / MINUTES.toMicros(1)

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
@@ -26,6 +26,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.{MapOutputTracker, SparkEnv, TaskContext}
 import org.apache.spark.serializer.SerializerManager

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
@@ -28,13 +28,14 @@ package org.apache.spark.sql.rapids.shims
 import java.math.BigInteger
 
 import ai.rapids.cudf.{BinaryOperable, ColumnVector, ColumnView, DType, RoundMode, Scalar}
-import com.nvidia.spark.rapids.{Arm, BoolUtils, GpuBinaryExpression, GpuColumnVector, GpuScalar}
+import com.nvidia.spark.rapids.{BoolUtils, GpuBinaryExpression, GpuColumnVector, GpuScalar}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, NullIntolerant}
 import org.apache.spark.sql.rapids.GpuDivModLike.makeZeroScalar
 import org.apache.spark.sql.types._
 
-object IntervalUtils extends Arm {
+object IntervalUtils {
 
   /**
    * Convert long cv to int cv, throws exception if any value in `longCv` exceeds the int limits.

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -24,6 +24,7 @@ import scala.math.{max, min}
 
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.{Expression, NullIntolerant}

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.rapids.execution
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.rapids.execution
 
 import ai.rapids.cudf.NvtxColor
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuExecutorBroadcastHelper.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuExecutorBroadcastHelper.scala
@@ -19,7 +19,8 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution
 
-import com.nvidia.spark.rapids.{Arm, ConcatAndConsumeAll, GpuColumnVector, GpuMetric, GpuShuffleCoalesceIterator, HostShuffleCoalesceIterator}
+import com.nvidia.spark.rapids.{ConcatAndConsumeAll, GpuColumnVector, GpuMetric, GpuShuffleCoalesceIterator, HostShuffleCoalesceIterator}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
@@ -36,7 +37,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * these relations on the executor because they do the work of the join on the GPU device itself,
  * which means they require a format of the data that can be used on the GPU.
  */
-object GpuExecutorBroadcastHelper extends Arm {
+object GpuExecutorBroadcastHelper {
 
   // This reads the shuffle data that we have retrieved using `getShuffleRDD` from the shuffle
   // exchange. WARNING: Do not use this method outside of this context. This method can only be

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayBuffer
 
+import com.nvidia.spark.rapids.Arm._
 import org.scalatest.FunSuite
 
-class ArmSuite extends FunSuite with Arm {
+class ArmSuite extends FunSuite {
   class TestResource extends AutoCloseable {
     var closed = false
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, CompressionType, DType, Table, TableWriter}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CsvScanRetrySuite.scala
@@ -21,7 +21,7 @@ import com.nvidia.spark.rapids.jni.RmmSpark
 
 import org.apache.spark.sql.types._
 
-class CsvScanRetrySuite extends RmmSparkRetrySuiteBase with Arm {
+class CsvScanRetrySuite extends RmmSparkRetrySuiteBase {
   test("test simple retry") {
     val bufferer = HostLineBuffererFactory.createBufferer(100, Array('\n'.toByte))
     bufferer.add("1,2".getBytes, 0, 3)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CudfTestHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnView, DType, HostColumnVector, HostColumnVectorCore}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals}
 
 /**
  * Convenience methods for testing cuDF calls directly. This code is largely copied
  * from the cuDF Java test suite.
  */
-object CudfTestHelper extends Arm {
+object CudfTestHelper {
 
   /**
    * Checks and asserts that passed in columns match

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -28,8 +29,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuCoalesceBatchesRetrySuite
   extends RmmSparkRetrySuiteBase
-    with MockitoSugar
-      with Arm {
+    with MockitoSugar {
 
   private def buildBatchesToCoalesce(): Seq[ColumnarBatch] = {
     (0 until 10).map { _ =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -22,6 +22,7 @@ import java.nio.file.Files
 import scala.collection.JavaConverters._
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, HostColumnVector, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.CodecType
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.IntVector

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuColumnarToRowSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuColumnarToRowSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 
 import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-class GpuDeviceManagerSuite extends FunSuite with Arm with BeforeAndAfter {
+class GpuDeviceManagerSuite extends FunSuite with BeforeAndAfter {
 
   before {
     TrampolineUtil.cleanupAnyExistingSession()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuExpressionTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuExpressionTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.types.{DataType, DataTypes, Decimal, DecimalType, StructType}
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.FileUtils.withTempPath
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 
-class GpuFileScanPrunePartitionSuite extends SparkQueryCompareTestSuite with Arm {
+class GpuFileScanPrunePartitionSuite extends SparkQueryCompareTestSuite {
 
   private def testGpuFileScanOutput(
       func: DataFrame => DataFrame,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuGenerateSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,19 @@
 
 package com.nvidia.spark.rapids
 
+import java.util
+
+import scala.collection.mutable.ArrayBuffer
+
 import ai.rapids.cudf.{ColumnVector, DType, Table}
 import ai.rapids.cudf.HostColumnVector.{BasicType, ListType}
-import java.util
-import scala.collection.mutable.ArrayBuffer
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuGenerateSuite
-  extends SparkQueryCompareTestSuite
-    with Arm {
+  extends SparkQueryCompareTestSuite {
   val rapidsConf = new RapidsConf(Map.empty[String, String])
 
   def makeListColumn(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.util.concurrent.Callable
 
 import ai.rapids.cudf.HostMemoryBuffer
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.PartitionedFileUtilsShim
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.FunSuite
@@ -29,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuMultiFileReaderSuite extends FunSuite with Arm {
+class GpuMultiFileReaderSuite extends FunSuite {
 
   test("avoid infinite loop when host buffers empty") {
     val conf = new Configuration(false)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.math.RoundingMode
 
 import ai.rapids.cudf.{ColumnVector, Cuda, DType, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
@@ -28,7 +29,7 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuPartitioningSuite extends FunSuite with Arm {
+class GpuPartitioningSuite extends FunSuite {
   var rapidsConf = new RapidsConf(Map[String, String]())
 
   private def buildBatch(): ColumnarBatch = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuReaderTypeSuites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.rapids.{ExternalSource, GpuFileSourceScanExec}
 
-trait ReaderTypeSuite extends SparkQueryCompareTestSuite with Arm {
+trait ReaderTypeSuite extends SparkQueryCompareTestSuite {
 
   /** File format */
   protected def format: String

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream}
 
 import ai.rapids.cudf.{ColumnVector, HostMemoryBuffer, JCudfSerialization, Table}
+import com.nvidia.spark.rapids.Arm._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
@@ -30,7 +31,7 @@ import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /** Tests for the "prepareBuildBatchesForJoin" function. */
-class GpuShuffledHashJoinExecSuite extends FunSuite with Arm with MockitoSugar {
+class GpuShuffledHashJoinExecSuite extends FunSuite with MockitoSugar {
   private val metricMap = mock[Map[String, GpuMetric]]
   when(metricMap(any())).thenReturn(NoopMetric)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.math.RoundingMode
 
 import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.FunSuite
 
 import org.apache.spark.SparkConf
@@ -26,7 +27,7 @@ import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
 import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuSinglePartitioningSuite extends FunSuite with Arm {
+class GpuSinglePartitioningSuite extends FunSuite {
   private def buildBatch(): ColumnarBatch = {
     withResource(new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1, 1, 1, 1, 1, 1, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSubPartitionSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm._
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, ExprId}
 import org.apache.spark.sql.rapids.execution.{GpuBatchSubPartitioner, GpuBatchSubPartitionIterator, GpuSubPartitionPairIterator}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuUnitTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
 import ai.rapids.cudf.DType._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, Nondeterministic}
 import org.apache.spark.sql.types._

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{CudfException, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.RmmSpark
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -28,8 +29,7 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 
 class HashAggregateRetrySuite
     extends RmmSparkRetrySuiteBase
-        with MockitoSugar
-        with Arm {
+        with MockitoSugar {
   private def buildReductionBatch(): SpillableColumnarBatch = {
     val reductionTable = new Table.TestBuilder()
       .column(5L, null.asInstanceOf[java.lang.Long], 3L, 1L)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JsonScanRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JsonScanRetrySuite.scala
@@ -22,7 +22,7 @@ import com.nvidia.spark.rapids.jni.RmmSpark
 import org.apache.spark.sql.catalyst.json.rapids.JsonPartitionReader
 import org.apache.spark.sql.types._
 
-class JsonScanRetrySuite extends RmmSparkRetrySuiteBase with Arm {
+class JsonScanRetrySuite extends RmmSparkRetrySuiteBase {
   test("test simple retry") {
     val bufferer = HostLineBuffererFactory.createBufferer(100, Array('\n'.toByte))
     bufferer.add("{\"a\": 1, \"b\": 2".getBytes, 0, 14)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/KnownNotNullSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/KnownNotNullSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.nvidia.spark.RapidsUDF
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.functions.col
 
@@ -54,7 +55,7 @@ class KnownNotNullSuite extends SparkQueryCompareTestSuite {
 /**
  * A Rapids UDF for test only.
  */
-trait PlusOne extends RapidsUDF with Serializable with Arm {
+trait PlusOne extends RapidsUDF with Serializable {
 
   override def evaluateColumnar(numRows: Int, args: ColumnVector*): ColumnVector = {
     require(args.length == 1,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,14 @@ import java.util
 
 import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer, DType, HostColumnVector, Table}
 import ai.rapids.cudf.HostColumnVector.{BasicType, StructData}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.CodecType
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types.{ArrayType, DataType, DecimalType, DoubleType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class MetaUtilsSuite extends FunSuite with Arm {
+class MetaUtilsSuite extends FunSuite {
   private val contiguousTableSparkTypes: Array[DataType] = Array(
     IntegerType,
     StringType,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetFieldIdSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetFieldIdSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
+import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetFileReader

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, RegexProgram}
+import com.nvidia.spark.rapids.Arm.withResource
 import java.sql.{Date, Timestamp}
 import org.scalatest.BeforeAndAfterEach
 import scala.collection.mutable.ListBuffer

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.nio.file.Files
 
 import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.RmmSpark
 import org.mockito.Mockito.spy
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.File
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, MemoryBuffer}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.StorageTier.{DEVICE, DISK, HOST, StorageTier}
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentMatchers.any
@@ -30,7 +31,7 @@ import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class RapidsBufferCatalogSuite extends FunSuite with MockitoSugar with Arm {
+class RapidsBufferCatalogSuite extends FunSuite with MockitoSugar {
   test("lookup unknown buffer") {
     val catalog = new RapidsBufferCatalog
     val bufferId = new RapidsBufferId {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
@@ -22,6 +22,7 @@ import java.math.RoundingMode
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentCaptor
@@ -32,7 +33,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerType, StringType}
 
-class RapidsDeviceMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
+class RapidsDeviceMemoryStoreSuite extends FunSuite with MockitoSugar {
   private def buildContiguousTable(): ContiguousTable = {
     withResource(new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1)
@@ -309,7 +310,7 @@ class RapidsDeviceMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
       throw new UnsupportedOperationException
   }
 
-  class MockSpillStore extends RapidsBufferStore(StorageTier.HOST) with Arm {
+  class MockSpillStore extends RapidsBufferStore(StorageTier.HOST) {
     val spilledBuffers = new ArrayBuffer[RapidsBufferId]
 
     override protected def createBuffer(

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.math.RoundingMode
 
 import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer, HostMemoryBuffer, Table}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{spy, times, verify}
 import org.scalatest.mockito.MockitoSugar
@@ -27,7 +28,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerType, StringType}
 
-class RapidsDiskStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar {
+class RapidsDiskStoreSuite extends FunSuiteWithTempDir with MockitoSugar {
 
   private def buildContiguousTable(): ContiguousTable = {
     withResource(new Table.TestBuilder()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.io.File
 
 import ai.rapids.cudf.{ContiguousTable, CuFile, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
@@ -31,7 +32,7 @@ import org.apache.spark.storage.BlockId
 
 object GdsTest extends Tag("GdsTest")
 
-class RapidsGdsStoreSuite extends FunSuiteWithTempDir with Arm with MockitoSugar {
+class RapidsGdsStoreSuite extends FunSuiteWithTempDir with MockitoSugar {
 
  test("single shot spill with shared path", GdsTest) {
    println("Trying to load CuFile")

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.math.RoundingMode
 
 import ai.rapids.cudf.{ContiguousTable, Cuda, HostColumnVector, HostMemoryBuffer, MemoryBuffer, Table}
+import com.nvidia.spark.rapids.Arm._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, spy, times, verify, when}
@@ -31,7 +32,7 @@ import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerTyp
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 
-class RapidsHostMemoryStoreSuite extends FunSuite with Arm with MockitoSugar {
+class RapidsHostMemoryStoreSuite extends FunSuite with MockitoSugar {
   private def buildContiguousTable(): ContiguousTable = {
     withResource(new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.RebaseHelper
+import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.FunSuite
 
-class RebaseHelperSuite extends FunSuite with Arm {
+class RebaseHelperSuite extends FunSuite {
   test("all null timestamp days column rebase check") {
     withResource(ColumnVector.timestampDaysFromBoxedInts(null, null, null)) { c =>
       assertResult(false)(RebaseHelper.isDateRebaseNeededInWrite(c))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -22,13 +22,14 @@ import scala.collection.mutable.{HashSet, ListBuffer}
 import scala.util.{Random, Try}
 
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, CudfException, RegexProgram}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RegexParser.toReadableString
 import org.scalatest.FunSuite
 
 import org.apache.spark.sql.rapids.GpuRegExpUtils
 import org.apache.spark.sql.types.DataTypes
 
-class RegularExpressionTranspilerSuite extends FunSuite with Arm {
+class RegularExpressionTranspilerSuite extends FunSuite {
 
   test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.commons.lang3.SerializationUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
@@ -26,7 +27,7 @@ import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class SerializationSuite extends FunSuite
-  with BeforeAndAfterAll with Arm {
+  with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     RapidsBufferCatalog.setDeviceStorage(new RapidsDeviceMemoryStore())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -145,7 +145,7 @@ object SparkSessionHolder extends Logging {
 /**
  * Set of tests that compare the output using the CPU version of spark vs our GPU version.
  */
-trait SparkQueryCompareTestSuite extends FunSuite with Arm {
+trait SparkQueryCompareTestSuite extends FunSuite {
   import SparkSessionHolder.withSparkSession
 
   def enableCsvConf(): SparkConf = enableCsvConf(new SparkConf())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVectorCore, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import java.io.File
 import org.scalatest.Assertions
@@ -30,7 +31,7 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /** A collection of utility methods useful in tests. */
-object TestUtils extends Assertions with Arm {
+object TestUtils extends Assertions {
   // Need to set a legacy config to allow clearing the active session
   private val clearSessionConf = {
     val conf = new SQLConf

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf._
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -27,8 +28,7 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 
 class WindowRetrySuite
     extends RmmSparkRetrySuiteBase
-        with MockitoSugar
-        with Arm {
+        with MockitoSugar {
   private def buildInputBatch() = {
     val windowTable = new Table.TestBuilder()
       .column(1.asInstanceOf[java.lang.Integer], 1, 1, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler, Table}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
@@ -29,7 +30,7 @@ import org.apache.spark.sql.types.{DataType, LongType}
 
 class WithRetrySuite
     extends FunSuite
-        with BeforeAndAfterEach with MockitoSugar with Arm {
+        with BeforeAndAfterEach with MockitoSugar {
 
   private def buildBatch: SpillableColumnarBatch = {
     val reductionTable = new Table.TestBuilder()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleClientSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.shuffle
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{DeviceMemoryBuffer, HostMemoryBuffer}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.ShuffleMetadata
 import com.nvidia.spark.rapids.format.{BufferMeta, TableMeta}
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleServerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import java.nio.ByteBuffer
 import java.util
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer}
-import com.nvidia.spark.rapids.{Arm, MetaUtils, RapidsBuffer, ShuffleMetadata}
+import com.nvidia.spark.rapids.{MetaUtils, RapidsBuffer, ShuffleMetadata}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.{any, anyLong}
@@ -29,7 +30,7 @@ import org.mockito.Mockito._
 
 import org.apache.spark.storage.ShuffleBlockBatchId
 
-class RapidsShuffleServerSuite extends RapidsShuffleTestHelper with Arm {
+class RapidsShuffleServerSuite extends RapidsShuffleTestHelper {
 
   def setupMocks(deviceBuffers: Seq[DeviceMemoryBuffer]): (RapidsShuffleRequestHandler,
       Seq[RapidsBuffer], util.HashMap[RapidsBuffer, Int]) = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -22,7 +22,8 @@ import java.util.concurrent.Executor
 import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, DeviceMemoryBuffer, HostMemoryBuffer}
-import com.nvidia.spark.rapids.{Arm, GpuColumnVector, MetaUtils, RapidsBufferHandle, RapidsConf, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.{GpuColumnVector, MetaUtils, RapidsBufferHandle, RapidsConf, RapidsDeviceMemoryStore, ShuffleMetadata, ShuffleReceivedBufferCatalog}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -52,8 +53,7 @@ class TestShuffleMetricsUpdater extends ShuffleMetricsUpdater {
 
 class RapidsShuffleTestHelper extends FunSuite
     with BeforeAndAfterEach
-    with MockitoSugar
-    with Arm {
+    with MockitoSugar {
   var mockTransaction: Transaction = _
   var mockConnection: MockClientConnection = _
   var mockTransport: RapidsShuffleTransport = _
@@ -156,7 +156,7 @@ class RapidsShuffleTestHelper extends FunSuite
   }
 }
 
-object RapidsShuffleTestHelper extends MockitoSugar with Arm {
+object RapidsShuffleTestHelper extends MockitoSugar {
   def buildMockTableMeta(tableId: Int, contigTable: ContiguousTable): TableMeta = {
     MetaUtils.buildTableMeta(tableId, contigTable)
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/AlwaysTrueUDF.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/tests/udf/scala/AlwaysTrueUDF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ package com.nvidia.spark.rapids.tests.udf.scala
 
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.nvidia.spark.RapidsUDF
-import com.nvidia.spark.rapids.Arm
+import com.nvidia.spark.rapids.Arm.withResource
 
 /**
  * A Scala user-defined function (UDF) that always returns true.
  * Used for testing RAPIDS accelerated UDFs with no inputs.
  */
-class AlwaysTrueUDF extends (() => Boolean) with RapidsUDF with Arm with Serializable {
+class AlwaysTrueUDF extends (() => Boolean) with RapidsUDF with Serializable {
   /** Row-by-row implementation that executes on the CPU */
   override def apply(): Boolean = true
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DateTimeUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.unit
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.{GpuBoundReference, GpuColumnVector, GpuLiteral, GpuUnitTests}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.rapids.{GpuDateAdd, GpuDateSub}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import scala.util.Random
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.{GpuAlias, GpuColumnVector, GpuIsNotNull, GpuIsNull, GpuLiteral, GpuOverrides, GpuScalar, GpuUnitTests, HostColumnarToGpu, RapidsConf}
+import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.shims.GpuBatchScanExec
 
 import org.apache.spark.SparkConf

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/GpuScalarUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/GpuScalarUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.unit
 
 import ai.rapids.cudf.Scalar
 import com.nvidia.spark.rapids._
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.types.{FloatType, IntegerType}
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/StringRepeatUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/StringRepeatUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids.unit
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuScalar, GpuUnitTests}
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.rapids.GpuStringRepeat
 import org.apache.spark.sql.types.DataTypes

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import scala.concurrent.duration._
 
 import ai.rapids.cudf
 import com.nvidia.spark.rapids.{GpuColumnVector, SparkQueryCompareTestSuite}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetWriter

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.rapids
 import java.util.UUID
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, MemoryBuffer}
-import com.nvidia.spark.rapids.{Arm, RapidsBuffer, RapidsBufferCatalog, RapidsBufferId, SpillableColumnarBatchImpl, StorageTier}
+import com.nvidia.spark.rapids.{RapidsBuffer, RapidsBufferCatalog, RapidsBufferId, SpillableColumnarBatchImpl, StorageTier}
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 import org.scalatest.FunSuite
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.TempLocalBlockId
 
-class SpillableColumnarBatchSuite extends FunSuite with Arm {
+class SpillableColumnarBatchSuite extends FunSuite {
 
   test("close updates catalog") {
     val id = TempSpillBufferId(0, TempLocalBlockId(new UUID(1, 2)))

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/execution/InternalColumnarRDDConverterSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.rapids.execution
 import scala.collection.mutable
 
 import com.nvidia.spark.rapids.{ColumnarRdd, ColumnarToRowIterator, GpuBatchUtilsSuite, GpuColumnVectorUtils, NoopMetric, RapidsHostColumnVector, SparkQueryCompareTestSuite, TestResourceFinder}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 
 import org.apache.spark.SparkConf

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -29,7 +29,8 @@ package org.apache.spark.sql.rapids
 import java.io.{ByteArrayOutputStream, InputStream}
 import java.nio.ByteBuffer
 
-import com.nvidia.spark.rapids.{Arm, GpuColumnarBatchSerializer, GpuColumnVector, NoopMetric, SparkSessionHolder}
+import com.nvidia.spark.rapids.{GpuColumnarBatchSerializer, GpuColumnVector, NoopMetric, SparkSessionHolder}
+import com.nvidia.spark.rapids.Arm.withResource
 import org.mockito.ArgumentMatchers.{eq => meq}
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
@@ -70,7 +71,7 @@ class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends Managed
 }
 
 class RapidsShuffleThreadedReaderSuite
-    extends FunSuite with BeforeAndAfterAll with Arm {
+    extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     RapidsShuffleInternalManagerBase.stopThreadPool()

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
@@ -24,8 +24,8 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
-import com.nvidis.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.GpuIntervalUtils
+import com.nvidis.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.{DayTimeIntervalType, StructField, StructType}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
@@ -25,7 +25,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.shims.GpuIntervalUtils
-import com.nvidis.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.{DayTimeIntervalType, StructField, StructType}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
@@ -24,6 +24,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidis.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.GpuIntervalUtils
 
 import org.apache.spark.sql.{DataFrame, SparkSession}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/CsvScanForIntervalSuite.scala
@@ -24,8 +24,8 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
-import com.nvidia.spark.rapids.shims.GpuIntervalUtils
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.shims.GpuIntervalUtils
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.{DayTimeIntervalType, StructField, StructType}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
@@ -23,6 +23,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.GpuIntervalUtils
 import org.scalatest.FunSuite
 
@@ -34,7 +35,7 @@ import org.apache.spark.sql.types.{DayTimeIntervalType => DT}
  * Unit test cases for testing `GpuIntervalUtils.toDayTimeIntervalString`
  *
  */
-class GpuIntervalUtilsTest extends FunSuite with Arm {
+class GpuIntervalUtilsTest extends FunSuite {
 
   def testDayTimeToString(fromField: Byte, endField: Byte,
       testData: Array[(Long, String)]): Unit = {


### PR DESCRIPTION
This turns `trait Arm` into `object Arm`, removes all inheritance from the old trait, and adds appropriate imports everywhere. 

I am targeting 23.06 for now since there is a PR for 23.04 for GpuProjectExec (https://github.com/NVIDIA/spark-rapids/pull/8107), since this issue was raised specifically around GpuProjectExec: https://github.com/NVIDIA/spark-rapids/issues/8095.