### PR TITLE
Remove doSetSpillable in favor of setSpillable

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBufferStore.scala
@@ -208,12 +208,8 @@ abstract class RapidsBufferStore(val tier: StorageTier)
     }
   }
 
-  protected def doSetSpillable(buffer: RapidsBufferBase, isSpillable: Boolean): Unit = {
-    buffers.setSpillable(buffer, isSpillable)
-  }
-
   protected def setSpillable(buffer: RapidsBufferBase, isSpillable: Boolean): Unit = {
-    throw new NotImplementedError(s"This store ${this} does not implement setSpillable")
+    buffers.setSpillable(buffer, isSpillable)
   }
 
   /**
@@ -458,5 +454,18 @@ abstract class RapidsBufferStore(val tier: StorageTier)
     }
 
     override def toString: String = s"$name buffer size=${getMemoryUsedBytes}"
+  }
+}
+
+/**
+ * Buffers that inherit from this type do not support changing the spillable status
+ * of a `RapidsBuffer`. This is only used right now for disk and GDS.
+ * @param tier storage tier of this store
+ */
+abstract class RapidsBufferStoreWithoutSpillabilitySupport(override val tier: StorageTier)
+    extends RapidsBufferStore(tier) {
+
+  override def setSpillable(rapidsBuffer: RapidsBufferBase, isSpillable: Boolean): Unit = {
+    throw new NotImplementedError(s"This store ${this} does not implement setSpillable")
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDeviceMemoryStore.scala
@@ -142,14 +142,6 @@ class RapidsDeviceMemoryStore(chunkedPackBounceBufferSize: Long = 128L*1024*1024
   }
 
   /**
-   * The RapidsDeviceMemoryStore is the only store that supports setting a buffer spillable
-   * or not.
-   */
-  override protected def setSpillable(buffer: RapidsBufferBase, spillable: Boolean): Unit = {
-    doSetSpillable(buffer, spillable)
-  }
-
-  /**
    * A per cuDF column event handler that handles calls to .close()
    * inside of the `ColumnVector` lock.
    */
@@ -293,7 +285,7 @@ class RapidsDeviceMemoryStore(chunkedPackBounceBufferSize: Long = 128L*1024*1024
      * all columns are spillable.
      */
     override def updateSpillability(): Unit = {
-      doSetSpillable(this, columnSpillability.size == numDistinctColumns)
+      setSpillable(this, columnSpillability.size == numDistinctColumns)
     }
 
     /**
@@ -304,7 +296,7 @@ class RapidsDeviceMemoryStore(chunkedPackBounceBufferSize: Long = 128L*1024*1024
      */
     override def getColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = {
       columnSpillability.clear()
-      doSetSpillable(this, false)
+      setSpillable(this, false)
       GpuColumnVector.from(table, sparkTypes)
     }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsDiskStore.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 /** A buffer store using files on the local disks. */
 class RapidsDiskStore(diskBlockManager: RapidsDiskBlockManager)
-    extends RapidsBufferStore(StorageTier.DISK) {
+    extends RapidsBufferStoreWithoutSpillabilitySupport(StorageTier.DISK) {
   private[this] val sharedBufferFiles = new ConcurrentHashMap[RapidsBufferId, File]
 
   override protected def createBuffer(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsGdsStore.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.rapids.{RapidsDiskBlockManager, TempSpillBufferId}
 class RapidsGdsStore(
     diskBlockManager: RapidsDiskBlockManager,
     batchWriteBufferSize: Long)
-    extends RapidsBufferStore(StorageTier.GDS) {
+    extends RapidsBufferStoreWithoutSpillabilitySupport(StorageTier.GDS) {
   private[this] val batchSpiller = new BatchSpiller()
 
   override protected def createBuffer(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsHostMemoryStore.scala
@@ -43,10 +43,6 @@ class RapidsHostMemoryStore(
 
   override def spillableOnAdd: Boolean = false
 
-  override protected def setSpillable(buffer: RapidsBufferBase, spillable: Boolean): Unit = {
-    doSetSpillable(buffer, spillable)
-  }
-
   override def getMaxSize: Option[Long] = Some(maxSize)
 
   private def allocateHostBuffer(
@@ -359,7 +355,7 @@ class RapidsHostMemoryStore(
      * all columns are spillable.
      */
     override def updateSpillability(): Unit = {
-      doSetSpillable(this, columnSpillability.size == numDistinctColumns)
+      setSpillable(this, columnSpillability.size == numDistinctColumns)
     }
 
     override def getColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = {
@@ -369,7 +365,7 @@ class RapidsHostMemoryStore(
 
     override def getHostColumnarBatch(sparkTypes: Array[DataType]): ColumnarBatch = {
       columnSpillability.clear()
-      doSetSpillable(this, false)
+      setSpillable(this, false)
       RapidsHostColumnVector.incRefCounts(hostCb)
     }
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9076

This PR removes doSetSpillable in favor of setSpillable and introduces an abstract class for those leaf stores that do not support this behavior.