### PR TITLE
TEST ONLY: DB CI matrix test failure [databricks]

### DIFF
--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -17,6 +17,7 @@
 
 set -ex
 
+echo '123'
 BUILD_TYPE=all
 
 if [[ $# -eq 1 ]]; then


### PR DESCRIPTION
For test only.



But add some failure script to trap CI into failure to check if failure case works well for [ PR8608](https://github.com/NVIDIA/spark-rapids/pull/8608)