### PR TITLE
Ensure the MT shuffle reader enables/disables with spark.rapids.shuff…

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1316,7 +1316,7 @@ abstract class RapidsShuffleInternalManagerBase(conf: SparkConf, val isDriver: B
         //   would need to be made to deal with missing metrics, for example, for a regular
         //   Exchange node.
         baseHandle.dependency match {
-          case gpuDep: GpuShuffleDependency[K, C, C] =>
+          case gpuDep: GpuShuffleDependency[K, C, C] if gpuDep.useMultiThreadedShuffle =>
             // We want to use batch fetch in the non-push shuffle case. Spark
             // checks for a config to see if batch fetch is enabled (this check), and
             // it also checks when getting (potentially merged) map status from


### PR DESCRIPTION
…le.enabled

Closes https://github.com/NVIDIA/spark-rapids/issues/8469

This was a miss when the threaded reader went in. It was not looking at the `GpuShuffleDependency.useMultiThreadedShuffle`, which the MT writer is looking at.