### PR TITLE
Fix `from_json` function failure when input contains empty or null strings

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -417,6 +417,16 @@ def test_from_json_struct_of_list(data_gen, schema):
             .select(f.from_json(f.col('a'), schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
+@pytest.mark.parametrize('data_gen', [StringGen('', nullable=True)])
+@pytest.mark.parametrize('schema', [StructType([StructField("a", StringType())]),
+                                    StructType([StructField("a", StringType()), StructField("b", IntegerType())])
+                                    ])
+def test_from_json_struct_empty_string_input(data_gen, schema):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, data_gen) \
+            .select(f.from_json(f.col('a'), schema)),
+        conf={"spark.rapids.sql.expression.JsonToStructs": True})
+
 @allow_non_gpu('FileSourceScanExec')
 @pytest.mark.skipif(is_before_spark_340(), reason='enableDateTimeParsingFallback is supported from Spark3.4.0')
 @pytest.mark.parametrize('filename,schema', [("dates.json", _date_schema),("dates.json", _timestamp_schema),

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -380,51 +380,46 @@ def test_from_json_map_fallback():
         'JsonToStructs',
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
-@pytest.mark.parametrize('data_gen', [StringGen(r'{"a": "[0-9]{0,5}", "b": "[A-Z]{0,5}", "c": 1234}')])
-@pytest.mark.parametrize('schema', [StructType([StructField("a", StringType())]),
-                                    StructType([StructField("d", StringType())]),
-                                    StructType([StructField("a", StringType()), StructField("b", StringType())]),
-                                    StructType([StructField("c", IntegerType()), StructField("a", StringType())]),
-                                    StructType([StructField("a", StringType()), StructField("a", StringType())])
+@pytest.mark.parametrize('schema', ['struct<a:string>',
+                                    'struct<d:string>',
+                                    'struct<a:string,b:string>',
+                                    'struct<c:int,a:string>',
+                                    'struct<a:string,a:string>',
                                     ])
-def test_from_json_struct(data_gen, schema):
+def test_from_json_struct(schema):
+    json_string_gen = StringGen(r'{"a": "[0-9]{0,5}", "b": "[A-Z]{0,5}", "c": 1234}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen) \
-            .select(f.from_json(f.col('a'), schema)),
+        lambda spark : unary_op_df(spark, json_string_gen) \
+            .select(f.from_json('a', schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
-@pytest.mark.parametrize('data_gen', [StringGen(r'{"teacher": "Alice", "student": {"name": "Bob", "age": 20}}')])
-@pytest.mark.parametrize('schema', [StructType([StructField("teacher", StringType())]),
-                                    StructType([StructField("student", StructType([StructField("name", StringType()), \
-                                                                                   StructField("age", IntegerType())]))])])
-def test_from_json_struct_of_struct(data_gen, schema):
+@pytest.mark.parametrize('schema', ['struct<teacher:string>',
+                                    'struct<student:struct<name:string,age:int>>',
+                                    'struct<teacher:string,student:struct<name:string,age:int>>'])
+def test_from_json_struct_of_struct(schema):
+    json_string_gen = StringGen(r'{"teacher": "Alice", "student": {"name": "Bob", "age": 20}}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen) \
-            .select(f.from_json(f.col('a'), schema)),
+        lambda spark : unary_op_df(spark, json_string_gen) \
+            .select(f.from_json('a', schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
-@pytest.mark.parametrize('data_gen', [StringGen(r'{"teacher": "Alice", "student": \[{"name": "Bob", "class": "junior"},' \
-                                                r'{"name": "Charlie", "class": "freshman"}\]}')])
-@pytest.mark.parametrize('schema', [StructType([StructField("teacher", StringType())]),
-                                    StructType([StructField("student", ArrayType(StructType([StructField("name", StringType()), \
-                                                                                             StructField("class", StringType())])))]),
-                                    StructType([StructField("teacher", StringType()), \
-                                                StructField("student", ArrayType(StructType([StructField("name", StringType()), \
-                                                                                             StructField("class", StringType())])))])])
-def test_from_json_struct_of_list(data_gen, schema):
+@pytest.mark.parametrize('schema', ['struct<teacher:string>',
+                                    'struct<student:array<struct<name:string, class:string>>>',
+                                    'struct<teacher:string,student:array<struct<name:string, class:string>>>'])
+def test_from_json_struct_of_list(schema):
+    json_string_gen = StringGen(r'{"teacher": "Alice", "student": \[{"name": "Bob", "class": "junior"},' \
+                                r'{"name": "Charlie", "class": "freshman"}\]}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen) \
-            .select(f.from_json(f.col('a'), schema)),
+        lambda spark : unary_op_df(spark, json_string_gen) \
+            .select(f.from_json('a', schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
-@pytest.mark.parametrize('data_gen', [StringGen('', nullable=True)])
-@pytest.mark.parametrize('schema', [StructType([StructField("a", StringType())]),
-                                    StructType([StructField("a", StringType()), StructField("b", IntegerType())])
-                                    ])
-def test_from_json_struct_empty_string_input(data_gen, schema):
+@pytest.mark.parametrize('schema', ['struct<a:string>', 'struct<a:string,b:int>'])
+def test_from_json_struct_all_empty_string_input(schema):
+    json_string_gen = StringGen('')
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen) \
-            .select(f.from_json(f.col('a'), schema)),
+        lambda spark : unary_op_df(spark, json_string_gen) \
+            .select(f.from_json('a', schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
 @allow_non_gpu('FileSourceScanExec')

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -387,7 +387,7 @@ def test_from_json_map_fallback():
                                     'struct<a:string,a:string>',
                                     ])
 def test_from_json_struct(schema):
-    json_string_gen = StringGen(r'{"a": "[0-9]{0,5}", "b": "[A-Z]{0,5}", "c": 1234}').with_special_pattern('', weight=50)
+    json_string_gen = StringGen(r'{"a": "[0-9]{0,5}", "b": "[A-Z]{0,5}", "c": 1\d\d\d}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.from_json('a', schema)),
@@ -397,18 +397,20 @@ def test_from_json_struct(schema):
                                     'struct<student:struct<name:string,age:int>>',
                                     'struct<teacher:string,student:struct<name:string,age:int>>'])
 def test_from_json_struct_of_struct(schema):
-    json_string_gen = StringGen(r'{"teacher": "Alice", "student": {"name": "Bob", "age": 20}}').with_special_pattern('', weight=50)
+    json_string_gen = StringGen(r'{"teacher": "[A-Z]{1}[a-z]{2,5}",' \
+                                r'"student": {"name": "[A-Z]{1}[a-z]{2,5}", "age": 1\d}}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.from_json('a', schema)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True})
 
 @pytest.mark.parametrize('schema', ['struct<teacher:string>',
-                                    'struct<student:array<struct<name:string, class:string>>>',
-                                    'struct<teacher:string,student:array<struct<name:string, class:string>>>'])
+                                    'struct<student:array<struct<name:string,class:string>>>',
+                                    'struct<teacher:string,student:array<struct<name:string,class:string>>>'])
 def test_from_json_struct_of_list(schema):
-    json_string_gen = StringGen(r'{"teacher": "Alice", "student": \[{"name": "Bob", "class": "junior"},' \
-                                r'{"name": "Charlie", "class": "freshman"}\]}').with_special_pattern('', weight=50)
+    json_string_gen = StringGen(r'{"teacher": "[A-Z]{1}[a-z]{2,5}",' \
+                                r'"student": \[{"name": "[A-Z]{1}[a-z]{2,5}", "class": "junior"},' \
+                                r'{"name": "[A-Z]{1}[a-z]{2,5}", "class": "freshman"}\]}').with_special_pattern('', weight=50)
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.from_json('a', schema)),

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -148,10 +148,10 @@ def test_contains():
                 f.col('a').contains(None)
                 ))
 
-def test_trim():
-    gen = mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}')
+@pytest.mark.parametrize('data_gen', [mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}'), StringGen('')])
+def test_trim(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
+            lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'TRIM(a)',
                 'TRIM("Ab" FROM a)',
                 'TRIM("A\ud720" FROM a)',

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -158,20 +158,20 @@ def test_trim():
                 'TRIM(BOTH NULL FROM a)',
                 'TRIM("" FROM a)'))
 
-def test_ltrim():
-    gen = mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}')
+@pytest.mark.parametrize('data_gen', [mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}'), StringGen('')])
+def test_ltrim(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
+            lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'LTRIM(a)',
                 'LTRIM("Ab", a)',
                 'TRIM(LEADING "A\ud720" FROM a)',
                 'TRIM(LEADING NULL FROM a)',
                 'TRIM(LEADING "" FROM a)'))
 
-def test_rtrim():
-    gen = mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}')
+@pytest.mark.parametrize('data_gen', [mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}'), StringGen('')])
+def test_rtrim(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, gen).selectExpr(
+            lambda spark: unary_op_df(spark, data_gen).selectExpr(
                 'RTRIM(a)',
                 'RTRIM("Ab", a)',
                 'TRIM(TRAILING "A\ud720" FROM a)',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -383,7 +383,11 @@ object GpuOrcScan {
 
       case (DType.STRING, DType.STRING) if originalFromDt.isInstanceOf[CharType] =>
         // Trim trailing whitespace off of output strings, to match CPU output.
-        col.rstrip()
+        if (col.getData == null) {
+          col.copyToColumnVector
+        } else {
+          col.rstrip()
+        }
 
       // TODO more types, tracked in https://github.com/NVIDIA/spark-rapids/issues/5895
       case (f, t) =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -383,11 +383,7 @@ object GpuOrcScan {
 
       case (DType.STRING, DType.STRING) if originalFromDt.isInstanceOf[CharType] =>
         // Trim trailing whitespace off of output strings, to match CPU output.
-        if (col.getData == null) {
-          col.copyToColumnVector
-        } else {
-          col.rstrip()
-        }
+        col.rstrip()
 
       // TODO more types, tracked in https://github.com/NVIDIA/spark-rapids/issues/5895
       case (f, t) =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -37,16 +37,16 @@ case class GpuJsonToStructs(
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
       case struct: StructType if (struct.fields.length > 0) => {
-        val jsonFields = struct.fields.foldRight (Array.empty[String]) ((field, acc) => 
+        val jsonFields: Array[String] = struct.fields.map { field => 
           field.dataType match {
-            case IntegerType => s""""${field.name}": 0""" +: acc
-            case StringType => s""""${field.name}": """"" +: acc
-            case s: StructType => s""""${field.name}": ${constructEmptyRow(s)}""" +: acc
-            case a: ArrayType => s""""${field.name}": ${constructEmptyRow(a)}""" +: acc
+            case IntegerType => s""""${field.name}": 0"""
+            case StringType => s""""${field.name}": """""
+            case s: StructType => s""""${field.name}": ${constructEmptyRow(s)}"""
+            case a: ArrayType => s""""${field.name}": ${constructEmptyRow(a)}"""
             case t => throw new IllegalArgumentException("GpuJsonToStructs currently" +
               s"does not support input schema with type $t.")
           }
-        )
+        }
         jsonFields.mkString("{", ", ", "}")
       }
       case array: ArrayType => s"[${constructEmptyRow(array.elementType)}]"

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -283,7 +283,11 @@ case class GpuStringTrimLeft(column: Expression, trimParameters: Option[Expressi
   val trimMethod = "gpuTrimLeft"
 
   override def strippedColumnVector(column: GpuColumnVector, t: Scalar): GpuColumnVector =
-    GpuColumnVector.from(column.getBase.lstrip(t), dataType)
+    if (column.getBase.getData == null) {
+      GpuColumnVector.from(column.getBase.incRefCount, dataType)
+    } else {
+      GpuColumnVector.from(column.getBase.lstrip(t), dataType)
+    }
 }
 
 case class GpuStringTrimRight(column: Expression, trimParameters: Option[Expression] = None)
@@ -303,7 +307,11 @@ case class GpuStringTrimRight(column: Expression, trimParameters: Option[Express
   val trimMethod = "gpuTrimRight"
 
   override def strippedColumnVector(column:GpuColumnVector, t:Scalar): GpuColumnVector =
-    GpuColumnVector.from(column.getBase.rstrip(t), dataType)
+    if (column.getBase.getData == null) {
+      GpuColumnVector.from(column.getBase.incRefCount, dataType)
+    } else {
+      GpuColumnVector.from(column.getBase.rstrip(t), dataType)
+    }
 }
 
 case class GpuConcatWs(children: Seq[Expression])

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -263,7 +263,11 @@ case class GpuStringTrim(column: Expression, trimParameters: Option[Expression] 
   val trimMethod = "gpuTrim"
 
   override def strippedColumnVector(column: GpuColumnVector, t: Scalar): GpuColumnVector =
-    GpuColumnVector.from(column.getBase.strip(t), dataType)
+    if (column.getBase.getData == null) {
+      GpuColumnVector.from(column.getBase.incRefCount, dataType)
+    } else {
+      GpuColumnVector.from(column.getBase.strip(t), dataType)
+    }
 }
 
 case class GpuStringTrimLeft(column: Expression, trimParameters: Option[Expression] = None)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/8522.

During testing, we found `from_json` function throws a `java.lang.ArrayIndexOutOfBoundsException` (from `ai.rapids.cudf.TableWithMeta.releaseTable`) when the input column contains empty or null strings. When pre-processing the input columns, we have replaced all empty string or null rows in the input column with "{}", but calling `ai.rapids.cudf.Table.readJSON` on the input column (containing other valid json strings) would result in tables with different number of columns, resulting in future ArrayIndexOutOfBoundsException since rows contain tables of different sizes.
=> To fix this issue, instead of replacing empty strings/nulls with "{}", we replace them with a dummy json string based on the input `schema`. For example, if `schema` is `StructType([StructField("a", StringType), StructField("b", IntegerType)])`, then we will replace empty strings and nulls with "{"a": "", "b": 0}". This ensures that all rows contain tables with the same number of columns after `readJSON`.

When testing the above solution, we encountered another issue with `strip` function: https://github.com/rapidsai/cudf/issues/13529. The problem only occurs when the input column contains only empty strings and nulls. Our approach is to first check the data buffer for the input string column, and if it is empty, we do not call `strip` and just call `incRefCount` on the origin column.