### PR TITLE
Speed up github verify checks [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -23,6 +23,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  COMMON_MVN_FLAGS: >
+    -Ddist.jar.compress=false
+    -DskipTests
+    -Dskip
+    -Dmaven.javadoc.skip
+
 jobs:
   get-shim-versions-from-dist:
     runs-on: ubuntu-latest
@@ -91,11 +98,9 @@ jobs:
           -pl integration_tests,tests -am
           -P 'individual,pre-merge'
           -Dbuildver=${{ matrix.spark-version }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
           -Dmaven.scalastyle.skip=true
           -Drat.skip=true
+          "$COMMON_MVN_FLAGS"
 
 
   verify-all-modules-with-headSparkVersion:
@@ -116,9 +121,7 @@ jobs:
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge'
           -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.sparkHeadVersion }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
+          "$COMMON_MVN_FLAGS"
 
   verify-modules-with-jdk11:
     needs: get-shim-versions-from-dist
@@ -133,15 +136,13 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-      
+
       - name: Build JDK11
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge,jdk11'
           -Dbuildver=${{ matrix.spark-version }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
+          "$COMMON_MVN_FLAGS"
 
   # TODO: use matrix to combine all jdk* jobs
   verify-modules-with-jdk17:
@@ -163,6 +164,4 @@ jobs:
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge,jdk17'
           -Dbuildver=${{ matrix.spark-version }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
+          "$COMMON_MVN_FLAGS"

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,7 +24,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COMMON_MVN_FLAGS: -Ddist.jar.compress=false -DskipTests -Dskip -Dmaven.javadoc.skip
+  COMMON_MVN_FLAGS: >
+    -Ddist.jar.compress=false
+    -DskipTests
+    -Dskip
+    -Dmaven.javadoc.skip
 
 jobs:
   get-shim-versions-from-dist:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -24,11 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COMMON_MVN_FLAGS: >
-    -Ddist.jar.compress=false
-    -DskipTests
-    -Dskip
-    -Dmaven.javadoc.skip
+  COMMON_MVN_FLAGS: -Ddist.jar.compress=false -DskipTests -Dskip -Dmaven.javadoc.skip
 
 jobs:
   get-shim-versions-from-dist:
@@ -100,7 +96,7 @@ jobs:
           -Dbuildver=${{ matrix.spark-version }}
           -Dmaven.scalastyle.skip=true
           -Drat.skip=true
-          "$COMMON_MVN_FLAGS"
+          $COMMON_MVN_FLAGS
 
 
   verify-all-modules-with-headSparkVersion:
@@ -121,7 +117,7 @@ jobs:
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge'
           -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.sparkHeadVersion }}
-          "$COMMON_MVN_FLAGS"
+          $COMMON_MVN_FLAGS
 
   verify-modules-with-jdk11:
     needs: get-shim-versions-from-dist
@@ -142,7 +138,7 @@ jobs:
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge,jdk11'
           -Dbuildver=${{ matrix.spark-version }}
-          "$COMMON_MVN_FLAGS"
+          $COMMON_MVN_FLAGS
 
   # TODO: use matrix to combine all jdk* jobs
   verify-modules-with-jdk17:
@@ -164,4 +160,4 @@ jobs:
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P 'individual,pre-merge,jdk17'
           -Dbuildver=${{ matrix.spark-version }}
-          "$COMMON_MVN_FLAGS"
+          $COMMON_MVN_FLAGS


### PR DESCRIPTION
Verify checks increased runtime since introduction from 2- minutes to 5-7 minutes, mostly due to large dependencies. At least stopping re-compressing them

- skip compressing dist jar: 30+ seconds
- refactor common maven flags

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
