### PR TITLE
Support `std` aggregation in reduction

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -17433,7 +17433,7 @@ are limited.
 <td rowSpan="6">`stddev_samp`, `std`, `stddev`</td>
 <td rowSpan="6">Aggregation computing sample standard deviation</td>
 <td rowSpan="6">None</td>
-<td rowSpan="2">reduction</td>
+<td rowSpan="2">aggregation</td>
 <td>input</td>
 <td> </td>
 <td> </td>
@@ -17441,7 +17441,7 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17462,7 +17462,7 @@ are limited.
 <td> </td>
 <td> </td>
 <td> </td>
-<td><b>NS</b></td>
+<td>S</td>
 <td> </td>
 <td> </td>
 <td> </td>
@@ -17476,7 +17476,7 @@ are limited.
 <td> </td>
 </tr>
 <tr>
-<td rowSpan="2">aggregation</td>
+<td rowSpan="2">reduction</td>
 <td>input</td>
 <td> </td>
 <td> </td>

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1784,9 +1784,9 @@ def test_std_variance_nulls(data_gen, conf, ansi_enabled):
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
 def test_std_variance_partial_replace_fallback(data_gen,
-                                                       conf,
-                                                       replace_mode,
-                                                       aqe_enabled):
+                                               conf,
+                                               replace_mode,
+                                               aqe_enabled):
     local_conf = copy_and_update(conf, {'spark.rapids.sql.hashAgg.replaceMode': replace_mode,
                                         'spark.sql.adaptive.enabled': aqe_enabled})
 

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1808,6 +1808,9 @@ def test_groupby_std_variance_partial_replace_fallback(data_gen,
         exist_classes=','.join(exist_clz),
         non_exist_classes=','.join(non_exist_clz),
         conf=local_conf)
