### PR TITLE
Add ability to debug dump input data only on errors

### DIFF
--- a/integration_tests/src/main/python/avro_test.py
+++ b/integration_tests/src/main/python/avro_test.py
@@ -109,6 +109,7 @@ def test_coalescing_uniform_sync(spark_tmp_path, v1_enabled_list):
     all_confs = copy_and_update(_enable_all_types_conf, {
         'spark.rapids.sql.format.avro.reader.type': 'COALESCING',
         'spark.rapids.sql.avro.debug.dumpPrefix': dump_path,
+        'spark.rapids.sql.avro.debug.dumpAlways': 'true',
         'spark.sql.sources.useV1SourceList': v1_enabled_list})
     with_gpu_session(
         lambda spark: spark.read.format("avro").load(data_path).collect(),

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquet.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquet.java
@@ -69,7 +69,8 @@ public class GpuParquet {
     private long maxBatchSizeBytes = Integer.MAX_VALUE;
     private long targetBatchSizeBytes = Integer.MAX_VALUE;
     private boolean useChunkedReader = false;
-    private String debugDumpPrefix = null;
+    private scala.Option<String> debugDumpPrefix = null;
+    private boolean debugDumpAlways = false;
     private scala.collection.immutable.Map<String, GpuMetric> metrics = null;
 
     private ReadBuilder(InputFile file) {
@@ -144,8 +145,9 @@ public class GpuParquet {
       return this;
     }
 
-    public ReadBuilder withDebugDumpPrefix(String dumpPrefix) {
+    public ReadBuilder withDebugDump(scala.Option<String> dumpPrefix, boolean dumpAlways) {
       this.debugDumpPrefix = dumpPrefix;
+      this.debugDumpAlways = dumpAlways;
       return this;
     }
 
@@ -160,7 +162,7 @@ public class GpuParquet {
           InternalRow.empty(), file.location(), start, length);
       return new GpuParquetReader(file, projectSchema, options, nameMapping, filter, caseSensitive,
           idToConstant, deleteFilter, partFile, conf, maxBatchSizeRows, maxBatchSizeBytes,
-          targetBatchSizeBytes, useChunkedReader, debugDumpPrefix, metrics);
+          targetBatchSizeBytes, useChunkedReader, debugDumpPrefix, debugDumpAlways, metrics);
     }
   }
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
@@ -86,7 +86,8 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
   private final boolean useChunkedReader;
-  private final String debugDumpPrefix;
+  private final scala.Option<String> debugDumpPrefix;
+  private final boolean debugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
 
   public GpuParquetReader(
@@ -95,7 +96,8 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
       Map<Integer, ?> idToConstant, GpuDeleteFilter deleteFilter,
       PartitionedFile partFile, Configuration conf, int maxBatchSizeRows,
       long maxBatchSizeBytes, long targetBatchSizeBytes, boolean useChunkedReader,
-      String debugDumpPrefix, scala.collection.immutable.Map<String, GpuMetric> metrics) {
+      scala.Option<String> debugDumpPrefix, boolean debugDumpAlways,
+      scala.collection.immutable.Map<String, GpuMetric> metrics) {
     this.input = input;
     this.expectedSchema = expectedSchema;
     this.options = options;
@@ -111,6 +113,7 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.useChunkedReader = useChunkedReader;
     this.debugDumpPrefix = debugDumpPrefix;
+    this.debugDumpAlways = debugDumpAlways;
     this.metrics = metrics;
   }
 
@@ -134,8 +137,8 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
       // reuse Parquet scan code to read the raw data from the file
       ParquetPartitionReader parquetPartReader = new ParquetPartitionReader(conf, partFile,
           new Path(input.location()), clippedBlocks, fileReadSchema, caseSensitive,
-          partReaderSparkSchema, debugDumpPrefix, maxBatchSizeRows, maxBatchSizeBytes,
-          targetBatchSizeBytes, useChunkedReader, metrics,
+          partReaderSparkSchema, debugDumpPrefix, debugDumpAlways,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, useChunkedReader, metrics,
           true, // isCorrectedInt96RebaseMode
           true, // isCorrectedRebaseMode
           true, // hasInt96Timestamps

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuBatchDataReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuBatchDataReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,13 +48,14 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
   private final boolean useChunkedReader;
-  private final String parquetDebugDumpPrefix;
+  private final scala.Option<String> parquetDebugDumpPrefix;
+  private final boolean parquetDebugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
 
   GpuBatchDataReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive,
                      Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
                      long targetBatchSizeBytes, boolean useChunkedReader,
-                     String parquetDebugDumpPrefix,
+                     scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
                      scala.collection.immutable.Map<String, GpuMetric> metrics) {
     super(table, task);
     this.expectedSchema = expectedSchema;
@@ -66,6 +67,7 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.useChunkedReader = useChunkedReader;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
+    this.parquetDebugDumpAlways = parquetDebugDumpAlways;
     this.metrics = metrics;
   }
 
@@ -99,7 +101,7 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
           .withMaxBatchSizeBytes(maxBatchSizeBytes)
           .withTargetBatchSizeBytes(targetBatchSizeBytes)
           .withUseChunkedReader(useChunkedReader)
-          .withDebugDumpPrefix(parquetDebugDumpPrefix)
+          .withDebugDump(parquetDebugDumpPrefix, parquetDebugDumpAlways)
           .withMetrics(metrics);
 
       if (nameMapping != null) {

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
@@ -67,7 +67,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
   private final long targetBatchSizeBytes;
 
   private final boolean useChunkedReader;
-  private final String parquetDebugDumpPrefix;
+  private final scala.Option<String> parquetDebugDumpPrefix;
+  private final boolean parquetDebugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
   private final boolean useMultiThread;
   private final FileFormat fileFormat;
@@ -85,7 +86,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
       boolean caseSensitive, Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
       long targetBatchSizeBytes,
       boolean useChunkedReader,
-      String parquetDebugDumpPrefix, int numThreads, int maxNumFileProcessed,
+      scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
+      int numThreads, int maxNumFileProcessed,
       boolean useMultiThread, FileFormat fileFormat,
       scala.collection.immutable.Map<String, GpuMetric> metrics,
       boolean queryUsesInputFile) {
@@ -98,6 +100,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.useChunkedReader = useChunkedReader;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
+    this.parquetDebugDumpAlways = parquetDebugDumpAlways;
     this.useMultiThread = useMultiThread;
     this.fileFormat = fileFormat;
     this.metrics = metrics;
@@ -329,7 +332,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     protected FilePartitionReaderBase createRapidsReader(PartitionedFile[] pFiles,
         StructType partitionSchema) {
       return new MultiFileCloudParquetPartitionReader(conf, pFiles,
-          this::filterParquetBlocks, caseSensitive, parquetDebugDumpPrefix,
+          this::filterParquetBlocks, caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways,
           maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, useChunkedReader,
           metrics, partitionSchema,
           numThreads, maxNumFileProcessed,
@@ -403,8 +406,9 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
 
       return new MultiFileParquetPartitionReader(conf, pFiles,
           JavaConverters.asScalaBuffer(clippedBlocks).toSeq(),
-          caseSensitive, parquetDebugDumpPrefix, useChunkedReader, maxBatchSizeRows,
-          maxBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema, numThreads,
+          caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways, useChunkedReader,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema,
+          numThreads,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
           false // useFieldId

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,7 +283,8 @@ abstract class GpuSparkScan extends ScanWithMetricsWrapper
       super(task.task, task.table(), task.expectedSchema(), task.isCaseSensitive(),
           task.getConfiguration(), task.getMaxBatchSizeRows(), task.getMaxBatchSizeBytes(),
           task.getTargetBatchSizeBytes(), task.useChunkedReader(),
-          task.getParquetDebugDumpPrefix(), task.getNumThreads(), task.getMaxNumFileProcessed(),
+          task.getParquetDebugDumpPrefix(), task.getParquetDebugDumpAlways(),
+          task.getNumThreads(), task.getMaxNumFileProcessed(),
           useMultiThread, ff, metrics, queryUsesInputFile);
     }
   }
@@ -293,7 +294,7 @@ abstract class GpuSparkScan extends ScanWithMetricsWrapper
       super(task.task, task.table(), task.expectedSchema(), task.isCaseSensitive(),
           task.getConfiguration(), task.getMaxBatchSizeRows(), task.getMaxBatchSizeBytes(),
           task.getTargetBatchSizeBytes(), task.useChunkedReader(),
-          task.getParquetDebugDumpPrefix(), metrics);
+          task.getParquetDebugDumpPrefix(), task.getParquetDebugDumpAlways(), metrics);
     }
   }
 
