### PR TITLE
Add in a layer of indirection for task completion callbacks [databricks]

### DIFF
--- a/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
+++ b/delta-lake/common/src/main/scala/com/nvidia/spark/rapids/delta/GpuRapidsProcessDeltaMergeJoinExec.scala
@@ -22,8 +22,8 @@ import ai.rapids.cudf.{NvtxColor, Table}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression}
@@ -239,7 +239,7 @@ class GpuRapidsProcessDeltaMergeJoinIterator(
   private[this] val opTime = metrics.getOrElse(GpuMetric.OP_TIME, NoopMetric)
   private[this] val numOutputRows = metrics.getOrElse(GpuMetric.NUM_OUTPUT_ROWS, NoopMetric)
 
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 
   override def hasNext: Boolean = {
     nextBatch = nextBatch.orElse(processNextBatch())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/CurrentBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/CurrentBatchIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import java.io.IOException
 import scala.collection.JavaConverters._
 
 import com.nvidia.spark.rapids.{ByteArrayInputFile, ParquetCachedBatch}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.{ParquetReadOptions, VersionParser}
 import org.apache.parquet.VersionParser.ParsedVersion
 import org.apache.parquet.hadoop.ParquetFileReader
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetReadSupport, ParquetToSparkSchemaConverter, ParquetWriteSupport}
 import org.apache.spark.sql.execution.vectorized.OffHeapColumnVector
@@ -105,9 +105,7 @@ abstract class CurrentBatchIterator(
     }
   }
 
-  TaskContext.get().addTaskCompletionListener[Unit]((_: TaskContext) => {
-    close()
-  })
+  onTaskCompletion(close())
 
   override def close(): Unit = {
     parquetFileReader.close()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -20,8 +20,8 @@ import ai.rapids.cudf.{GatherMap, NvtxColor, OutOfBoundsPolicy}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalf, withRestoreOnRetry, withRetry}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 
-import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.{InnerLike, JoinType, LeftOuter, RightOuter}
@@ -42,7 +42,7 @@ trait TaskAutoCloseableResource extends AutoCloseable {
     resources.clear()
   }
 
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -20,8 +20,9 @@ import ai.rapids.cudf.{GatherMap, NvtxColor, OutOfBoundsPolicy}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalf, withRestoreOnRetry, withRetry}
-import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.{InnerLike, JoinType, LeftOuter, RightOuter}
@@ -42,7 +43,12 @@ trait TaskAutoCloseableResource extends AutoCloseable {
     resources.clear()
   }
 
-  onTaskCompletionIfNotTest(close())
+  // Don't install the callback if in a unit test
+  Option(TaskContext.get()).foreach { tc =>
+    onTaskCompletion(tc) {
+      close()
+    }
+  }
 }
 
 /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AutoCloseColumnBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AutoCloseColumnBatchIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.nvidia.spark.rapids
 
