### PR TITLE
Allow WindowLocalExec to run on CPU for a map test.

### DIFF
--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -185,6 +185,7 @@ def test_basic_scalar_map_get_map_value(key_gen):
                 "spark.rapids.sql.castFloatToIntegralTypes.enabled": True})
 
 
+@allow_non_gpu('WindowLocalExec')
 @pytest.mark.parametrize('data_gen', supported_key_map_gens, ids=idfn)
 def test_map_scalars_supported_key_types(data_gen):
     key_gen = data_gen._key_gen


### PR DESCRIPTION
This PR is to allow `WindowLocalExec` to run on CPU for a map test, since `WindowLocalExec` may be a Dataproc specific exec, which can not run on GPU now.

closes #9021 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
