### PR TITLE
Fix nz timestamp unit tests

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
@@ -1019,7 +1019,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
         }
       },
         // disable timestampNTZ for parquet for 3.4+ tests to pass
-        new SparkConf().set("spark.sql.parquet.timestampNTZ.enabled", "false")
+        new SparkConf().set("spark.sql.parquet.inferTimestampNTZ.enabled", "false")
             .set("spark.rapids.sql.format.parquet.reader.footer.type", parserType))
     }
 
@@ -1052,7 +1052,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
             LocalDateTime.parse("1970-01-01T00:00:00.000002"))), data)
         }
       },
-        new SparkConf().set("spark.sql.parquet.timestampNTZ.enabled", "true")
+        new SparkConf().set("spark.sql.parquet.inferTimestampNTZ.enabled", "true")
             .set("spark.rapids.sql.format.parquet.reader.footer.type", parserType))
     }
     // INTERVAL is not supported by Spark


### PR DESCRIPTION
Fixes #7754.

Spark 3.4 actually removed the "heavier" `"spark.sql.parquet.timestampNTZ.enabled` configuration option (which prevented both inference and writing timestampNTZ with Parquet), and added the `spark.sql.parquet.inferTimestampNTZ.enabled` configuration option which only controls inference of the timestampNTZ type on reading Parquet (See https://github.com/apache/spark/pull/39856) 

This PR fixes the configuration so the unit test passes.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
