### PR TITLE
Filter out nulls for build batches when needed in hash joins

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
@@ -39,6 +39,7 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
   private val TARGET_SIZE_SMALL = 10L
   private val TARGET_SIZE_BIG = 1024L
   private val attrs = Array(AttributeReference("a1", IntegerType, nullable=false)())
+  private val buildGoals = Seq(RequireSingleBatch, RequireSingleBatchWithFilter(GpuLiteral(true)))
 
   private def newOneIntColumnTable(): Table = {
     withResource(ColumnVector.fromInts(1, 2, 3, 4, 5)) { cudfCol =>
@@ -48,6 +49,7 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
 
   private def testJoinPreparation(
       buildIter: Iterator[ColumnarBatch],
+      buildGoal: CoalesceSizeGoal,
       buildAttrs: Seq[Attribute] = attrs,
       targetSize: Long = TARGET_SIZE_BIG,
       optimalCase: Boolean = false)
@@ -61,7 +63,7 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
       mockStreamIter,
       targetSize,
       buildAttrs,
-      RequireSingleBatch, None, metricMap)
+      buildGoal, None, metricMap)
 
     verifyBuiltData(builtData)
     // build iterator should be drained
@@ -83,70 +85,80 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
   }
 
   test("test empty build iterator") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      testJoinPreparation(Iterator.empty) { builtData =>
-        assert(builtData.isLeft)
-        // we get an empty batch
-        assertBatchColsAndRowsAndClose(builtData.left.get, 1, 0)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        testJoinPreparation(Iterator.empty, goal) { builtData =>
+          assert(builtData.isLeft)
+          // we get an empty batch
+          assertBatchColsAndRowsAndClose(builtData.left.get, 1, 0)
+        }
       }
     }
   }
 
   test("test a batch of 0 cols and 0 rows") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = Iterator(GpuColumnVector.emptyBatchFromTypes(Array.empty))
-      testJoinPreparation(buildIter, Seq.empty) { builtData =>
-        assert(builtData.isLeft)
-        assertBatchColsAndRowsAndClose(builtData.left.get, 0, 0)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = Iterator(GpuColumnVector.emptyBatchFromTypes(Array.empty))
+        testJoinPreparation(buildIter, goal, Seq.empty) { builtData =>
+          assert(builtData.isLeft)
+          assertBatchColsAndRowsAndClose(builtData.left.get, 0, 0)
+        }
       }
     }
   }
 
   test("test a batch of 1 col and 0 rows") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = Iterator(GpuColumnVector.emptyBatchFromTypes(attrs.map(_.dataType)))
-      testJoinPreparation(buildIter) { builtData =>
-        assert(builtData.isLeft)
-        assertBatchColsAndRowsAndClose(builtData.left.get, 1, 0)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = Iterator(GpuColumnVector.emptyBatchFromTypes(attrs.map(_.dataType)))
+        testJoinPreparation(buildIter, goal) { builtData =>
+          assert(builtData.isLeft)
+          assertBatchColsAndRowsAndClose(builtData.left.get, 1, 0)
 
+        }
       }
     }
   }
 
   test("test a nonempty batch going over the limit") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = withResource(newOneIntColumnTable()) { testTable =>
-        Iterator(GpuColumnVector.from(testTable, attrs.map(_.dataType)))
-      }
-      testJoinPreparation(buildIter, targetSize = TARGET_SIZE_SMALL) { builtData =>
-        assert(builtData.isRight)
-        var batchCount = 0
-        val builtIt = builtData.right.get
-        builtIt.foreach { builtBatch =>
-          batchCount += 1
-          assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = withResource(newOneIntColumnTable()) { testTable =>
+          Iterator(GpuColumnVector.from(testTable, attrs.map(_.dataType)))
         }
-        assert(batchCount == 1)
+        testJoinPreparation(buildIter, goal, targetSize = TARGET_SIZE_SMALL) { builtData =>
+          assert(builtData.isRight)
+          var batchCount = 0
+          val builtIt = builtData.right.get
+          builtIt.foreach { builtBatch =>
+            batchCount += 1
+            assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+          }
+          assert(batchCount == 1)
+        }
       }
     }
   }
 
   test("test two batches going over the limit") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = withResource(newOneIntColumnTable()) { testTable =>
-        closeOnExcept(GpuColumnVector.from(testTable, attrs.map(_.dataType))) { batch1 =>
-          Iterator(batch1, GpuColumnVector.from(testTable, attrs.map(_.dataType)))
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = withResource(newOneIntColumnTable()) { testTable =>
+          closeOnExcept(GpuColumnVector.from(testTable, attrs.map(_.dataType))) { batch1 =>
+            Iterator(batch1, GpuColumnVector.from(testTable, attrs.map(_.dataType)))
+          }
         }
-      }
-      testJoinPreparation(buildIter, targetSize = TARGET_SIZE_SMALL) { builtData =>
-        assert(builtData.isRight)
-        var batchCount = 0
-        val builtIt = builtData.right.get
-        builtIt.foreach { builtBatch =>
-          batchCount += 1
-          assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+        testJoinPreparation(buildIter, goal, targetSize = TARGET_SIZE_SMALL) { builtData =>
+          assert(builtData.isRight)
+          var batchCount = 0
+          val builtIt = builtData.right.get
+          builtIt.foreach { builtBatch =>
+            batchCount += 1
+            assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+          }
+          assert(batchCount == 2)
         }
-        assert(batchCount == 2)
       }
     }
   }
