### PR TITLE
Add SpillableHostColumnarBatch

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/RapidsHostColumnVector.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -457,6 +457,23 @@ class RapidsBufferCatalog(
   }
 
   /**
+   * Acquires a RapidsBuffer that the caller expects to be host-backed and not
+   * device bound. This ensures that the buffer acquired implements the correct
+   * trait, otherwise it throws and removes its buffer acquisition.
+   *
+   * @param handle handle associated with this `RapidsBuffer`
+   * @return host-backed RapidsBuffer that has been acquired
+   */
+  def acquireHostBatchBuffer(handle: RapidsBufferHandle): RapidsHostBatchBuffer = {
+    closeOnExcept(acquireBuffer(handle)) {
+      case hrb: RapidsHostBatchBuffer => hrb
+      case other =>
+        throw new IllegalStateException(
+          s"Attempted to acquire a RapidsHostBatchBuffer, but got $other instead")
+    }
+  }
+
+  /**
    * Lookup the buffer that corresponds to the specified buffer ID at the specified storage tier,
    * and acquire it.
    * NOTE: It is the responsibility of the caller to close the buffer.
@@ -939,6 +956,17 @@ object RapidsBufferCatalog extends Logging {
    */
   def acquireBuffer(handle: RapidsBufferHandle): RapidsBuffer =
     singleton.acquireBuffer(handle)
+
+  /**
+   * Acquires a RapidsBuffer that the caller expects to be host-backed and not
+   * device bound. This ensures that the buffer acquired implements the correct
+   * trait, otherwise it throws and removes its buffer acquisition.
+   *
+   * @param handle handle associated with this `RapidsBuffer`
+   * @return host-backed RapidsBuffer that has been acquired
+   */
+  def acquireHostBatchBuffer(handle: RapidsBufferHandle): RapidsHostBatchBuffer =
+    singleton.acquireHostBatchBuffer(handle)
 
   def getDiskBlockManager(): RapidsDiskBlockManager = diskBlockManager
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -16,11 +16,19 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostMemoryBuffer, MemoryBuffer, NvtxColor, NvtxRange, PinnedMemoryPool}
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.mutable
+
+import ai.rapids.cudf.{Cuda, DeviceMemoryBuffer, HostColumnVector, HostMemoryBuffer, JCudfSerialization, MemoryBuffer, NvtxColor, NvtxRange, PinnedMemoryPool}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, freeOnExcept, withResource}
 import com.nvidia.spark.rapids.SpillPriorities.{applyPriorityOffset, HOST_MEMORY_BUFFER_SPILL_OFFSET}
 import com.nvidia.spark.rapids.StorageTier.StorageTier
 import com.nvidia.spark.rapids.format.TableMeta
