### PR TITLE
List supported Spark versions when no shim found

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -289,8 +289,11 @@ object ShimLoader extends Logging {
       provider.getClass.getName
     }.getOrElse {
         val supportedVersions = restProviders.map { case (p, _) => p.getShimVersion }.mkString(", ")
-        throw new IllegalArgumentException(s"Spark build $sparkVersion not supported. " +
-          s"Spark build versions supported by Spark RAPIDS: ${supportedVersions}")
+        throw new IllegalArgumentException(
+          s"This RAPIDS Plugin build does not support Spark build ${sparkVersion}. " +
+          s"Supported Spark build versions: ${supportedVersions}. " +
+          "Consult the Release documentation at " +
+          "https://nvidia.github.io/spark-rapids/docs/download.html")
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -288,10 +288,14 @@ object ShimLoader extends Logging {
       // this class will be loaded again by the real executor classloader
       provider.getClass.getName
     }.getOrElse {
-        val supportedVersions = restProviders.map { case (p, _) => p.getShimVersion }.mkString(", ")
+        val supportedVersions = restProviders.map {
+          case (p, _) =>
+            val buildVer = shimIdFromPackageName(p.getClass.getName).drop("spark".length)
+            s"${p.getShimVersion} {buildver=${buildVer}}"
+        }.mkString(", ")
         throw new IllegalArgumentException(
           s"This RAPIDS Plugin build does not support Spark build ${sparkVersion}. " +
-          s"Supported Spark build versions: ${supportedVersions}. " +
+          s"Supported Spark versions: ${supportedVersions}. " +
           "Consult the Release documentation at " +
           "https://nvidia.github.io/spark-rapids/docs/download.html")
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -44,7 +44,7 @@ case class SparkShimVersion(major: Int, minor: Int, patch: Int) extends ShimVers
 
 case class ClouderaShimVersion(major: Int, minor: Int, patch: Int, clouderaVersion: String)
   extends ShimVersion {
-  override def toString(): String = s"$major.$minor.$patch.$clouderaVersion"
+  override def toString(): String = s"$major.$minor.$patch-cloudera-$clouderaVersion"
 }
 
 case class DatabricksShimVersion(


### PR DESCRIPTION
Fixes #8202

- Attaches the list of all supported shim versions / buildvers to the error message
- Modifies ClouderaShimVersion toString to follow the same scheme as DatabricksShimVersion by including the vendor name  

Signed-off-by: Gera Shegalov <gera@apache.org>

Testing 

#### build with 3 shims without support for Spark 3.3.2 

```bash
./build/buildall --profile=321cdh,330cdh,340
```

#### start an intergration test with 3.3.2 SPARK_HOME

```bash
SPARK_HOME=~/dist/spark-3.3.2-bin-hadoop2 ./integration_tests/run_pyspark_from_build.sh -k 'array_exists'
```
yielding 
<details>
<summary>
<pre>
INTERNALERROR> py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
INTERNALERROR> : java.lang.IllegalArgumentException: This RAPIDS Plugin build does not support Spark build 3.3.2. Supported Spark versions: 3.2.1-cloudera-3.2.7171000 {buildver=321cdh}, 3.3.0-cloudera-3.3.7180 {buildver=330cdh}, 3.4.0 {buildver=340}. Consult the Release documentation at https://nvidia.github.io/spark-rapids/docs/download.html
</pre>
</summary>
<pre>
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.$anonfun$detectShimProvider$18(ShimLoader.scala:296)
INTERNALERROR>  at scala.Option.getOrElse(Option.scala:189)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.detectShimProvider(ShimLoader.scala:290)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.findShimProvider(ShimLoader.scala:307)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.initShimProviderIfNeeded(ShimLoader.scala:104)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.getShimClassLoader(ShimLoader.scala:197)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimReflectionUtils$.loadClass(ShimReflectionUtils.scala:29)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimReflectionUtils$.newInstanceOf(ShimReflectionUtils.scala:35)
INTERNALERROR>  at com.nvidia.spark.rapids.ShimLoader$.newDriverPlugin(ShimLoader.scala:351)
INTERNALERROR>  at com.nvidia.spark.SQLPlugin.driverPlugin(SQLPlugin.scala:29)
INTERNALERROR>  at org.apache.spark.internal.plugin.DriverPluginContainer.$anonfun$driverPlugins$1(PluginContainer.scala:47)
INTERNALERROR>  at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:293)
INTERNALERROR>  at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
INTERNALERROR>  at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
INTERNALERROR>  at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
INTERNALERROR>  at scala.collection.TraversableLike.flatMap(TraversableLike.scala:293)
INTERNALERROR>  at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:290)
INTERNALERROR>  at scala.collection.AbstractTraversable.flatMap(Traversable.scala:108)
INTERNALERROR>  at org.apache.spark.internal.plugin.DriverPluginContainer.<init>(PluginContainer.scala:46)
INTERNALERROR>  at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:210)
INTERNALERROR>  at org.apache.spark.internal.plugin.PluginContainer$.apply(PluginContainer.scala:193)
INTERNALERROR>  at org.apache.spark.SparkContext.<init>(SparkContext.scala:570)
INTERNALERROR>  at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
INTERNALERROR>  at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
INTERNALERROR>  at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
INTERNALERROR>  at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
INTERNALERROR>  at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
INTERNALERROR>  at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
INTERNALERROR>  at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
INTERNALERROR>  at py4j.Gateway.invoke(Gateway.java:238)
INTERNALERROR>  at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
INTERNALERROR>  at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
INTERNALERROR>  at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
INTERNALERROR>  at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
INTERNALERROR>  at java.lang.Thread.run(Thread.java:750)
</pre>
</details>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

6. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

7. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
