### PR TITLE
Add retry support to RowToColumnarIterator

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -309,26 +309,21 @@ public class GpuColumnVector extends GpuColumnVectorBase {
 
     @Override
     public void close() {
-      for (ai.rapids.cudf.HostColumnVector.ColumnBuilder b: builders) {
-        if (b != null) {
-          try {
+      try {
+        for (ai.rapids.cudf.HostColumnVector.ColumnBuilder b: builders) {
+          if (b != null) {
             b.close();
-          } catch (Throwable e) {
-            /* ignore the exception */
           }
         }
-      }
-      if (hostColumns != null) {
-        for (ai.rapids.cudf.HostColumnVector hcv: hostColumns) {
-          if (hcv != null) {
-            try {
+      } finally {
+        if (hostColumns != null) {
+          for (ai.rapids.cudf.HostColumnVector hcv: hostColumns) {
+            if (hcv != null) {
               hcv.close();
-            } catch (Throwable e) {
-              /* ignore the exception */
             }
           }
+          hostColumns = null;
         }
-        hostColumns = null;
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRowToColumnarExec.scala
@@ -653,8 +653,10 @@ class RowToColumnarIterator(
             .foreach(ctx => GpuSemaphore.acquireIfNecessary(ctx))
 
         val ret = withResource(new NvtxWithMetrics("RowToColumnar", NvtxColor.GREEN,
-          opTime)) { _ =>
-          builders.build(rowCount)
+            opTime)) { _ =>
+          RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch] {
+            builders.tryBuild(rowCount)
+          }
         }
         numInputRows += rowCount
         numOutputRows += rowCount

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RowToColumnarIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RowToColumnarIteratorRetrySuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types._
+
+class RowToColumnarIteratorRetrySuite extends RmmSparkRetrySuiteBase {
+  private val schema = StructType(Seq(StructField("a", IntegerType)))
+
+  test("test simple OOM retry") {
+    val rowIter: Iterator[InternalRow] = (1 to 10).map(InternalRow(_)).toIterator
+    val row2ColIter = new RowToColumnarIterator(
+      rowIter, schema, RequireSingleBatch, new GpuRowToColumnConverter(schema))
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+    Arm.withResource(row2ColIter.next()) { batch =>
+      assertResult(10)(batch.numRows())
+    }
+  }
+
+  test("test simple OOM split and retry") {
+    val rowIter: Iterator[InternalRow] = (1 to 10).map(InternalRow(_)).toIterator
+    val row2ColIter = new RowToColumnarIterator(
+      rowIter, schema, RequireSingleBatch, new GpuRowToColumnConverter(schema))
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+    assertThrows[SplitAndRetryOOM] {
+      row2ColIter.next()
+    }
+  }
+}


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/8350

This PR adds in the retry support to RowToColumnarIterator. 

This PR adds a new API named `tryBuild` in the `GpuColumnarBatchBuilder` class to support the retry mechanism.
Builders can build the columns only once. So this change holds the host columns built from the builders and reuses the host columns to build the columnar batch as many times as it needs. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
