### PR TITLE
Binary and ternary handling of scalar audit and some fixes [databricks]

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -21,7 +21,7 @@ from marks import incompat
 from spark_session import is_before_spark_313, is_before_spark_330, is_databricks113_or_later, is_spark_330_or_later, is_databricks104_or_later, is_spark_33X, is_spark_340_or_later, is_spark_330, is_spark_330cdh
 from pyspark.sql.types import *
 from pyspark.sql.types import IntegralType
-from pyspark.sql.functions import array_contains, col, element_at, lit
+from pyspark.sql.functions import array_contains, col, element_at, lit, array
 
 # max_val is a little larger than the default max size(20) of ArrayGen
 # so we can get the out-of-bound indices.
@@ -218,6 +218,9 @@ def test_array_contains(data_gen):
         return two_col_df(spark, arr_gen, data_gen)
 
     assert_gpu_and_cpu_are_equal_collect(lambda spark: get_input(spark).select(
+                                            array_contains(array(lit(None)), col('b')),
+                                            array_contains(array(), col('b')),
+                                            array_contains(array(lit(literal), lit(literal)), col('b')),
                                             array_contains(col('a'), literal.cast(data_gen.data_type)),
                                             array_contains(col('a'), col('b')),
                                             array_contains(col('a'), col('a')[5])))

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -18,7 +18,7 @@ from data_gen import *
 from datetime import date, datetime, timezone
 from marks import ignore_order, incompat, allow_non_gpu
 from pyspark.sql.types import *
-from spark_session import with_cpu_session, with_spark_session, is_before_spark_330
+from spark_session import with_cpu_session, is_before_spark_330
 import pyspark.sql.functions as f
 
 # We only support literal intervals for TimeSub
@@ -229,6 +229,16 @@ def test_unix_timestamp(data_gen):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(f.unix_timestamp(f.col('a'))))
 
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
+def test_unsupported_fallback_unix_timestamp(data_gen):
+    assert_gpu_fallback_collect(lambda spark: gen_df(
+        spark, [("a", data_gen), ("b", string_gen)], length=10).selectExpr(
+        "unix_timestamp(a, b)"),
+        "UnixTimestamp")
+
+
 @pytest.mark.parametrize('ansi_enabled', [True, False], ids=['ANSI_ON', 'ANSI_OFF'])
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
 def test_to_unix_timestamp(data_gen, ansi_enabled):
@@ -237,19 +247,48 @@ def test_to_unix_timestamp(data_gen, ansi_enabled):
         {'spark.sql.ansi.enabled': ansi_enabled})
 
 
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
+def test_unsupported_fallback_to_unix_timestamp(data_gen):
+    assert_gpu_fallback_collect(lambda spark: gen_df(
+        spark, [("a", data_gen), ("b", string_gen)], length=10).selectExpr(
+        "to_unix_timestamp(a, b)"),
+        "ToUnixTimestamp")
+
+
 @pytest.mark.parametrize('time_zone', ["UTC", "UTC+0", "UTC-0", "GMT", "GMT+0", "GMT-0"], ids=idfn)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
 def test_from_utc_timestamp(data_gen, time_zone):
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, data_gen).select(f.from_utc_timestamp(f.col('a'), time_zone)))
+        lambda spark: unary_op_df(spark, data_gen).select(f.from_utc_timestamp(f.col('a'), time_zone)))
 
-@allow_non_gpu('ProjectExec, FromUTCTimestamp')
+@allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('time_zone', ["PST", "MST", "EST", "VST", "NST", "AST"], ids=idfn)
 @pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
-def test_from_utc_timestamp_fallback(data_gen, time_zone):
+def test_from_utc_timestamp_unsupported_timezone_fallback(data_gen, time_zone):
     assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, data_gen).select(f.from_utc_timestamp(f.col('a'), time_zone)),
-    'ProjectExec')
+        lambda spark: unary_op_df(spark, data_gen).select(f.from_utc_timestamp(f.col('a'), time_zone)),
+    'FromUTCTimestamp')
+
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
+def test_unsupported_fallback_from_utc_timestamp(data_gen):
+    time_zone_gen = StringGen(pattern="UTC")
+    assert_gpu_fallback_collect(
+        lambda spark: gen_df(spark, [("a", data_gen), ("tzone", time_zone_gen)]).selectExpr(
+            "from_utc_timestamp(a, tzone)"),
+        'FromUTCTimestamp')
+
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', [long_gen], ids=idfn)
+def test_unsupported_fallback_from_unixtime(data_gen):
+    fmt_gen = StringGen(pattern="[M]")
+    assert_gpu_fallback_collect(
+        lambda spark: gen_df(spark, [("a", data_gen), ("fmt", fmt_gen)]).selectExpr(
+            "from_unixtime(a, fmt)"),
+        'FromUnixTime')
 
 
 @pytest.mark.parametrize('invalid,fmt', [
@@ -388,28 +427,30 @@ def test_date_format(data_gen, date_format):
 unsupported_date_formats = ['F']
 @pytest.mark.parametrize('date_format', unsupported_date_formats, ids=idfn)
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-@allow_non_gpu('ProjectExec,Alias,DateFormatClass,Literal,Cast')
+@allow_non_gpu('ProjectExec')
 def test_date_format_f(data_gen, date_format):
     assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)), 'ProjectExec')
+        lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)),
+        'DateFormatClass')
 
 @pytest.mark.parametrize('date_format', unsupported_date_formats, ids=idfn)
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-@allow_non_gpu('ProjectExec,Alias,DateFormatClass,Literal,Cast')
+@allow_non_gpu('ProjectExec')
 def test_date_format_f_incompat(data_gen, date_format):
     # note that we can't support it even with incompatibleDateFormats enabled
     conf = {"spark.rapids.sql.incompatibleDateFormats.enabled": "true"}
     assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)), 'ProjectExec', conf)
+        lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)),
+        'DateFormatClass', conf)
 
 maybe_supported_date_formats = ['dd-MM-yyyy', 'yyyy-MM-dd HH:mm:ss.SSS', 'yyyy-MM-dd HH:mm:ss.SSSSSS']
 @pytest.mark.parametrize('date_format', maybe_supported_date_formats, ids=idfn)
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
-@allow_non_gpu('ProjectExec,Alias,DateFormatClass,Literal,Cast')
+@allow_non_gpu('ProjectExec')
 def test_date_format_maybe(data_gen, date_format):
     assert_gpu_fallback_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)),
-        'ProjectExec')
+        'DateFormatClass')
 
 @pytest.mark.parametrize('date_format', maybe_supported_date_formats, ids=idfn)
 @pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
@@ -438,6 +479,30 @@ def test_date_format_mmyyyy_cast_canonicalization(spark_tmp_path):
             .withColumnRenamed("filename", "r_filename")
         return left.join(right, left.monthly_reporting_period == right.r_monthly_reporting_period, how='inner')
     assert_gpu_and_cpu_are_equal_collect(do_join_cast)
