### PR TITLE
Revert "Handle caching empty batch (#8507)" [databricks]

### DIFF
--- a/integration_tests/src/main/python/cache_test.py
+++ b/integration_tests/src/main/python/cache_test.py
@@ -254,17 +254,13 @@ def test_cache_additional_types(enable_vectorized, with_x_session, select_expr):
     # NOTE: we aren't comparing cpu and gpu results, we are comparing the cached and non-cached results.
     assert_equal(reg_result, cached_result)
 
-def generate_data_and_test_func_on_cached_df(with_x_session, func, data_gen, test_conf):
-    df = lambda spark: unary_op_df(spark, data_gen)
-    function_to_test_on_df(with_x_session, df, func, test_conf)
-
-def function_to_test_on_df(with_x_session, df_gen, func_on_df, test_conf):
+def function_to_test_on_cached_df(with_x_session, func, data_gen, test_conf):
     def with_cache(cached):
         def helper(spark):
-            _df = df_gen(spark)
+            df = unary_op_df(spark, data_gen)
             if cached:
-                _df.cache().count()
-            return func_on_df(_df)
+                df.cache().count()
+            return func(df)
         return helper
 
     reg_result = with_x_session(with_cache(False), test_conf)
@@ -279,7 +275,7 @@ def function_to_test_on_df(with_x_session, df_gen, func_on_df, test_conf):
 @ignore_order
 def test_cache_count(data_gen, with_x_session, enable_vectorized_conf, batch_size):
     test_conf = copy_and_update(enable_vectorized_conf, batch_size)
-    generate_data_and_test_func_on_cached_df(with_x_session, lambda df: df.count(), data_gen, test_conf)
+    function_to_test_on_cached_df(with_x_session, lambda df: df.count(), data_gen, test_conf)
 
 @pytest.mark.parametrize('data_gen', all_gen, ids=idfn)
 @pytest.mark.parametrize('with_x_session', [with_cpu_session, with_gpu_session])
