### PR TITLE
Conventional jar layout is not required for JDK9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,6 @@
                 <maven.compiler.release>11</maven.compiler.release>
                 <maven.compiler.source>11</maven.compiler.source>
                 <maven.compiler.target>11</maven.compiler.target>
-                <allowConventionalDistJar>true</allowConventionalDistJar>
             </properties>
         </profile>
         <profile>
@@ -534,7 +533,6 @@
                 <maven.compiler.release>17</maven.compiler.release>
                 <maven.compiler.source>17</maven.compiler.source>
                 <maven.compiler.target>17</maven.compiler.target>
-                <allowConventionalDistJar>true</allowConventionalDistJar>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
As of #5646  (22.10) specifying  allowConventionalDistJar is not necessary for the newer JDK's sake. The only legitimate use case is if the user does not want side-effects of dealing with a [multi-shim jar](https://github.com/NVIDIA/spark-rapids/blob/branch-23.08/CONTRIBUTING.md#building-a-distribution-for-a-single-spark-release) 

```bash
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn clean install  -Dbuildver=341 -DskipTests 

JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 TEST_PARALLEL=0 SPARK_HOME=~/dist/spark-3.4.1-bin-hadoop3 ./integration_tests/run_pyspark_from_build.sh -s -k array_exists
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
