### PR TITLE
Handle PySparkException in case of literal expressions

### DIFF
--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -376,8 +376,12 @@ def test_cast_neg_to_decimal_err():
     else:
         exception_content = "Decimal(compact, -120000000, 20, 0) cannot be represented as Decimal(7, 7)"
 
-    exception_type = "java.lang.ArithmeticException: " if is_before_spark_330() \
-        and not is_databricks104_or_later() else "org.apache.spark.SparkArithmeticException: "
+    if is_before_spark_330() and not is_databricks104_or_later():
+        exception_type = "java.lang.ArithmeticException: "
+    elif not is_before_spark_340():
+        exception_type = "pyspark.errors.exceptions.captured.ArithmeticException: "
+    else:
+        exception_type = "org.apache.spark.SparkArithmeticException: "
 
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
@@ -973,35 +977,52 @@ def test_greatest(data_gen):
                 f.greatest(*command_args)))
 
 
-def _test_div_by_zero(ansi_mode, expr):
-    ansi_conf = {'spark.sql.ansi.enabled': ansi_mode == 'ansi'}
+def _test_div_by_zero(ansi_mode, expr, exception):
+    ansi_conf = {'spark.sql.ansi.enabled': ansi_mode}
     data_gen = lambda spark: two_col_df(spark, IntegerGen(), IntegerGen(min_val=0, max_val=0), length=1)
     div_by_zero_func = lambda spark: data_gen(spark).selectExpr(expr)
-    if is_before_spark_320():
-        err_message = 'java.lang.ArithmeticException: divide by zero'
-    elif is_before_spark_330():
-        err_message = 'SparkArithmeticException: divide by zero'
-    elif is_before_spark_340() and not is_databricks113_or_later():
-        err_message = 'SparkArithmeticException: Division by zero'
-    else:
-        err_message = 'SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero'
 
-    if ansi_mode == 'ansi':
+    if ansi_mode:
         assert_gpu_and_cpu_error(df_fun=lambda spark: div_by_zero_func(spark).collect(),
                                  conf=ansi_conf,
-                                 error_message=err_message)
+                                 error_message=exception)
     else:
         assert_gpu_and_cpu_are_equal_collect(div_by_zero_func, ansi_conf)
 
