### PR TITLE
Upgrade scalatest version to 3.2.16

### DIFF
--- a/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
+++ b/integration_tests/src/test/scala/com/nvidia/spark/rapids/tests/mortgage/MortgageSparkSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package com.nvidia.spark.rapids.tests.mortgage
 
 import com.nvidia.spark.rapids.ShimLoader
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
-class MortgageSparkSuite extends FunSuite {
+class MortgageSparkSuite extends AnyFunSuite {
 
   /**
    * This is intentionally a def rather than a val so that scalatest uses the correct value (from

--- a/pom.xml
+++ b/pom.xml
@@ -903,8 +903,14 @@
             <dependency>
               <groupId>org.scalatest</groupId>
               <artifactId>scalatest_${scala.binary.version}</artifactId>
-              <version>3.0.5</version>
+              <version>3.2.16</version>
               <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.scalatestplus</groupId>
+                <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+                <version>3.2.16.0</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
               <groupId>org.junit.jupiter</groupId>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Flat buffers is a small jar, it's appropriate to use a fixed version -->
         <!-- Shade and relocate it in the aggregator module-->

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioConfigReaderSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioConfigReaderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class AlluxioConfigReaderSuite extends FunSuite {
+class AlluxioConfigReaderSuite extends AnyFunSuite {
 
   test("testReadAlluxioMasterAndPort") {
     val homeDir = Files.createTempDirectory("tmpAlluxioHomePrefix")

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioUtilsSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/AlluxioUtilsSuite.scala
@@ -21,8 +21,8 @@ import com.nvidia.spark.rapids.shims.PartitionedFileUtilsShim
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 import org.apache.spark.sql.RuntimeConfig
 import org.apache.spark.sql.execution.datasources.{PartitionDirectory, PartitionedFile}
@@ -61,7 +61,7 @@ class AlluxioFSMock extends AlluxioFS {
   }
 }
 
-class AlluxioUtilsSuite extends FunSuite {
+class AlluxioUtilsSuite extends AnyFunSuite {
 
   def setMockOnAlluxioUtils(): Unit = {
     AlluxioUtils.setAlluxioFS(new AlluxioFSMock())

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ArmSuite.scala
@@ -19,9 +19,9 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.Arm._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ArmSuite extends FunSuite {
+class ArmSuite extends AnyFunSuite {
   class TestResource extends AutoCloseable {
     var closed = false
 

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.resource.ResourceInformation
 
-class GpuDeviceManagerSuite extends FunSuite {
+class GpuDeviceManagerSuite extends AnyFunSuite {
 
   test("Test Spark gpu resource") {
     val sparkConf = new SparkConf()

--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ThreadFactoryBuilderTest.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/ThreadFactoryBuilderTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package com.nvidia.spark.rapids
 
 import java.util.concurrent.{Callable, Executors}
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ThreadFactoryBuilderTest extends FunSuite {
+class ThreadFactoryBuilderTest extends AnyFunSuite {
 
   test("test thread factory builder") {
     val pool1 = Executors.newFixedThreadPool(2,

--- a/sql-plugin/src/test/spark311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark311/scala/com/nvidia/spark/rapids/shims/spark311/SparkShimsSuite.scala
@@ -20,9 +20,9 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark311
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 1, 1))
   }

--- a/sql-plugin/src/test/spark312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark312/scala/com/nvidia/spark/rapids/shims/spark312/SparkShimsSuite.scala
@@ -20,9 +20,9 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark312
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 1, 2))
   }

--- a/sql-plugin/src/test/spark313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark313/scala/com/nvidia/spark/rapids/shims/spark313/SparkShimsSuite.scala
@@ -20,9 +20,9 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark313
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 1, 3))
   }

--- a/sql-plugin/src/test/spark320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark320/scala/com/nvidia/spark/rapids/shims/spark320/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark320
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 2, 0))
   }

--- a/sql-plugin/src/test/spark321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark321/scala/com/nvidia/spark/rapids/shims/spark321/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark321
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 2, 1))
   }

--- a/sql-plugin/src/test/spark321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark321cdh/scala/com/nvidia/spark/rapids/shims/spark321cdh/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark321cdh
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(VersionUtils.cmpSparkVersion(3, 2, 1) === 0)
   }

--- a/sql-plugin/src/test/spark322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark322/scala/com/nvidia/spark/rapids/shims/spark322/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark322
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 2, 2))
   }

--- a/sql-plugin/src/test/spark323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark323/scala/com/nvidia/spark/rapids/shims/spark323/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark323
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 2, 3))
   }

--- a/sql-plugin/src/test/spark324/scala/com/nvidia/spark/rapids/shims/spark324/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark324/scala/com/nvidia/spark/rapids/shims/spark324/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark324
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 2, 4))
   }

--- a/sql-plugin/src/test/spark330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark330/scala/com/nvidia/spark/rapids/shims/spark330/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark330
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 3, 0))
   }

--- a/sql-plugin/src/test/spark330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark330cdh/scala/com/nvidia/spark/rapids/shims/spark330cdh/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark330cdh
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(VersionUtils.cmpSparkVersion(3, 3, 0) === 0)
   }

--- a/sql-plugin/src/test/spark331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark331/scala/com/nvidia/spark/rapids/shims/spark331/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark331
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 3, 1))
   }

--- a/sql-plugin/src/test/spark332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark332/scala/com/nvidia/spark/rapids/shims/spark332/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark332
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 3, 2))
   }

--- a/sql-plugin/src/test/spark333/scala/com/nvidia/spark/rapids/shims/spark333/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark333/scala/com/nvidia/spark/rapids/shims/spark333/SparkShimsSuite.scala
@@ -20,11 +20,11 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark333
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DayTimeIntervalType, YearMonthIntervalType}
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   test("spark shims version") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 3, 3))
   }

--- a/sql-plugin/src/test/spark340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
+++ b/sql-plugin/src/test/spark340/scala/com/nvidia/spark/rapids/shims/spark340/SparkShimsSuite.scala
@@ -20,9 +20,9 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims.spark340
 
 import com.nvidia.spark.rapids._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SparkShimsSuite extends FunSuite with FQSuiteName {
+class SparkShimsSuite extends AnyFunSuite with FQSuiteName {
   ignore("spark shims version - https://github.com/NVIDIA/spark-rapids/issues/7676") {
     assert(ShimLoader.getShimVersion === SparkShimVersion(3, 4, 0))
   }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -49,6 +49,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>mockito-4-11_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
             <classifier>${cuda.version}</classifier>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AddressSpaceAllocatorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AddressSpaceAllocatorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class AddressSpaceAllocatorSuite extends FunSuite {
+class AddressSpaceAllocatorSuite extends AnyFunSuite {
   test("empty allocator") {
     val allocatorSize = 1024
     val allocator = new AddressSpaceAllocator(allocatorSize)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandlerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/DeviceMemoryEventHandlerSuite.scala
@@ -18,10 +18,10 @@ package com.nvidia.spark.rapids
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
-class DeviceMemoryEventHandlerSuite extends FunSuite with MockitoSugar {
+class DeviceMemoryEventHandlerSuite extends AnyFunSuite with MockitoSugar {
 
   test("a failed allocation should be retried if we spilled enough") {
     val mockCatalog = mock[RapidsBufferCatalog]

--- a/tests/src/test/scala/com/nvidia/spark/rapids/FunSuiteWithTempDir.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/FunSuiteWithTempDir.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@ package com.nvidia.spark.rapids
 
 import java.io.File
 
-import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
 
 // creates temp dir before test and deletes after test
-trait FunSuiteWithTempDir extends FunSuite with BeforeAndAfterEach {
+trait FunSuiteWithTempDir extends AnyFunSuite with BeforeAndAfterEach {
   val TEST_FILES_ROOT: File = TestUtils.getTempDir(this.getClass.getSimpleName)
 
   protected override def beforeEach(): Unit = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 import scala.util.Random
 
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, GenericRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-class GpuBatchUtilsSuite extends FunSuite {
+class GpuBatchUtilsSuite extends AnyFunSuite {
 
   val intSchema = new StructType(Array(
     StructField("c0", DataTypes.IntegerType, nullable = true),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
@@ -22,7 +22,7 @@ import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.types.{DataType, LongType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuDeviceManagerSuite.scala
@@ -18,13 +18,14 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer}
 import com.nvidia.spark.rapids.Arm.withResource
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-class GpuDeviceManagerSuite extends FunSuite with BeforeAndAfter {
+class GpuDeviceManagerSuite extends AnyFunSuite with BeforeAndAfter {
 
   before {
     TrampolineUtil.cleanupAnyExistingSession()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuKryoRegistratorSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuKryoRegistratorSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
-class GpuKryoRegistratorSuite extends FunSuite with BeforeAndAfter {
+class GpuKryoRegistratorSuite extends AnyFunSuite with BeforeAndAfter {
 
   before {
     TrampolineUtil.cleanupAnyExistingSession()

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuMultiFileReaderSuite.scala
@@ -22,7 +22,7 @@ import ai.rapids.cudf.HostMemoryBuffer
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.PartitionedFileUtilsShim
 import org.apache.hadoop.conf.Configuration
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuMultiFileReaderSuite extends FunSuite {
+class GpuMultiFileReaderSuite extends AnyFunSuite {
 
   test("avoid infinite loop when host buffers empty") {
     val conf = new Configuration(false)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuOutOfCoreSortRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuOutOfCoreSortRetrySuite.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RetryOOM, SplitAndRetryOOM}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -21,7 +21,7 @@ import java.math.RoundingMode
 
 import ai.rapids.cudf.{ColumnVector, Cuda, DType, Table}
 import com.nvidia.spark.rapids.Arm.withResource
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuPartitioningSuite extends FunSuite {
+class GpuPartitioningSuite extends AnyFunSuite {
   var rapidsConf = new RapidsConf(Map[String, String]())
 
   private def buildBatch(): ColumnarBatch = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
@@ -21,8 +21,8 @@ import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{TimeLimitedTests, TimeLimits}
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.SparkSession

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
@@ -18,15 +18,16 @@ package com.nvidia.spark.rapids
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{TimeLimitedTests, TimeLimits}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.SparkSession
 
-class GpuSemaphoreSuite extends FunSuite
+class GpuSemaphoreSuite extends AnyFunSuite
     with BeforeAndAfterEach with MockitoSugar with TimeLimits  with TimeLimitedTests {
   val timeLimit = Span(10, Seconds)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
@@ -22,8 +22,8 @@ import ai.rapids.cudf.{ColumnVector, HostMemoryBuffer, JCudfSerialization, Table
 import com.nvidia.spark.rapids.Arm._
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /** Tests for the "prepareBuildBatchesForJoin" function. */
-class GpuShuffledHashJoinExecSuite extends FunSuite with MockitoSugar {
+class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
   private val metricMap = mock[Map[String, GpuMetric]]
   when(metricMap(any())).thenReturn(NoopMetric)
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -20,14 +20,14 @@ import java.math.RoundingMode
 
 import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.Arm.withResource
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.rapids.{GpuShuffleEnv, RapidsDiskBlockManager}
 import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class GpuSinglePartitioningSuite extends FunSuite {
+class GpuSinglePartitioningSuite extends AnyFunSuite {
   private def buildBatch(): ColumnarBatch = {
     withResource(new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1, 1, 1, 1, 1, 1, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
@@ -22,7 +22,7 @@ import ai.rapids.cudf.{CudfException, Table}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.RmmSpark
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.{CudfAggregate, CudfSum}
 import org.apache.spark.sql.types.{DataType, IntegerType, LongType}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ImplicitsTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ImplicitsTestSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class ImplicitsTestSuite extends FlatSpec with Matchers {
+class ImplicitsTestSuite extends AnyFlatSpec with Matchers {
   private class RefCountTest (i: Int, throwOnClose: Boolean) extends AutoCloseable {
     var closeAttempted: Boolean = false
     var refCount: Int = 0

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetaUtilsSuite.scala
@@ -23,12 +23,12 @@ import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer, DType, HostColumnVec
 import ai.rapids.cudf.HostColumnVector.{BasicType, StructData}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.format.CodecType
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{ArrayType, DataType, DecimalType, DoubleType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class MetaUtilsSuite extends FunSuite {
+class MetaUtilsSuite extends AnyFunSuite {
   private val contiguousTableSparkTypes: Array[DataType] = Array(
     IntegerType,
     StringType,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
@@ -24,14 +24,14 @@ import com.nvidia.spark.rapids.StorageTier.{DEVICE, DISK, HOST, StorageTier}
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class RapidsBufferCatalogSuite extends FunSuite with MockitoSugar {
+class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
   test("lookup unknown buffer") {
     val catalog = new RapidsBufferCatalog
     val bufferId = new RapidsBufferId {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStoreSuite.scala
@@ -27,13 +27,13 @@ import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.{spy, verify}
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerType, StringType}
 
-class RapidsDeviceMemoryStoreSuite extends FunSuite with MockitoSugar {
+class RapidsDeviceMemoryStoreSuite extends AnyFunSuite with MockitoSugar {
   private def buildTable(): Table = {
     new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsDiskStoreSuite.scala
@@ -23,7 +23,7 @@ import ai.rapids.cudf.{ContiguousTable, DeviceMemoryBuffer, HostMemoryBuffer, Ta
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{spy, times, verify}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerType, StringType}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsExecutorPluginSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsExecutorPluginSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RapidsExecutorPluginSuite extends FunSuite {
+class RapidsExecutorPluginSuite extends AnyFunSuite {
   test("cudf version check") {
     assert(RapidsExecutorPlugin.cudfVersionSatisfied("7", "7"))
     assert(!RapidsExecutorPlugin.cudfVersionSatisfied("7", "8"))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsGdsStoreSuite.scala
@@ -25,7 +25,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
 import org.scalatest.Tag
 import org.scalatest.compatible.Assertion
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.storage.BlockId

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsHostMemoryStoreSuite.scala
@@ -24,15 +24,15 @@ import com.nvidia.spark.rapids.Arm._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, spy, times, verify, when}
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 import org.apache.spark.sql.types.{DataType, DecimalType, DoubleType, IntegerType, LongType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 
-class RapidsHostMemoryStoreSuite extends FunSuite with MockitoSugar {
+class RapidsHostMemoryStoreSuite extends AnyFunSuite with MockitoSugar {
   private def buildContiguousTable(): ContiguousTable = {
     withResource(new Table.TestBuilder()
         .column(5, null.asInstanceOf[java.lang.Integer], 3, 1)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
@@ -19,9 +19,9 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.RebaseHelper
 import com.nvidia.spark.rapids.Arm.withResource
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RebaseHelperSuite extends FunSuite {
+class RebaseHelperSuite extends AnyFunSuite {
   test("all null timestamp days column rebase check") {
     withResource(ColumnVector.timestampDaysFromBoxedInts(null, null, null)) { c =>
       assertResult(false)(RebaseHelper.isDateRebaseNeededInWrite(c))

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ListBuffer
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class RegularExpressionParserSuite extends FunSuite {
+class RegularExpressionParserSuite extends AnyFunSuite {
 
   test("detect regexp strings") {
     // Based on https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -24,12 +24,12 @@ import scala.util.{Random, Try}
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, CudfException, RegexProgram}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RegexParser.toReadableString
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.rapids.GpuRegExpUtils
 import org.apache.spark.sql.types.DataTypes
 
-class RegularExpressionTranspilerSuite extends FunSuite {
+class RegularExpressionTranspilerSuite extends AnyFunSuite {
 
   test("transpiler detects invalid cuDF patterns that cuDF now supports") {
     // these patterns compile in cuDF since https://github.com/rapidsai/cudf/pull/11654 was merged

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
@@ -18,11 +18,12 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler}
 import com.nvidia.spark.rapids.jni.RmmSpark
-import org.scalatest.{BeforeAndAfterEach, FunSuite}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.SparkSession
 
-class RmmSparkRetrySuiteBase extends FunSuite with BeforeAndAfterEach {
+class RmmSparkRetrySuiteBase extends AnyFunSuite with BeforeAndAfterEach {
   private var rmmWasInitialized = false
 
   override def beforeEach(): Unit = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
@@ -19,14 +19,15 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.commons.lang3.SerializationUtils
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.rapids.execution.{SerializeBatchDeserializeHostBuffer, SerializeConcatHostBuffersDeserializeBatch}
 import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
-class SerializationSuite extends FunSuite
+class SerializationSuite extends AnyFunSuite
   with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ShuffleBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ShuffleBufferCatalogSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.RapidsDiskBlockManager
 
-class ShuffleBufferCatalogSuite extends FunSuite with MockitoSugar {
+class ShuffleBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
   test("registered shuffles should be active") {
     val catalog = mock[RapidsBufferCatalog]
     val rapidsDiskBlockManager = mock[RapidsDiskBlockManager]

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -20,7 +20,8 @@ import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.util.{Locale, TimeZone}
 
-import org.scalatest.{Assertion, FunSuite}
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
 import scala.reflect.ClassTag
 import scala.util.{Failure, Try}
 
@@ -145,7 +146,7 @@ object SparkSessionHolder extends Logging {
 /**
  * Set of tests that compare the output using the CPU version of spark vs our GPU version.
  */
-trait SparkQueryCompareTestSuite extends FunSuite {
+trait SparkQueryCompareTestSuite extends AnyFunSuite {
   import SparkSessionHolder.withSparkSession
 
   def enableCsvConf(): SparkConf = enableCsvConf(new SparkConf())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -16,7 +16,8 @@
 
 package com.nvidia.spark.rapids
 
-import org.scalatest.{FunSuite, Ignore}
+import org.scalatest.Ignore
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -196,7 +197,7 @@ class StringOperatorsSuite extends SparkQueryCompareTestSuite {
   }
 }
 
-class RegExpUtilsSuite extends FunSuite {
+class RegExpUtilsSuite extends AnyFunSuite {
   test("get list of choices from regexp for multi-replace") {
     val regexChoices = Map(
       "aa|bb" -> Seq("aa", "bb"),

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
@@ -20,7 +20,7 @@ import ai.rapids.cudf._
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.catalyst.expressions.{Ascending, CurrentRow, ExprId, RangeFrame, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
 import org.apache.spark.sql.rapids.GpuCount

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -22,14 +22,14 @@ import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalf, wi
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{DataType, LongType}
 
 class WithRetrySuite
-    extends FunSuite
+    extends AnyFunSuite
         with BeforeAndAfterEach with MockitoSugar {
 
   private def buildBatch: SpillableColumnarBatch = {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -28,8 +28,9 @@ import com.nvidia.spark.rapids.format.TableMeta
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, when}
-import org.scalatest.{BeforeAndAfterEach, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.rapids.ShuffleMetricsUpdater
 import org.apache.spark.sql.types.IntegerType
@@ -51,7 +52,7 @@ class TestShuffleMetricsUpdater extends ShuffleMetricsUpdater {
   }
 }
 
-class RapidsShuffleTestHelper extends FunSuite
+class RapidsShuffleTestHelper extends AnyFunSuite
     with BeforeAndAfterEach
     with MockitoSugar {
   var mockTransaction: Transaction = _

--- a/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/UCXConnectionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/shuffle/UCXConnectionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package com.nvidia.spark.rapids.shuffle
 
 import com.nvidia.spark.rapids.shuffle.ucx.UCXConnection._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class UCXConnectionSuite extends FunSuite {
+class UCXConnectionSuite extends AnyFunSuite {
   test("generate active message id") {
     Seq(0, 1, 2, 100000, Int.MaxValue).foreach { eId =>
       assertResult(eId)(

--- a/tests/src/test/scala/org/apache/spark/sql/GpuSparkPlanSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/GpuSparkPlanSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.apache.spark.sql
 
 import com.nvidia.spark.rapids.SparkSessionHolder
 import com.nvidia.spark.rapids.shims.SparkShimImpl
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.plans.logical.Range
 
-class GpuSparkPlanSuite extends FunSuite {
+class GpuSparkPlanSuite extends AnyFunSuite {
 
   test("leafNodeDefaultParallelism for GpuRangeExec") {
 

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/CanonicalizeSuite.scala
@@ -16,12 +16,12 @@
 
 package org.apache.spark.sql.rapids
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal
 
-class CanonicalizeSuite extends FunSuite {
+class CanonicalizeSuite extends AnyFunSuite {
   /* In the future, if we decide to implement the Spark 3.3 algorithm to perform canonicalization
    * this unit test should still pass. We should use the implementation made in
    * https://github.com/apache/spark/pull/37851 (SPARK-40362) as a base.

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
@@ -22,13 +22,13 @@ import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, MemoryBuffer}
 import com.nvidia.spark.rapids.{RapidsBuffer, RapidsBufferCatalog, RapidsBufferId, SpillableColumnarBatchImpl, StorageTier}
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.types.{DataType, IntegerType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.TempLocalBlockId
 
-class SpillableColumnarBatchSuite extends FunSuite {
+class SpillableColumnarBatchSuite extends AnyFunSuite {
 
   test("close updates catalog") {
     val id = TempSpillBufferId(0, TempLocalBlockId(new UUID(1, 2)))

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressionsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.rapids.catalyst.expressions
 
 import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCast, GpuCoalesce, GpuIf, GpuIsNull, GpuLiteral, GpuMonotonicallyIncreasingID}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression}
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.{DecimalType, DoubleType, IntegerType, StringT
  * Many of these tests were derived from SubexpressionEliminationSuite in Apache Spark,
  * and changed to use GPU expressions.
  */
-class GpuEquivalentExpressionsSuite extends FunSuite with Logging {
+class GpuEquivalentExpressionsSuite extends AnyFunSuite with Logging {
 
   test("Gpu Expression Equivalence - basic") {
     val equivalence = new GpuEquivalentExpressions

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -72,7 +72,7 @@ class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends Managed
 }
 
 class RapidsShuffleThreadedReaderSuite
-    extends FunSuite with BeforeAndAfterAll {
+    extends AnyFunSuite with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     RapidsShuffleInternalManagerBase.stopThreadPool()

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -34,7 +34,8 @@ import com.nvidia.spark.rapids.{GpuColumnarBatchSerializer, GpuColumnVector, Noo
 import com.nvidia.spark.rapids.Arm.withResource
 import org.mockito.ArgumentMatchers.{eq => meq}
 import org.mockito.Mockito.{mock, when}
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark._
 import org.apache.spark.internal.config

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -40,7 +40,7 @@ import org.mockito.Answers.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{HashPartitioner, SparkConf, SparkException, TaskContext}
 import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
@@ -143,7 +143,7 @@ class TestIndexShuffleBlockResolver(
   override def createTempFile(file: File): File = { null }
 }
 
-class RapidsShuffleThreadedWriterSuite extends FunSuite
+class RapidsShuffleThreadedWriterSuite extends AnyFunSuite
     with BeforeAndAfterEach
     with BeforeAndAfterAll
     with MockitoSugar

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedWriterSuite.scala
@@ -39,7 +39,8 @@ import org.mockito.{Mock, MockitoAnnotations}
 import org.mockito.Answers.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatchers.{any, anyInt, anyLong}
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{HashPartitioner, SparkConf, SparkException, TaskContext}

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/GpuIntervalUtilsTest.scala
@@ -25,7 +25,7 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.GpuIntervalUtils
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.sql.catalyst.util.{IntervalStringStyles, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_DAY, MICROS_PER_HOUR, MICROS_PER_MINUTE, MICROS_PER_SECOND}
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types.{DayTimeIntervalType => DT}
  * Unit test cases for testing `GpuIntervalUtils.toDayTimeIntervalString`
  *
  */
-class GpuIntervalUtilsTest extends FunSuite {
+class GpuIntervalUtilsTest extends AnyFunSuite {
 
   def testDayTimeToString(fromField: Byte, endField: Byte,
       testData: Array[(Long, String)]): Unit = {

--- a/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
+++ b/udf-compiler/src/test/scala/com/nvidia/spark/OpcodeSuite.scala
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatter
 import scala.collection.mutable
 
 import com.nvidia.spark.rapids.RapidsConf
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkException
@@ -31,7 +31,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.functions.{udf => makeUdf}
 import org.apache.spark.sql.functions.{log => logalias}
 
-class OpcodeSuite extends FunSuite {
+class OpcodeSuite extends AnyFunSuite {
 
   val conf: SparkConf = new SparkConf()
     .set("spark.sql.extensions", "com.nvidia.spark.udf.Plugin")


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8600

A prerequisite to supporting Scala 2.13 is upgrading our scalatest version to a version that supports Scala 2.13.

Overview of changes:

- Upgrade scalatest version to 3.2.16 (this is the same version used in Apache Spark master branch)
- `FunSuite` is now `AnyFunSuite`
- scalatest Mockito support is now in separate dependency (`org.scalatestplus:mockito-4-11-2_12`)
- package name for `Matcher` changed