### PR TITLE
Drop ".dev0" suffix from Spark SNASHOT distro builds

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -28,10 +28,10 @@ else
     [[ ! -x "$(command -v zip)" ]] && { echo "fail to find zip command in $PATH"; exit 1; }
     PY4J_TMP=("${SPARK_HOME}"/python/lib/py4j-*-src.zip)
     PY4J_FILE=${PY4J_TMP[0]}
-    # PySpark uses ".dev0" instead of "-SNAPSHOT"
+    # PySpark uses ".dev0" for "-SNAPSHOT",  ".dev" for "preview"
     # https://github.com/apache/spark/blob/66f25e314032d562567620806057fcecc8b71f08/dev/create-release/release-build.sh#L267
     VERSION_STRING=$(PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} python -c \
-        "import pyspark, re; print(re.sub('\.dev0$', '', pyspark.__version__))"
+        "import pyspark, re; print(re.sub('\.dev0?$', '', pyspark.__version__))"
     )
 
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -28,14 +28,11 @@ else
     [[ ! -x "$(command -v zip)" ]] && { echo "fail to find zip command in $PATH"; exit 1; }
     PY4J_TMP=("${SPARK_HOME}"/python/lib/py4j-*-src.zip)
     PY4J_FILE=${PY4J_TMP[0]}
-    VERSION_STRING=$(
-        PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} \
-            python -c 'import pyspark; print(pyspark.__version__)'
-    )
-    VERSION_STRING="${VERSION_STRING/-SNAPSHOT/}"
     # PySpark uses ".dev0" instead of "-SNAPSHOT"
     # https://github.com/apache/spark/blob/66f25e314032d562567620806057fcecc8b71f08/dev/create-release/release-build.sh#L267
-    VERSION_STRING="${VERSION_STRING/.dev0/}"
+    VERSION_STRING=$(PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} python -c \
+        "import pyspark, re; print(re.sub('\.dev0$', '', pyspark.__version__))"
+    )
 
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
     [[ -z $SPARK_SHIM_VER ]] && { SPARK_SHIM_VER="spark${VERSION_STRING//./}"; }

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -26,7 +26,12 @@ then
 else
     echo "WILL RUN TESTS WITH SPARK_HOME: ${SPARK_HOME}"
     [[ ! -x "$(command -v zip)" ]] && { echo "fail to find zip command in $PATH"; exit 1; }
-    VERSION_STRING=`$SPARK_HOME/bin/pyspark --version 2>&1|grep -v Scala|awk '/version\ [0-9.]+/{print $NF}'`
+    PY4J_TMP=("${SPARK_HOME}"/python/lib/py4j-*-src.zip)
+    PY4J_FILE=${PY4J_TMP[0]}
+    VERSION_STRING=$(
+        PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} \
+            python -c 'import pyspark; print(pyspark.__version__)'
+    )
     VERSION_STRING="${VERSION_STRING/-SNAPSHOT/}"
     # PySpark uses ".dev0" instead of "-SNAPSHOT"
     # https://github.com/apache/spark/blob/66f25e314032d562567620806057fcecc8b71f08/dev/create-release/release-build.sh#L267

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -33,6 +33,10 @@ else
             python -c 'import pyspark; print(pyspark.__version__)'
     )
     VERSION_STRING="${VERSION_STRING/-SNAPSHOT/}"
+    # PySpark uses ".dev0" instead of "-SNAPSHOT"
+    # https://github.com/apache/spark/blob/66f25e314032d562567620806057fcecc8b71f08/dev/create-release/release-build.sh#L267
+    VERSION_STRING="${VERSION_STRING/.dev0/}"
+
     [[ -z $VERSION_STRING ]] && { echo "Unable to detect the Spark version at $SPARK_HOME"; exit 1; }
     [[ -z $SPARK_SHIM_VER ]] && { SPARK_SHIM_VER="spark${VERSION_STRING//./}"; }
 


### PR DESCRIPTION
Fixes #8588
Fixes #6872  

Alternative to #8589 

Drop [PEP 440](https://peps.python.org/pep-0440/#implicit-development-release-number) suffix for Python-based version extraction

Local testing with 3.3.0 downloaded from Apache and 3.3.0-SNAPSHOT built locally

```Python
JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 SPARK_HOME=~/gits/apache/spark/dist  TEST_PARALLEL=0 ./integration_tests/run_pyspark_from_build.sh -k 'array_exists'
```

Signed-off-by: Gera Shegalov <gera@apache.org>