### PR TITLE
Remove semicolon at the end of the package statement in Scala files

### DIFF
--- a/sql-plugin/src/test/spark311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "311"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark311;
+package com.nvidia.spark.rapids.shims.spark311
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "312"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark312;
+package com.nvidia.spark.rapids.shims.spark312
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "313"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark313;
+package com.nvidia.spark.rapids.shims.spark313
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "320"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark320;
+package com.nvidia.spark.rapids.shims.spark320
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "321"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark321;
+package com.nvidia.spark.rapids.shims.spark321
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "321cdh"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark321cdh;
+package com.nvidia.spark.rapids.shims.spark321cdh
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "322"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark322;
+package com.nvidia.spark.rapids.shims.spark322
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "323"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark323;
+package com.nvidia.spark.rapids.shims.spark323
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "330"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark330;
+package com.nvidia.spark.rapids.shims.spark330
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "330cdh"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark330cdh;
+package com.nvidia.spark.rapids.shims.spark330cdh
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "331"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark331;
+package com.nvidia.spark.rapids.shims.spark331
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "332"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark332;
+package com.nvidia.spark.rapids.shims.spark332
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark333/scala/com/nvidia/spark/rapids/shims/spark333/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark333/scala/com/nvidia/spark/rapids/shims/spark333/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "333"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark333;
+package com.nvidia.spark.rapids.shims.spark333
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite

--- a/sql-plugin/src/test/spark340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -17,7 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "340"}
 spark-rapids-shim-json-lines ***/
-package com.nvidia.spark.rapids.shims.spark340;
+package com.nvidia.spark.rapids.shims.spark340
 
 import com.nvidia.spark.rapids._
 import org.scalatest.FunSuite


### PR DESCRIPTION
This PR just removes the extra semicolon at the end of the package statement. 

Context: _Originally posted in https://github.com/NVIDIA/spark-rapids/pull/8239#discussion_r1187804293_ 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
