### PR TITLE
Add regression test for regexp_replace hanging with some inputs

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -447,7 +447,6 @@ The following regular expression patterns are not yet supported on the GPU and w
 - Character classes that use union, intersection, or subtraction semantics, such as `[a-d[m-p]]`, `[a-z&&[def]]`, 
   or `[a-z&&[^bc]]`
 - Empty groups: `()`
-- `regexp_replace` does not support back-references
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.
 

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -368,6 +368,8 @@ def test_array_repeat_with_count_column(data_gen):
             'array_repeat("abc", cnt)'))
 
 
+# TODO: revert skip after https://github.com/NVIDIA/spark-rapids/issues/8409 is resolved
+@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/8409')
 @pytest.mark.parametrize('data_gen', orderable_gens + nested_gens_sample, ids=idfn)
 def test_array_repeat_with_count_scalar(data_gen):
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -956,3 +956,11 @@ def test_regexp_memory_ok():
             'spark.rapids.sql.batchSizeBytes': '20' # 1 row in the batch
         }
     )
+
+def test_re_replace_all():
+    # regression test for https://github.com/NVIDIA/spark-rapids/issues/8323
+    gen = mk_str_gen('[a-z]{0,2}\n{0,2}[a-z]{0,2}\n{0,2}')
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, gen).selectExpr(
+            'REGEXP_REPLACE(a, ".*$", "PROD", 1)'),
+        conf=_regexp_conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -102,7 +102,8 @@ class GpuRegExpReplaceMeta(
         (javaPattern, cudfPattern, replacement) match {
           case (Some(javaPattern), Some(cudfPattern), Some(cudfReplacement)) =>
             if (containsBackref) {
-              GpuRegExpReplaceWithBackref(lhs, regexp, rep)(javaPattern, cudfPattern, cudfReplacement)
+              GpuRegExpReplaceWithBackref(lhs, regexp, rep)(javaPattern,
+                cudfPattern, cudfReplacement)
             } else {
               GpuRegExpReplace(lhs, regexp, rep)(javaPattern, cudfPattern, cudfReplacement,
                   None, None)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRegExpReplaceMeta.scala
@@ -102,7 +102,7 @@ class GpuRegExpReplaceMeta(
         (javaPattern, cudfPattern, replacement) match {
           case (Some(javaPattern), Some(cudfPattern), Some(cudfReplacement)) =>
             if (containsBackref) {
-              GpuRegExpReplaceWithBackref(lhs, regexp, rep)(cudfPattern, cudfReplacement)
+              GpuRegExpReplaceWithBackref(lhs, regexp, rep)(javaPattern, cudfPattern, cudfReplacement)
             } else {
               GpuRegExpReplace(lhs, regexp, rep)(javaPattern, cudfPattern, cudfReplacement,
                   None, None)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1105,6 +1105,7 @@ object GpuRegExpUtils {
     }
     parseAST(pattern) match {
       case RegexSequence(parts) if parts.lastOption.contains(RegexChar('$')) =>
+        // handle pattern ".*$"
         isASTEmptyRepetition(RegexSequence(parts.dropRight(1)))
       case other => isASTEmptyRepetition(other)
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1369,7 +1369,8 @@ case class GpuRegExpReplaceWithBackref(
       }
       withResource(isEmpty) { _ =>
         withResource(GpuScalar.from("", DataTypes.StringType)) { emptyString =>
-          withResource(input.getBase.stringReplaceWithBackrefs(prog, cudfReplacementString)) { replacement =>
+          withResource(input.getBase.stringReplaceWithBackrefs(prog,
+              cudfReplacementString)) { replacement =>
             isEmpty.ifElse(emptyString, replacement)
           }
         }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8323 and https://github.com/NVIDIA/spark-rapids/issues/8448

This PR adds a regression test for an issue that was [recently fixed](https://github.com/rapidsai/cudf/issues/13404) in cuDF. This test uncovered another bug (https://github.com/NVIDIA/spark-rapids/issues/8448), which is now also fixed in this PR.