### PR TITLE
Clone submodule using git command instead of checkoutSCM plugin

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -349,10 +349,10 @@ void checkoutCode(String url, String sha) {
                                     credentialsId: 'github-token',
                                     url          : url,
                                     refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true],
-                                [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
+             extensions      : [[$class: 'CloneOption', shallow: true]]
         ]
     )
+    sh "git submodule update --init"
     if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"
     }

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -213,10 +213,10 @@ void checkoutCode(String url, String sha) {
                                     credentialsId: 'github-token',
                                     url          : url,
                                     refspec      : '+refs/pull/*/merge:refs/remotes/origin/pr/*']],
-             extensions      : [[$class: 'CloneOption', shallow: true],
-                                [$class: 'SubmoduleOption', disableSubmodules: false, shallow: true, parentCredentials: true]]
+             extensions      : [[$class: 'CloneOption', shallow: true]]
         ]
     )
+    sh "git submodule update --init"
     if (!common.isSubmoduleInit(this)) {
         error "Failed to clone submodule : thirdparty/parquet-testing"
     }


### PR DESCRIPTION
To fix : https://github.com/NVIDIA/spark-rapids/issues/8930

As checkoutSCM plugin is unstable for pre-merge CI, it is often unable to clone submodules

Change to use `git submodule update --init` instead of checkoutSCM plugin, to clone submodule source code

Tried over 30 times this morning, and `git submodule update --init` can always clone submodule source, while checkoutSCM plugin failed every time.