### PR TITLE
[WIP] Update to allow 340 in premerge and in JDK 11 build

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -49,12 +49,12 @@ jobs:
           # do not add empty snapshot versions
           if [ ${#SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]} -gt 0 ]; then
             svArrBodySnapshot=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" "${SPARK_SHIM_VERSIONS_SNAPSHOTS_ONLY[@]}")
+            svArrBodySnapshot=${svArrBodySnapshot:1}
+            svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
+          else
+            svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot)
           fi
 
-          # add snapshot versions which are not in snapshot property in pom file
-          svArrBodySnapshot+=$(printf ",{\"spark-version\":\"%s\",\"isSnapshot\":true}" 340)
-          svArrBodySnapshot=${svArrBodySnapshot:1}
-          svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot,$svArrBodySnapshot)
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")

--- a/pom.xml
+++ b/pom.xml
@@ -658,9 +658,6 @@
         <ignore.shim.revisions.check>false</ignore.shim.revisions.check>
 
         <spark.shim.dest>${project.basedir}/target/${spark.version.classifier}/generated/src</spark.shim.dest>
-        <!-- TODO: Add 340 to noSnapshot.buildvers when 3.4.0 shim is complete
-             See https://github.com/NVIDIA/spark-rapids/issues/5824
-        -->
         <noSnapshot.buildvers>
             311,
             312,
@@ -673,7 +670,8 @@
             330,
             331,
             332,
-            330cdh
+            330cdh,
+            340
         </noSnapshot.buildvers>
         <snapshot.buildvers>
             333
@@ -692,7 +690,8 @@
             320
         </premergeUT1.buildvers>
         <premergeUT2.buildvers>
-            330
+            330,
+            340
         </premergeUT2.buildvers>
         <premergeUTF8.buildvers>
             320
@@ -700,13 +699,13 @@
         <jdk11.buildvers>
             312,
             321,
-            331
+            331,
+            340
         </jdk11.buildvers>
         <all.buildvers>
             ${noSnapshot.buildvers},
             ${snapshot.buildvers},
             ${databricks.buildvers},
-            340
         </all.buildvers>
         <shimplify.shims>${all.buildvers}</shimplify.shims>
         <cpd.sourceType>main</cpd.sourceType>


### PR DESCRIPTION
Partially fixes #5824.

Update the noSnapshots section and update github pre-merge steps for Spark 3.4.0.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
