### PR TITLE
Use weak keys in executor broadcast plan cache

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -22,11 +22,11 @@ import java.util.concurrent._
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
+import scala.ref.WeakReference
 import scala.util.control.NonFatal
 
 import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization, NvtxColor, NvtxRange}
 import ai.rapids.cudf.JCudfSerialization.SerializedTableHeader
-import com.google.common.collect.MapMaker
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
@@ -575,24 +575,23 @@ case class GpuBroadcastExchangeExec(
 
 /** Caches the mappings from canonical CPU exchanges to the GPU exchanges that replaced them */
 object ExchangeMappingCache extends Logging {
-  import scala.collection.JavaConverters._
   // Cache is a mapping from CPU broadcast plan to GPU broadcast plan. The cache should not
   // artificially hold onto unused plans, so we make both the keys and values weak. The values
   // point to their corresponding keys, so the keys will not be collected unless the value
   // can be collected. The values will be held during normal Catalyst planning until those
   // plans are no longer referenced, allowing both the key and value to be reaped at that point.
-  private val cache = new MapMaker().weakKeys().weakValues().makeMap[Exchange, Exchange]().asScala
+  private val cache = new mutable.WeakHashMap[Exchange, WeakReference[Exchange]]
 
   /** Try to find a recent GPU exchange that has replaced the specified CPU canonical plan. */
   def findGpuExchangeReplacement(cpuCanonical: Exchange): Option[Exchange] = {
-    cache.get(cpuCanonical)
+    cache.get(cpuCanonical).flatMap(_.get)
   }
 
   /** Add a GPU exchange to the exchange cache */
   def trackExchangeMapping(cpuCanonical: Exchange, gpuExchange: Exchange): Unit = {
     val old = findGpuExchangeReplacement(cpuCanonical)
     if (!old.exists(_.asInstanceOf[GpuBroadcastExchangeExec].isGpuPlanningComplete)) {
-      cache.put(cpuCanonical, gpuExchange)
+      cache.put(cpuCanonical, WeakReference(gpuExchange))
     }
   }
 }


### PR DESCRIPTION
Recently ran across a situation where driver ran out of memory, and large amounts of it were held by the executor broadcast plan cache added in #7849.  The problem is the cache does not have weak keys, and keys are never explicitly removed from the cache.  Since the keys are CPU broadcast plans, they could have a large child plan and hold onto significant memory.

This changes the cache setup to use weak keys. Originally the concern of using weak keys was that a GC event could reap keys from the cache prematurely, but this cannot happen in practice.  The values corresponding to keys are GPU broadcasts that reference the CPU plan they're replacing, which is also the key inserted into the cache.  Thus as long as the GPU broadcast is being referenced in a plan Catalyst is still considering for execution, then the CPU broadcast will also be reference, precluding GC from reaping it early.