### PR TITLE
Avoid calling Table.merge with BinaryType columns

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -264,28 +264,22 @@ class LongGen(DataGen):
     def start(self, rand):
         self._start(rand, lambda : rand.randint(self._min_val, self._max_val))
 
-class LongRangeGen(DataGen):
-    """Generate Longs in incrementing order."""
-    def __init__(self, nullable=False, start_val=0, direction="inc"):
+class UniqueLongGen(DataGen):
+    """Generates a sequence of longs with no repeating values except nulls."""
+    def __init__(self, nullable=False):
         super().__init__(LongType(), nullable=nullable)
-        self._start_val = start_val
-        self._current_val = start_val
-        if (direction == "dec"):
-            def dec_it():
-                tmp = self._current_val
-                self._current_val -= 1
-                return tmp
-            self._do_it = dec_it
+        self._current_val = 0
+
+    def next_val(self):
+        if self._current_val < 0:
+            self._current_val = -self._current_val + 1
         else:
-            def inc_it():
-                tmp = self._current_val
-                self._current_val += 1
-                return tmp
-            self._do_it = inc_it
+            self._current_val = -self._current_val - 1
+        return self._current_val
 
     def start(self, rand):
-        self._current_val = self._start_val
-        self._start(rand, self._do_it)
+        self._current_val = 0
+        self._start(rand, lambda: self.next_val())
 
 class RepeatSeqGen(DataGen):
     """Generate Repeated seq of `length` random items"""

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -552,12 +552,12 @@ _full_repeat_agg_column_for_collect_op = [
 _gen_data_for_collect_op = [[
     ('a', RepeatSeqGen(LongGen(), length=20)),
     ('b', value_gen),
-    ('c', LongRangeGen())] for value_gen in _repeat_agg_column_for_collect_op]
+    ('c', UniqueLongGen())] for value_gen in _repeat_agg_column_for_collect_op]
 
 _full_gen_data_for_collect_op = _gen_data_for_collect_op + [[
     ('a', RepeatSeqGen(LongGen(), length=20)),
     ('b', value_gen),
-    ('c', LongRangeGen())] for value_gen in _full_repeat_agg_column_for_collect_op]
+    ('c', UniqueLongGen())] for value_gen in _full_repeat_agg_column_for_collect_op]
 
 _repeat_agg_column_for_collect_list_op = [
         RepeatSeqGen(ArrayGen(int_gen), length=15),
@@ -875,7 +875,7 @@ def test_hash_groupby_collect_partial_replace_with_distinct_fallback(data_gen,
 def test_hash_groupby_typed_imperative_agg_without_gpu_implementation_fallback():
     assert_cpu_and_gpu_are_equal_sql_with_capture(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(LongGen(), length=20)),
-                                     ('v', LongRangeGen())], length=100),
+                                     ('v', UniqueLongGen())], length=100),
         exist_classes='ApproximatePercentile,ObjectHashAggregateExec',
         non_exist_classes='GpuApproximatePercentile,GpuObjectHashAggregateExec',
         table_name='table',
@@ -1411,7 +1411,7 @@ def test_hash_groupby_approx_percentile_long_repeated_keys(aqe_enabled):
     conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', RepeatSeqGen(LongGen(), length=20)),
-                                     ('v', LongRangeGen())], length=100),
+                                     ('v', UniqueLongGen())], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat
@@ -1420,7 +1420,7 @@ def test_hash_groupby_approx_percentile_long(aqe_enabled):
     conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
-                                     ('v', LongRangeGen())], length=100),
+                                     ('v', UniqueLongGen())], length=100),
         [0.05, 0.25, 0.5, 0.75, 0.95], conf)
 
 @incompat
@@ -1429,7 +1429,7 @@ def test_hash_groupby_approx_percentile_long_single(aqe_enabled):
     conf = {'spark.sql.adaptive.enabled': aqe_enabled}
     compare_percentile_approx(
         lambda spark: gen_df(spark, [('k', StringGen(nullable=False)),
-                                     ('v', LongRangeGen())], length=100),
+                                     ('v', UniqueLongGen())], length=100),
         0.5, conf)
 
 @incompat

--- a/integration_tests/src/main/python/sort_test.py
+++ b/integration_tests/src/main/python/sort_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -264,7 +264,9 @@ def test_large_orderby(data_gen, stable_sort):
 
 # This is similar to test_large_orderby, but here we want to test some types
 # that are not being sorted on, but are going along with it
