### PR TITLE
Fix reads for GZIP compressed Hive Text.

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_fallback_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql, assert_gpu_and_cpu_sql_writes_are_equal_collect, assert_gpu_fallback_collect
 from conftest import get_non_gpu_allowed
 from data_gen import *
 from enum import Enum
@@ -420,6 +420,31 @@ def test_custom_timestamp_formats_disabled(spark_tmp_path, data_gen, spark_tmp_t
         lambda spark: read_hive_text_table(spark, table_name),
         cpu_fallback_class_name=get_non_gpu_allowed()[0],
         conf=hive_text_enabled_conf)
+
+
+def test_read_compressed_hive_text(spark_tmp_table_factory):
+    """
+    This tests whether compressed Hive Text tables are readable from spark-rapids.
+    For GZIP compressed tables, spark-rapids should not attempt to split the input files.
+    """
+
+    table_name = spark_tmp_table_factory.get()
+
+    def create_table_with_compressed_files(spark):
+        spark.range(100000)\
+            .selectExpr("id",
+                        "cast(id as string) id_string")\
+            .repartition(1).write.format("hive").saveAsTable(table_name)
+
+    # Create Hive Text table with compression enabled.
+    with_cpu_session(create_table_with_compressed_files,
+                     {"hive.exec.compress.output": "true"})
+
+    # Attempt to read from table with very small (2KB) splits.
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: spark.sql("SELECT COUNT(1) FROM {}".format(table_name)),
+        conf={"spark.sql.files.maxPartitionBytes": "2048b"}
+    )
 
 
 # Hive Delimited Text writer tests follow.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -260,6 +260,8 @@ case class GpuHiveTableScanExec(requestedAttributes: Seq[Attribute],
     val maxSplitBytes      = FilePartition.maxSplitBytes(sparkSession, selectedPartitions)
 
     def canBeSplit(file: FileStatus, hadoopConf: Configuration): Boolean = {
+      // Checks if `file` can be split.
+      // Uncompressed Hive Text files may be split. GZIP compressed files are not.
       val codec = new CompressionCodecFactory(hadoopConf).getCodec(file.getPath)
       codec == null || codec.isInstanceOf[SplittableCompressionCodec]
     }


### PR DESCRIPTION
Fixes #8419.

This commit fixes how the GPU Hive Text reader determines whether the input file can be split, for reads.
Before this change, the input was deemed splittable by default. This leads to GZIP compressed Hive Text input to be split between tasks, causing read failures like the following:
```
Caused by: java.io.IOException: Cannot seek in DeflateCodec compressed stream
        at org.apache.hadoop.mapreduce.lib.input.LineRecordReader.initialize(LineRecordReader.java:113)
        at org.apache.spark.sql.execution.datasources.HadoopFileLinesReader.<init>(HadoopFileLinesReader.scala:65)
        at com.nvidia.spark.rapids.GpuTextBasedPartitionReader.<init>(GpuTextBasedPartitionReader.scala:218)
        at com.nvidia.spark.rapids.CSVPartitionReaderBase.<init>(GpuCSVScan.scala:302)
        at org.apache.spark.sql.hive.rapids.GpuHiveDelimitedTextPartitionReader.<init>(GpuHiveTableScanExec.scala:496)
```
This commit adds logic to examine the compression codec of each input file, and determine whether it is splittable.
