### PR TITLE
Fix Databricks build error for new added ORC test cases

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -294,6 +294,12 @@
                     <version>${hadoop.client.version}</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                    <version>${spark.version}</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>


### PR DESCRIPTION
fixes #8978

Add the ORC dependency to solve Databricks build error.

Signed-off-by: Chong Gao <res_life@163.com>
