### PR TITLE
Always create the main artifact along with a shim-classifier artifact [databricks]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -39,9 +39,9 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
+        uses: s4u/setup-maven-action@v1.8.0
         with:
-          distribution: adopt
+          java-distribution: adopt
           java-version: 8
 
       - name: all shim versions
@@ -81,12 +81,10 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
-
       - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
+        uses: s4u/setup-maven-action@v1.8.0
         with:
-          distribution: adopt
+          java-distribution: adopt
           java-version: 8
 
       - name: package tests check
@@ -108,14 +106,35 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        uses: actions/setup-java@v3
+        uses: s4u/setup-maven-action@v1.8.0
         with:
-          distribution: adopt
+          java-distribution: adopt
           java-version: ${{ matrix.java-version }}
-      
+
       - name: Build JDK
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
           -P "individual,pre-merge,jdk${{ matrix.java-version }}"
           -Dbuildver=${{ matrix.spark-version }}
+          $COMMON_MVN_FLAGS
+
+  install-modules:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        maven-version: [3.6.3, 3.8.8, 3.9.3]
+    steps:
+      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
+
+      - name: Setup Java and Maven Env
+        uses: s4u/setup-maven-action@v1.8.0
+        with:
+          java-distribution: adopt
+          java-version: 11
+          maven-version: ${{ matrix.maven-version }}
+
+      - name: Build JDK
+        run: >
+          mvn -Dmaven.wagon.http.retryHandler.count=3 -B install
+          -P "individual,pre-merge,jdk11"
           $COMMON_MVN_FLAGS

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -33,6 +33,7 @@ jobs:
   get-shim-versions-from-dist:
     runs-on: ubuntu-latest
     outputs:
+      defaultSparkVersion: ${{ steps.allShimVersionsStep.outputs.defaultSparkVersion }}
       sparkTailVersions: ${{ steps.allShimVersionsStep.outputs.tailVersions }}
       sparkJDKVersions: ${{ steps.allShimVersionsStep.outputs.jdkVersions }}
     steps:
@@ -62,6 +63,7 @@ jobs:
 
           echo "tailVersions=$svJsonStr" >> $GITHUB_OUTPUT
           # default version
+          echo "defaultSparkVersion=${SPARK_BASE_SHIM_VERSION}" >> $GITHUB_OUTPUT
           jdkHeadVersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":8}" "${SPARK_BASE_SHIM_VERSION}")
           # jdk11
           jdk11VersionArrBody=$(printf ",{\"spark-version\":\"%s\",\"java-version\":11}" "${SPARK_SHIM_VERSIONS_JDK11[@]}")
@@ -121,6 +123,7 @@ jobs:
           $COMMON_MVN_FLAGS
 
   install-modules:
+    needs: get-shim-versions-from-dist
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -134,6 +137,9 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      - name: Debug Output
+        run: echo "Runner PWD=$PWD"
+
       - name: Setup Maven Wrapper
         run: mvn wrapper:wrapper -Dmaven=${{ matrix.maven-version }}
 
@@ -141,4 +147,5 @@ jobs:
         run: >
           ./mvnw -Dmaven.wagon.http.retryHandler.count=3 -B install
           -P "individual,pre-merge,jdk11"
+          -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.defaultSparkVersion }}
           $COMMON_MVN_FLAGS

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -81,6 +81,8 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
+
       - name: Setup Java and Maven Env
         uses: s4u/setup-maven-action@v1.8.0
         with:

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -137,9 +137,6 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      - name: Debug Output
-        run: echo "Runner PWD=$PWD"
-
       - name: Setup Maven Wrapper
         run: mvn wrapper:wrapper -Dmaven=${{ matrix.maven-version }}
 

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -39,9 +39,9 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        uses: s4u/setup-maven-action@v1.8.0
+        uses: actions/setup-java@v3
         with:
-          java-distribution: adopt
+          distribution: adopt
           java-version: 8
 
       - name: all shim versions
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        uses: s4u/setup-maven-action@v1.8.0
+        uses: actions/setup-java@v3
         with:
-          java-distribution: adopt
+          distribution: adopt
           java-version: 8
 
       - name: package tests check
@@ -108,9 +108,9 @@ jobs:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
       - name: Setup Java and Maven Env
-        uses: s4u/setup-maven-action@v1.8.0
+        uses: actions/setup-java@v3
         with:
-          java-distribution: adopt
+          distribution: adopt
           java-version: ${{ matrix.java-version }}
 
       - name: Build JDK

--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -128,15 +128,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3 # refs/pull/:prNumber/merge
 
-      - name: Setup Java and Maven Env
-        uses: s4u/setup-maven-action@v1.8.0
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          java-distribution: adopt
+          distribution: adopt
           java-version: 11
