### PR TITLE
Restore test_substring_column

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -346,7 +346,6 @@ def test_substring():
                 'SUBSTRING(a, 0, 10)',
                 'SUBSTRING(a, 0, 0)'))
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/8147")
 def test_substring_column():
     str_gen = mk_str_gen('.{0,30}')
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
Fixes #8147.  rapidsai/cudf#13173 has been fixed, so this test can be restored.

This reverts commit 619afc6d64f7082d71661453ec4faecd7ba25eb1.