### PR TITLE
Add GPU support for KnownNullable expression (Spark 3.4.0)

### DIFF
--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.DataType
 
 case class GpuKnownNullable(child: Expression) extends GpuUnaryExpression {
-
   override def dataType: DataType = child.dataType
   override def nullable: Boolean = true
   override def doColumnar(input: GpuColumnVector): ColumnVector = input.getBase.incRefCount()

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "340"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuUnaryExpression}
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.types.DataType
+
+case class GpuKnownNullable(child: Expression) extends GpuUnaryExpression {
+
+  override def dataType: DataType = child.dataType
+  override def nullable: Boolean = true
+  override def doColumnar(input: GpuColumnVector): ColumnVector = input.getBase.incRefCount()
+}

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
@@ -22,8 +22,8 @@ package com.nvidia.spark.rapids.shims
 import com.nvidia.spark.rapids._
 
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
-import org.apache.spark.sql.catalyst.expressions.Empty2Null
 import org.apache.spark.sql.catalyst.expressions.{Expression, KnownNullable}
+import org.apache.spark.sql.catalyst.expressions.Empty2Null
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan}
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
@@ -23,7 +23,7 @@ import com.nvidia.spark.rapids._
 
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
 import org.apache.spark.sql.catalyst.expressions.Empty2Null
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, KnownNullable}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan}
 import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
@@ -89,6 +89,14 @@ trait Spark340PlusShims extends Spark331PlusShims {
           TypeSig.STRING, TypeSig.STRING),
         (a, conf, p, r) => new UnaryExprMeta[Empty2Null](a, conf, p, r) {
           override def convertToGpu(child: Expression): GpuExpression = GpuEmpty2Null(child)
+        }
+      ),
+      GpuOverrides.expr[KnownNullable](
+        "Tags the expression as being nullable",
+        ExprChecks.unaryProjectInputMatchesOutput(
+          TypeSig.all, TypeSig.all),
+        (a, conf, p, r) => new UnaryExprMeta[KnownNullable](a, conf, p, r) {
+          override def convertToGpu(child: Expression): GpuExpression = GpuKnownNullable(child)
         }
       ),
       GpuElementAtMeta.elementAtRule(true)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8015

Spark 3.4.0 adds a new `KnownNullable` expression. It simply wraps an expression and overrides the `nullable` to be true.

This PR implements the expression, resolving a number of integration test failures (see issue for details).

