### PR TITLE
Add array support for round robin partition; Refactor pluginSupportedOrderableSig [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids.delta
 
 import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaLog, DeltaOptions, DeltaParquetFileFormat}
-import com.nvidia.spark.rapids.{DeltaFormatType, FileFormatChecks, GpuOverrides, GpuParquetFileFormat, RapidsMeta, TypeSig, WriteFileOp}
+import com.nvidia.spark.rapids.{DeltaFormatType, FileFormatChecks, GpuOverrides, GpuParquetFileFormat, RapidsMeta, WriteFileOp}
 import com.nvidia.spark.rapids.delta.shims.DeltaLogShim
 
 import org.apache.spark.sql.SparkSession

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/RapidsDeltaUtils.scala
@@ -60,8 +60,7 @@ object RapidsDeltaUtils {
     // can involve a sort on all columns. The GPU doesn't currently support sorting on all types,
     // so we fallback if the GPU cannot support the round-robin partitioning.
     if (sqlConf.sortBeforeRepartition) {
-      val orderableTypeSig = (GpuOverrides.pluginSupportedOrderableSig + TypeSig.DECIMAL_128
-          + TypeSig.STRUCT).nested()
+      val orderableTypeSig = GpuOverrides.pluginSupportedOrderableSig
       val unorderableTypes = schema.map(_.dataType).filterNot { t =>
         orderableTypeSig.isSupportedByPlugin(t)
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -458,10 +458,9 @@ object GpuOverrides extends Logging {
     ret
   }
 
-  private[this] val _gpuCommonTypes = TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_64
+  val gpuCommonTypes = TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128
 
-  val pluginSupportedOrderableSig: TypeSig =
-    _gpuCommonTypes + TypeSig.STRUCT.nested(_gpuCommonTypes)
+  val pluginSupportedOrderableSig: TypeSig = (gpuCommonTypes + TypeSig.STRUCT).nested()
 
   private[this] def isStructType(dataType: DataType) = dataType match {
     case StructType(_) => true
@@ -1420,11 +1419,11 @@ object GpuOverrides extends Logging {
     expr[Coalesce] (
       "Returns the first non-null argument if exists. Otherwise, null",
       ExprChecks.projectOnly(
-        (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.BINARY +
+        (gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.BINARY +
           TypeSig.MAP + GpuTypeShims.additionalArithmeticSupportedTypes).nested(),
         TypeSig.all,
         repeatingParamCheck = Some(RepeatingParamCheck("param",
-          (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.BINARY +
+          (gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.BINARY +
             TypeSig.MAP + GpuTypeShims.additionalArithmeticSupportedTypes).nested(),
           TypeSig.all))),
       (a, conf, p, r) => new ExprMeta[Coalesce](a, conf, p, r) {
@@ -1984,16 +1983,16 @@ object GpuOverrides extends Logging {
     expr[If](
       "IF expression",
       ExprChecks.projectOnly(
-        (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
+        (gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
             TypeSig.BINARY + GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
         TypeSig.all,
         Seq(ParamCheck("predicate", TypeSig.BOOLEAN, TypeSig.BOOLEAN),
           ParamCheck("trueValue",
-            (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
+            (gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
                 TypeSig.BINARY + GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
             TypeSig.all),
           ParamCheck("falseValue",
-            (_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
+            (gpuCommonTypes + TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP +
                 TypeSig.BINARY + GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
             TypeSig.all))),
       (a, conf, p, r) => new ExprMeta[If](a, conf, p, r) {
@@ -2046,14 +2045,12 @@ object GpuOverrides extends Logging {
     expr[SortOrder](
       "Sort order",
       ExprChecks.projectOnly(
-        (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested() +
-         TypeSig.ARRAY.nested(_gpuCommonTypes + TypeSig.DECIMAL_128)
-           .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+        pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
+            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
         TypeSig.orderable,
         Seq(ParamCheck(
           "input",
-          (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested() +
-           TypeSig.ARRAY.nested(_gpuCommonTypes + TypeSig.DECIMAL_128)
+          pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
              .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
           TypeSig.orderable))),
       (sortOrder, conf, p, r) => new BaseExprMeta[SortOrder](sortOrder, conf, p, r) {
@@ -3631,8 +3628,7 @@ object GpuOverrides extends Logging {
     part[RangePartitioning](
       "Range partitioning",
       PartChecks(RepeatingParamCheck("order_key",
-        (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested() +
-         TypeSig.ARRAY.nested(_gpuCommonTypes + TypeSig.DECIMAL_128)
+        pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
         TypeSig.orderable)),
       (rp, conf, p, r) => new PartMeta[RangePartitioning](rp, conf, p, r) {
@@ -3757,7 +3753,7 @@ object GpuOverrides extends Logging {
       (p, conf, parent, r) => new BatchScanExecMeta(p, conf, parent, r)),
     exec[CoalesceExec](
       "The backend for the dataframe coalesce method",
-      ExecChecks((_gpuCommonTypes + TypeSig.DECIMAL_128 + TypeSig.STRUCT + TypeSig.ARRAY +
+      ExecChecks((gpuCommonTypes + TypeSig.STRUCT + TypeSig.ARRAY +
           TypeSig.MAP + TypeSig.BINARY + GpuTypeShims.additionalArithmeticSupportedTypes).nested(),
         TypeSig.all),
       (coalesce, conf, parent, r) => new SparkPlanMeta[CoalesceExec](coalesce, conf, parent, r) {
@@ -3790,7 +3786,7 @@ object GpuOverrides extends Logging {
       "Take the first limit elements as defined by the sortOrder, and do projection if needed",
       // The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
       // The types below are allowed as inputs and outputs.
-      ExecChecks((pluginSupportedOrderableSig + TypeSig.DECIMAL_128 +
+      ExecChecks((pluginSupportedOrderableSig +
           TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
       (takeExec, conf, p, r) =>
         new SparkPlanMeta[TakeOrderedAndProjectExec](takeExec, conf, p, r) {
@@ -3985,7 +3981,7 @@ object GpuOverrides extends Logging {
       "The backend for the sort operator",
       // The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
       // The types below are allowed as inputs and outputs.
-      ExecChecks((pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.ARRAY +
+      ExecChecks((pluginSupportedOrderableSig + TypeSig.ARRAY +
           TypeSig.STRUCT +TypeSig.MAP + TypeSig.BINARY).nested(), TypeSig.all),
       (sort, conf, p, r) => new GpuSortMeta(sort, conf, p, r)),
     exec[SortMergeJoinExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -1173,8 +1173,7 @@ abstract class GpuBaseAggregateMeta[INPUT <: SparkPlan](
     }
   }
 
-  private val orderable =
-    (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested()
+  private val orderable = pluginSupportedOrderableSig
 
   override def convertToGpu(): GpuExec = {
     lazy val aggModes = agg.aggregateExpressions.map(_.mode).toSet

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuShuffleExchangeExecBase.scala
@@ -89,7 +89,9 @@ abstract class GpuShuffleMetaBase(
       case _: RoundRobinPartitioning
         if SparkShimImpl.sessionFromPlan(shuffle).sessionState.conf
             .sortBeforeRepartition =>
-        val orderableTypes = GpuOverrides.pluginSupportedOrderableSig + TypeSig.DECIMAL_128
+        val orderableTypes = GpuOverrides.pluginSupportedOrderableSig +
+            TypeSig.ARRAY.nested(GpuOverrides.gpuCommonTypes)
+
         shuffle.output.map(_.dataType)
             .filterNot(orderableTypes.isSupportedByPlugin)
             .foreach { dataType =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/zorder/ZOrderRules.scala
@@ -44,7 +44,7 @@ object ZOrderRules {
         TypeSig.INT,
         TypeSig.INT,
         // Same as RangePartitioningExec
-        (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested(),
+        pluginSupportedOrderableSig,
         TypeSig.orderable),
       (a, conf, p, r) => new UnaryExprMeta[UnaryExpression](a, conf, p, r) {
         def getBoundsNOrder: (Array[InternalRow], SortOrder) = {

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusShims.scala
@@ -52,7 +52,7 @@ trait Spark340PlusShims extends Spark331PlusShims {
           "projection if needed",
       // The SortOrder TypeSig will govern what types can actually be used as sorting key data
       // type. The types below are allowed as inputs and outputs.
-      ExecChecks((pluginSupportedOrderableSig + TypeSig.DECIMAL_128 +
+      ExecChecks((pluginSupportedOrderableSig +
           TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
       (takeExec, conf, p, r) =>
         new SparkPlanMeta[TakeOrderedAndProjectExec](takeExec, conf, p, r) {


### PR DESCRIPTION
closes #7807


- Refactor `pluginSupportedOrderableSig`:
All the references of `pluginSupportedOrderableSig` are:
```
RapidsDeltaUtils.scala:
  val orderableTypeSig = (GpuOverrides.pluginSupportedOrderableSig + TypeSig.DECIMAL_128
    + TypeSig.STRUCT).nested()

expr[SortOrder]:
	(pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested() +
		TypeSig.ARRAY.nested(_gpuCommonTypes + TypeSig.DECIMAL_128)
  extra check: STRUCT is not supported as a child type for ARRAY

part[RangePartitioning]
	(pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested() +
		TypeSig.ARRAY.nested(_gpuCommonTypes + TypeSig.DECIMAL_128)

// The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
exec[TakeOrderedAndProjectExec]
	(pluginSupportedOrderableSig + TypeSig.DECIMAL_128 +
          TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested()

// The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
exec[TakeOrderedAndProjectExec]	Spark340
	(pluginSupportedOrderableSig + TypeSig.DECIMAL_128 +
		        TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested()

// The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
exec[SortExec]
	(pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.ARRAY +
          TypeSig.STRUCT +TypeSig.MAP + TypeSig.BINARY).nested()

aggregate.scala
  private val orderable =
    (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested()

GpuShuffleExchangeExecBase.scala
  val orderableTypes = GpuOverrides.pluginSupportedOrderableSig + TypeSig.DECIMAL_128

ZOrderRules.scala
expr[UnaryExpression]
        // Same as RangePartitioningExec
        (pluginSupportedOrderableSig + TypeSig.DECIMAL_128 + TypeSig.STRUCT).nested()
```
Originally pluginSupportedOrderableSig is `_gpuCommonTypes + TypeSig.STRUCT.nested(_gpuCommonTypes)`
All the above references except GpuShuffleExchangeExecBase use (... + TypeSig.STRUCT).nested(), so we can referator
pluginSupportedOrderableSig to (_gpuCommonTypes + TypeSig.STRUCT).nested

- all the references of _gpuCommonTypes plus decimal128, so put decimal128 into _gpuCommonTypes. Modify _gpuCommonTypes to public access


- Enable array(gpuCommonTypes) type in GpuShuffleExchangeExecBase. And add test cases for this feature.


Signed-off-by: Chong Gao <res_life@163.com>
