### PR TITLE
Fix check to do positional indexing in ORC

### DIFF
--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -431,6 +431,37 @@ def test_missing_column_names_count(spark_tmp_table_factory, reader_confs):
         lambda spark : spark.sql("SELECT * FROM {}".format(table_name)),
         reader_confs)
 
+# ORC checks if there are no column names by looking at the column names
+# so it is possible to have some of the names match the pattern and other not
+def setup_orc_file_partial_no_column_names(spark, table_name, location=None):
+    drop_query = "DROP TABLE IF EXISTS {}".format(table_name)
+    create_query = "CREATE TABLE `{}` (`_col1` INT, `arr` ARRAY<STRING>, `str` STRUCT<a: INT>) USING orc".format(table_name)
+    if location:
+        create_query += f" LOCATION '{location}'"
+    insert_query = "INSERT INTO {} VALUES(13, array('155'), named_struct('a', 2020))".format(table_name)
+    spark.sql(drop_query).collect
+    spark.sql(create_query).collect
+    spark.sql(insert_query).collect
+
+
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+def test_partial_missing_column_names(spark_tmp_table_factory, reader_confs):
+    table_name = spark_tmp_table_factory.get()
+    with_cpu_session(lambda spark : setup_orc_file_partial_no_column_names(spark, table_name))
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : spark.sql("SELECT str,arr FROM {}".format(table_name)),
+        reader_confs)
+
+@pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
+def test_partial_missing_column_names_count(spark_tmp_table_factory, reader_confs):
+    table_name = spark_tmp_table_factory.get()
+    with_cpu_session(lambda spark : setup_orc_file_partial_no_column_names(spark, table_name))
+    assert_gpu_and_cpu_row_counts_equal(
+        lambda spark : spark.sql("SELECT * FROM {}".format(table_name)),
+        reader_confs)
+
+
+
 @pytest.mark.parametrize('reader_confs', reader_opt_confs, ids=idfn)
 def test_missing_column_names_with_schema(spark_tmp_table_factory, spark_tmp_path, reader_confs):
     table_name = spark_tmp_table_factory.get()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -1588,7 +1588,7 @@ private case class GpuOrcFileFilterHandler(
     private val missingColumnNamePattern = Pattern.compile("_col\\d+")
 
     private def isMissingColumnNames(t: TypeDescription): Boolean = {
-      t.getFieldNames.asScala.exists(f => missingColumnNamePattern.matcher(f).matches())
+      t.getFieldNames.asScala.forall(f => missingColumnNamePattern.matcher(f).matches())
     }
   }
 }


### PR DESCRIPTION
 https://github.com/NVIDIA/spark-rapids/pull/8098 added in a check to fall back to position schema matching if we see all of the column names match `_col\\d+` except the logic was wrong and it was any of the columns in the file match this, instead of all of the columns.

This fixes that and adds in a few tests to verify the fix.


Thanks to @jlowe for helping me to debug it.