### PR TITLE
Terminate CI if fail to clone submodule [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -353,7 +353,7 @@ void checkoutCode(String url, String sha) {
                                 [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
         ]
     )
-    if (!fileExists("thirdparty/parquet-testing/data")) {
+    if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"
     }
 

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -353,6 +353,9 @@ void checkoutCode(String url, String sha) {
                                 [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
         ]
     )
+    if (!fileExists("thirdparty/parquet-testing/data")) {
+        error "Failed to clone submodule : thirdparty/parquet-testing"
+    }
 
     stash(name: "source_tree", includes: "**,.git/**", useDefaultExcludes: false)
 }

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -217,7 +217,7 @@ void checkoutCode(String url, String sha) {
                                 [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
         ]
     )
-    if (!fileExists("thirdparty/parquet-testing/data")) {
+    if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"
     }
 

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -217,6 +217,9 @@ void checkoutCode(String url, String sha) {
                                 [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
         ]
     )
+    if (!fileExists("thirdparty/parquet-testing/data")) {
+        error "Failed to clone submodule : thirdparty/parquet-testing"
+    }
 
     stash(name: 'source_tree', includes: '**,.git/**', useDefaultExcludes: false)
 }


### PR DESCRIPTION
To fix : https://github.com/NVIDIA/spark-rapids/issues/8822

There are intermittent failures unabling to colon the submodule repo due to GitHub incident,

and our CI will definitely fail when running integration tests if no submodule files.

So we check if the submodule exists ahead, otherwise error out earlier to save CI resources.
