### PR TITLE
Remove redundant open of ORC file

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1133,7 +1133,6 @@ private object OrcTools {
         OrcConf.USE_ZEROCOPY.getBoolean(conf)
       }
       val maxDiskRangeChunkLimit = OrcConf.ORC_MAX_DISK_RANGE_CHUNK_LIMIT.getInt(conf)
-      val file = filePath.getFileSystem(conf).open(filePath)
 
       val typeCount = org.apache.orc.OrcUtils.getOrcTypes(fileSchema).size
       //noinspection ScalaDeprecation


### PR DESCRIPTION
This removes a redundant open of an ORC file.  It appears to have been inadvertently added during the refactor from #4408.