### PR TITLE
Matrix stages to dynamically build Databricks shims [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -75,16 +75,6 @@ pipeline {
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CUDA_CLASSIFIER = 'cuda11'
-        // DB related ENVs
-        IDLE_TIMEOUT = '390' // 6.5 hours
-        NUM_WORKERS = '0'
-        DB_TYPE = getDbType()
-        DATABRICKS_HOST = DbUtils.getHost("$DB_TYPE")
-        DATABRICKS_TOKEN = credentials("${DbUtils.getToken("$DB_TYPE")}")
-        DATABRICKS_PUBKEY = credentials("SPARK_DATABRICKS_PUBKEY")
-        DATABRICKS_DRIVER = DbUtils.getDriver("$DB_TYPE")
-        DATABRICKS_WORKER = DbUtils.getWorker("$DB_TYPE")
-        INIT_SCRIPTS_DIR = "dbfs:/databricks/init_scripts/${BUILD_TAG}"
     }
 
     stages {
@@ -184,7 +174,6 @@ pipeline {
             steps {
                 script {
                     githubHelper.updateCommitStatus("$BUILD_URL", "Running - includes databricks", GitHubCommitState.PENDING)
-                    unstash "source_tree"
                 }
             }
         }
@@ -268,101 +257,27 @@ pipeline {
                     }
                 } // end of Unit Test stage
 
-                stage('DB runtime 10.4') {
-                    when {
-                        beforeAgent true
-                        anyOf {
-                            expression { db_build }
-                        }
-                    }
-
-                    agent {
-                        kubernetes {
-                            label "premerge-ci-db-10.4-${BUILD_NUMBER}"
-                            cloud 'sc-ipp-blossom-prod'
-                            yaml "${IMAGE_DB}"
-                        }
-                    }
-                    environment {
-                        DB_RUNTIME = '10.4'
-                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
-                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
-                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
-                    }
+                stage('Databricks') {
                     steps {
                         script {
-                            timeout(time: 6, unit: 'HOURS') {
-                                unstash "source_tree"
-                                databricksBuild()
+                            try {
+                                build(job: 'tim-rapids-databricks_premerge-github1',
+                                    propagate: true, wait: true,
+                                    parameters: [
+                                            string(name: 'REF', value: params.REF),
+                                            string(name: 'GITHUB_DATA', value: params.GITHUB_DATA)
+                                    ])
+                            } catch (e){
+                                // 'JOB_NAME #ID completed with status FAILURE xxx' --> 'JOB_NAME/ID'
+                                def dbJobId = e.getCauses()[0].getShortDescription().split('completed with status FAILURE')[0].replace(' #', '/').trim()
+                                def jobLogUrl = "$JENKINS_URL" + 'job/' + dbJobId + '/consoleText'
+                                // Output Databricks failure log
+                                sh "curl $jobLogUrl"
+                                throw e
                             }
                         }
                     }
-                } // end of DB runtime 10.4
-
-                stage('DB runtime 11.3') {
-                    when {
-                        beforeAgent true
-                        anyOf {
-                            expression { db_build }
-                        }
-                    }
-
-                    agent {
-                        kubernetes {
-                            label "premerge-ci-db-11.3-${BUILD_NUMBER}"
-                            cloud 'sc-ipp-blossom-prod'
-                            yaml "${IMAGE_DB}"
-                        }
-                    }
-                    environment {
-                        DB_RUNTIME = '11.3'
-                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
-                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
-                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
-                    }
-                    steps {
-                        script {
-                            timeout(time: 6, unit: 'HOURS') {
-                                unstash "source_tree"
-                                databricksBuild()
-                            }
-                        }
-                    }
-                } // end of DB runtime 11.3
-
-                stage('DB runtime 12.2') {
-                    when {
-                        beforeAgent true
-                        anyOf {
-                            expression { db_build }
-                        }
-                    }
-
-                    agent {
-                        kubernetes {
-                            label "premerge-ci-db-12.2-${BUILD_NUMBER}"
-                            cloud 'sc-ipp-blossom-prod'
-                            yaml "${IMAGE_DB}"
-                        }
-                    }
-                    environment {
-                        DB_RUNTIME = '12.2'
-                        DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
-                        BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
-                        BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
-                        INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
-                    }
-                    steps {
-                        script {
-                            timeout(time: 6, unit: 'HOURS') {
-                                unstash "source_tree"
-                                databricksBuild()
-                            }
-                        }
-                    }
-                } // end of DB runtime 12.2
+                }// end of Databricks
 
                 stage('Dummy stage: blue ocean log view') {
                     steps {
@@ -404,88 +319,6 @@ pipeline {
     }
 
 } // end of pipeline
-
-// params.DATABRICKS_TYPE: 'aws' or 'azure', param can be defined through the jenkins webUI
-String getDbType() {
-    return params.DATABRICKS_TYPE ? params.DATABRICKS_TYPE : 'aws'
-}
-
-void databricksBuild() {
-    def CLUSTER_ID = ''
-    def SPARK_MAJOR = BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS.replace('.', '')
-    def dbfs_path = "$INIT_SCRIPTS_DIR-$DB_TYPE"
-    try {
-        stage("Create $SPARK_MAJOR DB") {
-            script {
-                container('cpu') {
-                    sh "rm -rf spark-rapids-ci.tgz"
-                    sh "tar -zcf spark-rapids-ci.tgz *"
-                    def CREATE_PARAMS = " -r $DATABRICKS_RUNTIME -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN" +
-                            " -s $DB_TYPE -n CI-${BUILD_TAG}-${BASE_SPARK_VERSION} -k \"$DATABRICKS_PUBKEY\" -i $IDLE_TIMEOUT" +
-                            " -d $DATABRICKS_DRIVER -o $DATABRICKS_WORKER -e $NUM_WORKERS"
-
-                    // handle init scripts if exist
-                    if (env.INIT_SCRIPTS) {
-                        sh "bash -c 'dbfs mkdirs $dbfs_path'"
-                        env.INIT_SCRIPTS.split(',').each {
-                            sh "bash -c 'dbfs cp --overwrite jenkins/databricks/${it} $dbfs_path'"
-                        }
-                        // foo.sh,bar.sh --> dbfs:/path/foo.sh,dbfs:/path/bar.sh
-                        CREATE_PARAMS += " -f $dbfs_path/" + env.INIT_SCRIPTS.replace(',', ",$dbfs_path/")
-                    }
-
-                    CLUSTER_ID = sh(script: "python3 ./jenkins/databricks/create.py $CREATE_PARAMS",
-                            returnStdout: true).trim()
-                    echo CLUSTER_ID
-                }
-            }
-        }
-
-        stage("Build against $SPARK_MAJOR DB") {
-            script {
-                container('cpu') {
-                    withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
-                        def BUILD_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -z ./spark-rapids-ci.tgz" +
-                                " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/build.sh -d /home/ubuntu/build.sh" +
-                                " -v $BASE_SPARK_VERSION -i $BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS"
-                        sh "python3 ./jenkins/databricks/run-build.py $BUILD_PARAMS"
-                    }
-                }
-            }
-        }
-
-        stage("Test agaist $SPARK_MAJOR DB") {
-            script {
-                container('cpu') {
-                    try {
-                        withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
-                            def TEST_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID" +
-                                " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/test.sh -v $BASE_SPARK_VERSION -d /home/ubuntu/test.sh"
-                            if (params.SPARK_CONF) {
-                                TEST_PARAMS += " -f ${params.SPARK_CONF}"
-                            }
-                            sh "python3 ./jenkins/databricks/run-tests.py $TEST_PARAMS"
-                        }
-                    } finally {
-                        common.publishPytestResult(this, "${STAGE_NAME}")
-                    }
-                }
-            }
-        }
-
-    } finally {
-        if (CLUSTER_ID) {
-            container('cpu') {
-                retry(3) {
-                    if (env.INIT_SCRIPTS) {
-                        sh "bash -c 'dbfs rm -r $dbfs_path'"
-                    }
-                    sh "python3 ./jenkins/databricks/shutdown.py -s $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -d"
-                }
-            }
-        }
-    }
-}
 
 void uploadDocker(String IMAGE_NAME) {
     def DOCKER_CMD = "docker --config $WORKSPACE/.docker"

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -260,20 +260,17 @@ pipeline {
                 stage('Databricks') {
                     steps {
                         script {
-                            try {
-                                build(job: 'tim-rapids-databricks_premerge-github1',
-                                    propagate: true, wait: true,
-                                    parameters: [
-                                            string(name: 'REF', value: params.REF),
-                                            string(name: 'GITHUB_DATA', value: params.GITHUB_DATA)
-                                    ])
-                            } catch (e){
-                                // 'JOB_NAME #ID completed with status FAILURE xxx' --> 'JOB_NAME/ID'
-                                def dbJobId = e.getCauses()[0].getShortDescription().split('completed with status FAILURE')[0].replace(' #', '/').trim()
-                                def jobLogUrl = "$JENKINS_URL" + 'job/' + dbJobId + '/consoleText'
-                                // Output Databricks failure log
-                                sh "curl $jobLogUrl"
-                                throw e
+                            def DBJob = build(job: 'rapids-databricks_premerge-github',
+                                propagate: false, wait: true,
+                                parameters: [
+                                        string(name: 'REF', value: params.REF),
+                                        string(name: 'GITHUB_DATA', value: params.GITHUB_DATA)
+                                ])
+                            if ( DBJob.result != 'SUCCESS' ) {
+                                // Output Databricks failure logs to uploaded onto the pre-merge PR
+                                print(DBJob.getRawBuild().getLog())
+                                // Fail the pipeline
+                                error "Databricks build result : " + DBJob.result
                             }
                         }
                     }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -274,7 +274,7 @@ pipeline {
                             }
                         }
                     }
-                }// end of Databricks
+                } // end of Databricks
 
                 stage('Dummy stage: blue ocean log view') {
                     steps {

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -81,7 +81,7 @@ pipeline {
         } // end of Init githubHelper
 
         stage('Databricks') {
-            failFast false // keep running if one branch failed
+            failFast true // Abort running if one branch failed
             matrix {
                 axes {
                     axis {

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -1,0 +1,221 @@
+#!/usr/local/env groovy
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * Jenkinsfile for building rapids-plugin on Databricks cluster
+ *
+ */
+
+@Library(['shared-libs', 'blossom-lib']) _
+@Library('blossom-github-lib@master')
+
+import ipp.blossom.*
+
+def githubHelper // blossom github helper
+def IMAGE_DB = pod.getCPUYAML("${common.ARTIFACTORY_NAME}/sw-spark-docker/spark:rapids-databricks")
+
+pipeline {
+    agent {
+        kubernetes {
+            label "premerge-init-${BUILD_TAG}"
+            cloud 'sc-ipp-blossom-prod'
+            yaml "${IMAGE_DB}"
+        }
+    }
+
+    options {
+        ansiColor('xterm')
+        buildDiscarder(logRotator(numToKeepStr: '50'))
+        skipDefaultCheckout true
+        timeout(time: 12, unit: 'HOURS')
+    }
+
+    parameters {
+        string(name: 'REF', defaultValue: '',
+            description: 'Merged commit of specific PR')
+        string(name: 'GITHUB_DATA', defaultValue: '',
+            description: 'Json-formatted github data from upstream blossom-ci')
+    }
+
+    environment {
+        GITHUB_TOKEN = credentials("github-token")
+        PVC = credentials("pvc")
+        CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
+        // DB related ENVs
+        IDLE_TIMEOUT = '390' // 6.5 hours
+        NUM_WORKERS = '0'
+        DB_TYPE = getDbType()
+        DATABRICKS_HOST = DbUtils.getHost("$DB_TYPE")
+        DATABRICKS_TOKEN = credentials("${DbUtils.getToken("$DB_TYPE")}")
+        DATABRICKS_PUBKEY = credentials("SPARK_DATABRICKS_PUBKEY")
+        DATABRICKS_DRIVER = DbUtils.getDriver("$DB_TYPE")
+        DATABRICKS_WORKER = DbUtils.getWorker("$DB_TYPE")
+        INIT_SCRIPTS_DIR = "dbfs:/databricks/init_scripts/${BUILD_TAG}"
+    }
+
+    stages {
+        stage("Init githubHelper") {
+            steps {
+                script {
+                    githubHelper = GithubHelper.getInstance("${GITHUB_TOKEN}", params.GITHUB_DATA)
+                    // desc contains the PR ID and can be accessed from different builds
+                    currentBuild.description = githubHelper.getBuildDescription()
+                    checkoutCode(githubHelper.getCloneUrl(), githubHelper.getMergedSHA())
+                }
+            }
+        } // end of Init githubHelper
+
+        stage('Databricks') {
+            failFast false // keep running if one branch failed
+            matrix {
+                axes {
+                    axis {
+                        // 'name' and 'value' only supprt literal string in the declarative Jenkins
+                        // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
+                        name 'DB_RUNTIME'
+                        values '10.4', '11.3', '12.2'
+                    }
+                }
+                stages {
+                    stage('Build') {
+                        agent {
+                            kubernetes {
+                                label "premerge-ci-${DB_RUNTIME}-${BUILD_NUMBER}"
+                                cloud 'sc-ipp-blossom-prod'
+                                yaml "${IMAGE_DB}"
+                                workspaceVolume persistentVolumeClaimWorkspaceVolume(claimName: "${PVC}", readOnly: false)
+                                customWorkspace "${CUSTOM_WORKSPACE}-${DB_RUNTIME}-${BUILD_NUMBER}"
+                            }
+                        }
+                        environment {
+                            DATABRICKS_RUNTIME = DbUtils.getRuntime("$DB_RUNTIME")
+                            BASE_SPARK_VERSION = DbUtils.getSparkVer("$DB_RUNTIME")
+                            BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS = DbUtils.getInstallVer("$DB_RUNTIME")
+                            INIT_SCRIPTS = DbUtils.getInitScripts("$DB_RUNTIME")
+                        }
+                        steps {
+                            script {
+                                unstash('source_tree')
+                                databricksBuild()
+                            }
+                        }
+                    }
+                }
+            } // end of matrix
+        } // end of stage Databricks
+    } // end of stages
+} // end of pipeline
+
+// params.DATABRICKS_TYPE: 'aws' or 'azure', param can be defined through the jenkins webUI
+String getDbType() {
+    return params.DATABRICKS_TYPE ? params.DATABRICKS_TYPE : 'aws'
+}
+
+void databricksBuild() {
+    def CLUSTER_ID = ''
+    def SPARK_MAJOR = BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS.replace('.', '')
+    def dbfs_path = "$INIT_SCRIPTS_DIR-$DB_TYPE"
+    try {
+        stage("Create $SPARK_MAJOR DB") {
+            script {
+                container('cpu') {
+                    sh "rm -rf spark-rapids-ci.tgz"
+                    sh "tar -zcf spark-rapids-ci.tgz *"
+                    def CREATE_PARAMS = " -r $DATABRICKS_RUNTIME -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN" +
+                            " -s $DB_TYPE -n CI-${BUILD_TAG}-${BASE_SPARK_VERSION} -k \"$DATABRICKS_PUBKEY\" -i $IDLE_TIMEOUT" +
+                            " -d $DATABRICKS_DRIVER -o $DATABRICKS_WORKER -e $NUM_WORKERS"
+
+                    // handle init scripts if exist
+                    if (env.INIT_SCRIPTS) {
+                        sh "bash -c 'dbfs mkdirs $dbfs_path'"
+                        env.INIT_SCRIPTS.split(',').each {
+                            sh "bash -c 'dbfs cp --overwrite jenkins/databricks/${it} $dbfs_path'"
+                        }
+                        // foo.sh,bar.sh --> dbfs:/path/foo.sh,dbfs:/path/bar.sh
+                        CREATE_PARAMS += " -f $dbfs_path/" + env.INIT_SCRIPTS.replace(',', ",$dbfs_path/")
+                    }
+
+                    CLUSTER_ID = sh(script: "python3 ./jenkins/databricks/create.py $CREATE_PARAMS",
+                            returnStdout: true).trim()
+                    echo CLUSTER_ID
+                }
+            }
+        }
+
+        stage("Build against $SPARK_MAJOR DB") {
+            script {
+                container('cpu') {
+                    withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
+                        def BUILD_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -z ./spark-rapids-ci.tgz" +
+                                " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/build.sh -d /home/ubuntu/build.sh" +
+                                " -v $BASE_SPARK_VERSION -i $BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS"
+                        sh "python3 ./jenkins/databricks/run-build.py $BUILD_PARAMS"
+                    }
+                }
+            }
+        }
+
+        stage("Test agaist $SPARK_MAJOR DB") {
+            script {
+                container('cpu') {
+                    try {
+                        withCredentials([file(credentialsId: 'SPARK_DATABRICKS_PRIVKEY', variable: 'DATABRICKS_PRIVKEY')]) {
+                            def TEST_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID" +
+                                " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/test.sh -v $BASE_SPARK_VERSION -d /home/ubuntu/test.sh"
+                            if (params.SPARK_CONF) {
+                                TEST_PARAMS += " -f ${params.SPARK_CONF}"
+                            }
+                            sh "python3 ./jenkins/databricks/run-tests.py $TEST_PARAMS"
+                        }
+                    } finally {
+                        common.publishPytestResult(this, "${STAGE_NAME}")
+                    }
+                }
+            }
+        }
+
+    } finally {
+        if (CLUSTER_ID) {
+            container('cpu') {
+                retry(3) {
+                    if (env.INIT_SCRIPTS) {
+                        sh "bash -c 'dbfs rm -r $dbfs_path'"
+                    }
+                    sh "python3 ./jenkins/databricks/shutdown.py -s $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -d"
+                }
+            }
+        }
+    }
+}
+
+void checkoutCode(String url, String sha) {
+    checkout(
+        changelog: false,
+        poll: true,
+        scm: [
+            $class           : 'GitSCM', branches: [[name: sha]],
+            submoduleCfg     : [],
+            userRemoteConfigs: [[
+                                    credentialsId: 'github-token',
+                                    url          : url,
+                                    refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']]
+        ]
+    )
+
+    stash(name: 'source_tree', includes: '**,.git/**', useDefaultExcludes: false)
+}


### PR DESCRIPTION
To fix [issue/8640
](https://github.com/NVIDIA/spark-rapids/issues/8640)
Matrix stages to dynamically build Databricks shims
    
To make the Databricks pre-merge CI easier to maintain, move Databricks CI script into a new file: Jenkinsfile.premerge-databricks
    
Then we only need to update the Databricks runtime index([10.4, 11.3, 12.2](https://github.com/NVIDIA/spark-rapids/compare/branch-23.08...NvTimLiu:spark-rapids:db-ci-matrix?expand=1#diff-6c8e5ccec30b82138e0f9b11481874f247e1a4b27e74b1e7f6261263eac89ce1R91)) in Jenkinsfile.premerge-databricks to add/remove the Databricks shims
    
Signed-off-by: Tim Liu <timl@nvidia.com>
