### PR TITLE
Use repo1.maven.org/maven2 instead of default apache central url 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1282,5 +1282,23 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository Switchboard</name>
+            <layout>default</layout>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
fix #8153 

[repo.maven.apache.org](http://repo.maven.apache.org/) is unstable right now.

change the default to repo1.maven.org/maven2