### PR TITLE
Deprecate and delegate GpuCV.debug to cudf TableDebug

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -84,14 +84,6 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     TableDebug.get().debug(name, col);
   }
 
-  private static String hexString(byte[] bytes) {
-    StringBuilder str = new StringBuilder();
-    for (byte b : bytes) {
-      str.append(String.format("%02x", b&0xff));
-    }
-    return str.toString();
-  }
-
   /**
    * Print to standard error the contents of a column. Note that this should never be
    * called from production code, as it is very slow.  Also note that this is not production

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -16,15 +16,7 @@
 
 package com.nvidia.spark.rapids;
 
-import ai.rapids.cudf.BaseDeviceMemoryBuffer;
-import ai.rapids.cudf.ColumnView;
-import ai.rapids.cudf.DType;
-import ai.rapids.cudf.ArrowColumnBuilder;
-import ai.rapids.cudf.HostColumnVector;
-import ai.rapids.cudf.HostColumnVectorCore;
-import ai.rapids.cudf.Scalar;
-import ai.rapids.cudf.Schema;
-import ai.rapids.cudf.Table;
+import ai.rapids.cudf.*;
 import com.nvidia.spark.rapids.shims.GpuTypeShims;
 import org.apache.arrow.memory.ReferenceManager;
 
@@ -53,12 +45,11 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    * types as this really is just for debugging.
    * @param name the name of the table to print out.
    * @param table the table to print out.
+   * @deprecated Use ai.rapids.cudf.TableDebug
    */
