### PR TITLE
Normal and Multi Distributions for BigDataGen

### DIFF
--- a/integration_tests/DATA_GEN.md
+++ b/integration_tests/DATA_GEN.md
@@ -212,7 +212,7 @@ around this.
 
 ### NormalDistribution
 
-Often data is distributed in a normal or gaussian like distribution. 
+Often data is distributed in a normal or Gaussian like distribution. 
 `NormalDistribution` takes a mean and a standard deviation to provide a way to
 insert some basic skew into your data. Please note that this will clamp
 the produced values to the configured seed range, so if seed range is not large

--- a/integration_tests/DATA_GEN.md
+++ b/integration_tests/DATA_GEN.md
@@ -165,10 +165,6 @@ dataTable.toDF(spark).groupBy("a").count.show
 +----------+-------+
 ```
 
-Unfortunately generating data skew is not done yet, and will come later on, but
-for now we can also generate unique values. This is especially helpful if you
-want to simulate something like a fact table for a join.
-
 Please note that for nested types, like structs and arrays, the seeds passed into
 the parent type has little to no impact on the resulting output, except for nulls.
 It is the child columns that have their own distributions that need to be taken
@@ -213,6 +209,81 @@ Please note that this does not work well with structs or other nested types
 because the seeds passed into the parents do not control what the children
 generate. See [Multi-Column Keys](#multi-column-keys) for info on how to work
 around this.
+
+### NormalDistribution
+
+Often data is distributed in a normal or gaussian like distribution. 
+`NormalDistribution` takes a mean and a standard deviation to provide a way to
+insert some basic skew into your data. Please note that this will clamp
+the produced values to the configured seed range, so if seed range is not large
+enough to hold several standard deviations of values from the mean the
+actual distribution will be off.
+
+```scala
+val dataTable = DBGen().addTable("data", "a string", 100000)
+dataTable("a").setSeedMapping(NormalDistribution(50, 1.0)).setSeedRange(0, 100)
+dataTable.toDF(spark).groupBy("a").count().orderBy(desc("count")).show()
++----------+-----+
+|         a|count|
++----------+-----+
+| 0~{5)Uek>|34414|
+|,J~pA-KqBn|34030|
+|#"IlU%=azD|13651|
+|9=o`YbIDy{|13444|
+|xqW\HOC.;L| 2107|
+|F&1rC%ge3P| 2089|
+|bK%|@|fs9a|  129|
+|(Z=9IR8h83|  128|
+|Eb9fEBb-]B|    5|
+|T<oMow6W_L|    3|
++----------+-----+
+```
+
+### MultiDistribution
+
+There are times when you might want to combine more than one distribution. Like 
+having a `NormalDistribution` along with a `FlatDistribution` so that the data
+is skewed, but there is still nearly full coverage of the seed range. Of you could
+combine two `NormalDistribution` instances to have two different sized bumps at
+different key ranges. `MultiDistribution` allows you to do this. It takes a
+`Seq` of weight/`LocationToSeedMapping` pairs. The weights are relative to 
+each other and determine how often on mapping will be used vs another. If
+you wanted a `NormalDistribution` to be used 10 times as often as a 
+`FlatDistribution` you would give the normal a weight of 10 and the flat a 
+weight of 1.
+
+
+```scala
+val dataTable = DBGen().addTable("data", "a string", 100000)
+dataTable("a").setSeedMapping(MultiDistribution(Seq(
+  (10.0, NormalDistribution(50, 1.0)),
+  (1.0, FlatDistribution())))).setSeedRange(0, 100)
++----------+-----+
+|         a|count|
++----------+-----+
+| 0~{5)Uek>|31727|
+|,J~pA-KqBn|29461|
+|9=o`YbIDy{|12910|
+|#"IlU%=azD|12840|
+|F&1rC%ge3P| 2103|
+|xqW\HOC.;L| 2080|
+|(Z=9IR8h83|  214|
+|bK%|@|fs9a|  185|
+|n&]AosAQJf|  111|
+||H6h"R!7CH|  110|
+|-bVd8htg"^|  108|
+|u2^.x?oJBb|  107|
+| aMZ({x5#1|  107|
+|Qb#XoQx[{Z|  107|
+|5C&<?S31Kp|  106|
+|)Wf2']8yFm|  105|
+|_qo)|Ti2}n|  105|
+|S1Jdbn_hda|  104|
+|\SANbeK.?`|  103|
+|yba?^,?zP`|  103|
++----------+-----+
+only showing top 20 rows
+```
 
 ## Multi-Column Keys
 

--- a/integration_tests/src/main/scala/org/apache/spark/sql/tests/datagen/bigDataGen.scala
+++ b/integration_tests/src/main/scala/org/apache/spark/sql/tests/datagen/bigDataGen.scala
@@ -388,14 +388,14 @@ object MultiDistribution {
       val runningNormalizedWeights = normalizedWeights.tail
           .scanLeft(normalizedWeights.head)(_ + _).toArray
       val mappings = weightsNMappings.map(_._2).toArray
-      MultiDistribution(runningNormalizedWeights, mappings)
+      MultiDistribution(runningNormalizedWeights, mappings, 0)
     }
   }
 }
 
 case class MultiDistribution private (normalizedWeights: Array[Double],
     mappings: Array[LocationToSeedMapping],
-    colLocSeed: Long = 0) extends LocationToSeedMapping {
+    colLocSeed: Long) extends LocationToSeedMapping {
   require(normalizedWeights.length == mappings.length,
     s"${normalizedWeights.toList} vs ${mappings.toList}")
   require(normalizedWeights.length > 0)

--- a/integration_tests/src/main/scala/org/apache/spark/sql/tests/datagen/bigDataGen.scala
+++ b/integration_tests/src/main/scala/org/apache/spark/sql/tests/datagen/bigDataGen.scala
@@ -332,6 +332,92 @@ case class FlatDistribution(colLocSeed: Long = 0L,
 }
 
 /**
+ * A LocationToSeedMapping that generates seeds with a normal distribution around a
+ * given mean, and with a desired standard deviation. Not that if you set the
+ * seeds produced are bound to the seed range requested so if the range is too small
+ * or outside of the expected mean the results will not have the expected distribution
+ * of values.
+ * @param mean the desired mean as a double
+ * @param stdDev the desired standard deviation
+ */
+case class NormalDistribution(mean: Double,
+    stdDev: Double,
+    min: Long = Long.MinValue,
+    max: Long = Long.MaxValue,
+    colLocSeed: Long = 0) extends LocationToSeedMapping {
+
+  override def withColumnConf(colConf: ColumnConf): NormalDistribution = {
+    val colLocSeed = colConf.columnLoc.hashLoc
+    NormalDistribution(mean, stdDev, colConf.minSeed, colConf.maxSeed, colLocSeed)
+  }
+
+  override def apply(rowLoc: RowLocation): Long = {
+    val r = DataGen.getRandomFor(rowLoc.hashLoc(colLocSeed))
+    val g = r.nextGaussian() // g has a mean of 0 and a stddev of 1.0
+    val adjusted = mean + (g * stdDev)
+    // If the range of seeds is too small compared to the stddev and mean we will
+    // end up with an invalid distribution, but they asked for it.
+    math.max(min, math.min(max, adjusted.toLong))
+  }
+}
+
+object MultiDistribution {
+  /**
+   * Create a LocationToSeedMapping that combines multiple other LocationsToSeed mappings
+   * together based on weights.
+   * @param weightsNMappings The weights and mappings to use. The weights are relative to each
+   *                         other. So if you want two mappings with one applied 5 times more
+   *                         often than the other. You can set the weight of the more desirable
+   *                         one to 5.0 and the other to 1.0.
+   * @return a LocationToSeedMapping that fits the desired distribution.
+   */
+  def apply(weightsNMappings: Seq[(Double, LocationToSeedMapping)]): LocationToSeedMapping = {
+    if (weightsNMappings.length <= 0) {
+      throw new IllegalArgumentException("Need at least one mapping")
+    }
+
+    if (weightsNMappings.exists(_._1 <= 0.0)) {
+      throw new IllegalArgumentException("All weights must be positive")
+    }
+
+    if (weightsNMappings.length == 1) {
+      weightsNMappings.head._2
+    } else {
+      val weightSum = weightsNMappings.map(_._1).sum
+      val normalizedWeights = weightsNMappings.map(_._1 / weightSum)
+      val runningNormalizedWeights = normalizedWeights.tail
+          .scanLeft(normalizedWeights.head)(_ + _).toArray
+      val mappings = weightsNMappings.map(_._2).toArray
+      MultiDistribution(runningNormalizedWeights, mappings)
+    }
+  }
+}
+
+case class MultiDistribution private (normalizedWeights: Array[Double],
+    mappings: Array[LocationToSeedMapping],
+    colLocSeed: Long = 0) extends LocationToSeedMapping {
+  require(normalizedWeights.length == mappings.length,
+    s"${normalizedWeights.toList} vs ${mappings.toList}")
+  require(normalizedWeights.length > 0)
+
+  override def withColumnConf(colConf: ColumnConf): LocationToSeedMapping = {
+    val colLocSeed = colConf.columnLoc.hashLoc
+    val newMappings = mappings.map(_.withColumnConf(colConf))
+    MultiDistribution(normalizedWeights, newMappings, colLocSeed)
+  }
+
+  override def apply(rowLoc: RowLocation): Long = {
+    val r = DataGen.getRandomFor(rowLoc.hashLoc(colLocSeed))
+    val lookingFor = r.nextDouble()
+    var i = 0
+    while (i < (normalizedWeights.length - 1) && normalizedWeights(i) < lookingFor) {
+      i += 1
+    }
+    mappings(i)(rowLoc)
+  }
+}
+
+/**
  * A LocationToSeedMapping that generates a unique seed per row. The order in which the values are
  * generated is some what of a random like order. This should *NOT* be applied to any
  * columns that are under an array because it ues rowNum and assumes that this maps correctly
@@ -581,6 +667,21 @@ abstract class DataGen(var conf: ColumnConf,
   }
 
   def get(name: String): Option[DataGen] = None
+}
+
+/**
+ * A special GeneratorFunction that just returns the computed seed. This is helpful for
+ * debugging distributions or if you want long values without any abstraction in between.
+ */
+case class SeedPassThrough(mapping: LocationToSeedMapping = null) extends GeneratorFunction {
+  override def withLocationToSeedMapping(mapping: LocationToSeedMapping): GeneratorFunction =
+    SeedPassThrough(mapping)
+
+  override def withValueRange(min: Any, max: Any): GeneratorFunction =
+    throw new IllegalStateException("Value range is not supported")
+
+  override def apply(rowLoc: RowLocation): Any =
+    mapping(rowLoc)
 }
 
 /**


### PR DESCRIPTION
This fixes part of https://github.com/NVIDIA/spark-rapids/issues/8721

It adds in a NormalDistribution based off of Java's build in pseudo random nextGaussian API
It also adds in a MultDistribution which can be used to create a BiNormalDistribution.

I didn't do an `ExponentialDistribution` because I don't know if we really need it right now. Newer versions of java offer an API for this and I didn't feel like writing something from scratch to do it.