### PR TITLE
Moving row column conversion code from cudf to jni

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/InternalRowToColumnarBatchIterator.java
@@ -16,6 +16,8 @@
 
 package com.nvidia.spark.rapids;
 
+import com.nvidia.spark.rapids.jni.RowConversion;
+
 import ai.rapids.cudf.ColumnVector;
 import ai.rapids.cudf.DType;
 import ai.rapids.cudf.HostColumnVector;
@@ -168,8 +170,8 @@ public abstract class InternalRowToColumnarBatchIterator implements Iterator<Col
              // at most 184 double/long values. We are branching over the size of the output to
              // know which kernel to call. If rapidsTypes.length < 100 we call the fixed-width
              // optimized version, otherwise the generic one
-             Table.convertFromRowsFixedWidthOptimized(cv, rapidsTypes) :
-             Table.convertFromRows(cv, rapidsTypes)) {
+             RowConversion.convertFromRowsFixedWidthOptimized(cv, rapidsTypes) :
+             RowConversion.convertFromRows(cv, rapidsTypes)) {
       return GpuColumnVector.from(tab, outputTypes);
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -24,6 +24,7 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.splitSpillableInHalfByRows
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
+import com.nvidia.spark.rapids.jni.RowConversion
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.TaskContext
@@ -125,9 +126,9 @@ class AcceleratedColumnarToRowIterator(
               // the output to know which kernel to call. If schema.length < 100 we call the
               // fixed-width optimized version, otherwise the generic one
               if (schema.length < 100) {
-                table.convertToRowsFixedWidthOptimized()
+                RowConversion.convertToRowsFixedWidthOptimized(table)
               } else {
-                table.convertToRows()
+                RowConversion.convertToRows(table)
               }
             }
           }


### PR DESCRIPTION
We started moving the code from cudf to spark-rapids-jni a while ago, but left off at the actual switch over of the plugin. Next up is the PR to remove this code from the cudf side.