-  public static synchronized void debug(String name, Table table) {
-    System.err.println("DEBUG " + name + " " + table);
-    for (int col = 0; col < table.getNumberOfColumns(); col++) {
-      debug(String.valueOf(col), table.getColumn(col));
-    }
+  @Deprecated
+  public static void debug(String name, Table table) {
+    TableDebug.get().debug(name, table);
   }
 
   /**
@@ -69,31 +60,12 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    * @param name the name of the table to print out.
    * @param cb the batch to print out.
    */
-  public static synchronized void debug(String name, ColumnarBatch cb) {
+  public static void debug(String name, ColumnarBatch cb) {
     if (cb.numCols() <= 0) {
       System.err.println("DEBUG " + name + " NO COLS " + cb.numRows() + " ROWS");
     } else {
       try (Table table = from(cb)) {
-        debug(name, table);
-      }
-    }
-  }
-
-  private static synchronized void debugGPUAddrs(String name, ai.rapids.cudf.ColumnView col) {
-    try (BaseDeviceMemoryBuffer data = col.getData();
-         BaseDeviceMemoryBuffer validity = col.getValid()) {
-      System.err.println("GPU COLUMN " + name + " - NC: " + col.getNullCount()
-          + " DATA: " + data + " VAL: " + validity);
-    }
-    if (col.getType() == DType.STRUCT) {
-      for (int i = 0; i < col.getNumChildren(); i++) {
-        try (ColumnView child = col.getChildColumnView(i)) {
-          debugGPUAddrs(name + ":CHILD_" + i, child);
-        }
-      }
-    } else if (col.getType() == DType.LIST) {
-      try (ColumnView child = col.getChildColumnView(0)) {
-        debugGPUAddrs(name + ":DATA", child);
+        TableDebug.get().debug(name, table);
       }
     }
   }
@@ -105,12 +77,11 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    * types as this really is just for debugging.
    * @param name the name of the column to print out.
    * @param col the column to print out.
+   * @deprecated see ai.rapids.cudf.TableDebug
    */
-  public static synchronized void debug(String name, ai.rapids.cudf.ColumnView col) {
-    debugGPUAddrs(name, col);
-    try (HostColumnVector hostCol = col.copyToHost()) {
-      debug(name, hostCol);
-    }
+  @Deprecated
+  public static void debug(String name, ai.rapids.cudf.ColumnView col) {
+    TableDebug.get().debug(name, col);
   }
 
   private static String hexString(byte[] bytes) {
@@ -128,116 +99,11 @@ public class GpuColumnVector extends GpuColumnVectorBase {
    * types as this really is just for debugging.
    * @param name the name of the column to print out.
    * @param hostCol the column to print out.
+   * @deprecated Use ai.rapids.cudf.TableDebug
    */
-  public static synchronized void debug(String name, HostColumnVectorCore hostCol) {
-    DType type = hostCol.getType();
-    System.err.println("COLUMN " + name + " - " + type);
-    if (type.isDecimalType()) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " " + hostCol.getBigDecimal(i));
-        }
-      }
-    } else if (DType.STRING.equals(type)) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " \"" + hostCol.getJavaString(i) + "\" " +
-              hexString(hostCol.getUTF8(i)));
-        }
-      }
-    } else if (DType.INT32.equals(type)
-            || DType.INT8.equals(type)
-            || DType.INT16.equals(type)
-            || DType.INT64.equals(type)
-            || DType.TIMESTAMP_DAYS.equals(type)
-            || DType.TIMESTAMP_SECONDS.equals(type)
-            || DType.TIMESTAMP_MICROSECONDS.equals(type)
-            || DType.TIMESTAMP_MILLISECONDS.equals(type)
-            || DType.TIMESTAMP_NANOSECONDS.equals(type)
-            || DType.UINT8.equals(type)
-            || DType.UINT16.equals(type)
-            || DType.UINT32.equals(type)
-            || DType.UINT64.equals(type)) {
-      debugInteger(hostCol, type);
-   } else if (DType.BOOL8.equals(type)) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " " + hostCol.getBoolean(i));
-        }
-      }
-    } else if (DType.FLOAT64.equals(type)) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " " + hostCol.getDouble(i));
-        }
-      }
-    } else if (DType.FLOAT32.equals(type)) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " " + hostCol.getFloat(i));
-        }
-      }
-    } else if (DType.STRUCT.equals(type)) {
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } // The struct child columns are printed out later on.
-      }
-      for (int i = 0; i < hostCol.getNumChildren(); i++) {
-        debug(name + ":CHILD_" + i, hostCol.getChildColumnView(i));
-      }
-    } else if (DType.LIST.equals(type)) {
-      System.err.println("OFFSETS");
-      for (int i = 0; i < hostCol.getRowCount(); i++) {
-        if (hostCol.isNull(i)) {
-          System.err.println(i + " NULL");
-        } else {
-          System.err.println(i + " [" + hostCol.getStartListOffset(i) + " - " +
-              hostCol.getEndListOffset(i) + ")");
-        }
-      }
-      debug(name + ":DATA", hostCol.getChildColumnView(0));
-    } else {
-      System.err.println("TYPE " + type + " NOT SUPPORTED FOR DEBUG PRINT");
-    }
-  }
-
-  private static void debugInteger(HostColumnVectorCore hostCol, DType intType) {
-    for (int i = 0; i < hostCol.getRowCount(); i++) {
-      if (hostCol.isNull(i)) {
-        System.err.println(i + " NULL");
-      } else {
-        final int sizeInBytes = intType.getSizeInBytes();
-        final Object value;
-        switch (sizeInBytes) {
-          case Byte.BYTES:
-            value = hostCol.getByte(i);
-            break;
-          case Short.BYTES:
-            value = hostCol.getShort(i);
-            break;
-          case Integer.BYTES:
-            value = hostCol.getInt(i);
-            break;
-          case Long.BYTES:
-            value = hostCol.getLong(i);
-            break;
-          default:
-            throw new IllegalArgumentException("INFEASIBLE: Unsupported integer-like type " + intType);
-        }
-        System.err.println(i + " " + value);
-      }
-    }
+  @Deprecated
+  public static void debug(String name, HostColumnVectorCore hostCol) {
+    TableDebug.get().debug(name, hostCol);
   }
 
   static HostColumnVector.DataType convertFrom(DataType spark, boolean nullable) {

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFormatScanSuite.scala
@@ -24,8 +24,8 @@ import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.concurrent.duration._
 
 import ai.rapids.cudf
-import com.nvidia.spark.rapids.{GpuColumnVector, SparkQueryCompareTestSuite}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.ParquetWriter
@@ -46,6 +46,8 @@ import org.apache.spark.util.Utils
  * A lot of this testing code is based off of similar Spark tests.
  */
 class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually {
+  private val debugPrinter = cudf.TableDebug.get();
+
   implicit class RecordConsumerDSL(consumer: RecordConsumer) {
     def message(f: => Unit): Unit = {
       consumer.startMessage()
@@ -1130,7 +1132,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()
@@ -1166,7 +1168,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()
@@ -1209,7 +1211,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()
@@ -1251,7 +1253,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()
@@ -1293,7 +1295,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()
@@ -1434,7 +1436,7 @@ class ParquetFormatScanSuite extends SparkQueryCompareTestSuite with Eventually 
           })
 
           withResource(cudf.Table.readParquet(new File(testPath))) { table =>
-            GpuColumnVector.debug("DIRECT READ", table)
+            debugPrinter.debug("DIRECT READ", table)
           }
 
           val data = spark.read.parquet(testPath).collect()


### PR DESCRIPTION
Deprecate GpuColumnVector.debug in favor of ai.rapids.cudf.TableDebug

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
