### PR TITLE
Update test scripts and dockerfiles to match cudf change [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -46,8 +46,9 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-toolkit=${CUDA_VER} && \
+RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
     mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -58,8 +58,9 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
-RUN conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-toolkit=${CUDA_VER} && \
+RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
+    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
+    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
     mamba install -y spacy && python -m spacy download en_core_web_sm && \
     mamba install -y -c anaconda pytest requests && \
     mamba install -y -c conda-forge sre_yield && \

--- a/jenkins/databricks/init_cudf_udf.sh
+++ b/jenkins/databricks/init_cudf_udf.sh
@@ -21,7 +21,7 @@
 set -ex
 
 CUDF_VER=${CUDF_VER:-23.08}
-CUDA_VER=${CUDA_VER:-11.8.0}
+CUDA_VER=${CUDA_VER:-11.8}
 
 # Need to explicitly add conda into PATH environment, to activate conda environment.
 export PATH=/databricks/conda/bin:$PATH
@@ -50,7 +50,7 @@ conda install -y -c conda-forge mamba python=$PYTHON_VERSION
 ${base}/envs/cudf-udf/bin/mamba remove -y c-ares zstd libprotobuf pandas || true
 
 REQUIRED_PACKAGES=(
-  cuda-toolkit=$CUDA_VER
+  cuda-version=$CUDA_VER
   cudf=$CUDF_VER
   findspark
   pandas


### PR DESCRIPTION
fix #8827 

cudf conda pkg marked cuda12 as default pkg recently, 
and do not honor cuda-toolkit version in conda installation now.

So it would download cuda12 version cudf to databricks runtime (default driver 470) which could fail #8827 cases.

Verified locally with the change to use new `cuda-version` pkg to help navigate the correct cudf-py pkg.