### PR TITLE
Fix ORC decimal read when precision/scale changes

### DIFF
--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -133,3 +133,23 @@ def test_casting_from_overflow_double_to_timestamp(spark_tmp_path):
         conf={},
         error_message="ArithmeticException"
     )
+
+
+@pytest.mark.parametrize('data_gen', [DecimalGen(precision=9, scale=2),
+                                      DecimalGen(precision=18, scale=4),
+                                      DecimalGen(precision=38, scale=6)])
+@pytest.mark.parametrize('read_type', ["DECIMAL(9,2)",
+                                       "DECIMAL(18,4)",
+                                       "DECIMAL(38,6)"])
+def test_casting_decimal_to_decimal(spark_tmp_path, data_gen, read_type):
+    """
+    Tests that ORC files with decimal columns written with one set of
+    precision and scale are readable with different precision/scale.
+    """
+    orc_path = spark_tmp_path + '/orc_casting_from_decimal_to_decimal'
+    with_cpu_session(
+        lambda spark: unary_op_df(spark, data_gen).write.orc(orc_path)
+    )
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.read.schema("a " + read_type).orc(orc_path)
+    )


### PR DESCRIPTION
Fixes #8171.

This commit fixes the `QueryExecutionException` when decimal columns in ORC files are read with a schema specifying a decimal precision/scale that differs from the write schema.

In the case when the read schema's decimal precision/scale differs, the erstwhile behaviour was a read failure with the following exception:
```
Caused by: org.apache.spark.sql.execution.QueryExecutionException: GPU ORC does not support type conversion from file type decimal(18,6) (1) to reader type decimal(9,2) (1)
        at com.nvidia.spark.rapids.GpuOrcFileFilterHandler$GpuOrcPartitionReaderUtils.checkTypeCompatibility(GpuOrcScan.scala:1525)
        at com.nvidia.spark.rapids.GpuOrcFileFilterHandler$GpuOrcPartitionReaderUtils.$anonfun$checkTypeCompatibility$4(GpuOrcScan.scala:1495)
        at scala.Option.foreach(Option.scala:407)
...
```

With this fix, decimals should now be readable.