### PR TITLE
Skip Iceberg tests on Spark 3.4.0

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -215,7 +215,9 @@ run_iceberg_tests() {
   # get the major/minor version of Spark
   ICEBERG_SPARK_VER=$(echo $SPARK_VER | cut -d. -f1,2)
   IS_SPARK_33_OR_LATER=0
-  [[ "$(printf '%s\n' "3.3" "$ICEBERG_SPARK_VER" | sort -V | head -n1)" = "3.3" ]] && IS_SPARK_33_OR_LATER=1
+  MAJOR_VERSION=$(echo $ICEBERG_SPARK_VER | cut -d. -f1)
+  MINOR_VERSION=$(echo $ICEBERG_SPARK_VER | cut -d. -f2)
+  [[ "$MAJOR_VERSION" -ge "3" ]] && [[ "$MINOR_VERSION" -ge "3" ]] && IS_SPARK_33_OR_LATER=1
 
   # RAPIDS-iceberg does not support Spark 3.3+ yet
   if [[ "$IS_SPARK_33_OR_LATER" = "1" ]]; then


### PR DESCRIPTION
Since Apache Iceberg tests should be skipped for Spark 3.3 or above, this updates the version check to account for Spark 3.4 in addition to Spark 3.3 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