-          maven-version: ${{ matrix.maven-version }}
 
-      - name: Build JDK
+      - name: Setup Maven Wrapper
+        run: mvn wrapper:wrapper -Dmaven=${{ matrix.maven-version }}
+
+      - name: Install with Maven ${{ matrix.maven-version }}
         run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B install
+          ./mvnw -Dmaven.wagon.http.retryHandler.count=3 -B install
           -P "individual,pre-merge,jdk11"
           $COMMON_MVN_FLAGS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,10 @@ There are two types of branches in this repository:
 
 ## Building From Source
 
-We use [Maven](https://maven.apache.org) for most aspects of the build. Some important parts
+We use [Maven](https://maven.apache.org) for most aspects of the build. We test the build with latest
+patch versions for Maven 3.6.x, 3.8.x and 3.9.x. Maven version 3.6.0 or more recent is enforced.
+
+Some important parts
 of the build execute in the `verify` phase of the Maven build lifecycle.  We recommend when
 building at least running to the `verify` phase, e.g.:
 

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -35,6 +35,8 @@
         and they are auto-deduped using binary diff
         -->
         <rapids.shade.package>com.nvidia.shaded.spark</rapids.shade.package>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.shim.jar.test.phase>none</rapids.shim.jar.test.phase>
     </properties>
     <dependencies>
         <dependency>
@@ -64,23 +66,6 @@
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin.version}</version>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-test-jar</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/delta-lake/delta-20x/pom.xml
+++ b/delta-lake/delta-20x/pom.xml
@@ -31,6 +31,12 @@
     <description>Delta Lake 2.0.x support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -71,17 +77,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-21x/pom.xml
+++ b/delta-lake/delta-21x/pom.xml
@@ -31,6 +31,12 @@
     <description>Delta Lake 2.1.x support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -71,17 +77,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-22x/pom.xml
+++ b/delta-lake/delta-22x/pom.xml
@@ -31,6 +31,12 @@
     <description>Delta Lake 2.2.x support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -71,17 +77,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-24x/pom.xml
+++ b/delta-lake/delta-24x/pom.xml
@@ -31,6 +31,12 @@
     <description>Delta Lake 2.4.x support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -71,17 +77,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-spark321db/pom.xml
+++ b/delta-lake/delta-spark321db/pom.xml
@@ -31,6 +31,12 @@
     <description>Databricks 10.4 Delta Lake support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -264,17 +270,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-spark330db/pom.xml
+++ b/delta-lake/delta-spark330db/pom.xml
@@ -31,6 +31,12 @@
     <description>Databricks 11.3 Delta Lake support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -264,17 +270,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-spark332db/pom.xml
+++ b/delta-lake/delta-spark332db/pom.xml
@@ -31,6 +31,12 @@
     <description>Databricks 12.2 Delta Lake support for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -264,17 +270,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/delta-lake/delta-stub/pom.xml
+++ b/delta-lake/delta-stub/pom.xml
@@ -31,6 +31,12 @@
     <description>Delta Lake stub for the RAPIDS Accelerator for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -47,17 +53,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -577,7 +577,6 @@ self.log("... OK")
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>default-install</id>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -577,6 +577,7 @@ self.log("... OK")
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>default-install</id>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -42,6 +42,7 @@
         <target.classifier/>
         <dist.jar.name>${project.build.directory}/${project.build.finalName}-${cuda.version}.jar</dist.jar.name>
         <dist.jar.pom.url>jar:file:${dist.jar.name}!/META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml</dist.jar.pom.url>
+        <rapids.default.jar.phase>none</rapids.default.jar.phase>
     </properties>
     <profiles>
         <profile>
@@ -364,10 +365,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>default-jar</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
                         <id>create-parallel-worlds-jar</id>
                         <phase>package</phase>
                         <goals>
@@ -378,10 +375,6 @@
                             <classesDirectory>${project.build.directory}/parallel-world</classesDirectory>
                             <classifier>${cuda.version}</classifier>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-test-jar</id>
-                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -28,6 +28,8 @@
     <version>23.08.0-SNAPSHOT</version>
     <properties>
         <target.classifier/>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
     </properties>
     <dependencies>
         <dependency>
@@ -286,13 +288,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -693,11 +693,17 @@
         -->
         <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing|-Werror</scala.javac.args>
         <ucx.version>1.14</ucx.version>
+        <rapids.compressed.artifact>true</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern/>
+        <rapids.default.jar.phase>package</rapids.default.jar.phase>
         <!--
              If the shade package changes we need to also update jenkins/spark-premerge-build.sh
              so code coverage does not include the shaded classes.
         -->
         <rapids.shade.package>${spark.version.classifier}.com.nvidia.shaded.spark</rapids.shade.package>
+        <rapids.shim.jar.phase>none</rapids.shim.jar.phase>
+        <rapids.shim.jar.test.phase>package</rapids.shim.jar.test.phase>
+
         <!--
             cuda-toolkit 11.5+ will install nvidia GDS package by default
             if no compatible GDS device on test machine, the scala test would fail
@@ -737,7 +743,8 @@
         <spark332db.version>3.3.2-databricks</spark332db.version>
         <mockito.version>3.12.4</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
-        <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
+        <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
+        <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
         <guava.cdh.version>30.0-jre</guava.cdh.version>
         <arrow.cdh.version>2.0.0</arrow.cdh.version>
@@ -1196,9 +1203,45 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven.jar.plugin.version}</version>
+                    <!--
+                        Packaging type jar requires an output artifact without a classifier a.k.a.
+                        main artifact. Modules whose real "main" output artifact is a shim jar
+                        should comply by outputing a main jar without the class bytecode. In the pom
+                        of such a module set
+                          exludePattern to **/*
+                          rapids.shim.jar.phase to package to attach the shim artifact
+
+                       Modules feededing into dist need not be compressed.
+                        Set rapids.compressed.artifact to false
+                    -->
                     <executions>
                         <execution>
+                            <id>default-jar</id>
+                            <goals><goal>jar</goal></goals>
+                            <phase>${rapids.default.jar.phase}</phase>
+                            <configuration>
+                                <excludes>
+                                    <exclude>${rapids.default.jar.excludePattern}</exclude>
+                                </excludes>
+                                <archive>
+                                    <compress>${rapids.compressed.artifact}</compress>
+                                </archive>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>create-${spark.version.classifier}-jar</id>
+                            <goals><goal>jar</goal></goals>
+                            <phase>${rapids.shim.jar.phase}</phase>
+                            <configuration>
+                                <classifier>${spark.version.classifier}</classifier>
+                                <archive>
+                                    <compress>${rapids.compressed.artifact}</compress>
+                                </archive>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>default-test-jar</id>
+                            <phase>${rapids.shim.jar.test.phase}</phase>
                             <goals>
                                 <goal>test-jar</goal>
                             </goals>
@@ -1217,12 +1260,34 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>${maven.install.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                  <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                      <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                      <rules>
+                        <requireMavenVersion>
+                          <message>Minimum Maven version 3.6.x required</message>
+                          <version>[3.6,)</version>
+                        </requireMavenVersion>
+                        <!-- TODO add buildver validation -->
+                      </rules>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -679,8 +679,8 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>23.08.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>23.08.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>${project.version}</spark-rapids-jni.version>
+        <spark-rapids-private.version>${project.version}</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>
@@ -1213,6 +1213,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -679,8 +679,8 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>${project.version}</spark-rapids-jni.version>
-        <spark-rapids-private.version>${project.version}</spark-rapids-private.version>
+        <spark-rapids-jni.version>23.08.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>23.08.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -30,6 +30,12 @@
     <description>Accelerated shuffle plugin for the RAPIDS plugin for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -173,17 +179,6 @@
           </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
               <artifactId>maven-antrun-plugin</artifactId>
               <executions>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -29,6 +29,12 @@
     <description>The RAPIDS SQL plugin for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -508,17 +514,6 @@
           </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                       <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
               <artifactId>maven-antrun-plugin</artifactId>
               <executions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,6 +29,11 @@
     <description>RAPIDS plugin for Apache Spark integration tests</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -441,13 +446,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -29,6 +29,12 @@
     <description>The RAPIDS Scala UDF plugin for Apache Spark</description>
     <version>23.08.0-SNAPSHOT</version>
 
+    <properties>
+        <rapids.compressed.artifact>false</rapids.compressed.artifact>
+        <rapids.default.jar.excludePattern>**/*</rapids.default.jar.excludePattern>
+        <rapids.shim.jar.phase>package</rapids.shim.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.nvidia</groupId>
@@ -263,17 +269,6 @@
             </resource>
         </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <!-- transient jar, writing compressed can take several x time -->
-                        <compress>false</compress>
-                    </archive>
-                    <classifier>${spark.version.classifier}</classifier>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Fixes #8156 

Make sure that the main artifact is always produced even when the actual output  is the shim artifact
 
- Set install plugin version to 3.1.1
- Set jar plugin version to 3.3.0
- Create a generic maven-jar-plugin definition
- Configure modules that need a shim artifact via params
- Create an install check with recent patches to major Maven versions
- Add enforcer plugin, currently just validating the minimum version for Maven

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
