### PR TITLE
Adjust parallelism in spark-tests script to reduce memory footprint [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -164,9 +164,9 @@ if [[ $PARALLEL_TEST == "true" ]]; then
     PARALLELISM=$(nvidia-smi --query-gpu=memory.free --format=csv,noheader | \
       awk '{if (MAX < $1){ MAX = $1}} END {print int(MAX / (2 * 1024))}')
   fi
-  # parallelism > 6 could slow down the whole process, so we have a limitation for it
+  # parallelism > 5 could slow down the whole process, so we have a limitation for it
   # this is based on our CI gpu types, so we do not put it into the run_pyspark_from_build.sh
-  [[ ${PARALLELISM} -gt 6 ]] && PARALLELISM=6
+  [[ ${PARALLELISM} -gt 5 ]] && PARALLELISM=5
   MEMORY_FRACTION=$(python -c "print(1/($PARALLELISM + 0.1))")
 
   export TEST_PARALLEL=${PARALLELISM}


### PR DESCRIPTION
mitigate #8729 

We haven't figured out why JDK11 test run consumed more memory than other JDK versions and then was OOM killed by the system. (this could be related to different GC strategies in different JDK versions, but the issue was not resolved when trying to use non-default GC in jdk11). 

This change is trying to limit the parallelism of integration tests in nightly CI.
We have confirmed that setting parallelism as 5 does not increase the test run duration (verified w/ multiple GPU types),
and this could significantly help reduce the peak of host memory footprint (from >50GiB to >40GiB) in recent CI runs.