### PR TITLE
Support broadcast nested loop existence joins with no condition

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
@@ -80,7 +80,10 @@ object GpuBroadcastHelper {
     }
   }
 
-  /** Given a broadcast relation return an RDD of that relation. */
+  /**
+   * Given a broadcast relation return an RDD of that relation.
+   * @note This can only be called from driver code.
+   */
   def asRDD(sc: SparkContext, broadcast: Broadcast[Any]): RDD[ColumnarBatch] = {
     broadcast.value match {
       case broadcastBatch: SerializeConcatHostBuffersDeserializeBatch =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHelper.scala
@@ -21,7 +21,9 @@ import com.nvidia.spark.rapids.{GpuColumnVector, RmmRapidsRetryIterator}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 
+import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -75,6 +77,19 @@ object GpuBroadcastHelper {
       case v if SparkShimImpl.isEmptyRelation(v) => 0
       case t =>
         throw new IllegalStateException(s"Invalid broadcast batch received $t")
+    }
+  }
+
+  /** Given a broadcast relation return an RDD of that relation. */
+  def asRDD(sc: SparkContext, broadcast: Broadcast[Any]): RDD[ColumnarBatch] = {
+    broadcast.value match {
+      case broadcastBatch: SerializeConcatHostBuffersDeserializeBatch =>
+        val hostBatchRDD = sc.makeRDD(Seq(broadcastBatch), 1)
+        hostBatchRDD.map { serializedBatch =>
+          serializedBatch.batch.getColumnarBatch()
+        }
+      case v if SparkShimImpl.isEmptyRelation(v) => sc.emptyRDD
+      case t => throw new IllegalStateException(s"Invalid broadcast batch received $t")
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -597,7 +597,6 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
     }
   }
 
-  /** Special-case handling of an unconditional existence join that just needs to output*/
   /**
    * Special-case handling of an unconditional existence join that just needs to output the left
    * table along with an existence column that is all true if the right table has any rows or

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -533,9 +533,6 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
   }
 
   private def doUnconditionalJoin(relation: Any): RDD[ColumnarBatch] = {
-    // Existence join should have a condition
-    assert(!joinType.isInstanceOf[ExistenceJoin])
-
     if (output.isEmpty) {
       doUnconditionalJoinRowCount(relation)
     } else {
@@ -553,6 +550,8 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
         makeBuiltBatch(relation, buildTime, buildDataSize)
       }
       val joinIterator: RDD[ColumnarBatch] = joinType match {
+        case ExistenceJoin(_) =>
+          doUnconditionalExistenceJoin(relation, buildTime, buildDataSize)
         case LeftSemi =>
           if (gpuBuildSide == GpuBuildRight) {
             leftExistenceJoin(relation, exists=true, buildTime, buildDataSize)
@@ -598,6 +597,50 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
     }
   }
 
+  /** Special-case handling of an unconditional existence join that just needs to output*/
+  /**
+   * Special-case handling of an unconditional existence join that just needs to output the left
+   * table along with an existence column that is all true if the right table has any rows or
+   * all false otherwise.
+   */
+  private def doUnconditionalExistenceJoin(
+      relation: Any,
+      buildTime: GpuMetric,
+      buildDataSize: GpuMetric): RDD[ColumnarBatch] = {
+    def addExistsColumn(iter: Iterator[ColumnarBatch], exists: Boolean): Iterator[ColumnarBatch] = {
+      iter.map { batch =>
+        withResource(batch) { _ =>
+          GpuColumnVector.incRefCounts(batch)
+          val newCols = new Array[ColumnVector](batch.numCols + 1)
+          (0 until newCols.length - 1).foreach { i =>
+            newCols(i) = batch.column(i)
+          }
+          val existsCol = withResource(Scalar.fromBool(exists)) { existsScalar =>
+            GpuColumnVector.from(cudf.ColumnVector.fromScalar(existsScalar, batch.numRows),
+              BooleanType)
+          }
+          newCols(batch.numCols) = existsCol
+          new ColumnarBatch(newCols, batch.numRows)
+        }
+      }
+    }
+
+    if (gpuBuildSide == GpuBuildRight) {
+      left.executeColumnar.mapPartitions { iter =>
+        val buildHasRows = computeBuildRowCount(relation, buildTime, buildDataSize) > 0
+        addExistsColumn(iter, buildHasRows)
+      }
+    } else {
+      // try to check cheaply whether there are any rows in the streamed table at all
+      val streamTakePlan = GpuColumnarToRowExec(GpuLocalLimitExec(1, streamed))
+      val streamExists = !streamTakePlan.executeTake(1).isEmpty
+      val leftRDD = GpuBroadcastHelper.asRDD(sparkContext,relation.asInstanceOf[Broadcast[Any]])
+      leftRDD.mapPartitions { iter =>
+        addExistsColumn(iter, streamExists)
+      }
+    }
+  }
+
   /** Special-case handling of an unconditional join that just needs to output a row count. */
   private def doUnconditionalJoinRowCount(relation: Any): RDD[ColumnarBatch] = {
     if (joinType == LeftAnti) {
@@ -606,7 +649,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
         Iterator.single(new ColumnarBatch(Array(), 0))
       }
     } else {
-      lazy val buildCount = if (joinType == LeftSemi) {
+      lazy val buildCount = if (joinType == LeftSemi || joinType.isInstanceOf[ExistenceJoin]) {
         // one-to-one mapping from input rows to output rows
         1
       } else {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -24,9 +24,8 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.internal.config.EXECUTOR_ID
 import org.apache.spark.memory.TaskMemoryManager
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
@@ -172,11 +171,5 @@ object TrampolineUtil {
 
   def getSparkConf(spark: SparkSession): SQLConf = {
     spark.sqlContext.conf
-  }
-
-  def toLogicalPlan(df: DataFrame): LogicalPlan = df.logicalPlan
-
-  def toDataFrame(spark: SparkSession, plan: LogicalPlan): DataFrame = {
-    Dataset.ofRows(spark, plan)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -24,8 +24,9 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.internal.config.EXECUTOR_ID
 import org.apache.spark.memory.TaskMemoryManager
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.internal.SQLConf
@@ -171,5 +172,11 @@ object TrampolineUtil {
 
   def getSparkConf(spark: SparkSession): SQLConf = {
     spark.sqlContext.conf
+  }
+
+  def toLogicalPlan(df: DataFrame): LogicalPlan = df.logicalPlan
+
+  def toDataFrame(spark: SparkSession, plan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, plan)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.ExistenceJoin
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint}
-import org.apache.spark.sql.rapids.execution.TrampolineUtil
+import org.apache.spark.sql.rapids.TestTrampolineUtil
 import org.apache.spark.sql.types.BooleanType
 
 class JoinsSuite extends SparkQueryCompareTestSuite {
@@ -139,12 +139,12 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
               JoinHint(Some(HintInfo(Some(BROADCAST))), None)
             }
             val cpuPlan = Join(
-              TrampolineUtil.toLogicalPlan(df1),
-              TrampolineUtil.toLogicalPlan(df2),
+              TestTrampolineUtil.toLogicalPlan(df1),
+              TestTrampolineUtil.toLogicalPlan(df2),
               ExistenceJoin(AttributeReference("exists", BooleanType, false)()),
               None,
               joinHint)
-            TrampolineUtil.toDataFrame(df1.sparkSession, cpuPlan)
+            TestTrampolineUtil.toDataFrame(df1.sparkSession, cpuPlan)
           }
         }
       }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/JoinsSuite.scala
@@ -107,6 +107,9 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
       for (rightEmpty <- Seq(false, true)) {
         def generateLeftTable(spark: SparkSession): DataFrame = {
           if (leftEmpty) {
+            // Use a filter on a non-existent value to try to avoid Spark's query optimization
+            // from potentially optimizing out the nested loop join by realizing at query
+            // planning time that one of the dataframes is empty.
             longsDf(spark).filter("longs = 132435465768")
           } else {
             longsDf(spark)
@@ -115,6 +118,9 @@ class JoinsSuite extends SparkQueryCompareTestSuite {
 
         def generateRightTable(spark: SparkSession): DataFrame = {
           if (rightEmpty) {
+            // Use a filter on a non-existent value to try to avoid Spark's query optimization
+            // from potentially optimizing out the nested loop join by realizing at query
+            // planning time that one of the dataframes is empty.
             biggerLongsDf(spark).filter("longs = 132435465768")
           } else {
             biggerLongsDf(spark)

--- a/tests/src/test/scala/org/apache/spark/sql/rapids/TestTrampolineUtil.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/TestTrampolineUtil.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids
+
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+object TestTrampolineUtil {
+  def toLogicalPlan(df: DataFrame): LogicalPlan = df.logicalPlan
+
+  def toDataFrame(spark: SparkSession, plan: LogicalPlan): DataFrame = {
+    Dataset.ofRows(spark, plan)
+  }
+}


### PR DESCRIPTION
Fixes #9086.  Adds code to handle unconditional nested loop existence joins in both the build left and build right cases along with tests.