### PR TITLE
Specify expected JAVA_HOME and bin for mvn-verify-check [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -91,21 +91,26 @@ jobs:
           distribution: adopt
           java-version: 8
 
-      - name: check runtime
+      - name: check runtime before tests
         run: |
           env | grep JAVA
-          export JAVA_HOME=${JAVA_HOME_8_X64}
-          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
 
       - name: package tests check
-        run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B package
-          -pl integration_tests,tests -am
-          -P 'individual,pre-merge'
-          -Dbuildver=${{ matrix.spark-version }}
-          -Dmaven.scalastyle.skip=true
-          -Drat.skip=true
-          $COMMON_MVN_FLAGS
+        run: |
+          # https://github.com/NVIDIA/spark-rapids/issues/8847
+          # specify expected versions
+          export JAVA_HOME=${JAVA_HOME_8_X64}
+          export PATH=${JAVA_HOME}/bin:${PATH}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
+          # test command
+          mvn -Dmaven.wagon.http.retryHandler.count=3 -B package \
+            -pl integration_tests,tests -am \
+            -P 'individual,pre-merge' \
+            -Dbuildver=${{ matrix.spark-version }} \
+            -Dmaven.scalastyle.skip=true \
+            -Drat.skip=true \
+            ${{ env.COMMON_MVN_FLAGS }}
 
   verify-all-modules:
     needs: get-shim-versions-from-dist
@@ -121,18 +126,23 @@ jobs:
           distribution: adopt
           java-version: ${{ matrix.java-version }}
 
-      - name: check runtime
+      - name: check runtime before tests
         run: |
           env | grep JAVA
-          export JAVA_HOME=${JAVA_HOME_${{ matrix.java-version }}_X64}
-          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
 
       - name: Build JDK
-        run: >
-          mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify
-          -P "individual,pre-merge,jdk${{ matrix.java-version }}"
-          -Dbuildver=${{ matrix.spark-version }}
-          $COMMON_MVN_FLAGS
+        run: |
+          # https://github.com/NVIDIA/spark-rapids/issues/8847
+          # specify expected versions
+          export JAVA_HOME=${JAVA_HOME_${{ matrix.java-version }}_X64}
+          export PATH=${JAVA_HOME}/bin:${PATH}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
+          # test command
+          mvn -Dmaven.wagon.http.retryHandler.count=3 -B verify \
+            -P "individual,pre-merge,jdk${{ matrix.java-version }}" \
+            -Dbuildver=${{ matrix.spark-version }} \
+            ${{ env.COMMON_MVN_FLAGS }}
 
   install-modules:
     needs: get-shim-versions-from-dist
@@ -152,15 +162,20 @@ jobs:
       - name: Setup Maven Wrapper
         run: mvn wrapper:wrapper -Dmaven=${{ matrix.maven-version }}
 
-      - name: check runtime
+      - name: check runtime before tests
         run: |
           env | grep JAVA
-          export JAVA_HOME=${JAVA_HOME_11_X64}
-          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME"
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
 
       - name: Install with Maven ${{ matrix.maven-version }}
-        run: >
-          ./mvnw -Dmaven.wagon.http.retryHandler.count=3 -B install
-          -P "individual,pre-merge,jdk11"
-          -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.defaultSparkVersion }}
-          $COMMON_MVN_FLAGS
+        run: |
+          # https://github.com/NVIDIA/spark-rapids/issues/8847
+          # specify expected versions
+          export JAVA_HOME=export JAVA_HOME=${JAVA_HOME_11_X64}
+          export PATH=${JAVA_HOME}/bin:${PATH}
+          java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
+          # test command
+          ./mvnw -Dmaven.wagon.http.retryHandler.count=3 -B install \
+            -P "individual,pre-merge,jdk11" \
+            -Dbuildver=${{ needs.get-shim-versions-from-dist.outputs.defaultSparkVersion }} \
+            ${{ env.COMMON_MVN_FLAGS }}


### PR DESCRIPTION
fix #8847 

We monitored that setup-java action would not perform correctly if Github is suffering some perf incidents (I guess GitHub was doing some online service migration to mitigate the issue which could mess up w/ the test ENVs)

Let's force the expected versions in commands and stop relying on the actions.
