### PR TITLE
Add handling for SplitAndRetryOOM in nextCbFromGatherer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -132,7 +132,7 @@ abstract class AbstractGpuJoinIterator(
 
   private def nextCbFromGatherer(): Option[ColumnarBatch] = {
     withResource(new NvtxWithMetrics(gatherNvtxName, NvtxColor.DARK_GREEN, joinTime)) { _ =>
-      val minTargetSize = Math.min(targetSize, 64 * 1024 * 1024)
+      val minTargetSize = Math.min(targetSize, 64L * 1024 * 1024)
       val targetSizeWrapper = AutoCloseableTargetSize(targetSize, minTargetSize)
       val ret = gathererStore.map { gather =>
         gather.checkpoint()
@@ -141,7 +141,7 @@ abstract class AbstractGpuJoinIterator(
             val nextRows = JoinGatherer.getRowsInNextBatch(gather, attempt.targetSize)
             gather.gatherNext(nextRows)
           }
-        }.toSeq.head
+        }.next()
       }
       if (gathererStore.exists(_.isDone)) {
         gathererStore.foreach(_.close())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -620,7 +620,8 @@ object RmmRapidsRetryIterator extends Logging {
         val newTarget = target.targetSize / 2
         if (newTarget < target.minSize) {
           throw new SplitAndRetryOOM(
-            s"GPU OutOfMemory: targetSize cannot be split further!")
+            s"GPU OutOfMemory: targetSize: ${target.targetSize} cannot be split further!" +
+                s" minimum: ${target.minSize}")
         }
         Seq(AutoCloseableTargetSize(newTarget, target.minSize))
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -608,6 +608,23 @@ object RmmRapidsRetryIterator extends Logging {
       }
     }
   }
+
+  /**
+   * A common split function for an AutoCloseableTargetSize, which just divides the target size
+   * in half, and creates a seq with just one element representing the new target size.
+   * @return a Seq[AutoCloseableTargetSize] with 1 element.
+   */
+  def splitTargetSizeInHalf: AutoCloseableTargetSize => Seq[AutoCloseableTargetSize] =
+    (target: AutoCloseableTargetSize) => {
+      withResource(target) { _ =>
+        val newTarget = target.targetSize / 2
+        if (newTarget < target.minSize) {
+          throw new SplitAndRetryOOM(
+            s"GPU OutOfMemory: targetSize cannot be split further!")
+        }
+        Seq(AutoCloseableTargetSize(newTarget, target.minSize))
+      }
+  }
 }
 
 trait CheckpointRestore {
@@ -620,4 +637,15 @@ trait CheckpointRestore {
    * Restore state that was checkpointed.
    */
   def restore(): Unit
+}
+
+/**
+ * This is a wrapper that turns a target size into an autocloseable to allow it to be used
+ * in withRetry blocks.  It is intended to be used to help with cases where the split calculation
+ * happens inside the retry block, and depends on the target size.  On a SplitAndRetryOOM,
+ * a split policy like `splitTargetSizeInHalf` can be used to retry the block with a smaller target
+ * size.
+ */
+case class AutoCloseableTargetSize(targetSize: Long, minSize: Long) extends AutoCloseable {
+  override def close() = {}
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -648,5 +648,5 @@ trait CheckpointRestore {
  * size.
  */
 case class AutoCloseableTargetSize(targetSize: Long, minSize: Long) extends AutoCloseable {
-  override def close() = {}
+  override def close(): Unit = ()
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler, Table}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetry, withRetryNoSplit}
+import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalf, withRestoreOnRetry, withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
@@ -240,6 +240,50 @@ class WithRetrySuite
     } finally {
       assert(myCheckpointables(0).value == (initialValue + increment))
       assert(myCheckpointables(1).value == (initialValue + 10 + increment))
+    }
+  }
+
+  test("splitTargetSizeInHalf splits for AutoCloseableTargetSize") {
+    val initialValue = 20L
+    val minValue = 5L
+    val numSplits = 2
+    var doThrow = numSplits
+    var lastSplitSize = 0L
+    val myTarget = AutoCloseableTargetSize(initialValue, minValue)
+    try {
+      withRetry(myTarget, splitTargetSizeInHalf) { attempt =>
+        lastSplitSize = attempt.targetSize
+        if (doThrow > 0) {
+          doThrow = doThrow - 1
+          throw new SplitAndRetryOOM("in tests")
+        }
+      }.toSeq
+    } finally {
+      assert(lastSplitSize >= minValue)
+      assert(lastSplitSize == (initialValue / (2 * numSplits)))
+    }
+  }
+
+  test("splitTargetSizeInHalf on AutoCloseableTargetSize throws if limit reached") {
+    val initialValue = 20L
+    val minValue = 5L
+    val numSplits = 3
+    var doThrow = numSplits
+    var lastSplitSize = 0L
+    val myTarget = AutoCloseableTargetSize(initialValue, minValue)
+    try {
+      assertThrows[SplitAndRetryOOM] {
+        withRetry(myTarget, splitTargetSizeInHalf) { attempt =>
+          lastSplitSize = attempt.targetSize
+          if (doThrow > 0) {
+            doThrow = doThrow - 1
+            throw new SplitAndRetryOOM("in tests")
+          }
+        }.toSeq
+      }
+    } finally {
+      assert(lastSplitSize >= minValue)
+      assert(lastSplitSize == (initialValue / (2 * (numSplits - 1))))
     }
   }
 


### PR DESCRIPTION
This is a follow-up to #7930.

it adds handling for `SplitAndRetryOOM`'s for the join code that pulls the next columnar batch  from the gatherer.  I've seen a couple cases where we have existing split calculation code that depends on an integer target size that we pass to it, so on a split-and-retry-oom we want to recalculate the split using a smaller target size - we don't necessarily have an input batch that we are splitting (in this case, we are calculating the number of rows to pull from the gatherer).

This adds an AutoCloseable wrapper for (targetSize, minSize), and an associated split policy, `splitTargetSizeInHalf`.
