### PR TITLE
xfail test_substring_column

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -346,6 +346,7 @@ def test_substring():
                 'SUBSTRING(a, 0, 10)',
                 'SUBSTRING(a, 0, 0)'))
 
+@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/8147")
 def test_substring_column():
     str_gen = mk_str_gen('.{0,30}')
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Marking test_substring_column as expecting to fail due to #8147 to unblock premerge and nightly runs.