### PR TITLE
Fold `verify-all-modules-with-headSparkVersion` into `verify-all-modules` [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -33,7 +33,6 @@ jobs:
   get-shim-versions-from-dist:
     runs-on: ubuntu-latest
     outputs:
-      sparkHeadVersion: ${{ steps.allShimVersionsStep.outputs.headVersion }}
       sparkTailVersions: ${{ steps.allShimVersionsStep.outputs.tailVersions }}
       sparkJDKVersions: ${{ steps.allShimVersionsStep.outputs.jdkVersions }}
     steps:
@@ -61,7 +60,6 @@ jobs:
             svJsonStr=$(printf {\"include\":[%s]} $svArrBodyNoSnapshot)
           fi
 
-          echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           # default version
           jdkHeadVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":8}" "${SPARK_BASE_SHIM_VERSION}")

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -118,6 +118,6 @@ jobs:
       - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P 'individual,pre-merge,${{ matrix.java-version }}'
+          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
           -Dbuildver=${{ matrix.spark-version }}
           $COMMON_MVN_FLAGS

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -70,7 +70,7 @@ jobs:
           # jdk17
           jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17,\"profiles\":\"individual,pre-merge,jdk17\"}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           # jdk
-          jdkVersionArrBody=$jdk11VersionArrBody$jdk17VersionArrBody
+          jdkVersionArrBody=$jdkHeadVersionArrBody$jdk11VersionArrBody$jdk17VersionArrBody
           jdkVersionArrBody=${jdkVersionArrBody:1}
           jdkVersionJsonStr=$(printf {\"include\":[%s]} $jdkVersionArrBody)
           echo "jdkVersions=$jdkVersionJsonStr" >> $GITHUB_OUTPUT

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -63,10 +63,12 @@ jobs:
 
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
+          # jdk8
+          jdkHeadVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":8,\"profiles\":\"individual,pre-merge\"}" "${SPARK_BASE_SHIM_VERSION}")
           # jdk11
-          jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11,\"profiles\":\"individual,pre-merge,jdk11\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           # jdk17
-          jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
+          jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17,\"profiles\":\"individual,pre-merge,jdk17\"}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           # jdk
           jdkVersionArrBody=$jdk11VersionArrBody$jdk17VersionArrBody
           jdkVersionArrBody=${jdkVersionArrBody:1}
@@ -137,6 +139,6 @@ jobs:
       - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
+          -P "${{ matrix.profiles }}"
           -Dbuildver=${{ matrix.spark-version }}
           $COMMON_MVN_FLAGS

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -63,12 +63,12 @@ jobs:
 
           echo "headVersion=$SPARK_BASE_SHIM_VERSION" >> $GITHUB_OUTPUT
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
-          # jdk8
-          jdkHeadVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":8,\"profiles\":\"individual,pre-merge\"}" "${SPARK_BASE_SHIM_VERSION}")
+          # default version
+          jdkHeadVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":8}" "${SPARK_BASE_SHIM_VERSION}")
           # jdk11
-          jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11,\"profiles\":\"individual,pre-merge,jdk11\"}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
+          jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
           # jdk17
-          jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17,\"profiles\":\"individual,pre-merge,jdk17\"}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
+          jdk17VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":17}" "${SPARK_SHIM_VERSIONS_JDK17[@]}")
           # jdk
           jdkVersionArrBody=$jdkHeadVersionArrBody$jdk11VersionArrBody$jdk17VersionArrBody
           jdkVersionArrBody=${jdkVersionArrBody:1}
@@ -101,28 +101,7 @@ jobs:
           -Drat.skip=true
           $COMMON_MVN_FLAGS
 
-
-  verify-all-modules-with-headSparkVersion:
-    needs: get-shim-versions-from-dist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
-
-      - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 8
-
-      # includes RAT, code style and doc-gen checks of default shim
-      - name: verify all modules with lowest-supported Spark version
-        run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P 'individual,pre-merge'
-          -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.sparkHeadVersion }}
-          $COMMON_MVN_FLAGS
-
-  verify-modules-with-jdk:
+  verify-all-modules:
     needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
@@ -139,6 +118,6 @@ jobs:
       - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P "${{ matrix.profiles }}"
+          -P 'individual,pre-merge,${{ matrix.java-version }}'
           -Dbuildver=${{ matrix.spark-version }}
           $COMMON_MVN_FLAGS


### PR DESCRIPTION
fix #8401 

`verify-all-modules-with-headSparkVersion` has exactly same steps with `verify-all-modules`. So we add the combination of `jdk8` and `headSparkVersion` into `verify-all-modules` matrix. 

Also we renamed `verify-modules-with-jdk` to `verify-all-modules` to avoid misunderstanding, since the test cares about both jdk version and spark version.