### PR TITLE
Fix issues around bloom filter with multple columns [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -163,6 +163,12 @@ trait GpuExpression extends Expression {
       case c: GpuExpression => c.hasSideEffects
       case _ => false // This path should never really happen
     }
+
+  /**
+   * If this returns true then tiered project will stop looking to combine expressions when
+   * this is seen.
+   */
+  def disableTieredProjectCombine: Boolean = hasSideEffects
 }
 
 abstract class GpuLeafExpression extends GpuExpression with ShimExpression {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -436,6 +436,11 @@ object GpuScalar extends Logging {
             withResource(s.getListAsColumnView) { elementView =>
               GpuColumnVector.typeConversionAllowed(elementView, elementType)
             }
+          case MapType(keyType, valueType, _) =>
+            withResource(s.getListAsColumnView) { elementView =>
+              GpuColumnVector.typeConversionAllowed(elementView,
+                StructType(Seq(StructField("key", keyType), StructField("value", valueType))))
+            }
           case BinaryType =>
             withResource(s.getListAsColumnView) { childView =>
               DType.UINT8.equals(childView.getType)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/literals.scala
@@ -430,18 +430,32 @@ object GpuScalar extends Logging {
 
   private def typeConversionAllowed(s: Scalar, sType: DataType): Boolean = {
     s.getType match {
-      case dt if dt.isNestedType =>
+      case DType.LIST =>
         sType match {
-          // Now supports only list for nested type.
           case ArrayType(elementType, _) =>
-            if (DType.LIST.equals(dt)) {
-              withResource(s.getListAsColumnView) { elementView =>
-                GpuColumnVector.typeConversionAllowed(elementView, elementType)
-              }
-            } else {
-              false
+            withResource(s.getListAsColumnView) { elementView =>
+              GpuColumnVector.typeConversionAllowed(elementView, elementType)
+            }
+          case BinaryType =>
+            withResource(s.getListAsColumnView) { childView =>
+              DType.UINT8.equals(childView.getType)
             }
           case _ => false // Unsupported type
+        }
+      case DType.STRUCT =>
+        sType match {
+          case st: StructType =>
+            withResource(s.getChildrenFromStructScalar) { children =>
+              if (children.length == st.length) {
+                children.zip(st.map(_.dataType)).forall {
+                  case (cv, dt) =>
+                    GpuColumnVector.typeConversionAllowed(cv, dt)
+                }
+              } else {
+                false
+              }
+            }
+          case _ => false
         }
       case nonNested =>
         GpuColumnVector.getNonNestedRapidsType(sType).equals(nonNested)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.rapids.catalyst.expressions
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.{GpuAlias, GpuBloomFilterMightContain, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
+import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, AttributeSet, CaseWhen, Coalesce, Expression, If, LeafExpression, PlanExpression}
@@ -193,10 +193,8 @@ class GpuEquivalentExpressions {
     val skip = expr.isInstanceOf[LeafExpression] ||
       expr.isInstanceOf[GpuLeafExpression] ||
       expr.isInstanceOf[GpuUnevaluable] ||
-      // GpuBloomFilterMightContain is a work around because it requires a scalar as input,
-      // and tiered project can mess that up.
-      expr.isInstanceOf[GpuBloomFilterMightContain] ||
-      (expr.isInstanceOf[GpuExpression] && expr.asInstanceOf[GpuExpression].hasSideEffects) ||
+      (expr.isInstanceOf[GpuExpression] &&
+          expr.asInstanceOf[GpuExpression].disableTieredProjectCombine) ||
       // `LambdaVariable` is usually used as a loop variable, which can't be evaluated ahead of the
       // loop. So we can't evaluate sub-expressions containing `LambdaVariable` at the beginning.
       expr.find(_.isInstanceOf[LambdaVariable]).isDefined ||

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.rapids.catalyst.expressions
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.{GpuAlias, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
+import com.nvidia.spark.rapids.{GpuAlias, GpuBloomFilterMightContain, GpuCaseWhen, GpuCoalesce, GpuExpression, GpuIf, GpuLeafExpression, GpuUnevaluable}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, AttributeSet, CaseWhen, Coalesce, Expression, If, LeafExpression, PlanExpression}
@@ -193,6 +193,9 @@ class GpuEquivalentExpressions {
     val skip = expr.isInstanceOf[LeafExpression] ||
       expr.isInstanceOf[GpuLeafExpression] ||
       expr.isInstanceOf[GpuUnevaluable] ||
+      // GpuBloomFilterMightContain is a work around because it requires a scalar as input,
+      // and tiered project can mess that up.
+      expr.isInstanceOf[GpuBloomFilterMightContain] ||
       (expr.isInstanceOf[GpuExpression] && expr.asInstanceOf[GpuExpression].hasSideEffects) ||
       // `LambdaVariable` is usually used as a loop variable, which can't be evaluated ahead of the
       // loop. So we can't evaluate sub-expressions containing `LambdaVariable` at the beginning.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -60,7 +60,7 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
       case s: GpuScalar =>
         // For a scalar in we want a scalar out.
         if (!s.isValid) {
-          GpuScalar.from(null, dt)
+          GpuScalar(null, dt)
         } else {
           withResource(s.getBase.getChildrenFromStructScalar) { children =>
             GpuScalar.wrap(children(ordinal).getScalarElement(0), dt)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/complexTypeExtractors.scala
@@ -17,14 +17,13 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.{BinaryOp, ColumnVector, ColumnView, DType, Scalar}
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuListUtils, GpuMapUtils, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, UnaryExprMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuBinaryExpression, GpuColumnVector, GpuExpression, GpuExpressionsUtils, GpuListUtils, GpuMapUtils, GpuScalar, GpuUnaryExpression, RapidsConf, RapidsMeta, UnaryExprMeta}
 import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.ArrayIndexUtils.firstIndexAndNumElementUnchecked
 import com.nvidia.spark.rapids.BoolUtils.isAnyValidTrue
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims._
 
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, TypeUtils}
@@ -51,30 +50,29 @@ case class GpuGetStructField(child: Expression, ordinal: Int, name: Option[Strin
   override def sql: String =
     child.sql + s".${quoteIdentifier(name.getOrElse(childSchema(ordinal).name))}"
 
-  override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
-    withResourceIfAllowed(child.columnarEvalAny(batch)) { input =>
-      val dt = dataType
-      input match {
-        case cv: GpuColumnVector =>
-          withResource(cv.getBase.getChildColumnView(ordinal)) { view =>
-            GpuColumnVector.from(view.copyToColumnVector(), dt)
+  override def columnarEvalAny(batch: ColumnarBatch): Any = {
+    val dt = dataType
+    withResourceIfAllowed(child.columnarEvalAny(batch)) {
+      case cv: GpuColumnVector =>
+        withResource(cv.getBase.getChildColumnView(ordinal)) { view =>
+          GpuColumnVector.from(view.copyToColumnVector(), dt)
+        }
+      case s: GpuScalar =>
+        // For a scalar in we want a scalar out.
+        if (!s.isValid) {
+          GpuScalar.from(null, dt)
+        } else {
+          withResource(s.getBase.getChildrenFromStructScalar) { children =>
+            GpuScalar.wrap(children(ordinal).getScalarElement(0), dt)
           }
-        case null =>
-          GpuColumnVector.fromNull(batch.numRows(), dt)
-        // Literal struct values are wrapped in GpuScalar
-        case s: GpuScalar =>
-          s.getValue match {
-            case null =>
-              GpuColumnVector.fromNull(batch.numRows(), dt)
-            case ir: InternalRow =>
-              val tmp = ir.get(ordinal, dt)
-              withResource(GpuScalar.from(tmp, dt)) { scalar =>
-                GpuColumnVector.from(scalar, batch.numRows(), dt)
-              }
-          }
-      }
+        }
+      case other =>
+        throw new IllegalArgumentException(s"Got an unexpected type out of columnarEvalAny $other")
     }
   }
+
+  override def columnarEval(batch: ColumnarBatch): GpuColumnVector =
+    GpuExpressionsUtils.resolveColumnVector(columnarEvalAny(batch), batch.numRows())
 }
 
 /**

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
@@ -44,11 +44,13 @@ case class GpuBloomFilterMightContain(
   extends ShimBinaryExpression with GpuExpression with AutoCloseable {
 
   @transient private lazy val bloomFilter: GpuBloomFilter = {
-    Option(TaskContext.get).foreach(_.addTaskCompletionListener[Unit](_ => close()))
-    withResourceIfAllowed(bloomFilterExpression.columnarEvalAny(new ColumnarBatch(Array.empty))) {
+    val ret = withResourceIfAllowed(
+      bloomFilterExpression.columnarEvalAny(new ColumnarBatch(Array.empty))) {
       case s: GpuScalar => GpuBloomFilter(s)
       case x => throw new IllegalStateException(s"Expected GPU scalar, found $x")
     }
+    Option(TaskContext.get).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+    ret
   }
 
   override def nullable: Boolean = true

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
@@ -98,6 +98,9 @@ case class GpuBloomFilterMightContain(
     }
   }
 
+  // This is disabled until https://github.com/NVIDIA/spark-rapids/issues/8945 can be fixed
+  override def disableTieredProjectCombine: Boolean = true
+
   override def close(): Unit = {
     if (bloomFilter != null) {
       bloomFilter.close()


### PR DESCRIPTION
Spark has an optimization where it will combine multiple scalar subqueries into a single scalar subquery using a struct. When that happens the GpuBloomFilterMayContain code gets in trouble because of several different bugs. This addresses those bugs.

  1. The first bug is that GpuScalarSubquery would install a task callback before it had initialized the data it was going to close. This resulted in a loop where the init would fail and then when the callback happened to end the task it would fail again. It almost looked like ti was an infinite loop, but I never let it run long enough to know for sure.
   2. The second bug was that GpuStructGetField did not do the right thing for scalar input. This fixed that issue, and then as part of a memory optimization it kept the output a scalar too.
   3. The third bug was that a GpuScalar for a binary could not be constructed from a cudf.Scalar. This updates the code to deal with that, and also updates it so it can do the same for Structs.
   4. Finally the last issue was that tiered project was matching the scalar subquery above the GpuBloomFilterMayContain and ended up causing it to be turned into a ColumnVector instead of a Scalar. I fixed that by having TieredProject not try to work with the MayContain, but I plan on having a follow on issue to address this better.
