### PR TITLE
Update JNI and private version to released 23.08.0 [databricks]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,8 +548,8 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
-        <spark-rapids-jni.version>23.08.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>23.08.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>23.08.0</spark-rapids-jni.version>
+        <spark-rapids-private.version>23.08.0</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
bump up JNI and private versions to 23.08.0

**NOTE:** I will trigger CI after JNI and private artifacts are available at maven central