### PR TITLE
Add split and retry support for filter [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -100,7 +100,7 @@ abstract class GpuOptimisticTransactionBase
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan) else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
   }
 
   /**

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
@@ -80,7 +80,7 @@ abstract class GpuOptimisticTransactionBase(
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan) else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
   }
 
   /**

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -272,6 +272,10 @@ def test_filter_with_project(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, BooleanGen(), data_gen).filter(f.col('a')).selectExpr('*', 'a as a2'))
 
+def test_nondeterministic_filter():
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : unary_op_df(spark, LongGen(), 1).filter(f.rand(0) > 0.5))
+
 @pytest.mark.parametrize('expr', [f.lit(True), f.lit(False), f.lit(None).cast('boolean')], ids=idfn)
 def test_filter_with_lit(expr):
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3805,7 +3805,7 @@ object GpuOverrides extends Logging {
       (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {
         override def convertToGpu(): GpuExec = {
           GpuFilterExec(childExprs.head.convertToGpu(),
-            childPlans.head.convertIfNeeded())(conf.isTieredProjectEnabled)
+            childPlans.head.convertIfNeeded())(useTieredProject = conf.isTieredProjectEnabled)
         }
       }),
     exec[ShuffleExchangeExec](
@@ -3872,7 +3872,7 @@ object GpuOverrides extends Logging {
           // The GPU does not yet support conditional joins, so conditions are implemented
           // as a filter after the join when possible.
           condition.map(c => GpuFilterExec(c.convertToGpu(),
-            joinExec)(conf.isTieredProjectEnabled)).getOrElse(joinExec)
+            joinExec)(useTieredProject = conf.isTieredProjectEnabled)).getOrElse(joinExec)
         }
       }),
     exec[HashAggregateExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -79,7 +79,8 @@ class GpuShuffledHashJoinMeta(
       join.rightKeys)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)).getOrElse(joinExec)
+    filterCondition.map(c => GpuFilterExec(c,
+      joinExec)(conf.isTieredProjectEnabled)).getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -80,7 +80,7 @@ class GpuShuffledHashJoinMeta(
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
     filterCondition.map(c => GpuFilterExec(c,
-      joinExec)(conf.isTieredProjectEnabled)).getOrElse(joinExec)
+      joinExec)(useTieredProject = conf.isTieredProjectEnabled)).getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -95,6 +95,6 @@ class GpuSortMergeJoinMeta(
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
     filterCondition.map(c => GpuFilterExec(c,
-      joinExec)(conf.isTieredProjectEnabled)).getOrElse(joinExec)
+      joinExec)(useTieredProject = conf.isTieredProjectEnabled)).getOrElse(joinExec)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,7 @@ class GpuSortMergeJoinMeta(
       join.rightKeys)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)).getOrElse(joinExec)
+    filterCondition.map(c => GpuFilterExec(c,
+      joinExec)(conf.isTieredProjectEnabled)).getOrElse(joinExec)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -422,7 +422,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
 
     case p @ GpuProjectExecLike(
         projectList,
-        f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec, _)) =>
+        f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec)) =>
       // A FilterExec is between the ProjectExec and FileSourceScanExec, for cases like
       //   df.select("a").filter("a != 1")
       p.withNewChildren(Seq(
@@ -438,7 +438,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
 
     case p @ ProjectExec(
         projectList,
-        cr @ ColumnarToRowExec(f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec, _))) =>
+        cr @ ColumnarToRowExec(f @ GpuFilterExec(condition, fss: GpuFileSourceScanExec))) =>
       // cpu project + gpu filter + gpu file scan
       p.withNewChildren(Seq(
         cr.withNewChildren(Seq(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -155,7 +155,7 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     val input = if (isPreNeeded) {
-      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded())
+      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded())()
     } else {
       childPlans.head.convertIfNeeded()
     }
@@ -177,7 +177,7 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     if (isPostNeeded) {
-      GpuProjectExec(post.toList, windowExpr)
+      GpuProjectExec(post.toList, windowExpr)()
     } else {
       windowExpr
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -63,7 +63,7 @@ class GpuProjectExecMeta(
         }
       }
     }
-    GpuProjectExec(gpuExprs, gpuChild)(conf.isTieredProjectEnabled)
+    GpuProjectExec(gpuExprs, gpuChild)(useTieredProject = conf.isTieredProjectEnabled)
   }
 }
 

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -131,7 +131,7 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan) else plan
+      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
     }
 
     val writerBucketSpec: Option[GpuWriterBucketSpec] = bucketSpec.map { spec =>

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -69,7 +69,7 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)).getOrElse(joinExec)
+    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -87,7 +87,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         // ultimately this should be solved with the resolution of one or more of the following:
         // https://github.com/NVIDIA/spark-rapids/issues/3749
         // https://github.com/NVIDIA/spark-rapids/issues/3750
-        c => GpuFilterExec(c, joinExec, coalesceAfter = false)
+        c => GpuFilterExec(c, joinExec)(coalesceAfter = false)
       }.getOrElse(joinExec)
     }
   }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -56,7 +56,6 @@ class GpuBroadcastHashJoinMeta(
       case GpuBuildRight => right
     }
     verifyBuildSideWasReplaced(buildSideMeta)
-
     val joinExec = GpuBroadcastHashJoinExec(
       leftKeys.map(_.convertToGpu()),
       rightKeys.map(_.convertToGpu()),
@@ -68,10 +67,8 @@ class GpuBroadcastHashJoinMeta(
       join.isExecutorBroadcast)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)).getOrElse(joinExec)
+    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
   }
-  
-
 }
 
 case class GpuBroadcastHashJoinExec(

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -82,7 +82,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         // ultimately this should be solved with the resolution of one or more of the following:
         // https://github.com/NVIDIA/spark-rapids/issues/3749
         // https://github.com/NVIDIA/spark-rapids/issues/3750
-        c => GpuFilterExec(c, joinExec, coalesceAfter = false)
+        c => GpuFilterExec(c, joinExec)(coalesceAfter = false)
       }.getOrElse(joinExec)
     }
   }

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -223,7 +223,7 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan) else plan
+      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
     }
 
     writeAndCommit(job, description, committer) {

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -55,7 +55,7 @@ class GpuBroadcastHashJoinMeta(
       left, right)
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
-    filterCondition.map(c => GpuFilterExec(c, joinExec)).getOrElse(joinExec)
+    filterCondition.map(c => GpuFilterExec(c, joinExec)()).getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -73,7 +73,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         // ultimately this should be solved with the resolution of one or more of the following:
         // https://github.com/NVIDIA/spark-rapids/issues/3749
         // https://github.com/NVIDIA/spark-rapids/issues/3750
-        c => GpuFilterExec(c, joinExec, coalesceAfter = false)
+        c => GpuFilterExec(c, joinExec)(coalesceAfter = false)
       }.getOrElse(joinExec)
     }
   }


### PR DESCRIPTION
I was doing some benchmarking and needed a tiered project in filter to make my test faster. When looking at it I noticed that we didn't have retry for filter yet so I added it in.  I also cleaned up some of GpuProject to hide values from the user, like tiered project, that they should not care about. We can still see if tiered project is enabled by looking at the code and the configs.