### PR TITLE
Set `spark.executor.cores` for integration tests.

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -348,6 +348,7 @@ EOF
             --driver-java-options "$driverJavaOpts" \
             $SPARK_SUBMIT_FLAGS \
             --conf 'spark.rapids.memory.gpu.allocSize='"$gpuAllocSize" \
+            --conf 'spark.executor.cores='"10" \
             "${RUN_TESTS_COMMAND[@]}" "${TEST_COMMON_OPTS[@]}"
     fi
 fi


### PR DESCRIPTION
Fixes #9135. (By workaround.)

This change sets `spark.executor.cores` to `10`, if it is unset. This allows integration tests to work around the failure seen in `parquet_test.py:test_small_file_memory`, where the `COALESCING` Parquet reader's thread pool accidentally uses 128 threads with 8MB memory each, thus consuming the entire heap.

Note that this is a bit of a workaround.  A more robust solution would be to scale the Parquet reader's buffers based on the amount of available memory, and the number of threads.

