### PR TITLE
Fix GpuTimeAdd handling both input expressions being GpuScalar [databricks]

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -62,6 +62,17 @@ def test_timeadd_from_subquery(data_gen):
 
     assert_gpu_and_cpu_are_equal_collect(fun)
 
+@pytest.mark.parametrize('data_gen', vals, ids=idfn)
+def test_timesub_from_subquery(data_gen):
+
+    def fun(spark):
+        df = unary_op_df(spark, TimestampGen(start=datetime(5, 1, 1, tzinfo=timezone.utc), end=datetime(15, 1, 1, tzinfo=timezone.utc)), seed=1)
+        df.createOrReplaceTempView("testTime")
+        spark.sql("select a, ((select last(a) from testTime) - interval 1 day) as dateMinus from testTime").createOrReplaceTempView("testTime2")
+        return spark.sql("select * from testTime2 where dateMinus < current_timestamp")
+
+    assert_gpu_and_cpu_are_equal_collect(fun)
+
 # Should specify `spark.sql.legacy.interval.enabled` to test `DateAddInterval` after Spark 3.2.0,
 # refer to https://issues.apache.org/jira/browse/SPARK-34896
 # [SPARK-34896][SQL] Return day-time interval from dates subtraction

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -120,7 +120,7 @@ case class GpuTimeAdd(start: Expression,
           case _ =>
             throw new UnsupportedOperationException(
               "GpuTimeAdd takes column and interval as an argument only, the types " +
-                "passed are, left: ${lhs.getClass} right: ${rhs.getClass}")
+                s"passed are, left: ${lhs.getClass} right: ${rhs.getClass}")
         }
       }
     }

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -119,7 +119,8 @@ case class GpuTimeAdd(start: Expression,
             }
           case _ =>
             throw new UnsupportedOperationException(
-              "GpuTimeAdd takes column and interval as an argument only")
+              "GpuTimeAdd takes column and interval as an argument only, types " +
+                "are, left: ${lhs.getClass} right: ${rhs.getClass}")
         }
       }
     }

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -74,11 +74,11 @@ case class GpuTimeAdd(start: Expression,
   override def dataType: DataType = start.dataType
 
   override def columnarEval(batch: ColumnarBatch): Any = {
-    withResourceIfAllowed(left.columnarEval(batch)) { lhs =>
+    withResourceIfAllowed(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
       withResourceIfAllowed(right.columnarEval(batch)) { rhs =>
         // lhs is start, rhs is interval
         (lhs, rhs) match {
-          case (l: GpuColumnVector, intervalS: GpuScalar) =>
+          case (l, intervalS: GpuScalar) =>
             // get long type interval
             val interval = intervalS.dataType match {
               case CalendarIntervalType =>
@@ -105,7 +105,7 @@ case class GpuTimeAdd(start: Expression,
             } else {
               l.incRefCount()
             }
-          case (l: GpuColumnVector, r: GpuColumnVector) =>
+          case (l, r: GpuColumnVector) =>
             (l.dataType(), r.dataType) match {
               case (_: TimestampType, _: DayTimeIntervalType) =>
                 // DayTimeIntervalType is stored as long
@@ -119,8 +119,8 @@ case class GpuTimeAdd(start: Expression,
             }
           case _ =>
             throw new UnsupportedOperationException(
-              "GpuTimeAdd takes column and interval as an argument only, types " +
-                "are, left: ${lhs.getClass} right: ${rhs.getClass}")
+              "GpuTimeAdd takes column and interval as an argument only, the types " +
+                "passed are, left: ${lhs.getClass} right: ${rhs.getClass}")
         }
       }
     }

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -35,7 +35,7 @@ package org.apache.spark.sql.rapids.shims
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, BinaryOperable, ColumnVector, ColumnView, DType, Scalar}
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuScalar}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuScalar}
 import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimBinaryExpression


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/8293

GpuTimeAdd was failing with:
```
 Caused by: java.lang.UnsupportedOperationException: GpuTimeAdd takes column and interval as an argument only, the types passed are, left: class
 com.nvidia.spark.rapids.GpuScalar right: class com.nvidia.spark.rapids.GpuScalar
```

GpuTimeAdd currently doesn't handle both input expressions being GpuScalar.  This can happen when a subquery is input to the filter. The issue has more details.  I validated test fails without this fix and passes with it.

integration test created and also verified this fixed the customer query that ran into the issue.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
