### PR TITLE
[Spark 3.5.0] Shim access to StructType.fromAttributes

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuSubPartitionHashJoin.scala
@@ -26,6 +26,7 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.plans.InnerLike
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -559,7 +560,7 @@ abstract class BaseSubHashJoinIterator(
 
 trait GpuSubPartitionHashJoin extends Logging { self: GpuHashJoin =>
 
-  protected lazy val buildSchema: StructType = StructType.fromAttributes(buildPlan.output)
+  protected lazy val buildSchema: StructType = DataTypeUtilsShim.fromAttributes(buildPlan.output)
 
   def doJoinBySubPartition(
       builtIter: Iterator[ColumnarBatch],

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.rapids.shims.SparkUpgradeExceptionShims
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.storage.BlockManagerId
@@ -43,7 +44,7 @@ object TrampolineUtil {
   def unionLikeMerge(left: DataType, right: DataType): DataType =
     ShimTrampolineUtil.unionLikeMerge(left, right)
 
-  def fromAttributes(attrs: Seq[Attribute]): StructType = StructType.fromAttributes(attrs)
+  def fromAttributes(attrs: Seq[Attribute]): StructType = DataTypeUtilsShim.fromAttributes(attrs)
 
   def toAttributes(structType: StructType): Seq[Attribute] = structType.toAttributes
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/BatchGroupUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/BatchGroupUtils.scala
@@ -27,9 +27,8 @@ import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateOrdering
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.vectorized.ColumnarBatch
-
 
 /**
  * A helper class to pack the group related items for the Python input.
@@ -455,9 +454,9 @@ class CoGroupedIterator(
   // the cuDF Arrow writer and the communication protocol.
   // We don't want to create multiple empty batches, instead leverage the ref count.
   private lazy val emptyLeftBatch: ColumnarBatch =
-    GpuColumnVector.emptyBatch(StructType.fromAttributes(leftSchema))
+    GpuColumnVector.emptyBatch(DataTypeUtilsShim.fromAttributes(leftSchema))
   private lazy val emptyRightBatch: ColumnarBatch =
-    GpuColumnVector.emptyBatch(StructType.fromAttributes(rightSchema))
+    GpuColumnVector.emptyBatch(DataTypeUtilsShim.fromAttributes(rightSchema))
 
   // Suppose runs inside a task context.
   TaskContext.get().addTaskCompletionListener[Unit] { _ =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.AggregateInPandasExec
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -250,7 +251,7 @@ case class GpuAggregateInPandasExec(
           pythonRunnerConf,
           // The whole group data should be written in a single call, so here is unlimited
           Int.MaxValue,
-          StructType.fromAttributes(pyOutAttributes),
+          DataTypeUtilsShim.fromAttributes(pyOutAttributes),
           () => queue.finish())
 
         val pyOutputIterator = pyRunner.compute(pyInputIter, context.partitionId(), context)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.api.python._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -274,7 +275,7 @@ case class GpuArrowEvalPythonExec(
     // On Databricks when projecting only one column from a Python UDF output where containing
     // multiple result columns, there will be only one attribute in the 'resultAttrs' for the
     // projecting output, but the output schema for this Python UDF contains multiple columns.
-    val pythonOutputSchema = StructType.fromAttributes(udfs.map(_.resultAttribute))
+    val pythonOutputSchema = DataTypeUtilsShim.fromAttributes(udfs.map(_.resultAttribute))
 
     val childOutput = child.output
     val targetBatchSize = batchSize

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapCoGroupsInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapCoGroupsInPandasExec.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistrib
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.FlatMapCoGroupsInPandasExec
 import org.apache.spark.sql.rapids.execution.python.BatchGroupUtils._
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -134,7 +135,7 @@ case class GpuFlatMapCoGroupsInPandasExec(
     lazy val isPythonOnGpuEnabled = GpuPythonHelper.isPythonOnGpuEnabled(conf)
     // Python wraps the resulting columns in a single struct column.
     val pythonOutputSchema = StructType(
-      StructField("out_struct", StructType.fromAttributes(output)) :: Nil)
+      StructField("out_struct", DataTypeUtilsShim.fromAttributes(output)) :: Nil)
 
     // Resolve the argument offsets and related attributes.
     val GroupArgs(leftDedupAttrs, leftArgOffsets, leftGroupingOffsets) =
@@ -163,8 +164,8 @@ case class GpuFlatMapCoGroupsInPandasExec(
           chainedFunc,
           PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
           Array(leftArgOffsets ++ rightArgOffsets),
-          StructType.fromAttributes(leftDedupAttrs),
-          StructType.fromAttributes(rightDedupAttrs),
+          DataTypeUtilsShim.fromAttributes(leftDedupAttrs),
+          DataTypeUtilsShim.fromAttributes(rightDedupAttrs),
           sessionLocalTimeZone,
           pythonRunnerConf,
           // The whole group data should be written in a single call, so here is unlimited

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuFlatMapGroupsInPandasExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.FlatMapGroupsInPandasExec
 import org.apache.spark.sql.rapids.execution.python.BatchGroupUtils._
 import org.apache.spark.sql.rapids.execution.python.shims._
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -115,7 +116,7 @@ case class GpuFlatMapGroupsInPandasExec(
     val localChildOutput = child.output
     // Python wraps the resulting columns in a single struct column.
     val pythonOutputSchema = StructType(
-        StructField("out_struct", StructType.fromAttributes(localOutput)) :: Nil)
+        StructField("out_struct", DataTypeUtilsShim.fromAttributes(localOutput)) :: Nil)
 
     // Resolve the argument offsets and related attributes.
     val GroupArgs(dedupAttrs, argOffsets, groupingOffsets) =
@@ -124,7 +125,7 @@ case class GpuFlatMapGroupsInPandasExec(
     val runnerShims = GpuArrowPythonRunnerShims(conf,
                         chainedFunc,
                         Array(argOffsets),
-                        StructType.fromAttributes(dedupAttrs),
+                        DataTypeUtilsShim.fromAttributes(dedupAttrs),
                         pythonOutputSchema)
 
     // Start processing. Map grouped batches to ArrowPythonRunner results.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuWindowInPandasExecBase.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.python._
 import org.apache.spark.sql.rapids.GpuAggregateExpression
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -489,7 +490,7 @@ trait GpuWindowInPandasExecBase extends ShimUnaryExecNode with GpuPythonExecBase
     // where containing multiple result columns, there will be only one item in the
     // 'windowExpression' for the projecting output, but the output schema for this Python
     // UDF contains multiple columns.
-    val pythonOutputSchema = StructType.fromAttributes(udfExpressions.map(_.resultAttribute))
+    val pythonOutputSchema = DataTypeUtilsShim.fromAttributes(udfExpressions.map(_.resultAttribute))
     val childOutput = child.output
 
     // 8) Start processing.

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/DataTypeUtilsShim.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/DataTypeUtilsShim.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "321db"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "340"}
+{"spark": "341"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.shims
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.types.StructType
+
+object DataTypeUtilsShim {
+  def fromAttributes(attributes: Seq[Attribute]): StructType =
+    StructType.fromAttributes(attributes)
+}

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -33,6 +33,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.rapids.execution.python.{BatchQueue, CombiningIterator, GpuArrowPythonRunner, GpuPythonHelper, GpuPythonUDF, GpuWindowInPandasExecBase, GroupingIterator}
+import org.apache.spark.sql.rapids.shims.DataTypeUtilsShim
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -187,7 +188,7 @@ case class GpuWindowInPandasExec(
     // where containing multiple result columns, there will be only one item in the
     // 'windowExpression' for the projecting output, but the output schema for this Python
     // UDF contains multiple columns.
-    val pythonOutputSchema = StructType.fromAttributes(udfExpressions.map(_.resultAttribute))
+    val pythonOutputSchema = DataTypeUtilsShim.fromAttributes(udfExpressions.map(_.resultAttribute))
     val childOutput = child.output
 
     // 8) Start processing.


### PR DESCRIPTION
Part of https://github.com/NVIDIA/spark-rapids/issues/8121

Spark 3.5.0 moves `fromAttributes` from `StructType` to `DataTypeUtils` in [this commit](https://github.com/apache/spark/commit/5406982703cd9fcabda69b1a8078354be3ee739c#diff-f32824b644597f1fed45f7fec06658a7d223bd9bd961f4a6f95695a7bb9243d3) and it is also no longer private to the `sql` package.

This PR adds a new `DataTypeUtilsShim` where calls to `StructType.fromAttributes` are isolated. When we add support for Spark 3.5.0 we will add a version of this shim that calls `DataTypeUtils.fromAttributes` instead.