@@ -294,7 +290,7 @@ def test_cache_count(data_gen, with_x_session, enable_vectorized_conf, batch_siz
 @allow_non_gpu('ColumnarToRowExec')
 def test_cache_multi_batch(data_gen, with_x_session, enable_vectorized_conf, batch_size):
     test_conf = copy_and_update(enable_vectorized_conf, batch_size)
-    generate_data_and_test_func_on_cached_df(with_x_session, lambda df: df.collect(), data_gen, test_conf)
+    function_to_test_on_cached_df(with_x_session, lambda df: df.collect(), data_gen, test_conf)
 
 @pytest.mark.parametrize('data_gen', all_basic_map_gens + _cache_single_array_gens_no_null, ids=idfn)
 @pytest.mark.parametrize('enable_vectorized', enable_vectorized_confs, ids=idfn)
@@ -351,8 +347,4 @@ def test_aqe_cache_join(data_gen):
 @allow_non_gpu("InMemoryTableScanExec", "ProjectExec", "ColumnarToRowExec")
 def test_inmem_cache_count():
     conf={"spark.sql.session.timeZone": "America/Los_Angeles"}
-    function_to_test_on_df(with_gpu_session, lambda spark: unary_op_df(spark, int_gen).selectExpr("cast(a as timestamp)"), lambda df: df.count(), test_conf=conf)
-
-@pytest.mark.parametrize('with_x_session', [with_gpu_session, with_cpu_session])
-def test_batch_no_cols(with_x_session):
-    function_to_test_on_df(with_x_session, lambda spark: unary_op_df(spark, int_gen).drop("a"), lambda df: df.count(), test_conf={})
+    function_to_test_on_cached_df(with_gpu_session, lambda df: df.selectExpr("cast(a as timestamp)").cache().count(), int_gen, test_conf=conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -319,14 +319,11 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
       }
 
       input.flatMap(batch => {
-        // If the structSchema is empty or the batch has no cols in that case return a batch with
-        // just rows.
-        if (batch.numCols() == 0 || structSchema.isEmpty) {
-          val rows = batch.numRows()
+        if (batch.numCols() == 0 || batch.numRows() == 0) {
           if (batch.numCols() > 0 && batch.column(0).isInstanceOf[GpuColumnVector]) {
-            batch.close()
+            batch.close();
           }
-          List(ParquetCachedBatch(rows, new Array[Byte](0)))
+          List(ParquetCachedBatch(batch.numRows(), new Array[Byte](0)))
         } else {
           withResource(putOnGpuIfNeeded(batch)) { gpuCB =>
             compressColumnarBatchWithParquet(gpuCB, structSchema, schema.toStructType,
@@ -481,13 +478,6 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
       originalSelectedAttributes: Seq[Attribute]): RDD[ColumnarBatch] = {
 
     val cbRdd: RDD[ColumnarBatch] = input.map {
-      case parquetCB: ParquetCachedBatch if parquetCB.sizeInBytes == 0 =>
-        // If the buffer is empty, we have cached a batch with no columns, we don't need to decode
-        // it, instead just return a ColumnarBatch with only rows
-        withResource(new GpuColumnarBatchBuilder(originalSelectedAttributes.toStructType,
-          parquetCB.numRows)) {
-          builder => builder.build(parquetCB.numRows)
-        }
       case parquetCB: ParquetCachedBatch =>
         val parquetOptions = ParquetOptions.builder()
             .includeColumn(selectedAttributes.map(_.name).asJavaCollection).build()
@@ -870,18 +860,11 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
         if (!cbIter.hasNext) {
           Iterator.empty
         } else {
-          val cachedBatch = cbIter.next().asInstanceOf[ParquetCachedBatch]
-          if (cachedBatch.sizeInBytes == 0) {
-            // Edge case where we have stored an empty parquet file possibly a dataframe with no
-            // columns
-            List(new ColumnarBatch(null, cachedBatch.numRows)).iterator
-          } else {
-            new ShimCurrentBatchIterator(
-              cachedBatch,
-              conf,
-              selectedAttributes,
-              options, hadoopConf)
-          }
+          new ShimCurrentBatchIterator(
+            cbIter.next().asInstanceOf[ParquetCachedBatch],
+            conf,
+            selectedAttributes,
+            options, hadoopConf)
         }
       }
 
@@ -1073,78 +1056,61 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
       override def next(): CachedBatch = {
         if (queue.isEmpty) {
-          queue ++= convertRowIteratorToCachedBatch(getIterator)
-        }
-        if (!queue.isEmpty) {
-          queue.dequeue()
-        } else {
-          throw new IllegalStateException("Encountered an empty batch")
-        }
-      }
-
-      protected def convertRowIteratorToCachedBatch(
-          rowIterator: Iterator[InternalRow]): mutable.Queue[CachedBatch] = {
-        val queue = new mutable.Queue[CachedBatch]()
-        // to store a row if we have read it but there is no room in the parquet file to put it
-        // we will put it in the next CachedBatch
-        var leftOverRow: Option[InternalRow] = None
-        while (rowIterator.hasNext || leftOverRow.nonEmpty) {
-          // Each partition will be a single parquet file
-          var rows = 0
-          // at least a single block
-          val stream = new ByteArrayOutputStream(ByteArrayOutputFile.BLOCK_SIZE)
-          val outputFile: OutputFile = new ByteArrayOutputFile(stream)
-          conf.setConfString(SparkShimImpl.parquetRebaseWriteKey,
-            LegacyBehaviorPolicy.CORRECTED.toString)
-          if (cachedAttributes.isEmpty) {
-            // The schema is empty, most probably it is because of the edge case where there
-            // are no columns in the Dataframe but has rows so let's create an empty CachedBatch
-            // with rows
-            queue += new ParquetCachedBatch(rowIterator.size, new Array[Byte](0))
-            return queue
-          }
-          val recordWriter = SQLConf.withExistingConf(conf) {
-            parquetOutputFileFormat.getRecordWriter(outputFile, hadoopConf)
-          }
-          var totalSize = 0
-          while ((rowIterator.hasNext || leftOverRow.nonEmpty)
-            && totalSize < bytesAllowedPerBatch) {
-
-            val row = if (leftOverRow.nonEmpty) {
-              val a = leftOverRow.get
-              leftOverRow = None // reset value
-              a
-            } else {
-              rowIterator.next()
+          // to store a row if we have read it but there is no room in the parquet file to put it
+          // we will put it in the next CachedBatch
+          var leftOverRow: Option[InternalRow] = None
+          val rowIterator = getIterator
+          while (rowIterator.hasNext || leftOverRow.nonEmpty) {
+            // Each partition will be a single parquet file
+            var rows = 0
+            // at least a single block
+            val stream = new ByteArrayOutputStream(ByteArrayOutputFile.BLOCK_SIZE)
+            val outputFile: OutputFile = new ByteArrayOutputFile(stream)
+            conf.setConfString(SparkShimImpl.parquetRebaseWriteKey,
+              LegacyBehaviorPolicy.CORRECTED.toString)
+            val recordWriter = SQLConf.withExistingConf(conf) {
+              parquetOutputFileFormat.getRecordWriter(outputFile, hadoopConf)
             }
-            totalSize += {
-              row match {
-                case r: UnsafeRow =>
-                  r.getSizeInBytes
-                case _ =>
-                  estimatedSize
-              }
-            }
-            if (totalSize <= bytesAllowedPerBatch) {
-              rows += 1
-              if (rows < 0) {
-                throw new IllegalStateException("CachedBatch doesn't support rows larger " +
-                  "than Int.MaxValue")
-              }
-              recordWriter.write(null, row)
-            } else {
-              leftOverRow = Some(if (row.isInstanceOf[UnsafeRow]) {
-                row.copy()
+            var totalSize = 0
+            while ((rowIterator.hasNext || leftOverRow.nonEmpty)
+                && totalSize < bytesAllowedPerBatch) {
+
+              val row = if (leftOverRow.nonEmpty) {
+                val a = leftOverRow.get
+                leftOverRow = None // reset value
+                a
               } else {
-                row
-              })
+                rowIterator.next()
+              }
+              totalSize += {
+                row match {
+                  case r: UnsafeRow =>
+                    r.getSizeInBytes
+                  case _ =>
+                    estimatedSize
+                }
+              }
+              if (totalSize <= bytesAllowedPerBatch) {
+                rows += 1
+                if (rows < 0) {
+                  throw new IllegalStateException("CachedBatch doesn't support rows larger " +
+                      "than Int.MaxValue")
+                }
+                recordWriter.write(null, row)
+              } else {
+                leftOverRow = Some(if (row.isInstanceOf[UnsafeRow]) {
+                  row.copy()
+                } else {
+                  row
+                })
+              }
             }
+            // passing null as context isn't used in this method
+            recordWriter.close(null)
+            queue += ParquetCachedBatch(rows, stream.toByteArray)
           }
-          // passing null as context isn't used in this method
-          recordWriter.close(null)
-          queue += ParquetCachedBatch(rows, stream.toByteArray)
         }
-        queue
+        queue.dequeue()
       }
     }
 
@@ -1162,11 +1128,8 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
         hostBatches.clear()
       })
 
-      override def next(): CachedBatch = myIter.next()
-
-      override def hasNext(): Boolean = myIter.hasNext
-
-      val myIter = iter.asInstanceOf[Iterator[ColumnarBatch]].flatMap { batch =>
+      override def getIterator: Iterator[InternalRow] = new Iterator[InternalRow] {
+        val batch: ColumnarBatch = iter.asInstanceOf[Iterator[ColumnarBatch]].next
         val hostBatch = if (batch.column(0).isInstanceOf[GpuColumnVector]) {
           withResource(batch) { batch =>
             new ColumnarBatch(batch.safeMap(_.copyToHost()).toArray, batch.numRows())
@@ -1175,11 +1138,12 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
           batch
         }
         hostBatches += hostBatch
-        if (batch.numCols() == 0) {
-          List(ParquetCachedBatch(batch.numRows(), new Array[Byte](0)))
-        } else {
-          convertRowIteratorToCachedBatch(hostBatch.rowIterator().asScala).toList
-        }
+
+        val rowIterator = hostBatch.rowIterator().asScala
+
+        override def next: InternalRow = rowIterator.next
+
+        override def hasNext: Boolean = rowIterator.hasNext
       }
 
       override def close(): Unit = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.shims.SparkUpgradeExceptionShims
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.BlockManagerId
@@ -168,7 +167,4 @@ object TrampolineUtil {
     Utils.classForName(className, initialize, noSparkClassLoader)
   }
 
-  def getSparkConf(spark: SparkSession): SQLConf = {
-    spark.sqlContext.conf
-  }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CachedBatchWriterSuite.scala
@@ -16,29 +16,21 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.JavaConverters.asScalaIteratorConverter
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.{ColumnVector, CompressionType, DType, Table, TableWriter}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableFromBatchColumns
 import org.apache.hadoop.mapreduce.{RecordWriter, TaskAttemptContext}
-import org.mockito.ArgumentMatchers.{any, isA}
-import org.mockito.Mockito.{doAnswer, mock, mockStatic, spy, times, verify, when}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.SparkSession.setActiveSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
-import org.apache.spark.sql.rapids.metrics.source.MockTaskContext
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.storage.StorageLevel.MEMORY_ONLY
 
 
 /**
@@ -138,75 +130,6 @@ class CachedBatchWriterSuite extends SparkQueryCompareTestSuite {
         } else {
           CompressionType.NONE
         }) == opts.getCompressionType)
-    }
-  }
-
-  test("cache empty columnar batch on GPU") {
-    withGpuSparkSession(writeAndConsumeEmptyBatch)
-  }
-
-  private def writeAndConsumeEmptyBatch(spark: SparkSession): Unit = {
-    setActiveSession(spark)
-    val schema = Seq(AttributeReference("_col0", IntegerType, true)())
-    val columnarBatch0 = FuzzerUtils.createColumnarBatch(schema.toStructType, 0)
-    val columnarBatch = FuzzerUtils.createColumnarBatch(schema.toStructType, 10)
-    // increase count to verify the result later
-    columnarBatch.column(0).asInstanceOf[GpuColumnVector].getBase.incRefCount()
-    columnarBatch0.column(0).asInstanceOf[GpuColumnVector].getBase.incRefCount()
-
-    val rdd = spark.sparkContext.parallelize(Seq(columnarBatch, columnarBatch0))
-    val storageLevel = MEMORY_ONLY
-    val conf = TrampolineUtil.getSparkConf(spark)
-    val context = new MockTaskContext(taskAttemptId = 1, partitionId = 0)
-
-    // Default Serializer round trip
-    val defaultSer = new DefaultCachedBatchSerializer
-    val toClose = ListBuffer[ColumnarBatch]()
-    val irRdd = rdd.flatMap { batch =>
-      val hostBatch = if (batch.column(0).isInstanceOf[GpuColumnVector]) {
-        withResource(batch) { batch =>
-          new ColumnarBatch(batch.safeMap(_.copyToHost()).toArray, batch.numRows())
-        }
-      } else {
-        batch
-      }
-      toClose += hostBatch
-      hostBatch.rowIterator().asScala
-    }
-
-    val expectedCachedRdd = defaultSer
-      .convertInternalRowToCachedBatch(irRdd, schema, storageLevel, conf)
-    val expectedCbRdd = defaultSer
-      .convertCachedBatchToColumnarBatch(expectedCachedRdd, schema, schema, conf)
-    val defaultBatches = expectedCbRdd.compute(expectedCbRdd.partitions.head, context)
-
-    // PCBS round trip
-    val ser = new ParquetCachedBatchSerializer
-    val cachedRdd = ser.convertColumnarBatchToCachedBatch(rdd, schema, storageLevel, conf)
-    val cbRdd = ser.convertCachedBatchToColumnarBatch(cachedRdd, schema, schema, conf)
-    TrampolineUtil.setTaskContext(context)
-    try {
-      val batches = cbRdd.compute(cbRdd.partitions.head, context)
-
-      // Read the batches to consume the cache
-      assert(batches.hasNext)
-      assert(defaultBatches.hasNext)
-      val cb = batches.next()
-      val expectedCb = defaultBatches.next()
-      val hostCol = cb.column(0)
-      val hostColExpected = expectedCb.column(0)
-      assert(cb.numRows() == 10)
-      for (i <- 0 until 10) {
-        assert(hostCol.isNullAt(i) == hostColExpected.isNullAt(i))
-        if (!hostCol.isNullAt(i)) {
-          assert(hostCol.getInt(i) == hostColExpected.getInt(i))
-        }
-      }
-      assert(!batches.hasNext)
-      assert(!defaultBatches.hasNext)
-    } finally {
-      toClose.foreach(cb => cb.close())
-      TrampolineUtil.unsetTaskContext()
     }
   }
 


### PR DESCRIPTION
related to https://github.com/NVIDIA/spark-rapids/issues/8548

This reverts commit 5502547efc8fb263c0358fb78c46df149ec5b589. We will decide if we need to fix this in 23.06 later