### PR TITLE
Disable `test_read_compressed_hive_text` on CDH.

### DIFF
--- a/integration_tests/src/main/python/hive_delimited_text_test.py
+++ b/integration_tests/src/main/python/hive_delimited_text_test.py
@@ -422,6 +422,9 @@ def test_custom_timestamp_formats_disabled(spark_tmp_path, data_gen, spark_tmp_t
         conf=hive_text_enabled_conf)
 
 
+@pytest.mark.skipif(is_spark_cdh(),
+                    reason="Hive text reads are disabled on CDH, as per "
+                           "https://github.com/NVIDIA/spark-rapids/pull/7628")
 @pytest.mark.parametrize('codec', ['BZip2Codec',    # BZ2 compression, i.e. Splittable.
                                    'DefaultCodec',  # DEFLATE, i.e. Gzip, without headers. Unsplittable.
                                    'GzipCodec'])    # Gzip proper. Unsplittable.


### PR DESCRIPTION
Fixes #8483.

`test_read_compressed_hive_text()` tests reads of compressed Hive Text tables. This test must be skipped on CDH, because Hive Text reads are disabled on CDH. (See #7424, #7423.)

