### PR TITLE
Stop using invalid escape sequences

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -47,7 +47,7 @@ def test_get_json_object(json_str_pattern):
 def test_unsupported_fallback_get_json_object(json_str_pattern):
     gen = mk_json_str_gen(json_str_pattern)
     scalar_json = '{"store": {"fruit": "test"}}'
-    pattern = StringGen(pattern='\$\.[a-z]{1,9}')
+    pattern = StringGen(pattern=r'\$\.[a-z]{1,9}')
     def assert_gpu_did_fallback(sql_text):
         assert_gpu_fallback_collect(lambda spark:
             gen_df(spark, [('a', gen), ('b', pattern)], length=10).selectExpr(sql_text),

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import locale
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_collect, \
-    assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_error, \
+    assert_gpu_and_cpu_error, \
     assert_gpu_sql_fallback_collect
 from data_gen import *
 from marks import *
@@ -520,7 +519,7 @@ def test_word_boundaries():
                 'regexp_replace(a, "\\\\B", "#")',
             ),
         conf=_regexp_conf)
-        
+
 def test_character_classes():
     gen = mk_str_gen('[abcd]{1,3}[0-9]{1,3}[abcd]{1,3}[ \n\t\r]{0,2}')
     assert_gpu_and_cpu_are_equal_collect(
@@ -864,7 +863,7 @@ def test_regexp_replace_fallback_configured_off():
 @allow_non_gpu('ProjectExec')
 def test_unsupported_fallback_regexp_extract():
     gen = mk_str_gen('[abcdef]{0,2}')
-    regex_gen = StringGen('\[a-z\]\+')
+    regex_gen = StringGen(r'\[a-z\]\+')
     num_gen = IntegerGen(min_val=0, max_val=0, special_cases=[])
 
     def assert_gpu_did_fallback(sql_text):
@@ -886,7 +885,7 @@ def test_unsupported_fallback_regexp_extract():
 @allow_non_gpu('ProjectExec')
 def test_unsupported_fallback_regexp_extract_all():
     gen = mk_str_gen('[abcdef]{0,2}')
-    regex_gen = StringGen('\[a-z\]\+')
+    regex_gen = StringGen(r'\[a-z\]\+')
     num_gen = IntegerGen(min_val=0, max_val=0, special_cases=[])
     def assert_gpu_did_fallback(sql_text):
         assert_gpu_fallback_collect(lambda spark:
@@ -907,7 +906,7 @@ def test_unsupported_fallback_regexp_extract_all():
 @allow_non_gpu('ProjectExec', 'RegExpReplace')
 def test_unsupported_fallback_regexp_replace():
     gen = mk_str_gen('[abcdef]{0,2}')
-    regex_gen = StringGen('\[a-z\]\+')
+    regex_gen = StringGen(r'\[a-z\]\+')
     def assert_gpu_did_fallback(sql_text):
         assert_gpu_fallback_collect(lambda spark:
             gen_df(spark, [
@@ -992,7 +991,7 @@ def test_regexp_memory_fallback():
             'a rlike "1|2|3|4|5|6"'
         ),
         cpu_fallback_class_name='RLike',
-        conf={ 
+        conf={
             'spark.rapids.sql.regexp.enabled': True,
             'spark.rapids.sql.regexp.maxStateMemoryBytes': '10',
             'spark.rapids.sql.batchSizeBytes': '20' # 1 row in the batch
@@ -1014,7 +1013,7 @@ def test_regexp_memory_ok():
             'a rlike "(1)(2)(3)"',
             'a rlike "1|2|3|4|5|6"'
         ),
-        conf={ 
+        conf={
             'spark.rapids.sql.regexp.enabled': True,
             'spark.rapids.sql.regexp.maxStateMemoryBytes': '12',
             'spark.rapids.sql.batchSizeBytes': '20' # 1 row in the batch


### PR DESCRIPTION
Fixes #8980 

Replace strings with invalid escape sequences with the equivalent raw literals 

## Testing

```bash
$ ./integration_tests/run_pyspark_from_build.sh -k 'regexp_test or get_json_test' |& tee build.log
$ grep -c 'invalid escape' build.log 
0
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