-
-@pytest.mark.parametrize('expr', ['1/0', 'a/0', 'a/b'])
-def test_div_by_zero_ansi(expr):
-    _test_div_by_zero(ansi_mode='ansi', expr=expr)
-
-@pytest.mark.parametrize('expr', ['1/0', 'a/0', 'a/b'])
-def test_div_by_zero_nonansi(expr):
-    _test_div_by_zero(ansi_mode='nonAnsi', expr=expr)
-
+div_by_zero_data=['1/0', 'a/0', 'a/b']
+@pytest.mark.parametrize('expr, exception',
+    # is_before_320
+    [pytest.param(i, 'java.lang.ArithmeticException: divide by zero',
+                  marks=pytest.mark.skipif(not is_before_spark_320(),
+                                           reason="Skipping for Spark version >= 3.2.0"))
+                    for i in div_by_zero_data]
+    +
+    # else if is_before_330
+    [pytest.param(i, 'SparkArithmeticException: divide by zero',
+                 marks=pytest.mark.skipif(not (not is_before_spark_320() and is_before_spark_330()),
+                                          reason="Skipping for 3.2.0 > Spark version >= 3.3.0"))
+                    for i in div_by_zero_data]
+    +
+    # else if is_before_340 and not is_databricks_113_or_later
+    [pytest.param(i, 'SparkArithmeticException: Division by zero',
+                 marks=pytest.mark.skipif(not (not is_before_spark_330() and is_before_spark_340() and not is_databricks113_or_later()),
+                                          reason="Skipping for 3.3.0 > Spark version >= 3.4.0 or db >= 11.3"))
+                 for i in div_by_zero_data]
+    +
+    # else if is_spark_340 or databricks_113_or_later
+    [pytest.param('1/0', 'pyspark.errors.exceptions.captured.ArithmeticException: [DIVIDE_BY_ZERO] Division by zero',
+                 marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                          reason="Skipping for Spark version < 3.4.0 and db < 11.3")),
+    pytest.param('a/0', 'org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero',
+                 marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                          reason="Skipping for Spark version < 3.4.0 and db < 11.3")),
+    pytest.param('a/b', 'org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero',
+                 marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                          reason="Skipping for Spark version < 3.4.0 and db < 11.3"))]
+)
+@pytest.mark.parametrize('ansi_mode', [True, False])
+def test_div_by_zero(expr, exception, ansi_mode):
+    _test_div_by_zero(ansi_mode=ansi_mode, expr=expr, exception=exception)
 
 def _get_div_overflow_df(spark, expr):
     return spark.createDataFrame(
@@ -1017,20 +1038,36 @@ div_overflow_exprs = [
 # Only run this test for Spark v3.2.0 and later to verify IntegralDivide will
 # throw exceptions for overflow when ANSI mode is enabled.
 @pytest.mark.skipif(is_before_spark_320(), reason='https://github.com/apache/spark/pull/32260')
-@pytest.mark.parametrize('expr', div_overflow_exprs)
-@pytest.mark.parametrize('ansi_enabled', ['false', 'true'])
-def test_div_overflow_exception_when_ansi(expr, ansi_enabled):
+@pytest.mark.parametrize('expr, exception',
+                         [pytest.param(i, 'java.lang.ArithmeticException: Overflow in integral divide',
+                                       marks=pytest.mark.skipif(not is_before_spark_330(), reason="Skip for Spark version >= 3.3.0"))
+                          for i in div_overflow_exprs]
++
+                         [pytest.param(i, 'org.apache.spark.SparkArithmeticException: Overflow in integral divide',
+                                       marks=pytest.mark.skipif(not (not is_before_spark_330() and is_before_spark_340() and not is_databricks113_or_later()),
+                                                                reason="Skip for 3.3.0 > Spark version >= 3.4.0 or db >= 11.3"))
+                          for i in div_overflow_exprs]
++
+                         [pytest.param('CAST(-9223372036854775808L as LONG) DIV -1',
+                                       'pyspark.errors.exceptions.captured.ArithmeticException: [ARITHMETIC_OVERFLOW] Overflow in integral divide',
+                                       marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                                                reason="Skip for Spark version < 3.4.0 or db < 11.3")),
+                          pytest.param('a DIV CAST(-1 AS INT)', 'org.apache.spark.SparkArithmeticException: [ARITHMETIC_OVERFLOW] Overflow in integral divide',
+                                       marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                                                reason="Skip for Spark version < 3.4.0 or db < 11.3")),
+                          pytest.param('a DIV b', 'org.apache.spark.SparkArithmeticException: [ARITHMETIC_OVERFLOW] Overflow in integral divide',
+                                       marks=pytest.mark.skipif(not (not is_before_spark_340() or is_databricks113_or_later()),
+                                                                reason="Skip for Spark version < 3.4.0 or db < 11.3")),
+                          ]
+)
+@pytest.mark.parametrize('ansi_enabled', [False, True])
+def test_div_overflow_exception_when_ansi(expr, exception, ansi_enabled):
     ansi_conf = {'spark.sql.ansi.enabled': ansi_enabled}
