### PR TITLE
Use env var instead of file for IT DBR version

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -238,14 +238,10 @@ else
 
     # Extract Databricks version from deployed configs. This is set automatically on Databricks
     # notebooks but not when running Spark manually.
-    DB_DEPLOY_CONF=/databricks/common/conf/deploy.conf
-    if [[ -f $DB_DEPLOY_CONF ]]; then
-      DB_VER=$(grep spark.databricks.clusterUsageTags.sparkVersion $DB_DEPLOY_CONF | sed -e 's/.*"\(.*\)".*/\1/')
-      if [[ -z $DB_VER ]]; then
-        echo >&2 "Unable to determine Databricks version"
-        exit 1
-      fi
-      export PYSP_TEST_spark_databricks_clusterUsageTags_sparkVersion=$DB_VER
+    if [[ -n "${DATABRICKS_RUNTIME_VERSION}" ]]; then
+      # DATABRICKS_RUNTIME_VERSION = major.minor
+      # version matching checks the prefix ending with a dot: "major.minor." such as "11.3."
+      export PYSP_TEST_spark_databricks_clusterUsageTags_sparkVersion="${DATABRICKS_RUNTIME_VERSION}."
     fi
 
     # Set spark.task.maxFailures for most schedulers.


### PR DESCRIPTION
Fixes #8254

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