+    
+    exist_clz = ['StddevSamp',
+                 'GpuStddevSamp']
     assert_cpu_and_gpu_are_equal_collect_with_capture(
         lambda spark: gen_df(spark, data_gen, length=1000)
             .agg(

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1714,7 +1714,7 @@ def test_no_fallback_when_ansi_enabled(data_gen):
 @incompat
 @pytest.mark.parametrize('data_gen', _init_list_with_nans_and_no_nans_with_decimals, ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-def test_groupby_std_variance(data_gen, conf):
+def test_std_variance(data_gen, conf):
     local_conf = copy_and_update(conf, {
         'spark.rapids.sql.castDecimalToFloat.enabled': 'true'})
     assert_gpu_and_cpu_are_equal_sql(
@@ -1745,7 +1745,7 @@ def test_groupby_std_variance(data_gen, conf):
 @pytest.mark.parametrize('data_gen', [_grpkey_strings_with_extra_nulls], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
 @pytest.mark.parametrize('ansi_enabled', ['true', 'false'])
-def test_groupby_std_variance_nulls(data_gen, conf, ansi_enabled):
+def test_std_variance_nulls(data_gen, conf, ansi_enabled):
     local_conf = copy_and_update(conf, {'spark.sql.ansi.enabled': ansi_enabled})
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1000),
@@ -1783,7 +1783,7 @@ def test_groupby_std_variance_nulls(data_gen, conf, ansi_enabled):
 @pytest.mark.parametrize('replace_mode', _replace_modes_non_distinct, ids=idfn)
 @pytest.mark.parametrize('aqe_enabled', ['false', 'true'], ids=idfn)
 @pytest.mark.xfail(condition=is_databricks104_or_later(), reason='https://github.com/NVIDIA/spark-rapids/issues/4963')
-def test_groupby_std_variance_partial_replace_fallback(data_gen,
+def test_std_variance_partial_replace_fallback(data_gen,
                                                        conf,
                                                        replace_mode,
                                                        aqe_enabled):

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1729,6 +1729,14 @@ def test_groupby_std_variance(data_gen, conf):
         'var_samp(b)' +
         ' from data_table group by a',
         conf=local_conf)
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark : gen_df(spark, data_gen, length=1000),
+        "data_table",
+        'select ' +
+        'stddev(b),' +
+        'stddev_samp(b)'
+        ' from data_table',
+        conf=local_conf)
 
 
 @ignore_order(local=True)
@@ -1750,6 +1758,14 @@ def test_groupby_std_variance_nulls(data_gen, conf, ansi_enabled):
         'var_pop(c),' +
         'var_samp(c)' +
         ' from data_table group by a',
+        conf=local_conf)
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark : gen_df(spark, data_gen, length=1000),
+        "data_table",
+        'select ' +
+        'stddev(c),' +
+        'stddev_samp(c)'
+        ' from data_table',
         conf=local_conf)
 
 
@@ -1788,6 +1804,15 @@ def test_groupby_std_variance_partial_replace_fallback(data_gen,
                 f.variance('b'),
                 f.var_pop('b'),
                 f.var_samp('b')
+            ),
+        exist_classes=','.join(exist_clz),
+        non_exist_classes=','.join(non_exist_clz),
+        conf=local_conf)
+    assert_cpu_and_gpu_are_equal_collect_with_capture(
+        lambda spark: gen_df(spark, data_gen, length=1000)
+            .agg(
+                f.stddev('b'),
+                f.stddev_samp('b')
             ),
         exist_classes=','.join(exist_clz),
         non_exist_classes=','.join(non_exist_clz),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3274,7 +3274,7 @@ object GpuOverrides extends Logging {
       }),
     expr[StddevSamp](
       "Aggregation computing sample standard deviation",
-      ExprChecks.aggNotReduction(
+      ExprChecks.fullAgg(
           TypeSig.DOUBLE, TypeSig.DOUBLE,
           Seq(ParamCheck("input", TypeSig.DOUBLE,
             TypeSig.DOUBLE))),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -490,24 +490,24 @@ class CudfMergeM2 extends CudfAggregate {
         withResource(hcv.getChildColumnView(0)) { partialN =>
           withResource(hcv.getChildColumnView(1)) { partialMean =>
             withResource(hcv.getChildColumnView(2)) { partialM2 =>
-              var mergeN : Double = 0.0
+              var mergeN : Integer = 0
               var mergeMean : Double = 0.0
               var mergeM2 : Double = 0.0
 
               for (i <- 0 until partialN.getRowCount.toInt) {
-                val n = partialN.getDouble(i)
+                val n = partialN.getInt(i)
                 if(n > 0) {
                   val mean = partialMean.getDouble(i)
                   val m2 = partialM2.getDouble(i)
                   val delta = mean - mergeMean
                   val newN = n + mergeN
-                  mergeM2 += m2 + delta * delta * n * mergeN / newN
-                  mergeMean += delta * mergeN / newN
+                  mergeM2 += m2 + delta * delta * n.toDouble * mergeN.toDouble / newN.toDouble
+                  mergeMean = (mergeMean * mergeN + mean * n.toDouble) / newN.toDouble
                   mergeN = newN
                 }
               }
 
-              withResource(ColumnVector.fromDoubles(mergeN)) { cvMergeN =>
+              withResource(ColumnVector.fromInts(mergeN)) { cvMergeN =>
                 withResource(ColumnVector.fromDoubles(mergeMean)) { cvMergeMean =>
                   withResource(ColumnVector.fromDoubles(mergeM2)) { cvMergeM2 =>
                     Scalar.structFromColumnViews(cvMergeN, cvMergeMean, cvMergeM2)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -505,7 +505,7 @@ class CudfMergeM2 extends CudfAggregate {
                   val delta = mean - mergeMean
                   val newN = n + mergeN
                   mergeM2 += m2 + delta * delta * n.toDouble * mergeN.toDouble / newN.toDouble
-                  mergeMean = (mergeMean * mergeN + mean * n.toDouble) / newN.toDouble
+                  mergeMean = (mergeMean * mergeN.toDouble + mean * n.toDouble) / newN.toDouble
                   mergeN = newN
                 }
               }

--- a/tools/generated_files/supportedExprs.csv
+++ b/tools/generated_files/supportedExprs.csv
@@ -661,10 +661,10 @@ StddevPop,S,`stddev_pop`,None,aggregation,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,
 StddevPop,S,`stddev_pop`,None,aggregation,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevPop,S,`stddev_pop`,None,window,input,NA,NA,NA,NA,NA,NA,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevPop,S,`stddev_pop`,None,window,result,NA,NA,NA,NA,NA,NA,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,reduction,input,NA,NA,NA,NA,NA,NA,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
-StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,reduction,result,NA,NA,NA,NA,NA,NA,NS,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,aggregation,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,aggregation,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,reduction,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
+StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,reduction,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,window,input,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 StddevSamp,S,`stddev_samp`; `std`; `stddev`,None,window,result,NA,NA,NA,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
 Sum,S,`sum`,None,aggregation,input,NA,S,S,S,S,S,S,NA,NA,NA,S,NA,NA,NA,NA,NA,NA,NA


### PR DESCRIPTION
This adds support for `std` (i.e., `stddev_samp`) aggregation in reduction context, completing https://github.com/NVIDIA/spark-rapids/issues/62.

Closes https://github.com/NVIDIA/spark-rapids/issues/7891 and closes https://github.com/NVIDIA/spark-rapids/issues/62.