### PR TITLE
Spillable columnar batch takes ownership and improve code coverage

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -319,9 +319,14 @@ def test_hash_reduction_decimal_overflow_sum(precision):
         conf = {'spark.rapids.sql.batchSizeBytes': '128m'})
 
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)
-def test_hash_grpby_sum_count_action(data_gen):
+@pytest.mark.parametrize('override_split_until_size', [None, 1], ids=idfn)
+@pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
+def test_hash_grpby_sum_count_action(data_gen, override_split_until_size, override_batch_size_bytes):
     assert_gpu_and_cpu_row_counts_equal(
-        lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b'))
+        lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
+        conf = {
+            'spark.rapids.sql.test.overrides.splitUntilSize': override_split_until_size,
+            'spark.rapids.sql.batchSizeBytes': override_batch_size_bytes}
     )
 
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -322,11 +322,15 @@ def test_hash_reduction_decimal_overflow_sum(precision):
 @pytest.mark.parametrize('override_split_until_size', [None, 1], ids=idfn)
 @pytest.mark.parametrize('override_batch_size_bytes', [None, 1], ids=idfn)
 def test_hash_grpby_sum_count_action(data_gen, override_split_until_size, override_batch_size_bytes):
+    conf = {
+        'spark.rapids.sql.test.overrides.splitUntilSize': override_split_until_size
+    }
+    if override_batch_size_bytes is not None:
+        conf["spark.rapids.sql.batchSizeBytes"] = override_batch_size_bytes
+
     assert_gpu_and_cpu_row_counts_equal(
         lambda spark: gen_df(spark, data_gen, length=100).groupby('a').agg(f.sum('b')),
-        conf = {
-            'spark.rapids.sql.test.overrides.splitUntilSize': override_split_until_size,
-            'spark.rapids.sql.batchSizeBytes': override_batch_size_bytes}
+        conf = conf
     )
 
 @pytest.mark.parametrize('data_gen', [_longs_with_nulls], ids=idfn)

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -74,10 +74,9 @@ def _set_all_confs(conf):
     newconf.update(conf)
     for key, value in newconf.items():
         if _spark.conf.get(key, None) != value:
-            if value is None:
-                _spark.conf.unset(key)
-            else:
-                _spark.conf.set(key, value)
+            _spark.conf.set(key, value)
+
+
 
 def reset_spark_session_conf():
     """Reset all of the configs for a given spark session."""

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -71,7 +71,6 @@ def _set_all_confs(conf):
         _spark.conf.set("spark.rapids.sql.test.injectRetryOOM", "true")
     else:
         _spark.conf.set("spark.rapids.sql.test.injectRetryOOM", "false")
-    _spark.conf.set("spark.rapids.sql.test.isTestRun", "true")
     newconf.update(conf)
     for key, value in newconf.items():
         if _spark.conf.get(key, None) != value:

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -76,8 +76,6 @@ def _set_all_confs(conf):
         if _spark.conf.get(key, None) != value:
             _spark.conf.set(key, value)
 
-
-
 def reset_spark_session_conf():
     """Reset all of the configs for a given spark session."""
     _set_all_confs(_orig_conf)

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -71,10 +71,14 @@ def _set_all_confs(conf):
         _spark.conf.set("spark.rapids.sql.test.injectRetryOOM", "true")
     else:
         _spark.conf.set("spark.rapids.sql.test.injectRetryOOM", "false")
+    _spark.conf.set("spark.rapids.sql.test.isTestRun", "true")
     newconf.update(conf)
     for key, value in newconf.items():
         if _spark.conf.get(key, None) != value:
