### PR TITLE
Update documentation to add Databricks 12.2 as a supported platform [skip ci]

### DIFF
--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -38,6 +38,7 @@ Delta Lake writes:
 - Delta Lake version 2.4.0 on Apache Spark 3.4.x
 - Delta Lake on Databricks 10.4 LTS
 - Delta Lake on Databricks 11.3 LTS
+- Delta Lake on Databricks 12.2 LTS
 
 Delta Lake writes will not be accelerated on Spark 3.1.x or earlier.
 
@@ -49,7 +50,8 @@ operation which is typically triggered via the DataFrame `write` API, e.g.:
 `data.write.format("delta").save(...)`.
 
 Table creation from selection, table insertion from SQL, and table merges are not currently
-GPU accelerated. These operations will fallback to the CPU.
+GPU accelerated. These operations will fallback to the CPU. Writes against tables that have
+deletion vectors enabled will also fallback to the CPU.
 
 #### Automatic Optimization of Writes
 

--- a/docs/additional-functionality/delta-lake-support.md
+++ b/docs/additional-functionality/delta-lake-support.md
@@ -17,12 +17,13 @@ This document details the Delta Lake features that are supported.
 
 Delta Lake scans of the underlying Parquet files are presented in the query as normal Parquet
 reads, so the Parquet reads will be accelerated in the same way raw Parquet file reads are
-accelerated.
+accelerated. Reads against tables that have deletion vectors enabled will fallback to the CPU.
 
 ### Metadata Queries
 
 Reads of Delta Lake metadata, i.e.: the Delta log detailing the history of snapshots, will not
 be GPU accelerated. The CPU will continue to process metadata queries on Delta Lake tables.
+
 
 ## Writing Delta Lake Tables
 

--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -32,6 +32,7 @@ in our plugin:
 | 3.4.1           | com.nvidia.spark.rapids.spark341.RapidsShuffleManager    |
 | Databricks 10.4 | com.nvidia.spark.rapids.spark321db.RapidsShuffleManager  |
 | Databricks 11.3 | com.nvidia.spark.rapids.spark330db.RapidsShuffleManager  |
+| Databricks 12.2 | com.nvidia.spark.rapids.spark332db.RapidsShuffleManager  |
 
 ## Multi-Threaded Mode
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8660

Update documentation to add Databricks 12.2 information