### PR TITLE
Enable GPU acceleration of Bloom filter join expressions by default

### DIFF
--- a/integration_tests/src/main/python/join_test.py
+++ b/integration_tests/src/main/python/join_test.py
@@ -937,11 +937,6 @@ bloom_filter_confs = {
     "spark.sql.optimizer.runtime.bloomFilter.enabled": "true"
 }
 
-bloom_filter_exprs_enabled = {
-    "spark.rapids.sql.expression.BloomFilterMightContain": "true",
-    "spark.rapids.sql.expression.BloomFilterAggregate": "true"
-}
-
 def check_bloom_filter_join(confs, expected_classes, is_multi_column):
     def do_join(spark):
         if is_multi_column:
@@ -955,24 +950,13 @@ def check_bloom_filter_join(confs, expected_classes, is_multi_column):
     all_confs = copy_and_update(bloom_filter_confs, confs)
     assert_cpu_and_gpu_are_equal_collect_with_capture(do_join, expected_classes, conf=all_confs)
 
-@allow_non_gpu("FilterExec", "ObjectHashAggregateExec", "ShuffleExchangeExec")
-@ignore_order(local=True)
-@pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
-@pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
-@pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
-def test_bloom_filter_disabled_by_default(is_multi_column):
-    check_bloom_filter_join(confs={},
-                            expected_classes="BloomFilterMightContain,BloomFilterAggregate",
-                            is_multi_column=is_multi_column)
-
 @ignore_order(local=True)
 @pytest.mark.parametrize("batch_size", ['1g', '1000'], ids=idfn)
 @pytest.mark.parametrize("is_multi_column", [False, True], ids=idfn)
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
 def test_bloom_filter_join(batch_size, is_multi_column):
-    conf = copy_and_update(bloom_filter_exprs_enabled,
-                           {"spark.rapids.sql.batchSizeBytes": batch_size})
+    conf = {"spark.rapids.sql.batchSizeBytes": batch_size}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -983,8 +967,7 @@ def test_bloom_filter_join(batch_size, is_multi_column):
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
 def test_bloom_filter_join_cpu_probe(is_multi_column):
-    conf = copy_and_update(bloom_filter_exprs_enabled,
-                           {"spark.rapids.sql.expression.BloomFilterMightContain": "false"})
+    conf = {"spark.rapids.sql.expression.BloomFilterMightContain": "false"}
     check_bloom_filter_join(confs=conf,
                             expected_classes="BloomFilterMightContain,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -995,8 +978,7 @@ def test_bloom_filter_join_cpu_probe(is_multi_column):
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
 def test_bloom_filter_join_cpu_build(is_multi_column):
-    conf = copy_and_update(bloom_filter_exprs_enabled,
-                           {"spark.rapids.sql.expression.BloomFilterAggregate": "false"})
+    conf = {"spark.rapids.sql.expression.BloomFilterAggregate": "false"}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,BloomFilterAggregate",
                             is_multi_column=is_multi_column)
@@ -1008,8 +990,7 @@ def test_bloom_filter_join_cpu_build(is_multi_column):
 @pytest.mark.skipif(is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/8921")
 @pytest.mark.skipif(is_before_spark_330(), reason="Bloom filter joins added in Spark 3.3.0")
 def test_bloom_filter_join_split_cpu_build(agg_replace_mode, is_multi_column):
-    conf = copy_and_update(bloom_filter_exprs_enabled,
-                           {"spark.rapids.sql.hashAgg.replaceMode": agg_replace_mode})
+    conf = {"spark.rapids.sql.hashAgg.replaceMode": agg_replace_mode}
     check_bloom_filter_join(confs=conf,
                             expected_classes="GpuBloomFilterMightContain,BloomFilterAggregate,GpuBloomFilterAggregate",
                             is_multi_column=is_multi_column)

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
@@ -46,7 +46,7 @@ object BloomFilterShims {
         (a, conf, p, r) => new BinaryExprMeta[BloomFilterMightContain](a, conf, p, r) {
           override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
             GpuBloomFilterMightContain(lhs, rhs)
-        }).disabledByDefault("Bloom filter join acceleration is experimental"),
+        }),
       GpuOverrides.expr[BloomFilterAggregate](
         "Bloom filter build",
         ExprChecksImpl(Map(
@@ -64,7 +64,7 @@ object BloomFilterShims {
               a.estimatedNumItemsExpression.eval().asInstanceOf[Number].longValue,
               a.numBitsExpression.eval().asInstanceOf[Number].longValue)
           }
-        }).disabledByDefault("Bloom filter join acceleration is experimental")
+        })
     ).map(r => (r.getClassFor.asSubclass(classOf[Expression]), r)).toMap
   }
 }

--- a/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuite.scala
+++ b/tests/src/test/spark330/scala/com/nvidia/spark/rapids/BloomFilterAggregateQuerySuite.scala
@@ -38,8 +38,6 @@ import org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback
 
 class BloomFilterAggregateQuerySuite extends SparkQueryCompareTestSuite {
   val bloomFilterEnabledConf = new SparkConf()
-    .set("spark.rapids.sql.expression.BloomFilterMightContain", "true")
-    .set("spark.rapids.sql.expression.BloomFilterAggregate", "true")
   val funcId_bloom_filter_agg = new FunctionIdentifier("bloom_filter_agg")
   val funcId_might_contain = new FunctionIdentifier("might_contain")
 


### PR DESCRIPTION
Fixes #8965.  Enables GpuBloomFilterMightContain and GpuBloomFilterAggregate by default and updates the tests accordingly.