### PR TITLE
Update code to deal with new retry semantics

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -509,7 +509,11 @@ object RmmRapidsRetryIterator extends Logging {
       while (result.isEmpty && attemptIter.hasNext) {
         if (!firstAttempt) {
           // call thread block API
-          RmmSpark.blockThreadUntilReady()
+          try {
+            RmmSpark.blockThreadUntilReady()
+          } catch {
+            case _: SplitAndRetryOOM => doSplit = true
+          }
         }
         firstAttempt = false
         if (doSplit) {
@@ -553,7 +557,7 @@ object RmmRapidsRetryIterator extends Logging {
               // we want to throw early here, since we got an exception
               // we were not prepared to handle
               throw lastException
-            } 
+            }
             // else another exception wrapped a retry. So we are going to try again
         }
       }


### PR DESCRIPTION
In a PR I will post shortly the semantics of when a `SplitAndRetryOOM` is going to be thrown are changing so that `blockThreadUntilReady` is likely to be the thing that throws the exception.  These two patches together will fix. https://github.com/NVIDIA/spark-rapids-jni/issues/1066

This by itself should run just fine with the existing retry code so this should be merged in first followed by the JNI patch to avoid any downtime/errors.