+
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
+def test_unsupported_fallback_date_format(data_gen):
+    conf = {"spark.rapids.sql.incompatibleDateFormats.enabled": "true"}
+    assert_gpu_fallback_collect(
+        lambda spark : gen_df(spark, [("a", data_gen)]).selectExpr(
+            "date_format(a, a)"),
+        "DateFormatClass",
+        conf)
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_to_date():
+    date_gen = StringGen(pattern="2023-08-01")
+    pattern_gen = StringGen(pattern="[M]")
+    conf = {"spark.rapids.sql.incompatibleDateFormats.enabled": "true"}
+    assert_gpu_fallback_collect(
+        lambda spark: gen_df(spark, [("a", date_gen), ("b", pattern_gen)]).selectExpr(
+            "to_date(a, b)"),
+        'GetTimestamp',
+        conf)
+
 
 # (-62135510400, 253402214400) is the range of seconds that can be represented by timestamp_seconds 
 # considering the influence of time zone.

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
 
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect
 from data_gen import *
 from pyspark.sql.types import *
+from marks import *
 
 def mk_json_str_gen(pattern):
     return StringGen(pattern).with_special_case('').with_special_pattern('.{0,10}')
@@ -27,9 +28,32 @@ def mk_json_str_gen(pattern):
                    r'\{"a": "[a-z]{1,3}"\}'], ids=idfn)
 def test_get_json_object(json_str_pattern):
     gen = mk_json_str_gen(json_str_pattern)
+    scalar_json = '{"store": {"fruit": [{"name": "test"}]}}'
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, gen, length=10).selectExpr(
             'get_json_object(a,"$.a")',
             'get_json_object(a, "$.owner")',
-            'get_json_object(a, "$.store.fruit[0]")'),
+            'get_json_object(a, "$.store.fruit[0]")',
+            'get_json_object(\'%s\', "$.store.fruit[0]")' % scalar_json,
+            ),
         conf={'spark.sql.parser.escapedStringLiterals': 'true'})
+
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('json_str_pattern', [r'\{"store": \{"fruit": \[\{"weight":\d,"type":"[a-z]{1,9}"\}\], ' \
+                   r'"bicycle":\{"price":[1-9]\d\.\d\d,"color":"[a-z]{0,4}"\}\},' \
+                   r'"email":"[a-z]{1,5}\@[a-z]{3,10}\.com","owner":"[a-z]{3,8}"\}',
+                   r'\{"a": "[a-z]{1,3}"\}'], ids=idfn)
+def test_unsupported_fallback_get_json_object(json_str_pattern):
+    gen = mk_json_str_gen(json_str_pattern)
+    scalar_json = '{"store": {"fruit": "test"}}'
+    pattern = StringGen(pattern='\$\.[a-z]{1,9}')
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            gen_df(spark, [('a', gen), ('b', pattern)], length=10).selectExpr(sql_text),
+        'GetJsonObject',
+        conf={'spark.sql.parser.escapedStringLiterals': 'true'})
+
+    assert_gpu_did_fallback('get_json_object(a, b)')
+    assert_gpu_did_fallback('get_json_object(\'%s\', b)' % scalar_json)
+

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -118,13 +118,15 @@ supported_key_gens = \
 
 @pytest.mark.parametrize('data_gen', numeric_key_map_gens, ids=idfn)
 def test_get_map_value_numeric_keys(data_gen):
+    key_gen = data_gen._key_gen
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: gen_df(spark, [("a", data_gen)]).selectExpr(
-                'a[0]',
-                'a[1]',
-                'a[null]',
-                'a[-9]',
-                'a[999]'))
+        lambda spark: gen_df(spark, [("a", data_gen), ("ix", key_gen)]).selectExpr(
+            'a[ix]',
+            'a[0]',
+            'a[1]',
+            'a[null]',
+            'a[-9]',
+            'a[999]'))
 
 
 @pytest.mark.parametrize('key_gen', numeric_key_gens, ids=idfn)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -132,9 +132,7 @@ def test_get_map_value_numeric_keys(data_gen):
 @pytest.mark.parametrize('key_gen', numeric_key_gens, ids=idfn)
 def test_basic_scalar_map_get_map_value(key_gen):
     def query_map_scalar(spark):
