### PR TITLE
Add tests for column names with dots

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -181,7 +181,7 @@ def _prep_func_for_compare(func, mode):
     if should_sort_on_spark():
         def with_sorted(spark):
             df = func(spark)
-            return df.sort(df.columns)
+            return df.sort([f"`{x}`" for x in df.columns])
 
         sorted_func = with_sorted
     else:

--- a/integration_tests/src/main/python/orc_test.py
+++ b/integration_tests/src/main/python/orc_test.py
@@ -861,3 +861,22 @@ def test_read_case_col_name(spark_tmp_path, read_func, v1_enabled_list, orc_impl
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : reader(spark).selectExpr(col_name),
             conf=all_confs)
+
+@pytest.mark.parametrize("reader_confs", reader_opt_confs, ids=idfn)
+@ignore_order
+def test_orc_column_name_with_dots(spark_tmp_path, reader_confs):
+    data_path = spark_tmp_path + "/ORC_DATA"
+    reader = read_orc_df(data_path)
+    all_confs = reader_confs
+    gens = [
+        ("a.b", StructGen([
+            ("c.d.e", StructGen([
+                ("f.g", int_gen),
+                ("h", string_gen)])),
+            ("i.j", long_gen)])),
+        ("k", boolean_gen)]
+    with_cpu_session(lambda spark: gen_df(spark, gens).write.orc(data_path))
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark), conf=all_confs)
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`"), conf=all_confs)
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`.`c.d.e`.`f.g`"),
+                                         conf=all_confs)

--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1508,3 +1508,22 @@ def test_read_case_col_name(spark_tmp_path, read_func, v1_enabled_list, reader_c
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : reader(spark).selectExpr(col_name),
             conf=all_confs)
+
+@pytest.mark.parametrize("reader_confs", reader_opt_confs, ids=idfn)
+@ignore_order
+def test_parquet_column_name_with_dots(spark_tmp_path, reader_confs):
+    data_path = spark_tmp_path + "/PARQUET_DATA"
+    reader = read_parquet_df(data_path)
+    all_confs = reader_confs
+    gens = [
+        ("a.b", StructGen([
+            ("c.d.e", StructGen([
+                ("f.g", int_gen),
+                ("h", string_gen)])),
+            ("i.j", long_gen)])),
+        ("k", boolean_gen)]
+    with_cpu_session(lambda spark: gen_df(spark, gens).write.parquet(data_path))
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark), conf=all_confs)
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`"), conf=all_confs)
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`.`c.d.e`.`f.g`"),
+                                         conf=all_confs)

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -755,3 +755,18 @@ def test_write_with_planned_write_enabled(spark_tmp_path, planned_write_enabled,
         lambda spark, path: spark.read.parquet(path),
         data_path,
         conf)
+
+@ignore_order
+def test_parquet_write_column_name_with_dots(spark_tmp_path):
+    data_path = spark_tmp_path + "/PARQUET_DATA"
+    gens = [
+        ("a.b", StructGen([
+            ("c.d.e", StructGen([
+                ("f.g", int_gen),
+                ("h", string_gen)])),
+            ("i.j", long_gen)])),
+        ("k", boolean_gen)]
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        lambda spark, path:  gen_df(spark, gens).coalesce(1).write.parquet(path),
+        lambda spark, path: spark.read.parquet(path),
+        data_path)


### PR DESCRIPTION
Part of #8666.  Adds Parquet and ORC tests for column names with dots in them.  This also fixes a minor bug in the assert code where column names were not being escaped as needed when column names contain a dot.