### PR TITLE
Add iceberg test for nightly DB12.2 IT pipeline[skip ci]

### DIFF
--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -60,7 +60,7 @@ if [[ "$TEST_TAGS" == "iceberg" ]]; then
     # Set Iceberg related versions. See https://iceberg.apache.org/multi-engine-support/#apache-spark
     # Available versions https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/
     case "$SPARK_VER" in
-        "3.3.0")
+        "3.3.0" | "3.3.2")
             ICEBERG_VERSION=${ICEBERG_VERSION:-0.14.1}
             ;;
         "3.2.1")

--- a/jenkins/databricks/run_it.sh
+++ b/jenkins/databricks/run_it.sh
@@ -60,6 +60,7 @@ if [[ "$TEST_TAGS" == "iceberg" ]]; then
     # Set Iceberg related versions. See https://iceberg.apache.org/multi-engine-support/#apache-spark
     # Available versions https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/
     case "$SPARK_VER" in
+        # TODO: Will put shared scripts together for test.sh and run_it.sh
         "3.3.0" | "3.3.2")
             ICEBERG_VERSION=${ICEBERG_VERSION:-0.14.1}
             ;;


### PR DESCRIPTION
Quick fix of https://github.com/NVIDIA/spark-rapids/issues/8636, to not block our nightly integration test pipelines.

Add iceberg test for nightly DB12.2 IT pipeline.

Skip CI because the pre-merge CI will not run this changed file.

Will follow up to put shared scripts together for test.sh and run_it.sh
