### PR TITLE
Add a unit test for reordered canonicalized expressions in BinaryComparison

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+// import org.apache.spark.sql.types.{DataType, DataTypes, Decimal, DecimalType, StructType}
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.scalatest.FunSuite
+
+class CanonicalizeSuite extends FunSuite {
+  test("SPARK-40362: Commutative operator under BinaryComparison") {
+    Seq(GpuEqualTo, GpuEqualNullSafe, GpuGreaterThan,
+        GpuLessThan, GpuGreaterThanOrEqual, GpuLessThanOrEqual)
+      .foreach( bc => {
+        assert(bc(GpuAdd($"a", $"b", true), Literal(10))
+            .semanticEquals(bc(GpuAdd($"b", $"a", true), Literal(10))))
+      })
+  }
+}

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
@@ -16,12 +16,15 @@
 
 package org.apache.spark.sql.rapids
 
-// import org.apache.spark.sql.types.{DataType, DataTypes, Decimal, DecimalType, StructType}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.scalatest.FunSuite
 
 class CanonicalizeSuite extends FunSuite {
+  /* In the future, if we decide to implement the Spark 3.3 algorithm to perform canonicalization
+   * this unit test should still pass. We should use the implementation made in
+   * https://github.com/apache/spark/pull/37851 (SPARK-40362) as a base.
+   */
   test("SPARK-40362: Commutative operator under BinaryComparison") {
     Seq(GpuEqualTo, GpuEqualNullSafe, GpuGreaterThan,
         GpuLessThan, GpuGreaterThanOrEqual, GpuLessThanOrEqual)


### PR DESCRIPTION
Fixes #7898.

https://github.com/apache/spark/pull/37851 fixed a regression introduced by 
https://github.com/apache/spark/pull/34883 by ultimately completing a refactor that implemented `canonicalized` directly in several `Expression` classes. The fix was made Spark 3.4 and backported to Spark 3.3.1. Since `GpuCanonicalize` uses an algorithm derived from the previous implementation in the original Spark `Canonicalize` object that reordered the entire expression tree, we are not really affected by these changes. This algorithm still produces the correct behavior, and this is verified by the unit test added in this PR. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
