### PR TITLE
Add driver log warning when GPU is limiting scheduling resource

### DIFF
--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -36,7 +36,8 @@ will vary depending on your cluster manager. Here are some example configs:
 - Request your executor to have GPUs:
   - `--conf spark.executor.resource.gpu.amount=1`
 - Specify the number of GPUs per task:
-  - `--conf spark.task.resource.gpu.amount=0.125` will allow up to 8 concurrent tasks per executor. It's recommended to be 1/{executor core count} to get best performance.
+  - `--conf spark.task.resource.gpu.amount=0.125` will allow up to 8 concurrent tasks per executor.
+    It is recommended to be 1/{executor core count} to get the best performance.
 - Specify a GPU discovery script (required on YARN and K8S):
   - `--conf spark.executor.resource.gpu.discoveryScript=./getGpusResources.sh`
 - Explain why some operations of a query were not placed on a GPU or not:

--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -36,7 +36,7 @@ will vary depending on your cluster manager. Here are some example configs:
 - Request your executor to have GPUs:
   - `--conf spark.executor.resource.gpu.amount=1`
 - Specify the number of GPUs per task:
-  - `--conf spark.task.resource.gpu.amount=0.125`
+  - `--conf spark.task.resource.gpu.amount=0.125` will allow up to 8 concurrent tasks per executor. It's recommended to be 1/{executor core count} to get best performance.
 - Specify a GPU discovery script (required on YARN and K8S):
   - `--conf spark.executor.resource.gpu.discoveryScript=./getGpusResources.sh`
 - Explain why some operations of a query were not placed on a GPU or not:

--- a/docs/get-started/getting-started.md
+++ b/docs/get-started/getting-started.md
@@ -36,7 +36,7 @@ will vary depending on your cluster manager. Here are some example configs:
 - Request your executor to have GPUs:
   - `--conf spark.executor.resource.gpu.amount=1`
 - Specify the number of GPUs per task:
