### PR TITLE
Bump up private dep version to 23.06.1 [databricks]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <spark-rapids-jni.version>23.06.0</spark-rapids-jni.version>
-        <spark-rapids-private.version>23.06.0</spark-rapids-private.version>
+        <spark-rapids-private.version>23.06.1</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
related to #8579 

(NOT YET) We would rebuild private and release 23.06.1 artifact due to databricks runtime updates.

I will trigger the build after new private jar is available on maven central