-            _spark.conf.set(key, value)
+            if value is None:
+                _spark.conf.unset(key)
+            else:
+                _spark.conf.set(key, value)
 
 def reset_spark_session_conf():
     """Reset all of the configs for a given spark session."""

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -64,28 +64,10 @@ object GpuDeviceManager extends Logging {
 
   @volatile private var poolSizeLimit = 0L
 
-  private class DefaultOverrideProvider {
-    def splitUntilSizeOverride: Option[Long] = None
-  }
-
-  private class TestOverrideProvider extends DefaultOverrideProvider {
-    // for tests only
-    override def splitUntilSizeOverride: Option[Long] =
-      new RapidsConf(SQLConf.get).splitUntilSizeOverride
-  }
-
-  private lazy val overrideProvider: DefaultOverrideProvider = {
-    if (new RapidsConf(SQLConf.get).isTestRun) {
-      new TestOverrideProvider()
-    } else {
-      new DefaultOverrideProvider()
-    }
-  }
-
   // Never split below 100 MiB (but this is really just for testing)
   def getSplitUntilSize: Long = {
-    overrideProvider
-        .splitUntilSizeOverride
+    val conf = new RapidsConf(SQLConf.get)
+    conf.splitUntilSizeOverride
         .getOrElse(Math.max(poolSizeLimit / 8, 100 * 1024 * 1024))
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -22,8 +22,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import ai.rapids.cudf._
-import org.apache.spark.{SparkEnv, TaskContext}
 
+import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.sql.internal.SQLConf

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -372,7 +372,6 @@ case class GpuOutOfCoreSortIterator(
                 } else {
                   ct.close()
                 }
-
             }
           }
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -351,7 +351,7 @@ case class GpuOutOfCoreSortIterator(
           val sp = SpillableColumnarBatch(ct,
             sorter.projectedBatchTypes,
             SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-          currentSplit = currentSplit + 1
+          currentSplit += 1
           sortedCb = Some(sp)
           splits.slice(1, splits.length)
         } else {
@@ -364,7 +364,7 @@ case class GpuOutOfCoreSortIterator(
             stillPending.zip(lowerBoundaries).foreach {
               case (ct: ContiguousTable, lower: UnsafeRow) =>
                 splits(currentSplit) = null
-                currentSplit = currentSplit + 1
+                currentSplit += 1
                 if (ct.getRowCount > 0) {
                   val sp = SpillableColumnarBatch(ct, sorter.projectedBatchTypes,
                     SpillPriorities.ACTIVE_ON_DECK_PRIORITY)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1332,14 +1332,6 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(false)
 
-  val IS_TEST_RUN = conf("spark.rapids.sql.test.isTestRun")
-      .doc("Intended to be used by unit tests, set to true if we are running under tests. " +
-          "This allows creation of configuration override providers that can be dynamically set " +
-          "by the tests.")
-      .internal()
-      .booleanConf
-      .createWithDefault(false)
-
   val TEST_CONF = conf("spark.rapids.sql.test.enabled")
     .doc("Intended to be used by unit tests, if enabled all operations must run on the " +
       "GPU or an error happens.")
@@ -2186,8 +2178,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val concurrentGpuTasks: Int = get(CONCURRENT_GPU_TASKS)
 
   lazy val isTestEnabled: Boolean = get(TEST_CONF)
-
-  lazy val isTestRun: Boolean = get(IS_TEST_RUN)
 
   lazy val testRetryOOMInjectionEnabled : Boolean = get(TEST_RETRY_OOM_INJECTION_ENABLED)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1332,6 +1332,14 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(false)
 
+  val IS_TEST_RUN = conf("spark.rapids.sql.test.isTestRun")
+      .doc("Intended to be used by unit tests, set to true if we are running under tests. " +
+          "This allows creation of configuration override providers that can be dynamically set " +
+          "by the tests.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val TEST_CONF = conf("spark.rapids.sql.test.enabled")
     .doc("Intended to be used by unit tests, if enabled all operations must run on the " +
       "GPU or an error happens.")
@@ -1955,6 +1963,12 @@ object RapidsConf {
         "The chunked pack bounce buffer must be at least 1MB in size")
       .createWithDefault(128L * 1024 * 1024)
 
+  val SPLIT_UNTIL_SIZE_OVERRIDE = conf("spark.rapids.sql.test.overrides.splitUntilSize")
+      .doc("Only for tests: override the value of GpuDeviceManager.splitUntilSize")
+      .internal()
+      .longConf
+      .createOptional
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2172,6 +2186,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val concurrentGpuTasks: Int = get(CONCURRENT_GPU_TASKS)
 
   lazy val isTestEnabled: Boolean = get(TEST_CONF)
+
+  lazy val isTestRun: Boolean = get(IS_TEST_RUN)
 
   lazy val testRetryOOMInjectionEnabled : Boolean = get(TEST_RETRY_OOM_INJECTION_ENABLED)
 
@@ -2622,6 +2638,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val chunkedPackPoolSize: Long = get(CHUNKED_PACK_POOL_SIZE)
 
   lazy val chunkedPackBounceBufferSize: Long = get(CHUNKED_PACK_BOUNCE_BUFFER_SIZE)
+
+  lazy val splitUntilSizeOverride: Option[Long] = get(SPLIT_UNTIL_SIZE_OVERRIDE)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -160,12 +160,7 @@ object SpillableColumnarBatch {
       priority: Long): SpillableColumnarBatch = {
     withResource(ct) { _ =>
       val handle = RapidsBufferCatalog.addContiguousTable(ct, priority)
-      withResource(RapidsBufferCatalog.acquireBuffer(handle)) { _ =>
-        new SpillableColumnarBatchImpl(
-          handle,
-          ct.getRowCount.toInt,
-          sparkTypes)
-      }
+      new SpillableColumnarBatchImpl(handle, ct.getRowCount.toInt, sparkTypes)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -248,6 +248,9 @@ abstract class AbstractProjectSplitIterator(iter: Iterator[ColumnarBatch],
         if (numSplits <= 1) {
           cb
         } else {
+          // this should never happen but it is here just in case
+          require(cb.numCols() > 0,
+            "About to perform cuDF table operations with a rows-only batch.")
           numSplitsMetric += numSplits - 1
           val sb = SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
           val tables = withRetryNoSplit(sb) { sb =>
@@ -261,12 +264,14 @@ abstract class AbstractProjectSplitIterator(iter: Iterator[ColumnarBatch],
             }
           }
           withResource(tables) { tables =>
-            val ret = tables.head.getTable
-            tables.tail.foreach { ct =>
+            (1 until tables.length).foreach { ix =>
+              val tbl = tables(ix)
+              tables(ix) = null // everything but the head table will be nulled, queued
+                                // as spillable batches in `pending`
               pending.enqueue(
-                SpillableColumnarBatch(ct, schema, SpillPriorities.ACTIVE_BATCHING_PRIORITY))
+                SpillableColumnarBatch(tbl, schema, SpillPriorities.ACTIVE_BATCHING_PRIORITY))
             }
-            GpuColumnVector.from(ret, schema)
+            GpuColumnVector.from(tables.head.getTable, schema)
           }
         }
       }
@@ -312,11 +317,23 @@ class PreProjectSplitIterator(
     opTime: GpuMetric,
     numSplits: GpuMetric) extends AbstractProjectSplitIterator(iter, schema, opTime, numSplits) {
 
+  /**
+   * calcNumSplit will return the number of splits that we need for the input, in the case
+   * that we can detect that a projection using `boundExprs` would expand the output above
+   * `GpuDeviceManager.getSplitUntilSize`.
+   *
+   * @note In the corner case that `cb` is rows-only (no columns), this function returns 0 and the
+   * caller must be prepared to handle that case.
+   */
   override def calcNumSplits(cb: ColumnarBatch): Int = {
-    val minOutputSize = PreProjectSplitIterator.calcMinOutputSize(cb, boundExprs)
-    // If the minimum size is too large we will split before doing the project, to help avoid
-    // extreme cases where the output size is so large that we cannot split it afterwards.
-    math.max(1, math.ceil(minOutputSize / GpuDeviceManager.getSplitUntilSize.toDouble).toInt)
+    if (cb.numCols() == 0) {
+      0 // rows-only batches should not be split
+    } else {
+      val minOutputSize = PreProjectSplitIterator.calcMinOutputSize(cb, boundExprs)
+      // If the minimum size is too large we will split before doing the project, to help avoid
+      // extreme cases where the output size is so large that we cannot split it afterwards.
+      math.max(1, math.ceil(minOutputSize / GpuDeviceManager.getSplitUntilSize.toDouble).toInt)
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -135,12 +135,10 @@ class SerializeConcatHostBuffersDeserializeBatch(
               SpillPriorities.ACTIVE_BATCHING_PRIORITY)
           } else {
             // Regular GPU batch with rows/cols
-            withResource(data.toContiguousTable) { ct =>
-              SpillableColumnarBatch(
-                ct,
-                dataTypes,
-                SpillPriorities.ACTIVE_BATCHING_PRIORITY)
-            }
+            SpillableColumnarBatch(
+              data.toContiguousTable,
+              dataTypes,
+              SpillPriorities.ACTIVE_BATCHING_PRIORITY)
           }
         // At this point we no longer need the host data and should not need to touch it again.
         // Note that we don't close this using `withResources` around the creation of the

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -201,6 +201,7 @@ class GpuBatchSubPartitioner(
           subTables.zipWithIndex.foreach { case (table, id) =>
             // skip empty tables
             if (table.getRowCount > 0) {
+              subTables(id) = null
               pendingParts(id) += SpillableColumnarBatch(table, types,
                 SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
               numCurBatches += 1


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8669

This PR was originally done to address https://github.com/NVIDIA/spark-rapids/issues/8669 but I then spent time looking at code coverage of the code I had changed. I used both unit tests and integration tests to figure out that some classes were not being covered. 

I adjusted an integration test in hash_aggregate_test.py (`test_hash_grpby_sum_count_action`) to help me cover the code that would have instantitated `SpillableColumnarBatch`. In the process of doing so I found a bug in `AbstractProjectSplitIterator` that I am fixing here. As a result of testing this I did make changes to `RapidsConf` and the test framework that are marked as POC because I'd like feedback if we like the approach, if so I can spend time propagating the changes to the unit tests, or filing issues to do so. 

In a nutshell I think we need some changes to inject parameters, not unlike mocks, so that we can get the integration tests and also the unit tests to touch certain code paths that wouldn't be touched otherwise: in this example I forced the `GpuKeyBatchingIterator` to get started in the integration tests by setting `batchSizeBytes` to be 1, and I also forced the `PreProjectSplitIterator` to run by overriding the value of `getSplitUntilSize` which it used to trigger logic that wasn't covered.