### PR TITLE
Temply disable spark 350 shim build in nightly [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -678,7 +678,8 @@
             341
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            350
+            <!--TODO: re-enable https://github.com/NVIDIA/spark-rapids/issues/9116-->
+            <!--350-->
         </snapshot.buildvers>
         <databricks.buildvers>
             321db,


### PR DESCRIPTION
part of #9116, related to https://github.com/NVIDIA/spark-rapids/pull/8969

this change is trying to unblock mvn-verify github checks and nightly build before released 350 is out.
Developers could still verify the changes by 
1. Manually build and install spark RC libs locally, or
2. Changing the spark350 version to 3.5.1-SNAPSHOT (available in internal artifactory but not public)

Added TODO remind us to re-enable when available.

[skip ci] as mvn verify checks would help verify the shim list property changes