### PR TITLE
Fix Delta write stats if data schema is missing columns relative to table schema [databricks]

### DIFF
--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaIdentityColumnStatsTracker.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuDeltaIdentityColumnStatsTracker.scala
@@ -19,8 +19,8 @@ package com.nvidia.spark.rapids.delta
 import scala.collection.mutable
 
 import ai.rapids.cudf.ColumnView
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuScalar}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.GpuScalar
 import com.nvidia.spark.rapids.delta.shims.ShimJsonUtils
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Bou
 import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
 import org.apache.spark.sql.execution.datasources.WriteTaskStats
 import org.apache.spark.sql.types.NullType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 class GpuDeltaIdentityColumnStatsTracker(
     val dataSchema: Seq[Attribute],
@@ -61,7 +62,7 @@ object GpuDeltaIdentityColumnStatsTracker {
   def batchStatsToRow(
       dataCols: Seq[Attribute],
       identityStatsExpr: Expression,
-      identityInfo: Seq[(String, Boolean)]): (Array[ColumnView], InternalRow) => Unit = {
+      identityInfo: Seq[(String, Boolean)]): (ColumnarBatch, InternalRow) => Unit = {
     val aggregates = identityStatsExpr.collect {
       case ae: DeclarativeAggregate => ae
     }
@@ -73,7 +74,8 @@ object GpuDeltaIdentityColumnStatsTracker {
     assert(identityInfo.size == boundRefs.size,
       s"expected ${identityInfo.size} refs found ${boundRefs.size}")
     val zipped = identityInfo.map(_._2).zip(boundRefs).zipWithIndex
-    (columnViews: Array[ColumnView], row: InternalRow) => {
+    (batch: ColumnarBatch, row: InternalRow) => {
+      val columnViews = GpuColumnVector.extractBases(batch).asInstanceOf[Array[ColumnView]]
       zipped.foreach { case ((useMax, ref), i) =>
         val cview = columnViews(ref.ordinal)
         val gpuScalar = if (useMax) {

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
@@ -25,7 +25,6 @@ import java.net.URI
 
 import scala.collection.mutable.ListBuffer
 
-import ai.rapids.cudf.ColumnView
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.delta._
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -47,6 +46,7 @@ import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, Fi
 import org.apache.spark.sql.functions.to_json
 import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{Clock, SerializableConfiguration}
 
 /**
@@ -133,8 +133,9 @@ class GpuOptimisticTransaction
         }
 
         val statsSchema = statsCollection.statCollectionSchema
-        val batchStatsToRow = (columnViews: Array[ColumnView], row: InternalRow) => {
-          GpuStatisticsCollection.batchStatsToRow(statsSchema, columnViews, row)
+        val explodedDataSchema = statsCollection.explodedDataSchema
+        val batchStatsToRow = (batch: ColumnarBatch, row: InternalRow) => {
+          GpuStatisticsCollection.batchStatsToRow(statsSchema, explodedDataSchema, batch, row)
         }
         Some(new GpuDeltaJobStatisticsTracker(statsDataSchema, statsColExpr, batchStatsToRow))
       } else {

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
@@ -25,7 +25,6 @@ import java.net.URI
 
 import scala.collection.mutable.ListBuffer
 
-import ai.rapids.cudf.ColumnView
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.delta._
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -47,6 +46,7 @@ import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, Fi
 import org.apache.spark.sql.functions.to_json
 import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{Clock, SerializableConfiguration}
 
 /**
@@ -133,8 +133,9 @@ class GpuOptimisticTransaction
         }
 
         val statsSchema = statsCollection.statCollectionSchema
-        val batchStatsToRow = (columnViews: Array[ColumnView], row: InternalRow) => {
-          GpuStatisticsCollection.batchStatsToRow(statsSchema, columnViews, row)
+        val explodedDataSchema = statsCollection.explodedDataSchema
+        val batchStatsToRow = (batch: ColumnarBatch, row: InternalRow) => {
+          GpuStatisticsCollection.batchStatsToRow(statsSchema, explodedDataSchema, batch, row)
         }
         Some(new GpuDeltaJobStatisticsTracker(statsDataSchema, statsColExpr, batchStatsToRow))
       } else {

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
@@ -25,7 +25,6 @@ import java.net.URI
 
 import scala.collection.mutable.ListBuffer
 
-import ai.rapids.cudf.ColumnView
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.delta._
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -47,6 +46,7 @@ import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, Fi
 import org.apache.spark.sql.functions.to_json
 import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{Clock, SerializableConfiguration}
 
 /**
@@ -117,8 +117,9 @@ class GpuOptimisticTransaction
       val statsColExpr = getGpuStatsColExpr(statsDataSchema, statsCollection)
 
       val statsSchema = statsCollection.statCollectionSchema
-      val batchStatsToRow = (columnViews: Array[ColumnView], row: InternalRow) => {
-        GpuStatisticsCollection.batchStatsToRow(statsSchema, columnViews, row)
+      val explodedDataSchema = statsCollection.explodedDataSchema
+      val batchStatsToRow = (batch: ColumnarBatch, row: InternalRow) => {
+        GpuStatisticsCollection.batchStatsToRow(statsSchema, explodedDataSchema, batch, row)
       }
       (Some(new GpuDeltaJobStatisticsTracker(statsDataSchema, statsColExpr, batchStatsToRow)),
           Some(statsCollection))

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -25,7 +25,6 @@ import java.net.URI
 
 import scala.collection.mutable.ListBuffer
 
-import ai.rapids.cudf.ColumnView
 import com.databricks.sql.transaction.tahoe._
 import com.databricks.sql.transaction.tahoe.actions.FileAction
 import com.databricks.sql.transaction.tahoe.commands.cdc.CDCReader
@@ -48,6 +47,7 @@ import org.apache.spark.sql.functions.{col, to_json}
 import org.apache.spark.sql.rapids.{BasicColumnarWriteJobStatsTracker, ColumnarWriteJobStatsTracker, GpuFileFormatWriter, GpuWriteJobStatsTracker}
 import org.apache.spark.sql.rapids.delta.GpuIdentityColumn
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{Clock, SerializableConfiguration}
 
 
@@ -147,8 +147,9 @@ class GpuOptimisticTransaction(
       }
 
       val statsSchema = statsCollection.statCollectionSchema
-      val batchStatsToRow = (columnViews: Array[ColumnView], row: InternalRow) => {
-        GpuStatisticsCollection.batchStatsToRow(statsSchema, columnViews, row)
+      val explodedDataSchema = statsCollection.explodedDataSchema
+      val batchStatsToRow = (batch: ColumnarBatch, row: InternalRow) => {
+        GpuStatisticsCollection.batchStatsToRow(statsSchema, explodedDataSchema, batch, row)
       }
       Some(new GpuDeltaJobStatisticsTracker(statsDataSchema, statsColExpr, batchStatsToRow))
     } else {


### PR DESCRIPTION
Fixes #8263.

Delta Lake 2.2+ and Delta Lake on Databricks 11.3+ supports overwriting a table while preserving the old table's column for statistics gathering.  This requires mapping the data schema onto the stats collection schema, the latter of which may refer to columns that are missing in the data schema or be reordered relative to the stats collection schema.

This resolves the issue by creating an exploded schema map for the data schema. As we walk the stats collection schema as usual to generate the statistics, the exploded map can be referenced to know whether the column is present, and if it is, what ordinal it's at.