### PR TITLE
Enable output batches metric for GpuShuffleCoalesceExec by default

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -51,6 +51,8 @@ case class GpuShuffleCoalesceExec(child: SparkPlan, targetBatchByteSize: Long)
     CONCAT_TIME -> createNanoTimingMetric(DEBUG_LEVEL, DESCRIPTION_CONCAT_TIME)
   )
 
+  override protected val outputBatchesLevel = MODERATE_LEVEL
+
   override def output: Seq[Attribute] = child.output
 
   override def outputPartitioning: Partitioning = child.outputPartitioning


### PR DESCRIPTION
@revans2 recently noticed that GpuShuffleCoalesceExec nodes in the query plan did not report the number of output batches.  Given the whole point of this node is to coalesce many input batches into fewer output batches, it's typical to want to know how many output batches were produced.  This changes GpuShuffleCoalesceExec to upgrade the metric to MODERATE_LEVEL, which will enable the metric by default and matches the behavior of other execs that want to report output batch counts.