@@ -174,57 +186,65 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
   }
 
   test("test a 0-column serialized batch, optimal case") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = Iterator(getSerializedBatch(5))
-      testJoinPreparation(buildIter, Seq.empty, optimalCase = true) { builtData =>
-        assert(builtData.isLeft)
-        assertBatchColsAndRowsAndClose(builtData.left.get, 0, 5)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = Iterator(getSerializedBatch(5))
+        testJoinPreparation(buildIter, goal, Seq.empty, optimalCase = true) { builtData =>
+          assert(builtData.isLeft)
+          assertBatchColsAndRowsAndClose(builtData.left.get, 0, 5)
+        }
       }
     }
   }
 
   test("test a serialized batch, optimal case") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = withResource(newOneIntColumnTable()) { tbl =>
-        Iterator(getSerializedBatch(tbl))
-      }
-      testJoinPreparation(buildIter, optimalCase = true) { builtData =>
-        assert(builtData.isLeft)
-        assertBatchColsAndRowsAndClose(builtData.left.get, 1, 5)
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = withResource(newOneIntColumnTable()) { tbl =>
+          Iterator(getSerializedBatch(tbl))
+        }
+        testJoinPreparation(buildIter, goal, optimalCase = true) { builtData =>
+          assert(builtData.isLeft)
+          assertBatchColsAndRowsAndClose(builtData.left.get, 1, 5)
+        }
       }
     }
   }
 
   test("test two serialized batches, going over the limit") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = withResource(newOneIntColumnTable()) { tbl =>
-        closeOnExcept(getSerializedBatch(tbl)) { serializedBatch1 =>
-          Iterator(serializedBatch1, getSerializedBatch(tbl))
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = withResource(newOneIntColumnTable()) { tbl =>
+          closeOnExcept(getSerializedBatch(tbl)) { serializedBatch1 =>
+            Iterator(serializedBatch1, getSerializedBatch(tbl))
+          }
         }
-      }
-      testJoinPreparation(buildIter, targetSize = TARGET_SIZE_SMALL) { builtData =>
-        assert(builtData.isRight)
-        var batchCount = 0
-        val builtIt = builtData.right.get
-        builtIt.foreach { builtBatch =>
-          batchCount += 1
-          assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+        testJoinPreparation(buildIter, goal, targetSize = TARGET_SIZE_SMALL) { builtData =>
+          assert(builtData.isRight)
+          var batchCount = 0
+          val builtIt = builtData.right.get
+          builtIt.foreach { builtBatch =>
+            batchCount += 1
+            assertBatchColsAndRowsAndClose(builtBatch, 1, 5)
+          }
+          assert(batchCount == 2)
         }
-        assert(batchCount == 2)
       }
     }
   }
 
   test("test two serialized batches, stating within the limit, optimal case") {
-    TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
-      val buildIter = withResource(newOneIntColumnTable()) { tbl =>
-        closeOnExcept(getSerializedBatch(tbl)) { serializedBatch1 =>
-          Iterator(serializedBatch1, getSerializedBatch(tbl))
+    buildGoals.foreach { goal =>
+      TestUtils.withGpuSparkSession(new SparkConf()) { _ =>
+        val buildIter = withResource(newOneIntColumnTable()) { tbl =>
+          closeOnExcept(getSerializedBatch(tbl)) { serializedBatch1 =>
+            Iterator(serializedBatch1, getSerializedBatch(tbl))
+          }
         }
-      }
-      testJoinPreparation(buildIter, optimalCase = true) { builtData =>
-        assert(builtData.isLeft)
-        assertBatchColsAndRowsAndClose(builtData.left.get, 1, 10)
+        testJoinPreparation(buildIter, goal, optimalCase = true) { builtData =>
+          assert(builtData.isLeft)
+          assertBatchColsAndRowsAndClose(builtData.left.get, 1, 10)
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/8278

In GPU shuffled hash joins, before this PR, only when getting a single build batch, nulls will be filtered out according to the internal build goal. It is missing when we get multiple batches from the build side for the sub-partitioning joins. 

This PR adds in the null-filtering support for the multiple build batches case. And it also adds some debugging logs.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
