### PR TITLE
Fix "PytestUnknownMarkWarning: Unknown pytest.mark.inject_oom" warning

### DIFF
--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -1,4 +1,4 @@
-; Copyright (c) 2020-2022, NVIDIA CORPORATION.
+; Copyright (c) 2020-2023, NVIDIA CORPORATION.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ markers =
     approximate_float(rel, abs): float calculation is approximate instead of exact
     ignore_order(local): Ignores the order of the result in asserts. If local is true the results are sorted in python instead of using spark.
     incompat: Enable incompat operators
+    inject_oom: Inject OOM retry exceptions into the test
     limit(num_rows): Limit the number of rows that will be check in a result
     qarun: Mark qa test
     cudf_udf: Mark udf cudf test

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ validate_execs_in_gpu_plan = pytest.mark.validate_execs_in_gpu_plan
 approximate_float = pytest.mark.approximate_float
 ignore_order = pytest.mark.ignore_order
 incompat = pytest.mark.incompat
+inject_oom = pytest.mark.inject_oom
 limit = pytest.mark.limit
 qarun = pytest.mark.qarun
 cudf_udf = pytest.mark.cudf_udf


### PR DESCRIPTION
This fixes the following warning which is emitted when running the pyspark integration tests:
```
lib/python3.8/site-packages/_pytest/nodes.py:354: PytestUnknownMarkWarning: Unknown pytest.mark.inject_oom - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    marker_ = getattr(MARK_GEN, marker)
```
