### PR TITLE
Try print JVM core dump files if any test failures in CI

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -231,6 +231,7 @@ pipeline {
                                         ])
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
+                                        common.printJVMCoreDumps(this)
                                     }
                                 }
                             }
@@ -259,8 +260,14 @@ pipeline {
                                 timeout(time: 4, unit: 'HOURS') {
                                     try {
                                         sh "$PREMERGE_SCRIPT ci_2"
+                                        // DRAFT: test code
+                                        def folder = "$WORKSPACE/integration_tests/target/rundir"
+                                        sh "mkdir -p ${folder} && touch ${folder}/hs_err_pid909.log"
+                                        sh "echo 'this is a test core dump' > $WORKSPACE/integration_tests/target/rundir/hs_err_pid909.log"
+                                        error "let error out"
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
+                                        common.printJVMCoreDumps(this)
                                     }
                                 }
                             }

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -260,11 +260,6 @@ pipeline {
                                 timeout(time: 4, unit: 'HOURS') {
                                     try {
                                         sh "$PREMERGE_SCRIPT ci_2"
-                                        // DRAFT: test code
-                                        def folder = "$WORKSPACE/integration_tests/target/rundir"
-                                        sh "mkdir -p ${folder} && touch ${folder}/hs_err_pid909.log"
-                                        sh "echo 'this is a test core dump' > $WORKSPACE/integration_tests/target/rundir/hs_err_pid909.log"
-                                        error "let error out"
                                     } finally {
                                         common.publishPytestResult(this, "${STAGE_NAME}")
                                         common.printJVMCoreDumps(this)

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -145,7 +145,8 @@ ci_2() {
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
     export TEST_PARALLEL=5
-    ./integration_tests/run_pyspark_from_build.sh
+    # DRAFT: test code
+    #./integration_tests/run_pyspark_from_build.sh
     # enable avro test separately
     INCLUDE_SPARK_AVRO_JAR=true TEST='avro_test.py' ./integration_tests/run_pyspark_from_build.sh
     # export 'LC_ALL' to set locale with UTF-8 so regular expressions are enabled

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -57,7 +57,7 @@ mvn_verify() {
             $MVN_INSTALL_CMD -DskipTests -Dbuildver=$version
         fi
     done
-    
+
     # enable UTF-8 for regular expression tests
     for version in "${SPARK_SHIM_VERSIONS_PREMERGE_UTF8[@]}"
     do
@@ -65,7 +65,7 @@ mvn_verify() {
           -Dpytest.TEST_TAGS='' \
           -DwildcardSuites=com.nvidia.spark.rapids.ConditionalsSuite,com.nvidia.spark.rapids.RegularExpressionSuite,com.nvidia.spark.rapids.RegularExpressionTranspilerSuite
     done
-    
+
     # Here run Python integration tests tagged with 'premerge_ci_1' only, that would help balance test duration and memory
     # consumption from two k8s pods running in parallel, which executes 'mvn_verify()' and 'ci_2()' respectively.
     $MVN_CMD -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
@@ -145,8 +145,7 @@ ci_2() {
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
     export TEST_PARALLEL=5
-    # DRAFT: test code
-    #./integration_tests/run_pyspark_from_build.sh
+    ./integration_tests/run_pyspark_from_build.sh
     # enable avro test separately
     INCLUDE_SPARK_AVRO_JAR=true TEST='avro_test.py' ./integration_tests/run_pyspark_from_build.sh
     # export 'LC_ALL' to set locale with UTF-8 so regular expressions are enabled


### PR DESCRIPTION
fix #8269 

We try collect all JVM core dump files and print them out in CI log for easy debugging.
used file pattern `**/hs_err_pid*.*`

**NOTE:** I did not choose to use `-XX:ErrorFile=<path>` here is because there are too many diff scenarios in our CI environment and it requires to touch all JVM args in test scripts to get them work (it could be another follow-up).
so I decide to just simply search in workspace and print them out (We could also put files to somewhere through w/ jenkins ops only if needed) for CI usages

TODO: core dumps on CSP, this may be tackled if needed in the future