### PR TITLE
Init changelog 23.06 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,497 +1,269 @@
 # Change log
-Generated on 2023-05-09
+Generated on 2023-06-08
 
-## Release 23.04
-
-### Features
-|||
-|:---|:---|
-|[#7992](https://github.com/NVIDIA/spark-rapids/issues/7992)|[Audit][SPARK-40819][SQL][3.3] Timestamp nanos behaviour regression (parquet reader)|
-|[#7985](https://github.com/NVIDIA/spark-rapids/issues/7985)|[FEA] Expose Alluxio master URL to support K8s Env|
-|[#7880](https://github.com/NVIDIA/spark-rapids/issues/7880)|[FEA] retry framework task level metrics|
-|[#7394](https://github.com/NVIDIA/spark-rapids/issues/7394)|[FEA] Support Delta Lake auto compaction|
-|[#7920](https://github.com/NVIDIA/spark-rapids/issues/7920)|[FEA] Remove SpillCallback and executor level spill metrics|
-|[#7463](https://github.com/NVIDIA/spark-rapids/issues/7463)|[FEA] Drop support for Databricks-9.1 ML LTS|
-|[#7253](https://github.com/NVIDIA/spark-rapids/issues/7253)|[FEA] Implement OOM retry framework|
-|[#7042](https://github.com/NVIDIA/spark-rapids/issues/7042)|[FEA] Add support in the tools event parsing for ML functions, libraries, and expressions|
-
-### Performance
-|||
-|:---|:---|
-|[#7907](https://github.com/NVIDIA/spark-rapids/issues/7907)|[FEA] Optimize regexp_replace in multi-replace scenarios|
-|[#7691](https://github.com/NVIDIA/spark-rapids/issues/7691)|[FEA] Upgrade and document UCX 1.14|
-|[#6516](https://github.com/NVIDIA/spark-rapids/issues/6516)|[FEA] Enable RAPIDS Shuffle Manager smoke testing for the databricks environment|
-|[#7695](https://github.com/NVIDIA/spark-rapids/issues/7695)|[FEA] Transpile regexp_extract expression to only have the single capture group that is needed|
-|[#7393](https://github.com/NVIDIA/spark-rapids/issues/7393)|[FEA] Support Delta Lake optimized write|
-|[#6561](https://github.com/NVIDIA/spark-rapids/issues/6561)|[FEA] Make SpillableColumnarBatch inform Spill code of actual usage of the batch|
-|[#6864](https://github.com/NVIDIA/spark-rapids/issues/6864)|[BUG] Spilling logic can spill data that cannot be freed|
-
-### Bugs Fixed
-|||
-|:---|:---|
-|[#8111](https://github.com/NVIDIA/spark-rapids/issues/8111)|[BUG] test_delta_delete_entire_table failed in databricks 10.4 runtime|
-|[#8074](https://github.com/NVIDIA/spark-rapids/issues/8074)|[BUG] test_parquet_read_nano_as_longs_31x failed on Dataproc|
-|[#7997](https://github.com/NVIDIA/spark-rapids/issues/7997)|[BUG] executors died with too much off heap in yarn UCX CI `udf_test`|
-|[#8067](https://github.com/NVIDIA/spark-rapids/issues/8067)|[BUG] extras jar sometimes fails to load|
-|[#8038](https://github.com/NVIDIA/spark-rapids/issues/8038)|[BUG] vector leaked when running NDS 3TB with memory restricted|
-|[#8030](https://github.com/NVIDIA/spark-rapids/issues/8030)|[BUG] test_re_replace_no_unicode_fallback test failes on integratoin tests Yarn|
-|[#7971](https://github.com/NVIDIA/spark-rapids/issues/7971)|[BUG] withRestoreOnRetry should look at Throwable causes in addition to retry OOMs|
-|[#6990](https://github.com/NVIDIA/spark-rapids/issues/6990)|[BUG] Several integration test failures in Spark-3.4 SNAPSHOT build|
-|[#7924](https://github.com/NVIDIA/spark-rapids/issues/7924)|[BUG] Physical plan for regexp_extract does not escape newlines|
-|[#7341](https://github.com/NVIDIA/spark-rapids/issues/7341)|[BUG] Leverage OOM retry framework for ORC writes|
-|[#7921](https://github.com/NVIDIA/spark-rapids/issues/7921)|[BUG] ORC writes with bloom filters enabled do not fall back to the CPU|
-|[#7818](https://github.com/NVIDIA/spark-rapids/issues/7818)|[BUG] Reuse of broadcast exchange can lead to unnecessary CPU fallback|
-|[#7904](https://github.com/NVIDIA/spark-rapids/issues/7904)|[BUG] test_write_sql_save_table sporadically fails on Pascal|
-|[#7922](https://github.com/NVIDIA/spark-rapids/issues/7922)|[BUG] YARN IT test test_optimized_hive_ctas_basic failures|
-|[#7933](https://github.com/NVIDIA/spark-rapids/issues/7933)|[BUG] NDS running hits DPP error on Databricks 10.4 when enable Alluxio cache.|
-|[#7850](https://github.com/NVIDIA/spark-rapids/issues/7850)|[BUG] nvcomp usage for the UCX mode of the shuffle manager is broken|
-|[#7927](https://github.com/NVIDIA/spark-rapids/issues/7927)|[BUG] Shimplify adding new shim layer fails|
-|[#6138](https://github.com/NVIDIA/spark-rapids/issues/6138)|[BUG] cast timezone-awareness check positive for date/time-unrelated types|
-|[#7914](https://github.com/NVIDIA/spark-rapids/issues/7914)|[BUG] Parquet read with integer upcast crashes|
-|[#6961](https://github.com/NVIDIA/spark-rapids/issues/6961)|[BUG] Using `\d` (or others) inside a character class results in "Unsupported escape character" |
-|[#7908](https://github.com/NVIDIA/spark-rapids/issues/7908)|[BUG] Interpolate spark.version.classifier into scala:compile `secondaryCacheDir`|
-|[#7707](https://github.com/NVIDIA/spark-rapids/issues/7707)|[BUG] IndexOutOfBoundsException when joining on 2 integer columns with DPP|
-|[#7892](https://github.com/NVIDIA/spark-rapids/issues/7892)|[BUG] Invalid or unsupported escape character `t` when trying to use tab in regexp_replace|
-|[#7640](https://github.com/NVIDIA/spark-rapids/issues/7640)|[BUG] GPU OOM using GpuRegExpExtract|
-|[#7814](https://github.com/NVIDIA/spark-rapids/issues/7814)|[BUG] GPU's output differs from CPU's for big decimals when joining by sub-partitioning algorithm|
-|[#7796](https://github.com/NVIDIA/spark-rapids/issues/7796)|[BUG] Parquet chunked reader size of output exceeds column size limit|
-|[#7833](https://github.com/NVIDIA/spark-rapids/issues/7833)|[BUG] run_pyspark_from_build computes 5 MiB per runner instead of 5 GiB|
-|[#7855](https://github.com/NVIDIA/spark-rapids/issues/7855)|[BUG] shuffle_test test_hash_grpby_sum failed OOM in premerge CI|
-|[#7858](https://github.com/NVIDIA/spark-rapids/issues/7858)|[BUG] HostToGpuCoalesceIterator leaks all host batches|
-|[#7826](https://github.com/NVIDIA/spark-rapids/issues/7826)|[BUG] buildall dist jar contains aggregator dependency|
-|[#7729](https://github.com/NVIDIA/spark-rapids/issues/7729)|[BUG] Active GPU thread not holding the semaphore|
-|[#7820](https://github.com/NVIDIA/spark-rapids/issues/7820)|[BUG] Restore pandas require_minimum_pandas_version() check|
-|[#7829](https://github.com/NVIDIA/spark-rapids/issues/7829)|[BUG] Parquet buffer time not correct with multithreaded combining reader|
-|[#7819](https://github.com/NVIDIA/spark-rapids/issues/7819)|[BUG] GpuDeviceManager allows setting UVM regardless of other RMM configs|
-|[#7643](https://github.com/NVIDIA/spark-rapids/issues/7643)|[BUG] Databricks init scripts can fail silently|
-|[#7799](https://github.com/NVIDIA/spark-rapids/issues/7799)|[BUG] Cannot lexicographic compare a table with a LIST of STRUCT column at ai.rapids.cudf.Table.sortOrder|
-|[#7767](https://github.com/NVIDIA/spark-rapids/issues/7767)|[BUG] VS Code / Metals / Bloop integration fails with java.lang.RuntimeException: 'boom' |
-|[#6383](https://github.com/NVIDIA/spark-rapids/issues/6383)|[SPARK-40066][SQL] ANSI mode: always return null on invalid access to map column|
-|[#7093](https://github.com/NVIDIA/spark-rapids/issues/7093)|[BUG] Spark-3.4 - Integration test failures in map_test|
-|[#7779](https://github.com/NVIDIA/spark-rapids/issues/7779)|[BUG] AlluxioUtilsSuite uses illegal character underscore in URI scheme|
-|[#7725](https://github.com/NVIDIA/spark-rapids/issues/7725)|[BUG] cache_test failed w/ ParquetCachedBatchSerializer in spark 3.3.2-SNAPSHOT|
-|[#7639](https://github.com/NVIDIA/spark-rapids/issues/7639)|[BUG] Databricks premerge failing with cannot find pytest|
-|[#7694](https://github.com/NVIDIA/spark-rapids/issues/7694)|[BUG] Spark-3.4 build breaks due to removing InternalRowSet|
-|[#6598](https://github.com/NVIDIA/spark-rapids/issues/6598)|[BUG] CUDA error when casting large column vector from long to string|
-|[#7739](https://github.com/NVIDIA/spark-rapids/issues/7739)|[BUG] udf_test failed in databricks 11.3 ENV|
-|[#5748](https://github.com/NVIDIA/spark-rapids/issues/5748)|[BUG] 3 cast tests fails on Spark 3.4.0|
-|[#7688](https://github.com/NVIDIA/spark-rapids/issues/7688)|[BUG] GpuParquetScan fails with NullPointerException - Delta CDF query|
-|[#7648](https://github.com/NVIDIA/spark-rapids/issues/7648)|[BUG] java.lang.ClassCastException: SerializeConcatHostBuffersDeserializeBatch cannot be cast to.HashedRelation|
-|[#6988](https://github.com/NVIDIA/spark-rapids/issues/6988)|[BUG] Integration test failures with DecimalType on Spark-3.4 SNAPSHOT build|
-|[#7615](https://github.com/NVIDIA/spark-rapids/issues/7615)|[BUG] Build fails on Spark 3.4|
-|[#7557](https://github.com/NVIDIA/spark-rapids/issues/7557)|[AUDIT][SPARK-41970] Introduce SparkPath for typesafety|
-|[#7617](https://github.com/NVIDIA/spark-rapids/issues/7617)|[BUG] Build 340 failed due to miss shim code for GpuShuffleMeta|
-
-### PRs
-|||
-|:---|:---|
-|[#8247](https://github.com/NVIDIA/spark-rapids/pull/8247)|Bump up plugin version to 23.04.1-SNAPSHOT|
-|[#8248](https://github.com/NVIDIA/spark-rapids/pull/8248)|[Doc] update versions for 2304 hot fix [skip ci]|
-|[#8246](https://github.com/NVIDIA/spark-rapids/pull/8246)|Cherry-pick hotfix: Use weak keys in executor broadcast plan cache|
-|[#8092](https://github.com/NVIDIA/spark-rapids/pull/8092)|Init changelog for 23.04 [skip ci]|
-|[#8109](https://github.com/NVIDIA/spark-rapids/pull/8109)|Bump up JNI and private version to released 23.04.0|
-|[#7939](https://github.com/NVIDIA/spark-rapids/pull/7939)|[Doc]update download docs for 2304 version[skip ci]|
-|[#8127](https://github.com/NVIDIA/spark-rapids/pull/8127)|Avoid SQL result check of Delta Lake full delete on Databricks|
-|[#8098](https://github.com/NVIDIA/spark-rapids/pull/8098)|Fix loading of ORC files with missing column names|
-|[#8110](https://github.com/NVIDIA/spark-rapids/pull/8110)|Update ML integration page docs page [skip ci]|
-|[#8103](https://github.com/NVIDIA/spark-rapids/pull/8103)|Add license of spark-rapids private in NOTICE-binary[skip ci]|
-|[#8100](https://github.com/NVIDIA/spark-rapids/pull/8100)|Update/improve EMR getting started documentation [skip ci]|
-|[#8101](https://github.com/NVIDIA/spark-rapids/pull/8101)|Improve OOM exception messages|
-|[#8087](https://github.com/NVIDIA/spark-rapids/pull/8087)|Add an FAQ entry on encryption support [skip ci]|
-|[#8076](https://github.com/NVIDIA/spark-rapids/pull/8076)|Add in docs about RetryOOM [skip ci]|
-|[#8077](https://github.com/NVIDIA/spark-rapids/pull/8077)|Temporarily skip `test_parquet_read_nano_as_longs_31x` on dataproc|
-|[#8071](https://github.com/NVIDIA/spark-rapids/pull/8071)|Fix error in deploy script [skip ci]|
-|[#8070](https://github.com/NVIDIA/spark-rapids/pull/8070)|Fixes closed RapidsShuffleHandleImpl leak in ShuffleBufferCatalog|
-|[#8069](https://github.com/NVIDIA/spark-rapids/pull/8069)|Fix loading extra jar|
-|[#8044](https://github.com/NVIDIA/spark-rapids/pull/8044)|Fall back to CPU if  `spark.sql.legacy.parquet.nanosAsLong` is set|
-|[#8049](https://github.com/NVIDIA/spark-rapids/pull/8049)|[DOC] Adding user tool info to main qualification docs page [skip ci]|
-|[#8040](https://github.com/NVIDIA/spark-rapids/pull/8040)|Fix device vector leak in RmmRetryIterator.splitSpillableInHalfByRows|
-|[#8031](https://github.com/NVIDIA/spark-rapids/pull/8031)|Fix regexp_replace integration test that should fallback when unicode is disabled|
-|[#7828](https://github.com/NVIDIA/spark-rapids/pull/7828)|Fallback to arena allocator if RMM failed to initialize with async allocator|
-|[#8006](https://github.com/NVIDIA/spark-rapids/pull/8006)|Handle caused-by retry exceptions in withRestoreOnRetry|
-|[#8013](https://github.com/NVIDIA/spark-rapids/pull/8013)|[Doc] Adding user tools info into EMR getting started guide [skip ci]|
-|[#8007](https://github.com/NVIDIA/spark-rapids/pull/8007)|Fix leak where RapidsShuffleIterator for a completed task was kept alive|
-|[#8010](https://github.com/NVIDIA/spark-rapids/pull/8010)|Specify that UCX should be 1.12.1 only [skip ci]|
-|[#7967](https://github.com/NVIDIA/spark-rapids/pull/7967)|Transpile simple choice-type regular expressions into lists of choices to use with string replace multi|
-|[#7902](https://github.com/NVIDIA/spark-rapids/pull/7902)|Add oom retry handling for createGatherer in gpu hash joins|
-|[#7986](https://github.com/NVIDIA/spark-rapids/pull/7986)|Provides a config to expose Alluxio master URL to support K8s Env|
-|[#7936](https://github.com/NVIDIA/spark-rapids/pull/7936)|Stop showing internal details of ternary expressions in SparkPlan.toString|
-|[#7972](https://github.com/NVIDIA/spark-rapids/pull/7972)|Add in retry for ORC writes|
-|[#7975](https://github.com/NVIDIA/spark-rapids/pull/7975)|Publish documentation for private configs|
-|[#7976](https://github.com/NVIDIA/spark-rapids/pull/7976)|Disable GPU write for ORC and Parquet, if bloom-filters are enabled.|
-|[#7925](https://github.com/NVIDIA/spark-rapids/pull/7925)|Inject RetryOOM in CI where retry iterator is used|
-|[#7970](https://github.com/NVIDIA/spark-rapids/pull/7970)|[DOCS] Updating qual tool docs from latest in tools repo|
-|[#7952](https://github.com/NVIDIA/spark-rapids/pull/7952)|Add in minimal retry metrics|
-|[#7884](https://github.com/NVIDIA/spark-rapids/pull/7884)|Add Python requirements file for integration tests|
-|[#7958](https://github.com/NVIDIA/spark-rapids/pull/7958)|Add CheckpointRestore trait and withRestoreOnRetry|
-|[#7849](https://github.com/NVIDIA/spark-rapids/pull/7849)|Fix CPU broadcast exchanges being left unreplaced due to AQE and reuse|
-|[#7944](https://github.com/NVIDIA/spark-rapids/pull/7944)|Fix issue with dynamicpruning filters used in converted GPU scans when S3 paths are replaced with alluxio|
-|[#7949](https://github.com/NVIDIA/spark-rapids/pull/7949)|Lazily unspill the stream batches for joins by sub-partitioning|
-|[#7951](https://github.com/NVIDIA/spark-rapids/pull/7951)|Fix PMD docs URL [skip ci]|
-|[#7945](https://github.com/NVIDIA/spark-rapids/pull/7945)|Enable automerge from 2304 to 2306 [skip ci]|
-|[#7935](https://github.com/NVIDIA/spark-rapids/pull/7935)|Add GPU level task metrics|
-|[#7930](https://github.com/NVIDIA/spark-rapids/pull/7930)|Add OOM Retry handling for join gather next|
-|[#7942](https://github.com/NVIDIA/spark-rapids/pull/7942)|Revert "Upgrade to UCX 1.14.0 (#7877)"|
-|[#7889](https://github.com/NVIDIA/spark-rapids/pull/7889)|Support auto-compaction for Delta tables on|
-|[#7937](https://github.com/NVIDIA/spark-rapids/pull/7937)|Support hashing different types for sub-partitioning|
-|[#7877](https://github.com/NVIDIA/spark-rapids/pull/7877)|Upgrade to UCX 1.14.0|
-|[#7926](https://github.com/NVIDIA/spark-rapids/pull/7926)|Fixes issue where UCX compressed tables would be decompressed multiple times|
-|[#7928](https://github.com/NVIDIA/spark-rapids/pull/7928)|Adjust assert for SparkShims: no longer a per-shim file [skip ci]|
-|[#7895](https://github.com/NVIDIA/spark-rapids/pull/7895)|Some refactor of shuffled hash join|
-|[#7894](https://github.com/NVIDIA/spark-rapids/pull/7894)|Support tagging `Cast` for timezone conditionally|
-|[#7915](https://github.com/NVIDIA/spark-rapids/pull/7915)|Fix upcast of signed integral values when reading from Parquet|
-|[#7879](https://github.com/NVIDIA/spark-rapids/pull/7879)|Retry for file read operations|
-|[#7905](https://github.com/NVIDIA/spark-rapids/pull/7905)|[Doc] Fix some documentation issue based on VPR feedback on 23.04 branch (new PR) [skip CI] |
-|[#7912](https://github.com/NVIDIA/spark-rapids/pull/7912)|[Doc] Hotfix gh-pages for compatibility page format issue [skip ci]|
-|[#7913](https://github.com/NVIDIA/spark-rapids/pull/7913)|Fix resolution of GpuRapidsProcessDeltaMergeJoinExec expressions|
-|[#7916](https://github.com/NVIDIA/spark-rapids/pull/7916)|Add clarification for Delta Lake optimized write fallback due to sorting [skip ci]|
-|[#7906](https://github.com/NVIDIA/spark-rapids/pull/7906)|ColumnarToRowIterator should release the semaphore if parent is empty|
-|[#7909](https://github.com/NVIDIA/spark-rapids/pull/7909)|Interpolate buildver into secondaryCacheDir|
-|[#7844](https://github.com/NVIDIA/spark-rapids/pull/7844)|Update alluxio version to 2.9.0|
-|[#7896](https://github.com/NVIDIA/spark-rapids/pull/7896)|Update regular expression parser to handle escape character sequences|
-|[#7885](https://github.com/NVIDIA/spark-rapids/pull/7885)|Add Join Reordering Integration Test|
-|[#7862](https://github.com/NVIDIA/spark-rapids/pull/7862)|Reduce shimming of GpuFlatMapGroupsInPandasExec|
-|[#7859](https://github.com/NVIDIA/spark-rapids/pull/7859)|Remove 3.1.4-SNAPSHOT shim code|
-|[#7835](https://github.com/NVIDIA/spark-rapids/pull/7835)|Update to pull the rapids spark extra plugin jar|
-|[#7863](https://github.com/NVIDIA/spark-rapids/pull/7863)|[Doc] Address document issues [skip ci]|
-|[#7794](https://github.com/NVIDIA/spark-rapids/pull/7794)|Implement sub partitioning for large/skewed hash joins|
-|[#7864](https://github.com/NVIDIA/spark-rapids/pull/7864)|Add in basic support for OOM retry for project and filter|
-|[#7878](https://github.com/NVIDIA/spark-rapids/pull/7878)|Fixing host memory calculation to properly be 5GiB|
-|[#7860](https://github.com/NVIDIA/spark-rapids/pull/7860)|Enable manual copy-and-paste code detection [skip ci]|
-|[#7852](https://github.com/NVIDIA/spark-rapids/pull/7852)|Use withRetry in GpuCoalesceBatches|
-|[#7857](https://github.com/NVIDIA/spark-rapids/pull/7857)|Unshim getSparkShimVersion|
-|[#7854](https://github.com/NVIDIA/spark-rapids/pull/7854)|Optimize `regexp_extract*` by transpiling capture groups to non-capturing groups so that only the required capturing group is manifested|
-|[#7853](https://github.com/NVIDIA/spark-rapids/pull/7853)|Remove support for Databricks-9.1 ML LTS|
-|[#7856](https://github.com/NVIDIA/spark-rapids/pull/7856)|Update references to reduced dependencies pom [skip ci]|
-|[#7848](https://github.com/NVIDIA/spark-rapids/pull/7848)|Initialize only sql-plugin  to prevent missing submodule artifacts in buildall [skip ci]|
-|[#7839](https://github.com/NVIDIA/spark-rapids/pull/7839)|Add reduced pom to dist jar in the packaging phase|
-|[#7822](https://github.com/NVIDIA/spark-rapids/pull/7822)|Add in support for OOM retry|
-|[#7846](https://github.com/NVIDIA/spark-rapids/pull/7846)|Stop releasing semaphore in GpuUserDefinedFunction|
-|[#7840](https://github.com/NVIDIA/spark-rapids/pull/7840)|Execute mvn initialize before parallel build [skip ci]|
-|[#7222](https://github.com/NVIDIA/spark-rapids/pull/7222)|Automatic conversion to shimplified directory structure|
-|[#7824](https://github.com/NVIDIA/spark-rapids/pull/7824)|Use withRetryNoSplit in BasicWindowCalc|
-|[#7842](https://github.com/NVIDIA/spark-rapids/pull/7842)|Try fix broken blackduck scan [skip ci]|
-|[#7841](https://github.com/NVIDIA/spark-rapids/pull/7841)|Hardcode scan projects [skip ci]|
-|[#7830](https://github.com/NVIDIA/spark-rapids/pull/7830)|Fix buffer and Filter time with Parquet multithreaded combine reader|
-|[#7678](https://github.com/NVIDIA/spark-rapids/pull/7678)|Premerge CI to drop support for Databricks-9.1 ML LTS|
-|[#7823](https://github.com/NVIDIA/spark-rapids/pull/7823)|[BUG] Enable managed memory only if async allocator is not used|
-|[#7821](https://github.com/NVIDIA/spark-rapids/pull/7821)|Restore pandas import check in db113 runtime|
-|[#7810](https://github.com/NVIDIA/spark-rapids/pull/7810)|UnXfail large decimal window range queries|
-|[#7771](https://github.com/NVIDIA/spark-rapids/pull/7771)|Add withRetry and withRetryNoSplit and PoC with hash aggregate|
-|[#7815](https://github.com/NVIDIA/spark-rapids/pull/7815)|Fix the hyperlink to shimplify.py [skip ci]|
-|[#7812](https://github.com/NVIDIA/spark-rapids/pull/7812)|Fallback Delta Lake optimized writes if GPU cannot support partitioning|
-|[#7791](https://github.com/NVIDIA/spark-rapids/pull/7791)|Doc changes for new nested JSON reader [skip ci]|
-|[#7797](https://github.com/NVIDIA/spark-rapids/pull/7797)|Add GPU support for EphemeralSubstring|
-|[#7561](https://github.com/NVIDIA/spark-rapids/pull/7561)|Ant task to automatically convert to a simple shim layout|
-|[#7789](https://github.com/NVIDIA/spark-rapids/pull/7789)|Update script for integration tests on Databricks|
-|[#7798](https://github.com/NVIDIA/spark-rapids/pull/7798)|Do not error out DB IT test script when pytest code 5 [skip ci]|
-|[#7787](https://github.com/NVIDIA/spark-rapids/pull/7787)|Document a workaround to RuntimeException 'boom' [skip ci]|
-|[#7786](https://github.com/NVIDIA/spark-rapids/pull/7786)|Fix nested loop joins when there's no build-side columns|
-|[#7730](https://github.com/NVIDIA/spark-rapids/pull/7730)|[FEA] Switch to `regex_program` APIs|
-|[#7788](https://github.com/NVIDIA/spark-rapids/pull/7788)|Support released spark 3.3.2|
-|[#7095](https://github.com/NVIDIA/spark-rapids/pull/7095)|Fix the failure in `map_test.py` on Spark 3.4|
-|[#7769](https://github.com/NVIDIA/spark-rapids/pull/7769)|Fix issue where GpuSemaphore can throw NPE when logDebug is on|
-|[#7780](https://github.com/NVIDIA/spark-rapids/pull/7780)|Make AlluxioUtilsSuite pass for 340|
-|[#7772](https://github.com/NVIDIA/spark-rapids/pull/7772)|Fix cache test for Spark 3.3.2|
-|[#7717](https://github.com/NVIDIA/spark-rapids/pull/7717)|Move Databricks variables into blossom-lib|
-|[#7749](https://github.com/NVIDIA/spark-rapids/pull/7749)|Support Delta Lake optimized write on Databricks|
-|[#7696](https://github.com/NVIDIA/spark-rapids/pull/7696)|Create new version of  GpuBatchScanExec to fix Spark-3.4 build|
-|[#7747](https://github.com/NVIDIA/spark-rapids/pull/7747)|batched full join tracking batch does not need to be lazy|
-|[#7758](https://github.com/NVIDIA/spark-rapids/pull/7758)|Hardcode python 3.8 to be used in databricks runtime for cudf_udf ENV|
-|[#7716](https://github.com/NVIDIA/spark-rapids/pull/7716)|Clean the code of `GpuMetrics`|
-|[#7746](https://github.com/NVIDIA/spark-rapids/pull/7746)|Merge branch-23.02 into branch-23.04 [skip ci]|
-|[#7740](https://github.com/NVIDIA/spark-rapids/pull/7740)|Revert 7737 workaround for cudf setup in databricks 11.3 runtime [skip ci]|
-|[#7737](https://github.com/NVIDIA/spark-rapids/pull/7737)|Workaround for cudf setup in databricks 11.3 runtime|
-|[#7734](https://github.com/NVIDIA/spark-rapids/pull/7734)|Temporarily skip the test_parquet_read_ignore_missing on Databricks|
-|[#7728](https://github.com/NVIDIA/spark-rapids/pull/7728)|Fix estimatedNumBatches in case of OOM for Full Outer Join|
-|[#7718](https://github.com/NVIDIA/spark-rapids/pull/7718)|GpuParquetScan fails with NullPointerException during combining|
-|[#7712](https://github.com/NVIDIA/spark-rapids/pull/7712)|Enable Dynamic FIle Pruning on|
-|[#7702](https://github.com/NVIDIA/spark-rapids/pull/7702)|Merge 23.02 into 23.04|
-|[#7572](https://github.com/NVIDIA/spark-rapids/pull/7572)|Enables spillable/unspillable state for RapidsBuffer and allow buffer sharing|
-|[#7687](https://github.com/NVIDIA/spark-rapids/pull/7687)|Fix window tests for Spark-3.4|
-|[#7667](https://github.com/NVIDIA/spark-rapids/pull/7667)|Reenable tests originally bypassed for 3.4|
-|[#7542](https://github.com/NVIDIA/spark-rapids/pull/7542)|Support WriteFilesExec in Spark-3.4 to fix several tests|
-|[#7673](https://github.com/NVIDIA/spark-rapids/pull/7673)|Add missing spark shim test suites |
-|[#7655](https://github.com/NVIDIA/spark-rapids/pull/7655)|Fix Spark 3.4 build|
-|[#7621](https://github.com/NVIDIA/spark-rapids/pull/7621)|Document GNU sed for macOS auto-copyrighter users [skip ci]|
-|[#7618](https://github.com/NVIDIA/spark-rapids/pull/7618)|Update JNI to 23.04.0-SNAPSHOT and update new delta-stub ver to 23.04|
-|[#7541](https://github.com/NVIDIA/spark-rapids/pull/7541)|Init version 23.04.0-SNAPSHOT|
-
-## Release 23.02
+## Release 23.06
 
 ### Features
 |||
 |:---|:---|
-|[#6420](https://github.com/NVIDIA/spark-rapids/issues/6420)|[FEA]Support HiveTableScanExec to scan a Hive text table|
-|[#4897](https://github.com/NVIDIA/spark-rapids/issues/4897)|Profiling tool: create a section to focus on I/O metrics|
-|[#6419](https://github.com/NVIDIA/spark-rapids/issues/6419)|[FEA] Support write a Hive text table |
-|[#7280](https://github.com/NVIDIA/spark-rapids/issues/7280)|[FEA] Support UpdateCommand for Delta Lake|
-|[#7281](https://github.com/NVIDIA/spark-rapids/issues/7281)|[FEA] Support DeleteCommand for Delta Lake|
-|[#5272](https://github.com/NVIDIA/spark-rapids/issues/5272)|[FEA] Support from_json to get a MapType|
-|[#7007](https://github.com/NVIDIA/spark-rapids/issues/7007)|[FEA] Support Delta table MERGE INTO on Databricks.|
-|[#7521](https://github.com/NVIDIA/spark-rapids/issues/7521)|[FEA] Allow user to set concurrentGpuTasks after startup|
-|[#3300](https://github.com/NVIDIA/spark-rapids/issues/3300)|[FEA] Support batched full join|
-|[#6698](https://github.com/NVIDIA/spark-rapids/issues/6698)|[FEA] Support json_tuple|
-|[#6885](https://github.com/NVIDIA/spark-rapids/issues/6885)|[FEA] Support reverse|
-|[#6879](https://github.com/NVIDIA/spark-rapids/issues/6879)|[FEA] Support Databricks 11.3 ML LTS|
+|[#8079](https://github.com/NVIDIA/spark-rapids/issues/8079)|[FEA] Release Spark 3.4 Support|
+|[#8163](https://github.com/NVIDIA/spark-rapids/issues/8163)|[FEA] update release script and pipeline to support cuda12|
+|[#7043](https://github.com/NVIDIA/spark-rapids/issues/7043)|[FEA] Support Empty2Null expression on Spark 3.4.0|
+|[#8222](https://github.com/NVIDIA/spark-rapids/issues/8222)|[FEA] String Split Unsupported escaped character '.'|
+|[#8211](https://github.com/NVIDIA/spark-rapids/issues/8211)|[FEA] Add tencent blob store uri to spark rapids cloudScheme defaults|
+|[#4103](https://github.com/NVIDIA/spark-rapids/issues/4103)|[FEA] jdk17 support|
+|[#7094](https://github.com/NVIDIA/spark-rapids/issues/7094)|[FEA] Add a shim layer for Spark 3.2.4|
+|[#6202](https://github.com/NVIDIA/spark-rapids/issues/6202)|[SPARK-39528][SQL] Use V2 Filter in SupportsRuntimeFiltering|
+|[#6034](https://github.com/NVIDIA/spark-rapids/issues/6034)|[FEA] Support `offset` parameter in `TakeOrderedAndProject`|
+|[#1940](https://github.com/NVIDIA/spark-rapids/issues/1940)|[FEA] Spilling working batch of fixed length lazy explode|
+|[#8196](https://github.com/NVIDIA/spark-rapids/issues/8196)|[FEA] Add retry handling to GpuGenerateExec.fixedLenLazyArrayGenerate path|
+|[#7891](https://github.com/NVIDIA/spark-rapids/issues/7891)|[FEA] Support StddevSamp with cast(col as double)  for input|
+|[#62](https://github.com/NVIDIA/spark-rapids/issues/62)|[FEA] stddevsamp function|
+|[#7867](https://github.com/NVIDIA/spark-rapids/issues/7867)|[FEA] support json to struct function|
+|[#7883](https://github.com/NVIDIA/spark-rapids/issues/7883)|[FEA] support order by string in windowing function|
+|[#8188](https://github.com/NVIDIA/spark-rapids/issues/8188)|[FEA] Refactor shims to remove dependency from 340 to 330db for cast/try_cast|
+|[#7882](https://github.com/NVIDIA/spark-rapids/issues/7882)|[FEA] support StringTranslate function|
+|[#7843](https://github.com/NVIDIA/spark-rapids/issues/7843)|[FEA] build with CUDA 12|
+|[#8045](https://github.com/NVIDIA/spark-rapids/issues/8045)|[FEA] Support repetition in choice on regular expressions|
+|[#6882](https://github.com/NVIDIA/spark-rapids/issues/6882)|[FEA] Regular expressions - support line anchors in choice|
+|[#7901](https://github.com/NVIDIA/spark-rapids/issues/7901)|[FEA] better rlike function supported|
+|[#7784](https://github.com/NVIDIA/spark-rapids/issues/7784)|[FEA] Add Spark 3.3.3-SNAPSHOT to shims|
+|[#7260](https://github.com/NVIDIA/spark-rapids/issues/7260)|[FEA] Create a new Expression execution framework|
 
 ### Performance
 |||
 |:---|:---|
-|[#7436](https://github.com/NVIDIA/spark-rapids/issues/7436)|[FEA] Pruning partition columns supports cases of GPU file scan with CPU project and filter|
-|[#7219](https://github.com/NVIDIA/spark-rapids/issues/7219)|Improve performance of small file parquet reads from blobstores|
-|[#6807](https://github.com/NVIDIA/spark-rapids/issues/6807)|Improve the current documentation on RapidsShuffleManager|
-|[#5039](https://github.com/NVIDIA/spark-rapids/issues/5039)|[FEA] Parallelize shuffle compress/decompress with opportunistic idle task threads|
-|[#7196](https://github.com/NVIDIA/spark-rapids/issues/7196)|RegExpExtract does both extract and contains_re which is inefficient|
-|[#6862](https://github.com/NVIDIA/spark-rapids/issues/6862)|[FEA] GpuRowToColumnarExec for Binary is really slow compared to string|
+|[#7870](https://github.com/NVIDIA/spark-rapids/issues/7870)|[FEA] Turn on spark.rapids.sql.castDecimalToString.enabled by default|
+|[#7321](https://github.com/NVIDIA/spark-rapids/issues/7321)|[FEA] Improve performance of small file ORC reads from blobstores|
+|[#7672](https://github.com/NVIDIA/spark-rapids/issues/7672)|Make all buffers/columnar batches spillable by default|
 
 ### Bugs Fixed
 |||
 |:---|:---|
-|[#7069](https://github.com/NVIDIA/spark-rapids/issues/7069)|[BUG] GPU Hive Text Reader reads empty strings as null|
-|[#7068](https://github.com/NVIDIA/spark-rapids/issues/7068)|[BUG] GPU Hive Text Reader skips empty lines|
-|[#7448](https://github.com/NVIDIA/spark-rapids/issues/7448)|[BUG] GDS cufile test failed in elder cuda runtime|
-|[#7686](https://github.com/NVIDIA/spark-rapids/issues/7686)|[BUG] Large floating point values written as `Inf` not `Infinity` in Hive text writer|
-|[#7703](https://github.com/NVIDIA/spark-rapids/issues/7703)|[BUG] test_basic_hive_text_write fails|
-|[#7693](https://github.com/NVIDIA/spark-rapids/issues/7693)|[BUG] `test_partitioned_sql_parquet_write` fails on CDH|
-|[#7382](https://github.com/NVIDIA/spark-rapids/issues/7382)|[BUG] add dynamic partition overwrite tests for all formats|
-|[#7597](https://github.com/NVIDIA/spark-rapids/issues/7597)|[BUG] Incompatible timestamps in Hive delimited text writes|
-|[#7675](https://github.com/NVIDIA/spark-rapids/issues/7675)|[BUG] Multi-threaded shuffle bails with division-by-zero ArithmeticException|
-|[#7530](https://github.com/NVIDIA/spark-rapids/issues/7530)|[BUG] Add tests for RapidsShuffleManager|
-|[#7679](https://github.com/NVIDIA/spark-rapids/issues/7679)|[BUG] test_partitioned_parquet_write[PartitionWriteMode.Dynamic] failed in databricks runtimes|
-|[#7637](https://github.com/NVIDIA/spark-rapids/issues/7637)|[BUG] GpuBroadcastNestedLoopJoinExec:  Close called too many times|
-|[#7595](https://github.com/NVIDIA/spark-rapids/issues/7595)|[BUG] test_mod_mixed decimal test fails on 330db (Databricks 11.3) and TBD 340|
-|[#7575](https://github.com/NVIDIA/spark-rapids/issues/7575)|[BUG] On Databricks 11.3, Executor broadcast shuffles should stay on GPU even without columnar children |
-|[#7607](https://github.com/NVIDIA/spark-rapids/issues/7607)|[BUG] RegularExpressionTranspilerSuite exhibits multiple failures|
-|[#7574](https://github.com/NVIDIA/spark-rapids/issues/7574)|[BUG] simple json_tuple test failing with cudf error|
-|[#7446](https://github.com/NVIDIA/spark-rapids/issues/7446)|[BUG] prune_partition_column_test fails for Json in UCX CI|
-|[#7603](https://github.com/NVIDIA/spark-rapids/issues/7603)|[BUG] GpuIntervalUtilsTest leaks memory|
-|[#7090](https://github.com/NVIDIA/spark-rapids/issues/7090)|[BUG] Refactor line terminator handling code|
-|[#7472](https://github.com/NVIDIA/spark-rapids/issues/7472)|[BUG] The parquet chunked reader can fail for certain list cases.|
-|[#7560](https://github.com/NVIDIA/spark-rapids/issues/7560)|[BUG] Outstanding allocations detected at shutdown in python integration tests|
-|[#7516](https://github.com/NVIDIA/spark-rapids/issues/7516)|[BUG] multiple join cases cpu and gpu outputs mismatched in yarn|
-|[#7537](https://github.com/NVIDIA/spark-rapids/issues/7537)|[AUDIT] [SPARK-42039][SQL] SPJ: Remove Option in KeyGroupedPartitioning#partitionValuesOpt|
-|[#7535](https://github.com/NVIDIA/spark-rapids/issues/7535)|[BUG] Timestamp test cases failed due to Python time zone is not UTC|
-|[#7432](https://github.com/NVIDIA/spark-rapids/issues/7432)|[BUG][SPARK-41713][SPARK-41726] Spark 3.4 build fails.|
-|[#7517](https://github.com/NVIDIA/spark-rapids/issues/7517)|[DOC] doc/source of spark330db Shuffle Manager for Databricks-11.3 shim|
-|[#7505](https://github.com/NVIDIA/spark-rapids/issues/7505)|[BUG] Delta Lake writes with AQE can have unnecessary row transitions |
-|[#7454](https://github.com/NVIDIA/spark-rapids/issues/7454)|[BUG] Investigate binaryop.cpp:205: Unsupported operator for these types on Databricks 11.3|
-|[#7469](https://github.com/NVIDIA/spark-rapids/issues/7469)|[BUG] test_arrays_zip failures on nightly |
-|[#6894](https://github.com/NVIDIA/spark-rapids/issues/6894)|[BUG] Multithreaded rapids shuffle metrics incorrect|
-|[#7325](https://github.com/NVIDIA/spark-rapids/issues/7325)|[BUG] Fix integration test failures on Databricks-11.3|
-|[#7348](https://github.com/NVIDIA/spark-rapids/issues/7348)|[BUG] Fix integration tests for decimal type on db330 shim|
-|[#6978](https://github.com/NVIDIA/spark-rapids/issues/6978)|[BUG] NDS query 16 fails on EMR 6.8.0 with AQE enabled|
-|[#7133](https://github.com/NVIDIA/spark-rapids/issues/7133)|[BUG] Followup to AQE issues with reused columnar broadcast exchanges|
-|[#7208](https://github.com/NVIDIA/spark-rapids/issues/7208)|[BUG] Explicitly check if the platform is supported|
-|[#7397](https://github.com/NVIDIA/spark-rapids/issues/7397)|[BUG] shuffle smoke test hash_aggregate_test.py::test_hash_grpby_sum failed OOM intermittently in premerge|
-|[#7443](https://github.com/NVIDIA/spark-rapids/issues/7443)|[BUG] prune_partition_column_test fails for Avro|
-|[#7415](https://github.com/NVIDIA/spark-rapids/issues/7415)|[BUG] regex integration test failures on Databricks-11.3|
-|[#7226](https://github.com/NVIDIA/spark-rapids/issues/7226)|[BUG] GpuFileSourceScanExec always generates all partition columns|
-|[#7402](https://github.com/NVIDIA/spark-rapids/issues/7402)|[BUG] array_test.py::test_array_intersect failing cloudera|
-|[#7324](https://github.com/NVIDIA/spark-rapids/issues/7324)|[BUG] Support DayTimeIntervalType in Databricks-11.3 to fix integration tests|
-|[#7426](https://github.com/NVIDIA/spark-rapids/issues/7426)|[BUG] bloop compile times out on Databricks 11.3|
-|[#7328](https://github.com/NVIDIA/spark-rapids/issues/7328)|[BUG] Databricks-11.3 integration test failing due to IllegalStateException: the broadcast must be on the GPU too|
-|[#7327](https://github.com/NVIDIA/spark-rapids/issues/7327)|[BUG] Update Exception to fix Assertion error in Databricks-11.3 integration tests.|
-|[#7403](https://github.com/NVIDIA/spark-rapids/issues/7403)|[BUG] test_dynamic_partition_write_round_trip failed in CDH tests|
-|[#7368](https://github.com/NVIDIA/spark-rapids/issues/7368)|[BUG] with_hidden_metadata_fallback test failures on Databricks 11.3|
-|[#7400](https://github.com/NVIDIA/spark-rapids/issues/7400)|[BUG] parquet multithreaded combine reader can calculate size wrong|
-|[#7383](https://github.com/NVIDIA/spark-rapids/issues/7383)|[BUG] hive text partitioned reads using the `GpuHiveTableScanExec` are broken|
-|[#7350](https://github.com/NVIDIA/spark-rapids/issues/7350)|[BUG] test_conditional_with_side_effects_case_when fails|
-|[#7373](https://github.com/NVIDIA/spark-rapids/issues/7373)|[BUG] RapidsUDF does not support UDFs with no inputs|
-|[#7213](https://github.com/NVIDIA/spark-rapids/issues/7213)|[BUG] Parquet unsigned int scan test failure|
-|[#7344](https://github.com/NVIDIA/spark-rapids/issues/7344)|[BUG] Add PythonMapInArrowExec in 330db shim to fix integration test.|
-|[#7367](https://github.com/NVIDIA/spark-rapids/issues/7367)|[BUG] test_re_replace_repetition failed|
-|[#7345](https://github.com/NVIDIA/spark-rapids/issues/7345)|[BUG] Integration tests failing on Databricks-11.3 due to mixing of aggregations in HashAggregateExec and SortAggregateExec |
-|[#7378](https://github.com/NVIDIA/spark-rapids/issues/7378)|[BUG][ORC] `GpuInsertIntoHadoopFsRelationCommand` should use staging directory for dynamic partition overwrite|
-|[#7374](https://github.com/NVIDIA/spark-rapids/issues/7374)|[BUG] Hive reader does not always fall back to CPU when table contains nested types|
-|[#7284](https://github.com/NVIDIA/spark-rapids/issues/7284)|[BUG] Generated supported data source file is inaccurate for write data formats|
-|[#7347](https://github.com/NVIDIA/spark-rapids/issues/7347)|[BUG] Fix integration tests in Databricks-11.3 runtime by removing config spark.sql.ansi.strictIndexOperator|
-|[#7326](https://github.com/NVIDIA/spark-rapids/issues/7326)|[BUG] Support RoundCeil and RoundFloor on Databricks-11.3 shim to fix integration tests.|
-|[#7352](https://github.com/NVIDIA/spark-rapids/issues/7352)|[BUG] Databricks-11.3 IT failures - IllegalArgumentException: requirement failed for complexTypeExtractors|
-|[#6285](https://github.com/NVIDIA/spark-rapids/issues/6285)|[BUG] Add null values back to test_array_intersect for Spark 3.3+ and Databricks 10.4+|
-|[#7329](https://github.com/NVIDIA/spark-rapids/issues/7329)|[BUG] intermittently could not find ExecutedCommandExec in the GPU plan in delta_lake_write test|
-|[#7184](https://github.com/NVIDIA/spark-rapids/issues/7184)|[BUG] Fix integration test failures on Databricks 11.3|
-|[#7225](https://github.com/NVIDIA/spark-rapids/issues/7225)|[BUG] Partition columns mishandled when Parquet read is coalesced and chunked|
-|[#7303](https://github.com/NVIDIA/spark-rapids/issues/7303)|[BUG] Fix CPU fallback for custom timestamp formats in Hive delimited text|
-|[#7086](https://github.com/NVIDIA/spark-rapids/issues/7086)|[BUG] GPU Hive delimited text reader is more permissive than `LazySimpleSerDe` for timestamps|
-|[#7089](https://github.com/NVIDIA/spark-rapids/issues/7089)|[BUG] Reading invalid `DATE` strings yields exceptions instead of nulls|
-|[#6047](https://github.com/NVIDIA/spark-rapids/issues/6047)|[BUG] Look into field IDs when reading parquet using the native footer parser|
-|[#6989](https://github.com/NVIDIA/spark-rapids/issues/6989)|[BUG] Spark-3.4 - Integration test failures in array_test|
-|[#7122](https://github.com/NVIDIA/spark-rapids/issues/7122)|[BUG] Some tests of `limit_test` fail on Spark 3.4|
-|[#7144](https://github.com/NVIDIA/spark-rapids/issues/7144)|[BUG] Spark-3.4 integration test failures due to code update in FileFormatWriter.|
-|[#6915](https://github.com/NVIDIA/spark-rapids/issues/6915)|[BUG] Parquet of a binary decimal is not supported|
+|[#8483](https://github.com/NVIDIA/spark-rapids/issues/8483)|[BUG] `test_read_compressed_hive_text` fails on CDH|
+|[#8330](https://github.com/NVIDIA/spark-rapids/issues/8330)|[BUG] Handle Decimal128 computation with overflow of Remainder on Spark 3.4|
+|[#8448](https://github.com/NVIDIA/spark-rapids/issues/8448)|[BUG] GpuRegExpReplaceWithBackref with empty string input produces incorrect result on GPU in Spark 3.1.1|
+|[#8323](https://github.com/NVIDIA/spark-rapids/issues/8323)|[BUG] regexp_replace hangs with specific inputs and patterns|
+|[#8473](https://github.com/NVIDIA/spark-rapids/issues/8473)|[BUG] Complete aggregation with non-trivial grouping expression fails|
+|[#8440](https://github.com/NVIDIA/spark-rapids/issues/8440)|[BUG] the jar with scaladoc overwrites the jar with javadoc |
+|[#8469](https://github.com/NVIDIA/spark-rapids/issues/8469)|[BUG] Multi-threaded reader can't be toggled on/off|
+|[#8460](https://github.com/NVIDIA/spark-rapids/issues/8460)|[BUG] Compile failure on Databricks 11.3 with GpuHiveTableScanExec.scala|
+|[#8114](https://github.com/NVIDIA/spark-rapids/issues/8114)|[BUG] [AUDIT] [SPARK-42478] Make a serializable jobTrackerId instead of a non-serializable JobID in FileWriterFactory|
+|[#6786](https://github.com/NVIDIA/spark-rapids/issues/6786)|[BUG] NDS q95 fails with OOM at 10TB|
+|[#8419](https://github.com/NVIDIA/spark-rapids/issues/8419)|[BUG] Hive Text reader fails for GZIP compressed input|
+|[#8409](https://github.com/NVIDIA/spark-rapids/issues/8409)|[BUG] JVM agent crashed SIGFPE cudf::detail::repeat in integration tests|
+|[#8411](https://github.com/NVIDIA/spark-rapids/issues/8411)|[BUG] Close called too many times in Gpu json reader|
+|[#8400](https://github.com/NVIDIA/spark-rapids/issues/8400)|[BUG] Cloudera IT test failures - test_timesub_from_subquery|
+|[#8240](https://github.com/NVIDIA/spark-rapids/issues/8240)|[BUG] NDS power run hits GPU OOM on Databricks.|
+|[#8375](https://github.com/NVIDIA/spark-rapids/issues/8375)|[BUG] test_empty_filter[>] failed in 23.06 nightly|
+|[#8363](https://github.com/NVIDIA/spark-rapids/issues/8363)|[BUG] ORC reader NullPointerExecption|
+|[#8281](https://github.com/NVIDIA/spark-rapids/issues/8281)|[BUG] ParquetCachedBatchSerializer is crashing on count|
+|[#8331](https://github.com/NVIDIA/spark-rapids/issues/8331)|[BUG] Filter on dates with subquery results in ArrayIndexOutOfBoundsException|
+|[#8293](https://github.com/NVIDIA/spark-rapids/issues/8293)|[BUG] GpuTimeAdd throws UnsupportedOperationException takes column and interval as an argument only|
+|[#8161](https://github.com/NVIDIA/spark-rapids/issues/8161)|Add support for Remainder[DecimalType] for Spark 3.4 and DB 11.3|
+|[#8321](https://github.com/NVIDIA/spark-rapids/issues/8321)|[BUG] `test_read_hive_fixed_length_char` integ test fails on Spark 3.4|
+|[#8225](https://github.com/NVIDIA/spark-rapids/issues/8225)|[BUG] GpuGetArrayItem only supports ints as the ordinal.|
+|[#8294](https://github.com/NVIDIA/spark-rapids/issues/8294)|[BUG] ORC `CHAR(N)` columns written from Hive unreadable with RAPIDS plugin|
+|[#8186](https://github.com/NVIDIA/spark-rapids/issues/8186)|[BUG] integration test test_cast_nested can fail with non-empty nulls|
+|[#6190](https://github.com/NVIDIA/spark-rapids/issues/6190)|[SPARK-39731][SQL] Fix issue in CSV data sources when parsing dates in "yyyyMMdd" format with CORRECTED time parser policy|
+|[#8185](https://github.com/NVIDIA/spark-rapids/issues/8185)|[BUG] Scala Test md5 can produce non-empty nulls (merge and set validity)|
+|[#8235](https://github.com/NVIDIA/spark-rapids/issues/8235)|[BUG] Java agent crashed intermittently running integration tests|
+|[#7485](https://github.com/NVIDIA/spark-rapids/issues/7485)|[BUG] stop using mergeAndSetValidity for any nested type|
+|[#8263](https://github.com/NVIDIA/spark-rapids/issues/8263)|[BUG] Databricks 11.3 - Task failed while writing rows for Delta table -  java.lang.Integer cannot be cast to java.lang.Long|
+|[#7898](https://github.com/NVIDIA/spark-rapids/issues/7898)|Override `canonicalized` method to the Expressions|
+|[#8254](https://github.com/NVIDIA/spark-rapids/issues/8254)|[BUG] Unable to determine Databricks version in azure Databricks instances|
+|[#6967](https://github.com/NVIDIA/spark-rapids/issues/6967)|[BUG] Parquet List corner cases fail to be parsed|
+|[#6991](https://github.com/NVIDIA/spark-rapids/issues/6991)|[BUG] Integration test failures in Spark - 3.4 SNAPSHOT build|
+|[#7773](https://github.com/NVIDIA/spark-rapids/issues/7773)|[BUG] udf test failed cudf-py 23.04 ENV setup on databricks 11.3 runtime|
+|[#7934](https://github.com/NVIDIA/spark-rapids/issues/7934)|[BUG] User app fails with OOM - GpuOutOfCoreSortIterator|
+|[#8214](https://github.com/NVIDIA/spark-rapids/issues/8214)|[BUG] Exception when counting rows in an ORC file that has no column names|
+|[#8160](https://github.com/NVIDIA/spark-rapids/issues/8160)|[BUG] Arithmetic_ops_test failure for Spark 3.4|
+|[#7495](https://github.com/NVIDIA/spark-rapids/issues/7495)|Update GpuDataSource to match the change in Spark 3.4|
+|[#8189](https://github.com/NVIDIA/spark-rapids/issues/8189)|[BUG] test_array_element_at_zero_index_fail test failures in Spark 3.4 |
+|[#8043](https://github.com/NVIDIA/spark-rapids/issues/8043)|[BUG] Host memory leak in SerializedBatchIterator|
+|[#8194](https://github.com/NVIDIA/spark-rapids/issues/8194)|[BUG] JVM agent crash intermittently in CI integration test |
+|[#6182](https://github.com/NVIDIA/spark-rapids/issues/6182)|[SPARK-39319][CORE][SQL] Make query contexts as a part of `SparkThrowable`|
+|[#7491](https://github.com/NVIDIA/spark-rapids/issues/7491)|[AUDIT][SPARK-41448][SQL] Make consistent MR job IDs in FileBatchWriter and FileFormatWriter|
+|[#8149](https://github.com/NVIDIA/spark-rapids/issues/8149)|[BUG] dataproc init script does not fail clearly with newer versions of CUDA|
+|[#7624](https://github.com/NVIDIA/spark-rapids/issues/7624)|[BUG] `test_parquet_write_encryption_option_fallback` failed|
+|[#8019](https://github.com/NVIDIA/spark-rapids/issues/8019)|[BUG] Spark-3.4 - Integration test failures due to GpuCreateDataSourceTableAsSelectCommand|
+|[#8017](https://github.com/NVIDIA/spark-rapids/issues/8017)|[BUG]Spark-3.4 Integration tests failure  due to InsertIntoHadoopFsRelationCommand not running on GPU|
+|[#7492](https://github.com/NVIDIA/spark-rapids/issues/7492)|[AUDIT][SPARK-41468][SQL][FOLLOWUP] Handle NamedLambdaVariables in EquivalentExpressions|
+|[#6987](https://github.com/NVIDIA/spark-rapids/issues/6987)|[BUG] Unit Test failures in Spark-3.4 SNAPSHOT build|
+|[#8171](https://github.com/NVIDIA/spark-rapids/issues/8171)|[BUG] ORC read failure when reading decimals with different precision/scale from write schema|
+|[#7216](https://github.com/NVIDIA/spark-rapids/issues/7216)|[BUG] The PCBS tests fail on Spark 340|
+|[#8016](https://github.com/NVIDIA/spark-rapids/issues/8016)|[BUG] Spark-3.4 -  Integration tests failure due to missing InsertIntoHiveTable operator in GPU |
+|[#8166](https://github.com/NVIDIA/spark-rapids/issues/8166)|Databricks Delta defaults to LEGACY for int96RebaseModeInWrite|
+|[#8147](https://github.com/NVIDIA/spark-rapids/issues/8147)|[BUG] test_substring_column failed|
+|[#8164](https://github.com/NVIDIA/spark-rapids/issues/8164)|[BUG] failed AnsiCastShim build in datasbricks 11.3 runtime|
+|[#7757](https://github.com/NVIDIA/spark-rapids/issues/7757)|[BUG] Unit tests failure in AnsiCastOpSuite on Spark-3.4|
+|[#7756](https://github.com/NVIDIA/spark-rapids/issues/7756)|[BUG] Unit test failure in AdaptiveQueryExecSuite on Spark-3.4|
+|[#8153](https://github.com/NVIDIA/spark-rapids/issues/8153)|[BUG] `get-shim-versions-from-dist` workflow failing in CI|
+|[#7961](https://github.com/NVIDIA/spark-rapids/issues/7961)|[BUG] understand why unspill can throw an OutOfMemoryError and not a RetryOOM|
+|[#7755](https://github.com/NVIDIA/spark-rapids/issues/7755)|[BUG] Unit tests  failures in WindowFunctionSuite and CostBasedOptimizerSuite on Spark-3.4|
+|[#7752](https://github.com/NVIDIA/spark-rapids/issues/7752)|[BUG] Test in CastOpSuite fails on Spark-3.4|
+|[#7754](https://github.com/NVIDIA/spark-rapids/issues/7754)|[BUG]  unit test `nz timestamp` fails on Spark-3.4|
+|[#7018](https://github.com/NVIDIA/spark-rapids/issues/7018)|[BUG] The unit test `sorted partitioned write` fails on Spark 3.4|
+|[#8015](https://github.com/NVIDIA/spark-rapids/issues/8015)|[BUG] Spark 3.4 - Integration tests failure due to unsupported KnownNullable operator in Window|
+|[#7751](https://github.com/NVIDIA/spark-rapids/issues/7751)|[BUG]  Unit test `Write encrypted ORC fallback` fails on Spark-3.4|
+|[#8117](https://github.com/NVIDIA/spark-rapids/issues/8117)|[BUG] Compile error in RapidsErrorUtils when building against Spark 3.4.0 release |
+|[#5659](https://github.com/NVIDIA/spark-rapids/issues/5659)|[BUG] Minimize false positives when falling back to CPU for end of line/string anchors and newlines|
+|[#8012](https://github.com/NVIDIA/spark-rapids/issues/8012)|[BUG] Integration tests failing due to CreateDataSourceTableAsSelectCommand in Spark-3.4|
+|[#8061](https://github.com/NVIDIA/spark-rapids/issues/8061)|[BUG] join_test failed in integration tests|
+|[#8018](https://github.com/NVIDIA/spark-rapids/issues/8018)|[BUG] Spark-3.4 - Integration test failures in window aggregations for decimal types|
+|[#7581](https://github.com/NVIDIA/spark-rapids/issues/7581)|[BUG] INC AFTER CLOSE for ColumnVector during shutdown in the join code|
 
 ### PRs
 |||
 |:---|:---|
-|[#7763](https://github.com/NVIDIA/spark-rapids/pull/7763)|23.02 changelog update 2/14 [skip ci]|
-|[#7761](https://github.com/NVIDIA/spark-rapids/pull/7761)|[Doc] remove xgboost demo from aws-emr doc due to nccl issue [skip ci]|
-|[#7760](https://github.com/NVIDIA/spark-rapids/pull/7760)|Add notice in gds to install cuda 11.8 [skip ci]|
-|[#7570](https://github.com/NVIDIA/spark-rapids/pull/7570)|[Doc] 23.02 doc updates [skip ci]|
-|[#7735](https://github.com/NVIDIA/spark-rapids/pull/7735)|Update JNI version to released 23.02.0|
-|[#7721](https://github.com/NVIDIA/spark-rapids/pull/7721)|Fix issue where UCX mode was trying to use catalog from the driver|
-|[#7713](https://github.com/NVIDIA/spark-rapids/pull/7713)|Workaround for incompatible serialization for `Inf` floats in Hive text write|
-|[#7700](https://github.com/NVIDIA/spark-rapids/pull/7700)|Init 23.02 changelog and move 22 changelog to archives [skip ci]|
-|[#7708](https://github.com/NVIDIA/spark-rapids/pull/7708)|Set Hive write test to ignore order on verification.|
-|[#7697](https://github.com/NVIDIA/spark-rapids/pull/7697)|Disable Dynamic partitioning tests on CDH|
-|[#7556](https://github.com/NVIDIA/spark-rapids/pull/7556)|Write support for Hive delimited text tables|
-|[#7681](https://github.com/NVIDIA/spark-rapids/pull/7681)|Disable Hive delimited text reader tests for CDH.|
-|[#7610](https://github.com/NVIDIA/spark-rapids/pull/7610)|Add multithreaded Shuffle test|
-|[#7652](https://github.com/NVIDIA/spark-rapids/pull/7652)|Support Delta Lake UpdateCommand|
-|[#7680](https://github.com/NVIDIA/spark-rapids/pull/7680)|Fix Parquet dynamic partition test for|
-|[#7653](https://github.com/NVIDIA/spark-rapids/pull/7653)|Add dynamic partitioning test for Parquet writer.|
-|[#7576](https://github.com/NVIDIA/spark-rapids/pull/7576)|Support EXECUTOR_BROADCAST on Databricks 11.3 in BroadcastNestedLoopJoin|
-|[#7620](https://github.com/NVIDIA/spark-rapids/pull/7620)|Support Delta Lake DeleteCommand|
-|[#7638](https://github.com/NVIDIA/spark-rapids/pull/7638)|Update UCX docs to call out Ubuntu 22.04 is not supported yet [skip ci]|
-|[#7644](https://github.com/NVIDIA/spark-rapids/pull/7644)|Create a new ColumnarBatch from the broadcast when LazySpillable takes ownership|
-|[#7632](https://github.com/NVIDIA/spark-rapids/pull/7632)|Update UCX shuffle doc w/ memlock limit config [skip ci]|
-|[#7628](https://github.com/NVIDIA/spark-rapids/pull/7628)|Disable HiveTextReaders for CDH due to NVIDIA#7423|
-|[#7633](https://github.com/NVIDIA/spark-rapids/pull/7633)|Bump up add-to-project version to 0.4.0 [skip ci]|
-|[#7609](https://github.com/NVIDIA/spark-rapids/pull/7609)|Fallback to CPU for mod only for DB11.3 [Databricks]|
-|[#7591](https://github.com/NVIDIA/spark-rapids/pull/7591)|Prevent fixup of GpuShuffleExchangeExec when using EXECUTOR_BROADCAST|
-|[#7626](https://github.com/NVIDIA/spark-rapids/pull/7626)|Revert "Skip/xfail some regexp tests (#7608)"|
-|[#7598](https://github.com/NVIDIA/spark-rapids/pull/7598)|Disable decimal `pmod` due to #7553|
-|[#7571](https://github.com/NVIDIA/spark-rapids/pull/7571)|Refact deploy script to support gpg and nvsec signature [skip ci]|
-|[#7590](https://github.com/NVIDIA/spark-rapids/pull/7590)|Fix `json_tuple` cudf error and java array out-of-bound issue|
-|[#7604](https://github.com/NVIDIA/spark-rapids/pull/7604)|Fix memory leak in GpuIntervalUtilsTest|
-|[#7600](https://github.com/NVIDIA/spark-rapids/pull/7600)|Centralize source-related properties in parent pom for consistent usage in submodules|
-|[#7608](https://github.com/NVIDIA/spark-rapids/pull/7608)|Skip/xfail some regexp tests|
-|[#7211](https://github.com/NVIDIA/spark-rapids/pull/7211)|Fix regressions related to cuDF changes in handline of end-of-line/string anchors|
-|[#7596](https://github.com/NVIDIA/spark-rapids/pull/7596)|Fix deprecation warnings|
-|[#7578](https://github.com/NVIDIA/spark-rapids/pull/7578)|Fix double close on exception in GpuCoalesceBatches|
-|[#7584](https://github.com/NVIDIA/spark-rapids/pull/7584)|Write test for multithreaded combine wrong buffer size bug |
-|[#7580](https://github.com/NVIDIA/spark-rapids/pull/7580)|Support Delta Lake MergeIntoCommand|
-|[#7554](https://github.com/NVIDIA/spark-rapids/pull/7554)|Add mixed decimal testing for binary arithmetic ops|
-|[#7567](https://github.com/NVIDIA/spark-rapids/pull/7567)|Fix a small leak in generate|
-|[#7563](https://github.com/NVIDIA/spark-rapids/pull/7563)|Add patched Hive Metastore Client jar to  deps|
-|[#7533](https://github.com/NVIDIA/spark-rapids/pull/7533)|Support EXECUTOR_BROADCAST on Databricks 11.3 in BroadcastHashJoin|
-|[#7532](https://github.com/NVIDIA/spark-rapids/pull/7532)|Update Databricks docs to add a limitation against DB 11.3 [skip ci]|
-|[#7555](https://github.com/NVIDIA/spark-rapids/pull/7555)|Fix case where tracking batch is never updated in batched full join|
-|[#7547](https://github.com/NVIDIA/spark-rapids/pull/7547)|Refactor Delta Lake code to handle multiple versions per Spark version|
-|[#7513](https://github.com/NVIDIA/spark-rapids/pull/7513)|Remove usage to `ColumnView.repeatStringsSizes`|
-|[#7538](https://github.com/NVIDIA/spark-rapids/pull/7538)|Fix Spark 340 build error due to change in KeyGroupedPartitioning|
-|[#7549](https://github.com/NVIDIA/spark-rapids/pull/7549)|Remove unused Maven property shim.module.name|
-|[#7548](https://github.com/NVIDIA/spark-rapids/pull/7548)|Make RapidsBufferHandle AutoCloseable to prevent extra attempts to remove buffers|
-|[#7499](https://github.com/NVIDIA/spark-rapids/pull/7499)|README.md for auditing purposes [skip ci]|
-|[#7512](https://github.com/NVIDIA/spark-rapids/pull/7512)|Adds RapidsBufferHandle as an indirection layer to RapidsBufferId|
-|[#7527](https://github.com/NVIDIA/spark-rapids/pull/7527)|Allow concurrentGpuTasks to be set per job|
-|[#7539](https://github.com/NVIDIA/spark-rapids/pull/7539)|Enable automerge from 23.02 to 23.04 [skip ci]|
-|[#7536](https://github.com/NVIDIA/spark-rapids/pull/7536)|Fix datetime out-of-range error in pytest when timezone is not UTC|
-|[#7502](https://github.com/NVIDIA/spark-rapids/pull/7502)|Fix Spark 3.4 build errors|
-|[#7522](https://github.com/NVIDIA/spark-rapids/pull/7522)|Update docs and add Rapids shuffle manager for Databricks-11.3|
-|[#7507](https://github.com/NVIDIA/spark-rapids/pull/7507)|Fallback to CPU for unrecognized Distributions|
-|[#7515](https://github.com/NVIDIA/spark-rapids/pull/7515)|Fix leak in GpuHiveTableScanExec|
-|[#7504](https://github.com/NVIDIA/spark-rapids/pull/7504)|Align CI test scripts with new init scripts for Databricks [skip ci]|
-|[#7506](https://github.com/NVIDIA/spark-rapids/pull/7506)|Add RapidsDeltaWrite node to fix undesired transitions with AQE|
-|[#7414](https://github.com/NVIDIA/spark-rapids/pull/7414)|batched full hash join|
-|[#7509](https://github.com/NVIDIA/spark-rapids/pull/7509)|Fix json_test.py imports|
-|[#7269](https://github.com/NVIDIA/spark-rapids/pull/7269)|Add hadoop-def.sh to support multiple spark release tarballs|
-|[#7494](https://github.com/NVIDIA/spark-rapids/pull/7494)|Implement a simplified version of `from_json`|
-|[#7434](https://github.com/NVIDIA/spark-rapids/pull/7434)|Support `json_tuple`|
-|[#7489](https://github.com/NVIDIA/spark-rapids/pull/7489)|Remove the MIT license from tools jar[skip ci]|
-|[#7497](https://github.com/NVIDIA/spark-rapids/pull/7497)|Inserting multiple times to HashedPriorityQueue should not corrupt the heap|
-|[#7475](https://github.com/NVIDIA/spark-rapids/pull/7475)|Inject GpuCast for decimal AddSub when operands' precision/scale differ on 340, 330db|
-|[#7486](https://github.com/NVIDIA/spark-rapids/pull/7486)|Allow Shims to replace Hive execs|
-|[#7484](https://github.com/NVIDIA/spark-rapids/pull/7484)|Fix arrays_zip to not rely on broken segmented gather|
-|[#7460](https://github.com/NVIDIA/spark-rapids/pull/7460)|More cases support partition column pruning|
-|[#7462](https://github.com/NVIDIA/spark-rapids/pull/7462)|Changing metric component counters to avoid extraneous accruals|
-|[#7467](https://github.com/NVIDIA/spark-rapids/pull/7467)|Remove spark2-sql-plugin|
-|[#7474](https://github.com/NVIDIA/spark-rapids/pull/7474)|xfail array zip tests|
-|[#7464](https://github.com/NVIDIA/spark-rapids/pull/7464)|Enable integration tests against Databricks 11.3 in premerge|
-|[#7455](https://github.com/NVIDIA/spark-rapids/pull/7455)|Use GpuAlias when handling Empty2Null in GpuOptimisticTransaction|
-|[#7456](https://github.com/NVIDIA/spark-rapids/pull/7456)|Sort Delta log objects when comparing and avoid caching all logs|
-|[#7431](https://github.com/NVIDIA/spark-rapids/pull/7431)|Remove release script of spark-rapids/tools [skip ci]|
-|[#7421](https://github.com/NVIDIA/spark-rapids/pull/7421)|Remove spark-rapids/tools|
-|[#7418](https://github.com/NVIDIA/spark-rapids/pull/7418)|Fix for AQE+DPP issue on AWS EMR|
-|[#7444](https://github.com/NVIDIA/spark-rapids/pull/7444)|Explicitly check if the platform is supported|
-|[#7417](https://github.com/NVIDIA/spark-rapids/pull/7417)|Make cudf-udf tests runnable on Databricks 11.3|
-|[#7420](https://github.com/NVIDIA/spark-rapids/pull/7420)|Ubuntu build&test images default as 20.04|
-|[#7442](https://github.com/NVIDIA/spark-rapids/pull/7442)|Fix parsing of Delta Lake logs containing multi-line JSON records|
-|[#7438](https://github.com/NVIDIA/spark-rapids/pull/7438)|Add documentation for runnable command enable configs|
-|[#7439](https://github.com/NVIDIA/spark-rapids/pull/7439)|Suppress unknown RunnableCommand warnings by default|
-|[#7346](https://github.com/NVIDIA/spark-rapids/pull/7346)|[Doc]revert the changes in FAQ for deltalake table support[skip ci]|
-|[#7413](https://github.com/NVIDIA/spark-rapids/pull/7413)|[Doc]update getting started doc for EMR and databricks[skip ci]|
-|[#7445](https://github.com/NVIDIA/spark-rapids/pull/7445)|Support pruning partition columns for avro file scan|
-|[#7447](https://github.com/NVIDIA/spark-rapids/pull/7447)|Xfail the test of pruning partition column for json read|
-|[#7440](https://github.com/NVIDIA/spark-rapids/pull/7440)|Xfail largest decimals window aggregation|
-|[#7437](https://github.com/NVIDIA/spark-rapids/pull/7437)|Fix the regexp test failures on DB11.3|
-|[#7428](https://github.com/NVIDIA/spark-rapids/pull/7428)|Support pruning partition columns for GpuFileSourceScan|
-|[#7435](https://github.com/NVIDIA/spark-rapids/pull/7435)|Update IntelliJ IDEA doc [skip ci]|
-|[#7416](https://github.com/NVIDIA/spark-rapids/pull/7416)|Reorganize and shim ScanExecMeta overrides and fix interval file IO|
-|[#7427](https://github.com/NVIDIA/spark-rapids/pull/7427)|Install-file log4j-core on Databricks 11.3|
-|[#7424](https://github.com/NVIDIA/spark-rapids/pull/7424)|xfail Hive text tests failing on CDH|
-|[#7408](https://github.com/NVIDIA/spark-rapids/pull/7408)|Fallback to CPU for unrecognized ShuffleOrigin|
-|[#7422](https://github.com/NVIDIA/spark-rapids/pull/7422)|Skip test_dynamic_partition_write_round_trip in 321cdh|
-|[#7406](https://github.com/NVIDIA/spark-rapids/pull/7406)|Fix array_test.py::test_array_intersect for cloudera spark330|
-|[#6761](https://github.com/NVIDIA/spark-rapids/pull/6761)|Switch string to float casting to use new kernel|
-|[#7411](https://github.com/NVIDIA/spark-rapids/pull/7411)|Skip Int division test that causes scale less than precision|
-|[#7410](https://github.com/NVIDIA/spark-rapids/pull/7410)|Remove 314 from dist build list|
-|[#7412](https://github.com/NVIDIA/spark-rapids/pull/7412)|Fix the `with_hidden_metadata_fallback` test failures on DB11.3|
-|[#7362](https://github.com/NVIDIA/spark-rapids/pull/7362)|Fix multiplication and division test failures in 330db and 340 shim|
-|[#7405](https://github.com/NVIDIA/spark-rapids/pull/7405)|Fix multithreaded combine code initial size calculation|
-|[#7395](https://github.com/NVIDIA/spark-rapids/pull/7395)|Enable Delta Lake write acceleration by default|
-|[#7384](https://github.com/NVIDIA/spark-rapids/pull/7384)|Fix implementation of createReadRDDForDirectories to match DataSource…|
-|[#7391](https://github.com/NVIDIA/spark-rapids/pull/7391)|Exclude GDS test suite as default|
-|[#7390](https://github.com/NVIDIA/spark-rapids/pull/7390)|Aggregate Databricks 11.3 shim in the nightly dist jar|
-|[#7381](https://github.com/NVIDIA/spark-rapids/pull/7381)|Filter out some new timestamp-related Delta Lake tags when comparing logs|
-|[#7371](https://github.com/NVIDIA/spark-rapids/pull/7371)|Avoid shutting down RMM until all allocations have cleared|
-|[#7377](https://github.com/NVIDIA/spark-rapids/pull/7377)|Update RapidsUDF interface to support UDFs with no input parameters|
-|[#7388](https://github.com/NVIDIA/spark-rapids/pull/7388)|Fix `test_array_element_at_zero_index_fail` and `test_div_overflow_exception_when_ansi` DB 11.3 integration test failures|
-|[#7380](https://github.com/NVIDIA/spark-rapids/pull/7380)|[FEA] Support `reverse` for arrays|
-|[#7365](https://github.com/NVIDIA/spark-rapids/pull/7365)|Move PythonMapInArrowExec to shim for shared 330+ functionality (db11.3)|
-|[#7372](https://github.com/NVIDIA/spark-rapids/pull/7372)|Fix for incorrect nested-unsigned test|
-|[#7386](https://github.com/NVIDIA/spark-rapids/pull/7386)|Spark 3.1.4 snapshot fix setting of reproduceEmptyStringBug|
-|[#7385](https://github.com/NVIDIA/spark-rapids/pull/7385)|Fix Databricks version comparison in pytests|
-|[#7379](https://github.com/NVIDIA/spark-rapids/pull/7379)|Fixes bug where dynamic partition overwrite mode didn't work for ORC|
-|[#7370](https://github.com/NVIDIA/spark-rapids/pull/7370)|Fix non file read DayTimeInterval errors|
-|[#7375](https://github.com/NVIDIA/spark-rapids/pull/7375)|Fix CPU fallback for GpuHiveTableScanExec|
-|[#7355](https://github.com/NVIDIA/spark-rapids/pull/7355)|Fix Add and Subtract test failures in 330db and 340 shim|
-|[#7299](https://github.com/NVIDIA/spark-rapids/pull/7299)|Qualification tool: Update parsing of write data format|
-|[#7357](https://github.com/NVIDIA/spark-rapids/pull/7357)|Update the integration tests  to fit the removed config ` spark.sql.ansi.strictIndexOperator` in DB11.3 and Spark 3.4|
-|[#7369](https://github.com/NVIDIA/spark-rapids/pull/7369)|Re-enable some tests in ParseDateTimeSuite|
-|[#7366](https://github.com/NVIDIA/spark-rapids/pull/7366)|Support Databricks 11.3|
-|[#7354](https://github.com/NVIDIA/spark-rapids/pull/7354)|Fix arithmetic error messages in 330db, 340 shims|
-|[#7364](https://github.com/NVIDIA/spark-rapids/pull/7364)|Move Rounding ops to shim for 330+ (db11.3)|
-|[#7298](https://github.com/NVIDIA/spark-rapids/pull/7298)|Improve performance of small file parquet reads from blob stores|
-|[#7363](https://github.com/NVIDIA/spark-rapids/pull/7363)|Fix ExtractValue assertion with 330db shim|
-|[#7340](https://github.com/NVIDIA/spark-rapids/pull/7340)|Fix nested-unsigned test issues.|
-|[#7358](https://github.com/NVIDIA/spark-rapids/pull/7358)|Update Delta version to 1.1.0|
-|[#7301](https://github.com/NVIDIA/spark-rapids/pull/7301)|Add null values back to test_array_intersect for Spark 3.3.1+ and Databricks 10.4+|
-|[#7152](https://github.com/NVIDIA/spark-rapids/pull/7152)|Add a shim for Databricks 11.3 spark330db|
-|[#7333](https://github.com/NVIDIA/spark-rapids/pull/7333)|Avoid row number computation when the partition schema is empty|
-|[#7317](https://github.com/NVIDIA/spark-rapids/pull/7317)|Make multi-threaded shuffle not experimental and update docs|
-|[#7342](https://github.com/NVIDIA/spark-rapids/pull/7342)|Update plan capture listener to handle multiple plans per query.|
-|[#7338](https://github.com/NVIDIA/spark-rapids/pull/7338)|Fix auto merge conflict 7336 [skip ci]|
-|[#7335](https://github.com/NVIDIA/spark-rapids/pull/7335)|Fix auto merge conflict 7334[skip ci]|
-|[#7312](https://github.com/NVIDIA/spark-rapids/pull/7312)|Fix documentation bug|
-|[#7315](https://github.com/NVIDIA/spark-rapids/pull/7315)|Fix merge conflict with branch-22.12|
-|[#7296](https://github.com/NVIDIA/spark-rapids/pull/7296)|Enable hive text reads by default|
-|[#7304](https://github.com/NVIDIA/spark-rapids/pull/7304)|Correct partition columns handling for coalesced and chunked read|
-|[#7305](https://github.com/NVIDIA/spark-rapids/pull/7305)|Fix CPU fallback for custom timestamp formats in Hive text tables|
-|[#7293](https://github.com/NVIDIA/spark-rapids/pull/7293)|Refine '$LOCAL_JAR_PATH' as optional for integration test on databricks [skip ci]|
-|[#7285](https://github.com/NVIDIA/spark-rapids/pull/7285)|[FEA] Support `reverse` for strings|
-|[#7297](https://github.com/NVIDIA/spark-rapids/pull/7297)|Remove Decimal Support Section from compatibility docs [skip ci]|
-|[#7291](https://github.com/NVIDIA/spark-rapids/pull/7291)|Improve IntelliJ IDEA doc and usability|
-|[#7245](https://github.com/NVIDIA/spark-rapids/pull/7245)|Fix boolean, int, and float parsing. Improve decimal parsing for hive|
-|[#7265](https://github.com/NVIDIA/spark-rapids/pull/7265)|Fix Hive Delimited Text timestamp parsing|
-|[#7221](https://github.com/NVIDIA/spark-rapids/pull/7221)|Fix date parsing in Hive Delimited Text reader|
-|[#7287](https://github.com/NVIDIA/spark-rapids/pull/7287)|Don't use native parquet footer parser if field ids for read are needed|
-|[#7262](https://github.com/NVIDIA/spark-rapids/pull/7262)|Moving generated files to standalone tools dir|
-|[#7268](https://github.com/NVIDIA/spark-rapids/pull/7268)|Remove deprecated compatibility support in premerge|
-|[#7248](https://github.com/NVIDIA/spark-rapids/pull/7248)|Fix AlluxioUtilsSuite build on Databricks|
-|[#7207](https://github.com/NVIDIA/spark-rapids/pull/7207)|Change the hive text file parser to not use CSV input format|
-|[#7209](https://github.com/NVIDIA/spark-rapids/pull/7209)|Change RegExpExtract to use isNull checks instead of contains_re|
-|[#7212](https://github.com/NVIDIA/spark-rapids/pull/7212)|Removing common module and adding common files to sql-plugin|
-|[#7202](https://github.com/NVIDIA/spark-rapids/pull/7202)|Avoid sort in v1 write for static columns|
-|[#7167](https://github.com/NVIDIA/spark-rapids/pull/7167)|Handle two changes related to `FileFormatWriter` since Spark 340|
-|[#7194](https://github.com/NVIDIA/spark-rapids/pull/7194)|Skip tests that fail due to recent cuDF changes related to end of string/line anchors|
-|[#7170](https://github.com/NVIDIA/spark-rapids/pull/7170)|Fix the `limit_test` failures on Spark 3.4|
-|[#7075](https://github.com/NVIDIA/spark-rapids/pull/7075)|Fix the failure of `test_array_element_at_zero_index_fail` on Spark3.4|
-|[#7126](https://github.com/NVIDIA/spark-rapids/pull/7126)|Fix support for binary encoded decimal for parquet|
-|[#7113](https://github.com/NVIDIA/spark-rapids/pull/7113)|Use an improved API for appending binary to host vector|
-|[#7130](https://github.com/NVIDIA/spark-rapids/pull/7130)|Enable chunked parquet reads by default|
-|[#7074](https://github.com/NVIDIA/spark-rapids/pull/7074)|Update JNI and cudf-py version to 23.02|
-|[#7063](https://github.com/NVIDIA/spark-rapids/pull/7063)|Init version 23.02.0|
+|[#8441](https://github.com/NVIDIA/spark-rapids/pull/8441)|Memoizing DataGens in integration tests|
+|[#8516](https://github.com/NVIDIA/spark-rapids/pull/8516)|Avoid calling Table.merge with BinaryType columns|
+|[#8515](https://github.com/NVIDIA/spark-rapids/pull/8515)|Fix warning about deprecated parquet config|
+|[#8427](https://github.com/NVIDIA/spark-rapids/pull/8427)|[Doc] address Spark RAPIDS NVAIE VDR issues [skip ci]|
+|[#8486](https://github.com/NVIDIA/spark-rapids/pull/8486)|Move task completion listener registration to after variables are initialized|
+|[#8481](https://github.com/NVIDIA/spark-rapids/pull/8481)|Removed spark.rapids.sql.castDecimalToString.enabled and enabled GPU decimal to string by default|
+|[#8485](https://github.com/NVIDIA/spark-rapids/pull/8485)|Disable `test_read_compressed_hive_text` on CDH.|
+|[#8488](https://github.com/NVIDIA/spark-rapids/pull/8488)|Adds note on multi-threaded shuffle targetting <= 200 partitions and on TCP keep-alive for UCX [skip ci]|
+|[#8414](https://github.com/NVIDIA/spark-rapids/pull/8414)|Add support for computing remainder with Decimal128 operands with more precision on Spark 3.4|
+|[#8433](https://github.com/NVIDIA/spark-rapids/pull/8433)|Add regression test for regexp_replace hanging with some inputs|
+|[#8477](https://github.com/NVIDIA/spark-rapids/pull/8477)|Fix input binding of grouping expressions for complete aggregations|
+|[#8464](https://github.com/NVIDIA/spark-rapids/pull/8464)|Remove NOP Maven javadoc plugin definition|
+|[#8402](https://github.com/NVIDIA/spark-rapids/pull/8402)|Bring back UCX 1.14|
+|[#8470](https://github.com/NVIDIA/spark-rapids/pull/8470)|Ensure the MT shuffle reader enables/disables with spark.rapids.shuff…|
+|[#8462](https://github.com/NVIDIA/spark-rapids/pull/8462)|Fix compressed Hive text read on|
+|[#8458](https://github.com/NVIDIA/spark-rapids/pull/8458)|Add check for negative id when creating new MR job id|
+|[#8437](https://github.com/NVIDIA/spark-rapids/pull/8437)|Implement the bug fix for SPARK-41448 and shim it for Spark 3.2.4 and Spark 3.3.{2,3}|
+|[#8420](https://github.com/NVIDIA/spark-rapids/pull/8420)|Fix reads for GZIP compressed Hive Text.|
+|[#8445](https://github.com/NVIDIA/spark-rapids/pull/8445)|Document errors/warns in the logs during catalog shutdown [skip ci]|
+|[#8438](https://github.com/NVIDIA/spark-rapids/pull/8438)|Revert "skip test_array_repeat_with_count_scalar for now (#8424)"|
+|[#8385](https://github.com/NVIDIA/spark-rapids/pull/8385)|Reduce memory usage in GpuFileFormatDataWriter and GpuDynamicPartitionDataConcurrentWriter|
+|[#8304](https://github.com/NVIDIA/spark-rapids/pull/8304)|Support combining small files for multi-threaded ORC reads|
+|[#8413](https://github.com/NVIDIA/spark-rapids/pull/8413)|Stop double closing in json scan + skip test|
+|[#8430](https://github.com/NVIDIA/spark-rapids/pull/8430)|Update docs for spark.rapids.filecache.checkStale default change [skip ci]|
+|[#8424](https://github.com/NVIDIA/spark-rapids/pull/8424)|skip test_array_repeat_with_count_scalar to wait for fix #8409|
+|[#8405](https://github.com/NVIDIA/spark-rapids/pull/8405)|Change TimeAdd/Sub subquery tests to use min/max|
+|[#8408](https://github.com/NVIDIA/spark-rapids/pull/8408)|Document conventional dist jar layout for single-shim deployments [skip ci]|
+|[#8394](https://github.com/NVIDIA/spark-rapids/pull/8394)|Removed "peak device memory" metric|
+|[#8378](https://github.com/NVIDIA/spark-rapids/pull/8378)|Use spillable batch with retry in GpuCachedDoublePassWindowIterator|
+|[#8392](https://github.com/NVIDIA/spark-rapids/pull/8392)|Update IDEA dev instructions [skip ci]|
+|[#8387](https://github.com/NVIDIA/spark-rapids/pull/8387)|Rename inconsinstent profiles in api_validation|
+|[#8374](https://github.com/NVIDIA/spark-rapids/pull/8374)|Avoid processing empty batch in ParquetCachedBatchSerializer|
+|[#8386](https://github.com/NVIDIA/spark-rapids/pull/8386)|Fix check to do positional indexing in ORC|
+|[#8360](https://github.com/NVIDIA/spark-rapids/pull/8360)|use matrix to combine multiple jdk* jobs in maven-verify CI [skip ci]|
+|[#8371](https://github.com/NVIDIA/spark-rapids/pull/8371)|Fix V1 column name match is case-sensitive when dropping partition by columns|
+|[#8368](https://github.com/NVIDIA/spark-rapids/pull/8368)|Doc Update: Clarify both line anchors ^ and $ for regular expression compatibility [skip ci]|
+|[#8377](https://github.com/NVIDIA/spark-rapids/pull/8377)|Avoid a possible race in test_empty_filter|
+|[#8354](https://github.com/NVIDIA/spark-rapids/pull/8354)|[DOCS] Updating tools docs in spark-rapids [skip ci]|
+|[#8341](https://github.com/NVIDIA/spark-rapids/pull/8341)|Enable CachedBatchWriterSuite.testCompressColBatch|
+|[#8264](https://github.com/NVIDIA/spark-rapids/pull/8264)|Make tables spillable by default|
+|[#8364](https://github.com/NVIDIA/spark-rapids/pull/8364)|Fix NullPointerException in ORC multithreaded reader where we access context that could be null|
+|[#8322](https://github.com/NVIDIA/spark-rapids/pull/8322)|Avoid out of bounds on GpuInMemoryTableScan when reading no columns|
+|[#8342](https://github.com/NVIDIA/spark-rapids/pull/8342)|Elimnate javac warnings|
+|[#8334](https://github.com/NVIDIA/spark-rapids/pull/8334)|Add in support for filter on empty batch|
+|[#8355](https://github.com/NVIDIA/spark-rapids/pull/8355)|Speed up github verify checks [skip ci]|
+|[#8356](https://github.com/NVIDIA/spark-rapids/pull/8356)|Enable auto-merge from branch-23.06 to branch-23.08 [skip ci]|
+|[#8339](https://github.com/NVIDIA/spark-rapids/pull/8339)|Fix withResource order in GpuGenerateExec|
+|[#8340](https://github.com/NVIDIA/spark-rapids/pull/8340)|Stop calling contiguousSplit without splits from GpuSortExec|
+|[#8333](https://github.com/NVIDIA/spark-rapids/pull/8333)|Fix GpuTimeAdd handling both input expressions being GpuScalar|
+|[#8302](https://github.com/NVIDIA/spark-rapids/pull/8302)|Add support for DecimalType in Remainder for Spark 3.4 and DB 11.3|
+|[#8325](https://github.com/NVIDIA/spark-rapids/pull/8325)|Disable `test_read_hive_fixed_length_char` on Spark 3.4+.|
+|[#8327](https://github.com/NVIDIA/spark-rapids/pull/8327)|Enable spark.sql.legacy.parquet.nanosAsLong for Spark 3.2.4|
+|[#8328](https://github.com/NVIDIA/spark-rapids/pull/8328)|Fix Hive text file write to deal with CUDF changes|
+|[#8309](https://github.com/NVIDIA/spark-rapids/pull/8309)|Fix GpuTopN with offset for multiple batches|
+|[#8306](https://github.com/NVIDIA/spark-rapids/pull/8306)|Update code to deal with new retry semantics|
+|[#8307](https://github.com/NVIDIA/spark-rapids/pull/8307)|Full ordinal support in GetArrayItem|
+|[#8243](https://github.com/NVIDIA/spark-rapids/pull/8243)|Enable retry for Parquet writes|
+|[#8295](https://github.com/NVIDIA/spark-rapids/pull/8295)|Fix ORC reader for `CHAR(N)` columns written from Hive|
+|[#8298](https://github.com/NVIDIA/spark-rapids/pull/8298)|Append new authorized user to blossom-ci whitelist [skip ci]|
+|[#8276](https://github.com/NVIDIA/spark-rapids/pull/8276)|Fallback to CPU for `enableDateTimeParsingFallback` configuration|
+|[#8296](https://github.com/NVIDIA/spark-rapids/pull/8296)|Fix Multithreaded Readers working with Unity Catalog on Databricks|
+|[#8273](https://github.com/NVIDIA/spark-rapids/pull/8273)|Add support for escaped dot in character class in regexp parser|
+|[#8266](https://github.com/NVIDIA/spark-rapids/pull/8266)|Add test to confirm correct behavior for decimal average in Spark 3.4|
+|[#8291](https://github.com/NVIDIA/spark-rapids/pull/8291)|Fix delta stats tracker conf|
+|[#8287](https://github.com/NVIDIA/spark-rapids/pull/8287)|Fix Delta write stats if data schema is missing columns relative to table schema|
+|[#8286](https://github.com/NVIDIA/spark-rapids/pull/8286)|Add Tencent cosn:// to default cloud schemes|
+|[#8283](https://github.com/NVIDIA/spark-rapids/pull/8283)|Add split and retry support for filter|
+|[#8290](https://github.com/NVIDIA/spark-rapids/pull/8290)|Pre-merge docker build stage to support containerd runtime [skip ci]|
+|[#8257](https://github.com/NVIDIA/spark-rapids/pull/8257)|Support cuda12 jar's release [skip CI]|
+|[#8274](https://github.com/NVIDIA/spark-rapids/pull/8274)|Add a unit test for reordered canonicalized expressions in BinaryComparison|
+|[#8265](https://github.com/NVIDIA/spark-rapids/pull/8265)|Small code cleanup for pattern matching on Decimal type|
+|[#8255](https://github.com/NVIDIA/spark-rapids/pull/8255)|Enable locals,patvars,privates unused Scalac checks|
+|[#8234](https://github.com/NVIDIA/spark-rapids/pull/8234)|JDK17 build support in CI|
+|[#8256](https://github.com/NVIDIA/spark-rapids/pull/8256)|Use env var with version files as fallback for IT DBR version|
+|[#8239](https://github.com/NVIDIA/spark-rapids/pull/8239)|Add Spark 3.2.4 shim|
+|[#8221](https://github.com/NVIDIA/spark-rapids/pull/8221)|[Doc] update getting started guide based on latest databricks env [skip ci]|
+|[#8224](https://github.com/NVIDIA/spark-rapids/pull/8224)|Fix misinterpretation of Parquet's legacy ARRAY schemas.|
+|[#8241](https://github.com/NVIDIA/spark-rapids/pull/8241)|Update to filecache API changes|
+|[#8244](https://github.com/NVIDIA/spark-rapids/pull/8244)|Remove semicolon at the end of the package statement in Scala files|
+|[#8245](https://github.com/NVIDIA/spark-rapids/pull/8245)|Remove redundant open of ORC file|
+|[#8252](https://github.com/NVIDIA/spark-rapids/pull/8252)|Fix auto merge conflict 8250 [skip ci]|
+|[#8170](https://github.com/NVIDIA/spark-rapids/pull/8170)|Update GpuRunningWindowExec to use OOM retry framework|
+|[#8218](https://github.com/NVIDIA/spark-rapids/pull/8218)|Update to add 340 build and unit test in premerge and in JDK 11 build|
+|[#8232](https://github.com/NVIDIA/spark-rapids/pull/8232)|Add integration tests for inferred schema|
+|[#8223](https://github.com/NVIDIA/spark-rapids/pull/8223)|Use SupportsRuntimeV2Filtering in Spark 3.4.0|
+|[#8233](https://github.com/NVIDIA/spark-rapids/pull/8233)|cudf-udf integration test against python3.9 [skip ci]|
+|[#8226](https://github.com/NVIDIA/spark-rapids/pull/8226)|Offset support for TakeOrderedAndProject|
+|[#8237](https://github.com/NVIDIA/spark-rapids/pull/8237)|Use weak keys in executor broadcast plan cache|
+|[#8229](https://github.com/NVIDIA/spark-rapids/pull/8229)|Upgrade to jacoco 0.8.8 for JDK 17 support|
+|[#8216](https://github.com/NVIDIA/spark-rapids/pull/8216)|Add oom retry handling for GpuGenerate.fixedLenLazyArrayGenerate|
+|[#8191](https://github.com/NVIDIA/spark-rapids/pull/8191)|Add in retry-work to GPU OutOfCore Sort|
+|[#8228](https://github.com/NVIDIA/spark-rapids/pull/8228)|Partial JDK 17 support|
+|[#8227](https://github.com/NVIDIA/spark-rapids/pull/8227)|Adjust defaults for better performance out of the box|
+|[#8212](https://github.com/NVIDIA/spark-rapids/pull/8212)|Add file caching|
+|[#8179](https://github.com/NVIDIA/spark-rapids/pull/8179)|Fall back to CPU for try_cast in Spark 3.4.0|
+|[#8220](https://github.com/NVIDIA/spark-rapids/pull/8220)|Batch install-file executions in a single JVM|
+|[#8215](https://github.com/NVIDIA/spark-rapids/pull/8215)|Fix count from ORC files with no column names|
+|[#8192](https://github.com/NVIDIA/spark-rapids/pull/8192)|Handle PySparkException in case of literal expressions|
+|[#8190](https://github.com/NVIDIA/spark-rapids/pull/8190)|Fix element_at_index_zero integration test by using newer error message from Spark 3.4.0|
+|[#8203](https://github.com/NVIDIA/spark-rapids/pull/8203)|Clean up queued batches on task failures in RapidsShuffleThreadedBlockIterator|
+|[#8207](https://github.com/NVIDIA/spark-rapids/pull/8207)|Support `std` aggregation in reduction|
+|[#8174](https://github.com/NVIDIA/spark-rapids/pull/8174)|[FEA] support json to struct function |
+|[#8195](https://github.com/NVIDIA/spark-rapids/pull/8195)|Bump mockito to 3.12.4|
+|[#8193](https://github.com/NVIDIA/spark-rapids/pull/8193)|Increase databricks cluster autotermination to 6.5 hours [skip ci]|
+|[#8182](https://github.com/NVIDIA/spark-rapids/pull/8182)|Support STRING order-by columns for RANGE window functions|
+|[#8167](https://github.com/NVIDIA/spark-rapids/pull/8167)|Add oom retry handling to GpuGenerateExec.doGenerate path|
+|[#8183](https://github.com/NVIDIA/spark-rapids/pull/8183)|Disable asserts for non-empty nulls|
+|[#8177](https://github.com/NVIDIA/spark-rapids/pull/8177)|Fix 340 shim of GpuCreateDataSourceTableAsSelectCommand and shim GpuDataSource for 3.4.0|
+|[#8159](https://github.com/NVIDIA/spark-rapids/pull/8159)|Verify CPU fallback class when creating HIVE table [Databricks]|
+|[#8180](https://github.com/NVIDIA/spark-rapids/pull/8180)|Follow-up for ORC Decimal read failure (#8172)|
+|[#8172](https://github.com/NVIDIA/spark-rapids/pull/8172)|Fix ORC decimal read when precision/scale changes|
+|[#7227](https://github.com/NVIDIA/spark-rapids/pull/7227)|Fix PCBS integration tests for Spark-3.4|
+|[#8175](https://github.com/NVIDIA/spark-rapids/pull/8175)|Restore test_substring_column|
+|[#8162](https://github.com/NVIDIA/spark-rapids/pull/8162)|Support Java 17 for packaging|
+|[#8169](https://github.com/NVIDIA/spark-rapids/pull/8169)|Fix AnsiCastShim for 330db|
+|[#8168](https://github.com/NVIDIA/spark-rapids/pull/8168)|[DOC] Updating profiling/qualification docs for usability improvements [skip ci]|
+|[#8144](https://github.com/NVIDIA/spark-rapids/pull/8144)|Add 340 shim for GpuInsertIntoHiveTable|
+|[#8143](https://github.com/NVIDIA/spark-rapids/pull/8143)|Add handling for SplitAndRetryOOM in nextCbFromGatherer|
+|[#8102](https://github.com/NVIDIA/spark-rapids/pull/8102)|Rewrite two tests from AnsiCastOpSuite in Python and make compatible with Spark 3.4.0|
+|[#8152](https://github.com/NVIDIA/spark-rapids/pull/8152)|Fix Spark-3.4 test failure in AdaptiveQueryExecSuite|
+|[#8154](https://github.com/NVIDIA/spark-rapids/pull/8154)|Use repo1.maven.org/maven2 instead of default apache central url |
+|[#8150](https://github.com/NVIDIA/spark-rapids/pull/8150)|xfail test_substring_column|
+|[#8128](https://github.com/NVIDIA/spark-rapids/pull/8128)|Fix CastOpSuite failures with Spark 3.4|
+|[#8145](https://github.com/NVIDIA/spark-rapids/pull/8145)|Fix nz timestamp unit tests|
+|[#8146](https://github.com/NVIDIA/spark-rapids/pull/8146)|Set version of slf4j for Spark 3.4.0|
+|[#8058](https://github.com/NVIDIA/spark-rapids/pull/8058)|Add retry to BatchByKeyIterator|
+|[#8142](https://github.com/NVIDIA/spark-rapids/pull/8142)|Enable ParquetWriterSuite test 'sorted partitioned write' on Spark 3.4.0|
+|[#8035](https://github.com/NVIDIA/spark-rapids/pull/8035)|[FEA] support StringTranslate function|
+|[#8136](https://github.com/NVIDIA/spark-rapids/pull/8136)|Add GPU support for KnownNullable expression (Spark 3.4.0)|
+|[#8096](https://github.com/NVIDIA/spark-rapids/pull/8096)|Add OOM retry handling for existence joins|
+|[#8139](https://github.com/NVIDIA/spark-rapids/pull/8139)|Fix auto merge conflict 8138 [skip ci]|
+|[#8135](https://github.com/NVIDIA/spark-rapids/pull/8135)|Fix Orc writer test failure with Spark 3.4|
+|[#8129](https://github.com/NVIDIA/spark-rapids/pull/8129)|Fix compile error with Spark 3.4.0 release and bump to use 3.4.0 release JAR|
+|[#8093](https://github.com/NVIDIA/spark-rapids/pull/8093)|Add cuda12 build support [skip ci]|
+|[#8108](https://github.com/NVIDIA/spark-rapids/pull/8108)|Make Arm methods static|
+|[#8060](https://github.com/NVIDIA/spark-rapids/pull/8060)|Support repetitions in regexp choice expressions|
+|[#8081](https://github.com/NVIDIA/spark-rapids/pull/8081)|Re-enable empty repetition near end-of-line anchor for rlike, regexp_extract and regexp_replace|
+|[#8075](https://github.com/NVIDIA/spark-rapids/pull/8075)|Update some integration tests so that they are compatible with Spark 3.4.0|
+|[#8063](https://github.com/NVIDIA/spark-rapids/pull/8063)|Update docker to support integration tests against JDK17 [skip ci]|
+|[#8047](https://github.com/NVIDIA/spark-rapids/pull/8047)|Enable line/string anchors in choice|
+|[#7996](https://github.com/NVIDIA/spark-rapids/pull/7996)|Sub-partitioning supports repartitioning the input data multiple times|
+|[#8009](https://github.com/NVIDIA/spark-rapids/pull/8009)|Add in some more retry blocks|
+|[#8051](https://github.com/NVIDIA/spark-rapids/pull/8051)|MINOR: Improve assertion error in assert_py4j_exception|
+|[#8020](https://github.com/NVIDIA/spark-rapids/pull/8020)|[FEA] Add Spark 3.3.3-SNAPSHOT to shims|
+|[#8034](https://github.com/NVIDIA/spark-rapids/pull/8034)|Fix the check for dedicated per-shim files [skip ci]|
+|[#7978](https://github.com/NVIDIA/spark-rapids/pull/7978)|Update JNI and private deps version to 23.06.0-SNAPSHOT|
+|[#7965](https://github.com/NVIDIA/spark-rapids/pull/7965)|Remove stale references to the pre-shimplify dirs|
+|[#7948](https://github.com/NVIDIA/spark-rapids/pull/7948)|Init plugin version 23.06.0-SNAPSHOT|
 
 ## Older Releases
 Changelog of older releases can be found at [docs/archives](/docs/archives)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Generated on 2023-06-08
 |||
 |:---|:---|
 |[#8079](https://github.com/NVIDIA/spark-rapids/issues/8079)|[FEA] Release Spark 3.4 Support|
-|[#8163](https://github.com/NVIDIA/spark-rapids/issues/8163)|[FEA] update release script and pipeline to support cuda12|
 |[#7043](https://github.com/NVIDIA/spark-rapids/issues/7043)|[FEA] Support Empty2Null expression on Spark 3.4.0|
 |[#8222](https://github.com/NVIDIA/spark-rapids/issues/8222)|[FEA] String Split Unsupported escaped character '.'|
 |[#8211](https://github.com/NVIDIA/spark-rapids/issues/8211)|[FEA] Add tencent blob store uri to spark rapids cloudScheme defaults|
@@ -15,13 +14,11 @@ Generated on 2023-06-08
 |[#7094](https://github.com/NVIDIA/spark-rapids/issues/7094)|[FEA] Add a shim layer for Spark 3.2.4|
 |[#6202](https://github.com/NVIDIA/spark-rapids/issues/6202)|[SPARK-39528][SQL] Use V2 Filter in SupportsRuntimeFiltering|
 |[#6034](https://github.com/NVIDIA/spark-rapids/issues/6034)|[FEA] Support `offset` parameter in `TakeOrderedAndProject`|
-|[#1940](https://github.com/NVIDIA/spark-rapids/issues/1940)|[FEA] Spilling working batch of fixed length lazy explode|
 |[#8196](https://github.com/NVIDIA/spark-rapids/issues/8196)|[FEA] Add retry handling to GpuGenerateExec.fixedLenLazyArrayGenerate path|
 |[#7891](https://github.com/NVIDIA/spark-rapids/issues/7891)|[FEA] Support StddevSamp with cast(col as double)  for input|
 |[#62](https://github.com/NVIDIA/spark-rapids/issues/62)|[FEA] stddevsamp function|
 |[#7867](https://github.com/NVIDIA/spark-rapids/issues/7867)|[FEA] support json to struct function|
 |[#7883](https://github.com/NVIDIA/spark-rapids/issues/7883)|[FEA] support order by string in windowing function|
-|[#8188](https://github.com/NVIDIA/spark-rapids/issues/8188)|[FEA] Refactor shims to remove dependency from 340 to 330db for cast/try_cast|
 |[#7882](https://github.com/NVIDIA/spark-rapids/issues/7882)|[FEA] support StringTranslate function|
 |[#7843](https://github.com/NVIDIA/spark-rapids/issues/7843)|[FEA] build with CUDA 12|
 |[#8045](https://github.com/NVIDIA/spark-rapids/issues/8045)|[FEA] Support repetition in choice on regular expressions|

--- a/docs/archives/CHANGELOG_23.02_to_23.04.md
+++ b/docs/archives/CHANGELOG_23.02_to_23.04.md
@@ -1,0 +1,498 @@
+# Change log
+Generated on 2023-05-09
+
+## Release 23.04
+
+### Features
+|||
+|:---|:---|
+|[#7992](https://github.com/NVIDIA/spark-rapids/issues/7992)|[Audit][SPARK-40819][SQL][3.3] Timestamp nanos behaviour regression (parquet reader)|
+|[#7985](https://github.com/NVIDIA/spark-rapids/issues/7985)|[FEA] Expose Alluxio master URL to support K8s Env|
+|[#7880](https://github.com/NVIDIA/spark-rapids/issues/7880)|[FEA] retry framework task level metrics|
+|[#7394](https://github.com/NVIDIA/spark-rapids/issues/7394)|[FEA] Support Delta Lake auto compaction|
+|[#7920](https://github.com/NVIDIA/spark-rapids/issues/7920)|[FEA] Remove SpillCallback and executor level spill metrics|
+|[#7463](https://github.com/NVIDIA/spark-rapids/issues/7463)|[FEA] Drop support for Databricks-9.1 ML LTS|
+|[#7253](https://github.com/NVIDIA/spark-rapids/issues/7253)|[FEA] Implement OOM retry framework|
+|[#7042](https://github.com/NVIDIA/spark-rapids/issues/7042)|[FEA] Add support in the tools event parsing for ML functions, libraries, and expressions|
+
+### Performance
+|||
+|:---|:---|
+|[#7907](https://github.com/NVIDIA/spark-rapids/issues/7907)|[FEA] Optimize regexp_replace in multi-replace scenarios|
+|[#7691](https://github.com/NVIDIA/spark-rapids/issues/7691)|[FEA] Upgrade and document UCX 1.14|
+|[#6516](https://github.com/NVIDIA/spark-rapids/issues/6516)|[FEA] Enable RAPIDS Shuffle Manager smoke testing for the databricks environment|
+|[#7695](https://github.com/NVIDIA/spark-rapids/issues/7695)|[FEA] Transpile regexp_extract expression to only have the single capture group that is needed|
+|[#7393](https://github.com/NVIDIA/spark-rapids/issues/7393)|[FEA] Support Delta Lake optimized write|
+|[#6561](https://github.com/NVIDIA/spark-rapids/issues/6561)|[FEA] Make SpillableColumnarBatch inform Spill code of actual usage of the batch|
+|[#6864](https://github.com/NVIDIA/spark-rapids/issues/6864)|[BUG] Spilling logic can spill data that cannot be freed|
+
+### Bugs Fixed
+|||
+|:---|:---|
+|[#8111](https://github.com/NVIDIA/spark-rapids/issues/8111)|[BUG] test_delta_delete_entire_table failed in databricks 10.4 runtime|
+|[#8074](https://github.com/NVIDIA/spark-rapids/issues/8074)|[BUG] test_parquet_read_nano_as_longs_31x failed on Dataproc|
+|[#7997](https://github.com/NVIDIA/spark-rapids/issues/7997)|[BUG] executors died with too much off heap in yarn UCX CI `udf_test`|
+|[#8067](https://github.com/NVIDIA/spark-rapids/issues/8067)|[BUG] extras jar sometimes fails to load|
+|[#8038](https://github.com/NVIDIA/spark-rapids/issues/8038)|[BUG] vector leaked when running NDS 3TB with memory restricted|
+|[#8030](https://github.com/NVIDIA/spark-rapids/issues/8030)|[BUG] test_re_replace_no_unicode_fallback test failes on integratoin tests Yarn|
+|[#7971](https://github.com/NVIDIA/spark-rapids/issues/7971)|[BUG] withRestoreOnRetry should look at Throwable causes in addition to retry OOMs|
+|[#6990](https://github.com/NVIDIA/spark-rapids/issues/6990)|[BUG] Several integration test failures in Spark-3.4 SNAPSHOT build|
+|[#7924](https://github.com/NVIDIA/spark-rapids/issues/7924)|[BUG] Physical plan for regexp_extract does not escape newlines|
+|[#7341](https://github.com/NVIDIA/spark-rapids/issues/7341)|[BUG] Leverage OOM retry framework for ORC writes|
+|[#7921](https://github.com/NVIDIA/spark-rapids/issues/7921)|[BUG] ORC writes with bloom filters enabled do not fall back to the CPU|
+|[#7818](https://github.com/NVIDIA/spark-rapids/issues/7818)|[BUG] Reuse of broadcast exchange can lead to unnecessary CPU fallback|
+|[#7904](https://github.com/NVIDIA/spark-rapids/issues/7904)|[BUG] test_write_sql_save_table sporadically fails on Pascal|
+|[#7922](https://github.com/NVIDIA/spark-rapids/issues/7922)|[BUG] YARN IT test test_optimized_hive_ctas_basic failures|
+|[#7933](https://github.com/NVIDIA/spark-rapids/issues/7933)|[BUG] NDS running hits DPP error on Databricks 10.4 when enable Alluxio cache.|
+|[#7850](https://github.com/NVIDIA/spark-rapids/issues/7850)|[BUG] nvcomp usage for the UCX mode of the shuffle manager is broken|
+|[#7927](https://github.com/NVIDIA/spark-rapids/issues/7927)|[BUG] Shimplify adding new shim layer fails|
+|[#6138](https://github.com/NVIDIA/spark-rapids/issues/6138)|[BUG] cast timezone-awareness check positive for date/time-unrelated types|
+|[#7914](https://github.com/NVIDIA/spark-rapids/issues/7914)|[BUG] Parquet read with integer upcast crashes|
+|[#6961](https://github.com/NVIDIA/spark-rapids/issues/6961)|[BUG] Using `\d` (or others) inside a character class results in "Unsupported escape character" |
+|[#7908](https://github.com/NVIDIA/spark-rapids/issues/7908)|[BUG] Interpolate spark.version.classifier into scala:compile `secondaryCacheDir`|
+|[#7707](https://github.com/NVIDIA/spark-rapids/issues/7707)|[BUG] IndexOutOfBoundsException when joining on 2 integer columns with DPP|
+|[#7892](https://github.com/NVIDIA/spark-rapids/issues/7892)|[BUG] Invalid or unsupported escape character `t` when trying to use tab in regexp_replace|
+|[#7640](https://github.com/NVIDIA/spark-rapids/issues/7640)|[BUG] GPU OOM using GpuRegExpExtract|
+|[#7814](https://github.com/NVIDIA/spark-rapids/issues/7814)|[BUG] GPU's output differs from CPU's for big decimals when joining by sub-partitioning algorithm|
+|[#7796](https://github.com/NVIDIA/spark-rapids/issues/7796)|[BUG] Parquet chunked reader size of output exceeds column size limit|
+|[#7833](https://github.com/NVIDIA/spark-rapids/issues/7833)|[BUG] run_pyspark_from_build computes 5 MiB per runner instead of 5 GiB|
+|[#7855](https://github.com/NVIDIA/spark-rapids/issues/7855)|[BUG] shuffle_test test_hash_grpby_sum failed OOM in premerge CI|
+|[#7858](https://github.com/NVIDIA/spark-rapids/issues/7858)|[BUG] HostToGpuCoalesceIterator leaks all host batches|
+|[#7826](https://github.com/NVIDIA/spark-rapids/issues/7826)|[BUG] buildall dist jar contains aggregator dependency|
+|[#7729](https://github.com/NVIDIA/spark-rapids/issues/7729)|[BUG] Active GPU thread not holding the semaphore|
+|[#7820](https://github.com/NVIDIA/spark-rapids/issues/7820)|[BUG] Restore pandas require_minimum_pandas_version() check|
+|[#7829](https://github.com/NVIDIA/spark-rapids/issues/7829)|[BUG] Parquet buffer time not correct with multithreaded combining reader|
+|[#7819](https://github.com/NVIDIA/spark-rapids/issues/7819)|[BUG] GpuDeviceManager allows setting UVM regardless of other RMM configs|
+|[#7643](https://github.com/NVIDIA/spark-rapids/issues/7643)|[BUG] Databricks init scripts can fail silently|
+|[#7799](https://github.com/NVIDIA/spark-rapids/issues/7799)|[BUG] Cannot lexicographic compare a table with a LIST of STRUCT column at ai.rapids.cudf.Table.sortOrder|
+|[#7767](https://github.com/NVIDIA/spark-rapids/issues/7767)|[BUG] VS Code / Metals / Bloop integration fails with java.lang.RuntimeException: 'boom' |
+|[#6383](https://github.com/NVIDIA/spark-rapids/issues/6383)|[SPARK-40066][SQL] ANSI mode: always return null on invalid access to map column|
+|[#7093](https://github.com/NVIDIA/spark-rapids/issues/7093)|[BUG] Spark-3.4 - Integration test failures in map_test|
+|[#7779](https://github.com/NVIDIA/spark-rapids/issues/7779)|[BUG] AlluxioUtilsSuite uses illegal character underscore in URI scheme|
+|[#7725](https://github.com/NVIDIA/spark-rapids/issues/7725)|[BUG] cache_test failed w/ ParquetCachedBatchSerializer in spark 3.3.2-SNAPSHOT|
+|[#7639](https://github.com/NVIDIA/spark-rapids/issues/7639)|[BUG] Databricks premerge failing with cannot find pytest|
+|[#7694](https://github.com/NVIDIA/spark-rapids/issues/7694)|[BUG] Spark-3.4 build breaks due to removing InternalRowSet|
+|[#6598](https://github.com/NVIDIA/spark-rapids/issues/6598)|[BUG] CUDA error when casting large column vector from long to string|
+|[#7739](https://github.com/NVIDIA/spark-rapids/issues/7739)|[BUG] udf_test failed in databricks 11.3 ENV|
+|[#5748](https://github.com/NVIDIA/spark-rapids/issues/5748)|[BUG] 3 cast tests fails on Spark 3.4.0|
+|[#7688](https://github.com/NVIDIA/spark-rapids/issues/7688)|[BUG] GpuParquetScan fails with NullPointerException - Delta CDF query|
+|[#7648](https://github.com/NVIDIA/spark-rapids/issues/7648)|[BUG] java.lang.ClassCastException: SerializeConcatHostBuffersDeserializeBatch cannot be cast to.HashedRelation|
+|[#6988](https://github.com/NVIDIA/spark-rapids/issues/6988)|[BUG] Integration test failures with DecimalType on Spark-3.4 SNAPSHOT build|
+|[#7615](https://github.com/NVIDIA/spark-rapids/issues/7615)|[BUG] Build fails on Spark 3.4|
+|[#7557](https://github.com/NVIDIA/spark-rapids/issues/7557)|[AUDIT][SPARK-41970] Introduce SparkPath for typesafety|
+|[#7617](https://github.com/NVIDIA/spark-rapids/issues/7617)|[BUG] Build 340 failed due to miss shim code for GpuShuffleMeta|
+
+### PRs
+|||
+|:---|:---|
+|[#8251](https://github.com/NVIDIA/spark-rapids/pull/8251)|Update 23.04 changelog w/ hotfix [skip ci]|
+|[#8247](https://github.com/NVIDIA/spark-rapids/pull/8247)|Bump up plugin version to 23.04.1-SNAPSHOT|
+|[#8248](https://github.com/NVIDIA/spark-rapids/pull/8248)|[Doc] update versions for 2304 hot fix [skip ci]|
+|[#8246](https://github.com/NVIDIA/spark-rapids/pull/8246)|Cherry-pick hotfix: Use weak keys in executor broadcast plan cache|
+|[#8092](https://github.com/NVIDIA/spark-rapids/pull/8092)|Init changelog for 23.04 [skip ci]|
+|[#8109](https://github.com/NVIDIA/spark-rapids/pull/8109)|Bump up JNI and private version to released 23.04.0|
+|[#7939](https://github.com/NVIDIA/spark-rapids/pull/7939)|[Doc]update download docs for 2304 version[skip ci]|
+|[#8127](https://github.com/NVIDIA/spark-rapids/pull/8127)|Avoid SQL result check of Delta Lake full delete on Databricks|
+|[#8098](https://github.com/NVIDIA/spark-rapids/pull/8098)|Fix loading of ORC files with missing column names|
+|[#8110](https://github.com/NVIDIA/spark-rapids/pull/8110)|Update ML integration page docs page [skip ci]|
+|[#8103](https://github.com/NVIDIA/spark-rapids/pull/8103)|Add license of spark-rapids private in NOTICE-binary[skip ci]|
+|[#8100](https://github.com/NVIDIA/spark-rapids/pull/8100)|Update/improve EMR getting started documentation [skip ci]|
+|[#8101](https://github.com/NVIDIA/spark-rapids/pull/8101)|Improve OOM exception messages|
+|[#8087](https://github.com/NVIDIA/spark-rapids/pull/8087)|Add an FAQ entry on encryption support [skip ci]|
+|[#8076](https://github.com/NVIDIA/spark-rapids/pull/8076)|Add in docs about RetryOOM [skip ci]|
+|[#8077](https://github.com/NVIDIA/spark-rapids/pull/8077)|Temporarily skip `test_parquet_read_nano_as_longs_31x` on dataproc|
+|[#8071](https://github.com/NVIDIA/spark-rapids/pull/8071)|Fix error in deploy script [skip ci]|
+|[#8070](https://github.com/NVIDIA/spark-rapids/pull/8070)|Fixes closed RapidsShuffleHandleImpl leak in ShuffleBufferCatalog|
+|[#8069](https://github.com/NVIDIA/spark-rapids/pull/8069)|Fix loading extra jar|
+|[#8044](https://github.com/NVIDIA/spark-rapids/pull/8044)|Fall back to CPU if  `spark.sql.legacy.parquet.nanosAsLong` is set|
+|[#8049](https://github.com/NVIDIA/spark-rapids/pull/8049)|[DOC] Adding user tool info to main qualification docs page [skip ci]|
+|[#8040](https://github.com/NVIDIA/spark-rapids/pull/8040)|Fix device vector leak in RmmRetryIterator.splitSpillableInHalfByRows|
+|[#8031](https://github.com/NVIDIA/spark-rapids/pull/8031)|Fix regexp_replace integration test that should fallback when unicode is disabled|
+|[#7828](https://github.com/NVIDIA/spark-rapids/pull/7828)|Fallback to arena allocator if RMM failed to initialize with async allocator|
+|[#8006](https://github.com/NVIDIA/spark-rapids/pull/8006)|Handle caused-by retry exceptions in withRestoreOnRetry|
+|[#8013](https://github.com/NVIDIA/spark-rapids/pull/8013)|[Doc] Adding user tools info into EMR getting started guide [skip ci]|
+|[#8007](https://github.com/NVIDIA/spark-rapids/pull/8007)|Fix leak where RapidsShuffleIterator for a completed task was kept alive|
+|[#8010](https://github.com/NVIDIA/spark-rapids/pull/8010)|Specify that UCX should be 1.12.1 only [skip ci]|
+|[#7967](https://github.com/NVIDIA/spark-rapids/pull/7967)|Transpile simple choice-type regular expressions into lists of choices to use with string replace multi|
+|[#7902](https://github.com/NVIDIA/spark-rapids/pull/7902)|Add oom retry handling for createGatherer in gpu hash joins|
+|[#7986](https://github.com/NVIDIA/spark-rapids/pull/7986)|Provides a config to expose Alluxio master URL to support K8s Env|
+|[#7936](https://github.com/NVIDIA/spark-rapids/pull/7936)|Stop showing internal details of ternary expressions in SparkPlan.toString|
+|[#7972](https://github.com/NVIDIA/spark-rapids/pull/7972)|Add in retry for ORC writes|
+|[#7975](https://github.com/NVIDIA/spark-rapids/pull/7975)|Publish documentation for private configs|
+|[#7976](https://github.com/NVIDIA/spark-rapids/pull/7976)|Disable GPU write for ORC and Parquet, if bloom-filters are enabled.|
+|[#7925](https://github.com/NVIDIA/spark-rapids/pull/7925)|Inject RetryOOM in CI where retry iterator is used|
+|[#7970](https://github.com/NVIDIA/spark-rapids/pull/7970)|[DOCS] Updating qual tool docs from latest in tools repo|
+|[#7952](https://github.com/NVIDIA/spark-rapids/pull/7952)|Add in minimal retry metrics|
+|[#7884](https://github.com/NVIDIA/spark-rapids/pull/7884)|Add Python requirements file for integration tests|
+|[#7958](https://github.com/NVIDIA/spark-rapids/pull/7958)|Add CheckpointRestore trait and withRestoreOnRetry|
+|[#7849](https://github.com/NVIDIA/spark-rapids/pull/7849)|Fix CPU broadcast exchanges being left unreplaced due to AQE and reuse|
+|[#7944](https://github.com/NVIDIA/spark-rapids/pull/7944)|Fix issue with dynamicpruning filters used in converted GPU scans when S3 paths are replaced with alluxio|
+|[#7949](https://github.com/NVIDIA/spark-rapids/pull/7949)|Lazily unspill the stream batches for joins by sub-partitioning|
+|[#7951](https://github.com/NVIDIA/spark-rapids/pull/7951)|Fix PMD docs URL [skip ci]|
+|[#7945](https://github.com/NVIDIA/spark-rapids/pull/7945)|Enable automerge from 2304 to 2306 [skip ci]|
+|[#7935](https://github.com/NVIDIA/spark-rapids/pull/7935)|Add GPU level task metrics|
+|[#7930](https://github.com/NVIDIA/spark-rapids/pull/7930)|Add OOM Retry handling for join gather next|
+|[#7942](https://github.com/NVIDIA/spark-rapids/pull/7942)|Revert "Upgrade to UCX 1.14.0 (#7877)"|
+|[#7889](https://github.com/NVIDIA/spark-rapids/pull/7889)|Support auto-compaction for Delta tables on|
+|[#7937](https://github.com/NVIDIA/spark-rapids/pull/7937)|Support hashing different types for sub-partitioning|
+|[#7877](https://github.com/NVIDIA/spark-rapids/pull/7877)|Upgrade to UCX 1.14.0|
+|[#7926](https://github.com/NVIDIA/spark-rapids/pull/7926)|Fixes issue where UCX compressed tables would be decompressed multiple times|
+|[#7928](https://github.com/NVIDIA/spark-rapids/pull/7928)|Adjust assert for SparkShims: no longer a per-shim file [skip ci]|
+|[#7895](https://github.com/NVIDIA/spark-rapids/pull/7895)|Some refactor of shuffled hash join|
+|[#7894](https://github.com/NVIDIA/spark-rapids/pull/7894)|Support tagging `Cast` for timezone conditionally|
+|[#7915](https://github.com/NVIDIA/spark-rapids/pull/7915)|Fix upcast of signed integral values when reading from Parquet|
+|[#7879](https://github.com/NVIDIA/spark-rapids/pull/7879)|Retry for file read operations|
+|[#7905](https://github.com/NVIDIA/spark-rapids/pull/7905)|[Doc] Fix some documentation issue based on VPR feedback on 23.04 branch (new PR) [skip CI] |
+|[#7912](https://github.com/NVIDIA/spark-rapids/pull/7912)|[Doc] Hotfix gh-pages for compatibility page format issue [skip ci]|
+|[#7913](https://github.com/NVIDIA/spark-rapids/pull/7913)|Fix resolution of GpuRapidsProcessDeltaMergeJoinExec expressions|
+|[#7916](https://github.com/NVIDIA/spark-rapids/pull/7916)|Add clarification for Delta Lake optimized write fallback due to sorting [skip ci]|
+|[#7906](https://github.com/NVIDIA/spark-rapids/pull/7906)|ColumnarToRowIterator should release the semaphore if parent is empty|
+|[#7909](https://github.com/NVIDIA/spark-rapids/pull/7909)|Interpolate buildver into secondaryCacheDir|
+|[#7844](https://github.com/NVIDIA/spark-rapids/pull/7844)|Update alluxio version to 2.9.0|
+|[#7896](https://github.com/NVIDIA/spark-rapids/pull/7896)|Update regular expression parser to handle escape character sequences|
+|[#7885](https://github.com/NVIDIA/spark-rapids/pull/7885)|Add Join Reordering Integration Test|
+|[#7862](https://github.com/NVIDIA/spark-rapids/pull/7862)|Reduce shimming of GpuFlatMapGroupsInPandasExec|
+|[#7859](https://github.com/NVIDIA/spark-rapids/pull/7859)|Remove 3.1.4-SNAPSHOT shim code|
+|[#7835](https://github.com/NVIDIA/spark-rapids/pull/7835)|Update to pull the rapids spark extra plugin jar|
+|[#7863](https://github.com/NVIDIA/spark-rapids/pull/7863)|[Doc] Address document issues [skip ci]|
+|[#7794](https://github.com/NVIDIA/spark-rapids/pull/7794)|Implement sub partitioning for large/skewed hash joins|
+|[#7864](https://github.com/NVIDIA/spark-rapids/pull/7864)|Add in basic support for OOM retry for project and filter|
+|[#7878](https://github.com/NVIDIA/spark-rapids/pull/7878)|Fixing host memory calculation to properly be 5GiB|
+|[#7860](https://github.com/NVIDIA/spark-rapids/pull/7860)|Enable manual copy-and-paste code detection [skip ci]|
+|[#7852](https://github.com/NVIDIA/spark-rapids/pull/7852)|Use withRetry in GpuCoalesceBatches|
+|[#7857](https://github.com/NVIDIA/spark-rapids/pull/7857)|Unshim getSparkShimVersion|
+|[#7854](https://github.com/NVIDIA/spark-rapids/pull/7854)|Optimize `regexp_extract*` by transpiling capture groups to non-capturing groups so that only the required capturing group is manifested|
+|[#7853](https://github.com/NVIDIA/spark-rapids/pull/7853)|Remove support for Databricks-9.1 ML LTS|
+|[#7856](https://github.com/NVIDIA/spark-rapids/pull/7856)|Update references to reduced dependencies pom [skip ci]|
+|[#7848](https://github.com/NVIDIA/spark-rapids/pull/7848)|Initialize only sql-plugin  to prevent missing submodule artifacts in buildall [skip ci]|
+|[#7839](https://github.com/NVIDIA/spark-rapids/pull/7839)|Add reduced pom to dist jar in the packaging phase|
+|[#7822](https://github.com/NVIDIA/spark-rapids/pull/7822)|Add in support for OOM retry|
+|[#7846](https://github.com/NVIDIA/spark-rapids/pull/7846)|Stop releasing semaphore in GpuUserDefinedFunction|
+|[#7840](https://github.com/NVIDIA/spark-rapids/pull/7840)|Execute mvn initialize before parallel build [skip ci]|
+|[#7222](https://github.com/NVIDIA/spark-rapids/pull/7222)|Automatic conversion to shimplified directory structure|
+|[#7824](https://github.com/NVIDIA/spark-rapids/pull/7824)|Use withRetryNoSplit in BasicWindowCalc|
+|[#7842](https://github.com/NVIDIA/spark-rapids/pull/7842)|Try fix broken blackduck scan [skip ci]|
+|[#7841](https://github.com/NVIDIA/spark-rapids/pull/7841)|Hardcode scan projects [skip ci]|
+|[#7830](https://github.com/NVIDIA/spark-rapids/pull/7830)|Fix buffer and Filter time with Parquet multithreaded combine reader|
+|[#7678](https://github.com/NVIDIA/spark-rapids/pull/7678)|Premerge CI to drop support for Databricks-9.1 ML LTS|
+|[#7823](https://github.com/NVIDIA/spark-rapids/pull/7823)|[BUG] Enable managed memory only if async allocator is not used|
+|[#7821](https://github.com/NVIDIA/spark-rapids/pull/7821)|Restore pandas import check in db113 runtime|
+|[#7810](https://github.com/NVIDIA/spark-rapids/pull/7810)|UnXfail large decimal window range queries|
+|[#7771](https://github.com/NVIDIA/spark-rapids/pull/7771)|Add withRetry and withRetryNoSplit and PoC with hash aggregate|
+|[#7815](https://github.com/NVIDIA/spark-rapids/pull/7815)|Fix the hyperlink to shimplify.py [skip ci]|
+|[#7812](https://github.com/NVIDIA/spark-rapids/pull/7812)|Fallback Delta Lake optimized writes if GPU cannot support partitioning|
+|[#7791](https://github.com/NVIDIA/spark-rapids/pull/7791)|Doc changes for new nested JSON reader [skip ci]|
+|[#7797](https://github.com/NVIDIA/spark-rapids/pull/7797)|Add GPU support for EphemeralSubstring|
+|[#7561](https://github.com/NVIDIA/spark-rapids/pull/7561)|Ant task to automatically convert to a simple shim layout|
+|[#7789](https://github.com/NVIDIA/spark-rapids/pull/7789)|Update script for integration tests on Databricks|
+|[#7798](https://github.com/NVIDIA/spark-rapids/pull/7798)|Do not error out DB IT test script when pytest code 5 [skip ci]|
+|[#7787](https://github.com/NVIDIA/spark-rapids/pull/7787)|Document a workaround to RuntimeException 'boom' [skip ci]|
+|[#7786](https://github.com/NVIDIA/spark-rapids/pull/7786)|Fix nested loop joins when there's no build-side columns|
+|[#7730](https://github.com/NVIDIA/spark-rapids/pull/7730)|[FEA] Switch to `regex_program` APIs|
+|[#7788](https://github.com/NVIDIA/spark-rapids/pull/7788)|Support released spark 3.3.2|
+|[#7095](https://github.com/NVIDIA/spark-rapids/pull/7095)|Fix the failure in `map_test.py` on Spark 3.4|
+|[#7769](https://github.com/NVIDIA/spark-rapids/pull/7769)|Fix issue where GpuSemaphore can throw NPE when logDebug is on|
+|[#7780](https://github.com/NVIDIA/spark-rapids/pull/7780)|Make AlluxioUtilsSuite pass for 340|
+|[#7772](https://github.com/NVIDIA/spark-rapids/pull/7772)|Fix cache test for Spark 3.3.2|
+|[#7717](https://github.com/NVIDIA/spark-rapids/pull/7717)|Move Databricks variables into blossom-lib|
+|[#7749](https://github.com/NVIDIA/spark-rapids/pull/7749)|Support Delta Lake optimized write on Databricks|
+|[#7696](https://github.com/NVIDIA/spark-rapids/pull/7696)|Create new version of  GpuBatchScanExec to fix Spark-3.4 build|
+|[#7747](https://github.com/NVIDIA/spark-rapids/pull/7747)|batched full join tracking batch does not need to be lazy|
+|[#7758](https://github.com/NVIDIA/spark-rapids/pull/7758)|Hardcode python 3.8 to be used in databricks runtime for cudf_udf ENV|
+|[#7716](https://github.com/NVIDIA/spark-rapids/pull/7716)|Clean the code of `GpuMetrics`|
+|[#7746](https://github.com/NVIDIA/spark-rapids/pull/7746)|Merge branch-23.02 into branch-23.04 [skip ci]|
+|[#7740](https://github.com/NVIDIA/spark-rapids/pull/7740)|Revert 7737 workaround for cudf setup in databricks 11.3 runtime [skip ci]|
+|[#7737](https://github.com/NVIDIA/spark-rapids/pull/7737)|Workaround for cudf setup in databricks 11.3 runtime|
+|[#7734](https://github.com/NVIDIA/spark-rapids/pull/7734)|Temporarily skip the test_parquet_read_ignore_missing on Databricks|
+|[#7728](https://github.com/NVIDIA/spark-rapids/pull/7728)|Fix estimatedNumBatches in case of OOM for Full Outer Join|
+|[#7718](https://github.com/NVIDIA/spark-rapids/pull/7718)|GpuParquetScan fails with NullPointerException during combining|
+|[#7712](https://github.com/NVIDIA/spark-rapids/pull/7712)|Enable Dynamic FIle Pruning on|
+|[#7702](https://github.com/NVIDIA/spark-rapids/pull/7702)|Merge 23.02 into 23.04|
+|[#7572](https://github.com/NVIDIA/spark-rapids/pull/7572)|Enables spillable/unspillable state for RapidsBuffer and allow buffer sharing|
+|[#7687](https://github.com/NVIDIA/spark-rapids/pull/7687)|Fix window tests for Spark-3.4|
+|[#7667](https://github.com/NVIDIA/spark-rapids/pull/7667)|Reenable tests originally bypassed for 3.4|
+|[#7542](https://github.com/NVIDIA/spark-rapids/pull/7542)|Support WriteFilesExec in Spark-3.4 to fix several tests|
+|[#7673](https://github.com/NVIDIA/spark-rapids/pull/7673)|Add missing spark shim test suites |
+|[#7655](https://github.com/NVIDIA/spark-rapids/pull/7655)|Fix Spark 3.4 build|
+|[#7621](https://github.com/NVIDIA/spark-rapids/pull/7621)|Document GNU sed for macOS auto-copyrighter users [skip ci]|
+|[#7618](https://github.com/NVIDIA/spark-rapids/pull/7618)|Update JNI to 23.04.0-SNAPSHOT and update new delta-stub ver to 23.04|
+|[#7541](https://github.com/NVIDIA/spark-rapids/pull/7541)|Init version 23.04.0-SNAPSHOT|
+
+## Release 23.02
+
+### Features
+|||
+|:---|:---|
+|[#6420](https://github.com/NVIDIA/spark-rapids/issues/6420)|[FEA]Support HiveTableScanExec to scan a Hive text table|
+|[#4897](https://github.com/NVIDIA/spark-rapids/issues/4897)|Profiling tool: create a section to focus on I/O metrics|
+|[#6419](https://github.com/NVIDIA/spark-rapids/issues/6419)|[FEA] Support write a Hive text table |
+|[#7280](https://github.com/NVIDIA/spark-rapids/issues/7280)|[FEA] Support UpdateCommand for Delta Lake|
+|[#7281](https://github.com/NVIDIA/spark-rapids/issues/7281)|[FEA] Support DeleteCommand for Delta Lake|
+|[#5272](https://github.com/NVIDIA/spark-rapids/issues/5272)|[FEA] Support from_json to get a MapType|
+|[#7007](https://github.com/NVIDIA/spark-rapids/issues/7007)|[FEA] Support Delta table MERGE INTO on Databricks.|
+|[#7521](https://github.com/NVIDIA/spark-rapids/issues/7521)|[FEA] Allow user to set concurrentGpuTasks after startup|
+|[#3300](https://github.com/NVIDIA/spark-rapids/issues/3300)|[FEA] Support batched full join|
+|[#6698](https://github.com/NVIDIA/spark-rapids/issues/6698)|[FEA] Support json_tuple|
+|[#6885](https://github.com/NVIDIA/spark-rapids/issues/6885)|[FEA] Support reverse|
+|[#6879](https://github.com/NVIDIA/spark-rapids/issues/6879)|[FEA] Support Databricks 11.3 ML LTS|
+
+### Performance
+|||
+|:---|:---|
+|[#7436](https://github.com/NVIDIA/spark-rapids/issues/7436)|[FEA] Pruning partition columns supports cases of GPU file scan with CPU project and filter|
+|[#7219](https://github.com/NVIDIA/spark-rapids/issues/7219)|Improve performance of small file parquet reads from blobstores|
+|[#6807](https://github.com/NVIDIA/spark-rapids/issues/6807)|Improve the current documentation on RapidsShuffleManager|
+|[#5039](https://github.com/NVIDIA/spark-rapids/issues/5039)|[FEA] Parallelize shuffle compress/decompress with opportunistic idle task threads|
+|[#7196](https://github.com/NVIDIA/spark-rapids/issues/7196)|RegExpExtract does both extract and contains_re which is inefficient|
+|[#6862](https://github.com/NVIDIA/spark-rapids/issues/6862)|[FEA] GpuRowToColumnarExec for Binary is really slow compared to string|
+
+### Bugs Fixed
+|||
+|:---|:---|
+|[#7069](https://github.com/NVIDIA/spark-rapids/issues/7069)|[BUG] GPU Hive Text Reader reads empty strings as null|
+|[#7068](https://github.com/NVIDIA/spark-rapids/issues/7068)|[BUG] GPU Hive Text Reader skips empty lines|
+|[#7448](https://github.com/NVIDIA/spark-rapids/issues/7448)|[BUG] GDS cufile test failed in elder cuda runtime|
+|[#7686](https://github.com/NVIDIA/spark-rapids/issues/7686)|[BUG] Large floating point values written as `Inf` not `Infinity` in Hive text writer|
+|[#7703](https://github.com/NVIDIA/spark-rapids/issues/7703)|[BUG] test_basic_hive_text_write fails|
+|[#7693](https://github.com/NVIDIA/spark-rapids/issues/7693)|[BUG] `test_partitioned_sql_parquet_write` fails on CDH|
+|[#7382](https://github.com/NVIDIA/spark-rapids/issues/7382)|[BUG] add dynamic partition overwrite tests for all formats|
+|[#7597](https://github.com/NVIDIA/spark-rapids/issues/7597)|[BUG] Incompatible timestamps in Hive delimited text writes|
+|[#7675](https://github.com/NVIDIA/spark-rapids/issues/7675)|[BUG] Multi-threaded shuffle bails with division-by-zero ArithmeticException|
+|[#7530](https://github.com/NVIDIA/spark-rapids/issues/7530)|[BUG] Add tests for RapidsShuffleManager|
+|[#7679](https://github.com/NVIDIA/spark-rapids/issues/7679)|[BUG] test_partitioned_parquet_write[PartitionWriteMode.Dynamic] failed in databricks runtimes|
+|[#7637](https://github.com/NVIDIA/spark-rapids/issues/7637)|[BUG] GpuBroadcastNestedLoopJoinExec:  Close called too many times|
+|[#7595](https://github.com/NVIDIA/spark-rapids/issues/7595)|[BUG] test_mod_mixed decimal test fails on 330db (Databricks 11.3) and TBD 340|
+|[#7575](https://github.com/NVIDIA/spark-rapids/issues/7575)|[BUG] On Databricks 11.3, Executor broadcast shuffles should stay on GPU even without columnar children |
+|[#7607](https://github.com/NVIDIA/spark-rapids/issues/7607)|[BUG] RegularExpressionTranspilerSuite exhibits multiple failures|
+|[#7574](https://github.com/NVIDIA/spark-rapids/issues/7574)|[BUG] simple json_tuple test failing with cudf error|
+|[#7446](https://github.com/NVIDIA/spark-rapids/issues/7446)|[BUG] prune_partition_column_test fails for Json in UCX CI|
+|[#7603](https://github.com/NVIDIA/spark-rapids/issues/7603)|[BUG] GpuIntervalUtilsTest leaks memory|
+|[#7090](https://github.com/NVIDIA/spark-rapids/issues/7090)|[BUG] Refactor line terminator handling code|
+|[#7472](https://github.com/NVIDIA/spark-rapids/issues/7472)|[BUG] The parquet chunked reader can fail for certain list cases.|
+|[#7560](https://github.com/NVIDIA/spark-rapids/issues/7560)|[BUG] Outstanding allocations detected at shutdown in python integration tests|
+|[#7516](https://github.com/NVIDIA/spark-rapids/issues/7516)|[BUG] multiple join cases cpu and gpu outputs mismatched in yarn|
+|[#7537](https://github.com/NVIDIA/spark-rapids/issues/7537)|[AUDIT] [SPARK-42039][SQL] SPJ: Remove Option in KeyGroupedPartitioning#partitionValuesOpt|
+|[#7535](https://github.com/NVIDIA/spark-rapids/issues/7535)|[BUG] Timestamp test cases failed due to Python time zone is not UTC|
+|[#7432](https://github.com/NVIDIA/spark-rapids/issues/7432)|[BUG][SPARK-41713][SPARK-41726] Spark 3.4 build fails.|
+|[#7517](https://github.com/NVIDIA/spark-rapids/issues/7517)|[DOC] doc/source of spark330db Shuffle Manager for Databricks-11.3 shim|
+|[#7505](https://github.com/NVIDIA/spark-rapids/issues/7505)|[BUG] Delta Lake writes with AQE can have unnecessary row transitions |
+|[#7454](https://github.com/NVIDIA/spark-rapids/issues/7454)|[BUG] Investigate binaryop.cpp:205: Unsupported operator for these types on Databricks 11.3|
+|[#7469](https://github.com/NVIDIA/spark-rapids/issues/7469)|[BUG] test_arrays_zip failures on nightly |
+|[#6894](https://github.com/NVIDIA/spark-rapids/issues/6894)|[BUG] Multithreaded rapids shuffle metrics incorrect|
+|[#7325](https://github.com/NVIDIA/spark-rapids/issues/7325)|[BUG] Fix integration test failures on Databricks-11.3|
+|[#7348](https://github.com/NVIDIA/spark-rapids/issues/7348)|[BUG] Fix integration tests for decimal type on db330 shim|
+|[#6978](https://github.com/NVIDIA/spark-rapids/issues/6978)|[BUG] NDS query 16 fails on EMR 6.8.0 with AQE enabled|
+|[#7133](https://github.com/NVIDIA/spark-rapids/issues/7133)|[BUG] Followup to AQE issues with reused columnar broadcast exchanges|
+|[#7208](https://github.com/NVIDIA/spark-rapids/issues/7208)|[BUG] Explicitly check if the platform is supported|
+|[#7397](https://github.com/NVIDIA/spark-rapids/issues/7397)|[BUG] shuffle smoke test hash_aggregate_test.py::test_hash_grpby_sum failed OOM intermittently in premerge|
+|[#7443](https://github.com/NVIDIA/spark-rapids/issues/7443)|[BUG] prune_partition_column_test fails for Avro|
+|[#7415](https://github.com/NVIDIA/spark-rapids/issues/7415)|[BUG] regex integration test failures on Databricks-11.3|
+|[#7226](https://github.com/NVIDIA/spark-rapids/issues/7226)|[BUG] GpuFileSourceScanExec always generates all partition columns|
+|[#7402](https://github.com/NVIDIA/spark-rapids/issues/7402)|[BUG] array_test.py::test_array_intersect failing cloudera|
+|[#7324](https://github.com/NVIDIA/spark-rapids/issues/7324)|[BUG] Support DayTimeIntervalType in Databricks-11.3 to fix integration tests|
+|[#7426](https://github.com/NVIDIA/spark-rapids/issues/7426)|[BUG] bloop compile times out on Databricks 11.3|
+|[#7328](https://github.com/NVIDIA/spark-rapids/issues/7328)|[BUG] Databricks-11.3 integration test failing due to IllegalStateException: the broadcast must be on the GPU too|
+|[#7327](https://github.com/NVIDIA/spark-rapids/issues/7327)|[BUG] Update Exception to fix Assertion error in Databricks-11.3 integration tests.|
+|[#7403](https://github.com/NVIDIA/spark-rapids/issues/7403)|[BUG] test_dynamic_partition_write_round_trip failed in CDH tests|
+|[#7368](https://github.com/NVIDIA/spark-rapids/issues/7368)|[BUG] with_hidden_metadata_fallback test failures on Databricks 11.3|
+|[#7400](https://github.com/NVIDIA/spark-rapids/issues/7400)|[BUG] parquet multithreaded combine reader can calculate size wrong|
+|[#7383](https://github.com/NVIDIA/spark-rapids/issues/7383)|[BUG] hive text partitioned reads using the `GpuHiveTableScanExec` are broken|
+|[#7350](https://github.com/NVIDIA/spark-rapids/issues/7350)|[BUG] test_conditional_with_side_effects_case_when fails|
+|[#7373](https://github.com/NVIDIA/spark-rapids/issues/7373)|[BUG] RapidsUDF does not support UDFs with no inputs|
+|[#7213](https://github.com/NVIDIA/spark-rapids/issues/7213)|[BUG] Parquet unsigned int scan test failure|
+|[#7344](https://github.com/NVIDIA/spark-rapids/issues/7344)|[BUG] Add PythonMapInArrowExec in 330db shim to fix integration test.|
+|[#7367](https://github.com/NVIDIA/spark-rapids/issues/7367)|[BUG] test_re_replace_repetition failed|
+|[#7345](https://github.com/NVIDIA/spark-rapids/issues/7345)|[BUG] Integration tests failing on Databricks-11.3 due to mixing of aggregations in HashAggregateExec and SortAggregateExec |
+|[#7378](https://github.com/NVIDIA/spark-rapids/issues/7378)|[BUG][ORC] `GpuInsertIntoHadoopFsRelationCommand` should use staging directory for dynamic partition overwrite|
+|[#7374](https://github.com/NVIDIA/spark-rapids/issues/7374)|[BUG] Hive reader does not always fall back to CPU when table contains nested types|
+|[#7284](https://github.com/NVIDIA/spark-rapids/issues/7284)|[BUG] Generated supported data source file is inaccurate for write data formats|
+|[#7347](https://github.com/NVIDIA/spark-rapids/issues/7347)|[BUG] Fix integration tests in Databricks-11.3 runtime by removing config spark.sql.ansi.strictIndexOperator|
+|[#7326](https://github.com/NVIDIA/spark-rapids/issues/7326)|[BUG] Support RoundCeil and RoundFloor on Databricks-11.3 shim to fix integration tests.|
+|[#7352](https://github.com/NVIDIA/spark-rapids/issues/7352)|[BUG] Databricks-11.3 IT failures - IllegalArgumentException: requirement failed for complexTypeExtractors|
+|[#6285](https://github.com/NVIDIA/spark-rapids/issues/6285)|[BUG] Add null values back to test_array_intersect for Spark 3.3+ and Databricks 10.4+|
+|[#7329](https://github.com/NVIDIA/spark-rapids/issues/7329)|[BUG] intermittently could not find ExecutedCommandExec in the GPU plan in delta_lake_write test|
+|[#7184](https://github.com/NVIDIA/spark-rapids/issues/7184)|[BUG] Fix integration test failures on Databricks 11.3|
+|[#7225](https://github.com/NVIDIA/spark-rapids/issues/7225)|[BUG] Partition columns mishandled when Parquet read is coalesced and chunked|
+|[#7303](https://github.com/NVIDIA/spark-rapids/issues/7303)|[BUG] Fix CPU fallback for custom timestamp formats in Hive delimited text|
+|[#7086](https://github.com/NVIDIA/spark-rapids/issues/7086)|[BUG] GPU Hive delimited text reader is more permissive than `LazySimpleSerDe` for timestamps|
+|[#7089](https://github.com/NVIDIA/spark-rapids/issues/7089)|[BUG] Reading invalid `DATE` strings yields exceptions instead of nulls|
+|[#6047](https://github.com/NVIDIA/spark-rapids/issues/6047)|[BUG] Look into field IDs when reading parquet using the native footer parser|
+|[#6989](https://github.com/NVIDIA/spark-rapids/issues/6989)|[BUG] Spark-3.4 - Integration test failures in array_test|
+|[#7122](https://github.com/NVIDIA/spark-rapids/issues/7122)|[BUG] Some tests of `limit_test` fail on Spark 3.4|
+|[#7144](https://github.com/NVIDIA/spark-rapids/issues/7144)|[BUG] Spark-3.4 integration test failures due to code update in FileFormatWriter.|
+|[#6915](https://github.com/NVIDIA/spark-rapids/issues/6915)|[BUG] Parquet of a binary decimal is not supported|
+
+### PRs
+|||
+|:---|:---|
+|[#7763](https://github.com/NVIDIA/spark-rapids/pull/7763)|23.02 changelog update 2/14 [skip ci]|
+|[#7761](https://github.com/NVIDIA/spark-rapids/pull/7761)|[Doc] remove xgboost demo from aws-emr doc due to nccl issue [skip ci]|
+|[#7760](https://github.com/NVIDIA/spark-rapids/pull/7760)|Add notice in gds to install cuda 11.8 [skip ci]|
+|[#7570](https://github.com/NVIDIA/spark-rapids/pull/7570)|[Doc] 23.02 doc updates [skip ci]|
+|[#7735](https://github.com/NVIDIA/spark-rapids/pull/7735)|Update JNI version to released 23.02.0|
+|[#7721](https://github.com/NVIDIA/spark-rapids/pull/7721)|Fix issue where UCX mode was trying to use catalog from the driver|
+|[#7713](https://github.com/NVIDIA/spark-rapids/pull/7713)|Workaround for incompatible serialization for `Inf` floats in Hive text write|
+|[#7700](https://github.com/NVIDIA/spark-rapids/pull/7700)|Init 23.02 changelog and move 22 changelog to archives [skip ci]|
+|[#7708](https://github.com/NVIDIA/spark-rapids/pull/7708)|Set Hive write test to ignore order on verification.|
+|[#7697](https://github.com/NVIDIA/spark-rapids/pull/7697)|Disable Dynamic partitioning tests on CDH|
+|[#7556](https://github.com/NVIDIA/spark-rapids/pull/7556)|Write support for Hive delimited text tables|
+|[#7681](https://github.com/NVIDIA/spark-rapids/pull/7681)|Disable Hive delimited text reader tests for CDH.|
+|[#7610](https://github.com/NVIDIA/spark-rapids/pull/7610)|Add multithreaded Shuffle test|
+|[#7652](https://github.com/NVIDIA/spark-rapids/pull/7652)|Support Delta Lake UpdateCommand|
+|[#7680](https://github.com/NVIDIA/spark-rapids/pull/7680)|Fix Parquet dynamic partition test for|
+|[#7653](https://github.com/NVIDIA/spark-rapids/pull/7653)|Add dynamic partitioning test for Parquet writer.|
+|[#7576](https://github.com/NVIDIA/spark-rapids/pull/7576)|Support EXECUTOR_BROADCAST on Databricks 11.3 in BroadcastNestedLoopJoin|
+|[#7620](https://github.com/NVIDIA/spark-rapids/pull/7620)|Support Delta Lake DeleteCommand|
+|[#7638](https://github.com/NVIDIA/spark-rapids/pull/7638)|Update UCX docs to call out Ubuntu 22.04 is not supported yet [skip ci]|
+|[#7644](https://github.com/NVIDIA/spark-rapids/pull/7644)|Create a new ColumnarBatch from the broadcast when LazySpillable takes ownership|
+|[#7632](https://github.com/NVIDIA/spark-rapids/pull/7632)|Update UCX shuffle doc w/ memlock limit config [skip ci]|
+|[#7628](https://github.com/NVIDIA/spark-rapids/pull/7628)|Disable HiveTextReaders for CDH due to NVIDIA#7423|
+|[#7633](https://github.com/NVIDIA/spark-rapids/pull/7633)|Bump up add-to-project version to 0.4.0 [skip ci]|
+|[#7609](https://github.com/NVIDIA/spark-rapids/pull/7609)|Fallback to CPU for mod only for DB11.3 [Databricks]|
+|[#7591](https://github.com/NVIDIA/spark-rapids/pull/7591)|Prevent fixup of GpuShuffleExchangeExec when using EXECUTOR_BROADCAST|
+|[#7626](https://github.com/NVIDIA/spark-rapids/pull/7626)|Revert "Skip/xfail some regexp tests (#7608)"|
+|[#7598](https://github.com/NVIDIA/spark-rapids/pull/7598)|Disable decimal `pmod` due to #7553|
+|[#7571](https://github.com/NVIDIA/spark-rapids/pull/7571)|Refact deploy script to support gpg and nvsec signature [skip ci]|
+|[#7590](https://github.com/NVIDIA/spark-rapids/pull/7590)|Fix `json_tuple` cudf error and java array out-of-bound issue|
+|[#7604](https://github.com/NVIDIA/spark-rapids/pull/7604)|Fix memory leak in GpuIntervalUtilsTest|
+|[#7600](https://github.com/NVIDIA/spark-rapids/pull/7600)|Centralize source-related properties in parent pom for consistent usage in submodules|
+|[#7608](https://github.com/NVIDIA/spark-rapids/pull/7608)|Skip/xfail some regexp tests|
+|[#7211](https://github.com/NVIDIA/spark-rapids/pull/7211)|Fix regressions related to cuDF changes in handline of end-of-line/string anchors|
+|[#7596](https://github.com/NVIDIA/spark-rapids/pull/7596)|Fix deprecation warnings|
+|[#7578](https://github.com/NVIDIA/spark-rapids/pull/7578)|Fix double close on exception in GpuCoalesceBatches|
+|[#7584](https://github.com/NVIDIA/spark-rapids/pull/7584)|Write test for multithreaded combine wrong buffer size bug |
+|[#7580](https://github.com/NVIDIA/spark-rapids/pull/7580)|Support Delta Lake MergeIntoCommand|
+|[#7554](https://github.com/NVIDIA/spark-rapids/pull/7554)|Add mixed decimal testing for binary arithmetic ops|
+|[#7567](https://github.com/NVIDIA/spark-rapids/pull/7567)|Fix a small leak in generate|
+|[#7563](https://github.com/NVIDIA/spark-rapids/pull/7563)|Add patched Hive Metastore Client jar to  deps|
+|[#7533](https://github.com/NVIDIA/spark-rapids/pull/7533)|Support EXECUTOR_BROADCAST on Databricks 11.3 in BroadcastHashJoin|
+|[#7532](https://github.com/NVIDIA/spark-rapids/pull/7532)|Update Databricks docs to add a limitation against DB 11.3 [skip ci]|
+|[#7555](https://github.com/NVIDIA/spark-rapids/pull/7555)|Fix case where tracking batch is never updated in batched full join|
+|[#7547](https://github.com/NVIDIA/spark-rapids/pull/7547)|Refactor Delta Lake code to handle multiple versions per Spark version|
+|[#7513](https://github.com/NVIDIA/spark-rapids/pull/7513)|Remove usage to `ColumnView.repeatStringsSizes`|
+|[#7538](https://github.com/NVIDIA/spark-rapids/pull/7538)|Fix Spark 340 build error due to change in KeyGroupedPartitioning|
+|[#7549](https://github.com/NVIDIA/spark-rapids/pull/7549)|Remove unused Maven property shim.module.name|
+|[#7548](https://github.com/NVIDIA/spark-rapids/pull/7548)|Make RapidsBufferHandle AutoCloseable to prevent extra attempts to remove buffers|
+|[#7499](https://github.com/NVIDIA/spark-rapids/pull/7499)|README.md for auditing purposes [skip ci]|
+|[#7512](https://github.com/NVIDIA/spark-rapids/pull/7512)|Adds RapidsBufferHandle as an indirection layer to RapidsBufferId|
+|[#7527](https://github.com/NVIDIA/spark-rapids/pull/7527)|Allow concurrentGpuTasks to be set per job|
+|[#7539](https://github.com/NVIDIA/spark-rapids/pull/7539)|Enable automerge from 23.02 to 23.04 [skip ci]|
+|[#7536](https://github.com/NVIDIA/spark-rapids/pull/7536)|Fix datetime out-of-range error in pytest when timezone is not UTC|
+|[#7502](https://github.com/NVIDIA/spark-rapids/pull/7502)|Fix Spark 3.4 build errors|
+|[#7522](https://github.com/NVIDIA/spark-rapids/pull/7522)|Update docs and add Rapids shuffle manager for Databricks-11.3|
+|[#7507](https://github.com/NVIDIA/spark-rapids/pull/7507)|Fallback to CPU for unrecognized Distributions|
+|[#7515](https://github.com/NVIDIA/spark-rapids/pull/7515)|Fix leak in GpuHiveTableScanExec|
+|[#7504](https://github.com/NVIDIA/spark-rapids/pull/7504)|Align CI test scripts with new init scripts for Databricks [skip ci]|
+|[#7506](https://github.com/NVIDIA/spark-rapids/pull/7506)|Add RapidsDeltaWrite node to fix undesired transitions with AQE|
+|[#7414](https://github.com/NVIDIA/spark-rapids/pull/7414)|batched full hash join|
+|[#7509](https://github.com/NVIDIA/spark-rapids/pull/7509)|Fix json_test.py imports|
+|[#7269](https://github.com/NVIDIA/spark-rapids/pull/7269)|Add hadoop-def.sh to support multiple spark release tarballs|
+|[#7494](https://github.com/NVIDIA/spark-rapids/pull/7494)|Implement a simplified version of `from_json`|
+|[#7434](https://github.com/NVIDIA/spark-rapids/pull/7434)|Support `json_tuple`|
+|[#7489](https://github.com/NVIDIA/spark-rapids/pull/7489)|Remove the MIT license from tools jar[skip ci]|
+|[#7497](https://github.com/NVIDIA/spark-rapids/pull/7497)|Inserting multiple times to HashedPriorityQueue should not corrupt the heap|
+|[#7475](https://github.com/NVIDIA/spark-rapids/pull/7475)|Inject GpuCast for decimal AddSub when operands' precision/scale differ on 340, 330db|
+|[#7486](https://github.com/NVIDIA/spark-rapids/pull/7486)|Allow Shims to replace Hive execs|
+|[#7484](https://github.com/NVIDIA/spark-rapids/pull/7484)|Fix arrays_zip to not rely on broken segmented gather|
+|[#7460](https://github.com/NVIDIA/spark-rapids/pull/7460)|More cases support partition column pruning|
+|[#7462](https://github.com/NVIDIA/spark-rapids/pull/7462)|Changing metric component counters to avoid extraneous accruals|
+|[#7467](https://github.com/NVIDIA/spark-rapids/pull/7467)|Remove spark2-sql-plugin|
+|[#7474](https://github.com/NVIDIA/spark-rapids/pull/7474)|xfail array zip tests|
+|[#7464](https://github.com/NVIDIA/spark-rapids/pull/7464)|Enable integration tests against Databricks 11.3 in premerge|
+|[#7455](https://github.com/NVIDIA/spark-rapids/pull/7455)|Use GpuAlias when handling Empty2Null in GpuOptimisticTransaction|
+|[#7456](https://github.com/NVIDIA/spark-rapids/pull/7456)|Sort Delta log objects when comparing and avoid caching all logs|
+|[#7431](https://github.com/NVIDIA/spark-rapids/pull/7431)|Remove release script of spark-rapids/tools [skip ci]|
+|[#7421](https://github.com/NVIDIA/spark-rapids/pull/7421)|Remove spark-rapids/tools|
+|[#7418](https://github.com/NVIDIA/spark-rapids/pull/7418)|Fix for AQE+DPP issue on AWS EMR|
+|[#7444](https://github.com/NVIDIA/spark-rapids/pull/7444)|Explicitly check if the platform is supported|
+|[#7417](https://github.com/NVIDIA/spark-rapids/pull/7417)|Make cudf-udf tests runnable on Databricks 11.3|
+|[#7420](https://github.com/NVIDIA/spark-rapids/pull/7420)|Ubuntu build&test images default as 20.04|
+|[#7442](https://github.com/NVIDIA/spark-rapids/pull/7442)|Fix parsing of Delta Lake logs containing multi-line JSON records|
+|[#7438](https://github.com/NVIDIA/spark-rapids/pull/7438)|Add documentation for runnable command enable configs|
+|[#7439](https://github.com/NVIDIA/spark-rapids/pull/7439)|Suppress unknown RunnableCommand warnings by default|
+|[#7346](https://github.com/NVIDIA/spark-rapids/pull/7346)|[Doc]revert the changes in FAQ for deltalake table support[skip ci]|
+|[#7413](https://github.com/NVIDIA/spark-rapids/pull/7413)|[Doc]update getting started doc for EMR and databricks[skip ci]|
+|[#7445](https://github.com/NVIDIA/spark-rapids/pull/7445)|Support pruning partition columns for avro file scan|
+|[#7447](https://github.com/NVIDIA/spark-rapids/pull/7447)|Xfail the test of pruning partition column for json read|
+|[#7440](https://github.com/NVIDIA/spark-rapids/pull/7440)|Xfail largest decimals window aggregation|
+|[#7437](https://github.com/NVIDIA/spark-rapids/pull/7437)|Fix the regexp test failures on DB11.3|
+|[#7428](https://github.com/NVIDIA/spark-rapids/pull/7428)|Support pruning partition columns for GpuFileSourceScan|
+|[#7435](https://github.com/NVIDIA/spark-rapids/pull/7435)|Update IntelliJ IDEA doc [skip ci]|
+|[#7416](https://github.com/NVIDIA/spark-rapids/pull/7416)|Reorganize and shim ScanExecMeta overrides and fix interval file IO|
+|[#7427](https://github.com/NVIDIA/spark-rapids/pull/7427)|Install-file log4j-core on Databricks 11.3|
+|[#7424](https://github.com/NVIDIA/spark-rapids/pull/7424)|xfail Hive text tests failing on CDH|
+|[#7408](https://github.com/NVIDIA/spark-rapids/pull/7408)|Fallback to CPU for unrecognized ShuffleOrigin|
+|[#7422](https://github.com/NVIDIA/spark-rapids/pull/7422)|Skip test_dynamic_partition_write_round_trip in 321cdh|
+|[#7406](https://github.com/NVIDIA/spark-rapids/pull/7406)|Fix array_test.py::test_array_intersect for cloudera spark330|
+|[#6761](https://github.com/NVIDIA/spark-rapids/pull/6761)|Switch string to float casting to use new kernel|
+|[#7411](https://github.com/NVIDIA/spark-rapids/pull/7411)|Skip Int division test that causes scale less than precision|
+|[#7410](https://github.com/NVIDIA/spark-rapids/pull/7410)|Remove 314 from dist build list|
+|[#7412](https://github.com/NVIDIA/spark-rapids/pull/7412)|Fix the `with_hidden_metadata_fallback` test failures on DB11.3|
+|[#7362](https://github.com/NVIDIA/spark-rapids/pull/7362)|Fix multiplication and division test failures in 330db and 340 shim|
+|[#7405](https://github.com/NVIDIA/spark-rapids/pull/7405)|Fix multithreaded combine code initial size calculation|
+|[#7395](https://github.com/NVIDIA/spark-rapids/pull/7395)|Enable Delta Lake write acceleration by default|
+|[#7384](https://github.com/NVIDIA/spark-rapids/pull/7384)|Fix implementation of createReadRDDForDirectories to match DataSource…|
+|[#7391](https://github.com/NVIDIA/spark-rapids/pull/7391)|Exclude GDS test suite as default|
+|[#7390](https://github.com/NVIDIA/spark-rapids/pull/7390)|Aggregate Databricks 11.3 shim in the nightly dist jar|
+|[#7381](https://github.com/NVIDIA/spark-rapids/pull/7381)|Filter out some new timestamp-related Delta Lake tags when comparing logs|
+|[#7371](https://github.com/NVIDIA/spark-rapids/pull/7371)|Avoid shutting down RMM until all allocations have cleared|
+|[#7377](https://github.com/NVIDIA/spark-rapids/pull/7377)|Update RapidsUDF interface to support UDFs with no input parameters|
+|[#7388](https://github.com/NVIDIA/spark-rapids/pull/7388)|Fix `test_array_element_at_zero_index_fail` and `test_div_overflow_exception_when_ansi` DB 11.3 integration test failures|
+|[#7380](https://github.com/NVIDIA/spark-rapids/pull/7380)|[FEA] Support `reverse` for arrays|
+|[#7365](https://github.com/NVIDIA/spark-rapids/pull/7365)|Move PythonMapInArrowExec to shim for shared 330+ functionality (db11.3)|
+|[#7372](https://github.com/NVIDIA/spark-rapids/pull/7372)|Fix for incorrect nested-unsigned test|
+|[#7386](https://github.com/NVIDIA/spark-rapids/pull/7386)|Spark 3.1.4 snapshot fix setting of reproduceEmptyStringBug|
+|[#7385](https://github.com/NVIDIA/spark-rapids/pull/7385)|Fix Databricks version comparison in pytests|
+|[#7379](https://github.com/NVIDIA/spark-rapids/pull/7379)|Fixes bug where dynamic partition overwrite mode didn't work for ORC|
+|[#7370](https://github.com/NVIDIA/spark-rapids/pull/7370)|Fix non file read DayTimeInterval errors|
+|[#7375](https://github.com/NVIDIA/spark-rapids/pull/7375)|Fix CPU fallback for GpuHiveTableScanExec|
+|[#7355](https://github.com/NVIDIA/spark-rapids/pull/7355)|Fix Add and Subtract test failures in 330db and 340 shim|
+|[#7299](https://github.com/NVIDIA/spark-rapids/pull/7299)|Qualification tool: Update parsing of write data format|
+|[#7357](https://github.com/NVIDIA/spark-rapids/pull/7357)|Update the integration tests  to fit the removed config ` spark.sql.ansi.strictIndexOperator` in DB11.3 and Spark 3.4|
+|[#7369](https://github.com/NVIDIA/spark-rapids/pull/7369)|Re-enable some tests in ParseDateTimeSuite|
+|[#7366](https://github.com/NVIDIA/spark-rapids/pull/7366)|Support Databricks 11.3|
+|[#7354](https://github.com/NVIDIA/spark-rapids/pull/7354)|Fix arithmetic error messages in 330db, 340 shims|
+|[#7364](https://github.com/NVIDIA/spark-rapids/pull/7364)|Move Rounding ops to shim for 330+ (db11.3)|
+|[#7298](https://github.com/NVIDIA/spark-rapids/pull/7298)|Improve performance of small file parquet reads from blob stores|
+|[#7363](https://github.com/NVIDIA/spark-rapids/pull/7363)|Fix ExtractValue assertion with 330db shim|
+|[#7340](https://github.com/NVIDIA/spark-rapids/pull/7340)|Fix nested-unsigned test issues.|
+|[#7358](https://github.com/NVIDIA/spark-rapids/pull/7358)|Update Delta version to 1.1.0|
+|[#7301](https://github.com/NVIDIA/spark-rapids/pull/7301)|Add null values back to test_array_intersect for Spark 3.3.1+ and Databricks 10.4+|
+|[#7152](https://github.com/NVIDIA/spark-rapids/pull/7152)|Add a shim for Databricks 11.3 spark330db|
+|[#7333](https://github.com/NVIDIA/spark-rapids/pull/7333)|Avoid row number computation when the partition schema is empty|
+|[#7317](https://github.com/NVIDIA/spark-rapids/pull/7317)|Make multi-threaded shuffle not experimental and update docs|
+|[#7342](https://github.com/NVIDIA/spark-rapids/pull/7342)|Update plan capture listener to handle multiple plans per query.|
+|[#7338](https://github.com/NVIDIA/spark-rapids/pull/7338)|Fix auto merge conflict 7336 [skip ci]|
+|[#7335](https://github.com/NVIDIA/spark-rapids/pull/7335)|Fix auto merge conflict 7334[skip ci]|
+|[#7312](https://github.com/NVIDIA/spark-rapids/pull/7312)|Fix documentation bug|
+|[#7315](https://github.com/NVIDIA/spark-rapids/pull/7315)|Fix merge conflict with branch-22.12|
+|[#7296](https://github.com/NVIDIA/spark-rapids/pull/7296)|Enable hive text reads by default|
+|[#7304](https://github.com/NVIDIA/spark-rapids/pull/7304)|Correct partition columns handling for coalesced and chunked read|
+|[#7305](https://github.com/NVIDIA/spark-rapids/pull/7305)|Fix CPU fallback for custom timestamp formats in Hive text tables|
+|[#7293](https://github.com/NVIDIA/spark-rapids/pull/7293)|Refine '$LOCAL_JAR_PATH' as optional for integration test on databricks [skip ci]|
+|[#7285](https://github.com/NVIDIA/spark-rapids/pull/7285)|[FEA] Support `reverse` for strings|
+|[#7297](https://github.com/NVIDIA/spark-rapids/pull/7297)|Remove Decimal Support Section from compatibility docs [skip ci]|
+|[#7291](https://github.com/NVIDIA/spark-rapids/pull/7291)|Improve IntelliJ IDEA doc and usability|
+|[#7245](https://github.com/NVIDIA/spark-rapids/pull/7245)|Fix boolean, int, and float parsing. Improve decimal parsing for hive|
+|[#7265](https://github.com/NVIDIA/spark-rapids/pull/7265)|Fix Hive Delimited Text timestamp parsing|
+|[#7221](https://github.com/NVIDIA/spark-rapids/pull/7221)|Fix date parsing in Hive Delimited Text reader|
+|[#7287](https://github.com/NVIDIA/spark-rapids/pull/7287)|Don't use native parquet footer parser if field ids for read are needed|
+|[#7262](https://github.com/NVIDIA/spark-rapids/pull/7262)|Moving generated files to standalone tools dir|
+|[#7268](https://github.com/NVIDIA/spark-rapids/pull/7268)|Remove deprecated compatibility support in premerge|
+|[#7248](https://github.com/NVIDIA/spark-rapids/pull/7248)|Fix AlluxioUtilsSuite build on Databricks|
+|[#7207](https://github.com/NVIDIA/spark-rapids/pull/7207)|Change the hive text file parser to not use CSV input format|
+|[#7209](https://github.com/NVIDIA/spark-rapids/pull/7209)|Change RegExpExtract to use isNull checks instead of contains_re|
+|[#7212](https://github.com/NVIDIA/spark-rapids/pull/7212)|Removing common module and adding common files to sql-plugin|
+|[#7202](https://github.com/NVIDIA/spark-rapids/pull/7202)|Avoid sort in v1 write for static columns|
+|[#7167](https://github.com/NVIDIA/spark-rapids/pull/7167)|Handle two changes related to `FileFormatWriter` since Spark 340|
+|[#7194](https://github.com/NVIDIA/spark-rapids/pull/7194)|Skip tests that fail due to recent cuDF changes related to end of string/line anchors|
+|[#7170](https://github.com/NVIDIA/spark-rapids/pull/7170)|Fix the `limit_test` failures on Spark 3.4|
+|[#7075](https://github.com/NVIDIA/spark-rapids/pull/7075)|Fix the failure of `test_array_element_at_zero_index_fail` on Spark3.4|
+|[#7126](https://github.com/NVIDIA/spark-rapids/pull/7126)|Fix support for binary encoded decimal for parquet|
+|[#7113](https://github.com/NVIDIA/spark-rapids/pull/7113)|Use an improved API for appending binary to host vector|
+|[#7130](https://github.com/NVIDIA/spark-rapids/pull/7130)|Enable chunked parquet reads by default|
+|[#7074](https://github.com/NVIDIA/spark-rapids/pull/7074)|Update JNI and cudf-py version to 23.02|
+|[#7063](https://github.com/NVIDIA/spark-rapids/pull/7063)|Init version 23.02.0|
+
+## Older Releases
+Changelog of older releases can be found at [docs/archives](/docs/archives)

--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -44,13 +44,13 @@ Github personal access token: https://github.com/settings/tokens, and make you h
 Usage:
     cd spark-rapids/
 
-    # generate changelog for releases 23.02 to 23.04
+    # generate changelog for releases X, Y, Z
     scripts/generate-changelog --token=<GITHUB_PERSONAL_ACCESS_TOKEN> \
-    --releases=23.02,23.04
+    --releases=X,Y,Z
 
     # To a separate file like /tmp/CHANGELOG.md
     GITHUB_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN> scripts/generate-changelog \
-    --releases=23.02,23.04 \
+    --releases=X,Y,Z \
     --path=/tmp/CHANGELOG.md
 """
 import os


### PR DESCRIPTION
moved existing one to archived

generated new changelog w/ command,
```
GITHUB_TOKEN=<PAT> scripts/generate-changelog --releases=23.06
```

BTW Roadmap 23.02 was already deleted from Gihub project, so we cannot regenerate it. 
The archived doc was just simply copied from existing changelog