-  - `--conf spark.task.resource.gpu.amount=1`
+  - `--conf spark.task.resource.gpu.amount=0.125`
 - Specify a GPU discovery script (required on YARN and K8S):
   - `--conf spark.executor.resource.gpu.discoveryScript=./getGpusResources.sh`
 - Explain why some operations of a query were not placed on a GPU or not:

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -170,7 +170,7 @@ object RapidsPluginUtils extends Logging {
       // get worker's all cores num if spark.executor.cores is not set explicitly
       lazy val workerAllCores = Runtime.getRuntime.availableProcessors.toString()
       val executorCores = conf.get(EXECUTOR_CORES_KEY, workerAllCores).toDouble
-      val executorGpuAmount = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toInt
+      val executorGpuAmount = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toDouble
       if (executorCores != 0 && taskGpuAmountSetByUser > executorGpuAmount / executorCores) {
         logWarning("The current setting of spark.task.resource.gpu.amount " + 
         s"($taskGpuAmountSetByUser) is not ideal to get the best performance from the " + 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -166,16 +166,16 @@ object RapidsPluginUtils extends Logging {
     // (spark.executor.resource.gpu.amount / spark.executor.cores) then GPUs will be the limiting
     // resource for task scheduling.
     if (conf.contains(TASK_GPU_AMOUNT_KEY) && conf.contains(EXECUTOR_GPU_AMOUNT_KEY)) {
-      val gpuAmount = conf.get(TASK_GPU_AMOUNT_KEY).toDouble
+      val taskGpuAmountSetByUser = conf.get(TASK_GPU_AMOUNT_KEY).toDouble
       // get worker's all cores num if spark.executor.cores is not set explicitly
-      val workerAllCores = Runtime.getRuntime.availableProcessors.toString()
+      lazy val workerAllCores = Runtime.getRuntime.availableProcessors.toString()
       val executorCores = conf.get(EXECUTOR_CORES_KEY, workerAllCores).toDouble
-      val executorGpusPerCore = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toDouble / executorCores
-      
-      if (gpuAmount > executorGpusPerCore) {
-        logWarning("GPUs are the limiting resource for task scheduling because " + 
-        s"spark.task.resource.gpu.amount is set to ($gpuAmount). " + 
-        "This will significantly limit performance.")
+      val executorGpuAmount = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toInt
+      if (executorCores != 0 && taskGpuAmountSetByUser > executorGpuAmount / executorCores) {
+        logWarning("The current setting of spark.task.resource.gpu.amount " + 
+        s"($taskGpuAmountSetByUser) is not ideal to get the best performance from the " + 
+        "Spark Rapids plugin. It's recommended to be set to 1/{number of cores} unless " + 
+        "you have a special use case.")
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -174,7 +174,7 @@ object RapidsPluginUtils extends Logging {
       if (executorCores != 0 && taskGpuAmountSetByUser > executorGpuAmount / executorCores) {
         logWarning("The current setting of spark.task.resource.gpu.amount " + 
         s"($taskGpuAmountSetByUser) is not ideal to get the best performance from the " + 
-        "Spark Rapids plugin. It's recommended to be set to 1/{number of cores} unless " + 
+        "RAPIDS Accelerator plugin. It's recommended to be 1/{executor core count} unless " + 
         "you have a special use case.")
       }
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -165,10 +165,11 @@ object RapidsPluginUtils extends Logging {
     // If spark.task.resource.gpu.amount is larger than 
     // (spark.executor.resource.gpu.amount / spark.executor.cores) then GPUs will be the limiting
     // resource for task scheduling.
-    if (conf.contains(TASK_GPU_AMOUNT_KEY) && conf.contains(EXECUTOR_CORES_KEY) && 
-        conf.contains(EXECUTOR_GPU_AMOUNT_KEY)) {
+    if (conf.contains(TASK_GPU_AMOUNT_KEY) && conf.contains(EXECUTOR_GPU_AMOUNT_KEY)) {
       val gpuAmount = conf.get(TASK_GPU_AMOUNT_KEY).toDouble
-      val executorCores = conf.get(EXECUTOR_CORES_KEY).toDouble
+      // get worker's all cores num if spark.executor.cores is not set explicitly
+      val workerAllCores = Runtime.getRuntime.availableProcessors.toString()
+      val executorCores = conf.get(EXECUTOR_CORES_KEY, workerAllCores).toDouble
       val executorGpusPerCore = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toDouble / executorCores
       
       if (gpuAmount > executorGpusPerCore) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -168,11 +168,9 @@ object RapidsPluginUtils extends Logging {
     if (conf.contains(TASK_GPU_AMOUNT_KEY) && conf.contains(EXECUTOR_GPU_AMOUNT_KEY)) {
       val taskGpuAmountSetByUser = conf.get(TASK_GPU_AMOUNT_KEY).toDouble
       // get worker's all cores num if spark.executor.cores is not set explicitly
-      val executorCores = if (conf.contains(EXECUTOR_CORES_KEY)) {
-        conf.get(EXECUTOR_CORES_KEY).toDouble
-      } else {
-        Runtime.getRuntime.availableProcessors.toDouble
-      }
+      val executorCores = conf.getOption(EXECUTOR_CORES_KEY)
+          .map(_.toDouble)
+          .getOrElse(Runtime.getRuntime.availableProcessors.toDouble)
       val executorGpuAmount = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toDouble
       if (executorCores != 0 && taskGpuAmountSetByUser > executorGpuAmount / executorCores) {
         logWarning("The current setting of spark.task.resource.gpu.amount " + 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -168,8 +168,11 @@ object RapidsPluginUtils extends Logging {
     if (conf.contains(TASK_GPU_AMOUNT_KEY) && conf.contains(EXECUTOR_GPU_AMOUNT_KEY)) {
       val taskGpuAmountSetByUser = conf.get(TASK_GPU_AMOUNT_KEY).toDouble
       // get worker's all cores num if spark.executor.cores is not set explicitly
-      lazy val workerAllCores = Runtime.getRuntime.availableProcessors.toString()
-      val executorCores = conf.get(EXECUTOR_CORES_KEY, workerAllCores).toDouble
+      val executorCores = if (conf.contains(EXECUTOR_CORES_KEY)) {
+        conf.get(EXECUTOR_CORES_KEY).toDouble
+      } else {
+        Runtime.getRuntime.availableProcessors.toDouble
+      }
       val executorGpuAmount = conf.get(EXECUTOR_GPU_AMOUNT_KEY).toDouble
       if (executorCores != 0 && taskGpuAmountSetByUser > executorGpuAmount / executorCores) {
         logWarning("The current setting of spark.task.resource.gpu.amount " + 


### PR DESCRIPTION
Closes #8691

Many users mistakenly set spark.task.resource.gpu.amount=1 or some other value that makes it the limiting resource for scheduling rather than CPU cores. This limits the task parallelism of the cluster vs. a CPU run and is often unintentional. The result is a significantly slower GPU run than would otherwise be possible, and it's often not obvious to the user why it is so slow.

This PR adds a driver log warning on startup when the GPU is limiting the scheduling resource, which is when `spark.task.resource.gpu.amount is larger` > `spark.executor.resource.gpu.amount / spark.executor.cores`. 

It also changes the example value of `spark.task.resource.gpu.amount` in the Getting Started doc from 1 to 0.125 to not mislead users.

**Some local tests:**

0.5 > 4/12, warning
```
spark-shell --master local[*]   --jars ${SPARK_RAPIDS_PLUGIN_JAR}   --conf spark.plugins=com.nvidia.spark.SQLPlugin   --conf spark.rapids.sql.enabled=true   --conf spark.rapids.sql.explain=ALL --conf spark.task.resource.gpu.amount=0.5 --conf spark.executor.cores=12 --conf spark.executor.resource.gpu.amount=4
23/07/21 10:03:34 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/07/21 10:03:38 WARN ResourceUtils: The configuration of cores (exec = 12 task = 1, runnable tasks = 12) will result in wasted resources due to resource gpu limiting the number of runnable tasks per executor to: 8. Please adjust your configuration.
23/07/21 10:03:38 WARN RapidsPluginUtils: RAPIDS Accelerator 23.08.0-SNAPSHOT using cudf 23.08.0-SNAPSHOT.
23/07/21 10:03:38 WARN RapidsPluginUtils: spark.rapids.sql.multiThreadedRead.numThreads is set to 20.
23/07/21 10:03:38 WARN RapidsPluginUtils: The current setting of spark.task.resource.gpu.amount (0.5) is not ideal to get the best performance from the Spark Rapids plugin. It's recommended to be set to 1/{number of cores} unless you have a special use case.
23/07/21 10:03:38 WARN RapidsPluginUtils: RAPIDS Accelerator is enabled, to disable GPU support set `spark.rapids.sql.enabled` to false.
23/07/21 10:03:38 WARN RapidsPluginUtils: spark.rapids.sql.explain is set to `ALL`. Set it to 'NONE' to suppress the diagnostics logging about the query placement on the GPU.
Spark context Web UI available at http://dev-machine:4040
Spark context available as 'sc' (master = local[*], app id = local-1689905018772).
Spark session available as 'spark'.
```

0.125 < 2/8, no warning
```
spark-shell --master local[*]   --jars ${SPARK_RAPIDS_PLUGIN_JAR}   --conf spark.plugins=com.nvidia.spark.SQLPlugin   --conf spark.rapids.sql.enabled=true   --conf spark.rapids.sql.explain=ALL --conf spark.task.resource.gpu.amount=0.125 --conf spark.executor.cores=8 --conf spark.executor.resource.gpu.amount=2
23/07/21 10:04:29 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/07/21 10:04:33 WARN ResourceUtils: The configuration of resource: gpu (exec = 2, task = 0.125/8, runnable tasks = 16) will result in wasted resources due to resource cpus limiting the number of runnable tasks per executor to: 8. Please adjust your configuration.
23/07/21 10:04:33 WARN RapidsPluginUtils: RAPIDS Accelerator 23.08.0-SNAPSHOT using cudf 23.08.0-SNAPSHOT.
23/07/21 10:04:33 WARN RapidsPluginUtils: spark.rapids.sql.multiThreadedRead.numThreads is set to 20.
23/07/21 10:04:33 WARN RapidsPluginUtils: RAPIDS Accelerator is enabled, to disable GPU support set `spark.rapids.sql.enabled` to false.
23/07/21 10:04:33 WARN RapidsPluginUtils: spark.rapids.sql.explain is set to `ALL`. Set it to 'NONE' to suppress the diagnostics logging about the query placement on the GPU.
23/07/21 10:04:33 WARN ResourceUtils: The configuration of resource: gpu (exec = 2, task = 0.125/8, runnable tasks = 16) will result in wasted resources due to resource cpus limiting the number of runnable tasks per executor to: 8. Please adjust your configuration.
Spark context Web UI available at http://dev-machine:4040
Spark context available as 'sc' (master = local[*], app id = local-1689905073894).
Spark session available as 'spark'.
```

not set, no warning:
```
spark-shell --master local[*]   --jars ${SPARK_RAPIDS_PLUGIN_JAR}   --conf spark.plugins=com.nvidia.spark.SQLPlugin   --conf spark.rapids.sql.enabled=true   --conf spark.rapids.sql.explain=ALL
23/07/21 10:05:14 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/07/21 10:05:18 WARN RapidsPluginUtils: RAPIDS Accelerator 23.08.0-SNAPSHOT using cudf 23.08.0-SNAPSHOT.
23/07/21 10:05:18 WARN RapidsPluginUtils: RAPIDS Accelerator is enabled, to disable GPU support set `spark.rapids.sql.enabled` to false.
23/07/21 10:05:18 WARN RapidsPluginUtils: spark.rapids.sql.explain is set to `ALL`. Set it to 'NONE' to suppress the diagnostics logging about the query placement on the GPU.
Spark context Web UI available at http://dev-machine:4040
Spark context available as 'sc' (master = local[*], app id = local-1689905118816).
Spark session available as 'spark'.
```

not set spark.executor.cores 1 < 2/worker's core num, warning
```
spark-shell --master local[*]   --jars ${SPARK_RAPIDS_PLUGIN_JAR}   --conf spark.plugins=com.nvidia.spark.SQLPlugin   --conf spark.rapids.sql.enabled=true   --conf spark.rapids.sql.explain=ALL --conf spark.task.resource.gpu.amount=1 --conf spark.executor.resource.gpu.amount=2
23/07/21 10:06:00 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/07/21 10:06:05 WARN RapidsPluginUtils: RAPIDS Accelerator 23.08.0-SNAPSHOT using cudf 23.08.0-SNAPSHOT.
23/07/21 10:06:05 WARN RapidsPluginUtils: The current setting of spark.task.resource.gpu.amount (1.0) is not ideal to get the best performance from the Spark Rapids plugin. It's recommended to be set to 1/{number of cores} unless you have a special use case.
23/07/21 10:06:05 WARN RapidsPluginUtils: RAPIDS Accelerator is enabled, to disable GPU support set `spark.rapids.sql.enabled` to false.
23/07/21 10:06:05 WARN RapidsPluginUtils: spark.rapids.sql.explain is set to `ALL`. Set it to 'NONE' to suppress the diagnostics logging about the query placement on the GPU.
23/07/21 10:06:05 WARN ResourceUtils: The configuration of cores (exec = 8 task = 1, runnable tasks = 8) will result in wasted resources due to resource gpu limiting the number of runnable tasks per executor to: 2. Please adjust your configuration.
Spark context Web UI available at http://dev-machine:4040
Spark context available as 'sc' (master = local[*], app id = local-1689905165140).
Spark session available as 'spark'.
```
spark.executor.cores=0:
```
spark-shell --master local[*]   --jars ${SPARK_RAPIDS_PLUGIN_JAR}   --conf spark.plugins=com.nvidia.spark.SQLPlugin   --conf spark.rapids.sql.enabled=true   --conf spark.rapids.sql.explain=ALL --conf spark.task.resource.gpu.amount=0.5 --conf spark.executor.cores=0 --conf spark.executor.resource.gpu.amount=4
Exception in thread "main" org.apache.spark.SparkException: Executor cores must be a positive number
	at org.apache.spark.deploy.SparkSubmitArguments.error(SparkSubmitArguments.scala:634)
	at org.apache.spark.deploy.SparkSubmitArguments.validateSubmitArguments(SparkSubmitArguments.scala:260)
	at org.apache.spark.deploy.SparkSubmitArguments.validateArguments(SparkSubmitArguments.scala:234)
	at org.apache.spark.deploy.SparkSubmitArguments.<init>(SparkSubmitArguments.scala:119)
	at org.apache.spark.deploy.SparkSubmit$$anon$2$$anon$3.<init>(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.parseArguments(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:85)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1046)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1055)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
