### PR TITLE
Avoid processing empty batch in ParquetCachedBatchSerializer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -319,7 +319,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
       }
 
       input.flatMap(batch => {
-        if (batch.numCols() == 0) {
+        if (batch.numCols() == 0 || batch.numRows() == 0) {
           List(ParquetCachedBatch(batch.numRows(), new Array[Byte](0)))
         } else {
           withResource(putOnGpuIfNeeded(batch)) { gpuCB =>
@@ -344,9 +344,13 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
       origSchema: StructType,
       bytesAllowedPerBatch: Long,
       useCompression: Boolean): List[ParquetCachedBatch] = {
+    if (oldGpuCB.numRows() == 0) {
+      // return empty List of ParquetCachedBatch
+      return List.empty[ParquetCachedBatch]
+    }
     val estimatedRowSize = scala.Range(0, oldGpuCB.numCols()).map { idx =>
       oldGpuCB.column(idx).asInstanceOf[GpuColumnVector]
-          .getBase.getDeviceMemorySize / oldGpuCB.numRows()
+        .getBase.getDeviceMemorySize / oldGpuCB.numRows()
     }.sum
 
     val columns = for (i <- 0 until oldGpuCB.numCols()) yield {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -320,6 +320,9 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
       input.flatMap(batch => {
         if (batch.numCols() == 0 || batch.numRows() == 0) {
+          if (batch.numCols() > 0 && batch.column(0).isInstanceOf[GpuColumnVector]) {
+            batch.close();
+          }
           List(ParquetCachedBatch(batch.numRows(), new Array[Byte](0)))
         } else {
           withResource(putOnGpuIfNeeded(batch)) { gpuCB =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
@@ -51,19 +51,17 @@ class CachedBatchWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("convert columnar batch to cached batch on single col table with 0 rows in a batch") {
-    if (!withCpuSparkSession(s => s.version < "3.1.0")) {
-      withResource(new TestResources()) { resources =>
-        val (_, spyGpuCol0) = getCudfAndGpuVectors(resources)
-        val cb = new ColumnarBatch(Array(spyGpuCol0), 0)
-        val ser = new ParquetCachedBatchSerializer
-        val dummySchema = new StructType(
-          Array(StructField("empty", ByteType, false),
-            StructField("empty", ByteType, false),
-            StructField("empty", ByteType, false)))
-        val listOfPCB = ser.compressColumnarBatchWithParquet(cb, dummySchema, dummySchema,
-          BYTES_ALLOWED_PER_BATCH, false)
-        assert(listOfPCB.isEmpty)
-      }
+    withResource(new TestResources()) { resources =>
+      val (_, spyGpuCol0) = getCudfAndGpuVectors(resources)
+      val cb = new ColumnarBatch(Array(spyGpuCol0), 0)
+      val ser = new ParquetCachedBatchSerializer
+      val dummySchema = new StructType(
+        Array(StructField("empty", ByteType, false),
+          StructField("empty", ByteType, false),
+          StructField("empty", ByteType, false)))
+      val listOfPCB = ser.compressColumnarBatchWithParquet(cb, dummySchema, dummySchema,
+        BYTES_ALLOWED_PER_BATCH, false)
+      assert(listOfPCB.isEmpty)
     }
   }
 


### PR DESCRIPTION
This PR returns an empty ParquetCachedBatch if the incoming batch is empty.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
