### PR TITLE
Move LegacyBehaviorPolicy references to shim layer [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ParquetCachedBatchSerializer.scala
@@ -53,7 +53,6 @@ import org.apache.spark.sql.columnar.CachedBatch
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupport, ParquetToSparkSchemaConverter, ParquetWriteSupport, ShimCurrentBatchIterator}
 import org.apache.spark.sql.execution.datasources.parquet.rapids.ParquetRecordMaterializer
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.rapids.PCBSSchemaHelper
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -645,7 +644,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
         recordReader = columnIO.getRecordReader(pages, new ParquetRecordMaterializer(parquetSchema,
           cacheAttributes.toStructType,
           new ParquetToSparkSchemaConverter(hadoopConf), None /*convertTz*/ ,
-          LegacyBehaviorPolicy.CORRECTED))
+          "CORRECTED"))
       }
     }
 
@@ -1135,8 +1134,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
           // at least a single block
           val stream = new ByteArrayOutputStream(ByteArrayOutputFile.BLOCK_SIZE)
           val outputFile: OutputFile = new ByteArrayOutputFile(stream)
-          conf.setConfString(SparkShimImpl.parquetRebaseWriteKey,
-            LegacyBehaviorPolicy.CORRECTED.toString)
+          conf.setConfString(SparkShimImpl.parquetRebaseWriteKey, "CORRECTED")
           if (cachedAttributes.isEmpty) {
             // The schema is empty, most probably it is because of the edge case where there
             // are no columns in the Dataframe but has rows so let's create an empty CachedBatch
@@ -1270,8 +1268,7 @@ protected class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
     hadoopConf.setBoolean(SQLConf.PARQUET_INT96_AS_TIMESTAMP.key, false)
     hadoopConf.setBoolean(SQLConf.CASE_SENSITIVE.key, false)
 
-    hadoopConf.set(SparkShimImpl.parquetRebaseWriteKey,
-      LegacyBehaviorPolicy.CORRECTED.toString)
+    hadoopConf.set(SparkShimImpl.parquetRebaseWriteKey, "CORRECTED")
 
     hadoopConf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
       SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/util/rapids/DateFormatter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/util/rapids/DateFormatter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.util.{Date, Locale}
 
+import com.nvidia.spark.rapids.shims.LegacyBehaviorPolicyShim
 import org.apache.commons.lang3.time.FastDateFormat
 
 import org.apache.spark.sql.catalyst.util.{DateTimeFormatterHelper, DateTimeUtils, LegacyDateFormats}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils._
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy._
+
 
 // Copied from org/apache/spark/sql/catalyst/util/DateFormatter
 // for https://github.com/NVIDIA/spark-rapids/issues/6026
@@ -173,7 +173,7 @@ object DateFormatter {
       locale: Locale = defaultLocale,
       legacyFormat: LegacyDateFormat = LENIENT_SIMPLE_DATE_FORMAT,
       isParsing: Boolean): DateFormatter = {
-    if (SQLConf.get.legacyTimeParserPolicy == LEGACY) {
+    if (LegacyBehaviorPolicyShim.isLegacyTimeParserPolicy()) {
       getLegacyFormatter(format.getOrElse(defaultPattern), locale, legacyFormat)
     } else {
       val df = format

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.apache.parquet.schema.MessageType
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.parquet.{NoopUpdater, ParquetToSparkSchemaConverter}
 import org.apache.spark.sql.execution.datasources.parquet.rapids.shims.ShimParquetRowConverter
-import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -35,15 +34,15 @@ class ParquetRecordMaterializer(
    catalystSchema: StructType,
    schemaConverter: ParquetToSparkSchemaConverter,
    convertTz: Option[ZoneId],
-   datetimeRebaseMode: LegacyBehaviorPolicy.Value) extends RecordMaterializer[InternalRow] {
+   datetimeRebaseMode: String) extends RecordMaterializer[InternalRow] {
 
   private val rootConverter = new ShimParquetRowConverter(
     schemaConverter,
     parquetSchema,
     catalystSchema,
     convertTz,
-    datetimeRebaseMode, // always LegacyBehaviorPolicy.CORRECTED
-    LegacyBehaviorPolicy.EXCEPTION,
+    datetimeRebaseMode, // always "CORRECTED"
+    "EXCEPTION",
     false,
     NoopUpdater)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.execution.datasources.parquet.rapids
 
 import java.time.ZoneId
 
+import com.nvidia.spark.rapids.shims.LegacyBehaviorPolicyShim
 import org.apache.parquet.io.api.{GroupConverter, RecordMaterializer}
 import org.apache.parquet.schema.MessageType
 
@@ -42,7 +43,7 @@ class ParquetRecordMaterializer(
     catalystSchema,
     convertTz,
     datetimeRebaseMode, // always LegacyBehaviorPolicy.CORRECTED
-    "EXCEPTION",
+    LegacyBehaviorPolicyShim.EXCEPTION_STR,
     false,
     NoopUpdater)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetRecordMaterializer.scala
@@ -41,7 +41,7 @@ class ParquetRecordMaterializer(
     parquetSchema,
     catalystSchema,
     convertTz,
-    datetimeRebaseMode, // always "CORRECTED"
+    datetimeRebaseMode, // always LegacyBehaviorPolicy.CORRECTED
     "EXCEPTION",
     false,
     NoopUpdater)

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
@@ -21,13 +21,16 @@
 {"spark": "320"}
 {"spark": "321"}
 {"spark": "321cdh"}
+{"spark": "321db"}
 {"spark": "322"}
 {"spark": "323"}
 {"spark": "324"}
 {"spark": "330"}
 {"spark": "330cdh"}
+{"spark": "330db"}
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332db"}
 {"spark": "333"}
 {"spark": "340"}
 {"spark": "341"}

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
@@ -41,6 +41,9 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 
 object LegacyBehaviorPolicyShim {
+  val CORRECTED_STR: String =  LegacyBehaviorPolicy.CORRECTED.toString
+  val EXCEPTION_STR: String =  LegacyBehaviorPolicy.EXCEPTION.toString
+
   def isLegacyTimeParserPolicy(): Boolean = {
     SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
   }

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "333"}
+{"spark": "340"}
+{"spark": "341"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
+
+object LegacyBehaviorPolicyShim {
+  def isLegacyTimeParserPolicy(): Boolean = {
+    SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY
+  }
+}

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -37,8 +37,8 @@ class ShimParquetRowConverter(
     parquetType: GroupType,
     catalystType: StructType,
     convertTz: Option[ZoneId],
-    datetimeRebaseMode: LegacyBehaviorPolicy.Value,
-    int96RebaseMode: LegacyBehaviorPolicy.Value,
+    datetimeRebaseMode: String,
+    int96RebaseMode: String,
     int96CDPHive3Compatibility: Boolean,
     updater: ParentContainerUpdater
 ) extends ParquetRowConverter(
@@ -46,8 +46,8 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      datetimeRebaseMode,
-      int96RebaseMode,
+      LegacyBehaviorPolicy.withName(datetimeRebaseMode),
+      LegacyBehaviorPolicy.withName(int96RebaseMode),
       updater)
 
 class ShimVectorizedColumnReader(

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -35,8 +35,8 @@ class ShimParquetRowConverter(
     parquetType: GroupType,
     catalystType: StructType,
     convertTz: Option[ZoneId],
-    datetimeRebaseMode: LegacyBehaviorPolicy.Value,
-    int96RebaseMode: LegacyBehaviorPolicy.Value,
+    datetimeRebaseMode: String,
+    int96RebaseMode: String,
     int96CDPHive3Compatibility: Boolean,
     updater: ParentContainerUpdater
 ) extends ParquetRowConverter(
@@ -44,8 +44,8 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      datetimeRebaseMode,
-      int96RebaseMode,
+      LegacyBehaviorPolicy.withName(datetimeRebaseMode),
+      LegacyBehaviorPolicy.withName(int96RebaseMode),
       updater)
 
 class ShimVectorizedColumnReader(

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -51,8 +51,10 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)), // no need to rebase, so set originTimeZone as default
-      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)), // no need to rebase, so set originTimeZone as default
+      // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)),
+      // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)),
       updater)
 
 class ShimVectorizedColumnReader(

--- a/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark321/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -42,8 +42,8 @@ class ShimParquetRowConverter(
     parquetType: GroupType,
     catalystType: StructType,
     convertTz: Option[ZoneId],
-    datetimeRebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.CORRECTED
-    int96RebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.EXCEPTION
+    datetimeRebaseMode: String,  // always LegacyBehaviorPolicy.CORRECTED
+    int96RebaseMode: String,  // always LegacyBehaviorPolicy.EXCEPTION
     int96CDPHive3Compatibility: Boolean,
     updater: ParentContainerUpdater
 ) extends ParquetRowConverter(
@@ -51,8 +51,8 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      RebaseSpec(datetimeRebaseMode), // no need to rebase, so set originTimeZone as default
-      RebaseSpec(int96RebaseMode), // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)), // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)), // no need to rebase, so set originTimeZone as default
       updater)
 
 class ShimVectorizedColumnReader(

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -45,8 +45,8 @@ class ShimParquetRowConverter(
     parquetType: GroupType,
     catalystType: StructType,
     convertTz: Option[ZoneId],
-    datetimeRebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.CORRECTED
-    int96RebaseMode: LegacyBehaviorPolicy.Value,  // always LegacyBehaviorPolicy.EXCEPTION
+    datetimeRebaseMode: String,  // always LegacyBehaviorPolicy.CORRECTED
+    int96RebaseMode: String,  // always LegacyBehaviorPolicy.EXCEPTION
     int96CDPHive3Compatibility: Boolean,
     updater: ParentContainerUpdater
 ) extends ParquetRowConverter(
@@ -54,8 +54,8 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      RebaseSpec(datetimeRebaseMode), // no need to rebase, so set originTimeZone as default
-      RebaseSpec(int96RebaseMode), // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)), // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)), // no need to rebase, so set originTimeZone as default
       updater)
 
 class ShimVectorizedColumnReader(

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -54,8 +54,10 @@ class ShimParquetRowConverter(
       parquetType,
       catalystType,
       convertTz,
-      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)), // no need to rebase, so set originTimeZone as default
-      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)), // no need to rebase, so set originTimeZone as default
+      // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(datetimeRebaseMode)),
+      // no need to rebase, so set originTimeZone as default
+      RebaseSpec(LegacyBehaviorPolicy.withName(int96RebaseMode)),
       updater)
 
 class ShimVectorizedColumnReader(


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/8121

Spark 3.5.0 moves `LegacyBehaviorPolicy` out of `SQLConf` and into a top-level class, so we now need to shim all references to this class.