### PR TITLE
Removed resultDecimalType in GpuIntegralDecimalDivide [databricks]

### DIFF
--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -481,10 +481,8 @@ case class GpuIntegralDecimalDivide(
     super.columnarEval(batch)
   }
 
-  override def resultDecimalType(p1: Int, s1: Int, p2: Int, s2: Int): DecimalType = {
-    // This follows division rule
-    val intDig = p1 - s1 + s2
-    // No precision loss can happen as the result scale is 0.
-    DecimalType.bounded(intDig, 0)
-  }
+  /**
+   * We are not overriding resultDecimalType as the method `dataType` is overridden in this class
+   * and so the superclass method that calls resultDecimalType will never be called.
+  */
 }


### PR DESCRIPTION
The class `GpuIntegralDecimalDivide` doesn't need to override the `resultDecimalType` as it's overriding the `dataType` method which returns the type to a `Long` instead of calling into the resultDecimalType like other Expressions that extend `CudfBinaryArithmetic`

fixes #8198 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
