### PR TITLE
Add in retry-work to GPU OutOfCore Sort

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -23,6 +23,8 @@ import scala.collection.mutable.{ArrayBuffer, ArrayStack}
 import ai.rapids.cudf.{ColumnVector, ContiguousTable, NvtxColor, NvtxRange, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
+import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
+import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
@@ -196,9 +198,10 @@ class Pending(cpuOrd: LazilyGeneratedOrdering) extends AutoCloseable {
       cpuOrd.compare(a.firstRow, b.firstRow)
   })
   private var pendingSize = 0L
-  def add(buffer: SpillableColumnarBatch, row: UnsafeRow): Unit = {
-    pending.add(OutOfCoreBatch(buffer, row))
-    pendingSize += buffer.sizeInBytes
+
+  def add(batch: OutOfCoreBatch): Unit = {
+    pendingSize += batch.buffer.sizeInBytes
+    pending.add(batch)
   }
 
   def storedSize: Long = pendingSize
@@ -294,10 +297,22 @@ case class GpuOutOfCoreSortIterator(
    * A rather complex function. It will take a sorted table (either the output of a regular sort or
    * a merge sort), split it up, and place the split portions into the proper queues. If
    * sortedOffset >= 0 then everything below that offset is considered to be fully sorted and is
-   * placed in the sorted queue. Everything else is spilt into smaller batches as determined by
-   * this function and placed in the pending priority queue to be merge sorted.
+   * returned as an option of "SpillableColumnarBatch". Everything else is spilt into smaller
+   * batches as determined by this function and returned as a seq of "OutOfCoreBatch".
+   * Call `saveSplitResult` to place them into the cache correspondingly.
    */
-  private final def splitAfterSortAndSave(sortedTbl: Table, sortedOffset: Int = -1): Unit = {
+  private final def splitAfterSort(sortedSpill: SpillableColumnarBatch,
+      sortedOffset: Int = -1): (Option[SpillableColumnarBatch], Seq[OutOfCoreBatch]) = {
+    withResource(sortedSpill.getColumnarBatch()) { cb =>
+      withResource(GpuColumnVector.from(cb)) { table =>
+        splitTableAfterSort(table, sortedOffset)
+      }
+    }
+  }
+
+  private final def splitTableAfterSort(
+      sortedTbl: Table,
+      sortedOffset: Int = -1): (Option[SpillableColumnarBatch], Seq[OutOfCoreBatch]) = {
     var memUsed: Long = GpuColumnVector.getTotalDeviceMemoryUsed(sortedTbl)
     // We need to figure out how to split up the data into reasonable batches. We could try and do
     // something really complicated and figure out how much data get per batch, but in practice
@@ -310,6 +325,8 @@ case class GpuOutOfCoreSortIterator(
     // Protect ourselves from large rows when there are small targetSizes
     val targetRowCount = Math.max((targetBatchSize/averageRowSize).toInt, 1024)
 
+    var sortedCb: Option[SpillableColumnarBatch] = None
+    val pendingObs: ArrayBuffer[OutOfCoreBatch] = ArrayBuffer.empty
     if (sortedOffset == rows) {
       // The entire thing is sorted
       withResource(sortedTbl.contiguousSplit()) { splits =>
@@ -318,8 +335,7 @@ case class GpuOutOfCoreSortIterator(
         memUsed += ct.getBuffer.getLength
         val sp = SpillableColumnarBatch(ct, sorter.projectedBatchTypes,
           SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-        sortedSize += sp.sizeInBytes
-        sorted.add(sp)
+        sortedCb = Some(sp)
       }
     } else {
       val hasFullySortedData = sortedOffset > 0
@@ -353,27 +369,44 @@ case class GpuOutOfCoreSortIterator(
         val stillPending = if (hasFullySortedData) {
           val sp = SpillableColumnarBatch(splits.head, sorter.projectedBatchTypes,
             SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-          sortedSize += sp.sizeInBytes
-          sorted.add(sp)
+          sortedCb = Some(sp)
           splits.slice(1, splits.length)
         } else {
           splits
         }
 
-        assert(boundaries.length == stillPending.length)
-        stillPending.zip(boundaries).foreach {
-          case (ct: ContiguousTable, lower: UnsafeRow) =>
-            if (ct.getRowCount > 0) {
-              val sp = SpillableColumnarBatch(ct, sorter.projectedBatchTypes,
-                SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-              pending.add(sp, lower)
-            } else {
-              ct.close()
+        closeOnExcept(sortedCb) { _ =>
+          assert(boundaries.length == stillPending.length)
+          closeOnExcept(pendingObs) { _ =>
+            stillPending.zip(boundaries).foreach {
+              case (ct: ContiguousTable, lower: UnsafeRow) =>
+                if (ct.getRowCount > 0) {
+                  val sp = SpillableColumnarBatch(ct, sorter.projectedBatchTypes,
+                    SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+                  pendingObs += OutOfCoreBatch(sp, lower)
+                } else {
+                  ct.close()
+                }
             }
+          }
         }
       }
     }
     peakMemory = Math.max(peakMemory, memUsed)
+    (sortedCb, pendingObs)
+  }
+
+  /** Save the splitting result returned from `splitAfterSort` into the cache */
+  private final def saveSplitResult(
+      result: (Option[SpillableColumnarBatch], Seq[OutOfCoreBatch])): Unit = {
+    val (sortedSp, pendingObs) = result
+    closeOnExcept(pendingObs) { _ =>
+      sortedSp.foreach { sp =>
+        sortedSize += sp.sizeInBytes
+        sorted.add(sp)
+      }
+    }
+    pendingObs.foreach(pending.add)
   }
 
   /**
@@ -383,20 +416,39 @@ case class GpuOutOfCoreSortIterator(
   private final def firstPassReadBatches(): Unit = {
     while(iter.hasNext) {
       var memUsed = 0L
-      val sortedTbl = withResource(iter.next()) { batch =>
-        memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(batch)
-        withResource(new NvtxWithMetrics("initial sort", NvtxColor.CYAN, opTime)) { _ =>
-          sorter.appendProjectedAndSort(batch, sortTime)
-        }
+      val spillBatch = closeOnExcept(iter.next()) { batch =>
+        val scb = SpillableColumnarBatch(batch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+        memUsed += scb.sizeInBytes
+        scb
       }
-      memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(sortedTbl)
-      peakMemory = Math.max(peakMemory, memUsed)
+      val sortedIt =
+        withResource(new NvtxWithMetrics("initial sort", NvtxColor.CYAN, opTime)){ _ =>
+          withRetry(spillBatch, splitSpillableInHalfByRows) { attemptScb =>
+            withResource(attemptScb.getColumnarBatch()) { attemptCb =>
+              sorter.appendProjectedAndSort(attemptCb, sortTime)
+            }
+          }
+        }
+
       withResource(new NvtxWithMetrics("split input batch", NvtxColor.CYAN, opTime)) { _ =>
-        withResource(sortedTbl) { sortedTbl =>
-          val rows = sortedTbl.getRowCount.toInt
-          // filter out empty batches
-          if (rows > 0) {
-            splitAfterSortAndSave(sortedTbl)
+        while(sortedIt.hasNext) {
+          withResource(sortedIt.next()) { sortedTbl =>
+            memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(sortedTbl)
+            peakMemory = Math.max(peakMemory, memUsed)
+            val rows = sortedTbl.getRowCount.toInt
+            // filter out empty batches
+            if (rows > 0) {
+              val sp = withResource(sortedTbl) { _ =>
+                SpillableColumnarBatch(
+                  GpuColumnVector.from(sortedTbl, sorter.projectedBatchTypes),
+                  SpillPriorities.ACTIVE_ON_DECK_PRIORITY
+                )
+              }
+              val ret = withRetryNoSplit(sp) { attempt =>
+                splitAfterSort(attempt)
+              }
+              saveSplitResult(ret)
+            }
           }
         }
       }
@@ -423,6 +475,8 @@ case class GpuOutOfCoreSortIterator(
           bytesLeftToFetch -= buffer.sizeInBytes
         }
       }
+      // Here may need to retry work, however `mergeSortAndClose` already has some
+      // optimization to reduce the GPU memory pressure for some cases.
       val mergedBatch = sorter.mergeSortAndClose(pendingSort, sortTime)
       memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(mergedBatch)
 
@@ -458,9 +512,14 @@ case class GpuOutOfCoreSortIterator(
             return Some(sorter.removeProjectedColumns(mergedTbl))
           }
         }
-        withResource(GpuColumnVector.from(mergedBatch)) { mergedTbl =>
-          splitAfterSortAndSave(mergedTbl, sortSplitOffset)
+
+        val mergedSp = closeOnExcept(GpuColumnVector.incRefCounts(mergedBatch)) { _ =>
+          SpillableColumnarBatch(mergedBatch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
         }
+        val splitResult = withRetryNoSplit(mergedSp) { attempt =>
+          splitAfterSort(attempt, sortSplitOffset)
+        }
+        saveSplitResult(splitResult)
       }
     }
     None
@@ -472,28 +531,36 @@ case class GpuOutOfCoreSortIterator(
    */
   private final def concatOutput(): ColumnarBatch = {
     // combine all the sorted data into a single batch
-    withResource(ArrayBuffer[Table]()) { tables =>
+    withResource(ArrayBuffer[SpillableColumnarBatch]()) { spillCbs =>
       var totalBytes = 0L
-      while(!sorted.isEmpty && (tables.isEmpty ||
+      while(!sorted.isEmpty && (spillCbs.isEmpty ||
           (totalBytes + sorted.peek().sizeInBytes) < targetSize)) {
-        withResource(sorted.pop()) { tmp =>
-          sortedSize -= tmp.sizeInBytes
-          totalBytes += tmp.sizeInBytes
-          withResource(tmp.getColumnarBatch()) { batch =>
-            tables += GpuColumnVector.from(batch)
-          }
-        }
+        val tmp = sorted.pop()
+        sortedSize -= tmp.sizeInBytes
+        totalBytes += tmp.sizeInBytes
+        spillCbs += tmp
       }
       var memUsed = totalBytes
-      val ret = if (tables.length == 1) {
+      val ret = if (spillCbs.length == 1) {
         // We cannot concat a single table
-        sorter.removeProjectedColumns(tables.head)
+        withResource(spillCbs.head.getColumnarBatch()) { cb =>
+          withResource(GpuColumnVector.from(cb)) { tbl =>
+            sorter.removeProjectedColumns(tbl)
+          }
+        }
       } else {
-        withResource(Table.concatenate(tables: _*)) { combined =>
-          // ignore the output of removing the columns because it is just dropping columns
-          // so it will be smaller than this with not added memory
-          memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(combined)
-          sorter.removeProjectedColumns(combined)
+        withRetryNoSplit(spillCbs) { attempt =>
+          val tables = attempt.safeMap { sp =>
+            withResource(sp.getColumnarBatch())(GpuColumnVector.from)
+          }
+          withResource(tables) { _ =>
+            withResource(Table.concatenate(tables: _*)) { combined =>
+              // ignore the output of removing the columns because it is just dropping columns
+              // so it will be smaller than this with not added memory
+              memUsed += GpuColumnVector.getTotalDeviceMemoryUsed(combined)
+              sorter.removeProjectedColumns(combined)
+            }
+          }
         }
       }
       peakMemory = Math.max(peakMemory, memUsed)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuOutOfCoreSortRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuOutOfCoreSortRetrySuite.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.jni.{RetryOOM, SplitAndRetryOOM}
+import org.scalatest.mockito.MockitoSugar
+
+import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GpuOutOfCoreSortRetrySuite extends RmmSparkRetrySuiteBase with MockitoSugar {
+
+  private val ref = GpuBoundReference(0, IntegerType, nullable = false)(ExprId(0), "a")
+  private val sortOrder = SortOrder(ref, Ascending)
+  private val attrs = AttributeReference(ref.name, ref.dataType, ref.nullable)()
+  private val gpuSorter = new GpuSorter(Seq(sortOrder), Array(attrs))
+  private val NUM_ROWS = 100
+
+  private def buildBatch: ColumnarBatch = {
+    val ints = (NUM_ROWS / 2 until NUM_ROWS) ++ (0 until NUM_ROWS / 2)
+    new ColumnarBatch(
+      Array(GpuColumnVector.from(ColumnVector.fromInts(ints: _*), IntegerType)), NUM_ROWS)
+  }
+
+  test("GPU out-of-core sort without OOM failures") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024)
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when first-pass-sort RetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      firstPassSortExp = new RetryOOM())
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when first-pass-sort SplitAndRetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      firstPassSortExp = new SplitAndRetryOOM())
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when first-pass-split RetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      firstPassSplitExp = new RetryOOM())
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when first-pass-split SplitAndRetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      firstPassSplitExp = new SplitAndRetryOOM())
+    withResource(outCoreIter) { _ =>
+      assertThrows[SplitAndRetryOOM] {
+        outCoreIter.next()
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when merge-sort-split RetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      mergeSortExp = new RetryOOM())
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when merge-sort-split SplitAndRetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      mergeSortExp = new SplitAndRetryOOM())
+    withResource(outCoreIter) { _ =>
+      assertThrows[SplitAndRetryOOM] {
+        outCoreIter.next()
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when concat-output RetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      concatOutExp = new RetryOOM())
+    withResource(outCoreIter) { _ =>
+      withResource(outCoreIter.next()) { cb =>
+        // only one batch
+        assertResult(NUM_ROWS)(cb.numRows())
+        assertResult(true)(GpuColumnVector.isTaggedAsFinalBatch(cb))
+      }
+    }
+  }
+
+  test("GPU out-of-core sort with retry when concat-output SplitAndRetryOOM") {
+    val outCoreIter = new GpuOutOfCoreSortIteratorThatThrows(
+      Iterator(buildBatch),
+      gpuSorter,
+      new LazilyGeneratedOrdering(gpuSorter.cpuOrdering),
+      targetSize = 1024,
+      concatOutExp = new SplitAndRetryOOM())
+    withResource(outCoreIter) { _ =>
+      assertThrows[SplitAndRetryOOM] {
+        outCoreIter.next()
+      }
+    }
+  }
+
+  private class GpuOutOfCoreSortIteratorThatThrows(
+      iter: Iterator[ColumnarBatch],
+      sorter: GpuSorter,
+      cpuOrd: LazilyGeneratedOrdering,
+      targetSize: Long,
+      firstPassSortExp: Throwable = null,
+      firstPassSplitExp: Throwable = null,
+      mergeSortExp: Throwable = null,
+      concatOutExp: Throwable = null,
+      expMaxCount: Int = 1)
+    extends GpuOutOfCoreSortIterator(iter, sorter, cpuOrd, targetSize,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric){
+
+    private var expCnt = expMaxCount
+
+    override def onFirstPassSort(): Unit = if (firstPassSortExp != null && expCnt > 0) {
+      expCnt -= 1
+      throw firstPassSortExp
+    }
+
+    override def onFirstPassSplit(): Unit = if (firstPassSplitExp != null && expCnt > 0) {
+      expCnt -= 1
+      throw firstPassSplitExp
+    }
+
+    override def onMergeSortSplit(): Unit = if (mergeSortExp != null && expCnt > 0) {
+      expCnt -= 1
+      throw mergeSortExp
+    }
+
+    override def onConcatOutput(): Unit = if (concatOutExp != null && expCnt > 0) {
+      expCnt -= 1
+      throw concatOutExp
+    }
+  }
+
+}


### PR DESCRIPTION
closes #7934

This PR adds in OOM retry to GpuOutOfCore iterator.

TODO

- [x] Add unit tests

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
