### PR TITLE
WIP: Rename numBytesAdded/Removed metrics in Databricks 12.2 shims [databricks]

### DIFF
--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
@@ -248,6 +248,11 @@ case class GpuDeleteCommand(
           }
         }
     }
+
+    metrics.foreach {
+      case (k, v) => println(s"$k = $v")
+    }
+
     metrics("numRemovedFiles").set(numRemovedFiles)
     metrics("numAddedFiles").set(numAddedFiles)
     val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
@@ -256,12 +261,14 @@ case class GpuDeleteCommand(
     metrics("rewriteTimeMs").set(rewriteTimeMs)
     metrics("numAddedChangeFiles").set(numAddedChangeFiles)
     metrics("changeFileBytes").set(changeFileBytes)
-    metrics("numBytesAdded").set(numBytesAdded)
-    metrics("numBytesRemoved").set(numBytesRemoved)
+    metrics("numAddedBytes").set(numBytesAdded)
+    metrics("numRemovedBytes").set(numBytesRemoved)
     metrics("numFilesBeforeSkipping").set(numFilesBeforeSkipping)
     metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
     metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
     metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
+    metrics.get("numDeletionVectorsAdded").foreach(_.set(0))
+    metrics.get("numDeletionVectorsRemoved").foreach(_.set(0))
     numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
     numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
     numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeleteCommand.scala
@@ -249,10 +249,6 @@ case class GpuDeleteCommand(
         }
     }
 
-    metrics.foreach {
-      case (k, v) => println(s"$k = $v")
-    }
-
     metrics("numRemovedFiles").set(numRemovedFiles)
     metrics("numAddedFiles").set(numAddedFiles)
     val executionTimeMs = (System.nanoTime() - startTime) / 1000 / 1000
@@ -267,8 +263,6 @@ case class GpuDeleteCommand(
     metrics("numBytesBeforeSkipping").set(numBytesBeforeSkipping)
     metrics("numFilesAfterSkipping").set(numFilesAfterSkipping)
     metrics("numBytesAfterSkipping").set(numBytesAfterSkipping)
-    metrics.get("numDeletionVectorsAdded").foreach(_.set(0))
-    metrics.get("numDeletionVectorsRemoved").foreach(_.set(0))
     numPartitionsAfterSkipping.foreach(metrics("numPartitionsAfterSkipping").set)
     numPartitionsAddedTo.foreach(metrics("numPartitionsAddedTo").set)
     numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)

--- a/integration_tests/src/main/python/delta_lake_delete_test.py
+++ b/integration_tests/src/main/python/delta_lake_delete_test.py
@@ -131,7 +131,6 @@ def test_delta_delete_partitions(spark_tmp_path, use_cdf, partition_columns):
 @pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
 @pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(is_databricks122_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/8423")
 def test_delta_delete_rows(spark_tmp_path, use_cdf, partition_columns):
     # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
     num_slices_to_test = 1 if is_databricks_runtime() else 10

--- a/integration_tests/src/main/python/delta_lake_update_test.py
+++ b/integration_tests/src/main/python/delta_lake_update_test.py
@@ -90,7 +90,6 @@ def test_delta_update_disabled_fallback(spark_tmp_path, disable_conf):
 @pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
 @pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(is_databricks122_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/8423")
 def test_delta_update_entire_table(spark_tmp_path, use_cdf, partition_columns):
     def generate_dest_data(spark):
         return three_col_df(spark,
@@ -123,7 +122,6 @@ def test_delta_update_partitions(spark_tmp_path, use_cdf, partition_columns):
 @pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
 @pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(is_databricks122_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/8423")
 def test_delta_update_rows(spark_tmp_path, use_cdf, partition_columns):
     # Databricks changes the number of files being written, so we cannot compare logs unless there's only one slice
     num_slices_to_test = 1 if is_databricks_runtime() else 10
@@ -142,7 +140,6 @@ def test_delta_update_rows(spark_tmp_path, use_cdf, partition_columns):
 @pytest.mark.parametrize("use_cdf", [True, False], ids=idfn)
 @pytest.mark.parametrize("partition_columns", [None, ["a"]], ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.skipif(is_databricks122_or_later(), reason="https://github.com/NVIDIA/spark-rapids/issues/8423")
 def test_delta_update_dataframe_api(spark_tmp_path, use_cdf, partition_columns):
     from delta.tables import DeltaTable
     data_path = spark_tmp_path + "/DELTA_DATA"

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -54,7 +54,15 @@ def del_keys(key_list, c_val, g_val):
 
 def fixup_operation_metrics(opm):
     """Update the specified operationMetrics node to facilitate log comparisons"""
-    for k in "executionTimeMs", "numOutputBytes", "rewriteTimeMs", "scanTimeMs":
+    # note that we remove many byte metrics because number of bytes can vary
+    # between CPU and GPU.
+    # we remove deletion vector metrics because we do not support those yet
+    # see https://github.com/NVIDIA/spark-rapids/issues/8554
+    metrics_to_remove = ["executionTimeMs", "numOutputBytes", "rewriteTimeMs", "scanTimeMs",
+                         "numRemovedBytes", "numAddedBytes", "numTargetBytesAdded", "numTargetBytesInserted",
+                         "numTargetBytesUpdated", "numTargetBytesRemoved",
+                         "numDeletionVectorsAdded", "numDeletionVectorsRemoved"]
+    for k in metrics_to_remove:
         opm.pop(k, None)
 
 TMP_TABLE_PATTERN=re.compile(r"tmp_table_\w+")


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/8423

Databricks 12.2 renames the numBytes[Added|Removed] metrics in the Delete command to num[Added|Removed]Bytes for consistency with OSS Delta Lake.

Changes in this PR:

- Rename the metrics
- Enables some tests that were previously skipped
- Ignore deletion vector metrics because we do not yet support deletion vectors - this is WIP still

