### PR TITLE
Spillable host buffer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/MetaUtils.scala
@@ -155,12 +155,11 @@ object MetaUtils {
   }
 
   /**
-   * Constructs a table metadata buffer from a device buffer without describing any schema
+   * Constructs a table metadata buffer from a buffer length without describing any schema
    * for the buffer.
    */
-  def getTableMetaNoTable(buffer: DeviceMemoryBuffer): TableMeta = {
+  def getTableMetaNoTable(bufferSize: Long): TableMeta = {
     val fbb = new FlatBufferBuilder(1024)
-    val bufferSize = buffer.getLength
     BufferMeta.startBufferMeta(fbb)
     BufferMeta.addId(fbb, 0)
     BufferMeta.addSize(fbb, bufferSize)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -295,7 +295,7 @@ class RapidsBufferCatalog(
   }
 
   /**
-   * Adds a buffer to the either device or host storage. This does NOT take
+   * Adds a buffer to either the device or host storage. This does NOT take
    * ownership of the buffer, so it is the responsibility of the caller to close it.
    *
    * @param id the RapidsBufferId to use for this buffer

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -637,7 +637,8 @@ class RapidsBufferCatalog(
       spillStore: RapidsBufferStore,
       stream: Cuda.Stream): Unit = {
     val spillStoreMaxSize = spillStore.getMaxSize
-    var success = false
+    // if the spill store is empty, we should not warn extra (there was nothing to spill)
+    var success = spillStore.currentSize == 0
     if (spillStoreMaxSize.isDefined) {
       // this spillStore has a maximum size requirement (host only). We need to spill from it
       // in order to make room for `buffer`.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -637,8 +637,6 @@ class RapidsBufferCatalog(
       spillStore: RapidsBufferStore,
       stream: Cuda.Stream): Unit = {
     val spillStoreMaxSize = spillStore.getMaxSize
-    // if the spill store is empty, we should not warn extra (there was nothing to spill)
-    var success = spillStore.currentSize == 0
     if (spillStoreMaxSize.isDefined) {
       // this spillStore has a maximum size requirement (host only). We need to spill from it
       // in order to make room for `buffer`.
@@ -650,16 +648,7 @@ class RapidsBufferCatalog(
           logInfo(s"Spilled $amountSpilled bytes from the ${spillStore.name} store")
           TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
         }
-        success =
-          amountSpilled >= buffer.getMemoryUsedBytes ||
-            buffer.getMemoryUsedBytes > spillStoreMaxSize.get
       }
-    }
-    // TODO: this is just a warning for now
-    if (!success && spillStoreMaxSize.isDefined) {
-      logWarning(
-        s"Could not spill enough from ${spillStore.name} to stay " +
-          s"within ${spillStoreMaxSize.get} B")
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -21,7 +21,7 @@ import java.util.function.BiFunction
 
 import scala.collection.mutable.ArrayBuffer
 
-import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange, Rmm, Table}
+import ai.rapids.cudf.{ContiguousTable, Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange, Rmm, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsBufferCatalog.getExistingRapidsBufferAndAcquire
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
@@ -63,7 +63,8 @@ trait RapidsBufferHandle extends AutoCloseable {
  * `RapidsBufferCatalog.singleton` should be used instead.
  */
 class RapidsBufferCatalog(
-    deviceStorage: RapidsDeviceMemoryStore = RapidsBufferCatalog.deviceStorage)
+    deviceStorage: RapidsDeviceMemoryStore = RapidsBufferCatalog.deviceStorage,
+    hostStorage: RapidsHostMemoryStore = RapidsBufferCatalog.hostStorage)
   extends AutoCloseable with Logging {
 
   /** Map of buffer IDs to buffers sorted by storage tier */
@@ -198,7 +199,7 @@ class RapidsBufferCatalog(
   }
 
   /**
-   * Adds a buffer to the device storage. This does NOT take ownership of the
+   * Adds a buffer to the catalog and store. This does NOT take ownership of the
    * buffer, so it is the responsibility of the caller to close it.
    *
    * This version of `addBuffer` should not be called from the shuffle catalogs
@@ -212,7 +213,7 @@ class RapidsBufferCatalog(
    * @return RapidsBufferHandle handle for this buffer
    */
   def addBuffer(
-      buffer: DeviceMemoryBuffer,
+      buffer: MemoryBuffer,
       tableMeta: TableMeta,
       initialSpillPriority: Long,
       needsSync: Boolean = true): RapidsBufferHandle = synchronized {
@@ -294,29 +295,42 @@ class RapidsBufferCatalog(
   }
 
   /**
-   * Adds a buffer to the device storage. This does NOT take ownership of the
-   * buffer, so it is the responsibility of the caller to close it.
+   * Adds a buffer to the either device or host storage. This does NOT take
+   * ownership of the buffer, so it is the responsibility of the caller to close it.
    *
    * @param id the RapidsBufferId to use for this buffer
-   * @param buffer buffer that will be owned by the store
+   * @param buffer buffer that will be owned by the target store
    * @param tableMeta metadata describing the buffer layout
    * @param initialSpillPriority starting spill priority value for the buffer
    * @param needsSync whether the spill framework should stream synchronize while adding
-   *                  this device buffer (defaults to true)
+   *                  this buffer (defaults to true)
    * @return RapidsBufferHandle handle for this RapidsBuffer
    */
   def addBuffer(
       id: RapidsBufferId,
-      buffer: DeviceMemoryBuffer,
+      buffer: MemoryBuffer,
       tableMeta: TableMeta,
       initialSpillPriority: Long,
       needsSync: Boolean): RapidsBufferHandle = synchronized {
-    val rapidsBuffer = deviceStorage.addBuffer(
-      id,
-      buffer,
-      tableMeta,
-      initialSpillPriority,
-      needsSync)
+    val rapidsBuffer = buffer match {
+      case gpuBuffer: DeviceMemoryBuffer =>
+        deviceStorage.addBuffer(
+          id,
+          gpuBuffer,
+          tableMeta,
+          initialSpillPriority,
+          needsSync)
+      case hostBuffer: HostMemoryBuffer =>
+        hostStorage.addBuffer(
+          id,
+          hostBuffer,
+          tableMeta,
+          initialSpillPriority,
+          needsSync)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot call addBuffer with buffer $buffer")
+    }
     registerNewBuffer(rapidsBuffer)
     makeNewHandle(id, initialSpillPriority)
   }
@@ -591,6 +605,8 @@ class RapidsBufferCatalog(
         if (!bufferHasSpilled) {
           // if the spillStore specifies a maximum size spill taking this ceiling
           // into account before trying to create a buffer there
+          // TODO: we may need to handle what happens if we can't spill anymore
+          //   because all host buffers are being referenced.
           trySpillToMaximumSize(buffer, spillStore, stream)
 
           // copy the buffer to spillStore
@@ -621,6 +637,7 @@ class RapidsBufferCatalog(
       spillStore: RapidsBufferStore,
       stream: Cuda.Stream): Unit = {
     val spillStoreMaxSize = spillStore.getMaxSize
+    var success = false
     if (spillStoreMaxSize.isDefined) {
       // this spillStore has a maximum size requirement (host only). We need to spill from it
       // in order to make room for `buffer`.
@@ -632,7 +649,16 @@ class RapidsBufferCatalog(
           logInfo(s"Spilled $amountSpilled bytes from the ${spillStore.name} store")
           TrampolineUtil.incTaskMetricsDiskBytesSpilled(amountSpilled)
         }
+        success =
+          amountSpilled >= buffer.getMemoryUsedBytes ||
+            buffer.getMemoryUsedBytes > spillStoreMaxSize.get
       }
+    }
+    // TODO: this is just a warning for now
+    if (!success && spillStoreMaxSize.isDefined) {
+      logWarning(
+        s"Could not spill enough from ${spillStore.name} to stay " +
+          s"within ${spillStoreMaxSize.get} B")
     }
   }
 
@@ -869,7 +895,7 @@ object RapidsBufferCatalog extends Logging {
   }
 
   /**
-   * Adds a buffer to the device storage. This does NOT take ownership of the
+   * Adds a buffer to the catalog and store. This does NOT take ownership of the
    * buffer, so it is the responsibility of the caller to close it.
    * @param buffer buffer that will be owned by the store
    * @param tableMeta metadata describing the buffer layout
@@ -877,7 +903,7 @@ object RapidsBufferCatalog extends Logging {
    * @return RapidsBufferHandle associated with this buffer
    */
   def addBuffer(
-      buffer: DeviceMemoryBuffer,
+      buffer: MemoryBuffer,
       tableMeta: TableMeta,
       initialSpillPriority: Long): RapidsBufferHandle = {
     singleton.addBuffer(buffer, tableMeta, initialSpillPriority)
@@ -901,7 +927,7 @@ object RapidsBufferCatalog extends Logging {
   def getDiskBlockManager(): RapidsDiskBlockManager = diskBlockManager
 
   /**
-   * Given a `DeviceMemoryBuffer` find out if a `MemoryBuffer.EventHandler` is associated
+   * Given a `MemoryBuffer` find out if a `MemoryBuffer.EventHandler` is associated
    * with it.
    *
    * After getting the `RapidsBuffer` try to acquire it via `addReference`.
@@ -910,7 +936,7 @@ object RapidsBufferCatalog extends Logging {
    * are adding it again).
    *
    * @note public for testing
-   * @param buffer - the `DeviceMemoryBuffer` to inspect
+   * @param buffer - the `MemoryBuffer` to inspect
    * @return - Some(RapidsBuffer): the handler is associated with a rapids buffer
    *         and the rapids buffer is currently valid, or
    *
@@ -919,7 +945,7 @@ object RapidsBufferCatalog extends Logging {
    *           about to be removed).
    */
   private def getExistingRapidsBufferAndAcquire(
-      buffer: DeviceMemoryBuffer): Option[RapidsBuffer] = {
+      buffer: MemoryBuffer): Option[RapidsBuffer] = {
     val eh = buffer.getEventHandler
     eh match {
       case null =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
@@ -137,25 +137,8 @@ class RapidsDeviceMemoryStore(chunkedPackBounceBufferSize: Long = 128L*1024*1024
       initialSpillPriority)
     freeOnExcept(rapidsTable) { _ =>
       addBuffer(rapidsTable, needsSync)
-      rapidsTable.updateSpillability()
       rapidsTable
     }
-  }
-
-  /**
-   * Adds a device buffer to the spill framework, stream synchronizing with the producer
-   * stream to ensure that the buffer is fully materialized, and can be safely copied
-   * as part of the spill.
-   *
-   * @param needsSync true if we should stream synchronize before adding the buffer
-   */
-  private def addBuffer(
-      buffer: RapidsBufferBase,
-      needsSync: Boolean): Unit = {
-    if (needsSync) {
-      Cuda.DEFAULT_STREAM.sync()
-    }
-    addBuffer(buffer)
   }
 
   /**
@@ -309,7 +292,7 @@ class RapidsDeviceMemoryStore(chunkedPackBounceBufferSize: Long = 128L*1024*1024
      * - after adding a table to the store to mark the table as spillable if
      * all columns are spillable.
      */
-    def updateSpillability(): Unit = {
+    override def updateSpillability(): Unit = {
       doSetSpillable(this, columnSpillability.size == numDistinctColumns)
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -60,8 +60,6 @@ class RapidsHostMemoryStore(
       initialSpillPriority: Long,
       needsSync: Boolean): RapidsBuffer = {
     buffer.incRefCount()
-    // TODO: note that there is a difference between buffer.getLength
-    // andthe metadata sizes...
     val rapidsBuffer = new RapidsHostMemoryBuffer(
       id,
       buffer.getLength,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RapidsBufferCatalogSuite.scala
@@ -220,7 +220,7 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
         hostStore.setSpillStore(mockStore)
         val catalog = new RapidsBufferCatalog(deviceStore)
         val handle = withResource(DeviceMemoryBuffer.allocate(1024)) { buff =>
-          val meta = MetaUtils.getTableMetaNoTable(buff)
+          val meta = MetaUtils.getTableMetaNoTable(buff.getLength)
           catalog.addBuffer(
             buff, meta, -1)
         }
@@ -353,6 +353,9 @@ class RapidsBufferCatalogSuite extends AnyFunSuite with MockitoSugar {
       override def setSpillPriority(priority: Long): Unit = {
         currentPriority = priority
       }
+
+      override def withMemoryBufferReadLock[K](body: MemoryBuffer => K): K = { body(null) }
+      override def withMemoryBufferWriteLock[K](body: MemoryBuffer => K): K = { body(null) }
       override def close(): Unit = {}
     })
   }

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/SpillableColumnarBatchSuite.scala
@@ -61,5 +61,7 @@ class SpillableColumnarBatchSuite extends AnyFunSuite {
     override def close(): Unit = {}
     override def getColumnarBatch(
       sparkTypes: Array[DataType]): ColumnarBatch = null
+    override def withMemoryBufferReadLock[K](body: MemoryBuffer => K): K = { body(null) }
+    override def withMemoryBufferWriteLock[K](body: MemoryBuffer => K): K = { body(null) }
   }
 }


### PR DESCRIPTION
This contributes towards https://github.com/NVIDIA/spark-rapids/issues/8882 but it doesn't close it since we need to handle `HostColumnVectors` (it will end up being a `SpillableHostBatch` for now).

I can add more tests around host spillability but I do have a couple of TODOs in the code that I need some clarification on (possibly just put it in as is and add follow on as we add more support for host spillable).

Posting for some :eyes: to make sure I didn't miss something major.