@@ -308,7 +309,8 @@ abstract class GpuSparkScan extends ScanWithMetricsWrapper
     private final long maxBatchSizeBytes;
 
     private final long targetBatchSizeBytes;
-    private final String parquetDebugDumpPrefix;
+    private final scala.Option<String> parquetDebugDumpPrefix;
+    private final boolean parquetDebugDumpAlways;
     private final int numThreads;
     private final int maxNumFileProcessed;
 
@@ -333,6 +335,7 @@ abstract class GpuSparkScan extends ScanWithMetricsWrapper
       this.maxBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes();
       this.targetBatchSizeBytes = rapidsConf.gpuTargetBatchSizeBytes();
       this.parquetDebugDumpPrefix = rapidsConf.parquetDebugDumpPrefix();
+      this.parquetDebugDumpAlways = rapidsConf.parquetDebugDumpAlways();
       this.numThreads = rapidsConf.multiThreadReadNumThreads();
       this.maxNumFileProcessed = rapidsConf.maxNumParquetFilesParallel();
       this.useChunkedReader = rapidsConf.chunkedReaderEnabled();
@@ -371,8 +374,12 @@ abstract class GpuSparkScan extends ScanWithMetricsWrapper
       return targetBatchSizeBytes;
     }
 
-    public String getParquetDebugDumpPrefix() {
+    public scala.Option<String> getParquetDebugDumpPrefix() {
       return parquetDebugDumpPrefix;
+    }
+
+    public boolean getParquetDebugDumpAlways() {
+      return parquetDebugDumpAlways;
     }
 
     public int getNumThreads() {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -387,33 +387,6 @@ abstract class FilePartitionReaderBase(conf: Configuration, execMetrics: Map[Str
     batchIter = EmptyGpuColumnarBatchIterator
     isDone = true
   }
-
-  /**
-   * Dump the data from HostMemoryBuffer to a file named by debugDumpPrefix + random + format
-   *
-   * @param hmb             host data to be dumped
-   * @param dataLength      data size
-   * @param splits          PartitionedFile to be handled
-   * @param debugDumpPrefix file name prefix, if it is None, will not dump
-   * @param format          file name suffix, if it is None, will not dump
-   */
-  protected def dumpDataToFile(
-      hmb: HostMemoryBuffer,
-      dataLength: Long,
-      splits: Array[PartitionedFile],
-      debugDumpPrefix: Option[String] = None,
-      format: Option[String] = None): Unit = {
-    if (debugDumpPrefix.isDefined && format.isDefined) {
-      val (out, path) = FileUtils.createTempFile(conf, debugDumpPrefix.get, s".${format.get}")
-
-      withResource(out) { _ =>
-        withResource(new HostMemoryInputStream(hmb, dataLength)) { in =>
-          logInfo(s"Writing split data for ${splits.mkString(", ")} to $path")
-          IOUtils.copy(in, out)
-        }
-      }
-    }
-  }
 }
 
 // Contains the actual file path to read from and then an optional original path if its read from

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1127,6 +1127,7 @@ case class GpuParquetMultiFilePartitionReaderFactory(
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val useChunkedReader = rapidsConf.chunkedReaderEnabled
   private val debugDumpPrefix = rapidsConf.parquetDebugDumpPrefix
+  private val debugDumpAlways = rapidsConf.parquetDebugDumpAlways
   private val numThreads = rapidsConf.multiThreadReadNumThreads
   private val maxNumFileProcessed = rapidsConf.maxNumParquetFilesParallel
   private val ignoreMissingFiles = sqlConf.ignoreMissingFiles
@@ -1189,9 +1190,9 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     }
     val combineConf = CombineConf(combineThresholdSize, combineWaitTime)
     new MultiFileCloudParquetPartitionReader(conf, files, filterFunc, isCaseSensitive,
-      debugDumpPrefix, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetBatchSizeBytes,
-      useChunkedReader, metrics, partitionSchema, numThreads, maxNumFileProcessed,
-      ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId,
+      debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
+      targetBatchSizeBytes, useChunkedReader, metrics, partitionSchema, numThreads,
+      maxNumFileProcessed, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId,
       alluxioPathReplacementMap.getOrElse(Map.empty), alluxioReplacementTaskTime,
       queryUsesInputFile, keepReadsInOrderFromConf, combineConf)
   }
@@ -1303,9 +1304,9 @@ case class GpuParquetMultiFilePartitionReaderFactory(
       _ += TimeUnit.NANOSECONDS.toMillis(filterTime)
     }
     new MultiFileParquetPartitionReader(conf, files, clippedBlocks, isCaseSensitive,
-      debugDumpPrefix, useChunkedReader, maxReadBatchSizeRows, maxReadBatchSizeBytes,
-      targetBatchSizeBytes, metrics, partitionSchema, numThreads, ignoreMissingFiles,
-      ignoreCorruptFiles, readUseFieldId)
+      debugDumpPrefix, debugDumpAlways, useChunkedReader, maxReadBatchSizeRows,
+      maxReadBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema, numThreads,
+      ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId)
   }
 
   /**
@@ -1333,6 +1334,7 @@ case class GpuParquetPartitionReaderFactory(
 
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
   private val debugDumpPrefix = rapidsConf.parquetDebugDumpPrefix
+  private val debugDumpAlways = rapidsConf.parquetDebugDumpAlways
   private val maxReadBatchSizeRows = rapidsConf.maxReadBatchSizeRows
   private val maxReadBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes
   private val targetSizeBytes = rapidsConf.gpuTargetBatchSizeBytes
@@ -1364,8 +1366,8 @@ case class GpuParquetPartitionReaderFactory(
       _ += (System.nanoTime() - startTime)
     }
     new ParquetPartitionReader(conf, file, singleFileInfo.filePath, singleFileInfo.blocks,
-      singleFileInfo.schema, isCaseSensitive, readDataSchema,
-      debugDumpPrefix, maxReadBatchSizeRows, maxReadBatchSizeBytes, targetSizeBytes,
+      singleFileInfo.schema, isCaseSensitive, readDataSchema, debugDumpPrefix, debugDumpAlways,
+      maxReadBatchSizeRows, maxReadBatchSizeBytes, targetSizeBytes,
       useChunkedReader, metrics, singleFileInfo.isCorrectedInt96RebaseMode,
       singleFileInfo.isCorrectedRebaseMode, singleFileInfo.hasInt96Timestamps, readUseFieldId)
   }
@@ -1872,7 +1874,8 @@ private case class ParquetSingleDataBlockMeta(
  * @param clippedBlocks the block metadata from the original Parquet file that has been clipped
  *                      to only contain the column chunks to be read
  * @param isSchemaCaseSensitive whether schema is case sensitive
- * @param debugDumpPrefix a path prefix to use for dumping the fabricated Parquet data or null
+ * @param debugDumpPrefix a path prefix to use for dumping the fabricated Parquet data
+ * @param debugDumpAlways whether to debug dump always or only on errors
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
  * @param execMetrics metrics
@@ -1886,7 +1889,8 @@ class MultiFileParquetPartitionReader(
     splits: Array[PartitionedFile],
     clippedBlocks: Seq[ParquetSingleDataBlockMeta],
     override val isSchemaCaseSensitive: Boolean,
-    debugDumpPrefix: String,
+    debugDumpPrefix: Option[String],
+    debugDumpAlways: Boolean,
     useChunkedReader: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
@@ -1996,9 +2000,6 @@ class MultiFileParquetPartitionReader(
       clippedSchema: SchemaBase, readDataSchema: StructType,
       extraInfo: ExtraInfo): GpuDataProducer[Table] = {
 
-    // Dump parquet data into a file
-    dumpDataToFile(dataBuffer, dataSize, splits, Option(debugDumpPrefix), Some("parquet"))
-
     val parseOpts = getParquetOptions(readDataSchema, clippedSchema, useFieldId)
 
     // About to start using the GPU
@@ -2008,7 +2009,7 @@ class MultiFileParquetPartitionReader(
       dataBuffer, 0, dataSize, metrics,
       extraInfo.isCorrectedInt96RebaseMode, extraInfo.isCorrectedRebaseMode,
       extraInfo.hasInt96Timestamps, isSchemaCaseSensitive, useFieldId, readDataSchema,
-      clippedSchema, None)
+      clippedSchema, splits, debugDumpPrefix, debugDumpAlways)
   }
 
   override def writeFileHeader(buffer: HostMemoryBuffer, bContext: BatchContext): Long = {
@@ -2057,7 +2058,8 @@ class MultiFileParquetPartitionReader(
  * @param files the partitioned files to read
  * @param filterFunc a function to filter the necessary blocks from a given file
  * @param isSchemaCaseSensitive whether schema is case sensitive
- * @param debugDumpPrefix a path prefix to use for dumping the fabricated Parquet data or null
+ * @param debugDumpPrefix a path prefix to use for dumping the fabricated Parquet data
+ * @param debugDumpAlways whether to debug dump always or only on errors
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
  * @param execMetrics metrics
@@ -2080,7 +2082,8 @@ class MultiFileCloudParquetPartitionReader(
     files: Array[PartitionedFile],
     filterFunc: PartitionedFile => ParquetFileInfoWithBlockMeta,
     override val isSchemaCaseSensitive: Boolean,
-    debugDumpPrefix: String,
+    debugDumpPrefix: Option[String],
+    debugDumpAlways: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
@@ -2560,13 +2563,7 @@ class MultiFileCloudParquetPartitionReader(
       allPartValues: Option[Array[(Long, InternalRow)]]): Iterator[ColumnarBatch] = {
 
     val parseOpts = closeOnExcept(hostBuffer) { _ =>
-      // Dump parquet data into a file
-      dumpDataToFile(hostBuffer, dataSize, files, Option(debugDumpPrefix), Some("parquet"))
-      val parseOpts = getParquetOptions(readDataSchema, clippedSchema, useFieldId)
-
-      // about to start using the GPU
-      GpuSemaphore.acquireIfNecessary(TaskContext.get())
-      parseOpts
+      getParquetOptions(readDataSchema, clippedSchema, useFieldId)
     }
     val colTypes = readDataSchema.fields.map(f => f.dataType)
 
@@ -2577,6 +2574,9 @@ class MultiFileCloudParquetPartitionReader(
       Seq(hostBuffer)
     }
 
+    // about to start using the GPU
+    GpuSemaphore.acquireIfNecessary(TaskContext.get())
+
     RmmRapidsRetryIterator.withRetry(hostBuffer, splitBatchSizePolicy) { _ =>
       // The MakeParquetTableProducer will close the input buffer, and that would be bad
       // because we don't want to close it until we know that we are done with it
@@ -2585,7 +2585,8 @@ class MultiFileCloudParquetPartitionReader(
         parseOpts,
         hostBuffer, 0, dataSize, metrics,
         isCorrectInt96RebaseMode, isCorrectRebaseMode, hasInt96Timestamps,
-        isSchemaCaseSensitive, useFieldId, readDataSchema, clippedSchema, None)
+        isSchemaCaseSensitive, useFieldId, readDataSchema, clippedSchema, files,
+        debugDumpPrefix, debugDumpAlways)
 
       val batchIter = CachedGpuBatchIterator(tableReader, colTypes)
 
@@ -2607,7 +2608,7 @@ class MultiFileCloudParquetPartitionReader(
   }
 }
 
-object MakeParquetTableProducer {
+object MakeParquetTableProducer extends Logging {
   def apply(
       useChunkedReader: Boolean,
       conf: Configuration,
@@ -2624,41 +2625,45 @@ object MakeParquetTableProducer {
       useFieldId: Boolean,
       readDataSchema: StructType,
       clippedParquetSchema: MessageType,
-      filePath: Option[Path]): GpuDataProducer[Table] = {
+      splits: Array[PartitionedFile],
+      debugDumpPrefix: Option[String],
+      debugDumpAlways: Boolean,
+  ): GpuDataProducer[Table] = {
     if (useChunkedReader) {
       ParquetTableReader(conf, chunkSizeByteLimit, opts, buffer, offset, len, metrics,
         isCorrectedInt96RebaseMode, isCorrectedRebaseMode, hasInt96Timestamps,
         isSchemaCaseSensitive, useFieldId, readDataSchema, clippedParquetSchema,
-        filePath)
+        splits, debugDumpPrefix, debugDumpAlways)
     } else {
-      val table = try {
-        RmmRapidsRetryIterator.withRetryNoSplit(buffer) { _ =>
-          withResource(new NvtxWithMetrics("Parquet decode", NvtxColor.DARK_GREEN,
-            metrics(GPU_DECODE_TIME))) { _ =>
-            Table.readParquet(opts, buffer, offset, len)
+      val table = withResource(buffer) { _ =>
+        try {
+          RmmRapidsRetryIterator.withRetryNoSplit[Table] {
+            withResource(new NvtxWithMetrics("Parquet decode", NvtxColor.DARK_GREEN,
+              metrics(GPU_DECODE_TIME))) { _ =>
+              Table.readParquet(opts, buffer, offset, len)
+            }
           }
+        } catch {
+          case e: Exception =>
+            val dumpMsg = debugDumpPrefix.map { prefix =>
+              val p = DumpUtils.dumpBuffer(conf, buffer, offset, len, prefix, ".parquet")
+              s", data dumped to $p"
+            }.getOrElse("")
+            throw new IOException(s"Error when processing ${splits.mkString("; ")}$dumpMsg", e)
         }
-      } catch {
-        case e: Exception =>
-          val path = filePath match {
-            case Some(path) => s"$path"
-            case None => ""
-          }
-          throw new IOException("Error when processing file " +
-              s"[path: $path, range: $offset-${offset + len}]", e)
       }
       closeOnExcept(table) { _ =>
+        debugDumpPrefix.foreach { prefix =>
+          if (debugDumpAlways) {
+            val p = DumpUtils.dumpBuffer(conf, buffer, offset, len, prefix, ".parquet")
+            logWarning(s"Wrote data for ${splits.mkString(", ")} to $p")
+          }
+        }
         GpuParquetScan.throwIfNeeded(table, isCorrectedInt96RebaseMode, isCorrectedRebaseMode,
           hasInt96Timestamps)
         if (readDataSchema.length < table.getNumberOfColumns) {
-          filePath match {
-            case Some(path) =>
-              throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-                  s"but read ${table.getNumberOfColumns} from $path")
-            case None =>
-              throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-                  s"but read ${table.getNumberOfColumns}")
-          }
+          throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
+            s"but read ${table.getNumberOfColumns} from ${splits.mkString("; ")}")
         }
       }
       metrics(NUM_OUTPUT_BATCHES) += 1
@@ -2684,29 +2689,36 @@ case class ParquetTableReader(
     useFieldId: Boolean,
     readDataSchema: StructType,
     clippedParquetSchema: MessageType,
-    filePath: Option[Path]) extends GpuDataProducer[Table] {
+    splits: Array[PartitionedFile],
+    debugDumpPrefix: Option[String],
+    debugDumpAlways: Boolean) extends GpuDataProducer[Table] with Logging {
   private[this] val reader = new ParquetChunkedReader(chunkSizeByteLimit, opts, buffer, offset, len)
+
+  private[this] lazy val splitsString = splits.mkString("; ")
 
   override def hasNext: Boolean = reader.hasNext
 
   override def next: Table = {
     val table = withResource(new NvtxWithMetrics("Parquet decode", NvtxColor.DARK_GREEN,
       metrics(GPU_DECODE_TIME))) { _ =>
-      reader.readChunk()
+      try {
+        reader.readChunk()
+      } catch {
+        case e: Exception =>
+          val dumpMsg = debugDumpPrefix.map { prefix =>
+            val p = DumpUtils.dumpBuffer(conf, buffer, offset, len, prefix, ".parquet")
+            s", data dumped to $p"
+          }.getOrElse("")
+          throw new IOException(s"Error when processing $splitsString$dumpMsg", e)
+      }
     }
 
     closeOnExcept(table) { _ =>
       GpuParquetScan.throwIfNeeded(table, isCorrectedInt96RebaseMode, isCorrectedRebaseMode,
         hasInt96Timestamps)
       if (readDataSchema.length < table.getNumberOfColumns) {
-        filePath match {
-          case Some(path) =>
-            throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-                s"but read ${table.getNumberOfColumns} from $path")
-          case None =>
-            throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
-                s"but read ${table.getNumberOfColumns}")
-        }
+        throw new QueryExecutionException(s"Expected ${readDataSchema.length} columns " +
+          s"but read ${table.getNumberOfColumns} from $splitsString")
       }
     }
     metrics(NUM_OUTPUT_BATCHES) += 1
@@ -2715,6 +2727,12 @@ case class ParquetTableReader(
   }
 
   override def close(): Unit = {
+    debugDumpPrefix.foreach { prefix =>
+      if (debugDumpAlways) {
+        val p = DumpUtils.dumpBuffer(conf, buffer, offset, len, prefix, ".parquet")
+        logWarning(s"Wrote data for $splitsString to $p")
+      }
+    }
     reader.close()
     buffer.close()
   }
@@ -2736,6 +2754,7 @@ case class ParquetTableReader(
  *                             clipped to contain only the columns to be read
  * @param readDataSchema the Spark schema describing what will be read
  * @param debugDumpPrefix a path prefix to use for dumping the fabricated Parquet data or null
+ * @param debugDumpAlways whether to debug dump always or only on errors
  */
 class ParquetPartitionReader(
     override val conf: Configuration,
@@ -2745,7 +2764,8 @@ class ParquetPartitionReader(
     clippedParquetSchema: MessageType,
     override val isSchemaCaseSensitive: Boolean,
     readDataSchema: StructType,
-    debugDumpPrefix: String,
+    debugDumpPrefix: Option[String],
+    debugDumpAlways: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
@@ -2810,14 +2830,9 @@ class ParquetPartitionReader(
             dataBuffer.close()
             CachedGpuBatchIterator(EmptyTableReader, colTypes)
           } else {
-            closeOnExcept(dataBuffer) { _ =>
-              // Dump parquet data into a file
-              dumpDataToFile(dataBuffer, dataSize, Array(split), Option(debugDumpPrefix),
-                Some("parquet"))
+            // about to start using the GPU
+            GpuSemaphore.acquireIfNecessary(TaskContext.get())
 
-              // about to start using the GPU
-              GpuSemaphore.acquireIfNecessary(TaskContext.get())
-            }
             RmmRapidsRetryIterator.withRetryNoSplit(dataBuffer) { _ =>
               // Inc the ref count because MakeParquetTableProducer will try to close the dataBuffer
               // which we don't want until we know that the retry is done with it.
@@ -2828,7 +2843,8 @@ class ParquetPartitionReader(
                 isCorrectedInt96RebaseMode, isCorrectedRebaseMode,
                 hasInt96Timestamps, isSchemaCaseSensitive,
                 useFieldId, readDataSchema,
-                clippedParquetSchema, Some(filePath))
+                clippedParquetSchema, Array(split),
+                debugDumpPrefix, debugDumpAlways)
               CachedGpuBatchIterator(producer, colTypes)
             }
           }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -2627,7 +2627,7 @@ object MakeParquetTableProducer extends Logging {
       clippedParquetSchema: MessageType,
       splits: Array[PartitionedFile],
       debugDumpPrefix: Option[String],
-      debugDumpAlways: Boolean,
+      debugDumpAlways: Boolean
   ): GpuDataProducer[Table] = {
     if (useChunkedReader) {
       ParquetTableReader(conf, chunkSizeByteLimit, opts, buffer, offset, len, metrics,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1368,19 +1368,40 @@ object RapidsConf {
     .doc("A path prefix where Parquet split file data is dumped for debugging.")
     .internal()
     .stringConf
-    .createWithDefault(null)
+    .createOptional
+
+  val PARQUET_DEBUG_DUMP_ALWAYS = conf("spark.rapids.sql.parquet.debug.dumpAlways")
+    .doc(s"This only has an effect if $PARQUET_DEBUG_DUMP_PREFIX is set. If true then " +
+      "Parquet data is dumped for every read operation otherwise only on a read error.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
 
   val ORC_DEBUG_DUMP_PREFIX = conf("spark.rapids.sql.orc.debug.dumpPrefix")
     .doc("A path prefix where ORC split file data is dumped for debugging.")
     .internal()
     .stringConf
-    .createWithDefault(null)
+    .createOptional
+
+  val ORC_DEBUG_DUMP_ALWAYS = conf("spark.rapids.sql.orc.debug.dumpAlways")
+    .doc(s"This only has an effect if $ORC_DEBUG_DUMP_PREFIX is set. If true then " +
+      "ORC data is dumped for every read operation otherwise only on a read error.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
 
   val AVRO_DEBUG_DUMP_PREFIX = conf("spark.rapids.sql.avro.debug.dumpPrefix")
     .doc("A path prefix where AVRO split file data is dumped for debugging.")
     .internal()
     .stringConf
-    .createWithDefault(null)
+    .createOptional
+
+  val AVRO_DEBUG_DUMP_ALWAYS = conf("spark.rapids.sql.avro.debug.dumpAlways")
+    .doc(s"This only has an effect if $AVRO_DEBUG_DUMP_PREFIX is set. If true then " +
+      "Avro data is dumped for every read operation otherwise only on a read error.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
 
   val HASH_AGG_REPLACE_MODE = conf("spark.rapids.sql.hashAgg.replaceMode")
     .doc("Only when hash aggregate exec has these modes (\"all\" by default): " +
@@ -2250,11 +2271,17 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val maxReadBatchSizeBytes: Long = get(MAX_READER_BATCH_SIZE_BYTES)
 
-  lazy val parquetDebugDumpPrefix: String = get(PARQUET_DEBUG_DUMP_PREFIX)
+  lazy val parquetDebugDumpPrefix: Option[String] = get(PARQUET_DEBUG_DUMP_PREFIX)
 
-  lazy val orcDebugDumpPrefix: String = get(ORC_DEBUG_DUMP_PREFIX)
+  lazy val parquetDebugDumpAlways: Boolean = get(PARQUET_DEBUG_DUMP_ALWAYS)
 
-  lazy val avroDebugDumpPrefix: String = get(AVRO_DEBUG_DUMP_PREFIX)
+  lazy val orcDebugDumpPrefix: Option[String] = get(ORC_DEBUG_DUMP_PREFIX)
+
+  lazy val orcDebugDumpAlways: Boolean = get(ORC_DEBUG_DUMP_ALWAYS)
+
+  lazy val avroDebugDumpPrefix: Option[String] = get(AVRO_DEBUG_DUMP_PREFIX)
+
+  lazy val avroDebugDumpAlways: Boolean = get(AVRO_DEBUG_DUMP_ALWAYS)
 
   lazy val hashAggReplaceMode: String = get(HASH_AGG_REPLACE_MODE)
 


### PR DESCRIPTION
Fixes #6964, #8672.

This changes the default semantics of the debug dump prefix configs to only dump the data on an exception.  Dumping on every read is still possible by setting a new dumpAlways config to true, but it defaults to false.  This is because for most situations, we're interested only in dumping the data that lead to a read error in libcudf.

This also updates the read exception to use the input splits specified for the read so the exception shows which files were trying to be read when the error occurred.