-        df = unary_op_df(spark, key_gen).selectExpr('map(0, "zero", 1, "one")[a]')
-        df.explain()
-        return df
+        return unary_op_df(spark, key_gen).selectExpr('map(0, "zero", 1, "one")[a]')
     assert_gpu_and_cpu_are_equal_collect(
         query_map_scalar, {"spark.rapids.sql.explain": "NONE",
                            # this is set to True so we don't fall back due to float/double -> int
@@ -152,14 +150,6 @@ def test_map_scalars_supported_key_types(key_gen):
         # when k, v are expressions, but it doesn't do this for a scalar subquery.
         return spark.sql('select t.key, (select first(m) from map_tbl where map_tbl.key=map_tbl.key)[key] from map_tbl t')
     assert_gpu_and_cpu_are_equal_collect(query_map_scalar, {"spark.rapids.sql.explain": "NONE"})
-
-
-@allow_non_gpu('ProjectExec')
-@pytest.mark.parametrize('key_gen', numeric_key_gens, ids=idfn)
-def test_cpu_fallback_map_scalars(key_gen):
-    def query_map_scalar(spark):
-        return unary_op_df(spark, key_gen).selectExpr('map(0, "zero", 1, "one")[a]')
-    assert_gpu_fallback_collect(query_map_scalar, "ProjectExec", {"spark.rapids.sql.explain": "NONE"})
 
 
 @pytest.mark.parametrize('data_gen',

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -91,8 +91,10 @@ def get_map_value_gens(precision=18, scale=0):
                           for value in get_map_value_gens()],
                          ids=idfn)
 def test_get_map_value_string_keys(data_gen):
+    index_gen = StringGen()
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, data_gen).selectExpr(
+            lambda spark: gen_df(spark, [("a", data_gen), ("ix", index_gen)]).selectExpr(
+                'a[ix]',
                 'a["key_0"]',
                 'a["key_1"]',
                 'a[null]',
@@ -111,8 +113,10 @@ numeric_key_map_gens = [MapGen(key, value(), max_length=6)
 
 @pytest.mark.parametrize('data_gen', numeric_key_map_gens, ids=idfn)
 def test_get_map_value_numeric_keys(data_gen):
+    key_gen = data_gen._key_gen
     assert_gpu_and_cpu_are_equal_collect(
-            lambda spark: unary_op_df(spark, data_gen).selectExpr(
+            lambda spark: gen_df(spark, [("a", data_gen), ("ix", key_gen)]).selectExpr(
+                'a[ix]',
                 'a[0]',
                 'a[1]',
                 'a[null]',

--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -21,8 +21,9 @@ from conftest import is_databricks_runtime
 from data_gen import *
 from marks import *
 from pyspark.sql.types import *
+import pyspark.sql.utils
 import pyspark.sql.functions as f
-from spark_session import is_databricks104_or_later, is_before_spark_320
+from spark_session import with_cpu_session, with_gpu_session, is_databricks104_or_later, is_before_spark_320
 
 _regexp_conf = { 'spark.rapids.sql.regexp.enabled': 'true' }
 
@@ -73,28 +74,74 @@ def test_split_positive_limit():
             'split(a, "C", 3)',
             'split(a, "_", 999)'))
 
+
 @pytest.mark.parametrize('data_gen,delim', [(mk_str_gen('([ABC]{0,3}_?){0,7}'), '_'),
     (mk_str_gen('([MNP_]{0,3}\\.?){0,5}'), '.'),
     (mk_str_gen('([123]{0,3}\\^?){0,5}'), '^')], ids=idfn)
 def test_substring_index(data_gen,delim):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : unary_op_df(spark, data_gen).select(
+                f.substring_index(f.lit('123'), delim, 1),
                 f.substring_index(f.col('a'), delim, 1),
                 f.substring_index(f.col('a'), delim, 3),
                 f.substring_index(f.col('a'), delim, 0),
                 f.substring_index(f.col('a'), delim, -1),
                 f.substring_index(f.col('a'), delim, -4)))
 
+
+@allow_non_gpu('ProjectExec')
+@pytest.mark.parametrize('data_gen', [mk_str_gen('([ABC]{0,3}_?){0,7}')], ids=idfn)
+def test_unsupported_fallback_substring_index(data_gen):
+    delim_gen = StringGen(pattern="_")
+    num_gen = IntegerGen(min_val=0, max_val=10, special_cases=[])
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            gen_df(spark, [("a", data_gen),
+                           ("delim", delim_gen),
+                           ("num", num_gen)], length=10).selectExpr(sql_text),
+            "SubstringIndex")
+
+    assert_gpu_did_fallback("SUBSTRING_INDEX(a, '_', num)")
+    assert_gpu_did_fallback("SUBSTRING_INDEX(a, delim, 0)")
+    assert_gpu_did_fallback("SUBSTRING_INDEX(a, delim, num)")
+    assert_gpu_did_fallback("SUBSTRING_INDEX('a_b', '_', num)")
+    assert_gpu_did_fallback("SUBSTRING_INDEX('a_b', delim, 0)")
+    assert_gpu_did_fallback("SUBSTRING_INDEX('a_b', delim, num)")
+
+
 # ONLY LITERAL WIDTH AND PAD ARE SUPPORTED
 def test_lpad():
     gen = mk_str_gen('.{0,5}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
+                'LPAD("literal", 2, " ")',
                 'LPAD(a, 2, " ")',
                 'LPAD(a, NULL, " ")',
                 'LPAD(a, 5, NULL)',
                 'LPAD(a, 5, "G")',
                 'LPAD(a, -1, "G")'))
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_lpad():
+    gen = mk_str_gen('.{0,5}')
+    pad_gen = StringGen(pattern="G")
+    num_gen = IntegerGen(min_val=0, max_val=10, special_cases=[])
+
+    def assert_gpu_did_fallback(sql_string):
+        assert_gpu_fallback_collect(lambda spark:
+            gen_df(spark, [("a", gen),
+                           ("len", num_gen),
+                           ("pad", pad_gen)], length=10).selectExpr(sql_string),
+            "StringLPad")
+
+    assert_gpu_did_fallback('LPAD(a, 2, pad)')
+    assert_gpu_did_fallback('LPAD(a, len, " ")')
+    assert_gpu_did_fallback('LPAD(a, len, pad)')
+    assert_gpu_did_fallback('LPAD("foo", 2, pad)')
+    assert_gpu_did_fallback('LPAD("foo", len, " ")')
+    assert_gpu_did_fallback('LPAD("foo", len, pad)')
+
 
 # ONLY LITERAL WIDTH AND PAD ARE SUPPORTED
 def test_rpad():
@@ -106,6 +153,28 @@ def test_rpad():
                 'RPAD(a, 5, NULL)',
                 'RPAD(a, 5, "G")',
                 'RPAD(a, -1, "G")'))
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_rpad():
+    gen = mk_str_gen('.{0,5}')
+    pad_gen = StringGen(pattern="G")
+    num_gen = IntegerGen(min_val=0, max_val=10, special_cases=[])
+
+    def assert_gpu_did_fallback(sql_string):
+        assert_gpu_fallback_collect(lambda spark:
+            gen_df(spark, [("a", gen),
+                           ("len", num_gen),
+                           ("pad", pad_gen)], length=10).selectExpr(sql_string),
+            "StringRPad")
+
+    assert_gpu_did_fallback('RPAD(a, 2, pad)')
+    assert_gpu_did_fallback('RPAD(a, len, " ")')
+    assert_gpu_did_fallback('RPAD(a, len, pad)')
+    assert_gpu_did_fallback('RPAD("foo", 2, pad)')
+    assert_gpu_did_fallback('RPAD("foo", len, " ")')
+    assert_gpu_did_fallback('RPAD("foo", len, pad)')
+
 
 # ONLY LITERAL SEARCH PARAMS ARE SUPPORTED
 def test_position():
