### PR TITLE
Don't go over shuffle limits on CPU

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuHashPartitioningBase.scala
@@ -56,8 +56,7 @@ abstract class GpuHashPartitioningBase(expressions: Seq[Expression], numPartitio
           partitionInternalAndClose(batch)
         }
       }
-      val ret = sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
-      ret.zipWithIndex.filter(_._1 != null)
+      sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuPartitioning.scala
@@ -28,6 +28,11 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuShuffleEnv
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
+object GpuPartitioning {
+  // The maximum size of an Array minus a bit for overhead for metadata
+  val MaxCpuBatchSize = 2147483639L - 2048L
+}
+
 trait GpuPartitioning extends Partitioning {
   private[this] val (maxCompressionBatchSize, _useGPUShuffle, _useMultiThreadedShuffle) = {
     val rapidsConf = new RapidsConf(SQLConf.get)
@@ -89,11 +94,36 @@ trait GpuPartitioning extends Partitioning {
     batches
   }
 
+  private def reslice(batch: ColumnarBatch, numSlices: Int): Seq[ColumnarBatch] = {
+    if (batch.numCols() > 0) {
+      withResource(batch) { _ =>
+        val totalRows = batch.numRows()
+        val rowsPerBatch = math.ceil(totalRows.toDouble / numSlices).toInt
+        val first = batch.column(0).asInstanceOf[SlicedGpuColumnVector]
+        val startOffset = first.getStart
+        val endOffset = first.getEnd
+        val hostColumns = (0 until batch.numCols()).map { index =>
+          batch.column(index).asInstanceOf[SlicedGpuColumnVector].getWrap
+        }.toArray
+
+        startOffset.until(endOffset, rowsPerBatch).map { startIndex =>
+          val end = math.min(startIndex + rowsPerBatch, endOffset)
+          sliceBatch(hostColumns, startIndex, end)
+        }.toList
+      }
+    } else {
+      // This should never happen, but...
+      Seq(batch)
+    }
+  }
+
   def sliceInternalOnCpuAndClose(numRows: Int, partitionIndexes: Array[Int],
-      partitionColumns: Array[GpuColumnVector]): Array[ColumnarBatch] = {
+      partitionColumns: Array[GpuColumnVector]): Array[(ColumnarBatch, Int)] = {
     // We need to make sure that we have a null count calculated ahead of time.
     // This should be a temp work around.
     partitionColumns.foreach(_.getBase.getNullCount)
+    val totalInputSize = GpuColumnVector.getTotalDeviceMemoryUsed(partitionColumns)
+    val mightNeedToSplit = totalInputSize > GpuPartitioning.MaxCpuBatchSize
 
     val hostPartColumns = withResource(partitionColumns) { _ =>
       partitionColumns.map(_.copyToHost())
@@ -102,22 +132,46 @@ trait GpuPartitioning extends Partitioning {
       // Leaving the GPU for a while
       GpuSemaphore.releaseIfNecessary(TaskContext.get())
 
-      val ret = new Array[ColumnarBatch](numPartitions)
+      val origParts = new Array[ColumnarBatch](numPartitions)
       var start = 0
       for (i <- 1 until Math.min(numPartitions, partitionIndexes.length)) {
         val idx = partitionIndexes(i)
-        ret(i - 1) = sliceBatch(hostPartColumns, start, idx)
+        origParts(i - 1) = sliceBatch(hostPartColumns, start, idx)
         start = idx
       }
-      ret(numPartitions - 1) = sliceBatch(hostPartColumns, start, numRows)
-      ret
+      origParts(numPartitions - 1) = sliceBatch(hostPartColumns, start, numRows)
+      val tmp = origParts.zipWithIndex.filter(_._1 != null)
+      // Spark CPU shuffle in some cases has limits on the size of the data a single
+      //  row can have. It is a little complicated because the limit is on the compressed
+      //  and encrypted buffer, but for now we are just going to assume it is about the same
+      // size.
+      if (mightNeedToSplit) {
+        tmp.flatMap {
+          case (batch, part) =>
+            val totalSize = SlicedGpuColumnVector.getTotalHostMemoryUsed(batch)
+            val numOutputBatches =
+              math.ceil(totalSize.toDouble / GpuPartitioning.MaxCpuBatchSize).toInt
+            if (numOutputBatches > 1) {
+              // For now we are going to slice it on number of rows instead of looking
+              // at each row to try and decide. If we get in trouble we can probably
+              // make this recursive and keep splitting more until it is small enough.
+              reslice(batch, numOutputBatches).map { subBatch =>
+                (subBatch, part)
+              }
+            } else {
+              Seq((batch, part))
+            }
+        }
+      } else {
+        tmp
+      }
     } finally {
       hostPartColumns.safeClose()
     }
   }
 
   def sliceInternalGpuOrCpuAndClose(numRows: Int, partitionIndexes: Array[Int],
-      partitionColumns: Array[GpuColumnVector]): Array[ColumnarBatch] = {
+      partitionColumns: Array[GpuColumnVector]): Array[(ColumnarBatch, Int)] = {
     val sliceOnGpu = usesGPUShuffle
     val nvtxRangeKey = if (sliceOnGpu) {
       "sliceInternalOnGpu"
@@ -128,7 +182,8 @@ trait GpuPartitioning extends Partitioning {
     // for large number of small splits.
     withResource(new NvtxRange(nvtxRangeKey, NvtxColor.CYAN)) { _ =>
       if (sliceOnGpu) {
-        sliceInternalOnGpuAndClose(numRows, partitionIndexes, partitionColumns)
+        val tmp = sliceInternalOnGpuAndClose(numRows, partitionIndexes, partitionColumns)
+        tmp.zipWithIndex.filter(_._1 != null)
       } else {
         sliceInternalOnCpuAndClose(numRows, partitionIndexes, partitionColumns)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRangePartitioner.scala
@@ -221,15 +221,13 @@ case class GpuRangePartitioner(
   override def columnarEvalAny(batch: ColumnarBatch): Any = {
     if (rangeBounds.nonEmpty) {
       val (parts, partitionColumns) = computeBoundsAndClose(batch)
-      val slicedCb = sliceInternalGpuOrCpuAndClose(partitionColumns.head.getRowCount.toInt,
+      sliceInternalGpuOrCpuAndClose(partitionColumns.head.getRowCount.toInt,
         parts, partitionColumns)
-      slicedCb.zipWithIndex.filter(_._1 != null)
     } else {
       // Nothing needs to be sliced but a contiguous table is needed for GPU shuffle which
       // slice will produce.
-      val sliced = sliceInternalGpuOrCpuAndClose(batch.numRows, Array(0),
+      sliceInternalGpuOrCpuAndClose(batch.numRows, Array(0),
         GpuColumnVector.extractColumns(batch))
-      sliced.zipWithIndex.filter(_._1 != null)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRoundRobinPartitioning.scala
@@ -77,9 +77,7 @@ case class GpuRoundRobinPartitioning(numPartitions: Int)
           partitionRange.close()
         }
       }
-      val ret: Array[ColumnarBatch] =
-        sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
-      ret.zipWithIndex.filter(_._1 != null)
+      sliceInternalGpuOrCpuAndClose(numRows, partitionIndexes, partitionColumns)
     } finally {
       totalRange.close()
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSinglePartitioning.scala
@@ -44,11 +44,10 @@ case object GpuSinglePartitioning extends GpuExpression with ShimExpression
     } else {
       // Nothing needs to be sliced but a contiguous table is needed for GPU shuffle which
       // slice will produce.
-      val sliced = sliceInternalGpuOrCpuAndClose(
+      sliceInternalGpuOrCpuAndClose(
         batch.numRows,
         Array(0),
         GpuColumnVector.extractColumns(batch))
-      sliced.zipWithIndex.filter(_._1 != null)
     }
   }
 


### PR DESCRIPTION
Fixes #45 

I don't have a good way to test this right now. The scale tests should definitely cover it.  I ran some manual tests.

NSD at scale factor 3k showed no performance regression with the internal benchmark setup.  Technically with 3 runs one of the queries showed a 500 ms regression and another showed a 800 ms advantage with a p value < 0.05, but overall the run time was 3 seconds slower with no real measurable difference.

However when I run my manual test there was a 10% performance regression.

```
import org.apache.spark.sql.tests.datagen._
val table = DBGen().addTable("test_table", "s1 string, s2 string, s3 string, s4 string", 200000000L)
table("s1").setSeedRange(0, 1)
table("s4").setSeedRange(5, 5)
table.toDF(spark, 12).write.mode("overwrite").parquet("./target/INPUT")
spark.time(spark.read.parquet("./target/INPUT").selectExpr("*", "min(s3) OVER (PARTITION BY s1 ORDER BY s2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS min_s3", "max(s3) OVER (PARTITION BY s1 ORDER BY s2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as max_s3").repartition(col("s4")).write.mode("overwrite").parquet("./target/OUTPUT"))
```

When the shuffle partitions are set to 200 (the default which uses the optimized sort bypass shuffle) then without the patch the time took 91140 ms, but with the patch the time was 100215 ms.  Note that this was just a single run. I want to do more, but you get the point.  The good news is that with 201 partitions, where the bypass shuffle no longer works, the original code would crash with an out of memory error, due to limitations in java/scala arrays, and the new code will not crash.

I think this is an acceptable tradeoff, especially because it is really rare to ever hit a situation like this to begin with. I will run a few more tests to see if the pattern holds for the time.