### PR TITLE
Add test to confirm correct behavior for decimal average in Spark 3.4

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -366,8 +366,7 @@ class GpuParquetWriter(
 
       // Decimal types are checked and transformed only for the top level column because we don't
       // have access to Spark's data type of the nested column.
-      case (cv, dtOpt) if dtOpt.isDefined && dtOpt.get == DecimalType =>
-        val d = dtOpt.get.asInstanceOf[DecimalType]
+      case (cv, Some(d: DecimalType)) =>
         // There is a bug in Spark that causes a problem if we write Decimals with
         // precision < 10 as Decimal64.
         // https://issues.apache.org/jira/browse/SPARK-34167

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetFileFormat.scala
@@ -366,7 +366,8 @@ class GpuParquetWriter(
 
       // Decimal types are checked and transformed only for the top level column because we don't
       // have access to Spark's data type of the nested column.
-      case (cv, Some(d: DecimalType)) =>
+      case (cv, dtOpt) if dtOpt.isDefined && dtOpt.get == DecimalType =>
+        val d = dtOpt.get.asInstanceOf[DecimalType]
         // There is a bug in Spark that causes a problem if we write Decimals with
         // precision < 10 as Decimal64.
         // https://issues.apache.org/jira/browse/SPARK-34167

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
@@ -121,6 +121,7 @@ class DecimalBinaryOpSuite extends GpuExpressionTestSuite {
       schema.head.dataType, DataTypes.BooleanType, expectedFunSV, schema)
   }
 
+  // https://github.com/NVIDIA/spark-rapids/issues/6076
   testSparkResultsAreEqual("SPARK-24957: average with decimal followed by " +
       "aggregation returning wrong result", decimals) {
     df => df.groupBy("text").agg(avg("number").as("avg_res"))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DecimalBinaryOpSuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.DType
 
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.functions.{avg, sum}
 import org.apache.spark.sql.rapids.{GpuEqualTo, GpuGreaterThan, GpuGreaterThanOrEqual, GpuLessThan, GpuLessThanOrEqual}
 import org.apache.spark.sql.types.{DataTypes, Decimal, DecimalType}
 
@@ -118,5 +119,11 @@ class DecimalBinaryOpSuite extends GpuExpressionTestSuite {
     val expectedFunSV = (x: Decimal) => Option(litValue <= x)
     checkEvaluateGpuUnaryExpression(GpuLessThanOrEqual(lit, leftExpr),
       schema.head.dataType, DataTypes.BooleanType, expectedFunSV, schema)
+  }
+
+  testSparkResultsAreEqual("SPARK-24957: average with decimal followed by " +
+      "aggregation returning wrong result", decimals) {
+    df => df.groupBy("text").agg(avg("number").as("avg_res"))
+        .groupBy("text").agg(sum("avg_res"))
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -1665,6 +1665,19 @@ trait SparkQueryCompareTestSuite extends FunSuite {
     ).toDF("doubles", "more_doubles")
   }
 
+  def decimals(session: SparkSession): DataFrame = {
+    import session.sqlContext.implicits._
+    Seq[(String, BigDecimal)](
+      ("a", BigDecimal("12.0")),
+      ("a", BigDecimal("12.0")),
+      ("a", BigDecimal("11.9999999988")),
+      ("a", BigDecimal("12.0")),
+      ("a", BigDecimal("12.0")),
+      ("a", BigDecimal("11.9999999988")),
+      ("a", BigDecimal("11.9999999988"))
+    ).toDF("text", "number")
+  }
+
   def doubleWithDifferentKindsOfNansAndZeros(session: SparkSession): DataFrame = {
     import session.sqlContext.implicits._
     Seq[(Double, Int)](


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/6076

This PR adds a test to confirm that we see the expected behavior in Spark 3.4 when performing `AVG` on decimal data.

I implemented a version of the test `SPARK-24957: average with decimal followed by aggregation returning wrong result` from the Spark PR linked to in the issue (https://github.com/apache/spark/commit/46071a9caa).

When I ran this test against Spark 3.3.2, both CPU and GPU produced 11.9999999994857142860000.

When I ran this test against Spark 3.4.0, both CPU and GPU produced 11.9999999994857142857143.

These values match the before and after values in the Spark PR. This confirms that we have the correct behavior.

The expressions in the query plans differ slightly between 33x and 340

## 332

```
(input[1, decimal(38,18), true](sum#153) / input[2, bigint, true](count#154))
```

## 340

```
(input[1, decimal(38,18), true](sum#348) / cast(input[2, bigint, true](count#349) as decimal(20,0)))
```

Thanks to @razajafri for helping confirm that we are seeing the expected behavior.