@@ -124,13 +193,34 @@ def test_locate():
             lambda spark: unary_op_df(spark, gen).selectExpr(
                 'locate("Z", a, -1)',
                 'locate("Z", a, 4)',
+                'locate("abc", "1abcd", 0)',
+                'locate("abc", "1abcd", 10)',
                 'locate("A", a, 500)',
                 'locate("_", a, NULL)'))
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_locate():
+    gen = mk_str_gen('.{0,3}Z_Z.{0,3}A.{0,3}')
+    pos_gen = IntegerGen()
+
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            gen_df(spark, [("a", gen), ("pos", pos_gen)], length=10).selectExpr(sql_text),
+            'StringLocate')
+
+    assert_gpu_did_fallback('locate(a, a, -1)')
+    assert_gpu_did_fallback('locate("a", a, pos)')
+    assert_gpu_did_fallback('locate(a, a, pos)')
+    assert_gpu_did_fallback('locate(a, "a", pos)')
+
 
 def test_instr():
     gen = mk_str_gen('.{0,3}Z_Z.{0,3}A.{0,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
+                'instr("A", "A")',
+                'instr("a", "A")',
                 'instr(a, "Z")',
                 'instr(a, "A")',
                 'instr(a, "_")',
@@ -138,15 +228,42 @@ def test_instr():
                 'instr(NULL, "A")',
                 'instr(NULL, NULL)'))
 
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_instr():
+    gen = mk_str_gen('.{0,3}Z_Z.{0,3}A.{0,3}')
+
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).selectExpr(sql_text),
+            'StringInstr')
+
+    assert_gpu_did_fallback('instr(a, a)')
+    assert_gpu_did_fallback('instr("a", a)')
+
+
 def test_contains():
     gen = mk_str_gen('.{0,3}Z?_Z?.{0,3}A?.{0,3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).select(
+                f.lit('Z').contains('Z'),
+                f.lit('foo').contains('Z_'),
                 f.col('a').contains('Z'),
                 f.col('a').contains('Z_'),
                 f.col('a').contains(''),
-                f.col('a').contains(None)
-                ))
+                f.col('a').contains(None)))
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_contains():
+    gen = StringGen(pattern='[a-z]')
+    def assert_gpu_did_fallback(op):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).select(op),
+            'Contains')
+
+    assert_gpu_did_fallback(f.lit('Z').contains(f.col('a')))
+    assert_gpu_did_fallback(f.col('a').contains(f.col('a')))
+
 
 @pytest.mark.parametrize('data_gen', [mk_str_gen('[Ab \ud720]{0,3}A.{0,3}Z[ Ab]{0,3}'), StringGen('')])
 def test_trim(data_gen):
@@ -182,20 +299,50 @@ def test_startswith():
     gen = mk_str_gen('[Ab\ud720]{3}A.{0,3}Z[Ab\ud720]{3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).select(
+                f.lit('foo').startswith('f'),
+                f.lit('bar').startswith('1'),
                 f.col('a').startswith('A'),
                 f.col('a').startswith(''),
                 f.col('a').startswith(None),
                 f.col('a').startswith('A\ud720')))
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_startswith():
+    gen = StringGen(pattern='[a-z]')
+
+    def assert_gpu_did_fallback(op):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).select(op),
+            'StartsWith')
+
+    assert_gpu_did_fallback(f.lit("TEST").startswith(f.col("a")))
+    assert_gpu_did_fallback(f.col("a").startswith(f.col("a")))
 
 
 def test_endswith():
     gen = mk_str_gen('[Ab\ud720]{3}A.{0,3}Z[Ab\ud720]{3}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).select(
+                f.lit('foo').startswith('f'),
+                f.lit('bar').startswith('1'),
                 f.col('a').endswith('A'),
                 f.col('a').endswith(''),
                 f.col('a').endswith(None),
                 f.col('a').endswith('A\ud720')))
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_endswith():
+    gen = StringGen(pattern='[a-z]')
+
+    def assert_gpu_did_fallback(op):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).select(op),
+            'EndsWith')
+
+    assert_gpu_did_fallback(f.lit("TEST").endswith(f.col("a")))
+    assert_gpu_did_fallback(f.col("a").endswith(f.col("a")))
+
 
 def test_concat_ws_basic():
     gen = StringGen(nullable=True)
@@ -423,12 +570,31 @@ def test_replace():
     gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).selectExpr(
+                'REPLACE("TEST", "TEST", "PROD")',
+                'REPLACE("NO", "T\ud720", "PROD")',
                 'REPLACE(a, "TEST", "PROD")',
                 'REPLACE(a, "T\ud720", "PROD")',
                 'REPLACE(a, "", "PROD")',
                 'REPLACE(a, "T", NULL)',
                 'REPLACE(a, NULL, "PROD")',
                 'REPLACE(a, "T", "")'))
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_replace():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).selectExpr(sql_text),
+            'StringReplace')
+
+    assert_gpu_did_fallback('REPLACE(a, "TEST", a)')
+    assert_gpu_did_fallback('REPLACE(a, a, "TEST")')
+    assert_gpu_did_fallback('REPLACE(a, a, a)')
+    assert_gpu_did_fallback('REPLACE("TEST", "TEST", a)')
+    assert_gpu_did_fallback('REPLACE("TEST", a, "TEST")')
+    assert_gpu_did_fallback('REPLACE("TEST", a, a)')
+
 
 @incompat
 def test_translate():
@@ -443,6 +609,23 @@ def test_translate():
                 'translate(a, "TEST", NULL)',
                 'translate("AaBbCc", "abc", "123")',
                 'translate("AaBbCc", "abc", "1")'))
+
+@incompat
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_translate():
+    gen = mk_str_gen('.{0,5}TEST[\ud720 A]{0,5}')
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).selectExpr(sql_text),
+            'StringTranslate')
+
+    assert_gpu_did_fallback('TRANSLATE(a, "TEST", a)')
+    assert_gpu_did_fallback('TRANSLATE(a, a, "TEST")')
+    assert_gpu_did_fallback('TRANSLATE(a, a, a)')
+    assert_gpu_did_fallback('TRANSLATE("TEST", "TEST", a)')
+    assert_gpu_did_fallback('TRANSLATE("TEST", a, "TEST")')
+    assert_gpu_did_fallback('TRANSLATE("TEST", a, a)')
+
 
 @incompat
 @pytest.mark.skipif(is_before_spark_320(), reason="Only in Spark 3.2+ does translate() support unicode \
@@ -509,6 +692,8 @@ def test_like():
             .with_special_case('%SystemDrive%\\Users\\John')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).select(
+                f.lit('_oo_').like('_oo_'),
+                f.lit('_aa_').like('_oo_'),
                 f.col('a').like('%o%'), # turned into contains
                 f.col('a').like('%a%'), # turned into contains
                 f.col('a').like(''), #turned into equals
@@ -525,7 +710,32 @@ def test_like():
                 f.col('a').like('_$%'),
                 f.col('a').like('_._'),
                 f.col('a').like('_?|}{_%'),
-                f.col('a').like('%a{3}%'))) 
+                f.col('a').like('%a{3}%')))
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_like():
+    gen = StringGen('[a-z]')
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).selectExpr(sql_text),
+            'Like')
+
+    assert_gpu_did_fallback("'lit' like a")
+    assert_gpu_did_fallback("a like a")
+
+
+@allow_non_gpu('ProjectExec')
+def test_unsupported_fallback_rlike():
+    gen = StringGen('\/lit\/')
+
+    def assert_gpu_did_fallback(sql_text):
+        assert_gpu_fallback_collect(lambda spark:
+            unary_op_df(spark, gen, length=10).selectExpr(sql_text),
+            'RLike')
+
+    assert_gpu_did_fallback("'lit' rlike a")
+    assert_gpu_did_fallback("a rlike a")
+
 
 def test_like_simple_escape():
     gen = mk_str_gen('(\u20ac|\\w){0,3}a[|b*.$\r\n]{0,2}c\\w{0,3}')\

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -268,6 +268,20 @@ trait GpuBinaryExpression extends ShimBinaryExpression with GpuExpression {
   }
 }
 
