### PR TITLE
Remove NOP Maven javadoc plugin definition

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -28,7 +28,6 @@ env:
     -Ddist.jar.compress=false
     -DskipTests
     -Dskip
-    -Dmaven.javadoc.skip
 
 jobs:
   get-shim-versions-from-dist:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ Before proceeding with importing spark-rapids into IDEA or switching to a differ
 profile, execute the install phase with the corresponding `buildver`, e.g. for Spark 3.4.0:
 
 ```bash
- mvn clean install -Dbuildver=340 -Dskip -Dmaven.javadoc.skip -DskipTests
+ mvn clean install -Dbuildver=340 -Dskip -DskipTests
 ```
 
 ##### Importing the project
@@ -326,7 +326,6 @@ mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall -pl aggregator -am \
   -Dbuildver=320 \
   -DskipTests \
   -Dskip \
-  -Dmaven.javadoc.skip \
   -Dmaven.scalastyle.skip=true \
   -Dmaven.updateconfig.skip=true
 ```
@@ -410,7 +409,7 @@ it by making sure Metals Server (Bloop client) and Bloop Server are both running
       mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall \
       -DdownloadSources=true \
       -Dbuildver=331 \
-      -Dskip -DskipTests -Dmaven.javadoc.skip
+      -Dskip -DskipTests
     ```
 
 1. Add [`metals.javaHome`][2] to VSCode preferences to point to Java 11+.

--- a/build/buildall
+++ b/build/buildall
@@ -71,7 +71,6 @@ function bloopInstall() {
         -Dbuildver="$bv" \
         -DskipTests \
         -Dskip \
-        -Dmaven.javadoc.skip \
         -Dmaven.scalastyle.skip=true \
         -Dmaven.updateconfig.skip=true
 
@@ -240,7 +239,6 @@ function build_single_shim() {
       -DskipTests \
       -Dbuildver="$BUILD_VER" \
       -Drat.skip="$SKIP_CHECKS" \
-      -Dmaven.javadoc.skip="$SKIP_CHECKS" \
       -Dskip \
       -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
       -pl aggregator -am > "$LOG_FILE" 2>&1 || {
@@ -254,7 +252,7 @@ export -f build_single_shim
 
 # First build the aggregator module for all SPARK_SHIM_VERSIONS in parallel skipping expensive plugins that
 # - either deferred to 311 because the check is identical in all shim profiles such as scalastyle
-# - or deferred to 311 because we currently don't require it per shim such as javadoc generation
+# - or deferred to 311 because we currently don't require it per shim such as scaladoc generation
 # - or there is a dedicated step to run against a particular shim jar such as unit tests, in
 #   the near future we will run unit tests against a combined multi-shim jar to catch classloading
 #   regressions even before pytest-based integration_tests
@@ -282,5 +280,5 @@ time (
   echo "Resuming from $joinShimBuildFrom build only using $BASE_VER"
   $MVN $FINAL_OP -rf $joinShimBuildFrom $MODULE_OPT $MVN_PROFILE_OPT $INCLUDED_BUILDVERS_OPT \
     -Dbuildver="$BASE_VER" \
-    -DskipTests -Dskip -Dmaven.javadoc.skip
+    -DskipTests -Dskip
 )

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -414,13 +414,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <detectOfflineLinks>false</detectOfflineLinks>
-                </configuration>
-            </plugin>
         </plugins>
 
         <resources>

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -28,7 +28,7 @@ elif [[ $# -gt 1 ]]; then
 fi
 
 MVN_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3"
-MVN_BUILD_ARGS="-Drat.skip=true -Dmaven.javadoc.skip=true -Dskip -Dmaven.scalastyle.skip=true -Dcuda.version=$CUDA_CLASSIFIER"
+MVN_BUILD_ARGS="-Drat.skip=true -Dskip -Dmaven.scalastyle.skip=true -Dcuda.version=$CUDA_CLASSIFIER"
 
 mvn_verify() {
     echo "Run mvn verify..."

--- a/pom.xml
+++ b/pom.xml
@@ -578,22 +578,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.2</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadoc</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <doclint>none</doclint>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2020, NVIDIA CORPORATION. All Rights Reserved.
+  Copyright (c) 2020-2023, NVIDIA CORPORATION. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -107,8 +107,6 @@ You can also disable only one rule, by specifying its rule id, as specified in:
     <!-- ================================================================================ -->
     <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
     <!-- ================================================================================ -->
-
-    <!-- This project uses Javadoc rather than Scaladoc so scaladoc checks are disabled -->
     <check enabled="false" class="org.scalastyle.scalariform.ScalaDocChecker" level="warning"/>
 
 </scalastyle>


### PR DESCRIPTION
Fixes #8440

Java classes are processed by doc-jar in scala-maven-plugin as we leave the default `sendJavaToScalac=true` unchanged

```bash
$ find sql-plugin/  -regex '.*/GpuPackedTableColumn.\(java\|html\|class\)'
sql-plugin/target/spark311/site/scaladocs/com/nvidia/spark/rapids/GpuPackedTableColumn.html
sql-plugin/target/spark311/classes/com/nvidia/spark/rapids/GpuPackedTableColumn.class
sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuPackedTableColumn.jav
```
     
Signed-off-by: Gera Shegalov <gera@apache.org> 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
