### PR TITLE
Databricks shim version for integration test [databricks]

### DIFF
--- a/jenkins/databricks/common_vars.sh
+++ b/jenkins/databricks/common_vars.sh
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+SPARK_VER=${SPARK_VER:-$(< /databricks/spark/VERSION)}
+export SPARK_SHIM_VER=${SPARK_SHIM_VER:-spark${SPARK_VER//.}db}
+
 # Setup SPARK_HOME if need
 if [[ -z "$SPARK_HOME" ]]; then
     # Configure spark environment on Databricks

--- a/jenkins/databricks/test.sh
+++ b/jenkins/databricks/test.sh
@@ -49,7 +49,6 @@ source jenkins/databricks/common_vars.sh
 BASE_SPARK_VERSION=${BASE_SPARK_VERSION:-$(< /databricks/spark/VERSION)}
 SHUFFLE_SPARK_SHIM=${SHUFFLE_SPARK_SHIM:-spark${BASE_SPARK_VERSION//./}db}
 SHUFFLE_SPARK_SHIM=${SHUFFLE_SPARK_SHIM//\-SNAPSHOT/}
-[[ -z $SPARK_SHIM_VER ]] && export SPARK_SHIM_VER=spark${BASE_SPARK_VERSION//.}db
 
 IS_SPARK_321_OR_LATER=0
 [[ "$(printf '%s\n' "3.2.1" "$BASE_SPARK_VERSION" | sort -V | head -n1)" = "3.2.1" ]] && IS_SPARK_321_OR_LATER=1


### PR DESCRIPTION
Follow up https://github.com/NVIDIA/spark-rapids/pull/8828

To fix: https://github.com/NVIDIA/spark-rapids/issues/8923

Move SPARK_SHIM_VER into share Databricks script file.

Need to set SPARK_SHIM_VER=`spark3xxdb` to run integration tests against `spark3xxdb` integration test jar, otherwise some test cases would failed as below due to referring to `spark3xx.jar` integration test jar

`mortgage_test.py::test_mortgage[IGNORE_ORDER, INCOMPAT, APPROXIMATE_FLOAT, ALLOW_NON_GPU(ANY), LIMIT(100000)] - TypeError: 'JavaPackage' object is not callable`