### PR TITLE
Add support for xxhash64

### DIFF
--- a/integration_tests/src/main/python/hashing_test.py
+++ b/integration_tests/src/main/python/hashing_test.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
+from data_gen import *
+from marks import allow_non_gpu, ignore_order
+
+_xxhash_gens = all_gen + [null_gen]
+
+_struct_of_xxhash_gens = StructGen([(f"c{i}", g) for i, g in enumerate(_xxhash_gens)])
+
+_xxhash_fallback_gens = single_level_array_gens + nested_array_gens_sample + [
+    all_basic_struct_gen,
+    struct_array_gen_no_nans,
+    _struct_of_xxhash_gens]
+
+@ignore_order(local=True)
+@pytest.mark.parametrize("gen", _xxhash_gens, ids=idfn)
+def test_xxhash64_single_column(gen):
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : unary_op_df(spark, gen).selectExpr("a", "xxhash64(a)"))
+
+@ignore_order(local=True)
+def test_xxhash64_multi_column():
+    gen = StructGen(_struct_of_xxhash_gens.children, nullable=False)
+    col_list = ",".join(gen.data_type.fieldNames())
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark : gen_df(spark, gen).selectExpr("c0", f"xxhash64({col_list})"))
+
+@allow_non_gpu("ProjectExec")
+@ignore_order(local=True)
+@pytest.mark.parametrize("gen", _xxhash_fallback_gens, ids=idfn)
+def test_xxhash64_fallback(gen):
+    assert_gpu_fallback_collect(
+        lambda spark : unary_op_df(spark, gen).selectExpr("a", "xxhash64(a)"),
+        "ProjectExec")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3071,6 +3071,18 @@ object GpuOverrides extends Logging {
         def convertToGpu(): GpuExpression =
           GpuMurmur3Hash(childExprs.map(_.convertToGpu()), a.seed)
       }),
+    expr[XxHash64](
+      "xxhash64 hash operator",
+      ExprChecks.projectOnly(TypeSig.LONG, TypeSig.LONG,
+        repeatingParamCheck = Some(RepeatingParamCheck("input",
+          TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128, TypeSig.all))),
+      (a, conf, p, r) => new ExprMeta[XxHash64](a, conf, p, r) {
+        override val childExprs: Seq[BaseExprMeta[_]] = a.children
+          .map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+
+        def convertToGpu(): GpuExpression =
+          GpuXxHash64(childExprs.map(_.convertToGpu()), a.seed)
+      }),
     expr[Contains](
       "Contains",
       ExprChecks.binaryProject(TypeSig.BOOLEAN, TypeSig.BOOLEAN,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/HashFunctions.scala
@@ -17,12 +17,15 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView}
-import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec, GpuTieredProject, GpuUnaryExpression}
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuProjectExec, GpuUnaryExpression}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.jni.Hash
 import com.nvidia.spark.rapids.shims.{HashUtils, ShimExpression}
 
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, NullIntolerant}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -41,6 +44,32 @@ case class GpuMd5(child: Expression)
   }
 }
 
+abstract class GpuHashExpression extends GpuExpression with ShimExpression {
+  override def foldable: Boolean = children.forall(_.foldable)
+
+  override def nullable: Boolean = false
+
+  private def hasMapType(dt: DataType): Boolean = {
+    dt.existsRecursively(_.isInstanceOf[MapType])
+  }
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (children.length < 1) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName requires at least one argument")
+    } else if (children.exists(child => hasMapType(child.dataType)) &&
+      !SQLConf.get.getConf(SQLConf.LEGACY_ALLOW_HASH_ON_MAPTYPE)) {
+      TypeCheckResult.TypeCheckFailure(
+        s"input to function $prettyName cannot contain elements of MapType. In Spark, same maps " +
+          "may have different hashcode, thus hash expressions are prohibited on MapType elements." +
+          s" To restore previous behavior set ${SQLConf.LEGACY_ALLOW_HASH_ON_MAPTYPE.key} " +
+          "to true.")
+    } else {
+      TypeCheckResult.TypeCheckSuccess
+    }
+  }
+}
+
 object GpuMurmur3Hash {
   def compute(batch: ColumnarBatch,
       boundExpr: Seq[Expression],
@@ -55,29 +84,27 @@ object GpuMurmur3Hash {
       }
     }
   }
-
-  def computeTiered(batch: ColumnarBatch,
-      boundExpr: GpuTieredProject,
-      seed: Int = 42): ColumnVector = {
-    withResource(boundExpr.project(batch)) { args =>
-      val bases = GpuColumnVector.extractBases(args)
-      val normalized = bases.safeMap { cv =>
-        HashUtils.normalizeInput(cv).asInstanceOf[ColumnView]
-      }
-      withResource(normalized) { _ =>
-        ColumnVector.spark32BitMurmurHash3(seed, normalized)
-      }
-    }
-  }
 }
 
-case class GpuMurmur3Hash(children: Seq[Expression], seed: Int) extends GpuExpression
-  with ShimExpression {
+case class GpuMurmur3Hash(children: Seq[Expression], seed: Int) extends GpuHashExpression {
   override def dataType: DataType = IntegerType
 
-  override def toString: String = s"hash($children)"
-  def nullable: Boolean = children.exists(_.nullable)
+  override def prettyName: String = "hash"
 
-  def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
     GpuColumnVector.from(GpuMurmur3Hash.compute(batch, children, seed), dataType)
+}
+
+
+case class GpuXxHash64(children: Seq[Expression], seed: Long) extends GpuHashExpression {
+  override def dataType: DataType = LongType
+
+  override def prettyName: String = "xxhash64"
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    withResource(children.safeMap(_.columnarEval(batch))) { childCols =>
+      val cudfCols = childCols.map(_.getBase.asInstanceOf[ColumnView]).toArray
+      GpuColumnVector.from(Hash.xxhash64(seed, cudfCols), dataType)
+    }
+  }
 }


### PR DESCRIPTION
Fixes #8633.

Adds limited GPU support for the XxHash64 support along with tests.  Nested types are currently not supported due to limitations in the GPU kernels in spark-rapids-jni.
