### PR TITLE
[DOC] adding java 11 to download docs [skip ci]

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -31,7 +31,7 @@ The plugin is tested on the following architectures:
 
 	NVIDIA Driver*: 470+
 
-	Python 3.6+, Scala 2.12, Java 8, Java 17
+	Python 3.6+, Scala 2.12, Java 8, Java 11, Java 17
 
 	Supported Spark versions:
 		Apache Spark 3.1.1, 3.1.2, 3.1.3 


### PR DESCRIPTION
This PR adds Java 11 to list of supported java versions in the download docs.


signed-off-by: Suraj Aralihalli <suraj.ara16@gmail.com>