### PR TITLE
Revert "skip test_array_repeat_with_count_scalar for now (#8424)" [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -368,8 +368,6 @@ def test_array_repeat_with_count_column(data_gen):
             'array_repeat("abc", cnt)'))
 
 
-# TODO: revert skip after https://github.com/NVIDIA/spark-rapids/issues/8409 is resolved
-@pytest.mark.skip(reason='https://github.com/NVIDIA/spark-rapids/issues/8409')
 @pytest.mark.parametrize('data_gen', orderable_gens + nested_gens_sample, ids=idfn)
 def test_array_repeat_with_count_scalar(data_gen):
     assert_gpu_and_cpu_are_equal_collect(


### PR DESCRIPTION
close #8409 
the fix was merged in https://github.com/rapidsai/cudf/pull/13459 and is now in latest JNI snapshot

This reverts commit 4ea8a10fe8753bd5de218e91ce824401d1958720 to enable test_array_repeat_with_count_scalar case.

