### PR TITLE
Avoid a possible race in test_empty_filter

### DIFF
--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -281,11 +281,11 @@ def test_empty_filter(op, spark_tmp_path):
 
     def do_it(spark):
         df = spark.createDataFrame([(14, "Tom"), (23, "Alice"), (16, "Bob")], ["age", "name"])
-        # we repartition the data to 3 because for some reason spark writes 4 files for 3 rows.
+        # we repartition the data to 1 because for some reason Spark can write 4 files for 3 rows.
         # In this case that causes a race condition with the last aggregation which can result
         # in a null being returned. For some reason this happens a lot on the GPU in local mode
         # and not on the CPU in local mode.
-        df.repartition(3).write.mode("overwrite").parquet(spark_tmp_path)
+        df.repartition(1).write.mode("overwrite").parquet(spark_tmp_path)
         df = spark.read.parquet(spark_tmp_path)
         curDate = df.withColumn("current_date", f.current_date())
         curDate.createOrReplaceTempView("empty_filter_test_curDate")


### PR DESCRIPTION
We had a nightly test fail on this new test. I have not been able to reproduce the failure myself, but it looks like a failure I was seeing before.  For some reason there is a race where Spark can end up writing an empty file. I thought it was if the number of tasks is larger than the number of rows that this could happen, but it looks like it can also happen if there is a very small number of rows. I guess that the python splits are not 100% deterministic somehow.  When that happens we end up with an extra non-empty task doing the aggregation. If there is a file, but not data in the file the first stage of a `last` aggregation will insert in a null row.  If we get unlucky and that null row is the last one in the final aggregation, then the result of `last` is null which is the same a false when doing a filter and all of the data is filtered out.

Either way this avoids all of those oddities and just creates a single file with the data in it so that we don't have to worry about it any more.  I hope.