### PR TITLE
Output unified diff when GPU output deviates

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -23,6 +23,8 @@ from spark_session import with_cpu_session, with_gpu_session
 import time
 import types as pytypes
 import data_gen
+import difflib
+import sys
 
 def _assert_equal(cpu, gpu, float_check, path):
     t = type(cpu)
@@ -104,8 +106,11 @@ def assert_equal(cpu, gpu):
     try:
       _assert_equal(cpu, gpu, float_check=get_float_check(), path=[])
     except:
-      print("CPU OUTPUT: %s" % cpu)
-      print("GPU OUTPUT: %s" % gpu)
+      sys.stdout.writelines(difflib.unified_diff(
+          a=[f"{x}\n" for x in cpu],
+          b=[f"{x}\n" for x in gpu],
+          fromfile='CPU OUTPUT',
+          tofile='GPU OUTPUT'))
       raise
 
 def _has_incompat_conf(conf):

--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -104,14 +104,14 @@ def _assert_equal(cpu, gpu, float_check, path):
 def assert_equal(cpu, gpu):
     """Verify that the result from the CPU and the GPU are equal"""
     try:
-      _assert_equal(cpu, gpu, float_check=get_float_check(), path=[])
+        _assert_equal(cpu, gpu, float_check=get_float_check(), path=[])
     except:
