### PR TITLE
Update ubuntu dockerfiles default to 20.04 and deprecating centos one [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -386,10 +386,10 @@ guide for Databricks. The following are extra steps required to enable UCX.
 ```
 #!/bin/bash
 sudo apt install -y wget libnuma1 &&
-wget https://github.com/openucx/ucx/releases/download/v1.14.0/ucx-1.14.0-ubuntu18.04-mofed5-cuda11.tar.bz2 &&
-tar -xvf ucx-1.14.0-ubuntu18.04-mofed5-cuda11.tar.bz2 &&
+wget https://github.com/openucx/ucx/releases/download/v1.14.0/ucx-1.14.0-ubuntu20.04-mofed5-cuda11.tar.bz2 &&
+tar -xvf ucx-1.14.0-ubuntu20.04-mofed5-cuda11.tar.bz2 &&
 sudo dpkg -i ucx-1.14.0.deb ucx-cuda-1.14.0.deb &&
-rm ucx-1.14.0-ubuntu18.04-mofed5-cuda11.tar.bz2 ucx-1.14.0.deb ucx-cuda-1.14.0.deb
+rm ucx-1.14.0-ubuntu20.04-mofed5-cuda11.tar.bz2 ucx-1.14.0.deb ucx-cuda-1.14.0.deb
 ```
 
 Save the script in DBFS and add it to the "Init Scripts" list:

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Sample Dockerfile to install UCX in a Ubuntu 18.04 image
+# Sample Dockerfile to install UCX in a Ubuntu 20.04 image
 #
 # The parameters are: 
 #   - CUDA_VER: 11.8.0 by default

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-# Sample Dockerfile to install UCX in a Unbuntu 18.04 image with RDMA support.
+# Sample Dockerfile to install UCX in a Unbuntu 20.04 image with RDMA support.
 #
 # The parameters are: 
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 

--- a/docs/get-started/Dockerfile.cuda
+++ b/docs/get-started/Dockerfile.cuda
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nvidia/cuda:11.8.0-devel-ubuntu18.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu20.04
 ARG spark_uid=185
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771

--- a/jenkins/Dockerfile-blossom.integration.centos
+++ b/jenkins/Dockerfile-blossom.integration.centos
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-###
+### DEPRECATED: https://github.com/NVIDIA/spark-rapids/issues/8789
 #
 # Arguments:
 #    CUDA_VER=11.0+

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -46,9 +46,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cudatoolkit=${CUDA_VER} && \
+RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-toolkit=${CUDA_VER} && \
     mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -58,9 +58,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cudatoolkit=${CUDA_VER} && \
+RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-toolkit=${CUDA_VER} && \
     mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -50,7 +50,7 @@ conda install -y -c conda-forge mamba python=$PYTHON_VERSION
 ${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas || true
 
 REQUIRED_PACKAGES=(
-  cudatoolkit=$CUDA_VER
+  cuda-toolkit=$CUDA_VER
   cudf=$CUDF_VER
   findspark
   pandas

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -21,7 +21,7 @@
 set -ex
 
 CUDF_VER=${CUDF_VER:-23.08}
-CUDA_VER=${CUDA_VER:-11.0}
+CUDA_VER=${CUDA_VER:-11.8.0}
 
 # Need to explicitly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH


### PR DESCRIPTION
part of #8789 

update some defaults in dockerfiles and document to use ubuntu20.04. 
And add comment to deprecating centos test support

use new cuda-toolkit pkg on conda nvidia channel `cudatoolkit -> cuda-toolkit `
(the elder one is deprecated, the newer one supports 11.4+)