### PR TITLE
Verify CPU fallback class when creating HIVE table [Databricks]

### DIFF
--- a/integration_tests/src/main/python/hive_write_test.py
+++ b/integration_tests/src/main/python/hive_write_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ def test_optimized_hive_bucketed_fallback_33X(gens, storage, spark_tmp_table_fac
 
 # Since Spark 3.4.0, the internal "SortExec" will be pulled out by default
 # from the FileFormatWriter. Then it is visible in the planning stage.
-@allow_non_gpu("DataWritingCommandExec", "SortExec", "HiveHash")
+@allow_non_gpu("DataWritingCommandExec", "SortExec", "WriteFilesExec")
 @pytest.mark.skipif(not (is_hive_available() and is_spark_340_or_later()),
                     reason="Requires Hive and Spark 3.4+ to write bucketed Hive tables with SortExec pulled out")
 @pytest.mark.parametrize("gens", [_basic_gens], ids=idfn)
@@ -148,5 +148,5 @@ def test_optimized_hive_bucketed_fallback(gens, storage, planned_write, spark_tm
             """CREATE TABLE {} STORED AS {}
             CLUSTERED BY (b) INTO 3 BUCKETS
             AS SELECT * FROM {}""".format(spark_tmp_table_factory.get(), storage, in_table)),
-        "DataWritingCommandExec",
+        "ExecutedCommandExec",
         {"spark.sql.optimizer.plannedWrite.enabled": planned_write})


### PR DESCRIPTION
This PR checks the appropriate fallback class for Spark 3.4 when creating a Hive table.

In Spark 3.4, the CTAS is being converted to an `ExecutedCommandExec` instead of the `DataWritingCommandExec`

fixes #8017 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
