### PR TITLE
Add retry-without-split in InternalRowToColumnarBatchIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferCatalog.scala
@@ -807,6 +807,16 @@ object RapidsBufferCatalog extends Logging {
   }
 
   /**
+   * Set a `RapidsHostMemoryStore` instance to use when instantiating our
+   * catalog.
+   *
+   * @note This should only be called from tests!
+   */
+  def setHostStorage(rdhs: RapidsHostMemoryStore): Unit = {
+    hostStorage = rdhs
+  }
+
+  /**
    * Set a `RapidsBufferCatalog` instance to use our singleton.
    * @note This should only be called from tests!
    */

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GeneratedInternalRowToCudfRowIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GeneratedInternalRowToCudfRowIteratorRetrySuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{doAnswer, spy, times, verify}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.types.{DataType, LongType}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GeneratedInternalRowToCudfRowIteratorRetrySuite
+    extends RmmSparkRetrySuiteBase
+        with MockitoSugar {
+  private def buildBatch(): ColumnarBatch = {
+    val reductionTable = new Table.TestBuilder()
+        .column(5L, null.asInstanceOf[java.lang.Long], 3L, 1L)
+        .build()
+    withResource(reductionTable) { tbl =>
+      GpuColumnVector.from(tbl, Seq(LongType).toArray[DataType])
+    }
+  }
+
+  test("a retry when copying to device is handled") {
+    val batch = buildBatch()
+    val ctriter = new ColumnarToRowIterator(
+      Seq(batch).iterator,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+    val myIter = GeneratedInternalRowToCudfRowIterator(
+      ctriter, schema, TargetSize(Int.MaxValue),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    // this forces a retry on the copy of the host column to a device column
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+    withResource(myIter.next()) { devBatch =>
+      withResource(buildBatch()) { expected =>
+        TestUtils.compareBatches(expected, devBatch)
+      }
+    }
+    assert(!GpuColumnVector.extractBases(batch).exists(_.getRefCount > 0))
+    assert(!myIter.hasNext)
+    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+  }
+
+  test("a retry when converting to a table is handled") {
+    val batch = buildBatch()
+    val batchIter = Seq(batch).iterator
+    var rapidsBufferSpy: RapidsBuffer = null
+    doAnswer(new Answer[AnyRef]() {
+      override def answer(invocation: InvocationOnMock): AnyRef = {
+        val res = invocation.callRealMethod()
+        // we mock things this way due to code generation issues with mockito.
+        // when we add a table we have
+        RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 3)
+        rapidsBufferSpy = spy(res.asInstanceOf[RapidsBuffer])
+        rapidsBufferSpy
+      }
+    }).when(deviceStorage)
+        .addTable(any(), any(), any(), any())
+
+    val ctriter = new ColumnarToRowIterator(batchIter,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+    val myIter = spy(GeneratedInternalRowToCudfRowIterator(
+      ctriter, schema, TargetSize(Int.MaxValue),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
+    assertResult(0)(RmmSpark.getAndResetNumRetryThrow(RmmSpark.getCurrentThreadId))
+    withResource(myIter.next()) { devBatch =>
+      withResource(buildBatch()) { expected =>
+        TestUtils.compareBatches(expected, devBatch)
+      }
+    }
+    // TODO: enable this assert, for some reason this is returning 0, but I verified
+    //  via the debugger and printfs that we are retrying 2 times total in the first block,
+    //   and 3 times in the second block that I have added retries to.
+    //  assertResult(5)(RmmSpark.getAndResetNumRetryThrow(RmmSpark.getCurrentThreadId))
+    assert(!myIter.hasNext)
+    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+    // This is my wrap around of checking that we did retry the last part
+    // where we are converting the device column of rows into an actual column.
+    // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
+    // a batch.
+    verify(rapidsBufferSpy, times(4))
+        .getColumnarBatch(any())
+  }
+
+  test("spilling the device column of rows works") {
+    val batch = buildBatch()
+    val batchIter = Seq(batch).iterator
+    var rapidsBufferSpy: RapidsBuffer = null
+    doAnswer(new Answer[AnyRef]() {
+      override def answer(invocation: InvocationOnMock): AnyRef = {
+        val res = invocation.callRealMethod()
+        // we mock things this way due to code generation issues with mockito.
+        // when we add a table we have
+        RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 3)
+        rapidsBufferSpy = spy(res.asInstanceOf[RapidsBuffer])
+        // at this point we have created a buffer in the Spill Framework
+        // lets spill it
+        RapidsBufferCatalog.singleton.synchronousSpill(deviceStorage, 0)
+        rapidsBufferSpy
+      }
+    }).when(deviceStorage)
+        .addTable(any(), any(), any(), any())
+
+    val ctriter = new ColumnarToRowIterator(batchIter,
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+    val myIter = spy(GeneratedInternalRowToCudfRowIterator(
+      ctriter, schema, TargetSize(Int.MaxValue),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
+    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
+    assertResult(0)(RmmSpark.getAndResetNumRetryThrow(RmmSpark.getCurrentThreadId))
+    withResource(myIter.next()) { devBatch =>
+      withResource(buildBatch()) { expected =>
+        TestUtils.compareBatches(expected, devBatch)
+      }
+    }
+    // TODO: enable this assert, for some reason this is returning 0, but I verified
+    //  via the debugger and printfs that we are retrying 2 times total in the first block,
+    //   and 3 times in the second block that I have added retries to.
+    //  assertResult(5)(RmmSpark.getAndResetNumRetryThrow(RmmSpark.getCurrentThreadId))
+    assert(!myIter.hasNext)
+    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+    // This is my wrap around of checking that we did retry the last part
+    // where we are converting the device column of rows into an actual column.
+    // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
+    // a batch.
+    verify(rapidsBufferSpy, times(4))
+        .getColumnarBatch(any())
+  }
+
+  test("a split and retry when copying to device is not handled, and we throw") {
+    val batch = buildBatch()
+    val batchIter = Seq(batch).iterator
+
+    val ctriter = new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric)
+    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+    val myIter = GeneratedInternalRowToCudfRowIterator(
+      ctriter, schema, TargetSize(1),
+      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+    assertThrows[SplitAndRetryOOM] {
+      myIter.next()
+    }
+    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
@@ -37,8 +37,12 @@ class RmmSparkRetrySuiteBase extends AnyFunSuite with BeforeAndAfterEach {
       Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024)
     }
     deviceStorage = spy(new RapidsDeviceMemoryStore())
-    val catalog = new RapidsBufferCatalog(deviceStorage)
+    val hostStore = new RapidsHostMemoryStore(1L * 1024 * 1024)
+    deviceStorage.setSpillStore(hostStore)
+    val catalog = new RapidsBufferCatalog(deviceStorage, hostStore)
+    // set these against the singleton so we close them later
     RapidsBufferCatalog.setDeviceStorage(deviceStorage)
+    RapidsBufferCatalog.setHostStorage(hostStore)
     RapidsBufferCatalog.setCatalog(catalog)
     val mockEventHandler = new BaseRmmEventHandler()
     RmmSpark.setEventHandler(mockEventHandler)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RmmSparkRetrySuiteBase.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler}
 import com.nvidia.spark.rapids.jni.RmmSpark
+import org.mockito.Mockito.spy
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -25,6 +26,7 @@ import org.apache.spark.sql.SparkSession
 
 class RmmSparkRetrySuiteBase extends AnyFunSuite with BeforeAndAfterEach {
   private var rmmWasInitialized = false
+  protected var deviceStorage: RapidsDeviceMemoryStore = null
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -34,7 +36,7 @@ class RmmSparkRetrySuiteBase extends AnyFunSuite with BeforeAndAfterEach {
       rmmWasInitialized = true
       Rmm.initialize(RmmAllocationMode.CUDA_DEFAULT, null, 512 * 1024 * 1024)
     }
-    val deviceStorage = new RapidsDeviceMemoryStore()
+    deviceStorage = spy(new RapidsDeviceMemoryStore())
     val catalog = new RapidsBufferCatalog(deviceStorage)
     RapidsBufferCatalog.setDeviceStorage(deviceStorage)
     RapidsBufferCatalog.setCatalog(catalog)


### PR DESCRIPTION
Closes #8349.

This adds retry without split support to `InternalRowToColumnarBatchIterator`, which is the superclass of `GeneratedInternalRowToCudfRowIterator`.

I am not seeing an easy way to add split, so I'd like to document how we would do that in a different issues (open for comment).

Follow on #9168 because due to the fact that this class is codegened, mockito is very confused and I can't easily spy or mock this object. With the follow on I think we can cover that retries did indeed happened where we want them to, but I am confused on why that code doesn't work hence the follow on.