### PR TITLE
Revert to the JVM-based Spark version extraction in pytests

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -26,12 +26,7 @@ then
 else
     echo "WILL RUN TESTS WITH SPARK_HOME: ${SPARK_HOME}"
     [[ ! -x "$(command -v zip)" ]] && { echo "fail to find zip command in $PATH"; exit 1; }
-    PY4J_TMP=(${SPARK_HOME}/python/lib/py4j-*-src.zip)
-    PY4J_FILE=${PY4J_TMP[0]}
-    VERSION_STRING=$(
-        PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} \
-            python -c 'import pyspark; print(pyspark.__version__)'
-    )
+    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|grep -v Scala|awk '/version\ [0-9.]+/{print $NF}'`
     VERSION_STRING="${VERSION_STRING/-SNAPSHOT/}"
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
     [[ -z $SPARK_SHIM_VER ]] && { SPARK_SHIM_VER="spark${VERSION_STRING//./}"; }


### PR DESCRIPTION
Addresses #8588 
Reopens #6872 

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