-import org.apache.spark.TaskContext
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -39,7 +40,7 @@ class AutoCloseColumnBatchIterator[U](itr: Iterator[U], nextBatch: Iterator[U] =
     }
   }
 
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => closeCurrentBatch()))
+  onTaskCompletionIfNotTest(closeCurrentBatch())
 
   override def hasNext: Boolean = {
     closeCurrentBatch()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.TaskContext
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 
 /**
  * Helper iterator that wraps a BufferedIterator of AutoCloseable subclasses.
@@ -28,8 +28,7 @@ import org.apache.spark.TaskContext
  */
 class CloseableBufferedIterator[T <: AutoCloseable](wrapped: BufferedIterator[T])
   extends BufferedIterator[T] with AutoCloseable {
-  // register against task completion to close any leaked buffered items
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 
   private[this] var isClosed = false
   override def head: T = wrapped.head

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -22,9 +22,10 @@ import ai.rapids.cudf.{Cuda, NvtxColor, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRetry, withRetryNoSplit}
-import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.{ShimExpression, ShimUnaryExecNode}
 
+import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -300,7 +301,12 @@ abstract class AbstractGpuCoalesceIterator(
   /** Optional row limit */
   var batchRowLimit: Int = 0
 
-  onTaskCompletionIfNotTest(clearOnDeck())
+  // Don't install the callback if in a unit test
+  Option(TaskContext.get()).foreach { tc =>
+    onTaskCompletion(tc) {
+      clearOnDeck()
+    }
+  }
 
   private def getHasOnDeck: Boolean = {
     while (!hasOnDeck && iter.hasNext) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -17,8 +17,8 @@
 package com.nvidia.spark.rapids
 
 import com.nvidia.spark.rapids.Arm.closeOnExcept
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -40,9 +40,7 @@ abstract class GpuColumnarBatchIterator(closeWithTask: Boolean)
     extends Iterator[ColumnarBatch] with AutoCloseable {
   private var isClosed = false
   if (closeWithTask) {
-    Option(TaskContext.get).foreach { tc =>
-      tc.addTaskCompletionListener[Unit](_ => close())
-    }
+    onTaskCompletionIfNotTest(close())
   }
 
   final override def close(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchSerializer.scala
@@ -26,8 +26,9 @@ import ai.rapids.cudf.{HostColumnVector, HostMemoryBuffer, JCudfSerialization, N
 import ai.rapids.cudf.JCudfSerialization.SerializedTableHeader
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
+import org.apache.spark.TaskContext
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
 import org.apache.spark.sql.types.NullType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -38,10 +39,13 @@ class SerializedBatchIterator(dIn: DataInputStream)
   private[this] var toBeReturned: Option[ColumnarBatch] = None
   private[this] var streamClosed: Boolean = false
 
-  onTaskCompletionIfNotTest {
-    toBeReturned.foreach(_.close())
-    toBeReturned = None
-    dIn.close()
+  // Don't install the callback if in a unit test
+  Option(TaskContext.get()).foreach { tc =>
+    onTaskCompletion(tc) {
+      toBeReturned.foreach(_.close())
+      toBeReturned = None
+      dIn.close()
+    }
   }
 
   def tryReadNextHeader(): Option[Long] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -18,9 +18,9 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.NvtxColor
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuMetric._
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -119,8 +119,9 @@ class GpuExpandIterator(
   private val numOutputRows = metrics(NUM_OUTPUT_ROWS)
   private val opTime = metrics(OP_TIME)
 
-  Option(TaskContext.get())
-    .foreach(_.addTaskCompletionListener[Unit](_ => sb.foreach(_.close())))
+  onTaskCompletionIfNotTest {
+    sb.foreach(_.close())
+  }
 
   override def hasNext: Boolean = sb.isDefined || it.hasNext
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -22,9 +22,9 @@ import ai.rapids.cudf.{ColumnVector, DType, NvtxColor, NvtxRange, OrderByArg, Sc
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.{ShimExpression, ShimUnaryExecNode}
 
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, Generator, ReplicateRows}
@@ -593,7 +593,7 @@ abstract class GpuExplodeBase extends GpuUnevaluableUnaryExpression with GpuGene
         spillableCurrentBatch = null
       }
 
-      TaskContext.get().addTaskCompletionListener[Unit](_ => closeCurrent())
+      onTaskCompletion(closeCurrent())
 
       def fetchNextBatch(): Unit = {
         indexIntoData = 0

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuKeyBatchingIterator.scala
@@ -22,8 +22,8 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.{ColumnVector, NvtxColor, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -49,7 +49,7 @@ class GpuKeyBatchingIterator(
   private val pending = mutable.Queue[SpillableColumnarBatch]()
   private var pendingSize: Long = 0
 
-  TaskContext.get().addTaskCompletionListener[Unit](_ => close())
+  onTaskCompletion(close())
 
   def close(): Unit = {
     pending.foreach(_.close())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSemaphore.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.{ConcurrentHashMap, Semaphore}
 import scala.collection.mutable
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.RmmSpark
 import org.apache.commons.lang3.mutable.MutableInt
 
@@ -142,7 +143,7 @@ private final class GpuSemaphore() extends Logging {
           activeTasks.put(
             taskAttemptId,
             TaskInfo(new MutableInt(1), Thread.currentThread(), permits))
-          context.addTaskCompletionListener[Unit](completeTask)
+          onTaskCompletion(context, completeTask)
         }
         GpuDeviceManager.initializeFromTask()
       } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -21,6 +21,7 @@ import java.util
 import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization, NvtxColor, NvtxRange}
 import ai.rapids.cudf.JCudfSerialization.{HostConcatResult, SerializedTableHeader}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
@@ -94,7 +95,7 @@ class HostShuffleCoalesceIterator(
   private[this] var numRowsInBatch: Int = 0
   private[this] var batchByteSize: Long = 0L
 
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 
   override def close(): Unit = {
     serializedTables.forEach(_.close())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -25,9 +25,9 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry, withRetryNoSplit}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder, UnsafeProjection, UnsafeRow}
@@ -138,7 +138,7 @@ case class GpuSortExec(
       if (outOfCore) {
         val iter = GpuOutOfCoreSortIterator(cbIter, sorter,
           targetSize, opTime, sortTime, outputBatch, outputRows)
-        TaskContext.get().addTaskCompletionListener(_ -> iter.close())
+        onTaskCompletion(iter.close())
         iter
       } else {
         GpuSortEachBatchIterator(cbIter, sorter, singleBatch,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -25,9 +25,9 @@ import ai.rapids.cudf
 import ai.rapids.cudf.{AggregationOverWindow, DType, GroupByOptions, GroupByScanAggregation, NullPolicy, NvtxColor, ReplacePolicy, ReplacePolicyWithColumn, Scalar, ScanAggregation, ScanType, Table, WindowOptions}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{withRestoreOnRetry, withRetryNoSplit}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.{GpuWindowUtil, ShimUnaryExecNode}
 
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, AttributeSeq, AttributeSet, CurrentRow, Expression, FrameType, NamedExpression, RangeFrame, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
@@ -1494,7 +1494,7 @@ class GpuRunningWindowIterator(
   private var lastOrder: Array[Scalar] = Array.empty
   private var isClosed: Boolean = false
 
-  TaskContext.get().addTaskCompletionListener[Unit](_ => close())
+  onTaskCompletion(close())
 
   private def saveLastParts(newLastParts: Array[Scalar]): Unit = {
     lastParts.foreach(_.close())
@@ -1733,7 +1733,7 @@ class GpuCachedDoublePassWindowIterator(
   private var lastPartsProcessing: Array[Scalar] = Array.empty
   private var isClosed: Boolean = false
 
-  TaskContext.get().addTaskCompletionListener[Unit](_ => close())
+  onTaskCompletion(close())
 
   private def saveLastPartsCaching(newLastParts: Array[Scalar]): Unit = {
     lastPartsCaching.foreach(_.close())

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/PartitionReaderIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.TaskContext
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.datasources.PartitionedFile
@@ -28,7 +29,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  */
 class PartitionReaderIterator(reader: PartitionReader[ColumnarBatch])
     extends Iterator[ColumnarBatch] with AutoCloseable {
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 
   var hasNextResult: Option[Boolean] = None
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, RmmSparkThreadState, SplitAndRetryOOM}
 
 import org.apache.spark.TaskContext
@@ -403,6 +404,11 @@ object RmmRapidsRetryIterator extends Logging {
     def this(input: Iterator[T], fn: T => K) =
       this(input, fn, null)
 
+    private val onClose = onTaskCompletionIfNotTest {
+      attemptStack.safeClose()
+      attemptStack.clear()
+    }
+
     protected val attemptStack = new mutable.ArrayStack[T]()
 
     override def hasNext: Boolean = input.hasNext || attemptStack.nonEmpty
@@ -433,12 +439,15 @@ object RmmRapidsRetryIterator extends Logging {
         RmmSpark.currentThreadEndRetryBlock()
       }
       attemptStack.pop().close()
+      if (attemptStack.isEmpty && !input.hasNext) {
+        // No need to call the onClose because the attemptStack is empty
+        onClose.removeCallback()
+      }
       res
     }
 
     override def close(): Unit = {
-      attemptStack.safeClose()
-      attemptStack.clear()
+      onClose.removeAndCall()
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RmmRapidsRetryIterator.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
-import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, RmmSparkThreadState, SplitAndRetryOOM}
 
 import org.apache.spark.TaskContext
@@ -404,9 +404,16 @@ object RmmRapidsRetryIterator extends Logging {
     def this(input: Iterator[T], fn: T => K) =
       this(input, fn, null)
 
-    private val onClose = onTaskCompletionIfNotTest {
+    private def closeInternal(): Unit = {
       attemptStack.safeClose()
       attemptStack.clear()
+    }
+
+    // Don't install the callback if in a unit test
+    private val onClose = Option(TaskContext.get()).map { tc =>
+      onTaskCompletion(tc) {
+        closeInternal()
+      }
     }
 
     protected val attemptStack = new mutable.ArrayStack[T]()
@@ -441,13 +448,13 @@ object RmmRapidsRetryIterator extends Logging {
       attemptStack.pop().close()
       if (attemptStack.isEmpty && !input.hasNext) {
         // No need to call the onClose because the attemptStack is empty
-        onClose.removeCallback()
+        onClose.foreach(_.removeCallback())
       }
       res
     }
 
     override def close(): Unit = {
-      onClose.removeAndCall()
+      onClose.map(_.removeAndCall()).getOrElse(closeInternal())
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ScalableTaskCompletion.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ScalableTaskCompletion.scala
@@ -96,7 +96,7 @@ object ScalableTaskCompletion {
    * Spark itself.
    */
   private class TopLevelTaskCompletion extends Function[TaskContext, Unit] {
-    private val pending = new util.Stack[UserTaskCompletion]()
+    private val pending = new util.LinkedList[UserTaskCompletion]()
     private var callbacksDone = false
 
     override def apply(tc: TaskContext): Unit = {
@@ -146,7 +146,7 @@ object ScalableTaskCompletion {
     }
 
     def removeAllAndShutdown(): Unit = synchronized {
-      while(!pending.empty()) {
+      while(pending.size() > 0) {
         val ucb = pending.pop
         ucb(ucb.tc)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ScalableTaskCompletion.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ScalableTaskCompletion.scala
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import java.util
+
+import org.apache.spark.TaskContext
+
+/**
+ * A handle that can be used to remove a callback if needed
+ */
+trait TaskCompletionCallbackHandle {
+  /**
+   * Removes the callback but does not call it if it has not already been called.
+   */
+  def removeCallback(): Unit
+
+  /**
+   * Removes the callback and calls it if it has not been called already.
+   */
+  def removeAndCall(): Unit
+}
+
+/**
+ * Provides a task completion listeners in Spark that you can remove if needed to help with scaling.
+ */
+object ScalableTaskCompletion {
+  // Note: There are three levels of synchronization that can happen here. The order that they are
+  // grabbed should always be
+  //
+  // ScalableTaskCompletion -> TopLevelTaskCompletion -> UserTaskCompletion
+  //
+  // to avoid any potential deadlocks
+
+  /**
+   * Wrapper around a user callback function.
+   */
+  private class UserTaskCompletion(val tc: TaskContext,
+      f: Either[() => Unit, TaskContext => Unit])
+      extends TaskCompletionCallbackHandle
+          with Function[TaskContext, Unit] {
+    private var wasCalled = false
+
+    override def removeCallback(): Unit = {
+      val topLevel = ScalableTaskCompletion.getTopLevel(tc.taskAttemptId())
+      if (topLevel != null) {
+        topLevel.remove(this)
+      }
+    }
+
+    override def apply(tc: TaskContext): Unit = synchronized {
+      if (!wasCalled) {
+        wasCalled = true
+        f match {
+          case Left(l) => l()
+          case Right(r) => r(tc)
+        }
+      }
+    }
+
+    override def removeAndCall(): Unit = {
+      removeCallback()
+      apply(tc)
+    }
+  }
+
+  /**
+   * Testing wrapper around the user callback function. It is not common and is here to allow
+   * us to still have things behave correctly in some unit tests.
+   */
+  private class TestTaskCompletion(f: () => Unit)
+      extends TaskCompletionCallbackHandle {
+    override def removeCallback(): Unit = {
+      // NOOP
+    }
+
+    override def removeAndCall(): Unit = f()
+  }
+
+  /**
+   * Keeps track of user callbacks for a given task. It is also the callback from
+   * Spark itself.
+   */
+  private class TopLevelTaskCompletion extends Function[TaskContext, Unit] {
+    private val pending = new util.Stack[UserTaskCompletion]()
+    private var callbacksDone = false
+
+    override def apply(tc: TaskContext): Unit = {
+      var error: Throwable = null
+      synchronized {
+        while (!pending.isEmpty) {
+          val utc = pending.pop
+          try {
+            utc(tc)
+          } catch {
+            case t: Throwable =>
+              if (error == null) {
+                error = t
+              } else {
+                error.addSuppressed(t)
+              }
+          }
+        }
+        callbacksDone = true
+      }
+      try {
+        ScalableTaskCompletion.removeTopLevel(tc.taskAttemptId())
+      } catch {
+        case t: Throwable =>
+          if (error == null) {
+            error = t
+          } else {
+            error.addSuppressed(t)
+          }
+      }
+      if (error != null) {
+        throw error
+      }
+    }
+
+    def add(u: UserTaskCompletion): Unit = synchronized {
+      if (callbacksDone) {
+        // Added a callback after it was done calling them back already
+        u(u.tc)
+      } else {
+        pending.add(u)
+      }
+    }
+
+    def remove(u: UserTaskCompletion): Unit = synchronized {
+      pending.remove(u)
+    }
+
+    def removeAllAndShutdown(): Unit = synchronized {
+      while(!pending.empty()) {
+        val ucb = pending.pop
+        ucb(ucb.tc)
+      }
+    }
+  }
+
+  /**
+   * Callbacks indexed by the task attempt id.
+   */
+  private val pendingCallbacks = new util.HashMap[Long, TopLevelTaskCompletion]
+
+  private def getTopLevel(id: Long): TopLevelTaskCompletion = synchronized {
+    pendingCallbacks.get(id)
+  }
+
+  private def removeTopLevel(id: Long): TopLevelTaskCompletion = synchronized {
+    pendingCallbacks.remove(id)
+  }
+
+  private def add(ucb: UserTaskCompletion): TaskCompletionCallbackHandle = {
+    val tc = ucb.tc
+    val id = tc.taskAttemptId()
+    synchronized {
+      val tl = if (!pendingCallbacks.containsKey(id)) {
+        val topLevel = new TopLevelTaskCompletion
+        tc.addTaskCompletionListener[Unit](topLevel)
+        pendingCallbacks.put(id, topLevel)
+        topLevel
+      } else {
+        pendingCallbacks.get(id)
+      }
+      tl.add(ucb)
+    }
+
+    ucb
+  }
+
+  /**
+   * When the passed in task context completes, call the given function
+   * @return a handle that can be used to remove the callback
+   */
+  def onTaskCompletion(tc: TaskContext)(f: => Unit): TaskCompletionCallbackHandle =
+    add(new UserTaskCompletion(tc, Left(() => f)))
+
+  /**
+   * When the passed in task context completes, call the given function.
+   * @return a handle that can be used to remove the callback
+   */
+  def onTaskCompletion(tc: TaskContext, f: TaskContext => Unit): TaskCompletionCallbackHandle = {
+    // Note the API here takes both a task context and the function at once. This is a little
+    // uglier than what we support for the no argument version. This is because Scala says it
+    // is ambiguous to have both here. The other version is more commonly used so it gets the
+    // cleaner API.
+    add(new UserTaskCompletion(tc, Right(f)))
+  }
+
+  /**
+   * When the current task completes call the given function.
+   * @return a handle that can be used to remove the callback
+   */
+  def onTaskCompletion(f: => Unit): TaskCompletionCallbackHandle = {
+    val tc: TaskContext = TaskContext.get()
+    add(new UserTaskCompletion(tc, Left(() => f)))
+  }
+
+  /**
+   * When the current task completes call the given function
+   * @return a handle that can be used to remove the callback
+   */
+  def onTaskCompletion(f: TaskContext => Unit): TaskCompletionCallbackHandle = {
+    val tc: TaskContext = TaskContext.get()
+    add(new UserTaskCompletion(tc, Right(f)))
+  }
+
+  /**
+   * When the current task completes, if there is a current task call the given function.
+   * @return a handle that can be used to remove the callback.
+   */
+  def onTaskCompletionIfNotTest(f: => Unit): TaskCompletionCallbackHandle = {
+    Option(TaskContext.get()).map { tc =>
+      add(new UserTaskCompletion(tc, Left(() => f)))
+    }.getOrElse(new TestTaskCompletion(() => f))
+  }
+
+  /**
+   * When the current task completes, if there is a current task call the function
+   * @return a handle that can be used to remove the callback, if there is a task.
+   */
+  def onTaskCompletionIfNotTest(f: TaskContext => Unit): Option[TaskCompletionCallbackHandle] = {
+    Option(TaskContext.get()).map { tc =>
+      add(new UserTaskCompletion(tc, Right(f)))
+    }
+  }
+
+  /**
+   * For testing only. This resets the state in case a test was using mocks and we didn't get
+   * the callbacks we expected to clean things up. Any callbacks registered will be called, if
+   * needed and then removed.
+   */
+  def reset(): Unit = synchronized {
+    pendingCallbacks.values().forEach { topLevel =>
+      topLevel.removeAllAndShutdown()
+    }
+    pendingCallbacks.clear()
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -29,6 +29,7 @@ import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.GpuOverrides.pluginSupportedOrderableSig
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry, withRetryNoSplit}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.shims.{AggregationTagging, ShimUnaryExecNode}
 
 import org.apache.spark.TaskContext
@@ -730,7 +731,7 @@ class GpuMergeAggregateIterator(
   /** Whether a batch is pending for a reduction-only aggregation */
   private[this] var hasReductionOnlyBatch: Boolean = isReductionOnly
 
-  Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+  onTaskCompletionIfNotTest(close())
 
   override def hasNext: Boolean = {
     sortFallbackIter.map(_.hasNext).getOrElse {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -25,6 +25,7 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry, withRetryNoSplit}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.shims._
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
@@ -418,7 +419,7 @@ case class GpuProjectAstExec(
             }
           }
 
-        Option(TaskContext.get).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+        onTaskCompletionIfNotTest(close())
 
         override def hasNext: Boolean = {
           if (cbIter.hasNext) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/python/PythonWorkerSemaphore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/python/PythonWorkerSemaphore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.python
 import java.util.concurrent.{ConcurrentHashMap, Semaphore}
 
 import com.nvidia.spark.rapids.RapidsConf
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.python.PythonConfEntries.CONCURRENT_PYTHON_WORKERS
 import org.apache.commons.lang3.mutable.MutableInt
 
@@ -105,7 +106,7 @@ private final class PythonWorkerSemaphore(tasksPerGpu: Int) extends Logging {
     if (refs == null) {
       // first time this task has been seen
       activeTasks.put(taskAttemptId, new MutableInt(1))
-      context.addTaskCompletionListener[Unit](completeTask)
+      onTaskCompletion(tc => completeTask(tc))
     } else {
       refs.increment()
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.{GpuSemaphore, RapidsBuffer, RapidsBufferHandle, RapidsConf, ShuffleReceivedBufferCatalog}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.RmmSpark
 
 import org.apache.spark.TaskContext
@@ -308,7 +309,7 @@ class RapidsShuffleIterator(
 
   private[this] val taskContext: Option[TaskContext] = Option(TaskContext.get())
 
-  taskContext.foreach(_.addTaskCompletionListener[Unit](_ => receiveBufferCleaner()))
+  taskContext.foreach(onTaskCompletion(_)(receiveBufferCleaner()))
 
   def pollForResult(timeoutSeconds: Long): Option[ShuffleClientResult] = {
     Option(resolvedBatches.poll(timeoutSeconds, TimeUnit.SECONDS))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriter.scala
@@ -25,6 +25,7 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetryNoSplit
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.GpuFileFormatDataWriterShim
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.TaskAttemptContext
@@ -762,7 +763,7 @@ class GpuDynamicPartitionDataConcurrentWriter(
   private val concurrentWriters = mutable.HashMap[String, WriterStatusWithCaches]()
 
   // guarantee to close the caches and writers when task is finished
-  taskContext.addTaskCompletionListener[Unit](_ => closeCachesAndWriters())
+  onTaskCompletion(taskContext)(closeCachesAndWriters())
 
   private val outDataTypes = description.dataColumns.map(_.dataType).toArray
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable
 
 import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.RmmSpark
 import java.{lang => jl}
 
@@ -171,11 +172,11 @@ object GpuTaskMetrics extends Logging {
       // avoid double registering the task metrics...
       if (!taskLevelMetrics.contains(id)) {
         taskLevelMetrics.put(id, metrics)
-        tc.addTaskCompletionListener { tc =>
+        onTaskCompletion(tc, tc =>
           synchronized {
             taskLevelMetrics.remove(tc.taskAttemptId())
           }
-        }
+        )
       }
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuAggregateInPandasExec.scala
@@ -22,6 +22,7 @@ import ai.rapids.cudf
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
@@ -170,7 +171,7 @@ case class GpuAggregateInPandasExec(
     child.executeColumnar().mapPartitionsInternal { inputIter =>
       val queue: BatchQueue = new BatchQueue()
       val context = TaskContext.get()
-      context.addTaskCompletionListener[Unit](_ => queue.close())
+      onTaskCompletion(queue.close())
 
       if (isPythonOnGpuEnabled) {
         GpuPythonHelper.injectGpuInfo(pyFuncs, isPythonOnGpuEnabled)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import ai.rapids.cudf._
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.api.python._
@@ -126,7 +127,7 @@ trait GpuPythonArrowOutput { _: GpuPythonRunnerBase[_] =>
 
       private[this] var arrowReader: StreamedTableReader = _
 
-      context.addTaskCompletionListener[Unit] { _ =>
+      onTaskCompletion(context) {
         if (arrowReader != null) {
           arrowReader.close()
           arrowReader = null

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/shims/GpuFileScanRDD.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/shims/GpuFileScanRDD.scala
@@ -17,6 +17,7 @@ package org.apache.spark.sql.rapids.shims
 
 import java.io.{FileNotFoundException, IOException}
 
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import org.apache.parquet.io.ParquetDecodingException
 
 import org.apache.spark.{Partition => RDDPartition, SparkUpgradeException, TaskContext}
@@ -187,7 +188,7 @@ class GpuFileScanRDD(
     }
 
     // Register an on-task-completion callback to close the input stream.
-    context.addTaskCompletionListener[Unit](_ => iterator.close())
+    onTaskCompletion(context)(iterator.close())
 
     iterator.asInstanceOf[Iterator[InternalRow]] // This is an erasure hack.
   }

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -22,6 +22,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids.{MetricsBatchIterator, PartitionIterator}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, SparkException, TaskContext}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -51,7 +52,7 @@ class GpuDataSourceRDD(
     val inputPartition = castPartition(split).inputPartition
     val batchReader = partitionReaderFactory.createColumnarReader(inputPartition)
     val iter = new MetricsBatchIterator(new PartitionIterator[ColumnarBatch](batchReader))
-    context.addTaskCompletionListener[Unit](_ => batchReader.close())
+    onTaskCompletion(batchReader.close())
     // TODO: SPARK-25083 remove the type erasure hack in data source scan
     new InterruptibleIterator(context, iter.asInstanceOf[Iterator[InternalRow]])
   }

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -32,13 +32,13 @@ import java.io.IOException
 
 import com.nvidia.spark.CurrentBatchIterator
 import com.nvidia.spark.rapids.ParquetCachedBatch
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.ParquetReadOptions
 import org.apache.parquet.column.ColumnDescriptor
 import org.apache.parquet.schema.Type
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.datasources.parquet.rapids.shims.ShimVectorizedColumnReader
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector
@@ -156,8 +156,8 @@ class ShimCurrentBatchIterator(
 
   override def hasNext: Boolean = rowsReturned < totalRowCount
 
-  TaskContext.get().addTaskCompletionListener[Unit]((_: TaskContext) => {
+  onTaskCompletion {
     close()
-  })
+  }
 
 }

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -26,6 +26,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids.{MetricsBatchIterator, PartitionIterator}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, SparkException, TaskContext}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -57,7 +58,7 @@ class GpuDataSourceRDD(
     val inputPartition = castPartition(split).inputPartition
     val batchReader = partitionReaderFactory.createColumnarReader(inputPartition)
     val iter = new MetricsBatchIterator(new PartitionIterator[ColumnarBatch](batchReader))
-    context.addTaskCompletionListener[Unit](_ => batchReader.close())
+    onTaskCompletion(batchReader.close())
     // TODO: SPARK-25083 remove the type erasure hack in data source scan
     new InterruptibleIterator(context, iter.asInstanceOf[Iterator[InternalRow]])
   }

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 
 import org.apache.spark.TaskContext
@@ -194,7 +195,7 @@ case class GpuWindowInPandasExec(
     child.executeColumnar().mapPartitions { inputIter =>
       val context = TaskContext.get()
       val queue: BatchQueue = new BatchQueue()
-      context.addTaskCompletionListener[Unit](_ => queue.close())
+      onTaskCompletion(context)(query.close())
 
       val boundDataRefs = GpuBindReferences.bindGpuReferences(dataInputs, childOutput)
       // Re-batching the input data by GroupingIterator

--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -195,7 +195,7 @@ case class GpuWindowInPandasExec(
     child.executeColumnar().mapPartitions { inputIter =>
       val context = TaskContext.get()
       val queue: BatchQueue = new BatchQueue()
-      onTaskCompletion(context)(query.close())
+      onTaskCompletion(context)(queue.close())
 
       val boundDataRefs = GpuBindReferences.bindGpuReferences(dataInputs, childOutput)
       // Re-batching the input data by GroupingIterator

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
@@ -29,9 +29,9 @@ package com.nvidia.spark.rapids
 
 import com.nvidia.spark.rapids.Arm.{withResource, withResourceIfAllowed}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.ReallyAGpuExpression
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletionIfNotTest
 import com.nvidia.spark.rapids.shims.ShimBinaryExpression
 
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.{Expression, GetStructField, PlanExpression}
 import org.apache.spark.sql.catalyst.trees.TreePattern.OUTER_REFERENCE
@@ -49,7 +49,7 @@ case class GpuBloomFilterMightContain(
       case s: GpuScalar => GpuBloomFilter(s)
       case x => throw new IllegalStateException(s"Expected GPU scalar, found $x")
     }
-    Option(TaskContext.get).foreach(_.addTaskCompletionListener[Unit](_ => close()))
+    onTaskCompletionIfNotTest(close())
     ret
   }
 

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -28,6 +28,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids.{MetricsBatchIterator, PartitionIterator}
+import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, SparkException, TaskContext}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -82,9 +83,8 @@ class GpuDataSourceRDD(
               new PartitionIterator[ColumnarBatch](batchReader))
             (iter, batchReader)
           }
-          context.addTaskCompletionListener[Unit] { _ =>
-            reader.close()
-          }
+          onTaskCompletion(reader.close())
+
           currentIter = Some(iter)
           hasNext
         }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{TimeLimitedTests, TimeLimits}
@@ -32,6 +31,7 @@ class GpuSemaphoreSuite extends AnyFunSuite
   val timeLimit = Span(10, Seconds)
 
   override def beforeEach(): Unit = {
+    ScalableTaskCompletion.reset()
     GpuSemaphore.shutdown()
     // semaphore tests depend on a SparkEnv being available
     val activeSession = SparkSession.getActiveSession
@@ -44,6 +44,7 @@ class GpuSemaphoreSuite extends AnyFunSuite
   }
 
   override def afterEach(): Unit = {
+    ScalableTaskCompletion.reset()
     GpuSemaphore.shutdown()
     SparkSession.getActiveSession.foreach(_.stop())
     SparkSession.clearActiveSession()
@@ -67,14 +68,5 @@ class GpuSemaphoreSuite extends AnyFunSuite
     GpuSemaphore.acquireIfNecessary(context)
     GpuSemaphore.releaseIfNecessary(context)
     GpuSemaphore.releaseIfNecessary(context)
-  }
-
-  test("Completion listener registered on first acquire") {
-    val context = mockContext(1)
-    GpuSemaphore.acquireIfNecessary(context)
-    verify(context, times(1)).addTaskCompletionListener[Unit](any())
-    GpuSemaphore.acquireIfNecessary(context)
-    GpuSemaphore.acquireIfNecessary(context)
-    verify(context, times(1)).addTaskCompletionListener[Unit](any())
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuSemaphoreSuite.scala
@@ -16,6 +16,7 @@
 
 package com.nvidia.spark.rapids
 
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{TimeLimitedTests, TimeLimits}
@@ -68,5 +69,14 @@ class GpuSemaphoreSuite extends AnyFunSuite
     GpuSemaphore.acquireIfNecessary(context)
     GpuSemaphore.releaseIfNecessary(context)
     GpuSemaphore.releaseIfNecessary(context)
+  }
+
+  test("Completion listener registered on first acquire") {
+    val context = mockContext(1)
+    GpuSemaphore.acquireIfNecessary(context)
+    verify(context, times(1)).addTaskCompletionListener[Unit](any())
+    GpuSemaphore.acquireIfNecessary(context)
+    GpuSemaphore.acquireIfNecessary(context)
+    verify(context, times(1)).addTaskCompletionListener[Unit](any())
   }
 }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/GpuFileFormatDataWriterSuite.scala
@@ -16,7 +16,7 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf.TableWriter
-import com.nvidia.spark.rapids.{ColumnarOutputWriter, ColumnarOutputWriterFactory, GpuBoundReference, GpuColumnVector, RapidsBufferCatalog, RapidsDeviceMemoryStore}
+import com.nvidia.spark.rapids.{ColumnarOutputWriter, ColumnarOutputWriterFactory, GpuBoundReference, GpuColumnVector, RapidsBufferCatalog, RapidsDeviceMemoryStore, ScalableTaskCompletion}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.{RetryOOM, SplitAndRetryOOM}
 import org.apache.hadoop.conf.Configuration
@@ -98,6 +98,7 @@ class GpuFileFormatDataWriterSuite extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   def resetMocks(): Unit = {
+    ScalableTaskCompletion.reset()
     allCols = null
     partSpec = null
     dataSpec = null


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/8482

It touches a lot of files because I wanted to move as much of the old API over to the new one so that I could properly test it. I think there may be other places where removing a callback might be nice too, but I didn't take that route here.