### PR TITLE
Increase databricks cluster autotermination to 6.5 hours [skip ci]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -76,7 +76,7 @@ pipeline {
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CUDA_CLASSIFIER = 'cuda11'
         // DB related ENVs
-        IDLE_TIMEOUT = '240' // 4 hours
+        IDLE_TIMEOUT = '390' // 6.5 hours
         NUM_WORKERS = '0'
         DB_TYPE = getDbType()
         DATABRICKS_HOST = DbUtils.getHost("$DB_TYPE")
@@ -292,7 +292,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            timeout(time: 5, unit: 'HOURS') {
+                            timeout(time: 6, unit: 'HOURS') {
                                 unstash "source_tree"
                                 databricksBuild()
                             }
@@ -324,7 +324,7 @@ pipeline {
                     }
                     steps {
                         script {
-                            timeout(time: 5, unit: 'HOURS') {
+                            timeout(time: 6, unit: 'HOURS') {
                                 unstash "source_tree"
                                 databricksBuild()
                             }


### PR DESCRIPTION
as title.

We saw current DB pre-merge CI test require ~ 4 hours, sometimes over 4 hours if PR is trying to add new cases https://github.com/NVIDIA/spark-rapids/pull/8179

lets increase the timeout for now