### PR TITLE
Bump Jython to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -944,7 +944,7 @@
                     <dependency>
                         <groupId>org.python</groupId>
                         <artifactId>jython-standalone</artifactId>
-                        <version>2.7.2</version>
+                        <version>2.7.2b3</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -944,7 +944,7 @@
                     <dependency>
                         <groupId>org.python</groupId>
                         <artifactId>jython-standalone</artifactId>
-                        <version>2.7.2b3</version>
+                        <version>2.7.3</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
Bumping Jython to 2.7.3 to address [CVE-2013-2027](https://github.com/advisories/GHSA-9347-9w64-q5wp)