### PR TITLE
Import `scala.collection` intead of `collection`

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -521,7 +521,7 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
 
   override def queuePending(reqs: Seq[PendingTransferRequest]): Unit =
     altList.synchronized {
-      import collection.JavaConverters._
+      import scala.collection.JavaConverters._
       validHandlers.add(reqs.head.handler)
       altList.addAll(reqs.asJava)
       logDebug(s"THROTTLING ${altList.size} queued requests")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -92,7 +92,7 @@ object ConcatAndConsumeAll {
    */
   def getSingleBatchWithVerification(batches: Iterator[ColumnarBatch],
       format: Seq[Attribute]): ColumnarBatch = {
-    import collection.JavaConverters._
+    import scala.collection.JavaConverters._
     if (!batches.hasNext) {
       GpuColumnVector.emptyBatch(format.asJava)
     } else {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8998 (Spark 3.5.0 audit issue)

Import `scala.collection.JavaConverters` instead of `collection.JavaConverters` in preparation for Scala 2.13. 