-@pytest.mark.parametrize('data_gen', [byte_gen,
+@pytest.mark.parametrize('data_gen', [
+    binary_gen,
+    byte_gen,
     string_gen,
     float_gen,
     date_gen,
@@ -276,10 +278,10 @@ def test_large_orderby(data_gen, stable_sort):
     ArrayGen(byte_gen, max_length=5)], ids=idfn)
 @pytest.mark.order(2)
 def test_large_orderby_nested_ridealong(data_gen):
-    # We use a LongRangeGen to avoid duplicate keys that can cause ambiguity in the sort
-    #  results, especially on distributed clusters.
+    # We use a UniqueLongGen to avoid duplicate keys that can cause ambiguity in the sort
+    # results, especially on distributed clusters.
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, LongRangeGen(), data_gen, length=1024*127)\
+            lambda spark : two_col_df(spark, UniqueLongGen(), data_gen, length=1024*127)\
                     .orderBy(f.col('a').desc()),
             conf = {'spark.rapids.sql.batchSizeBytes': '16384'})
 
@@ -296,8 +298,8 @@ def test_large_orderby_nested_ridealong(data_gen):
     ArrayGen(decimal_gen_128bit, max_length=5)], ids=idfn)
 @pytest.mark.order(2)
 def test_orderby_nested_ridealong_limit(data_gen):
-    # We use a LongRangeGen to avoid duplicate keys that can cause ambiguity in the sort
-    #  results, especially on distributed clusters.
+    # We use a UniqueLongGen to avoid duplicate keys that can cause ambiguity in the sort
+    # results, especially on distributed clusters.
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark : two_col_df(spark, LongRangeGen(), data_gen)\
+            lambda spark : two_col_df(spark, UniqueLongGen(), data_gen)\
                     .orderBy(f.col('a').desc()).limit(100))

--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -158,7 +158,7 @@ def test_float_window_min_max_all_nans(data_gen):
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
 def test_decimal128_count_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
