### PR TITLE
Fix building dockerfile.cuda hanging at tzdata installation [skip ci]

### DIFF
--- a/docs/get-started/Dockerfile.cuda
+++ b/docs/get-started/Dockerfile.cuda
@@ -61,7 +61,7 @@ COPY getGpusResources.sh /opt/sparkRapidsPlugin
 RUN mkdir /opt/spark/python
 # TODO: Investigate running both pip and pip3 via virtualenvs
 RUN apt-get update && \
-    apt install -y python python-pip && \
+    apt install -y python wget && wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && python get-pip.py && \
     apt install -y python3 python3-pip && \
     # We remove ensurepip since it adds no functionality since pip is
     # installed on the image and it just takes up 1.6MB on the image

--- a/docs/get-started/Dockerfile.cuda
+++ b/docs/get-started/Dockerfile.cuda
@@ -21,6 +21,7 @@ ARG spark_uid=185
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
 # Install java dependencies
+ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-8-jre
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
 ENV PATH $PATH:/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin:/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin


### PR DESCRIPTION
even though we did not explicitly install tzdata pkgs, some other pkg installations requiring tzdata as dep for cuda dockerfile would hang while building image, 
```
13:36:31  ------------------
13:36:31  
13:36:31  Please select the geographic area in which you live. Subsequent configuration
13:36:31  questions will narrow this down by presenting a list of cities, representing
13:36:31  the time zones in which they are located.
13:36:31  
13:36:31    1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
13:36:31    2. America     5. Arctic     8. Europe    11. SystemV
13:36:31    3. Antarctica  6. Asia       9. Indian    12. US
```

add `DEBIAN_FRONTEND="noninteractive"` to solve this issue. 

Verified internally default as UTC on CI machines
```
14:48:56  Current default time zone: 'Etc/UTC'
14:48:56  Local time is now:      Wed Aug  9 06:48:55 UTC 2023.
14:48:56  Universal Time is now:  Wed Aug  9 06:48:55 UTC 2023.
```

Also found some deprecated python-pip pkg, and replaced it w/ get-pip script in this change
```
E: Package 'python-pip' has no installation candidate
```