### PR TITLE
Clean up queued batches on task failures in RapidsShuffleThreadedBlockIterator

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -547,10 +547,10 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
     }
   }
 
-  Option(TaskContext.get()).foreach {_.addTaskCompletionListener[Unit]( _ => {
+  context.addTaskCompletionListener[Unit]( _ => {
     // should not be needed, but just in case
     closeShuffleReadRange()
-  })}
+  })
 
   private def fetchContinuousBlocksInBatch: Boolean = {
     val conf = SparkEnv.get.conf
@@ -637,12 +637,12 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
     }
 
     // Register a completion handler to close any queued cbs.
-    Option(TaskContext.get()).foreach {_.addTaskCompletionListener[Unit]( _ => {
+    context.addTaskCompletionListener[Unit]( _ => {
       queued.forEach {
         case (_, cb:ColumnarBatch) => cb.close()
       }
       queued.clear()
-    })}
+    })
 
     override def hasNext: Boolean = {
       if (fallbackIter != null) {


### PR DESCRIPTION
Fixes #8043.

`RapidsShuffleThreadedBlockIterator` has a queue for batches from deserialized tasks that needs to be cleaned up on task failures.  I have not been able to reproduce #8043 with 23.06 builds, but I was able to reproduce with 23.04 by running NDS with reduced gpu memory (6g).  So I tested this by applying this patch to 23.04 and then verifying that I did not get any HOST BUFFER leaks.
