### PR TITLE
skip test_array_repeat_with_count_scalar to wait for fix #8409

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -368,6 +368,8 @@ def test_array_repeat_with_count_column(data_gen):
             'array_repeat("abc", cnt)'))
 
 
+# TODO: revert skip after https://github.com/NVIDIA/spark-rapids/issues/8409 is resolved
+@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/8409')
 @pytest.mark.parametrize('data_gen', orderable_gens + nested_gens_sample, ids=idfn)
 def test_array_repeat_with_count_scalar(data_gen):
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
related to #8409 

skip case `test_array_repeat_with_count_scalar` to unblock other CIs.
We do not xfail here is due to this case may crash java agent which would fail all following cases