### PR TITLE
Fix input binding of grouping expressions for complete aggregations [databricks]

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1863,3 +1863,12 @@ def test_min_max_for_single_level_struct(data_gen):
         "hash_agg_table",
         'select min(a) from hash_agg_table',
         _float_conf)
+
+# Some Spark implementations will optimize this aggregation as a
+# complete aggregation (i.e.: only one aggregation node in the plan)
+@ignore_order(local=True)
+def test_hash_aggregate_complete_with_grouping_expressions():
+    assert_gpu_and_cpu_are_equal_sql(
+        lambda spark : spark.range(10).withColumn("id2", f.col("id")),
+        "hash_agg_complete_table",
+        "select id, avg(id) from hash_agg_complete_table group by id, id2 + 1")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -849,7 +849,7 @@ class GpuHashAggregateIterator(
         aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
 
     val boundFinalProjections = if (modeInfo.hasFinalMode || modeInfo.hasCompleteMode) {
-      val finalProjections = groupingExpressions ++
+      val finalProjections = groupingAttributes ++
           aggregateExpressions.map(_.aggregateFunction.evaluateExpression)
       Some(GpuBindReferences.bindGpuReferences(finalProjections, aggBufferAttributes))
     } else {


### PR DESCRIPTION
Fixes #8473.  For a complete aggregation we should be binding against the grouping attributes rather than the grouping expressions, as any non-trivial expressions should have been pre-projected before entering the complete aggregation.