### PR TITLE
Add in configs for host memory limits

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -337,7 +337,7 @@ object RapidsConf {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefault(0)
 
-  val OFF_HEAP_LIMIT_ENABLED = conf("spark.rapids.memory.hostOffHeapLimit.enabled")
+  val OFF_HEAP_LIMIT_ENABLED = conf("spark.rapids.memory.host.OffHeapLimit.enabled")
       .doc("Should the off heap limit be enforced or not.")
       .startupOnly()
       // This might change as a part of https://github.com/NVIDIA/spark-rapids/issues/8878
@@ -345,7 +345,7 @@ object RapidsConf {
       .booleanConf
       .createWithDefault(false)
 
-  val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.hostOffHeapLimit.size")
+  val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.host.OffHeapLimit.size")
       .doc("The maximum amount of off heap memory that the plugin will use. " +
           "This includes pinned memory and some overhead memory. If pinned is larger " +
           "than this - overhead pinned will be truncated.")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -337,6 +337,32 @@ object RapidsConf {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefault(0)
 
+  val OFF_HEAP_LIMIT_ENABLED = conf("spark.rapids.memory.hostOffHeapLimit.enabled")
+      .doc("Should the off heap limit be enforced or not.")
+      .startupOnly()
+      // This might change as a part of https://github.com/NVIDIA/spark-rapids/issues/8878
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
+  val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.hostOffHeapLimit.size")
+      .doc("The maximum amount of off heap memory that the plugin will use. " +
+          "This includes pinned memory and some overhead memory. If pinned is larger " +
+          "than this - overhead pinned will be truncated.")
+      .startupOnly()
+      .internal() // https://github.com/NVIDIA/spark-rapids/issues/8878 should be replaced with
+      // .commonlyUsed()
+      .bytesConf(ByteUnit.BYTE)
+      .createOptional // The default
+
+  val TASK_OVERHEAD_SIZE = conf("spark.rapids.memory.hostPageable.taskOverhead.size")
+      .doc("The amount of off heap memory reserved per task for overhead activities " +
+          "like C++ heap/stack and a few other small things that are hard to control for.")
+      .startupOnly()
+      .internal() // https://github.com/NVIDIA/spark-rapids/issues/8878
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(15L * 1024 * 1024) // 15 MiB
+
   val RMM_DEBUG = conf("spark.rapids.memory.gpu.debug")
     .doc("Provides a log of GPU memory allocations and frees. If set to " +
       "STDOUT or STDERR the logging will go there. Setting it to NONE disables logging. " +
@@ -2186,6 +2212,12 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val includeImprovedFloat: Boolean = get(IMPROVED_FLOAT_OPS)
 
   lazy val pinnedPoolSize: Long = get(PINNED_POOL_SIZE)
+
+  lazy val offHeapLimitEnabled: Boolean = get(OFF_HEAP_LIMIT_ENABLED)
+
+  lazy val offHeapLimit: Option[Long] = get(OFF_HEAP_LIMIT_SIZE)
+
+  lazy val perTaskOverhead: Long = get(TASK_OVERHEAD_SIZE)
 
   lazy val concurrentGpuTasks: Int = get(CONCURRENT_GPU_TASKS)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -337,7 +337,7 @@ object RapidsConf {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefault(0)
 
-  val OFF_HEAP_LIMIT_ENABLED = conf("spark.rapids.memory.host.OffHeapLimit.enabled")
+  val OFF_HEAP_LIMIT_ENABLED = conf("spark.rapids.memory.host.offHeapLimit.enabled")
       .doc("Should the off heap limit be enforced or not.")
       .startupOnly()
       // This might change as a part of https://github.com/NVIDIA/spark-rapids/issues/8878
@@ -345,7 +345,7 @@ object RapidsConf {
       .booleanConf
       .createWithDefault(false)
 
-  val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.host.OffHeapLimit.size")
+  val OFF_HEAP_LIMIT_SIZE = conf("spark.rapids.memory.host.offHeapLimit.size")
       .doc("The maximum amount of off heap memory that the plugin will use. " +
           "This includes pinned memory and some overhead memory. If pinned is larger " +
           "than this - overhead pinned will be truncated.")
@@ -355,7 +355,7 @@ object RapidsConf {
       .bytesConf(ByteUnit.BYTE)
       .createOptional // The default
 
-  val TASK_OVERHEAD_SIZE = conf("spark.rapids.memory.hostPageable.taskOverhead.size")
+  val TASK_OVERHEAD_SIZE = conf("spark.rapids.memory.host.taskOverhead.size")
       .doc("The amount of off heap memory reserved per task for overhead activities " +
           "like C++ heap/stack and a few other small things that are hard to control for.")
       .startupOnly()


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/8875
This fixes https://github.com/NVIDIA/spark-rapids/issues/8876
This fixes https://github.com/NVIDIA/spark-rapids/issues/8877

There will still be work to do as we try to find the correct tuning parameters etc. But this feels like an okay starting point. I also included a lot more logging and warnings than I think are needed in the final release. This is mostly to help with us getting started.