### PR TITLE
Fall back to CPU if `spark.sql.execution.arrow.useLargeVarTypes` is true

### DIFF
--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,7 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "330"}
-{"spark": "330cdh"}
-{"spark": "330db"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "332db"}
-{"spark": "333"}
-{"spark": "340"}
-{"spark": "341"}
+{"spark": "350"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
@@ -31,6 +23,7 @@ import com.nvidia.spark.rapids._
 
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.PythonMapInArrowExec
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.execution.python.GpuPythonMapInArrowExecMeta
 
 object PythonMapInArrowExecShims {
@@ -42,7 +35,14 @@ object PythonMapInArrowExecShims {
           " for the Python process when enabled.",
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT).nested(),
           TypeSig.all),
-        (mapPy, conf, p, r) => new GpuPythonMapInArrowExecMeta(mapPy, conf, p, r))
+        (mapPy, conf, p, r) => new GpuPythonMapInArrowExecMeta(mapPy, conf, p, r) {
+          override def tagPlanForGpu() {
+            super.tagPlanForGpu()
+            if (SQLConf.get.getConf(SQLConf.ARROW_EXECUTION_USE_LARGE_VAR_TYPES)) {
+              willNotWorkOnGpu(s"${SQLConf.ARROW_EXECUTION_USE_LARGE_VAR_TYPES.key} is not supported on GPU")
+            }
+          }
+      })
     ).map(r => (r.getClassFor.asSubclass(classOf[SparkPlan]), r)).toMap
 
 }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9017

Spark 3.5.0 adds a new configuration option `spark.sql.execution.arrow.useLargeVarTypes`, which is specific to `DataFrame.mapInArrow`. Here are the docs:

```
When using Apache Arrow, use large variable width vectors for string and binary
types. Regular string and binary types have a 2GiB limit for a column in a single
record batch. Large variable types remove this limitation at the cost of higher memory
usage per value. Note that this only works for DataFrame.mapInArrow.
```

We cannot support this on the GPU so this PR adds code to fallback to CPU.