### PR TITLE
Fix warning about deprecated parquet config

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1123,11 +1123,11 @@ case class GpuParquetMultiFilePartitionReaderFactory(
       }.getOrElse(rapidsConf.getMultithreadedCombineThreshold)
   private val combineWaitTime =
     RapidsConf.PARQUET_MULTITHREADED_COMBINE_WAIT_TIME.get(sqlConf)
-      .map {
+      .map { f =>
         logWarning(s"${RapidsConf.PARQUET_MULTITHREADED_COMBINE_WAIT_TIME} is deprecated, " +
           s"use ${RapidsConf.READER_MULTITHREADED_COMBINE_WAIT_TIME} instead. But for now " +
           "the deprecated one will be honored if both are set.")
-        _.intValue()
+        f.intValue()
       }.getOrElse(rapidsConf.getMultithreadedCombineWaitTime)
   private val keepReadsInOrderFromConf =
     RapidsConf.PARQUET_MULTITHREADED_READ_KEEP_ORDER.get(sqlConf)


### PR DESCRIPTION
When a config was deprecated the code added to warn about the deprecation did the wrong thing.

In scala a map on an `Option` takes a function as an input parameter and will only run the function if a value is set. But in this case the block of code passed in was not interpreted as a function. It was interpreted as a block of code that returned a function, so the warning was run every time and then returned a function that would translate the value to an integer.

This fixes it. 