### PR TITLE
Implement the bug fix for SPARK-41448 and shim it for Spark 3.2.4 and Spark 3.3.{2,3} [databricks]

### DIFF
--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -57,6 +57,7 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{WriteTaskResult, WriteTaskStats}
 import org.apache.spark.sql.execution.datasources.FileFormatWriter.OutputSpec
+import org.apache.spark.sql.rapids.shims.RapidsHadoopWriterUtils
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -248,14 +249,15 @@ object GpuFileFormatWriter extends Logging {
         rdd
       }
 
-      val jobIdInstant = new Date().getTime
+      // SPARK-41448 map reduce job IDs need to consistent across attempts for correctness
+      val jobTrackerId = SparkHadoopWriterUtils.createJobTrackerID(new Date)
       val ret = new Array[WriteTaskResult](rddWithNonEmptyPartitions.partitions.length)
       sparkSession.sparkContext.runJob(
         rddWithNonEmptyPartitions,
         (taskContext: TaskContext, iter: Iterator[ColumnarBatch]) => {
           executeTask(
             description = description,
-            jobIdInstant = jobIdInstant,
+            jobTrackerId = jobTrackerId,
             sparkStageId = taskContext.stageId(),
             sparkPartitionId = taskContext.partitionId(),
             sparkAttemptNumber = taskContext.taskAttemptId().toInt & Integer.MAX_VALUE,
@@ -289,7 +291,7 @@ object GpuFileFormatWriter extends Logging {
   /** Writes data out in a single Spark task. */
   private def executeTask(
       description: GpuWriteJobDescription,
-      jobIdInstant: Long,
+      jobTrackerId: String,
       sparkStageId: Int,
       sparkPartitionId: Int,
       sparkAttemptNumber: Int,
@@ -297,7 +299,7 @@ object GpuFileFormatWriter extends Logging {
       iterator: Iterator[ColumnarBatch],
       concurrentOutputWriterSpec: Option[GpuConcurrentOutputWriterSpec]): WriteTaskResult = {
 
-    val jobId = SparkHadoopWriterUtils.createJobID(new Date(jobIdInstant), sparkStageId)
+    val jobId = RapidsHadoopWriterUtils.createJobID(jobTrackerId, sparkStageId)
     val taskId = new TaskID(jobId, TaskType.MAP, sparkPartitionId)
     val taskAttemptId = new TaskAttemptID(taskId, sparkAttemptNumber)
 

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "321db"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.hadoop.mapred.JobID
+
+object RapidsHadoopWriterUtils {
+  // SPARK-41448 create a jobID directly from the jobTrackerID
+  def createJobID(jobTrackerID: String, id: Int): JobID = {
+    new JobID(jobTrackerID, id)
+  }
+}

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -28,7 +28,6 @@
 {"spark": "330cdh"}
 {"spark": "330db"}
 {"spark": "331"}
-{"spark": "332"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 

--- a/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "324"}
+{"spark": "333"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.hadoop.mapred.JobID
+
+import org.apache.spark.internal.io.SparkHadoopWriterUtils
+
+/* This shim object uses the underlying fix from SparkHadoopWriterUtils in case this
+   logic is updated in the future for other versions of Spark 3.3 */
+object RapidsHadoopWriterUtils {
+  // SPARK-41448 create a jobID directly from the jobTrackerID
+  def createJobID(jobTrackerID: String, id: Int): JobID = {
+    SparkHadoopWriterUtils.createJobID(jobTrackerID, id)
+  }
+}
+

--- a/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "324"}
+{"spark": "332"}
 {"spark": "333"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
+++ b/sql-plugin/src/main/spark324/scala/org/apache/spark/sql/rapids/shims/RapidsHadoopWriterUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ import org.apache.hadoop.mapred.JobID
 
 import org.apache.spark.internal.io.SparkHadoopWriterUtils
 
-/* This shim object uses the underlying fix from SparkHadoopWriterUtils in case this
-   logic is updated in the future for other versions of Spark 3.3 */
+/**
+ * This shim object uses the underlying fix from SparkHadoopWriterUtils in case this
+ *  logic is updated in the future for other versions of Spark 3.3
+ */
 object RapidsHadoopWriterUtils {
   // SPARK-41448 create a jobID directly from the jobTrackerID
   def createJobID(jobTrackerID: String, id: Int): JobID = {

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -259,6 +259,7 @@ object GpuFileFormatWriter extends Logging {
         rdd
       }
 
+      // SPARK-41448 map reduce job IDs need to consistent across attempts for correctness
       val jobTrackerID = SparkHadoopWriterUtils.createJobTrackerID(new Date())
       val ret = new Array[WriteTaskResult](rddWithNonEmptyPartitions.partitions.length)
       sparkSession.sparkContext.runJob(


### PR DESCRIPTION
Fixes #8114.

This makes the map reduce job ID consistent across attempts in GpuFileFormatWriter. This fix was already fully incorporated into the Spark 3.4.0 shim code (and that shim has several other fixes), so this addresses all other Spark versions. It shims the 3.2.4/3.3.2/3.3.3 fix out so if there are further upstream fixes, the shim should accommodate those automatically.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
