### PR TITLE
Add retry support to GpuOutOfCoreSortIterator.mergeSortEnoughToOutput 

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -141,10 +141,12 @@ class AcceleratedColumnarToRowIterator(
           }
         }
         setCurrentBatch(pendingCvs.dequeue())
-        return true
+        true
       }
+    } else { // scb.numRows() <= 0
+      scb.close()
+      false
     }
-    false
   }
 
   private[this] def loadNextBatch(): Unit = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -455,51 +455,58 @@ case class GpuOutOfCoreSortIterator(
           bytesLeftToFetch -= buffer.sizeInBytes
         }
       }
-      // Here may need to retry work, however `mergeSortAndClose` already has some
-      // optimization to reduce the GPU memory pressure for some cases.
-      val mergedBatch = sorter.mergeSortAndClose(pendingSort, sortTime)
 
-      val (retBatch, sortedOffset) = closeOnExcept(mergedBatch) { _ =>
+      val mergedSpillBatch =
+        closeOnExcept(sorter.mergeSortWithRetry(pendingSort, sortTime)) { mergedBatch =>
+          SpillableColumnarBatch(mergedBatch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+        }
+
+      val (retBatch, sortedOffset) = closeOnExcept(mergedSpillBatch) { _ =>
         // First we want figure out what is fully sorted from what is not
         val sortSplitOffset = if (pending.isEmpty) {
           // No need to split it
-          mergedBatch.numRows()
+          mergedSpillBatch.numRows()
         } else {
           // The data is only fully sorted if there is nothing pending that is smaller than it
           // so get the next "smallest" row that is pending.
           val cutoff = pending.peek().firstRow
-          withResource(converters.convertBatch(Array(cutoff),
-            TrampolineUtil.fromAttributes(sorter.projectedBatchSchema))) { cutoffCb =>
-            withResource(sorter.upperBound(mergedBatch, cutoffCb)) { result =>
-              withResource(result.copyToHost()) { hostResult =>
-                assert(hostResult.getRowCount == 1)
-                hostResult.getInt(0)
+          val result = RmmRapidsRetryIterator.withRetryNoSplit[ColumnVector] {
+            withResource(converters.convertBatch(Array(cutoff),
+              TrampolineUtil.fromAttributes(sorter.projectedBatchSchema))) { cutoffCb =>
+              withResource(mergedSpillBatch.getColumnarBatch()) { mergedBatch =>
+                sorter.upperBound(mergedBatch, cutoffCb)
               }
             }
           }
+          withResource(result) { _ =>
+            withResource(result.copyToHost()) { hostResult =>
+              assert(hostResult.getRowCount == 1)
+              hostResult.getInt(0)
+            }
+          }
         }
-        if (sortSplitOffset == mergedBatch.numRows() && sorted.isEmpty &&
-          (GpuColumnVector.getTotalDeviceMemoryUsed(mergedBatch) >= targetSize ||
-            pending.isEmpty)) {
+        if (sortSplitOffset == mergedSpillBatch.numRows() && sorted.isEmpty &&
+            (mergedSpillBatch.sizeInBytes >= targetSize || pending.isEmpty)) {
           // This is a special case where we have everything we need to output already so why
           // bother with another contig split just to put it into the queue
-          withResource(GpuColumnVector.from(mergedBatch)) { mergedTbl =>
-            (Some(sorter.removeProjectedColumns(mergedTbl)), sortSplitOffset)
+          val projectedBatch = RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch] {
+            withResource(mergedSpillBatch.getColumnarBatch()) { mergedBatch =>
+              withResource(GpuColumnVector.from(mergedBatch)) { mergedTbl =>
+                sorter.removeProjectedColumns(mergedTbl)
+              }
+            }
           }
+          (Some(projectedBatch), sortSplitOffset)
         } else {
           (None, sortSplitOffset)
         }
       }
 
       if (retBatch.nonEmpty) {
-        withResource(mergedBatch) { _ =>
-          return retBatch
-        }
+        mergedSpillBatch.close()
+        return retBatch
       } else {
-        val mergedSp = closeOnExcept(mergedBatch) { _ =>
-          SpillableColumnarBatch(mergedBatch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-        }
-        val splitResult = withRetryNoSplit(mergedSp) { attempt =>
+        val splitResult = withRetryNoSplit(mergedSpillBatch) { attempt =>
           onMergeSortSplit()
           splitAfterSort(attempt, sortedOffset)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -456,13 +456,7 @@ case class GpuOutOfCoreSortIterator(
         }
       }
 
-      val mergedSpillBatch = {
-        val mergedBatch = sorter.mergeSortAndCloseWithRetry(pendingSort, sortTime)
-        closeOnExcept(mergedBatch) { _ =>
-          SpillableColumnarBatch(mergedBatch, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-        }
-      }
-
+      val mergedSpillBatch = sorter.mergeSortAndCloseWithRetry(pendingSort, sortTime)
       val (retBatch, sortedOffset) = closeOnExcept(mergedSpillBatch) { _ =>
         // First we want figure out what is fully sorted from what is not
         val sortSplitOffset = if (pending.isEmpty) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -240,7 +240,7 @@ class GpuSorter(
    * @param sortTime metric for the time spent doing the merge sort
    * @return the sorted data.
    */
-  final def mergeSortWithRetry(
+  final def mergeSortAndCloseWithRetry(
       spillableBatches: mutable.ArrayStack[SpillableColumnarBatch],
       sortTime: GpuMetric): ColumnarBatch = {
     withResource(new NvtxWithMetrics("merge sort", NvtxColor.DARK_GREEN, sortTime)) { _ =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, NvtxColor, OrderByArg, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, Expression, NullsFirst, NullsLast, SortOrder}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
@@ -242,87 +243,73 @@ class GpuSorter(
    */
   final def mergeSortAndCloseWithRetry(
       spillableBatches: mutable.ArrayStack[SpillableColumnarBatch],
-      sortTime: GpuMetric): ColumnarBatch = {
+      sortTime: GpuMetric): SpillableColumnarBatch = {
+    closeOnExcept(spillableBatches) { _ =>
+      assert(spillableBatches.nonEmpty)
+    }
     withResource(new NvtxWithMetrics("merge sort", NvtxColor.DARK_GREEN, sortTime)) { _ =>
       if (spillableBatches.size == 1) {
         // Single batch no need for a merge sort
-        withResource(spillableBatches.pop()) { sb =>
-          sb.getColumnarBatch()
-        }
-      } else {
-        val tablesToMerge = new mutable.ArrayStack[Table]()
-        closeOnExcept(spillableBatches) { _ =>
-          val merged: Table = {
-            // In the current version of cudf merge does not work for lists and maps.
-            // This should be fixed by https://github.com/rapidsai/cudf/issues/8050
-            // Nested types in sort key columns is not supported either.
-            if (hasNestedInKeyColumns || hasUnsupportedNestedInRideColumns) {
-              // so as a work around we concatenate all of the data together and then sort it.
-              // It is slower, but it works
-              val concatenated = closeOnExcept(tablesToMerge) { _ =>
-                while (spillableBatches.nonEmpty) {
-                  // We retry work with a single spillable batch, then it can be closed
-                  // eagerly. (See https://github.com/NVIDIA/spark-rapids/pull/6931)
-                  // If we want to retry the whole work of moving data to GPU, concatenating
-                  // tables and sorting the result table in a single block, we need to change
-                  // to hold all the batches in `spillableBatches` until the work is done.
-                  // Then they can not be closed eagerly. Not sure whether we should do it.
-                  val tl = RmmRapidsRetryIterator.withRetryNoSplit(spillableBatches.pop()) { sb =>
-                    withResource(sb.getColumnarBatch()) { cb =>
-                      GpuColumnVector.from(cb)
-                    }
-                  }
-                  tablesToMerge.push(tl)
-                }
-                val concatenated = RmmRapidsRetryIterator.withRetryNoSplit(tablesToMerge) { _ =>
-                  Table.concatenate(tablesToMerge: _*)
-                }
-                // we no longer care about the old tables, we closed them
-                tablesToMerge.clear()
-                concatenated
+        spillableBatches.pop()
+      } else { // spillableBatches.size > 1
+        // In the current version of cudf merge does not work for lists and maps.
+        // This should be fixed by https://github.com/rapidsai/cudf/issues/8050
+        // Nested types in sort key columns is not supported either.
+        if (hasNestedInKeyColumns || hasUnsupportedNestedInRideColumns) {
+          // so as a work around we concatenate all of the data together and then sort it.
+          // It is slower, but it works
+          val merged = RmmRapidsRetryIterator.withRetryNoSplit(spillableBatches) { _ =>
+            val tablesToMerge = spillableBatches.safeMap { sb =>
+              withResource(sb.getColumnarBatch()) { cb =>
+                GpuColumnVector.from(cb)
               }
-              RmmRapidsRetryIterator.withRetryNoSplit(concatenated) { _ =>
-                concatenated.orderBy(cudfOrdering: _*)
-              }
-            } else {
-              while (spillableBatches.nonEmpty || tablesToMerge.size > 1) {
-                // pop a spillable batch if there is one to pop
-                var spillableCandidate: Option[SpillableColumnarBatch] = None
-                if (spillableBatches.nonEmpty) {
-                  spillableCandidate = Some(spillableBatches.pop())
-                }
-
-                // optionally add a table to `tablesToMerge`
-                closeOnExcept(tablesToMerge) { _ =>
-                  withResource(spillableCandidate) {
-                    _.foreach { sb =>
-                      // materialize a potentially spilled batch
-                      val tl = RmmRapidsRetryIterator.withRetryNoSplit[Table] {
-                        withResource(sb.getColumnarBatch()) { batch =>
-                          GpuColumnVector.from(batch)
-                        }
-                      }
-                      tablesToMerge.push(tl)
-                    }
-                  }
-                }
-
-                if (tablesToMerge.size > 1) {
-                  val merged = RmmRapidsRetryIterator.withRetryNoSplit(tablesToMerge) { _ =>
-                    Table.merge(tablesToMerge.toArray, cudfOrdering: _*)
-                  }
-                  // we no longer care about the old tables, we closed them
-                  tablesToMerge.clear()
-
-                  // add the result to be merged with the next spillable batch
-                  tablesToMerge.push(merged)
-                }
-              }
-              tablesToMerge.pop()
+            }
+            val concatenated = withResource(tablesToMerge) { _ =>
+              Table.concatenate(tablesToMerge: _*)
+            }
+            withResource(concatenated) { _ =>
+              concatenated.orderBy(cudfOrdering: _*)
             }
           }
-          withResource(merged) { merged =>
-            GpuColumnVector.from(merged, projectedBatchTypes)
+          withResource(merged) { _ =>
+            closeOnExcept(GpuColumnVector.from(merged, projectedBatchTypes)) { b =>
+              SpillableColumnarBatch(b, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+            }
+          }
+        } else {
+          closeOnExcept(spillableBatches) { _ =>
+            val batchesToMerge = new mutable.ArrayStack[SpillableColumnarBatch]()
+            closeOnExcept(batchesToMerge) { _ =>
+              while (spillableBatches.nonEmpty || batchesToMerge.size > 1) {
+                // pop a spillable batch if there is one, and add it to `batchesToMerge`.
+                if (spillableBatches.nonEmpty) {
+                  batchesToMerge.push(spillableBatches.pop())
+                }
+                if (batchesToMerge.size > 1) {
+                  val merged = RmmRapidsRetryIterator.withRetryNoSplit(batchesToMerge) { _ =>
+                    val tablesToMerge = batchesToMerge.safeMap { sb =>
+                      withResource(sb.getColumnarBatch()) { cb =>
+                        GpuColumnVector.from(cb)
+                      }
+                    }
+                    withResource(tablesToMerge) { _ =>
+                      Table.merge(tablesToMerge.toArray, cudfOrdering: _*)
+                    }
+                  }
+                  // we no longer care about the old batches, we closed them
+                  batchesToMerge.clear()
+
+                  // add the result to be merged with the next spillable batch
+                  val mergedSb = withResource(merged) { _ =>
+                    closeOnExcept(GpuColumnVector.from(merged, projectedBatchTypes)) { b =>
+                      SpillableColumnarBatch(b, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+                    }
+                  }
+                  batchesToMerge.push(mergedSb)
+                }
+              }
+              batchesToMerge.pop()
+            }
           }
         }
       }


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/8351

This PR adds in retry support for more operations in `GpuOutOfCoreSortIterator`, including computing the split offset and bringing the data back to GPU to remove the projected columns.

Besides, to keep being eager to close the input batches in the `mergeSortAndClose` function (introduced by https://github.com/NVIDIA/spark-rapids/pull/6931), instead of retrying the call to the whole `mergeSortAndClose` function, we retry the operations inside it, including bringing the data back to GPU, concatenating tables, sort the concatenated table and merging the input tables.

It also covers a small followup change in `GpuColumnToRowExec` for PR #9088.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
