### PR TITLE
Try mitigate mismatched JDK versions in mvn-verify checks [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -91,6 +91,12 @@ jobs:
           distribution: adopt
           java-version: 8
 
+      - name: check runtime
+        run: |
+          env | grep JAVA
+          export JAVA_HOME=${JAVA_HOME_8_X64}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
+
       - name: package tests check
         run: >
           mvn -Dmaven.wagon.http.retryHandler.count=3 -B package
@@ -114,6 +120,12 @@ jobs:
         with:
           distribution: adopt
           java-version: ${{ matrix.java-version }}
+
+      - name: check runtime
+        run: |
+          env | grep JAVA
+          export JAVA_HOME=${JAVA_HOME_${{ matrix.java-version }}_X64}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
 
       - name: Build JDK
         run: >
@@ -139,6 +151,12 @@ jobs:
 
       - name: Setup Maven Wrapper
         run: mvn wrapper:wrapper -Dmaven=${{ matrix.maven-version }}
+
+      - name: check runtime
+        run: |
+          env | grep JAVA
+          export JAVA_HOME=${JAVA_HOME_11_X64}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
 
       - name: Install with Maven ${{ matrix.maven-version }}
         run: >


### PR DESCRIPTION
try to mitigate https://github.com/NVIDIA/spark-rapids/issues/8847

We guess that it could be related to github actions cannot isolate ENV of multiple runners on the same host well.

Try:
1. add new step to print out more runtime details for debugging,
2. explicitly specify JAVA_HOME

New check runtime step:
```
env | grep JAVA
  export JAVA_HOME=${JAVA_HOME_8_X64}
  java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
  shell: /usr/bin/bash -e {0}
  env:
    COMMON_MVN_FLAGS: -Ddist.jar.compress=false -DskipTests -Dskip
  
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.[3](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:3)82-5/x6[4](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:4)
    JAVA_HOME_8_X64: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.382-[5](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:5)/x[6](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:6)4
JAVA_HOME_11_X64=/usr/lib/jvm/temurin-11-jdk-amd64
JAVA_HOME=/opt/hostedtoolcache/Java_Adopt_jdk/8.0.382-5/x64
JAVA_HOME_8_X64=/opt/hostedtoolcache/Java_Adopt_jdk/8.0.382-5/x64
JAVA_HOME_1[7](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:7)_X64=/usr/lib/jvm/temurin-17-jdk-amd64
openjdk version "1.[8](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:8).0_382"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_382-b05)
OpenJDK 64-Bit Server VM (Temurin)(build 25.382-b05, mixed mode)
Apache Maven 3.8.8 (4c87b05d[9](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:9)aedce574290d1acc98575ed5eb6cd39)
Maven home: /usr/share/apache-maven-3.8.8
Java version: 1.8.0_382, vendor: Temurin, runtime: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.382-5/x64/jre
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-[10](https://github.com/NVIDIA/spark-rapids/actions/runs/5687687352/job/15416441514#step:4:10)41-azure", arch: "amd64", family: "unix"
ENV JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/8.0.382-5/x64
```