### PR TITLE
Fixed peak device memory metrics doesn't work in parquet coalesce reading

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1953,7 +1953,7 @@ class MultiFileParquetPartitionReader(
       extraInfo.isCorrectedInt96RebaseMode, extraInfo.isCorrectedRebaseMode,
       extraInfo.hasInt96Timestamps, isSchemaCaseSensitive, useFieldId, readDataSchema,
       clippedSchema, None,
-      _ => ()) // The max size is computed later on...
+      tableSize => maxDeviceMemory = max(tableSize, maxDeviceMemory))
   }
 
   override def writeFileHeader(buffer: HostMemoryBuffer, bContext: BatchContext): Long = {


### PR DESCRIPTION
Fixes #8297 

The peak device memory always showed 0 when using coalesce reading in the GPU Parquet scan.

This PR updated the `onTableSize` argument in `MakeParquetTableProducer` when reading parquet files with coalescing. Originally there was an empty function and commented that the max size is computed later on. However, the peak device memory was not calculated in the GPU Parquet scan when coalescing reading was enabled.

I tested this locally by reading Parquet files with coalescing:

before this PR:
<img width="391" alt="before" src="https://github.com/NVIDIA/spark-rapids/assets/7326403/5e534259-fd5b-4080-a875-7294f699a968">

and after this PR:
<img width="412" alt="after" src="https://github.com/NVIDIA/spark-rapids/assets/7326403/e16e0713-36fd-4e41-9690-47cd51ef55bd">


Signed-off-by: Haoyang Li <haoyangl@nvidia.com>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
