### PR TITLE
Fix count from ORC files with no column names

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -424,6 +424,14 @@ def test_missing_column_names(spark_tmp_table_factory, reader_confs):
         reader_confs)
 
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+def test_missing_column_names_count(spark_tmp_table_factory, reader_confs):
+    table_name = spark_tmp_table_factory.get()
+    with_cpu_session(lambda spark : setup_orc_file_no_column_names(spark, table_name))
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark : spark.sql("SELECT * FROM {}".format(table_name)),
+        reader_confs)
+
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 def test_missing_column_names_with_schema(spark_tmp_table_factory, spark_tmp_path, reader_confs):
     table_name = spark_tmp_table_factory.get()
     table_location = spark_tmp_path + "/ORC_DATA"
@@ -432,6 +440,14 @@ def test_missing_column_names_with_schema(spark_tmp_table_factory, spark_tmp_pat
         lambda spark : spark.read.schema("a int, b string, c int").orc(table_location),
         reader_confs)
 
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+def test_missing_column_names_count_with_schema(spark_tmp_table_factory, spark_tmp_path, reader_confs):
+    table_name = spark_tmp_table_factory.get()
+    table_location = spark_tmp_path + "/ORC_DATA"
+    with_cpu_session(lambda spark : setup_orc_file_no_column_names(spark, table_name, table_location))
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark : spark.read.schema("a int, b string, c int").orc(table_location),
+        reader_confs)
 
 def setup_orc_file_with_column_names(spark, table_name):
     drop_query = "DROP TABLE IF EXISTS {}".format(table_name)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1188,7 +1188,10 @@ private case class GpuOrcFileFilterHandler(
         // reader to EmptyPartitionReader for throwing exception
         null
       } else {
-        val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
+        val requestedColIds = resultedColPruneInfo.get._1
+        // Normally without column names we cannot prune the file schema to the read schema,
+        // but if no columns are requested from the file (e.g.: row count) then we can prune.
+        val canPruneCols = resultedColPruneInfo.get._2 || requestedColIds.isEmpty
         OrcUtils.orcResultSchemaString(canPruneCols, dataSchema, readDataSchema,
           partitionSchema, conf)
         assert(requestedColIds.length == readDataSchema.length,


### PR DESCRIPTION
Fixes #8214.  Exception was occurring because normally when there are no column names we cannot prune the file schema since it needs to "line up" with the read schema. However in the case where we do not need any columns from the file, we actually can prune the file schema since it's the special-case of loading only row counts and no columns.  Lacking column names is not a problem when not reading any columns.