### PR TITLE
Support Retry for GpuTopN and GpuSortEachBatchIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -165,8 +165,8 @@ case class GpuSortEachBatchIterator(
     val scb = closeOnExcept(iter.next()) { cb =>
       SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
     }
-    withResource(new NvtxWithMetrics("sort op", NvtxColor.WHITE, opTime)) { _ =>
-      val ret = sorter.fullySortBatchAndCloseWithRetry(scb, sortTime)
+    val ret = sorter.fullySortBatchAndCloseWithRetry(scb, sortTime, opTime)
+    opTime.ns {
       outputBatches += 1
       outputRows += ret.numRows()
       if (singleBatch) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -389,4 +389,18 @@ class GpuSorter(
       GpuColumnVector.from(sortedTbl, originalTypes)
     }
   }
+
+  /**
+   * Similar as fullySortBatch, but with retry support.
+   * The input `inputSbBatch` will be closed after the call.
+   */
+  final def fullySortBatchAndCloseWithRetry(
+      inputSbBatch: SpillableColumnarBatch,
+      sortTime: GpuMetric): ColumnarBatch = {
+    RmmRapidsRetryIterator.withRetryNoSplit(inputSbBatch) { _ =>
+      withResource(inputSbBatch.getColumnarBatch()) { inputBatch =>
+        fullySortBatch(inputBatch, sortTime)
+      }
+    }
+  }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -396,10 +396,13 @@ class GpuSorter(
    */
   final def fullySortBatchAndCloseWithRetry(
       inputSbBatch: SpillableColumnarBatch,
-      sortTime: GpuMetric): ColumnarBatch = {
+      sortTime: GpuMetric,
+      opTime: GpuMetric): ColumnarBatch = {
     RmmRapidsRetryIterator.withRetryNoSplit(inputSbBatch) { _ =>
-      withResource(inputSbBatch.getColumnarBatch()) { inputBatch =>
-        fullySortBatch(inputBatch, sortTime)
+      withResource(new NvtxWithMetrics("sort op", NvtxColor.WHITE, opTime)) { _ =>
+        withResource(inputSbBatch.getColumnarBatch()) { inputBatch =>
+          fullySortBatch(inputBatch, sortTime)
+        }
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -22,6 +22,8 @@ import ai.rapids.cudf.{NvtxColor, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
+import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry}
+import com.nvidia.spark.rapids.SpillPriorities.ACTIVE_ON_DECK_PRIORITY
 import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
 
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
@@ -183,15 +185,13 @@ class GpuCollectLimitMeta(
 }
 
 object GpuTopN {
-  private[this] def concatAndClose(a: SpillableColumnarBatch,
+  private[this] def concatAndClose(a: ColumnarBatch,
       b: ColumnarBatch,
       concatTime: GpuMetric): ColumnarBatch = {
     withResource(new NvtxWithMetrics("readNConcat", NvtxColor.CYAN, concatTime)) { _ =>
       val dataTypes = GpuColumnVector.extractTypes(b)
       val aTable = withResource(a) { a =>
-        withResource(a.getColumnarBatch()) { aBatch =>
-          GpuColumnVector.from(aBatch)
-        }
+        GpuColumnVector.from(a)
       }
       val ret = withResource(aTable) { aTable =>
         withResource(b) { b =>
@@ -248,54 +248,72 @@ object GpuTopN {
       inputRows: GpuMetric,
       outputBatches: GpuMetric,
       outputRows: GpuMetric,
-      offset: Int): Iterator[ColumnarBatch] =
-    new Iterator[ColumnarBatch]() {
+      offset: Int): Iterator[SpillableColumnarBatch] =
+    new Iterator[SpillableColumnarBatch]() {
       override def hasNext: Boolean = iter.hasNext
 
       private[this] var pending: Option[SpillableColumnarBatch] = None
 
-      override def next(): ColumnarBatch = {
-        while (iter.hasNext) {
-          val input = iter.next()
-          withResource(new NvtxWithMetrics("TOP N", NvtxColor.ORANGE, opTime)) { _ =>
-            inputBatches += 1
-            inputRows += input.numRows()
-            lazy val totalSize = GpuColumnVector.getTotalDeviceMemoryUsed(input) +
-                pending.map(_.sizeInBytes).getOrElse(0L)
-
-            val runningResult = if (pending.isEmpty) {
-              withResource(input) { input =>
-                apply(limit, sorter, input, sortTime)
-              }
-            } else if (totalSize > Integer.MAX_VALUE) {
-              // The intermediate size is likely big enough we don't want to risk an overflow,
-              // so sort/slice before we concat and sort/slice again.
-              val tmp = withResource(input) { input =>
-                apply(limit, sorter, input, sortTime)
-              }
-              withResource(concatAndClose(pending.get, tmp, concatTime)) { concat =>
-                apply(limit, sorter, concat, sortTime)
-              }
-            } else {
-              // The intermediate size looks like we could never overflow the indexes so
-              // do it the more efficient way and concat first followed by the sort/slice
-              withResource(concatAndClose(pending.get, input, concatTime)) { concat =>
-                apply(limit, sorter, concat, sortTime)
+      override def next(): SpillableColumnarBatch = {
+        if (!hasNext) {
+          throw new NoSuchElementException()
+        }
+        closeOnExcept(pending) { _ =>
+          while (iter.hasNext) {
+            val inputScb = closeOnExcept(iter.next()) { cb =>
+              inputBatches += 1
+              inputRows += cb.numRows()
+              SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+            }
+            withResource(new NvtxWithMetrics("TOP N", NvtxColor.ORANGE, opTime)) { _ =>
+              withRetry(inputScb, splitSpillableInHalfByRows) { attempt =>
+                val inputCb = attempt.getColumnarBatch()
+                if (pending.isEmpty) {
+                  withResource(inputCb) { _ =>
+                    apply(limit, sorter, inputCb, sortTime)
+                  }
+                } else { // pending is not empty
+                  val totalSize = attempt.sizeInBytes + pending.get.sizeInBytes
+                  val tmpCb = if (totalSize > Int.MaxValue) {
+                    // The intermediate size is likely big enough we don't want to risk an overflow,
+                    // so sort/slice before we concat and sort/slice again.
+                    withResource(inputCb) { _ =>
+                      apply(limit, sorter, inputCb, sortTime)
+                    }
+                  } else {
+                    // The intermediate size looks like we could never overflow the indexes so
+                    // do it the more efficient way and concat first followed by the sort/slice
+                    inputCb
+                  }
+                  val pendingCb = closeOnExcept(tmpCb) { _ =>
+                    pending.get.getColumnarBatch()
+                  }
+                  withResource(concatAndClose(pendingCb, tmpCb, concatTime)) { concat =>
+                    apply(limit, sorter, concat, sortTime)
+                  }
+                }
+              }.foreach { runningResult =>
+                pending.foreach(_.close())
+                pending = None
+                pending = closeOnExcept(runningResult) { _ =>
+                  Some(SpillableColumnarBatch(runningResult, ACTIVE_ON_DECK_PRIORITY))
+                }
               }
             }
-            pending =
-                Some(SpillableColumnarBatch(runningResult, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
-          }
-        }
-        val tmp = pending.get.getColumnarBatch()
-        pending.get.close()
+          } // end of while
+        } // end of "closeOnExcept(pending)"
+
+        val tempScb = pending.get
         pending = None
         val ret = if (offset > 0) {
-          withResource(tmp) { _ =>
-            applyOffset(tmp, offset)
+          val retCb = RmmRapidsRetryIterator.withRetryNoSplit(tempScb) { _ =>
+            withResource(tempScb.getColumnarBatch()) { tempCb =>
+              applyOffset(tempCb, offset)
+            }
           }
+          closeOnExcept(retCb)(SpillableColumnarBatch(_, ACTIVE_ON_DECK_PRIORITY))
         } else {
-          tmp
+          tempScb
         }
         outputBatches += 1
         outputRows += ret.numRows()
@@ -353,11 +371,17 @@ case class GpuTopN(
       val topN = GpuTopN(localLimit, sorter, iter, opTime, sortTime, concatTime,
         inputBatches, inputRows, outputBatches, outputRows, offset)
       if (localProjectList != childOutput) {
-        topN.map { batch =>
-          GpuProjectExec.projectAndClose(batch, boundProjectExprs, opTime)
+        topN.map { scb =>
+          opTime.ns {
+            GpuProjectExec.projectAndCloseWithRetrySingleBatch(scb, boundProjectExprs)
+          }
         }
       } else {
-        topN
+        topN.map { scb =>
+          opTime.ns {
+            RmmRapidsRetryIterator.withRetryNoSplit(scb)(_.getColumnarBatch())
+          }
+        }
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/LimitRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/LimitRetrySuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.jni.RmmSpark
+
+import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, SortOrder}
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class LimitRetrySuite extends RmmSparkRetrySuiteBase {
+
+  private val ref = GpuBoundReference(0, IntegerType, nullable = false)(ExprId(0), "a")
+  private val attrs = AttributeReference(ref.name, ref.dataType, ref.nullable)()
+  private val gpuSorter = new GpuSorter(Seq(SortOrder(ref, Ascending)), Array(attrs))
+  private val NUM_ROWS = 100
+
+  private def buildBatch1: ColumnarBatch = {
+    val ints = 0 until NUM_ROWS by 2
+    new ColumnarBatch(
+      Array(GpuColumnVector.from(ColumnVector.fromInts(ints: _*), IntegerType)), ints.length)
+  }
+
+  private def buildBatch2: ColumnarBatch = {
+    val ints = 1 until NUM_ROWS by 2
+    new ColumnarBatch(
+      Array(GpuColumnVector.from(ColumnVector.fromInts(ints: _*), IntegerType)), ints.length)
+  }
+
+  test("GPU topn with split and retry OOM") {
+    val limit = 20
+    Seq(0, 5).foreach { offset =>
+      val topNIter = GpuTopN(limit, gpuSorter, Seq(buildBatch1, buildBatch2).toIterator,
+        NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric,
+        offset)
+      val numRows = limit - offset
+      var curValue = offset
+      var pos = 0
+      RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+      assert(topNIter.hasNext)
+      withResource(topNIter.next()) { scb =>
+        withResource(scb.getColumnarBatch()) { cb =>
+          withResource(cb.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hCol =>
+            while (pos < hCol.getRowCount.toInt) {
+              assertResult(curValue)(hCol.getInt(pos))
+              pos += 1
+              curValue += 1
+            }
+          }
+        }
+      }
+      assertResult(numRows)(pos)
+      // only one batch
+      assert(!topNIter.hasNext)
+    }
+  }
+}


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/8310
closes https://github.com/NVIDIA/spark-rapids/issues/8352

This PR adds retry support to both `GpuTopN` and `GpuSortEachBatchIterator`.

For `GpuSortEachBatchIterator`, this change introduces a new API `fullySortBatchAndCloseWithRetry` in `GpuSorter`, which replaces the call to the original `fullySortBatch` in `GpuSortEachBatchIterator`.

`GpuTopN` is a little complicated. It is not a good idea to leverage this new API `fullySortBatchAndCloseWithRetry`, otherwise we will get a nested retry block. Instead we only need to retry the whole processing that returns a pending result for the next iteration. It also supports Split and Retry. Besides, retry is also added to the processing of applying the offset after getting the final result.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
