### PR TITLE
Use number of threads on executor instead of driver to set core count

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -165,7 +165,8 @@ object MultiFileReaderThreadPool extends Logging {
       val numThreads = Math.max(numThreadsFromConf, GpuDeviceManager.getNumCores)
 
       if (numThreadsFromConf != numThreads) {
-        logWarning(s"Using $numThreads as the number of threads for the thread pool.")
+        logWarning(s"Configuring the file reader thread pool with a max of $numThreads " +
+            s"threads instead of ${RapidsConf.MULTITHREAD_READ_NUM_THREADS} = $numThreadsFromConf")
       }
       initThreadPool(numThreads)
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -158,11 +158,11 @@ object MultiFileReaderThreadPool extends Logging {
   /**
    * Get the existing thread pool or create one with the given thread count if it does not exist.
    * @note The thread number will be ignored if the thread pool is already created, or modified
-   *       if it is not the right size compared to the number of tasks.
+   *       if it is not the right size compared to the number of cores available.
    */
   def getOrCreateThreadPool(numThreadsFromConf: Int): ThreadPoolExecutor = {
     threadPool.getOrElse {
-      val numThreads = Math.max(numThreadsFromConf, GpuDeviceManager.getNumTasks)
+      val numThreads = Math.max(numThreadsFromConf, GpuDeviceManager.getNumCores)
 
       if (numThreadsFromConf != numThreads) {
         logWarning(s"Using $numThreads as the number of threads for the thread pool.")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -157,10 +157,18 @@ object MultiFileReaderThreadPool extends Logging {
 
   /**
    * Get the existing thread pool or create one with the given thread count if it does not exist.
-   * @note The thread number will be ignored if the thread pool is already created.
+   * @note The thread number will be ignored if the thread pool is already created, or modified
+   *       if it is not the right size compared to the number of tasks.
    */
-  def getOrCreateThreadPool(numThreads: Int): ThreadPoolExecutor = {
-    threadPool.getOrElse(initThreadPool(numThreads))
+  def getOrCreateThreadPool(numThreadsFromConf: Int): ThreadPoolExecutor = {
+    threadPool.getOrElse {
+      val numThreads = Math.max(numThreadsFromConf, GpuDeviceManager.getNumTasks)
+
+      if (numThreadsFromConf != numThreads) {
+        logWarning(s"Using $numThreads as the number of threads for the thread pool.")
+      }
+      initThreadPool(numThreads)
+    }
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -170,7 +170,7 @@ object RapidsPluginUtils extends Logging {
 
     // If spark.task.resource.gpu.amount is larger than
     // (spark.executor.resource.gpu.amount / spark.executor.cores) then GPUs will be the limiting
-    // resource for task scheduling., but we can only output the warning if executor cores is set
+    // resource for task scheduling, but we can only output the warning if executor cores is set
     // because this is happening on the driver so the number of tasks in the runtime is not
     // relevant
     if (conf.contains(TASK_GPU_AMOUNT_KEY) &&

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -110,7 +110,7 @@ object RapidsPluginUtils extends Logging {
     }
   }
 
-  def estimateExecTasksOnExec(conf: SparkConf): Int = {
+  def estimateCoresOnExec(conf: SparkConf): Int = {
     conf.getOption(RapidsPluginUtils.EXECUTOR_CORES_KEY)
         .map(_.toInt)
         .getOrElse(Runtime.getRuntime.availableProcessors)
@@ -328,7 +328,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       reRegisterCheckLeakHook()
 
       val sparkConf = pluginContext.conf()
-      val numTasks = RapidsPluginUtils.estimateExecTasksOnExec(sparkConf)
+      val numCores = RapidsPluginUtils.estimateCoresOnExec(sparkConf)
       val conf = new RapidsConf(extraConf.asScala.toMap)
 
       // Compare if the cudf version mentioned in the classpath is equal to the version which
@@ -356,7 +356,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       if (!GpuDeviceManager.rmmTaskInitEnabled) {
         logInfo("Initializing memory from Executor Plugin")
         GpuDeviceManager.initializeGpuAndMemory(pluginContext.resources().asScala.toMap, conf,
-          numTasks)
+          numCores)
         if (GpuShuffleEnv.isRapidsShuffleAvailable(conf)) {
           GpuShuffleEnv.initShuffleManager()
           if (GpuShuffleEnv.isUCXShuffleAndEarlyStart(conf)) {


### PR DESCRIPTION
There are a few cases where the user does not have to set the executor cores config. This is most typically in local mode, but can also happen in standalone mode too. Before this patch if it was not set, then fixup code that runs on the driver would use the number of CPU cores that the java runtime is aware of as a stand-in for it.  But because this ran on the driver it would only fix cases when the driver and executor ran on the same host and in the same container.  This updates the code to wait until the number of cores is known, on the executor, before making the final decision on the thread pool size.