### PR TITLE
Added documentation for assertion on non-empty nulls [skip ci]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,6 +15,14 @@ problem. Please also look at the current list of
 [bugs](https://github.com/NVIDIA/spark-rapids/issues?q=is%3Aopen+is%3Aissue+label%3Abug) which are
 typically incompatibilities that we have not yet addressed.
 
+## Non-empty nulls
+
+The SQL plugin doesn't support nested types to have non-empty nulls and if data being processed 
+contains non-empty nulls, it will throw an AssertionError. If you still want to continue using this 
+data, disable assertions by setting `-da:ai.rapids.cudf.AssertEmptyNulls` in extra Java parameters 
+for the Driver and the Executor but know that this will result in undefined behavior as 
+[cudf](https://github.com/rapidsai/cudf) doesn't support non-empty nulls.
+
 ## Ordering of Output
 
 There are some operators where Spark does not guarantee the order of the output.


### PR DESCRIPTION
This PR attempts at updating documentation to add recently added assertion on non-empty.

fixes #8238
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
