### PR TITLE
Test ORC predicate pushdown (PPD) with timestamps decimals booleans

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
@@ -70,7 +70,8 @@ class OrcPushDownSuite extends SparkQueryCompareTestSuite {
         val withoutFilters = dfRead.queryExecution.executedPlan.transform {
           case GpuFilterExec(_, child) => child
         }
-        val actual = spark.internalCreateDataFrame(withoutFilters.execute(), schema, false).count()
+        val actual = spark.internalCreateDataFrame(withoutFilters.execute(), schema, false)
+            .count()
         assert(actual < 10)
       })
     }
@@ -97,7 +98,8 @@ class OrcPushDownSuite extends SparkQueryCompareTestSuite {
   //       val withoutFilters = dfRead.queryExecution.executedPlan.transform {
   //         case FilterExec(_, child) => child
   //       }
-  //       val actual = spark.internalCreateDataFrame(withoutFilters.execute(), schema, false).count()
+  //       val actual = spark.internalCreateDataFrame(withoutFilters.execute(), schema, false)
+  //           .count()
   //       assert(actual < 10)
   //     })
   //   }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import java.sql.Timestamp
+
+import com.nvidia.spark.rapids.{GpuFilterExec, SparkQueryCompareTestSuite}
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+class OrcPushDownSuite extends SparkQueryCompareTestSuite {
+
+  private def checkPredicatePushDown(spark: SparkSession, df: DataFrame, 
+      numRows: Int, predicate: String): Unit = {
+    withTempPath { file =>
+      df.repartition(10).write.orc(file.getCanonicalPath)
+      val dfRead = spark.read.orc(file.getCanonicalPath).where(predicate)
+      val schema = dfRead.schema
+      val withoutFilters = dfRead.queryExecution.executedPlan.transform {
+        case GpuFilterExec(_, child) => child
+      }
+      val actual = spark.internalCreateDataFrame(withoutFilters.execute(), schema, false).count()
+      assert(actual < numRows)
+    }
+  }
+
+  test("Support for pushing down filters for boolean types") {
+    withGpuSparkSession(spark => {
+      val data = (0 until 10).map(i => Tuple1(i == 2))
+      checkPredicatePushDown(spark, spark.createDataFrame(data).toDF("a"), 10, "a == true")
+    })
+  }
+
+  test("Support for pushing down filters for decimal types") {
+    withCpuSparkSession(spark => {
+      val data = (0 until 10).map(i => Tuple1(BigDecimal.valueOf(i)))
+      checkPredicatePushDown(spark, spark.createDataFrame(data).toDF("a"), 10, "a == 2")
+    })
+  }
+
+  test("Support for pushing down filters for timestamp types") {
+    withGpuSparkSession(spark => {
+      val timeString = "2015-08-20 14:57:00"
+      val data = (0 until 10).map { i =>
+        val milliseconds = Timestamp.valueOf(timeString).getTime + i * 3600
+        Tuple1(new Timestamp(milliseconds))
+      }
+      checkPredicatePushDown(spark, spark.createDataFrame(data).toDF("a"), 10, 
+          s"a == '$timeString'")
+    })
+  }
+}

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/OrcPushDownSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.execution.FilterExec
 
 class OrcPushDownSuite extends SparkQueryCompareTestSuite {
 
-  private def checkPredicatePushDown(spark: SparkSession, filepath: String, numRows: Int, predicate: String): Unit = {
+  private def checkPredicatePushDown(spark: SparkSession, filepath: String, numRows: Int, 
+      predicate: String): Unit = {
     val df = spark.read.orc(filepath).where(predicate)
     val schema = df.schema
     val withoutFilters = df.queryExecution.executedPlan.transform {


### PR DESCRIPTION
Closes #8823 

[Corresponding tests in Spark](https://github.com/apache/spark/blob/026aa4fdbdcad218d29d047f99852b64e12939b4/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala#L451)

Note: The test "Support for pushing down filters for timestamp types" will fail now. I think plugin is not support orc PPD with timestamps, don't know if it is a known issue. Will do some investigation on it.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
