### PR TITLE
Enable ParquetWriterSuite test 'sorted partitioned write' on Spark 3.4.0

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetWriterSuite.scala
@@ -86,11 +86,6 @@ class ParquetWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("sorted partitioned write") {
-    assume(!isSpark340OrLater,
-      "Skipping on Spark 3.4+ because of " +
-      "https://issues.apache.org/jira/browse/SPARK-40588 and " +
-      "https://issues.apache.org/jira/browse/SPARK-40885")
-
     val conf = new SparkConf().set(RapidsConf.SQL_ENABLED.key, "true")
     val tempFile = File.createTempFile("partitioned", ".parquet")
     try {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/7018

We were ignoring a test on Spark 3.4.0 due to bugs that have now been fixed. This PR enables the test again.