### PR TITLE
Fix Orc writer test failure with Spark 3.4

### DIFF
--- a/tests/src/test/spark321/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
+++ b/tests/src/test/spark321/scala/com/nvidia/spark/rapids/OrcEncryptionSuite.scala
@@ -53,7 +53,7 @@ class OrcEncryptionSuite extends SparkQueryCompareTestSuite {
     "Write encrypted ORC fallback",
     "DataWritingCommandExec",
     intsDf,
-    execsAllowedNonGpu = Seq("ShuffleExchangeExec", "DataWritingCommandExec")) {
+    execsAllowedNonGpu = Seq("ShuffleExchangeExec", "DataWritingCommandExec", "WriteFilesExec")) {
     frame =>
       // ORC encryption is only allowed in 3.2+
       val isValidTestForSparkVersion = ShimLoader.getShimVersion match {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7751

A test was failing against 3.4 because the plan includes the new `WriteFilesExec` operator, and this was not part of the `execsAllowedNonGpu` list.

This PR adds this operator to `execsAllowedNonGpu`.