+
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /**
  * A buffer store using host memory.
@@ -65,12 +73,28 @@ class RapidsHostMemoryStore(
       buffer.getLength,
       tableMeta,
       initialSpillPriority,
-      buffer)
+      buffer,
+      needsSerialization = false)
     freeOnExcept(rapidsBuffer) { _ =>
       logDebug(s"Adding host buffer for: [id=$id, size=${buffer.getLength}, " +
         s"uncompressed=${rapidsBuffer.meta.bufferMeta.uncompressedSize}, " +
         s"meta_id=${tableMeta.bufferMeta.id}, " +
         s"meta_size=${tableMeta.bufferMeta.size}]")
+      addBuffer(rapidsBuffer, needsSync)
+      rapidsBuffer
+    }
+  }
+
+  def addBatch(id: RapidsBufferId,
+               hostCb: ColumnarBatch,
+               initialSpillPriority: Long,
+               needsSync: Boolean): RapidsBuffer = {
+    RapidsHostColumnVector.incRefCounts(hostCb)
+    val rapidsBuffer = new RapidsHostColumnarBatch(
+      id,
+      hostCb,
+      initialSpillPriority)
+    freeOnExcept(rapidsBuffer) { _ =>
       addBuffer(rapidsBuffer, needsSync)
       rapidsBuffer
     }
@@ -123,7 +147,8 @@ class RapidsHostMemoryStore(
       size: Long,
       meta: TableMeta,
       spillPriority: Long,
-      buffer: HostMemoryBuffer)
+      buffer: HostMemoryBuffer,
+      override val needsSerialization: Boolean = false)
       extends RapidsBufferBase(id, meta, spillPriority)
         with MemoryBuffer.EventHandler {
     override val storageTier: StorageTier = StorageTier.HOST
@@ -189,6 +214,216 @@ class RapidsHostMemoryStore(
         buffer.setEventHandler(null)
       }
       super.free()
+    }
+  }
+
+  /**
+   * A per cuDF host column event handler that handles calls to .close()
+   * inside of the `HostColumnVector` lock.
+   */
+  class RapidsHostColumnEventHandler
+    extends HostColumnVector.EventHandler {
+
+    // Every RapidsHostColumnarBatch that references this column has an entry in this map.
+    // The value represents the number of times (normally 1) that a ColumnVector
+    // appears in the RapidsHostColumnarBatch. This is also the HosColumnVector refCount at which
+    // the column is considered spillable.
+    // The map is protected via the ColumnVector lock.
+    private val registration = new mutable.HashMap[RapidsHostColumnarBatch, Int]()
+
+    /**
+     * Every RapidsHostColumnarBatch iterates through its columns and either creates
+     * a `RapidsHostColumnEventHandler` object and associates it with the column's
+     * `eventHandler` or calls into the existing one, and registers itself.
+     *
+     * The registration has two goals: it accounts for repetition of a column
+     * in a `RapidsHostColumnarBatch`. If a batch has the same column repeated it must adjust
+     * the refCount at which this column is considered spillable.
+     *
+     * The second goal is to account for aliasing. If two host batches alias this column
+     * we are going to mark it as non spillable.
+     *
+     * @param rapidsHostCb - the host batch that is registering itself with this tracker
+     */
+    def register(rapidsHostCb: RapidsHostColumnarBatch, repetition: Int): Unit = {
+      registration.put(rapidsHostCb, repetition)
+    }
+
+    /**
+     * This is invoked during `RapidsHostColumnarBatch.free` in order to remove the entry
+     * in `registration`.
+     *
+     * @param rapidsHostCb - the batch that is de-registering itself
+     */
+    def deregister(rapidsHostCb: RapidsHostColumnarBatch): Unit = {
+      registration.remove(rapidsHostCb)
+    }
+
+    // called with the cudf HostColumnVector lock held from cuDF's side
+    override def onClosed(cudfCv: HostColumnVector, refCount: Int): Unit = {
+      // we only handle spillability if there is a single batch registered
+      // (no aliasing)
+      if (registration.size == 1) {
+        val (rapidsHostCb, spillableRefCount) = registration.head
+        if (spillableRefCount == refCount) {
+          rapidsHostCb.onColumnSpillable(cudfCv)
+        }
+      }
+    }
+  }
+
+  /**
+   * A `RapidsHostColumnarBatch` is the spill store holder of ColumnarBatch backed by
+   * HostColumnVector.
+   *
+   * This class owns the host batch and will close it when `close` is called.
+   *
+   * @param id the `RapidsBufferId` this batch is associated with
+   * @param batch the host ColumnarBatch we are managing
+   * @param spillPriority a starting spill priority
+   */
+  class RapidsHostColumnarBatch(
+      id: RapidsBufferId,
+      hostCb: ColumnarBatch,
+      spillPriority: Long)
+      extends RapidsBufferBase(
+        id,
+        null,
+        spillPriority) {
+
+    override val storageTier: StorageTier = StorageTier.HOST
+
+    override val needsSerialization: Boolean = true
+
+    // This is the current size in batch form. It is to be used while this
+    // batch hasn't migrated to another store.
+    private val hostSizeInByes: Long = RapidsHostColumnVector.getTotalHostMemoryUsed(hostCb)
+
+    // By default all columns are NOT spillable since we are not the only owners of
+    // the columns (the caller is holding onto a ColumnarBatch that will be closed
+    // after instantiation, triggering onClosed callbacks)
+    // This hash set contains the columns that are currently spillable.
+    private val columnSpillability = new ConcurrentHashMap[HostColumnVector, Boolean]()
+
+    private val numDistinctColumns = RapidsHostColumnVector.extractBases(hostCb).distinct.size
+
+    // we register our event callbacks as the very first action to deal with
+    // spillability
+    registerOnCloseEventHandler()
+
+    /** Release the underlying resources for this buffer. */
+    override protected def releaseResources(): Unit = {
+      hostCb.close()
+    }
+
+    override def meta: TableMeta = {
+      null
+    }
+
+    override def getMemoryUsedBytes: Long = hostSizeInByes
+
+    /**
+     * Mark a column as spillable
+     *
+     * @param column the ColumnVector to mark as spillable
+     */
+    def onColumnSpillable(column: HostColumnVector): Unit = {
+      columnSpillability.put(column, true)
+      updateSpillability()
+    }
+
+    /**
+     * Update the spillability state of this RapidsHostColumnarBatch. This is invoked from
+     * two places:
+     *
+     * - from the onColumnSpillable callback, which is invoked from a
+     * HostColumnVector.EventHandler.onClosed callback.
+     *
+     * - after adding a batch to the store to mark the batch as spillable if
+     * all columns are spillable.
+     */
+    override def updateSpillability(): Unit = {
+      doSetSpillable(this, columnSpillability.size == numDistinctColumns)
+    }
+
+    override def getColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = {
+      throw new UnsupportedOperationException(
+        "RapidsHostColumnarBatch does not support getColumnarBatch")
+    }
+
+    override def getHostColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = {
+      columnSpillability.clear()
+      doSetSpillable(this, false)
+      RapidsHostColumnVector.incRefCounts(hostCb)
+    }
+
+    override def getMemoryBuffer: MemoryBuffer = {
+      throw new UnsupportedOperationException(
+        "RapidsHostColumnarBatch does not support getMemoryBuffer")
+    }
+
+    override def getCopyIterator: RapidsBufferCopyIterator = {
+      throw new UnsupportedOperationException(
+        "RapidsHostColumnarBatch does not support getCopyIterator")
+    }
+
+    override def serializeToStream(outputStream: OutputStream): Unit = {
+      val columns = RapidsHostColumnVector.extractBases(hostCb)
+      JCudfSerialization.writeToStream(columns, outputStream, 0, hostCb.numRows())
+    }
+
+    override def free(): Unit = {
+      // lets remove our handler from the chain of handlers for each column
+      removeOnCloseEventHandler()
+      super.free()
+    }
+
+    private def registerOnCloseEventHandler(): Unit = {
+      val columns = RapidsHostColumnVector.extractBases(hostCb)
+      // cudfColumns could contain duplicates. We need to take this into account when we are
+      // deciding the floor refCount for a duplicated column
+      val repetitionPerColumn = new mutable.HashMap[HostColumnVector, Int]()
+      columns.foreach { col =>
+        val repetitionCount = repetitionPerColumn.getOrElse(col, 0)
+        repetitionPerColumn(col) = repetitionCount + 1
+      }
+      repetitionPerColumn.foreach { case (distinctCv, repetition) =>
+        // lock the column because we are setting its event handler, and we are inspecting
+        // its refCount.
+        distinctCv.synchronized {
+          val eventHandler = distinctCv.getEventHandler match {
+            case null =>
+              val eventHandler = new RapidsHostColumnEventHandler
+              distinctCv.setEventHandler(eventHandler)
+              eventHandler
+            case existing: RapidsHostColumnEventHandler =>
+              existing
+            case other =>
+              throw new IllegalStateException(
+                s"Invalid column event handler $other")
+          }
+          eventHandler.register(this, repetition)
+          if (repetition == distinctCv.getRefCount) {
+            onColumnSpillable(distinctCv)
+          }
+        }
+      }
+    }
+
+    // this method is called from free()
+    private def removeOnCloseEventHandler(): Unit = {
+      val distinctColumns = RapidsHostColumnVector.extractBases(hostCb).distinct
+      distinctColumns.foreach { distinctCv =>
+        distinctCv.synchronized {
+          distinctCv.getEventHandler match {
+            case eventHandler: RapidsHostColumnEventHandler =>
+              eventHandler.deregister(this)
+            case t =>
+              throw new IllegalStateException(
+                s"Invalid column event handler $t")
+          }
+        }
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -122,6 +122,72 @@ class SpillableColumnarBatchImpl (
   }
 }
 
+class JustRowsHostColumnarBatch(numRows: Int)
+  extends SpillableColumnarBatch {
+  override def numRows(): Int = numRows
+  override def setSpillPriority(priority: Long): Unit = () // NOOP nothing to spill
+
+  def getColumnarBatch(): ColumnarBatch = {
+    new ColumnarBatch(Array.empty, numRows)
+  }
+
+  override def close(): Unit = () // NOOP nothing to close
+  override val sizeInBytes: Long = 0L
+
+  override def dataTypes: Array[DataType] = Array.empty
+}
+
+/**
+ * The implementation of [[SpillableHostColumnarBatch]] that points to buffers that can be spilled.
+ * @note the buffer should be in the cache by the time this is created and this is taking over
+ *       ownership of the life cycle of the batch.  So don't call this constructor directly please
+ *       use `SpillableHostColumnarBatch.apply` instead.
+ */
+class SpillableHostColumnarBatchImpl (
+    handle: RapidsBufferHandle,
+    rowCount: Int,
+    sparkTypes: Array[DataType],
+    catalog: RapidsBufferCatalog)
+  extends SpillableColumnarBatch {
+
+  override def dataTypes: Array[DataType] = sparkTypes
+  /**
+   * The number of rows stored in this batch.
+   */
+  override def numRows(): Int = rowCount
+
+  private def withRapidsBuffer[T](fn: RapidsBuffer => T): T = {
+    withResource(catalog.acquireBuffer(handle)) { rapidsBuffer =>
+      fn(rapidsBuffer)
+    }
+  }
+
+  override lazy val sizeInBytes: Long = {
+    withRapidsBuffer(_.getMemoryUsedBytes)
+  }
+
+  /**
+   * Set a new spill priority.
+   */
+  override def setSpillPriority(priority: Long): Unit = {
+    handle.setSpillPriority(priority)
+  }
+
+  override def getColumnarBatch(): ColumnarBatch = {
+    withRapidsBuffer { rapidsBuffer =>
+      rapidsBuffer.getHostColumnarBatch(sparkTypes)
+    }
+  }
+
+  /**
+   * Remove the `ColumnarBatch` from the cache.
+   */
+  override def close(): Unit = {
+    // closing my reference
+    handle.close()
+  }
+}
+
 object SpillableColumnarBatch {
   /**
    * Create a new SpillableColumnarBatch.
@@ -207,9 +273,46 @@ object SpillableColumnarBatch {
       }
     }
   }
-
 }
 
+object SpillableHostColumnarBatch {
+  /**
+   * Create a new SpillableColumnarBatch backed by host columns.
+   *
+   * @note This takes over ownership of batch, and batch should not be used after this.
+   * @param batch         the batch to make spillable
+   * @param priority      the initial spill priority of this batch
+   */
+  def apply(
+      batch: ColumnarBatch,
+      priority: Long,
+      catalog: RapidsBufferCatalog = RapidsBufferCatalog.singleton): SpillableColumnarBatch = {
+    val numRows = batch.numRows()
+    if (batch.numCols() <= 0) {
+      // We consumed it
+      batch.close()
+      new JustRowsHostColumnarBatch(numRows)
+    } else {
+      val types = RapidsHostColumnVector.extractColumns(batch).map(_.dataType())
+      val handle = addHostBatch(batch, priority, catalog)
+      new SpillableHostColumnarBatchImpl(
+        handle,
+        numRows,
+        types,
+        catalog)
+    }
+  }
+
+  private[this] def addHostBatch(
+      batch: ColumnarBatch,
+      initialSpillPriority: Long,
+      catalog: RapidsBufferCatalog): RapidsBufferHandle = {
+    withResource(batch) { batch =>
+      catalog.addBatch(batch, initialSpillPriority)
+    }
+  }
+
+}
 /**
  * Just like a SpillableColumnarBatch but for buffers.
  */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SpillableColumnarBatch.scala
@@ -151,19 +151,20 @@ class SpillableHostColumnarBatchImpl (
   extends SpillableColumnarBatch {
 
   override def dataTypes: Array[DataType] = sparkTypes
+
   /**
    * The number of rows stored in this batch.
    */
   override def numRows(): Int = rowCount
 
-  private def withRapidsBuffer[T](fn: RapidsBuffer => T): T = {
-    withResource(catalog.acquireBuffer(handle)) { rapidsBuffer =>
+  private def withRapidsHostBatchBuffer[T](fn: RapidsHostBatchBuffer => T): T = {
+    withResource(catalog.acquireHostBatchBuffer(handle)) { rapidsBuffer =>
       fn(rapidsBuffer)
     }
   }
 
   override lazy val sizeInBytes: Long = {
-    withRapidsBuffer(_.getMemoryUsedBytes)
+    withRapidsHostBatchBuffer(_.getMemoryUsedBytes)
   }
 
   /**
@@ -174,8 +175,8 @@ class SpillableHostColumnarBatchImpl (
   }
 
   override def getColumnarBatch(): ColumnarBatch = {
-    withRapidsBuffer { rapidsBuffer =>
-      rapidsBuffer.getHostColumnarBatch(sparkTypes)
+    withRapidsHostBatchBuffer { hostBatchBuffer =>
+      hostBatchBuffer.getHostColumnarBatch(sparkTypes)
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/SerializedHostTableUtils.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/SerializedHostTableUtils.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.execution
+
+import java.io.{DataInputStream, InputStream}
+
+import ai.rapids.cudf.{HostMemoryBuffer, JCudfSerialization}
+import com.nvidia.spark.rapids.Arm.closeOnExcept
+import com.nvidia.spark.rapids.RapidsHostColumnVector
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
+
+import org.apache.spark.sql.types.DataType
+
+object SerializedHostTableUtils {
+  /**
+   * Read in a cuDF serialized table into host memory from an input stream.
+   */
+  def readTableHeaderAndBuffer(
+      in: InputStream): (JCudfSerialization.SerializedTableHeader, HostMemoryBuffer) = {
+    val din = new DataInputStream(in)
+    val header = new JCudfSerialization.SerializedTableHeader(din)
+    if (!header.wasInitialized()) {
+      throw new IllegalStateException("Could not read serialized table header")
+    }
+    closeOnExcept(HostMemoryBuffer.allocate(header.getDataLen)) { buffer =>
+      JCudfSerialization.readTableIntoBuffer(din, header, buffer)
+      if (!header.wasDataRead()) {
+        throw new IllegalStateException("Could not read serialized table data")
+      }
+      (header, buffer)
+    }
+  }
+
+  /**
+   * Deserialize a cuDF serialized table to host build column vectors
+   */
+  def buildHostColumns(
+      header: JCudfSerialization.SerializedTableHeader,
+      buffer: HostMemoryBuffer,
+      dataTypes: Array[DataType]): Array[RapidsHostColumnVector] = {
+    assert(dataTypes.length == header.getNumColumns)
+    closeOnExcept(JCudfSerialization.unpackHostColumnVectors(header, buffer)) { hostColumns =>
+      assert(hostColumns.length == dataTypes.length)
+      dataTypes.zip(hostColumns).safeMap { case (dataType, hostColumn) =>
+        new RapidsHostColumnVector(dataType, hostColumn)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8882

This is ready for another pair of eyes to take a look a the approach, especially around serialization/deserialization of host-backed ColumnarBatch. 

Note that this doesn't support "[unspill](https://github.com/NVIDIA/spark-rapids/issues/9107)", as the path to get a memory buffer is not supported for a batch. We need follow on work after this like unspill and how to deal with [GDS](https://github.com/NVIDIA/spark-rapids/issues/9106) being configured. We also are using JCudfSerialization to write and read from a JVM stream to write/read from disk and there are likely faster ways of doing this we can look into, but they should be under the hood.

I am going to run this through NDS just in case, so I'll mark it as a draft for now. 