### PR TITLE
Ensure columnarEval always returns a GpuColumnVector [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
@@ -24,8 +24,9 @@ package com.databricks.sql.transaction.tahoe.rapids
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.databricks.sql.transaction.tahoe.constraints.{CheckDeltaInvariant, Constraint}
 import com.databricks.sql.transaction.tahoe.constraints.Constraints.{Check, NotNull}
-import com.nvidia.spark.rapids.{DataFromReplacementRule, ExprChecks, GpuBindReferences, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuOverrides, RapidsConf, RapidsMeta, TypeSig, UnaryExprMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, ExprChecks, GpuBindReferences, GpuColumnVector, GpuExpression, GpuOverrides, RapidsConf, RapidsMeta, TypeSig, UnaryExprMeta}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.delta.shims.InvariantViolationExceptionShim
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 

--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCheckDeltaInvariant.scala
@@ -62,8 +62,8 @@ case class GpuCheckDeltaInvariant(
       constraint)
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(child, batch)) { col =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(child.columnarEval(batch)) { col =>
       constraint match {
         case n: NotNull =>
           if (col.getBase.hasNulls) {

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuCheckDeltaInvariant.scala
@@ -24,6 +24,7 @@ package org.apache.spark.sql.delta.rapids
 import ai.rapids.cudf.{ColumnVector, Scalar}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 
 import org.apache.spark.internal.Logging
@@ -62,8 +63,8 @@ case class GpuCheckDeltaInvariant(
       constraint)
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(child, batch)) { col =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(child.columnarEval(batch)) { col =>
       constraint match {
         case n: NotNull =>
           if (col.getBase.hasNulls) {

--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
@@ -357,7 +357,7 @@ class GpuRapidsProcessDeltaMergeJoinIterator(
       predicate: Expression): (ColumnarBatch, ColumnarBatch) = {
     withResource(input) { _ =>
       withResource(GpuColumnVector.from(input)) { inTable =>
-        val predCol = GpuExpressionsUtils.columnarEvalToColumn(predicate, input)
+        val predCol = predicate.columnarEval(input)
         val matchedBatch = closeOnExcept(predCol) { _ =>
           withResource(inTable.filter(predCol.getBase)) { matchedTable =>
             GpuColumnVector.from(matchedTable, inputTypes)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
@@ -134,9 +134,9 @@ case class ApproxPercentileFromTDigestExpr(
     finalDataType: DataType)
   extends GpuExpression with ShimExpression {
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     val expr = child.asInstanceOf[GpuExpression]
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(expr, batch)) { cv =>
+    withResource(expr.columnarEval(batch)) { cv =>
       percentiles match {
         case Left(p) =>
           // For the scalar case, we still pass cuDF an array of percentiles

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -175,7 +175,7 @@ case class GpuBoundReference(ordinal: Int, dataType: DataType, nullable: Boolean
   override def toString: String =
     s"input[$ordinal, ${dataType.simpleString}, $nullable]($name#${exprId.id})"
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     batch.column(ordinal) match {
       case fb: GpuColumnVectorFromBuffer =>
         // When doing a project we might re-order columns or do other things that make it

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -124,10 +124,8 @@ trait GpuExpression extends Expression {
    * value. Scalar values typically happen if they are a part of the expression i.e. col("a") + 100.
    * In this case the 100 is a literal that Add would have to be able to handle.
    *
-   * By convention any `GpuColumnVector` returned by [[columnarEvalAny]]
-   * is owned by the caller and will need to be closed by them. This can happen by putting it into
-   * a `ColumnarBatch` and closing the batch or by closing the vector directly if it is a
-   * temporary value.
+   * By convention any `AutoCloseable` returned by [[columnarEvalAny]] is owned by the caller and
+   * will need to be closed by them.
    */
   def columnarEvalAny(batch: ColumnarBatch): Any = columnarEval(batch)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -47,7 +47,7 @@ abstract class GpuHashPartitioningBase(expressions: Seq[Expression], numPartitio
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
     //  We are doing this here because the cudf partition command is at this level
     withResource(new NvtxRange("Hash partition", NvtxColor.PURPLE)) { _ =>
       val numRows = batch.numRows

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -57,7 +57,7 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
     val schema = Array.fill[DataType](fieldExpressions.length)(StringType)
 
     val fieldScalars = fieldExpressions.safeMap { field =>
-      withResourceIfAllowed(field.columnarEval(inputBatch)) { fieldVal =>
+      withResourceIfAllowed(field.columnarEvalAny(inputBatch)) { fieldVal =>
         fieldVal match {
           case fieldScalar: GpuScalar =>
             // Specials characters like '.', '[', ']' are not supported in field names

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMonotonicallyIncreasingID.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMonotonicallyIncreasingID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ case class GpuMonotonicallyIncreasingID() extends GpuLeafExpression {
   @transient private[this] var partitionMask: Long = _
   @transient private[this] var wasInitialized: Boolean = _
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     if (!wasInitialized) {
       count = 0
       partitionMask = TaskContext.getPartitionId().toLong << 33

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -36,6 +36,11 @@ trait GpuPartitioning extends Partitioning {
       GpuShuffleEnv.useMultiThreadedShuffle(rapidsConf))
   }
 
+  def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    throw new IllegalStateException(
+      "Partitioners should do not support columnarEval, only columnarEvalAny")
+  }
+
   def usesGPUShuffle: Boolean = _useGPUShuffle
 
   def usesMultiThreadedShuffle: Boolean = _useMultiThreadedShuffle

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -36,9 +36,9 @@ trait GpuPartitioning extends Partitioning {
       GpuShuffleEnv.useMultiThreadedShuffle(rapidsConf))
   }
 
-  def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+  final def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     throw new IllegalStateException(
-      "Partitioners should do not support columnarEval, only columnarEvalAny")
+      "Partitioners do not support columnarEval, only columnarEvalAny")
   }
 
   def usesGPUShuffle: Boolean = _useGPUShuffle

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
@@ -218,7 +218,7 @@ case class GpuRangePartitioner(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
     if (rangeBounds.nonEmpty) {
       val (parts, partitionColumns) = computeBoundsAndClose(batch)
       val slicedCb = sliceInternalGpuOrCpuAndClose(partitionColumns.head.getRowCount.toInt,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -61,7 +61,7 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
     if (batch.numCols() <= 0) {
       return Array(batch).zipWithIndex
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ case object GpuSinglePartitioning extends GpuExpression with ShimExpression
    * into a `ColumnarBatch` and closing the batch or by closing the vector directly if it is a
    * temporary value.
    */
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
     if (batch.numCols == 0) {
       Array(batch).zipWithIndex
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSparkPartitionID.scala
@@ -40,7 +40,7 @@ case class GpuSparkPartitionID() extends GpuLeafExpression {
 
   override val prettyName = "SPARK_PARTITION_ID"
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     if (!wasInitialized) {
       partitionId = TaskContext.getPartitionId()
       wasInitialized = true

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/constraintExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/constraintExpressions.scala
@@ -31,6 +31,10 @@ trait ShimTaggingExpression extends TaggingExpression with ShimUnaryExpression
  */
 case class GpuKnownFloatingPointNormalized(child: Expression) extends ShimTaggingExpression
     with GpuExpression {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
+    child.columnarEvalAny(batch)
+  }
+
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     child.columnarEval(batch)
   }
@@ -43,6 +47,10 @@ case class GpuKnownFloatingPointNormalized(child: Expression) extends ShimTaggin
 case class GpuKnownNotNull(child: Expression) extends ShimTaggingExpression
     with GpuExpression {
   override def nullable: Boolean = false
+
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
+    child.columnarEvalAny(batch)
+  }
 
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     child.columnarEval(batch)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/constraintExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/constraintExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ trait ShimTaggingExpression extends TaggingExpression with ShimUnaryExpression
  */
 case class GpuKnownFloatingPointNormalized(child: Expression) extends ShimTaggingExpression
     with GpuExpression {
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     child.columnarEval(batch)
   }
 }
@@ -44,7 +44,7 @@ case class GpuKnownNotNull(child: Expression) extends ShimTaggingExpression
     with GpuExpression {
   override def nullable: Boolean = false
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     child.columnarEval(batch)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -21,8 +21,8 @@ import scala.collection.mutable
 import ai.rapids.cudf
 import ai.rapids.cudf.DType
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.shims.ShimExpression
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
+import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.internal.SQLConf

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/higherOrderFunctions.scala
@@ -22,6 +22,7 @@ import ai.rapids.cudf
 import ai.rapids.cudf.DType
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimExpression
+import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression}
 import org.apache.spark.sql.internal.SQLConf
@@ -74,7 +75,7 @@ case class GpuLambdaFunction(
   override def dataType: DataType = function.dataType
   override def nullable: Boolean = function.nullable
 
-  override def columnarEval(batch: ColumnarBatch): Any =
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     function.asInstanceOf[GpuExpression].columnarEval(batch)
 }
 
@@ -273,11 +274,10 @@ trait GpuArrayTransformBase extends GpuSimpleHigherOrderFunction {
   protected def transformListColumnView(
     lambdaTransformedCV: cudf.ColumnView): GpuColumnVector
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(argument, batch)) { arg =>
-      val dataCol = withResource(
-        makeElementProjectBatch(batch, arg.getBase)) { cb =>
-        GpuExpressionsUtils.columnarEvalToColumn(function, cb)
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(argument.columnarEval(batch)) { arg =>
+      val dataCol = withResource(makeElementProjectBatch(batch, arg.getBase)) { cb =>
+        function.columnarEval(cb)
       }
       withResource(dataCol) { _ =>
         val cv = GpuListUtils.replaceListDataColumnAsView(arg.getBase, dataCol.getBase)
@@ -490,11 +490,10 @@ case class GpuTransformKeys(
     GpuTransformKeys(boundArg, boundFunc, isBound = true, boundIntermediate)
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(argument, batch)) { arg =>
-      val newKeysCol = withResource(
-        makeElementProjectBatch(batch, arg.getBase)) { cb =>
-        GpuExpressionsUtils.columnarEvalToColumn(function, cb)
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(argument.columnarEval(batch)) { arg =>
+      val newKeysCol = withResource(makeElementProjectBatch(batch, arg.getBase)) { cb =>
+        function.columnarEval(cb)
       }
       withResource(newKeysCol) { newKeysCol =>
         withResource(GpuMapUtils.replaceExplodedKeyAsView(arg.getBase, newKeysCol.getBase)) {
@@ -540,11 +539,10 @@ case class GpuTransformValues(
     GpuTransformValues(boundArg, boundFunc, isBound = true, boundIntermediate)
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(argument, batch)) { arg =>
-      val newValueCol = withResource(
-        makeElementProjectBatch(batch, arg.getBase)) { cb =>
-        GpuExpressionsUtils.columnarEvalToColumn(function, cb)
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(argument.columnarEval(batch)) { arg =>
+      val newValueCol = withResource(makeElementProjectBatch(batch, arg.getBase)) { cb =>
+        function.columnarEval(cb)
       }
       withResource(newValueCol) { newValueCol =>
         withResource(GpuMapUtils.replaceExplodedValueAsView(arg.getBase, newValueCol.getBase)) {
@@ -572,11 +570,11 @@ case class GpuMapFilter(argument: Expression,
     GpuMapFilter(boundArg, boundFunc, isBound = true, boundIntermediate)
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(GpuExpressionsUtils.columnarEvalToColumn(argument, batch)) { mapArg =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(argument.columnarEval(batch)) { mapArg =>
       // `mapArg` is list of struct(key, value)
       val plainBoolCol = withResource(makeElementProjectBatch(batch, mapArg.getBase)) { cb =>
-        GpuExpressionsUtils.columnarEvalToColumn(function, cb)
+        function.columnarEval(cb)
       }
 
       withResource(plainBoolCol) { plainBoolCol =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,12 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 object RapidsPluginImplicits {
 
   implicit class ReallyAGpuExpression(exp: Expression) {
-    def columnarEval(batch: ColumnarBatch): Any = {
+    def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
       exp.asInstanceOf[GpuExpression].columnarEval(batch)
+    }
+
+    def columnarEvalAny(batch: ColumnarBatch): Any = {
+      exp.asInstanceOf[GpuExpression].columnarEvalAny(batch)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -696,10 +696,14 @@ case class GpuLiteral (value: Any, dataType: DataType) extends GpuLeafExpression
     case _ => value.toString
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
     // Returns a Scalar instead of the value to support the scalar of nested type, and
     // simplify the handling of result from a `expr.columnarEval`.
     GpuScalar(value, dataType)
+  }
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    GpuExpressionsUtils.resolveColumnVector(columnarEvalAny(batch), batch.numRows())
   }
 
   override def convertToAst(numFirstTableColumns: Int): ast.AstExpression = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/namedExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,8 +105,13 @@ case class GpuAlias(child: Expression, name: String)(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any =
+  // pass through any calls to columarEval to child
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     child.columnarEval(batch)
+
+  // pass through any calls to columarEvalAny to child
+  override def columnarEvalAny(batch: ColumnarBatch): Any =
+    child.columnarEvalAny(batch)
 
   override def doColumnar(input: GpuColumnVector): ColumnVector =
     throw new IllegalStateException("GpuAlias should never have doColumnar called")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AggregateFunctions.scala
@@ -20,8 +20,8 @@ import ai.rapids.cudf
 import ai.rapids.cudf.{Aggregation128Utils, BinaryOp, ColumnVector, DType, GroupByAggregation, GroupByScanAggregation, NaNEquality, NullEquality, NullPolicy, NvtxColor, NvtxRange, ReductionAggregation, ReplacePolicy, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, ShimUnaryExpression, TypeUtilsShims}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
+import com.nvidia.spark.rapids.shims.{GpuDeterministicFirstLastCollectShim, ShimExpression, ShimUnaryExpression, TypeUtilsShims}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInputFileBlock.scala
@@ -44,7 +44,7 @@ case class GpuInputFileName() extends GpuLeafExpression {
    */
   override def disableCoalesceUntilInput(): Boolean = true
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     withResource(Scalar.fromString(InputFileBlockHolder.getInputFilePath.toString)) { scalar =>
       GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }
@@ -79,7 +79,7 @@ case class GpuInputFileBlockStart() extends GpuLeafExpression {
    */
   override def disableCoalesceUntilInput(): Boolean = true
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     withResource(Scalar.fromLong(InputFileBlockHolder.getStartOffset)) { scalar =>
       GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }
@@ -106,7 +106,7 @@ case class GpuInputFileBlockLength() extends GpuLeafExpression {
    */
   override def disableCoalesceUntilInput(): Boolean = true
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     withResource(Scalar.fromLong(InputFileBlockHolder.getLength)) { scalar =>
       GpuColumnVector.from(ColumnVector.fromScalar(scalar, batch.numRows()), dataType)
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.{GpuExpression, GpuScalar}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuScalar}
 import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExprId}
@@ -66,8 +66,9 @@ case class GpuScalarSubquery(
       ExprId(0))
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     require(updated, s"$this has not finished")
-    GpuScalar(result, dataType)
+    GpuExpressionsUtils.resolveColumnVector(
+      GpuScalar(result, dataType), batch.numRows())
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalarSubquery.scala
@@ -66,9 +66,13 @@ case class GpuScalarSubquery(
       ExprId(0))
   }
 
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
+    require(updated, s"$this has not finished")
+    GpuScalar(result, dataType)
+  }
+
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     require(updated, s"$this has not finished")
-    GpuExpressionsUtils.resolveColumnVector(
-      GpuScalar(result, dataType), batch.numRows())
+    GpuExpressionsUtils.resolveColumnVector(columnarEvalAny(batch), batch.numRows())
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -78,6 +78,6 @@ case class GpuMurmur3Hash(children: Seq[Expression], seed: Int) extends GpuExpre
   override def toString: String = s"hash($children)"
   def nullable: Boolean = children.exists(_.nullable)
 
-  def columnarEval(batch: ColumnarBatch): Any =
+  def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     GpuColumnVector.from(GpuMurmur3Hash.compute(batch, children, seed), dataType)
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -63,7 +63,7 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
 
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(IntegerType, LongType))
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     withResource(new NvtxRange("GpuRand", NvtxColor.RED)) { _ =>
       val partId = TaskContext.getPartitionId()
       if (partId != previousPartition || !wasInitialized) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -24,7 +24,6 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAllValidTrue
-import com.nvidia.spark.rapids.GpuExpressionsUtils.columnarEvalToColumn
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression
 
@@ -48,18 +47,21 @@ case class GpuConcat(children: Seq[Expression]) extends GpuComplexTypeMergingExp
 
   override def nullable: Boolean = children.exists(_.nullable)
 
-  override def columnarEval(batch: ColumnarBatch): Any = dataType match {
-    // Explicitly return null for empty concat as Spark, since cuDF doesn't support empty concat.
-    case dt if children.isEmpty => GpuScalar.from(null, dt)
-    // For single column concat, we pass the result of child node to avoid extra cuDF call.
-    case _ if children.length == 1 => children.head.columnarEval(batch)
-    case StringType => stringConcat(batch)
-    case ArrayType(_, _) => listConcat(batch)
-    case _ => throw new IllegalArgumentException(s"unsupported dataType $dataType")
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    val res = dataType match {
+      // Explicitly return null for empty concat as Spark, since cuDF doesn't support empty concat.
+      case dt if children.isEmpty => GpuScalar.from(null, dt)
+      // For single column concat, we pass the result of child node to avoid extra cuDF call.
+      case _ if children.length == 1 => children.head.columnarEval(batch)
+      case StringType => stringConcat(batch)
+      case ArrayType(_, _) => listConcat(batch)
+      case _ => throw new IllegalArgumentException(s"unsupported dataType $dataType")
+    }
+    GpuExpressionsUtils.resolveColumnVector(res, batch.numRows())
   }
 
   private def stringConcat(batch: ColumnarBatch): GpuColumnVector = {
-    withResource(children.safeMap(columnarEvalToColumn(_, batch).getBase())) {cols =>
+    withResource(children.safeMap(_.columnarEval(batch).getBase())) {cols =>
       // run string concatenate
       GpuColumnVector.from(
         cudf.ColumnVector.stringConcatenate(cols.toArray[ColumnView]), StringType)
@@ -67,7 +69,7 @@ case class GpuConcat(children: Seq[Expression]) extends GpuComplexTypeMergingExp
   }
 
   private def listConcat(batch: ColumnarBatch): GpuColumnVector = {
-    withResource(children.safeMap(columnarEvalToColumn(_, batch).getBase())) {cols =>
+    withResource(children.safeMap(_.columnarEval(batch).getBase())) {cols =>
       // run list concatenate
       GpuColumnVector.from(cudf.ColumnVector.listConcatenateByRow(cols: _*), dataType)
     }
@@ -89,19 +91,20 @@ case class GpuMapConcat(children: Seq[Expression]) extends GpuComplexTypeMerging
 
   override def nullable: Boolean = children.exists(_.nullable)
 
-  override def columnarEval(batch: ColumnarBatch): Any = (dataType, children.length) match {
-    // Explicitly return null for empty concat as Spark, since cuDF doesn't support empty concat.
-    case (dt, 0) => GpuColumnVector.fromNull(batch.numRows(), dt)
-    // For single column concat, we pass the result of child node to avoid extra cuDF call.
-    case (_, 1) => children.head.columnarEval(batch)
-    case (_, _) => {
-      withResource(children.safeMap(columnarEvalToColumn(_, batch).getBase())) {cols =>
-        withResource(cudf.ColumnVector.listConcatenateByRow(cols: _*)) {structs =>
-          GpuCreateMap.createMapFromKeysValuesAsStructs(dataType, structs)
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+    (dataType, children.length) match {
+      // Explicitly return null for empty concat as Spark, since cuDF doesn't support empty concat.
+      case (dt, 0) => GpuColumnVector.fromNull(batch.numRows(), dt)
+      // For single column concat, we pass the result of child node to avoid extra cuDF call.
+      case (_, 1) => children.head.columnarEval(batch)
+      case (_, _) => {
+        withResource(children.safeMap(_.columnarEval(batch).getBase())) {cols =>
+          withResource(cudf.ColumnVector.listConcatenateByRow(cols: _*)) {structs =>
+            GpuCreateMap.createMapFromKeysValuesAsStructs(dataType, structs)
+          }
         }
       }
     }
-  }
 }
 
 object GpuElementAtMeta {
@@ -791,30 +794,30 @@ case class GpuArraysZip(children: Seq[Expression]) extends GpuExpression with Sh
   @transient private lazy val arrayElementTypes =
     children.map(_.dataType.asInstanceOf[ArrayType].elementType)
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector  = {
+    val res = if (children.isEmpty) {
+      GpuScalar(new GenericArrayData(Array.empty[Any]), dataType)
+    } else {
+      // Prepare input columns
+      val inputs = children.safeMap { expr =>
+        expr.columnarEval(batch).getBase
+      }
 
-    if (children.isEmpty) {
-      return GpuScalar(new GenericArrayData(Array.empty[Any]), dataType)
-    }
+      val cleanedInputs = withResource(inputs) { inputs =>
+        normalizeNulls(inputs)
+      }
 
-    // Prepare input columns
-    val inputs = children.safeMap { expr =>
-      GpuExpressionsUtils.columnarEvalToColumn(expr, batch).getBase
-    }
+      val padded = withResource(cleanedInputs) { cleanedInputs =>
+        padArraysToMaxLength(cleanedInputs)
+      }
 
-    val cleanedInputs = withResource(inputs) { inputs =>
-      normalizeNulls(inputs)
-    }
-
-    val padded = withResource(cleanedInputs) { cleanedInputs =>
-      padArraysToMaxLength(cleanedInputs)
-    }
-
-    withResource(padded) { _ =>
-      closeOnExcept(zipArrays(padded)) { ret =>
-        GpuColumnVector.from(ret, dataType)
+      withResource(padded) { _ =>
+        closeOnExcept(zipArrays(padded)) { ret =>
+          GpuColumnVector.from(ret, dataType)
+        }
       }
     }
+    GpuExpressionsUtils.resolveColumnVector(res, batch.numRows())
   }
 
   /**
@@ -963,9 +966,9 @@ trait GpuArrayBinaryLike extends GpuComplexTypeMergingExpression with NullIntole
   def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector
   def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResourceIfAllowed(left.columnarEval(batch)) { lhs =>
-      withResourceIfAllowed(right.columnarEval(batch)) { rhs =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResourceIfAllowed(left.columnarEvalAny(batch)) { lhs =>
+      withResourceIfAllowed(right.columnarEvalAny(batch)) { rhs =>
         (lhs, rhs) match {
           case (l: GpuColumnVector, r: GpuColumnVector) =>
             GpuColumnVector.from(doColumnar(l, r), dataType)
@@ -1453,13 +1456,13 @@ case class GpuSequence(start: Expression, stop: Expression, stepOpt: Option[Expr
   // can throw exceptions such as "Illegal sequence boundaries: step > 0 but start > stop"
   override def hasSideEffects: Boolean = true
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResource(columnarEvalToColumn(start, batch)) { startGpuCol =>
-      withResource(stepOpt.map(columnarEvalToColumn(_, batch))) { stepGpuColOpt =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(start.columnarEval(batch)) { startGpuCol =>
+      withResource(stepOpt.map(_.columnarEval(batch))) { stepGpuColOpt =>
         val startCol = startGpuCol.getBase
 
         // 1 Compute the sequence size for each row.
-        val (sizeCol, stepCol) = withResource(columnarEvalToColumn(stop, batch)) { stopGpuCol =>
+        val (sizeCol, stepCol) = withResource(stop.columnarEval(batch)) { stopGpuCol =>
           val stopCol = stopGpuCol.getBase
           val steps = stepGpuColOpt.map(_.getBase.incRefCount())
               .getOrElse(defaultStepsFunc(startCol, stopCol))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -51,8 +51,8 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
   override def sql: String =
     child.sql + s".${quoteIdentifier(name.getOrElse(childSchema(ordinal).name))}"
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResourceIfAllowed(child.columnarEval(batch)) { input =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResourceIfAllowed(child.columnarEvalAny(batch)) { input =>
       val dt = dataType
       input match {
         case cv: GpuColumnVector =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -332,8 +332,7 @@ object GpuBroadcastNestedLoopJoinExecBase {
                 BooleanType)
             }
           } else {
-            withResource(GpuExpressionsUtils.columnarEvalToColumn(
-              boundCondition, streamBatch)) { condEval =>
+            withResource(boundCondition.columnarEval(streamBatch)) { condEval =>
               withResource(Scalar.fromBool(false)) { falseScalar =>
                 GpuColumnVector.from(condEval.getBase.replaceNulls(falseScalar), BooleanType)
               }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
@@ -299,7 +299,7 @@ object GpuShuffleExchangeExecBase {
     }
     val partitioner: GpuExpression = getPartitioner(newRdd, outputAttributes, newPartitioning)
     def getPartitioned: ColumnarBatch => Any = {
-      batch => partitioner.columnarEval(batch)
+      batch => partitioner.columnarEvalAny(batch)
     }
     val rddWithPartitionIds: RDD[Product2[Int, ColumnarBatch]] = {
       newRdd.mapPartitions { iter =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuHilbertLongIndex.scala
@@ -42,7 +42,7 @@ case class GpuHilbertLongIndex(numBits: Int, children: Seq[Expression])
 
   override def nullable: Boolean = false
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     val ret = withResource(GpuProjectExec.project(batch, children)) { inputs =>
       withResource(new NvtxRange("HILBERT INDEX", NvtxColor.PURPLE)) { _ =>
         val bases = GpuColumnVector.extractBases(inputs)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuInterleaveBits.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/GpuInterleaveBits.scala
@@ -52,7 +52,7 @@ case class GpuInterleaveBits(children: Seq[Expression])
 
   override def nullable: Boolean = false
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     val ret = withResource(GpuProjectExec.project(batch, children)) { inputs =>
       withResource(new NvtxRange("interleaveBits", NvtxColor.PURPLE)) { _ =>
         val bases = GpuColumnVector.extractBases(inputs)

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -27,11 +27,12 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning, GpuUnevaluable}
+import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning}
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, OrderedDistribution}
 import org.apache.spark.sql.types.{DataType, IntegerType}
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * A GPU accelerated `org.apache.spark.sql.catalyst.plans.physical.Partitioning` that partitions
@@ -49,8 +50,7 @@ case class GpuRangePartitioning(
     numPartitions: Int)
     extends GpuExpression
         with ShimExpression
-        with GpuPartitioning
-        with GpuUnevaluable {
+        with GpuPartitioning {
 
   override def children: Seq[SortOrder] = gpuOrdering
   override def nullable: Boolean = false
@@ -84,5 +84,9 @@ case class GpuRangePartitioning(
         case _ => false
       }
     }
+  }
+
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
+    throw new IllegalStateException("This cannot be executed")
   }
 }

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -27,12 +27,11 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning}
+import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning, GpuUnevaluable}
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, OrderedDistribution}
 import org.apache.spark.sql.types.{DataType, IntegerType}
-import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * A GPU accelerated `org.apache.spark.sql.catalyst.plans.physical.Partitioning` that partitions
@@ -47,7 +46,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  */
 case class GpuRangePartitioning(
     gpuOrdering: Seq[SortOrder],
-    numPartitions: Int) extends GpuExpression with ShimExpression with GpuPartitioning {
+    numPartitions: Int)
+    extends GpuExpression
+        with ShimExpression
+        with GpuPartitioning
+        with GpuUnevaluable {
 
   override def children: Seq[SortOrder] = gpuOrdering
   override def nullable: Boolean = false
@@ -82,7 +85,4 @@ case class GpuRangePartitioning(
       }
     }
   }
-
-  override def columnarEvalAny(batch: ColumnarBatch): Any =
-    throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -83,6 +83,6 @@ case class GpuRangePartitioning(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any =
+  override def columnarEvalAny(batch: ColumnarBatch): Any =
     throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -37,7 +37,7 @@ package org.apache.spark.sql.rapids.shims
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, BinaryOperable, ColumnVector, ColumnView, DType, Scalar}
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuScalar}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuScalar}
 import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimBinaryExpression
@@ -75,9 +75,9 @@ case class GpuTimeAdd(start: Expression,
 
   override def dataType: DataType = start.dataType
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    withResourceIfAllowed(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
-      withResourceIfAllowed(right.columnarEval(batch)) { rhs =>
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResourceIfAllowed(left.columnarEval(batch)) { lhs =>
+      withResourceIfAllowed(right.columnarEvalAny(batch)) { rhs =>
         // lhs is start, rhs is interval
         (lhs, rhs) match {
           case (l, intervalS: GpuScalar) =>

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -79,6 +79,6 @@ case class GpuRangePartitioning(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any =
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -79,6 +79,6 @@ case class GpuRangePartitioning(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+  override def columnarEvalAny(batch: ColumnarBatch): Any =
     throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -87,6 +87,6 @@ case class GpuRangePartitioning(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): Any =
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -27,7 +27,7 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuPartitioning}
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, OrderedDistribution}

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -27,7 +27,7 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuPartitioning}
+import com.nvidia.spark.rapids.{GpuExpression, GpuPartitioning}
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, OrderedDistribution}
@@ -87,6 +87,6 @@ case class GpuRangePartitioning(
     }
   }
 
-  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+  override def columnarEvalAny(batch: ColumnarBatch): Any =
     throw new IllegalStateException("This cannot be executed")
 }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -67,7 +67,7 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
 trait GpuAddSub extends CudfBinaryArithmetic {
   override def outputTypeOverride: DType = GpuColumnVector.getNonNestedRapidsType(dataType)
   val failOnError: Boolean
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     val outputType = dataType
     val leftInputType = left.dataType
     val rightInputType = right.dataType
@@ -92,13 +92,11 @@ trait GpuAddSub extends CudfBinaryArithmetic {
               super.columnarEval(batch)
             } else {
               // eval operands using the output precision
-              val castLhs = withResource(
-                GpuExpressionsUtils.columnarEvalToColumn(left, batch)
-              ) { lhs =>
+              val castLhs = withResource(left.columnarEval(batch)) { lhs =>
                 GpuCast.doCast(lhs.getBase(), leftInputType, resultType, false, false, false)
               }
               val castRhs = closeOnExcept(castLhs){ _ =>
-                withResource(GpuExpressionsUtils.columnarEvalToColumn(right, batch)) { rhs =>
+                withResource(right.columnarEval(batch)) { rhs =>
                   GpuCast.doCast(rhs.getBase(), rightInputType, resultType, false, false, false)
                 }
               }
@@ -137,14 +135,14 @@ trait GpuAddSub extends CudfBinaryArithmetic {
 
   protected def prepareInputAndExecute(
       batch: ColumnarBatch,
-      resultType: DecimalType): Any = {
-    val castLhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
+      resultType: DecimalType): GpuColumnVector = {
+    val castLhs = withResource(left.columnarEval(batch)) { lhs =>
       lhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, lhs.getBase.getType.getScale))
     }
     val retTab = withResource(castLhs) { castLhs =>
-      val castRhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(right, batch)) { rhs =>
+      val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         rhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, rhs.getBase.getType.getScale))
-      }
+      
       withResource(castRhs) { castRhs =>
         do128BitOperation(castLhs, castRhs, -resultType.scale)
       }
@@ -294,7 +292,7 @@ case class GpuDecimalRemainder(left: Expression, right: Expression)
   }
 
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     if (useLongDivision) {
       longRemainder(batch)
     } else {
@@ -302,12 +300,12 @@ case class GpuDecimalRemainder(left: Expression, right: Expression)
     }
   }
 
-  private def longRemainder(batch: ColumnarBatch): Any = {
-    val castLhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
+  private def longRemainder(batch: ColumnarBatch): GpuColumnVector = {
+    val castLhs = withResource(left.columnarEval(batch)) { lhs =>
       lhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, lhs.getBase.getType.getScale))
     }
     val retTab = withResource(castLhs) { castLhs =>
-      val castRhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(right, batch)) { rhs =>
+      val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
           fixed.castTo(DType.create(DType.DTypeEnum.DECIMAL128, fixed.getType.getScale))
         }
@@ -340,13 +338,13 @@ case class GpuDecimalRemainder(left: Expression, right: Expression)
     GpuColumnVector.from(retCol, dataType)
   }
 
-  private def regularRemainder(batch: ColumnarBatch): Any = {
-    val castLhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(left, batch)) { lhs =>
+  private def regularRemainder(batch: ColumnarBatch): GpuColumnVector = {
+    val castLhs = withResource(left.columnarEval(batch)) { lhs =>
       GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType, ansiMode = failOnError,
         legacyCastToString = false, stringToDateAnsiModeEnabled = false)
     }
     withResource(castLhs) { castLhs =>
-      val castRhs = withResource(GpuExpressionsUtils.columnarEvalToColumn(right, batch)) { rhs =>
+      val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
           GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType, ansiMode = failOnError,
             legacyCastToString = false, stringToDateAnsiModeEnabled = false)

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -27,6 +27,7 @@ import scala.math.{max, min}
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -475,8 +475,8 @@ case class GpuIntegralDecimalDivide(
 
   override def failOnError: Boolean = SQLConf.get.ansiEnabled
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
-    super.columnarEval(batch).asInstanceOf[GpuColumnVector]
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    super.columnarEval(batch)
   }
 
   override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -142,7 +142,7 @@ trait GpuAddSub extends CudfBinaryArithmetic {
     val retTab = withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         rhs.getBase.castTo(DType.create(DType.DTypeEnum.DECIMAL128, rhs.getBase.getType.getScale))
-      
+      }
       withResource(castRhs) { castRhs =>
         do128BitOperation(castLhs, castRhs, -resultType.scale)
       }

--- a/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
+++ b/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
@@ -47,7 +47,7 @@ case class GpuCheckOverflowInTableInsert(child: GpuCast, columnName: String)
 
   override def dataType: DataType = child.dataType
 
-  override def columnarEval(batch: ColumnarBatch): Any = {
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
     try {
       child.columnarEval(batch)
     } catch {

--- a/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
+++ b/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
@@ -23,7 +23,7 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.{GpuCast, GpuExpression}
+import com.nvidia.spark.rapids.{GpuCast, GpuColumnVector, GpuExpression}
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
 
 import org.apache.spark.SparkArithmeticException

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSinglePartitioningSuite.scala
@@ -56,7 +56,8 @@ class GpuSinglePartitioningSuite extends AnyFunSuite {
             val expected = contigTables.head
             // partition will consume batch, so increment refcounts enabling withResource to close
             GpuColumnVector.extractBases(batch).foreach(_.incRefCount())
-            val result = partitioner.columnarEval(batch).asInstanceOf[Array[(ColumnarBatch, Int)]]
+            val result =
+              partitioner.columnarEvalAny(batch).asInstanceOf[Array[(ColumnarBatch, Int)]]
             try {
               assertResult(1)(result.length)
               assertResult(0)(result.head._2)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/unit/DecimalUnitTest.scala
@@ -24,8 +24,8 @@ import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.{GpuAlias, GpuColumnVector, GpuIsNotNull, GpuIsNull, GpuLiteral, GpuOverrides, GpuScalar, GpuUnitTests, HostColumnarToGpu, RapidsConf}
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.shims.GpuBatchScanExec
-import org.apache.spark.SparkConf
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal}
 import org.apache.spark.sql.execution.FileSourceScanExec


### PR DESCRIPTION
Contributes to https://github.com/NVIDIA/spark-rapids/issues/8303

This PR changes `columnarEval` to now always return a `GpuColumnVector` for all expressions. In most cases this was already the case, in others I had to use: `GpuExpressionsUtils.resolveColumnVector(any, numRows)` to ensure a vector would be returned.

This also introduces `columnarEvalAny` as some expressions need to return Any. The default implementation of `columnarEvalAny` is to call `columnarEval`, so you are either getting a `GpuColumnVector` or a `GpuScalar`. Code that calls `columnarEvalAny` has to be prepared to handle both.

I also removed `GpuProjectExec.projectSingle` and `GpuExpressionUtils.columnarEvalToColumn`

This is the set of expressions that override `columnarEvalAny` as of this PR:

- GpuLiteral
- GpuAlias (e.g. `GpuAlias(GpuLiteral(..))`)
- Gpu[Round|Hash|Single|Range]Partitioning: these return an `Iterator[(ColumnarBatch, Int)]`. I could special case this to something like `columnarEvalPartitioning`, but I didn't as they are special cases and the caller code already is setup to handle the partitioning calls.
- GpuUnevaluable

For good measure I added overrides for these as pass through, but I don't think we'll ever see them in a plan with something that matters:
- GpuKnownNotNull
- GpuKnownFloatingPointNormalized