### PR TITLE
Batch install-file executions in a single JVM [databricks]

### DIFF
--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -277,12 +277,13 @@ set_dep_jars()
 # Install dependency jars to MVN repository.
 install_dependencies()
 {
-    local depsPomXml="install-deps-pom.xml"
+    local depsPomXml="$(mktemp /tmp/install-databricks-deps-XXXXXX-pom.xml)"
+    mkdir -p target
     set_sw_versions
     set_jars_prefixes
     set_dep_jars
     echo > ${depsPomXml} '<?xml version="1.0" encoding="UTF-8"?>
-    <project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -297,36 +298,49 @@ install_dependencies()
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
     '
     # Please note we are installing all of these dependencies using the Spark version
     # (SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS) to make it easier to specify the dependencies in
     # the pom files
     for key in "${!artifacts[@]}"; do
+
+        # TODO dedicated groups array?
+        # to minimize changes parse group/artifacts apart
+        #
+        echo Generating an execution for ${artifacts[${key}]}
+        dashGroupDashArtifact=(${artifacts[${key}]})
+
+        IFS="=" read -r -a dashGroup <<< "${dashGroupDashArtifact[0]}"
+        groupId=${dashGroup[1]}
+
+        IFS="=" read -r -a dashArtifact <<< "${dashGroupDashArtifact[1]}"
+        artifactId=${dashArtifact[1]}
         echo >> ${depsPomXml} "
                     <execution>
-                        <id>install-db-jar</id>
+                        <id>install-db-jar-${key}</id>
                         <phase>initialize</phase>
-                        <goals><goal>install-file<goal></goals>
+                        <goals><goal>install-file</goal></goals>
                         <configuration>
                             <localRepository>$M2DIR</localRepository>
-                            <file>$JARDIR/${dep_jars[$key]}</file>
-                            <artifactId>${artifacts[$key]}</artifactId>
-                            <version>$SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS</version>
+                            <file>${JARDIR}/${dep_jars[$key]}</file>
+                            <groupId>${groupId}</groupId>
+                            <artifactId>${artifactId}</artifactId>
+                            <version>${SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS}</version>
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>
                     "
     done
     echo >> ${depsPomXml} '
-                    </executions>
-                </plugin>
-            </plugins>
-        </build>
-    </project>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
     '
-    $MVN_CMD -f ${depsPomXml}
-
+    $MVN_CMD -f ${depsPomXml} initialize
 }
 
 ##########################

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -277,21 +277,56 @@ set_dep_jars()
 # Install dependency jars to MVN repository.
 install_dependencies()
 {
+    local depsPomXml="install-deps-pom.xml"
     set_sw_versions
     set_jars_prefixes
     set_dep_jars
+    echo > ${depsPomXml} '<?xml version="1.0" encoding="UTF-8"?>
+    <project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.nvidia</groupId>
+    <artifactId>rapids-4-spark-db-deps-installer</artifactId>
+    <description>bulk dbdeps install</description>
+    <version>23.06.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+    '
     # Please note we are installing all of these dependencies using the Spark version
     # (SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS) to make it easier to specify the dependencies in
     # the pom files
     for key in "${!artifacts[@]}"; do
-        echo "running mvn command for $key..."
-        $MVN_CMD -B install:install-file \
-            -Dmaven.repo.local=$M2DIR \
-            -Dfile=$JARDIR/${dep_jars[$key]} \
-            ${artifacts[$key]} \
-            -Dversion=$SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS \
-            -Dpackaging=jar
+        echo >> ${depsPomXml} "
+                    <execution>
+                        <id>install-db-jar</id>
+                        <phase>initialize</phase>
+                        <goals><goal>install-file<goal></goals>
+                        <configuration>
+                            <localRepository>$M2DIR</localRepository>
+                            <file>$JARDIR/${dep_jars[$key]}</file>
+                            <artifactId>${artifacts[$key]}</artifactId>
+                            <version>$SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                    "
     done
+    echo >> ${depsPomXml} '
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </project>
+    '
+    $MVN_CMD -f ${depsPomXml}
+
 }
 
 ##########################


### PR DESCRIPTION
Fixes #8219 

- Generate a pom file in a temp directory 
- Use it to install all external jars in a couple of seconds

Signed-off-by: Gera Shegalov <gera@apache.org>