### PR TITLE
Change TimeAdd/Sub subquery tests to use min/max

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -57,7 +57,7 @@ def test_timeadd_from_subquery(data_gen):
     def fun(spark):
         df = unary_op_df(spark, TimestampGen(start=datetime(5, 1, 1, tzinfo=timezone.utc), end=datetime(15, 1, 1, tzinfo=timezone.utc)), seed=1)
         df.createOrReplaceTempView("testTime")
-        spark.sql("select a, ((select last(a) from testTime) + interval 1 day) as datePlus from testTime").createOrReplaceTempView("testTime2")
+        spark.sql("select a, ((select max(a) from testTime) + interval 1 day) as datePlus from testTime").createOrReplaceTempView("testTime2")
         return spark.sql("select * from testTime2 where datePlus > current_timestamp")
 
     assert_gpu_and_cpu_are_equal_collect(fun)
@@ -68,7 +68,7 @@ def test_timesub_from_subquery(data_gen):
     def fun(spark):
         df = unary_op_df(spark, TimestampGen(start=datetime(5, 1, 1, tzinfo=timezone.utc), end=datetime(15, 1, 1, tzinfo=timezone.utc)), seed=1)
         df.createOrReplaceTempView("testTime")
-        spark.sql("select a, ((select last(a) from testTime) - interval 1 day) as dateMinus from testTime").createOrReplaceTempView("testTime2")
+        spark.sql("select a, ((select min(a) from testTime) - interval 1 day) as dateMinus from testTime").createOrReplaceTempView("testTime2")
         return spark.sql("select * from testTime2 where dateMinus < current_timestamp")
 
     assert_gpu_and_cpu_are_equal_collect(fun)


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/8400

There is an issue with last() where sometimes it can get a task with no data and thus the results come out different depending on the partitioning and what data goes to what tasks.  Replace last with min/max to make it more reliable.

I tested on cloudera and was able to reproduce the issue and then see it fixed with this change.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