-    err_exp = 'java.lang.ArithmeticException' if is_before_spark_330() else \
-        'org.apache.spark.SparkArithmeticException'
-    err_mess = ': Overflow in integral divide' \
-        if is_before_spark_340() and not is_databricks113_or_later() else \
-        ': [ARITHMETIC_OVERFLOW] Overflow in integral divide'
-    if ansi_enabled == 'true':
+    if ansi_enabled:
         assert_gpu_and_cpu_error(
             df_fun=lambda spark: _get_div_overflow_df(spark, expr).collect(),
             conf=ansi_conf,
-            error_message=err_exp + err_mess)
+            error_message=exception)
     else:
         assert_gpu_and_cpu_are_equal_collect(
             func=lambda spark: _get_div_overflow_df(spark, expr),

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -17,7 +17,6 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 import math
 from pyspark.sql import Row
-from py4j.protocol import Py4JJavaError
 
 import pytest
 from spark_session import with_cpu_session, with_gpu_session
@@ -603,16 +602,16 @@ def assert_gpu_and_cpu_are_equal_sql(df_fun, table_name, sql, conf=None, debug=F
             return spark.sql(sql)
     assert_gpu_and_cpu_are_equal_collect(do_it_all, conf, is_cpu_first=is_cpu_first)
 
-def assert_py4j_exception(func, error_message):
+def assert_spark_exception(func, error_message):
     """
     Assert that a specific Java exception is thrown
     :param func: a function to be verified
     :param error_message: a string such as the one produce by java.lang.Exception.toString
     :return: Assertion failure if no exception matching error_message has occurred.
     """
-    with pytest.raises(Py4JJavaError) as py4jError:
+    with pytest.raises(Exception) as excinfo:
         func()
-    actual_error = str(py4jError.value.java_exception)
+    actual_error = excinfo.exconly()
     assert error_message in actual_error, f"Expected error '{error_message}' did not appear in '{actual_error}'"
 
 def assert_gpu_and_cpu_error(df_fun, conf, error_message):
@@ -624,8 +623,8 @@ def assert_gpu_and_cpu_error(df_fun, conf, error_message):
     :return: Assertion failure if either GPU or CPU versions has not generated error messages
              expected
     """
-    assert_py4j_exception(lambda: with_cpu_session(df_fun, conf), error_message)
-    assert_py4j_exception(lambda: with_gpu_session(df_fun, conf), error_message)
+    assert_spark_exception(lambda: with_cpu_session(df_fun, conf), error_message)
+    assert_spark_exception(lambda: with_gpu_session(df_fun, conf), error_message)
 
 def with_cpu_sql(df_fun, table_name, sql, conf=None, debug=False):
     if conf is None:

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_py4j_exception
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_gpu_fallback_collect, assert_spark_exception
 from data_gen import *
 from spark_session import is_before_spark_320, is_before_spark_330, with_gpu_session
 from marks import allow_non_gpu, approximate_float

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -444,7 +444,7 @@ def test_delta_write_append_only(spark_tmp_path):
                      .save(data_path),
                      conf=delta_writes_enabled_conf)
     # verify overwrite fails
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: unary_op_df(spark, gen).write.format("delta").mode("overwrite").save(data_path),
             conf=delta_writes_enabled_conf),
@@ -469,7 +469,7 @@ def test_delta_write_constraint_not_null(spark_tmp_path):
                      conf=delta_writes_enabled_conf)
 
     # verify write of null value throws
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: unary_op_df(spark, null_gen).write.format("delta").mode("append").save(data_path),
             conf=delta_writes_enabled_conf),
@@ -499,7 +499,7 @@ def test_delta_write_constraint_check(spark_tmp_path):
     def gen_bad_data(spark):
         return gen_good_data(spark).union(spark.range(1).withColumn("x", f.col("id")))
 
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: gen_bad_data(spark).write.format("delta").mode("append").save(data_path),
             conf=delta_writes_enabled_conf),
@@ -526,7 +526,7 @@ def test_delta_write_constraint_check_fallback(spark_tmp_path):
     # verify write of values that violate the constraint throws
     def gen_bad_data(spark):
         return spark.range(1000).withColumn("x", f.col("id") + 1)
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: gen_bad_data(spark).write.format("delta").mode("append").save(data_path),
             conf=add_disable_conf),

--- a/integration_tests/src/main/python/iceberg_test.py
+++ b/integration_tests/src/main/python/iceberg_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal, assert_gpu_fallback_collect, assert_py4j_exception
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal, assert_gpu_fallback_collect, assert_spark_exception
 from data_gen import *
 from marks import allow_non_gpu, iceberg, ignore_order
 from spark_session import is_before_spark_320, is_databricks_runtime, with_cpu_session, with_gpu_session
@@ -122,7 +122,7 @@ def test_iceberg_unsupported_formats(spark_tmp_table_factory, data_gens, iceberg
                   "TBLPROPERTIES('write.format.default' = '{}') ".format(iceberg_format) + \
                   "AS SELECT * FROM {}".format(tmpview))
     with_cpu_session(setup_iceberg_table)
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda : with_gpu_session(
             lambda spark : spark.sql("SELECT * FROM {}".format(table)).collect(),
             conf={'spark.rapids.sql.format.parquet.reader.type': reader_type}),
@@ -172,7 +172,7 @@ def test_iceberg_read_parquet_compression_codec(spark_tmp_table_factory, codec_i
     query = "SELECT * FROM {}".format(table)
     read_conf = {'spark.rapids.sql.format.parquet.reader.type': reader_type}
     if error_msg:
-        assert_py4j_exception(
+        assert_spark_exception(
             lambda : with_gpu_session(lambda spark : spark.sql(query).collect(), conf=read_conf),
             error_msg)
     else:
@@ -550,7 +550,7 @@ def test_iceberg_v2_delete_unsupported(spark_tmp_table_factory, reader_type):
                   "AS SELECT * FROM {}".format(tmpview))
         spark.sql("DELETE FROM {} WHERE a < 0".format(table))
     with_cpu_session(setup_iceberg_table)
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda : with_gpu_session(
             lambda spark : spark.sql("SELECT * FROM {}".format(table)).collect(),
             conf={'spark.rapids.sql.format.parquet.reader.type': reader_type}),

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -16,7 +16,7 @@ import os
 import pytest
 
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_cpu_and_gpu_are_equal_sql_with_capture, assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_row_counts_equal, \
-    assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_py4j_exception
+    assert_gpu_fallback_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_error, assert_spark_exception
 from data_gen import *
 from marks import *
 import pyarrow as pa
@@ -1395,35 +1395,35 @@ def test_parquet_check_schema_compatibility_nested_types(spark_tmp_path):
     with_cpu_session(lambda spark: gen_df(spark, gen_list).coalesce(1).write.parquet(data_path))
 
     read_array_long_as_int = StructType([StructField('array_long', ArrayType(IntegerType()))])
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_array_long_as_int).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
 
     read_arr_arr_int_as_long = StructType(
         [StructField('array_array_int', ArrayType(ArrayType(LongType())))])
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_arr_arr_int_as_long).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
 
     read_struct_flt_as_dbl = StructType([StructField(
         'struct_float', StructType([StructField('f', DoubleType())]))])
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_struct_flt_as_dbl).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
 
     read_struct_arr_int_as_long = StructType([StructField(
         'struct_array_int', StructType([StructField('a', ArrayType(LongType()))]))])
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_struct_arr_int_as_long).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
 
     read_map_str_str_as_str_int = StructType([StructField(
         'map', MapType(StringType(), IntegerType()))])
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.schema(read_map_str_str_as_str_int).parquet(data_path).collect()),
         error_message='Parquet column cannot be converted')
@@ -1452,12 +1452,12 @@ def test_parquet_read_encryption(spark_tmp_path, reader_confs, v1_enabled_list):
             parquet(data_path), conf=encryption_confs)
 
     # test with missing encryption conf reading encrypted file
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.parquet(data_path).collect()),
         error_message='Could not read footer for file')
 
-    assert_py4j_exception(
+    assert_spark_exception(
         lambda: with_gpu_session(
             lambda spark: spark.read.parquet(data_path).collect(), conf=conf),
         error_message='The GPU does not support reading encrypted Parquet files')

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write, assert_py4j_exception
+from asserts import assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_and_cpu_writes_are_equal_collect, assert_gpu_fallback_write, assert_spark_exception
 from datetime import date, datetime, timezone
 from data_gen import *
 from enum import Enum
@@ -161,7 +161,7 @@ def test_part_write_round_trip(spark_tmp_path, parquet_gen):
 def test_catch_int96_overflow(spark_tmp_path, data_gen):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     confs = copy_and_update(writer_confs, {'spark.sql.parquet.outputTimestampType': 'INT96'})
-    assert_py4j_exception(lambda: with_gpu_session(
+    assert_spark_exception(lambda: with_gpu_session(
         lambda spark: unary_op_df(spark, data_gen).coalesce(1).write.parquet(data_path), conf=confs), "org.apache.spark.SparkException: Job aborted.")
 
 


### PR DESCRIPTION
Spark 3.4.0 and possibly later versions throw a PySparkException instead of a Py4JJavaError only when the expression is a `literal`. To handle this this PR passes the exception message as part of the call to the test function. 

We also changed the name of `assert_py4j_exception` to `assert_spark_exception` as it handles `PySparkException` in addition to `Py4JJavaError`

fixes #8160

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
