### PR TITLE
Fix host memory buffer leaks in SerializationSuite

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SerializationSuite.scala
@@ -154,9 +154,10 @@ class SerializationSuite extends AnyFunSuite
         withBroadcast(broadcast) { _ =>
           withResource(broadcast.hostBatch) { hostBatch1 =>
             TestUtils.compareBatches(expectedHostBatch, hostBatch1)
-            val clonedObj = SerializationUtils.clone(broadcast)
-            withResource(clonedObj.hostBatch) { hostBatch2 =>
-              TestUtils.compareBatches(expectedHostBatch, hostBatch2)
+            withBroadcast(SerializationUtils.clone(broadcast)) { clonedObj =>
+              withResource(clonedObj.hostBatch) { hostBatch2 =>
+                TestUtils.compareBatches(expectedHostBatch, hostBatch2)
+              }
             }
           }
         }
@@ -176,9 +177,10 @@ class SerializationSuite extends AnyFunSuite
           // we materialized
           withResource(broadcast.hostBatch) { hostBatch1 =>
             TestUtils.compareBatches(expectedHostBatch, hostBatch1)
-            val clonedObj = SerializationUtils.clone(broadcast)
-            withResource(clonedObj.hostBatch) { hostBatch2 =>
-              TestUtils.compareBatches(expectedHostBatch, hostBatch2)
+            withBroadcast(SerializationUtils.clone(broadcast)) { clonedObj =>
+              withResource(clonedObj.hostBatch) { hostBatch2 =>
+                TestUtils.compareBatches(expectedHostBatch, hostBatch2)
+              }
             }
           }
         }


### PR DESCRIPTION
Saw some logged leaks in recent unit test runs and tracked them down to host memory buffer leaks in SerializationSuite.  This fixes those host memory buffer leaks.