### PR TITLE
adding java 11 to download docs (#9109)

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -31,7 +31,7 @@ The plugin is tested on the following architectures:
 
 	NVIDIA Driver*: 470+
 
-	Python 3.6+, Scala 2.12, Java 8, Java 17
+	Python 3.6+, Scala 2.12, Java 8, Java 11, Java 17
 
 	Supported Spark versions:
 		Apache Spark 3.1.1, 3.1.2, 3.1.3 


### PR DESCRIPTION
indexed from gh-pages

Only "Adding java11 to download.md" commit is cherry-picked into source branch. 

signed-off-by: Suraj Aralihalli <suraj.ara16@gmail.com>