### PR TITLE
Add limitation for the UCX shuffle keep_alive workaround [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -481,4 +481,4 @@ performance degradation with several Spark actions, consider tuning this setting
   ```
   ERROR UCX: UcpListener detected an error for executorId 2: UCXError(-25,Connection reset by remote peer)
   ```
-  Consider turning off keep-alive for UCX using: `spark.executorEnv.UCX_TCP_KEEPINTVL=inf`.
+  Consider turning off keep-alive for UCX using: `spark.executorEnv.UCX_TCP_KEEPINTVL=inf`. NOTE: this would only mitigate the issue but not resolve it.


### PR DESCRIPTION
related to https://github.com/NVIDIA/spark-rapids/issues/7940#issuecomment-1583971544

As the issue should be taken care in 23.08, lets update the workaround part to make it clear in 23.06