### PR TITLE
Fix import order

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -18,13 +18,14 @@ package com.nvidia.spark.rapids
 
 import java.net.URL
 
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.util.Try
+
 import com.nvidia.spark.GpuCachedBatchSerializer
 import com.nvidia.spark.rapids.delta.DeltaProbe
 import com.nvidia.spark.rapids.iceberg.IcebergProvider
 import org.apache.commons.lang3.reflect.MethodUtils
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.util.Try
 
 import org.apache.spark.{SPARK_BRANCH, SPARK_BUILD_DATE, SPARK_BUILD_USER, SPARK_REPO_URL, SPARK_REVISION, SPARK_VERSION, SparkConf, SparkEnv}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/GpuHiveTableScanExec.scala
@@ -16,6 +16,13 @@
 
 package org.apache.spark.sql.hive.rapids
 
+import java.net.URI
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.HashSet
+import scala.collection.mutable
+
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, NvtxColor, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.rapids.{ColumnarPartitionReaderWithPartitionValues, CSVPartitionReaderBase, DateUtils, GpuColumnVector, GpuExec, GpuMetric, HostStringColBufferer, HostStringColBuffererFactory, NvtxWithMetrics, PartitionReaderIterator, PartitionReaderWithBytesRead, RapidsConf}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
@@ -23,15 +30,10 @@ import com.nvidia.spark.rapids.GpuMetric.{BUFFER_TIME, DEBUG_LEVEL, DESCRIPTION_
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.CastStrings
 import com.nvidia.spark.rapids.shims.{ShimFilePartitionReaderFactory, ShimSparkPlan, SparkShimImpl}
-import java.net.URI
-import java.util.concurrent.TimeUnit.NANOSECONDS
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
 import org.apache.hadoop.io.compress.{CompressionCodecFactory, SplittableCompressionCodec}
-import scala.collection.JavaConverters._
-import scala.collection.immutable.HashSet
-import scala.collection.mutable
 
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuTaskMetrics.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
+import java.{lang => jl}
 import java.io.ObjectInputStream
 import java.util.Locale
 import java.util.concurrent.TimeUnit
@@ -26,7 +27,6 @@ import ai.rapids.cudf.{NvtxColor, NvtxRange}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.jni.RmmSpark
-import java.{lang => jl}
 
 import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.internal.Logging

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -29,11 +29,11 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.IOException
+import java.util
 
 import com.nvidia.spark.CurrentBatchIterator
 import com.nvidia.spark.rapids.ParquetCachedBatch
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
-import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.ParquetReadOptions
 import org.apache.parquet.column.ColumnDescriptor

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -28,13 +28,13 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.io.IOException
+import java.util
 
 import scala.collection.JavaConverters._
 
 import com.nvidia.spark.CurrentBatchIterator
 import com.nvidia.spark.rapids.ParquetCachedBatch
 import com.nvidia.spark.rapids.shims.ParquetTimestampNTZShims
-import java.util
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.ParquetReadOptions
 import org.apache.parquet.column.page.PageReadStore

--- a/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/TestUtils.scala
@@ -16,10 +16,11 @@
 
 package com.nvidia.spark.rapids
 
+import java.io.File
+
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVectorCore, Table}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
-import java.io.File
 import org.scalatest.Assertions
 
 import org.apache.spark.SparkConf

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CFG.scala
@@ -16,10 +16,11 @@
 
 package com.nvidia.spark.udf
 
-import CatalystExpressionBuilder.simplify
-import javassist.bytecode.{CodeIterator, ConstPool, InstructionPrinter, Opcode}
 import scala.annotation.tailrec
 import scala.collection.immutable.{HashMap, SortedMap, SortedSet}
+
+import CatalystExpressionBuilder.simplify
+import javassist.bytecode.{CodeIterator, ConstPool, InstructionPrinter, Opcode}
 
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging


### PR DESCRIPTION
It appears that scalastyle is no longer enforcing import order in some cases. I am not sure why, but it seems to be a bug in scalastyle since the checks are running and passing.



