### PR TITLE
Remove legacy spark version check

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
@@ -66,25 +66,21 @@ class CachedBatchWriterSuite extends SparkQueryCompareTestSuite {
   }
 
   test("convert large columnar batch to cached batch on single col table") {
-    if (!withCpuSparkSession(s => s.version < "3.1.0")) {
-      withResource(new TestResources()) { resources =>
-        val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors(resources)
-        val splitAt = 2086912
-        testCompressColBatch(resources, Array(spyCol0), Array(spyGpuCol0), splitAt)
-        verify(spyCol0).split(splitAt)
-      }
+    withResource(new TestResources()) { resources =>
+      val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors(resources)
+      val splitAt = 2086912
+      testCompressColBatch(resources, Array(spyCol0), Array(spyGpuCol0), splitAt)
+      verify(spyCol0).split(splitAt)
     }
   }
 
   test("convert large columnar batch to cached batch on multi-col table") {
-    if (!withCpuSparkSession(s => s.version < "3.1.0")) {
-      withResource(new TestResources()) { resources =>
-        val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors(resources)
-        val splitAt = Seq(695637, 1391274, 2086911, 2782548)
-        testCompressColBatch(resources, Array(spyCol0, spyCol0, spyCol0),
+    withResource(new TestResources()) { resources =>
+      val (spyCol0, spyGpuCol0) = getCudfAndGpuVectors(resources)
+      val splitAt = Seq(695637, 1391274, 2086911, 2782548)
+      testCompressColBatch(resources, Array(spyCol0, spyCol0, spyCol0),
         Array(spyGpuCol0, spyGpuCol0, spyGpuCol0), splitAt: _*)
-        verify(spyCol0, times(3)).split(splitAt: _*)
-      }
+      verify(spyCol0, times(3)).split(splitAt: _*)
     }
   }
 


### PR DESCRIPTION
This PR removes the check for Spark versions before 3.1.0

fixes #8380 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
