### PR TITLE
Add a case to test ORC writing/reading with lots of nulls

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -398,6 +398,10 @@ properly without it. These tests assume Delta Lake is not configured and are dis
 If Spark has been configured to support Delta Lake then these tests can be enabled by adding the
 `--delta_lake` option to the command.
 
+### Enabling large data tests
+Some tests are testing large data which will take a long time. By default, these tests are disabled.
+These tests can be enabled by adding the `--large_data_test` option to the command.
+
 ## Writing tests
 
 There are a number of libraries provided to help someone write new tests.

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -56,3 +56,6 @@ def pytest_addoption(parser):
         "--force_parquet_testing_tests", action="store_true", default=False,
         help="if true forces parquet-testing tests to fail if input data cannot be found"
     )
+    parser.addoption(
+        "--large_data_test", action='store_true', default=False, help="if enable tests with large data"
+    )

--- a/integration_tests/pytest.ini
+++ b/integration_tests/pytest.ini
@@ -33,5 +33,6 @@ markers =
     iceberg: Mark a test that requires Iceberg has been configured, skipping if tests are not configured for Iceberg
     delta_lake: Mark a test that requires Delta Lake has been configured, skipping if tests are not configured for Delta Lake
     regexp: Mark a test that tests regular expressions on the GPU (only works when UTF-8 is enabled)
+    large_data_test: Mark tests with large data
 filterwarnings =
     ignore:.*pytest.mark.order.*:_pytest.warning_types.PytestUnknownMarkWarning

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -218,6 +218,10 @@ def pytest_runtest_setup(item):
         if not item.config.getoption('delta_lake'):
             pytest.skip('delta lake tests not configured to run')
 
+    if item.get_closest_marker('large_data_test'):
+        if not item.config.getoption('large_data_test'):
+            pytest.skip('tests for large data not configured to run')
+
 def pytest_configure(config):
     global _runtime_env
     _runtime_env = config.getoption('runtime_env')

--- a/integration_tests/src/main/python/marks.py
+++ b/integration_tests/src/main/python/marks.py
@@ -30,3 +30,4 @@ nightly_host_mem_consuming_case = pytest.mark.nightly_host_mem_consuming_case
 fuzz_test = pytest.mark.fuzz_test
 iceberg = pytest.mark.iceberg
 delta_lake = pytest.mark.delta_lake
+large_data_test = pytest.mark.large_data_test


### PR DESCRIPTION
closes #8731 

This is to test large number of nulls.
- Add a case to test ORC writing/reading with lots of nulls.
- Add large_data_test mark in pytest, by default, disable the tests with large_data_test mark.

Signed-off-by: Chong Gao <res_life@163.com>
