### PR TITLE
Fix meta class cast exception when generator not supported

### DIFF
--- a/integration_tests/src/main/python/generate_expr_test.py
+++ b/integration_tests/src/main/python/generate_expr_test.py
@@ -207,7 +207,7 @@ def test_posexplode_nested_outer_array_data(data_gen):
             'a', 'pos', 'posexplode_outer(c)'),
         conf=conf_to_enforce_split_input)
 
-@allow_non_gpu("GenerateExec")
+@allow_non_gpu("GenerateExec", "ShuffleExchangeExec")
 @ignore_order(local=True)
 def test_generate_outer_fallback():
     assert_gpu_fallback_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -46,7 +46,7 @@ class GpuGenerateExecSparkPlanMeta(
   }
 
   override def tagPlanForGpu(): Unit = {
-    if (gen.outer &&
+    if (gen.outer && childExprs.head.isInstanceOf[GeneratorExprMeta[_]] &&
       !childExprs.head.asInstanceOf[GeneratorExprMeta[Generator]].supportOuter) {
       willNotWorkOnGpu(s"outer is not currently supported with ${gen.generator.nodeName}")
     }


### PR DESCRIPTION
Fixes #9034.  GpuGenerateExecSparkPlanMeta was blindly downcasting in tagPlanForGpu.  That's safe in convertToGpu, as we've pre-checked that all the exprs are supported.  However in tagging a child may be unsupported, and therefore the downcast needs to be checked before casting.