+trait GpuBinaryExpression_Any_Scalar extends GpuBinaryExpression {
+  protected val anyScalarExceptionMessage: String =
+    s"$prettyName: LHS can be a column or scalar and " +
+        s"RHS has to be a scalar (got left: $left, right: $right)"
+
+  override final def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    throw new UnsupportedOperationException(anyScalarExceptionMessage)
+  }
+
+  override final def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
+    throw new UnsupportedOperationException(anyScalarExceptionMessage)
+  }
+}
+
 trait GpuBinaryOperator extends BinaryOperator with GpuBinaryExpression
 
 trait CudfBinaryExpression extends GpuBinaryExpression {
@@ -422,6 +436,92 @@ trait GpuTernaryExpression extends ShimTernaryExpression with GpuExpression {
     }
   }
 }
+
+trait GpuTernaryExpression_Any_Scalar_Scalar extends GpuTernaryExpression {
+  protected val anyScalarScalarErrorMessage: String =
+    s"$prettyName: first argument can be a column or a scalar, second and third arguments " +
+        s"have to be scalars (got first: $first, second: $second, third: $third)"
+
+  final override def doColumnar(
+      strExpr: GpuColumnVector,
+      searchExpr: GpuColumnVector,
+      replaceExpr: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+
+  final override def doColumnar(
+      strExpr: GpuScalar,
+      searchExpr: GpuColumnVector,
+      replaceExpr: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+
+  final override def doColumnar(
+      strExpr: GpuScalar,
+      searchExpr: GpuScalar,
+      replaceExpr: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+
+  final override def doColumnar(
+      strExpr: GpuScalar,
+      searchExpr: GpuColumnVector,
+      replaceExpr: GpuScalar): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+
+  final override def doColumnar(
+      strExpr: GpuColumnVector,
+      searchExpr: GpuScalar,
+      replaceExpr: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+
+  final override def doColumnar(
+      strExpr: GpuColumnVector,
+      searchExpr: GpuColumnVector,
+      replaceExpr: GpuScalar): ColumnVector =
+    throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
+}
+
+trait GpuTernaryExpression_Scalar_Any_Scalar extends GpuTernaryExpression {
+  protected val scalarAnyScalarExceptionMessage: String =
+    s"$prettyName: first argument has to be a scalar, second argument can be a column " +
+        s"or a scalar, and third argument has to be a scalar " +
+        s"(got first: $first, second: $second, third: $third)"
+
+  final override def doColumnar(
+      val0: GpuColumnVector,
+      val1: GpuColumnVector,
+      val2: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+
+  final override def doColumnar(
+      val0: GpuScalar,
+      val1: GpuColumnVector,
+      val2: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+
+  final override def doColumnar(
+      val0: GpuScalar,
+      val1: GpuScalar,
+      val2: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+
+  final override def doColumnar(
+      val0: GpuColumnVector,
+      val1: GpuScalar,
+      val2: GpuColumnVector): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+
+  final override def doColumnar(
+      val0: GpuColumnVector,
+      val1: GpuScalar,
+      val2: GpuScalar): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+
+  final override def doColumnar(
+      val0: GpuColumnVector,
+      val1: GpuColumnVector,
+      val2: GpuScalar): ColumnVector =
+    throw new UnsupportedOperationException(scalarAnyScalarExceptionMessage)
+}
+
 
 trait GpuComplexTypeMergingExpression extends ComplexTypeMergingExpression
     with GpuExpression with ShimExpression {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -268,7 +268,7 @@ trait GpuBinaryExpression extends ShimBinaryExpression with GpuExpression {
   }
 }
 
-trait GpuBinaryExpression_Any_Scalar extends GpuBinaryExpression {
+trait GpuBinaryExpressionArgsAnyScalar extends GpuBinaryExpression {
   protected val anyScalarExceptionMessage: String =
     s"$prettyName: LHS can be a column or scalar and " +
         s"RHS has to be a scalar (got left: $left, right: $right)"
@@ -437,7 +437,7 @@ trait GpuTernaryExpression extends ShimTernaryExpression with GpuExpression {
   }
 }
 
-trait GpuTernaryExpression_Any_Scalar_Scalar extends GpuTernaryExpression {
+trait GpuTernaryExpressionArgsAnyScalarScalar extends GpuTernaryExpression {
   protected val anyScalarScalarErrorMessage: String =
     s"$prettyName: first argument can be a column or a scalar, second and third arguments " +
         s"have to be scalars (got first: $first, second: $second, third: $third)"
@@ -479,7 +479,7 @@ trait GpuTernaryExpression_Any_Scalar_Scalar extends GpuTernaryExpression {
     throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
 }
 
-trait GpuTernaryExpression_Scalar_Any_Scalar extends GpuTernaryExpression {
+trait GpuTernaryExpressionArgsScalarAnyScalar extends GpuTernaryExpression {
   protected val scalarAnyScalarExceptionMessage: String =
     s"$prettyName: first argument has to be a scalar, second argument can be a column " +
         s"or a scalar, and third argument has to be a scalar " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -268,6 +268,16 @@ trait GpuBinaryExpression extends ShimBinaryExpression with GpuExpression {
   }
 }
 
+/**
+ * Expressions subclassing this trait guarantee that they implement:
+ *   doColumnar(GpuScalar, GpuScalar)
+ *   doColumnar(GpuColumnVector, GpuScalar)
+ *
+ * The default implementation throws for all other permutations.
+ *
+ * The binary expression must fallback to the CPU for the doColumnar cases
+ * that would throw. The default implementation here should never execute.
+ */
 trait GpuBinaryExpressionArgsAnyScalar extends GpuBinaryExpression {
   protected val anyScalarExceptionMessage: String =
     s"$prettyName: LHS can be a column or scalar and " +
@@ -437,6 +447,16 @@ trait GpuTernaryExpression extends ShimTernaryExpression with GpuExpression {
   }
 }
 
+/**
+ * Expressions subclassing this trait guarantee that they implement:
+ *   doColumnar(GpuScalar, GpuScalar, GpuScalar)
+ *   doColumnar(GpuColumnVector, GpuScalar, GpuScalar)
+ *
+ * The default implementation throws for all other permutations.
+ *
+ * The ternary expression must fallback to the CPU for the doColumnar cases
+ * that would throw. The default implementation here should never execute.
+ */
 trait GpuTernaryExpressionArgsAnyScalarScalar extends GpuTernaryExpression {
   protected val anyScalarScalarErrorMessage: String =
     s"$prettyName: first argument can be a column or a scalar, second and third arguments " +
@@ -479,6 +499,16 @@ trait GpuTernaryExpressionArgsAnyScalarScalar extends GpuTernaryExpression {
     throw new UnsupportedOperationException(anyScalarScalarErrorMessage)
 }
 
+/**
+ * Expressions subclassing this trait guarantee that they implement:
+ *   doColumnar(GpuScalar, GpuScalar, GpuScalar)
+ *   doColumnar(GpuScalar, GpuColumnVector, GpuScalar)
+ *
+ * The default implementation throws for all other permutations.
+ *
+ * The ternary expression must fallback to the CPU for the doColumnar cases
+ * that would throw. The default implementation here should never execute.
+ */
 trait GpuTernaryExpressionArgsScalarAnyScalar extends GpuTernaryExpression {
   protected val scalarAnyScalarExceptionMessage: String =
     s"$prettyName: first argument has to be a scalar, second argument can be a column " +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{DataType, StringType}
 
 case class GpuGetJsonObject(json: Expression, path: Expression)
-    extends GpuBinaryExpression_Any_Scalar
+    extends GpuBinaryExpressionArgsAnyScalar
         with ExpectsInputTypes {
   override def left: Expression = json
   override def right: Expression = path

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -22,22 +22,15 @@ import com.nvidia.spark.rapids.Arm.withResource
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{DataType, StringType}
 
-case class GpuGetJsonObject(json: Expression, path: Expression) extends GpuBinaryExpression with
-  ExpectsInputTypes {
+case class GpuGetJsonObject(json: Expression, path: Expression)
+    extends GpuBinaryExpression_Any_Scalar
+        with ExpectsInputTypes {
   override def left: Expression = json
   override def right: Expression = path
   override def dataType: DataType = StringType
   override def inputTypes: Seq[DataType] = Seq(StringType, StringType)
   override def nullable: Boolean = true
   override def prettyName: String = "get_json_object"
-
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    throw new UnsupportedOperationException("JSON path must be a scalar value")
-  }
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
-    throw new UnsupportedOperationException("JSON path must be a scalar value")
-  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     lhs.getBase().getJSONObject(rhs.getBase)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2444,14 +2444,7 @@ object GpuOverrides extends Logging {
           TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.MAP + TypeSig.BINARY),
           TypeSig.MAP.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes + TypeSig.DECIMAL_128, TypeSig.all)),
-      (in, conf, p, r) => new GetMapValueMeta(in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          if (isLit(in.left) && (!isLit(in.right))) {
-            willNotWorkOnGpu("Looking up Map Scalars with Key Vectors " +
-              "is not currently unsupported.")
-          }
-        }
-      }),
+      (in, conf, p, r) => new GetMapValueMeta(in, conf, p, r){}),
     GpuElementAtMeta.elementAtRule(false),
     expr[MapKeys](
       "Returns an unordered array containing the keys of the map",
@@ -2553,12 +2546,6 @@ object GpuOverrides extends Logging {
           TypeSig.ARRAY.nested(TypeSig.all)),
         ("key", TypeSig.commonCudfTypes, TypeSig.all)),
       (in, conf, p, r) => new BinaryExprMeta[ArrayContains](in, conf, p, r) {
-        override def tagExprForGpu(): Unit = {
-          // do not support literal arrays as LHS
-          if (extractLit(in.left).isDefined) {
-            willNotWorkOnGpu("Literal arrays are not supported for array_contains")
-          }
-        }
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
           GpuArrayContains(lhs, rhs)
       }),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -453,7 +453,7 @@ case class GpuMapEntries(child: Expression) extends GpuUnaryExpression with Expe
 }
 
 case class GpuSortArray(base: Expression, ascendingOrder: Expression)
-    extends GpuBinaryExpression_Any_Scalar with ExpectsInputTypes {
+    extends GpuBinaryExpressionArgsAnyScalar with ExpectsInputTypes {
 
   override def left: Expression = base
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/collectionOperations.scala
@@ -453,7 +453,7 @@ case class GpuMapEntries(child: Expression) extends GpuUnaryExpression with Expe
 }
 
 case class GpuSortArray(base: Expression, ascendingOrder: Expression)
-    extends GpuBinaryExpression with ExpectsInputTypes {
+    extends GpuBinaryExpression_Any_Scalar with ExpectsInputTypes {
 
   override def left: Expression = base
 
@@ -481,13 +481,6 @@ case class GpuSortArray(base: Expression, ascendingOrder: Expression)
       TypeCheckResult.TypeCheckFailure(s"$prettyName only supports array input, but found $dt")
   }
 
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): cudf.ColumnVector =
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-        "the sort_array operator to work")
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): cudf.ColumnVector =
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-        "the sort_array operator to work")
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): cudf.ColumnVector = {
     val isDescending = isDescendingOrder(rhs)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
-import ai.rapids.cudf.{BinaryOp, ColumnVector, DType, Scalar}
+import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuListUtils, GpuMapUtils, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, UnaryExprMeta}
 import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
@@ -241,8 +241,11 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
     }
   }
 
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector =
-    throw new IllegalStateException("Map lookup keys must be scalar values")
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    withResource(GpuColumnVector.from(lhs, rhs.getRowCount.toInt, left.dataType)) { expandedLhs =>
+      doColumnar(expandedLhs, rhs)
+    }
+  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     val map = lhs.getBase
@@ -284,7 +287,7 @@ case class GpuArrayContains(left: Expression, right: Expression)
    * or if the list does not contain any null elements.
    */
   private def orNotContainsNull(containsResult: ColumnVector,
-                                inputListsColumn:ColumnVector): ColumnVector = {
+                                inputListsColumn: ColumnView): ColumnVector = {
     val notContainsNull = withResource(inputListsColumn.listContainsNulls) {
       _.not
     }
@@ -303,11 +306,27 @@ case class GpuArrayContains(left: Expression, right: Expression)
     }
   }
 
-  override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector =
-    throw new IllegalStateException("This is not supported yet")
+  override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {
+    withResource(ColumnVector.fromScalar(lhs.getBase, numRows)) { inputListsColumn =>
+      withResource(ColumnVector.fromScalar(rhs.getBase, numRows)) { keysColumn =>
+        //NOTE: listContainsColumn expects that input and the keys columns to have the same
+        // number of rows
+        withResource(inputListsColumn.listContainsColumn(keysColumn)) {
+          orNotContainsNull(_, inputListsColumn)
+        }
+      }
+    }
+  }
 
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector =
-    throw new IllegalStateException("This is not supported yet")
+  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
+    withResource(ColumnVector.fromScalar(lhs.getBase, rhs.getRowCount.toInt)) { inputListsColumn =>
+      //NOTE: listContainsColumn expects that input and the keys columns to have the same
+      // number of rows
+      withResource(inputListsColumn.listContainsColumn(rhs.getBase)) {
+        orNotContainsNull(_, inputListsColumn)
+      }
+    }
+  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
     val inputListsColumn = lhs.getBase

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -214,6 +214,11 @@ case class GpuGetMapValue(child: Expression, key: Expression, failOnError: Boole
     }
   }
 
+  /**
+   * `Null` is returned for invalid ordinals.
+   */
+  override def nullable: Boolean = true
+
   override def dataType: DataType = child.dataType.asInstanceOf[MapType].valueType
 
   override def inputTypes: Seq[AbstractDataType] = Seq(AnyDataType, keyType)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -1001,7 +1001,9 @@ case class GpuFromUnixTime(
     format: Expression,
     strfFormat: String,
     timeZoneId: Option[String] = None)
-  extends GpuBinaryExpressionArgsAnyScalar with TimeZoneAwareExpression with ImplicitCastInputTypes {
+  extends GpuBinaryExpressionArgsAnyScalar
+    with TimeZoneAwareExpression
+    with ImplicitCastInputTypes {
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -20,7 +20,7 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DType, RegexProgram, Scalar}
-import com.nvidia.spark.rapids.{BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuBinaryExpression_Any_Scalar, GpuCast, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
+import com.nvidia.spark.rapids.{BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuBinaryExpressionArgsAnyScalar, GpuCast, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -298,7 +298,7 @@ case class GpuDateFormatClass(timestamp: Expression,
     format: Expression,
     strfFormat: String,
     timeZoneId: Option[String] = None)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with TimeZoneAwareExpression with ImplicitCastInputTypes {
 
   override def dataType: DataType = StringType
@@ -801,7 +801,7 @@ case class RegexReplace(search: String, replace: String)
  * first converting to microseconds and then dividing by the downScaleFactor
  */
 abstract class GpuToTimestamp
-  extends GpuBinaryExpression_Any_Scalar with TimeZoneAwareExpression with ExpectsInputTypes {
+  extends GpuBinaryExpressionArgsAnyScalar with TimeZoneAwareExpression with ExpectsInputTypes {
 
   import GpuToTimestamp._
 
@@ -1001,7 +1001,7 @@ case class GpuFromUnixTime(
     format: Expression,
     strfFormat: String,
     timeZoneId: Option[String] = None)
-  extends GpuBinaryExpression_Any_Scalar with TimeZoneAwareExpression with ImplicitCastInputTypes {
+  extends GpuBinaryExpressionArgsAnyScalar with TimeZoneAwareExpression with ImplicitCastInputTypes {
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
@@ -1065,7 +1065,7 @@ class FromUTCTimestampExprMeta(
 }
 
 case class GpuFromUTCTimestamp(timestamp: Expression, timezone: Expression)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
       with NullIntolerant {
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -20,7 +20,7 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf.{BinaryOp, CaptureGroups, ColumnVector, ColumnView, DType, RegexProgram, Scalar}
-import com.nvidia.spark.rapids.{BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuCast, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
+import com.nvidia.spark.rapids.{BinaryExprMeta, BoolUtils, DataFromReplacementRule, DateUtils, GpuBinaryExpression, GpuBinaryExpression_Any_Scalar, GpuCast, GpuColumnVector, GpuExpression, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta}
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuOverrides.{extractStringLit, getTimeParserPolicy}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -298,7 +298,8 @@ case class GpuDateFormatClass(timestamp: Expression,
     format: Expression,
     strfFormat: String,
     timeZoneId: Option[String] = None)
-  extends GpuBinaryExpression with TimeZoneAwareExpression with ImplicitCastInputTypes {
+  extends GpuBinaryExpression_Any_Scalar
+      with TimeZoneAwareExpression with ImplicitCastInputTypes {
 
   override def dataType: DataType = StringType
   override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType, StringType)
@@ -313,15 +314,6 @@ case class GpuDateFormatClass(timestamp: Expression,
 
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
-
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("rhs has to be a scalar for the date_format to work")
-  }
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-        "the date_format to work")
-  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
@@ -809,7 +801,7 @@ case class RegexReplace(search: String, replace: String)
  * first converting to microseconds and then dividing by the downScaleFactor
  */
 abstract class GpuToTimestamp
-  extends GpuBinaryExpression with TimeZoneAwareExpression with ExpectsInputTypes {
+  extends GpuBinaryExpression_Any_Scalar with TimeZoneAwareExpression with ExpectsInputTypes {
 
   import GpuToTimestamp._
 
@@ -829,15 +821,6 @@ abstract class GpuToTimestamp
   val timeParserPolicy = getTimeParserPolicy
 
   val failOnError: Boolean = SQLConf.get.ansiEnabled
-
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("rhs has to be a scalar for the unixtimestamp to work")
-  }
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-      "the unixtimestamp to work")
-  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     val tmp = if (lhs.dataType == StringType) {
@@ -1018,15 +1001,7 @@ case class GpuFromUnixTime(
     format: Expression,
     strfFormat: String,
     timeZoneId: Option[String] = None)
-  extends GpuBinaryExpression with TimeZoneAwareExpression with ImplicitCastInputTypes {
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("rhs has to be a scalar for the from_unixtime to work")
-  }
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-      "the from_unixtime to work")
-  }
+  extends GpuBinaryExpression_Any_Scalar with TimeZoneAwareExpression with ImplicitCastInputTypes {
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
@@ -1090,22 +1065,14 @@ class FromUTCTimestampExprMeta(
 }
 
 case class GpuFromUTCTimestamp(timestamp: Expression, timezone: Expression)
-  extends GpuBinaryExpression with ImplicitCastInputTypes with NullIntolerant {
+  extends GpuBinaryExpression_Any_Scalar
+      with ImplicitCastInputTypes
+      with NullIntolerant {
 
   override def left: Expression = timestamp
   override def right: Expression = timezone
   override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType, StringType)
   override def dataType: DataType = TimestampType
-
-  override def doColumnar(lhs: GpuColumnVector, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalStateException(
-      "Cannot have time zone given by a column vector in GpuFromUTCTimestamp")
-  }
-
-  override def doColumnar(lhs: GpuScalar, rhs: GpuColumnVector): ColumnVector = {
-    throw new IllegalStateException(
-      "Cannot have time zone given by a column vector in GpuFromUTCTimestamp")
-  }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     if (rhs.getBase.isValid) {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -576,7 +576,7 @@ abstract class CudfBinaryMathExpression(name: String) extends CudfBinaryExpressi
 
 // Due to SPARK-39226, the dataType of round-like functions differs by Spark versions.
 abstract class GpuRoundBase(child: Expression, scale: Expression, outputType: DataType)
-  extends GpuBinaryExpression_Any_Scalar with Serializable with ImplicitCastInputTypes {
+  extends GpuBinaryExpressionArgsAnyScalar with Serializable with ImplicitCastInputTypes {
 
   override def left: Expression = child
   override def right: Expression = scale

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/mathExpressions.scala
@@ -576,7 +576,7 @@ abstract class CudfBinaryMathExpression(name: String) extends CudfBinaryExpressi
 
 // Due to SPARK-39226, the dataType of round-like functions differs by Spark versions.
 abstract class GpuRoundBase(child: Expression, scale: Expression, outputType: DataType)
-  extends GpuBinaryExpression with Serializable with ImplicitCastInputTypes {
+  extends GpuBinaryExpression_Any_Scalar with Serializable with ImplicitCastInputTypes {
 
   override def left: Expression = child
   override def right: Expression = scale
@@ -759,16 +759,6 @@ abstract class GpuRoundBase(child: Expression, scale: Expression, outputType: Da
     } else {
       lhs.round(scale, roundMode)
     }
-  }
-
-  override def doColumnar(value: GpuColumnVector, scale: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-      "the round operator to work")
-  }
-
-  override def doColumnar(value: GpuScalar, scale: GpuColumnVector): ColumnVector = {
-    throw new IllegalArgumentException("lhs has to be a vector and rhs has to be a scalar for " +
-      "the round operator to work")
   }
 
   override def doColumnar(numRows: Int, value: GpuScalar, scale: GpuScalar): ColumnVector = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -722,13 +722,6 @@ trait HasGpuStringReplace {
     }
   }
 
-  def doStringReplace(
-      strExpr: GpuColumnVector,
-      searchExpr: GpuColumnVector,
-      replaceExpr: GpuColumnVector): ColumnVector = {
-    strExpr.getBase.stringReplace(searchExpr.getBase, replaceExpr.getBase)
-  }
-
   def doStringReplaceMulti(
     strExpr: GpuColumnVector,
     search: Seq[String],
@@ -741,9 +734,6 @@ trait HasGpuStringReplace {
   }
 }
 
-// This could support more than Any_Scalar_Scalar, but it doesn't for performance/coverage
-// reasons. Its TypeSig is ensuring that `searchExpr` and `replaceExpr` are literals, so
-// we will fallback and throw.
 case class GpuStringReplace(
     srcExpr: Expression,
     searchExpr: Expression,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -91,7 +91,7 @@ case class GpuOctetLength(child: Expression) extends GpuUnaryExpression with Exp
 }
 
 case class GpuStringLocate(substr: Expression, col: Expression, start: Expression)
-  extends GpuTernaryExpression_Scalar_Any_Scalar
+  extends GpuTernaryExpressionArgsScalarAnyScalar
       with ImplicitCastInputTypes {
 
   override def dataType: DataType = IntegerType
@@ -151,7 +151,7 @@ case class GpuStringLocate(substr: Expression, col: Expression, start: Expressio
 }
 
 case class GpuStartsWith(left: Expression, right: Expression)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with Predicate
       with ImplicitCastInputTypes
       with NullIntolerant {
@@ -177,7 +177,7 @@ case class GpuStartsWith(left: Expression, right: Expression)
 }
 
 case class GpuEndsWith(left: Expression, right: Expression)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with Predicate
       with ImplicitCastInputTypes
       with NullIntolerant {
@@ -384,7 +384,7 @@ case class GpuConcatWs(children: Seq[Expression])
 }
 
 case class GpuContains(left: Expression, right: Expression)
-    extends GpuBinaryExpression_Any_Scalar
+    extends GpuBinaryExpressionArgsAnyScalar
         with Predicate
         with ImplicitCastInputTypes
         with NullIntolerant {
@@ -738,7 +738,7 @@ case class GpuStringReplace(
     srcExpr: Expression,
     searchExpr: Expression,
     replaceExpr: Expression)
-  extends GpuTernaryExpression_Any_Scalar_Scalar
+  extends GpuTernaryExpressionArgsAnyScalarScalar
       with ImplicitCastInputTypes
       with HasGpuStringReplace {
 
@@ -776,7 +776,7 @@ case class GpuStringTranslate(
     srcExpr: Expression,
     fromExpr: Expression,
     toExpr: Expression)
-  extends GpuTernaryExpression_Any_Scalar_Scalar
+  extends GpuTernaryExpressionArgsAnyScalarScalar
       with ImplicitCastInputTypes {
 
   override def dataType: DataType = srcExpr.dataType
@@ -859,7 +859,7 @@ object CudfRegexp {
 }
 
 case class GpuLike(left: Expression, right: Expression, escapeChar: Char)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
       with NullIntolerant  {
 
@@ -1086,7 +1086,7 @@ class GpuRLikeMeta(
 }
 
 case class GpuRLike(left: Expression, right: Expression, pattern: String)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
       with NullIntolerant  {
 
@@ -1108,7 +1108,7 @@ case class GpuRLike(left: Expression, right: Expression, pattern: String)
 }
 
 abstract class GpuRegExpTernaryBase
-    extends GpuTernaryExpression_Any_Scalar_Scalar {
+    extends GpuTernaryExpressionArgsAnyScalarScalar {
 
   override def dataType: DataType = StringType
 
@@ -1577,7 +1577,7 @@ case class GpuSubstringIndex(strExpr: Expression,
     regexp: String,
     ignoredDelimExpr: Expression,
     ignoredCountExpr: Expression)
-  extends GpuTernaryExpression_Any_Scalar_Scalar with ImplicitCastInputTypes {
+  extends GpuTernaryExpressionArgsAnyScalarScalar with ImplicitCastInputTypes {
 
   override def dataType: DataType = StringType
   override def inputTypes: Seq[DataType] = Seq(StringType, StringType, IntegerType)
@@ -1616,7 +1616,7 @@ case class GpuSubstringIndex(strExpr: Expression,
 }
 
 trait BasePad
-    extends GpuTernaryExpression_Any_Scalar_Scalar
+    extends GpuTernaryExpressionArgsAnyScalarScalar
         with ImplicitCastInputTypes
         with NullIntolerant {
   val str: Expression
@@ -1961,7 +1961,7 @@ case class GpuStringToMap(strExpr: Expression,
 }
 
 case class GpuStringInstr(str: Expression, substr: Expression)
-  extends GpuBinaryExpression_Any_Scalar
+  extends GpuBinaryExpressionArgsAnyScalar
       with ImplicitCastInputTypes
       with NullIntolerant  {
   // Locate the position of the first occurrence of substr column in the given string.


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8303

I need to add tests, and this is a draft for that reason.

I would like to show the approach here to make sure it's not too far off. I have added new subclasses of `GpuBinaryExpression` and `GpuTernaryExpression` to final override certain methods that we used to override + throw in specific expressions. For example, `GpuBinaryExpression_Any_Scalar` will throw if `doColumnar(*, GpuColumnVector)` is invoked. I tried to standardize the error message.

This change also implements some `doColumnar` functions that it looks like we can implement for: ArrayContains and GetMapValue. I will add tests to make sure I cover these, and again those are not included yet.