+        lambda spark: three_col_df(spark, byte_gen, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' count(c) over '
@@ -170,7 +170,7 @@ def test_decimal128_count_window(data_gen):
 @pytest.mark.parametrize('data_gen', [decimal_gen_128bit], ids=idfn)
 def test_decimal128_count_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
+        lambda spark: two_col_df(spark, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' count(b) over '
@@ -182,7 +182,7 @@ def test_decimal128_count_window_no_part(data_gen):
 @pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_sum_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
+        lambda spark: three_col_df(spark, byte_gen, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' sum(c) over '
@@ -194,7 +194,7 @@ def test_decimal_sum_window(data_gen):
 @pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_sum_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
+        lambda spark: two_col_df(spark, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' sum(b) over '
@@ -207,7 +207,7 @@ def test_decimal_sum_window_no_part(data_gen):
 @pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_running_sum_window(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: three_col_df(spark, byte_gen, LongRangeGen(), data_gen),
+        lambda spark: three_col_df(spark, byte_gen, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' sum(c) over '
@@ -220,7 +220,7 @@ def test_decimal_running_sum_window(data_gen):
 @pytest.mark.parametrize('data_gen', decimal_gens, ids=idfn)
 def test_decimal_running_sum_window_no_part(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark: two_col_df(spark, LongRangeGen(), data_gen),
+        lambda spark: two_col_df(spark, UniqueLongGen(), data_gen),
         'window_agg_table',
         'select '
         ' sum(b) over '
@@ -387,7 +387,7 @@ def test_window_aggs_for_rows(data_gen, batch_size):
 @pytest.mark.parametrize('batch_size', ['1000', '1g'], ids=idfn)
 @pytest.mark.parametrize('data_gen', [
     [('grp', RepeatSeqGen(int_gen, length=20)),  # Grouping column.
-     ('ord', LongRangeGen(nullable=True)),       # Order-by column (after cast to STRING).
+     ('ord', UniqueLongGen(nullable=True)),       # Order-by column (after cast to STRING).
      ('agg', IntegerGen())]                      # Aggregation column.
 ], ids=idfn)
 def test_range_windows_with_string_order_by_column(data_gen, batch_size):
@@ -448,7 +448,7 @@ def test_window_running_no_part(b_gen, batch_size):
         query_parts.append('sum(b) over (order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_col')
 
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark : two_col_df(spark, LongRangeGen(), b_gen, length=1024 * 14),
+        lambda spark : two_col_df(spark, UniqueLongGen(), b_gen, length=1024 * 14),
         "window_agg_table",
         'select ' +
         ', '.join(query_parts) +
@@ -473,7 +473,7 @@ def test_running_float_sum_no_part(batch_size):
             'sum(cast(b as float)) over (order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as shrt_flt_sum',
             'sum(abs(flt)) over (order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as flt_sum']
 
-    gen = StructGen([('a', LongRangeGen()),('b', short_gen),('flt', float_gen),('dbl', double_gen)], nullable=False)
+    gen = StructGen([('a', UniqueLongGen()),('b', short_gen),('flt', float_gen),('dbl', double_gen)], nullable=False)
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, gen, length=1024 * 14),
         "window_agg_table",
@@ -560,7 +560,7 @@ def test_window_running(b_gen, c_gen, batch_size):
         query_parts.append('sum(c) over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as sum_col')
 
     assert_gpu_and_cpu_are_equal_sql(
-        lambda spark : three_col_df(spark, LongRangeGen(), RepeatSeqGen(b_gen, length=100), c_gen, length=1024 * 14),
+        lambda spark : three_col_df(spark, UniqueLongGen(), RepeatSeqGen(b_gen, length=100), c_gen, length=1024 * 14),
         "window_agg_table",
         'select ' +
         ', '.join(query_parts) +
@@ -588,7 +588,7 @@ def test_window_running_float_decimal_sum(batch_size):
             'sum(abs(flt)) over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as flt_sum',
             'sum(cast(c as Decimal(6,1))) over (partition by b order by a rows between UNBOUNDED PRECEDING AND CURRENT ROW) as dec_sum']
 
-    gen = StructGen([('a', LongRangeGen()),('b', RepeatSeqGen(int_gen, length=1000)),('c', short_gen),('flt', float_gen),('dbl', double_gen)], nullable=False)
+    gen = StructGen([('a', UniqueLongGen()),('b', RepeatSeqGen(int_gen, length=1000)),('c', short_gen),('flt', float_gen),('dbl', double_gen)], nullable=False)
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, gen, length=1024 * 14),
         "window_agg_table",
@@ -692,7 +692,7 @@ lead_lag_array_data_gens =\
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('d_gen', lead_lag_array_data_gens, ids=meta_idfn('agg:'))
-@pytest.mark.parametrize('c_gen', [LongRangeGen()], ids=meta_idfn('orderBy:'))
+@pytest.mark.parametrize('c_gen', [UniqueLongGen()], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('b_gen', [long_gen], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('a_gen', [long_gen], ids=meta_idfn('partBy:'))
 def test_window_aggs_for_rows_lead_lag_on_arrays(a_gen, b_gen, c_gen, d_gen):
@@ -778,7 +778,7 @@ def test_percent_rank_single_part_multiple_batches():
 @allow_non_gpu('WindowExec', 'Alias', 'WindowExpression', 'Lead', 'Literal', 'WindowSpecDefinition', 'SpecifiedWindowFrame')
 @ignore_order(local=True)
 @pytest.mark.parametrize('d_gen', all_basic_gens, ids=meta_idfn('agg:'))
-@pytest.mark.parametrize('c_gen', [LongRangeGen()], ids=meta_idfn('orderBy:'))
+@pytest.mark.parametrize('c_gen', [UniqueLongGen()], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('b_gen', [long_gen], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('a_gen', [long_gen], ids=meta_idfn('partBy:'))
 def test_window_aggs_lead_ignore_nulls_fallback(a_gen, b_gen, c_gen, d_gen):
@@ -802,7 +802,7 @@ def test_window_aggs_lead_ignore_nulls_fallback(a_gen, b_gen, c_gen, d_gen):
 @allow_non_gpu('WindowExec', 'Alias', 'WindowExpression', 'Lag', 'Literal', 'WindowSpecDefinition', 'SpecifiedWindowFrame')
 @ignore_order(local=True)
 @pytest.mark.parametrize('d_gen', all_basic_gens, ids=meta_idfn('agg:'))
-@pytest.mark.parametrize('c_gen', [LongRangeGen()], ids=meta_idfn('orderBy:'))
+@pytest.mark.parametrize('c_gen', [UniqueLongGen()], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('b_gen', [long_gen], ids=meta_idfn('orderBy:'))
 @pytest.mark.parametrize('a_gen', [long_gen], ids=meta_idfn('partBy:'))
 def test_window_aggs_lag_ignore_nulls_fallback(a_gen, b_gen, c_gen, d_gen):
@@ -947,7 +947,7 @@ def test_window_aggregations_for_big_decimal_ranges(data_gen):
 
 _gen_data_for_collect_list = [
     ('a', RepeatSeqGen(LongGen(), length=20)),
-    ('b', LongRangeGen()),
+    ('b', UniqueLongGen()),
     ('c_bool', BooleanGen()),
     ('c_short', ShortGen()),
     ('c_int', IntegerGen()),
@@ -1062,8 +1062,8 @@ def test_running_window_function_exec_for_all_aggs():
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
 def test_join_sum_window_of_window(data_gen):
     def do_it(spark):
-        agg_table = gen_df(spark, StructGen([('a_1', LongRangeGen()), ('c', data_gen)], nullable=False))
-        part_table = gen_df(spark, StructGen([('a_2', LongRangeGen()), ('b', byte_gen)], nullable=False))
+        agg_table = gen_df(spark, StructGen([('a_1', UniqueLongGen()), ('c', data_gen)], nullable=False))
+        part_table = gen_df(spark, StructGen([('a_2', UniqueLongGen()), ('b', byte_gen)], nullable=False))
         agg_table.createOrReplaceTempView("agg")
         part_table.createOrReplaceTempView("part")
         # Note that if we include `c` in the select clause here (the output projection), the bug described
@@ -1085,7 +1085,7 @@ def test_join_sum_window_of_window(data_gen):
 # And GpuCollectSet does not yet support struct type.
 _gen_data_for_collect_set = [
     ('a', RepeatSeqGen(LongGen(), length=20)),
-    ('b', LongRangeGen()),
+    ('b', UniqueLongGen()),
     ('c_bool', RepeatSeqGen(BooleanGen(), length=15)),
     ('c_int', RepeatSeqGen(IntegerGen(), length=15)),
     ('c_long', RepeatSeqGen(LongGen(), length=15)),
@@ -1105,7 +1105,7 @@ _gen_data_for_collect_set = [
 
 _gen_data_for_collect_set_nested = [
     ('a', RepeatSeqGen(LongGen(), length=20)),
-    ('b', LongRangeGen()),
+    ('b', UniqueLongGen()),
     ('c_int', RepeatSeqGen(IntegerGen(), length=15)),
     ('c_struct_array_1', RepeatSeqGen(struct_array_gen_no_nans, length=15)),
     ('c_struct_array_2', RepeatSeqGen(StructGen([
@@ -1271,7 +1271,7 @@ def test_window_aggs_for_rows_collect_set_nested_array():
 def test_nested_part_fallback(part_gen):
     data_gen = [
             ('a', RepeatSeqGen(part_gen, length=20)),
-            ('b', LongRangeGen()),
+            ('b', UniqueLongGen()),
             ('c', int_gen)]
     window_spec = Window.partitionBy('a').orderBy('b').rowsBetween(-5, 5)
 
@@ -1287,7 +1287,7 @@ def test_nested_part_fallback(part_gen):
 def test_nested_part_struct(part_gen):
     data_gen = [
             ('a', RepeatSeqGen(part_gen, length=20)),
-            ('b', LongRangeGen()),
+            ('b', UniqueLongGen()),
             ('c', int_gen)]
     window_spec = Window.partitionBy('a').orderBy('b').rowsBetween(-5, 5)
 
@@ -1303,7 +1303,7 @@ def test_nested_part_struct(part_gen):
 @pytest.mark.parametrize('ride_along', all_basic_gens + decimal_gens + array_gens_sample + struct_gens_sample + map_gens_sample, ids=idfn)
 def test_window_ride_along(ride_along):
     assert_gpu_and_cpu_are_equal_sql(
-            lambda spark : gen_df(spark, [('a', LongRangeGen()), ('b', ride_along)]),
+            lambda spark : gen_df(spark, [('a', UniqueLongGen()), ('b', ride_along)]),
             "window_agg_table",
             'select *,'
             ' row_number() over (order by a) as row_num '

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -23,7 +23,7 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, Expression, NullsFirst, NullsLast, SortOrder}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, MapType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object SortUtils {
@@ -211,9 +211,14 @@ class GpuSorter(
     }
   }
 
-  private[this] lazy val hasNestedInKeyColumns = cpuOrderingInternal.exists ( order =>
-    DataTypeUtils.isNestedType(order.child.dataType)
-  )
+  private[this] lazy val hasNestedInKeyColumns = cpuOrderingInternal.exists { order =>
+    order.child.dataType match {
+      case _: BinaryType =>
+        // binary is represented in cudf as a LIST column of UINT8
+        true
+      case t => DataTypeUtils.isNestedType(t)
+    }
+  }
 
   /** (This can be removed once https://github.com/rapidsai/cudf/issues/8050 is addressed) */
   private[this] lazy val hasUnsupportedNestedInRideColumns = {
@@ -221,7 +226,7 @@ class GpuSorter(
     val rideColumnIndices = projectedBatchTypes.indices.toSet -- keyColumnIndices
     rideColumnIndices.exists { idx =>
       TrampolineUtil.dataTypeExistsRecursively(projectedBatchTypes(idx),
-        t => t.isInstanceOf[ArrayType] || t.isInstanceOf[MapType])
+        t => t.isInstanceOf[ArrayType] || t.isInstanceOf[MapType] || t.isInstanceOf[BinaryType])
     }
   }
 


### PR DESCRIPTION
This fixes an exception that can be thrown by cudf's Table.merge when called with BinaryType columns.  BinaryType is represented by a cudf LIST column of UINT8 which is treated as a nested type, but SortUtils does not consider BinaryType to be a nested type for avoiding the call to Table.merge.  A sort test was updated to add binary types to catch this, but it required changing LongRangeGen, which generates already sorted data, to UniqueRangeGen which similarly generates unique long values but critically are _not_ sorted in a way where each generated batch can be emitted verbatim in the sorted output (i.e.: a merge of batches is required).