### PR TITLE
Add support for escaped dot in character class in regexp parser

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -226,6 +226,19 @@ def test_split_regexp_disabled_fallback():
             'split(a, "[o]", 5) from string_split_table',
             conf)
 
+def test_split_escaped_chars_in_character_class():
+    data_gen = mk_str_gen(r'([0-9][\\\.\[\]\^\-\+]){1,4}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'split(a, "[\\\\.]", 2)',
+            'split(a, "[\\\\[]", 2)',
+            'split(a, "[\\\\]]", 2)',
+            'split(a, "[\\\\^]", 2)',
+            'split(a, "[\\\\-]", 2)',
+            'split(a, "[\\\\+]", 2)',
+            'split(a, "[\\\\\\\\]", 2)',
+        ))
+
 
 def test_re_replace():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -229,14 +229,16 @@ def test_split_regexp_disabled_fallback():
 def test_split_escaped_chars_in_character_class():
     data_gen = mk_str_gen(r'([0-9][\\\.\[\]\^\-\+]){1,4}')
     assert_gpu_and_cpu_are_equal_collect(
+        # note that regexp patterns are double-escaped to support
+        # passing from Python to Java
         lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'split(a, "[\\\\.]", 2)',
-            'split(a, "[\\\\[]", 2)',
-            'split(a, "[\\\\]]", 2)',
-            'split(a, "[\\\\^]", 2)',
-            'split(a, "[\\\\-]", 2)',
-            'split(a, "[\\\\+]", 2)',
-            'split(a, "[\\\\\\\\]", 2)',
+            r'split(a, "[\\.]", 2)',
+            r'split(a, "[\\[]", 2)',
+            r'split(a, "[\\]]", 2)',
+            r'split(a, "[\\^]", 2)',
+            r'split(a, "[\\-]", 2)',
+            r'split(a, "[\\+]", 2)',
+            r'split(a, "[\\\\]", 2)',
         ))
 
 

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -73,13 +73,6 @@ def test_split_positive_limit():
             'split(a, "C", 3)',
             'split(a, "_", 999)'))
 
-def test_split_escaped_dot():
-    data_gen = mk_str_gen(r'([0-9]\.){1,4}')
-    assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen).selectExpr(
-            'split(a, "[\\\\.]", 2)'
-        ))
-
 @pytest.mark.parametrize('data_gen,delim', [(mk_str_gen('([ABC]{0,3}_?){0,7}'), '_'),
     (mk_str_gen('([MNP_]{0,3}\\.?){0,5}'), '.'),
     (mk_str_gen('([123]{0,3}\\^?){0,5}'), '^')], ids=idfn)

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -73,6 +73,13 @@ def test_split_positive_limit():
             'split(a, "C", 3)',
             'split(a, "_", 999)'))
 
+def test_split_escaped_dot():
+    data_gen = mk_str_gen(r'([0-9]\.){1,4}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen).selectExpr(
+            'split(a, "[\\\\.]", 2)'
+        ))
+
 @pytest.mark.parametrize('data_gen,delim', [(mk_str_gen('([ABC]{0,3}_?){0,7}'), '_'),
     (mk_str_gen('([MNP_]{0,3}\\.?){0,5}'), '.'),
     (mk_str_gen('([123]{0,3}\\^?){0,5}'), '^')], ids=idfn)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -187,7 +187,7 @@ class RegexParser(pattern: String) {
   }
 
   private def parseCharacterClass(): RegexCharacterClass = {
-    val supportedMetaCharacters = "\\^-[]+"
+    val supportedMetaCharacters = "\\^-[]+."
 
     def getEscapedComponent(): RegexCharacterClassComponent = {
       peek() match {
@@ -206,7 +206,7 @@ class RegexParser(pattern: String) {
           }
         case Some(ch) =>
           consumeExpected(ch) match {
-            // NOTE: Should switch to ASCII mode to simplify and expland this fix
+            // NOTE: Should switch to ASCII mode to simplify and expand this fix
             case 'd' => RegexCharacterRange(RegexChar('0'), RegexChar('9'))
             // List of character literals with an escape from here, under "Characters"
             // https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8222

Changes in PR:

- Add test to repro the issue
- Add `.` to list of allowed escaped characters in a character class
- Fix a typo in a comment