### PR TITLE
Add retry and SplitAndRetry support to AcceleratedColumnarToRowIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -134,7 +134,7 @@ class AcceleratedColumnarToRowIterator(
         }
         assert(it.hasNext, "Got an unexpected empty iterator after setting up batch with retry")
         it.foreach { rowsCvList =>
-          withResource(rowsCvList) { - =>
+          withResource(rowsCvList) { _ =>
             rowsCvList.foreach { rowsCv =>
               pendingCvs += rowsCv.copyToHost()
             }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.jni.RmmSpark
+
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId}
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class ColumnToRowIteratorRetrySuite extends RmmSparkRetrySuiteBase {
+
+  private val ref = GpuBoundReference(0, IntegerType, nullable = false)(ExprId(0), "a")
+  private val attrs = Seq(AttributeReference(ref.name, ref.dataType, ref.nullable)())
+  private val NUM_ROWS = 50
+
+  private def buildBatch: ColumnarBatch = {
+    val ints = 0 until NUM_ROWS
+    new ColumnarBatch(
+      Array(GpuColumnVector.from(ColumnVector.fromInts(ints: _*), IntegerType)), NUM_ROWS)
+  }
+
+  test("Accelerated columnar to row with retry OOM") {
+    val aCol2RowIter = new AcceleratedColumnarToRowIterator(
+      attrs,
+      Iterator(buildBatch),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, inTestMode = true)
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+    var numRows = 0
+    aCol2RowIter.foreach { _ =>
+      // only one batch
+      numRows += 1
+    }
+    assertResult(NUM_ROWS)(numRows)
+  }
+
+  test("Accelerated columnar_to_row with split and retry OOM") {
+    val aCol2RowIter = new AcceleratedColumnarToRowIterator(
+      attrs,
+      Iterator(buildBatch),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, inTestMode = true)
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+    var numRows = 0
+    aCol2RowIter.foreach { _ =>
+      // only one batch
+      numRows += 1
+    }
+    assertResult(NUM_ROWS)(numRows)
+  }
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
@@ -43,7 +43,6 @@ class ColumnToRowIteratorRetrySuite extends RmmSparkRetrySuiteBase {
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
     var numRows = 0
     aCol2RowIter.foreach { _ =>
-      // only one batch
       numRows += 1
     }
     assertResult(NUM_ROWS)(numRows)
@@ -57,7 +56,6 @@ class ColumnToRowIteratorRetrySuite extends RmmSparkRetrySuiteBase {
     RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
     var numRows = 0
     aCol2RowIter.foreach { _ =>
-      // only one batch
       numRows += 1
     }
     assertResult(NUM_ROWS)(numRows)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ColumnToRowIteratorRetrySuite.scala
@@ -39,7 +39,7 @@ class ColumnToRowIteratorRetrySuite extends RmmSparkRetrySuiteBase {
     val aCol2RowIter = new AcceleratedColumnarToRowIterator(
       attrs,
       Iterator(buildBatch),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, inTestMode = true)
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
     RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
     var numRows = 0
     aCol2RowIter.foreach { _ =>
@@ -52,7 +52,7 @@ class ColumnToRowIteratorRetrySuite extends RmmSparkRetrySuiteBase {
     val aCol2RowIter = new AcceleratedColumnarToRowIterator(
       attrs,
       Iterator(buildBatch),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, inTestMode = true)
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
     RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
     var numRows = 0
     aCol2RowIter.foreach { _ =>


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/8348

This PR adds retry and `SplitAndRetry` support to `AcceleratedColumnarToRowIterator`.

It will retry converting columns to rows by cudf when getting any oom exception.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