-      sys.stdout.writelines(difflib.unified_diff(
-          a=[f"{x}\n" for x in cpu],
-          b=[f"{x}\n" for x in gpu],
-          fromfile='CPU OUTPUT',
-          tofile='GPU OUTPUT'))
-      raise
+        sys.stdout.writelines(difflib.unified_diff(
+            a=[f"{x}\n" for x in cpu],
+            b=[f"{x}\n" for x in gpu],
+            fromfile='CPU OUTPUT',
+            tofile='GPU OUTPUT'))
+        raise
 
 def _has_incompat_conf(conf):
     return ('spark.rapids.sql.incompatibleOps.enabled' in conf and


### PR DESCRIPTION
Output a unified diff, which is much more readable - if the difference is small - 
instead of two super-long strings with the entire output for CPU and GPU each

An example for some current work in progress where around a dozen out of 2048 rows differ:

```Diff
--- CPU OUTPUT
+++ GPU OUTPUT
@@ -269,7 +269,7 @@
 Row(a='901627024371030426', conv(a, 10, 10)='901627024371030426')
 Row(a=None, conv(a, 10, 10)=None)
 Row(a='572593699758615081', conv(a, 10, 10)='572593699758615081')
-Row(a='\x9a\x06L\x08¬\x1cC«Ho', conv(a, 10, 10)='0')
+Row(a='\x9a\x06L\x08¬\x1cC«Ho', conv(a, 10, 10)=None)
 Row(a='923838063082713104', conv(a, 10, 10)='923838063082713104')
 Row(a='816287764469187981', conv(a, 10, 10)='816287764469187981')
 Row(a='168862841137373567', conv(a, 10, 10)='168862841137373567')
@@ -420,7 +420,7 @@
 Row(a='18042116008366960', conv(a, 10, 10)='18042116008366960')
 Row(a='344962566349925841', conv(a, 10, 10)='344962566349925841')
 Row(a='477425930346693878', conv(a, 10, 10)='477425930346693878')
-Row(a='6Â9ù\x9a\x8e¤ÎÂ9', conv(a, 10, 10)='6')
+Row(a='6Â9ù\x9a\x8e¤ÎÂ9', conv(a, 10, 10)=None)
 Row(a='461588103572291001', conv(a, 10, 10)='461588103572291001')
 Row(a='160189608683158579', conv(a, 10, 10)='160189608683158579')
 Row(a='158314626118866327', conv(a, 10, 10)='158314626118866327')
@@ -516,7 +516,7 @@
 Row(a='332416342940701722', conv(a, 10, 10)='332416342940701722')
 Row(a='247906078181314182', conv(a, 10, 10)='247906078181314182')
 Row(a='786474267467256790', conv(a, 10, 10)='786474267467256790')
-Row(a='úë´¹.ÇK-$[', conv(a, 10, 10)='0')
+Row(a='úë´¹.ÇK-$[', conv(a, 10, 10)=None)
 Row(a='528252866890721608', conv(a, 10, 10)='528252866890721608')
 Row(a='107930457223342208', conv(a, 10, 10)='107930457223342208')
 Row(a='801442202736866796', conv(a, 10, 10)='801442202736866796')
@@ -712,7 +712,7 @@
 Row(a='950515802034623319', conv(a, 10, 10)='950515802034623319')
 Row(a='842916857629977688', conv(a, 10, 10)='842916857629977688')
 Row(a='901913585575523363', conv(a, 10, 10)='901913585575523363')
-Row(a='¯0¸\x93¡B¯Eçã', conv(a, 10, 10)='0')
+Row(a='¯0¸\x93¡B¯Eçã', conv(a, 10, 10)=None)
 Row(a='677105653778983468', conv(a, 10, 10)='677105653778983468')
 Row(a='566159095020315801', conv(a, 10, 10)='566159095020315801')
 Row(a='086424679996313597', conv(a, 10, 10)='86424679996313597')
@@ -873,7 +873,7 @@
 Row(a='39628468969849732', conv(a, 10, 10)='39628468969849732')
 Row(a='562402848074042753', conv(a, 10, 10)='562402848074042753')
 Row(a='990181047168917453', conv(a, 10, 10)='990181047168917453')
-Row(a='T´I @Ï\x876ßu', conv(a, 10, 10)='0')
+Row(a='T´I @Ï\x876ßu', conv(a, 10, 10)=None)
 Row(a='16895498198695655', conv(a, 10, 10)='16895498198695655')
 Row(a='654905886515270115', conv(a, 10, 10)='654905886515270115')
 Row(a=None, conv(a, 10, 10)=None)
@@ -891,7 +891,7 @@
 Row(a='800454027500226530', conv(a, 10, 10)='800454027500226530')
 Row(a='546635454582317919', conv(a, 10, 10)='546635454582317919')
 Row(a='881817360189104877', conv(a, 10, 10)='881817360189104877')
-Row(a='\x080»\x01«7\x83ùÎÌ', conv(a, 10, 10)='0')
+Row(a='\x080»\x01«7\x83ùÎÌ', conv(a, 10, 10)=None)
 Row(a='146441906141395535', conv(a, 10, 10)='146441906141395535')
 Row(a='853121277008467883', conv(a, 10, 10)='853121277008467883')
 Row(a='093176233755166515', conv(a, 10, 10)='93176233755166515')
@@ -913,7 +913,7 @@
 Row(a='468496101654393865', conv(a, 10, 10)='468496101654393865')
 Row(a='030361763302034872', conv(a, 10, 10)='30361763302034872')
 Row(a='422643759077610736', conv(a, 10, 10)='422643759077610736')
-Row(a='?é¸)\x9cl\x1c\x89v;', conv(a, 10, 10)='0')
+Row(a='?é¸)\x9cl\x1c\x89v;', conv(a, 10, 10)=None)
 Row(a='694473118396360406', conv(a, 10, 10)='694473118396360406')
 Row(a='852151982196829482', conv(a, 10, 10)='852151982196829482')
 Row(a='199363230716184886', conv(a, 10, 10)='199363230716184886')
@@ -1605,7 +1605,7 @@
 Row(a='892082178699242787', conv(a, 10, 10)='892082178699242787')
 Row(a='806662822142621830', conv(a, 10, 10)='806662822142621830')
 Row(a='270357150989919529', conv(a, 10, 10)='270357150989919529')
-Row(a='¿p]µ\x0f²¢\x03ÙÎ', conv(a, 10, 10)='0')
+Row(a='¿p]µ\x0f²¢\x03ÙÎ', conv(a, 10, 10)=None)
 Row(a='444408466160238188', conv(a, 10, 10)='444408466160238188')
 Row(a='85789097758896923', conv(a, 10, 10)='85789097758896923')
 Row(a='871604889789848551', conv(a, 10, 10)='871604889789848551')
@@ -1713,7 +1713,7 @@
 Row(a='025829497077691349', conv(a, 10, 10)='25829497077691349')
 Row(a='066840737184154278', conv(a, 10, 10)='66840737184154278')
 Row(a='708306862664247095', conv(a, 10, 10)='708306862664247095')
-Row(a='åfihÏ5£,Íí', conv(a, 10, 10)='0')
+Row(a='åfihÏ5£,Íí', conv(a, 10, 10)=None)
 Row(a='986921581901225874', conv(a, 10, 10)='986921581901225874')
 Row(a='838054559736714080', conv(a, 10, 10)='838054559736714080')
 Row(a='363565888685486036', conv(a, 10, 10)='363565888685486036')
@@ -1780,7 +1780,7 @@
 Row(a='21371032066637043', conv(a, 10, 10)='21371032066637043')
 Row(a='602741384947308956', conv(a, 10, 10)='602741384947308956')
 Row(a=None, conv(a, 10, 10)=None)
-Row(a='/¦]ò\x96\x11\x0f\x08LT', conv(a, 10, 10)='0')
+Row(a='/¦]ò\x96\x11\x0f\x08LT', conv(a, 10, 10)=None)
 Row(a='04107866085381954', conv(a, 10, 10)='4107866085381954')
 Row(a='047661796897460913', conv(a, 10, 10)='47661796897460913')
 Row(a='713574446609612171', conv(a, 10, 10)='713574446609612171')
@@ -1877,7 +1877,7 @@
 Row(a='725078584992030058', conv(a, 10, 10)='725078584992030058')
 Row(a='070868770685954891', conv(a, 10, 10)='70868770685954891')
 Row(a='548206226837378195', conv(a, 10, 10)='548206226837378195')
-Row(a='\x18Yv\x13ä\x9bgÐEQ', conv(a, 10, 10)='0')
+Row(a='\x18Yv\x13ä\x9bgÐEQ', conv(a, 10, 10)=None)
 Row(a='658824930129222035', conv(a, 10, 10)='658824930129222035')
 Row(a='461188815286298765', conv(a, 10, 10)='461188815286298765')
 Row(a='800599985995894692', conv(a, 10, 10)='800599985995894692')
@@ -2001,7 +2001,7 @@
 Row(a='833516859246548822', conv(a, 10, 10)='833516859246548822')
 Row(a='127462502289143306', conv(a, 10, 10)='127462502289143306')
 Row(a='418924904103619338', conv(a, 10, 10)='418924904103619338')
-Row(a='Ó\t\x94mùh»\x0c\x0f{', conv(a, 10, 10)='0')
+Row(a='Ó\t\x94mùh»\x0c\x0f{', conv(a, 10, 10)=None)
 Row(a='771286128444918372', conv(a, 10, 10)='771286128444918372')
 Row(a='24446953783423185', conv(a, 10, 10)='24446953783423185')
 Row(a='947491434073298615', conv(a, 10, 10)='947491434073298615')
@@ -2041,7 +2041,7 @@
 Row(a='245905302366427708', conv(a, 10, 10)='245905302366427708')
 Row(a='992361255146956383', conv(a, 10, 10)='992361255146956383')
 Row(a='706883313541655830', conv(a, 10, 10)='706883313541655830')
-Row(a='ßIÿ;2\x85\x10\x8bÿ\x06', conv(a, 10, 10)='0')
+Row(a='ßIÿ;2\x85\x10\x8bÿ\x06', conv(a, 10, 10)=None)
 Row(a='980410172095724335', conv(a, 10, 10)='980410172095724335')
 Row(a='461415782646826952', conv(a, 10, 10)='461415782646826952')
 Row(a='32423942080009114', conv(a, 10, 10)='32423942080009114')
```

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
