### PR TITLE
Fix parquet_write_test.py::test_hive_timestamp_value failure for Databricks [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -761,8 +761,8 @@ def test_hive_timestamp_value_fallback(spark_tmp_table_factory, spark_tmp_path):
 
     def func_test(create_table, read_table, data_path, conf):
         assert_gpu_fallback_write(
-            lambda spark, path: create_table(spark, path),
-            lambda spark, path: read_table(spark, path),
+            create_table,
+            read_table,
             data_path,
             ['DataWritingCommandExec'],
             conf)

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -731,6 +731,7 @@ def test_dynamic_partitioned_parquet_write(spark_tmp_table_factory, spark_tmp_pa
     )
 
 # Test to avoid regression on a known bug in Spark. For details please visit https://github.com/NVIDIA/spark-rapids/issues/8693
+@pytest.mark.allow_non_gpu_databricks("DataWritingCommandExec")
 def test_hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path):
 
     def create_table(spark, path):

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -730,21 +730,44 @@ def test_dynamic_partitioned_parquet_write(spark_tmp_table_factory, spark_tmp_pa
         conf={}
     )
 
-# Test to avoid regression on a known bug in Spark. For details please visit https://github.com/NVIDIA/spark-rapids/issues/8693
-@pytest.mark.allow_non_gpu_databricks("DataWritingCommandExec")
-def test_hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path):
+def hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path, ts_rebase, func):
+    conf={'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': ts_rebase,
+          'spark.sql.legacy.parquet.int96RebaseModeInWrite': ts_rebase}
 
     def create_table(spark, path):
         tmp_table = spark_tmp_table_factory.get()
         spark.sql(f"CREATE TABLE {tmp_table} STORED AS PARQUET " +
-        f""" LOCATION '{path}' AS SELECT CAST('2015-01-01 00:00:00' AS TIMESTAMP) as t; """)
+                  f""" LOCATION '{path}' AS SELECT CAST('2015-01-01 00:00:00' AS TIMESTAMP) as t; """)
 
     def read_table(spark, path):
         return spark.read.parquet(path)
 
     data_path = spark_tmp_path + '/PARQUET_DATA'
-    assert_gpu_and_cpu_writes_are_equal_collect(create_table, read_table, data_path)
-    assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.read.parquet(data_path + '/CPU'))
+
+    func(create_table, read_table, data_path, conf)
+
+# Test to avoid regression on a known bug in Spark. For details please visit https://github.com/NVIDIA/spark-rapids/issues/8693
+def test_hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path):
+
+    def func_test(create_table, read_table, data_path, conf):
+        assert_gpu_and_cpu_writes_are_equal_collect(create_table, read_table, data_path, conf=conf)
+        assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.read.parquet(data_path + '/CPU'))
+
+    hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path, 'CORRECTED', func_test)
+
+# Test to avoid regression on a known bug in Spark. For details please visit https://github.com/NVIDIA/spark-rapids/issues/8693
+@allow_non_gpu('DataWritingCommandExec')
+def test_hive_timestamp_value_fallback(spark_tmp_table_factory, spark_tmp_path):
+
+    def func_test(create_table, read_table, data_path, conf):
+        assert_gpu_fallback_write(
+            lambda spark, path: create_table(spark, path),
+            lambda spark, path: read_table(spark, path),
+            data_path,
+            ['DataWritingCommandExec'],
+            conf)
+
+    hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path, 'LEGACY', func_test)
 
 @ignore_order
 @pytest.mark.skipif(is_before_spark_340(), reason="`spark.sql.optimizer.plannedWrite.enabled` is only supported in Spark 340+")

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -756,7 +756,7 @@ def test_hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path):
     hive_timestamp_value(spark_tmp_table_factory, spark_tmp_path, 'CORRECTED', func_test)
 
 # Test to avoid regression on a known bug in Spark. For details please visit https://github.com/NVIDIA/spark-rapids/issues/8693
-@allow_non_gpu('DataWritingCommandExec')
+@allow_non_gpu('DataWritingCommandExec', 'WriteFilesExec')
 def test_hive_timestamp_value_fallback(spark_tmp_table_factory, spark_tmp_path):
 
     def func_test(create_table, read_table, data_path, conf):


### PR DESCRIPTION
Added `allow_non_gpu_databricks` to the test to pass for DB

fixes #8726 
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
