### PR TITLE
Fix V1 column name match is case-sensitive when dropping partition by columns

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -160,3 +160,24 @@ def test_read_count(spark_tmp_path, v1_enabled_list, reader_type, batch_size_row
     assert_gpu_and_cpu_row_counts_equal(
         lambda spark: spark.read.format("avro").load(data_path),
         conf=all_confs)
+
+@pytest.mark.parametrize('col_name', ['K0', 'k0', 'K3', 'k3', 'V0', 'v0'], ids=idfn)
+@ignore_order
+def test_read_case_col_name(spark_tmp_path, col_name):
+    gen_list =[('k0', LongGen(nullable=False, min_val=0, max_val=0)), 
+            ('k1', LongGen(nullable=False, min_val=1, max_val=1)),
+            ('k2', LongGen(nullable=False, min_val=2, max_val=2)),
+            ('k3', LongGen(nullable=False, min_val=3, max_val=3)),
+            ('v0', LongGen()),
+            ('v1', LongGen()),
+            ('v2', LongGen()),
+            ('v3', LongGen())]
+ 
+    gen = StructGen(gen_list, nullable=False)
+    data_path = spark_tmp_path + '/AVRO_DATA'
+    with_cpu_session(
+            lambda spark : gen_df(spark, gen).write.partitionBy('k0', 'k1', 'k2', 'k3').format('avro').save(data_path))
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : spark.read.format('avro').load(data_path).selectExpr(col_name),
+            conf=_enable_all_types_conf)

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/csv_test.py
+++ b/integration_tests/src/main/python/csv_test.py
@@ -582,3 +582,28 @@ def test_csv_datetime_parsing_fallback_no_datetime(std_input_path, filename, sch
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : spark.read.schema(schema).option('enableDateTimeParsingFallback', "true").csv(data_path),
         conf=_enable_all_types_conf)
+
+@pytest.mark.parametrize('read_func', [read_csv_df, read_csv_sql])
+@pytest.mark.parametrize('v1_enabled_list', ["", "csv"])
+@pytest.mark.parametrize('col_name', ['K0', 'k0', 'K3', 'k3', 'V0', 'v0'], ids=idfn)
+@ignore_order
+def test_read_case_col_name(spark_tmp_path, spark_tmp_table_factory, read_func, v1_enabled_list, col_name):
+    all_confs = {'spark.sql.sources.useV1SourceList': v1_enabled_list}
+    gen_list =[('k0', LongGen(nullable=False, min_val=0, max_val=0)), 
+            ('k1', LongGen(nullable=False, min_val=1, max_val=1)),
+            ('k2', LongGen(nullable=False, min_val=2, max_val=2)),
+            ('k3', LongGen(nullable=False, min_val=3, max_val=3)),
+            ('v0', LongGen()),
+            ('v1', LongGen()),
+            ('v2', LongGen()),
+            ('v3', LongGen())]
+ 
+    gen = StructGen(gen_list, nullable=False)
+    data_path = spark_tmp_path + '/CSV_DATA'
+    reader = read_func(data_path, gen.data_type, spark_tmp_table_factory)
+    with_cpu_session(
+            lambda spark : gen_df(spark, gen).write.partitionBy('k0', 'k1', 'k2', 'k3').csv(data_path))
+
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : reader(spark).selectExpr(col_name),
+            conf=all_confs)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -393,22 +393,30 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
     }
   }
 
+  def extractAttrReferences[A <: Expression](expression: A): Seq[AttributeReference] = {
+    expression match {
+      case a: AttributeReference =>
+        Seq(a)
+      case other: Expression =>
+        other.children.flatMap(extractAttrReferences)
+    }
+  }
+
   private def withPrunedPartSchema(
       fss: GpuFileSourceScanExec,
       referenceList: Seq[Expression]): GpuFileSourceScanExec = {
     // Luckily partition columns do not support nested types. So only need to prune the
     // top level columns.
-    val prunedPartSchema = StructType(fss.relation.partitionSchema.filter { f =>
-      // The partition columns used in the referenceList will be kept.
-      referenceList.exists { expr =>
-        expr.find {
-          // It is safe to use the column name for comparison for the two cases listed in
-          // `prunePartitionForFileSourceScan`
-          case attr: AttributeReference => attr.name == f.name
-          case _ => false
-        }.isDefined
-      }})
-    fss.copy(requiredPartitionSchema = Some(prunedPartSchema))(fss.rapidsConf)
+    // Prune the output of the Scan so it only includes things that the referenceList will
+    // actually read
+    val neededExprIds = referenceList.flatMap(extractAttrReferences).map(_.exprId).toSet
+    val partOutAttrs = fss.output.splitAt(fss.requiredSchema.length)._2
+    val neededPartIndexes = partOutAttrs.zipWithIndex.filter{
+      case (provided, _) => neededExprIds.contains(provided.exprId)
+    }.map(_._2)
+
+    val prunedPartSchema = Some(StructType(neededPartIndexes.map(fss.relation.partitionSchema)))
+    fss.copy(requiredPartitionSchema = prunedPartSchema)(fss.rapidsConf)
   }
 
   // This tries to prune the partition schema for GpuFileSourceScanExec by leveraging


### PR DESCRIPTION
Because of the feature in the V1 readers that we added to prune unneeded partition columns we introduced a bug where Spark would match the columns in a case-insensitive way, but we would throw it out because it didn't match in a case-sensitive way.

To avoid all of that this patch switches the match over to using the expression id which is what Spark uses for binding anyways.

The tests added were being a little cautious. This is specific to V1, but I included tests for V2 also and test that verify that we can still match if the case is the same, and that we match non-partition columns correctly too.

Because of that without the patch only 112 of the 314 tests that were added fail.