### PR TITLE
[DOC] update spark.rapids.sql.concurrentGpuTasks default value in tuning guide [skip ci]

### DIFF
--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -130,7 +130,7 @@ will be faster to not wait when you can get the data across the network fast eno
 ## Number of Concurrent Tasks per GPU
 Configuration key: [`spark.rapids.sql.concurrentGpuTasks`](configs.md#sql.concurrentGpuTasks)
 
-Default value: `1`
+Default value: `2`
 
 The RAPIDS Accelerator can further limit the number of tasks that are actively sharing the GPU.
 It does this using a semaphore. When metrics or documentation refers to the GPU semaphore it


### PR DESCRIPTION
Indexed from branch-23.10

This PR corrects the `spark.rapids.sql.concurrentGpuTasks` default value in the tuning guide.

Signed-off-by: Suraj Aralihalli <suraj.ara16@gmail.com>