### PR TITLE
use matrix to combine multiple jdk* jobs in maven-verify CI [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -126,10 +126,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - java-version: 11
-            spark-version: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
-          - jave-version: 17
-            spark-version: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
+          - java-ver: 11
+            spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
+          - jave-ver: 17
+            spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -137,13 +137,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: ${{ matrix.java-version }}
+          java-version: ${{ matrix.java-ver }}
       
       - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
-          -Dbuildver=${{ matrix.spark-version }}
+          -P "individual,pre-merge,jdk${{ matrix.java-ver }}"
+          -Dbuildver=${{ matrix.spark-ver }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -64,7 +64,8 @@ jobs:
           jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           jdk17VersionArrBody=${jdkVersionArrBody:1}
           # jdk
-          jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdk11VersionArrBody + $jdk17VersionArrBody)
+          jdkVersionArrBody=$jdk11VersionArrBody+','+$jdk17VersionArrBody
+          jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdkVersions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
 
   package-tests:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -58,10 +58,10 @@ jobs:
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           # jdk11
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"java-version\": 11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           jdk11VersionArrBody=${jdkVersionArrBody:1}
           # jdk17
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",  \"java-version\": 17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           jdk17VersionArrBody=${jdkVersionArrBody:1}
           # jdk
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdk11VersionArrBody + $jdk17VersionArrBody)

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -138,12 +138,11 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-        run: >
-          echo ${{ matrix.java-ver }}
-          echo ${{ matrix.spark-ver }}
       
       - name: Build JDK
         run: >
+          echo ${{ matrix.java-ver }}
+          echo ${{ matrix.spark-ver }}
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P "individual,pre-merge,jdk${{ matrix.java-ver }}"
           -Dbuildver=${{ matrix.spark-ver }}

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: matrix.java-version
+          java-version: ${{ matrix.java-version }}
       
       - name: Build JDK
         run: >

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -29,8 +29,7 @@ jobs:
     outputs:
       sparkHeadVersion: ${{ steps.allShimVersionsStep.outputs.headVersion }}
       sparkTailVersions: ${{ steps.allShimVersionsStep.outputs.tailVersions }}
-      sparkJDK11Versions: ${{ steps.allShimVersionsStep.outputs.jdk11Versions }}
-      sparkJDK17Versions: ${{ steps.allShimVersionsStep.outputs.jdk17Versions }}
+      sparkJDKVersions: ${{ steps.allShimVersionsStep.outputs.jdkVersions }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -59,15 +58,14 @@ jobs:
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           # jdk11
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
-          jdkVersionArrBody=${jdkVersionArrBody:1}
-          jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
-          echo "jdk11Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\", \"java-version\": 11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdk11VersionArrBody=${jdkVersionArrBody:1}
           # jdk17
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\"}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
-          jdkVersionArrBody=${jdkVersionArrBody:1}
-          jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
-          echo "jdk17Versions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
+          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",  \"java-version\": 17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
+          jdk17VersionArrBody=${jdkVersionArrBody:1}
+          # jdk
+          jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdk11VersionArrBody + $jdk17VersionArrBody)
+          echo "jdkVersions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
 
   package-tests:
     needs: get-shim-versions-from-dist
@@ -124,11 +122,7 @@ jobs:
     needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        java-version: [11, 17]
-        # include:
-        #     spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
-        #     spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
+      matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDKVersions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -142,7 +136,7 @@ jobs:
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P "individual,pre-merge,jdk${{ matrix.java-version }}"
-          -Dbuildver=${{ matrix.spark-ver }}
+          -Dbuildver=${{ matrix.spark-version }}
           -DskipTests
           -Dskip
           -Dmaven.javadoc.skip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -125,11 +125,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - java-ver: 11
-            spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
-          - jave-ver: 17
-            spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
+        java-version: [11, 17]
+        # include:
+        #     spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
+        #     spark-ver: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -137,14 +136,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       
       - name: Build JDK
         run: >
-          echo ${{ matrix.java-ver }}
-          echo ${{ matrix.spark-ver }}
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P "individual,pre-merge,jdk${{ matrix.java-ver }}"
+          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
           -Dbuildver=${{ matrix.spark-ver }}
           -DskipTests
           -Dskip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -58,13 +58,12 @@ jobs:
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           # jdk11
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
-          jdk11VersionArrBody=${jdkVersionArrBody:1}
+          jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           # jdk17
-          jdkVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
-          jdk17VersionArrBody=${jdkVersionArrBody:1}
+          jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           # jdk
-          jdkVersionArrBody=$jdk11VersionArrBody+','+$jdk17VersionArrBody
+          jdkVersionArrBody=$jdk11VersionArrBody$jdk17VersionArrBody
+          jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdkVersions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -120,11 +120,16 @@ jobs:
           -Dskip
           -Dmaven.javadoc.skip
 
-  verify-modules-with-jdk11:
+  verify-modules-with-jdk:
     needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
+      matrix:
+        include:
+          - java-version: 11
+            spark-version: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK11Versions) }}
+          - jave-version: 17
+            spark-version: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
@@ -132,36 +137,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: matrix.java-version
       
-      - name: Build JDK11
+      - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P 'individual,pre-merge,jdk11'
-          -Dbuildver=${{ matrix.spark-version }}
-          -DskipTests
-          -Dskip
-          -Dmaven.javadoc.skip
-
-  # TODO: use matrix to combine all jdk* jobs
-  verify-modules-with-jdk17:
-    needs: get-shim-versions-from-dist
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.get-shim-versions-from-dist.outputs.sparkJDK17Versions) }}
-    steps:
-      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
-
-      - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 17
-
-      - name: Build JDK17
-        run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P 'individual,pre-merge,jdk17'
+          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
           -Dbuildver=${{ matrix.spark-version }}
           -DskipTests
           -Dskip

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -137,7 +137,10 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: ${{ matrix.java-ver }}
+          java-version: 11
+        run: >
+          echo ${{ matrix.java-ver }}
+          echo ${{ matrix.spark-ver }}
       
       - name: Build JDK
         run: >


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

fix #8275 

Added `jdk-version` to original matrix json.
Now the matrix list is like `{"include":[{"spark-version":"xxx","java-version":xx}]}'`

Also merged `jdk11` and `jdk17` stage into one `jdk` stage with the new matrix list.


