### PR TITLE
Fix delta stats tracker conf [databricks]

### DIFF
--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
@@ -167,15 +167,19 @@ class GpuOptimisticTransaction
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()
 
+      val hadoopConf = spark.sessionState.newHadoopConfWithOptions(
+        metadata.configuration ++ deltaLog.options)
+
       if (spark.conf.get(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED)) {
+        val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
-          new SerializableConfiguration(deltaLog.newDeltaHadoopConf()),
+          serializableHadoopConf,
           BasicWriteJobStatsTracker.metrics)
         registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
-          val hadoopConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
-          val tracker = new GpuWriteJobStatsTracker(hadoopConf, grw.basicMetrics, grw.taskMetrics)
+          val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,
+            grw.basicMetrics, grw.taskMetrics)
           statsTrackers.append(tracker)
         }
       }
@@ -203,10 +207,7 @@ class GpuOptimisticTransaction
           fileFormat = gpuFileFormat,
           committer = committer,
           outputSpec = outputSpec,
-          // scalastyle:off deltahadoopconfiguration
-          hadoopConf =
-            spark.sessionState.newHadoopConfWithOptions(metadata.configuration ++ deltaLog.options),
-          // scalastyle:on deltahadoopconfiguration
+          hadoopConf = hadoopConf,
           partitionColumns = partitioningColumns,
           bucketSpec = None,
           statsTrackers = optionalStatsTracker.toSeq ++ statsTrackers,

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
@@ -167,15 +167,19 @@ class GpuOptimisticTransaction
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()
 
+      val hadoopConf = spark.sessionState.newHadoopConfWithOptions(
+        metadata.configuration ++ deltaLog.options)
+
       if (spark.conf.get(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED)) {
+        val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
-          new SerializableConfiguration(deltaLog.newDeltaHadoopConf()),
+          serializableHadoopConf,
           BasicWriteJobStatsTracker.metrics)
         registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
-          val hadoopConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
-          val tracker = new GpuWriteJobStatsTracker(hadoopConf, grw.basicMetrics, grw.taskMetrics)
+          val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,
+            grw.basicMetrics, grw.taskMetrics)
           statsTrackers.append(tracker)
         }
       }
@@ -203,10 +207,7 @@ class GpuOptimisticTransaction
           fileFormat = gpuFileFormat,
           committer = committer,
           outputSpec = outputSpec,
-          // scalastyle:off deltahadoopconfiguration
-          hadoopConf =
-            spark.sessionState.newHadoopConfWithOptions(metadata.configuration ++ deltaLog.options),
-          // scalastyle:on deltahadoopconfiguration
+          hadoopConf = hadoopConf,
           partitionColumns = partitioningColumns,
           bucketSpec = None,
           statsTrackers = optionalStatsTracker.toSeq ++ statsTrackers,

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -226,9 +226,7 @@ class GpuOptimisticTransaction(
           fileFormat = gpuFileFormat,
           committer = committer,
           outputSpec = outputSpec,
-          // scalastyle:off deltahadoopconfiguration
           hadoopConf = hadoopConf,
-          // scalastyle:on deltahadoopconfiguration
           partitionColumns = partitioningColumns,
           bucketSpec = None,
           statsTrackers = optionalStatsTracker.toSeq ++ identityTracker.toSeq ++ statsTrackers,

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -203,15 +203,19 @@ class GpuOptimisticTransaction(
 
       val statsTrackers: ListBuffer[ColumnarWriteJobStatsTracker] = ListBuffer()
 
+      val hadoopConf = spark.sessionState.newHadoopConfWithOptions(
+        metadata.configuration ++ deltaLog.options)
+
       if (spark.conf.get(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED)) {
+        val serializableHadoopConf = new SerializableConfiguration(hadoopConf)
         val basicWriteJobStatsTracker = new BasicColumnarWriteJobStatsTracker(
-          new SerializableConfiguration(deltaLog.newDeltaHadoopConf()),
+          serializableHadoopConf,
           BasicWriteJobStatsTracker.metrics)
         registerSQLMetrics(spark, basicWriteJobStatsTracker.driverSideMetrics)
         statsTrackers.append(basicWriteJobStatsTracker)
         gpuRapidsWrite.foreach { grw =>
-          val hadoopConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
-          val tracker = new GpuWriteJobStatsTracker(hadoopConf, grw.basicMetrics, grw.taskMetrics)
+          val tracker = new GpuWriteJobStatsTracker(serializableHadoopConf,
+            grw.basicMetrics, grw.taskMetrics)
           statsTrackers.append(tracker)
         }
       }
@@ -241,8 +245,7 @@ class GpuOptimisticTransaction(
           committer = committer,
           outputSpec = outputSpec,
           // scalastyle:off deltahadoopconfiguration
-          hadoopConf =
-            spark.sessionState.newHadoopConfWithOptions(metadata.configuration ++ deltaLog.options),
+          hadoopConf = hadoopConf,
           // scalastyle:on deltahadoopconfiguration
           partitionColumns = partitioningColumns,
           bucketSpec = None,

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -244,9 +244,7 @@ class GpuOptimisticTransaction(
           fileFormat = gpuFileFormat,
           committer = committer,
           outputSpec = outputSpec,
-          // scalastyle:off deltahadoopconfiguration
           hadoopConf = hadoopConf,
-          // scalastyle:on deltahadoopconfiguration
           partitionColumns = partitioningColumns,
           bucketSpec = None,
           statsTrackers = optionalStatsTracker.toSeq ++ identityTracker.toSeq ++ statsTrackers,


### PR DESCRIPTION
A user reported an issue where the basic stats tracker was unable to access the filesystem _after_ the files were written to the filesystem.  This was caused by using the wrong Hadoop conf in the basic stat task tracker.  This changes the GPU Delta Lake write code to use the same Hadoop configuration for the stat trackers that are used for the file write.  That way if we're able to properly access the filesystem for the write we'll also be able to properly access the filesystem for statistics gathering.