### PR TITLE
Prevent returning internal compiler expressions when compiling UDFs

### DIFF
--- a/udf-compiler/src/main/scala/com/nvidia/spark/udf/CatalystExpressionBuilder.scala
+++ b/udf-compiler/src/main/scala/com/nvidia/spark/udf/CatalystExpressionBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,13 @@ case class CatalystExpressionBuilder(private val function: AnyRef) extends Loggi
     if (compiled.isEmpty) {
       logDebug(s"[CatalystExpressionBuilder] failed to compile")
     } else {
-      logDebug(s"[CatalystExpressionBuilder] compiled expression: ${compiled.get.toString}")
+      val expr = compiled.get
+      val internal = expr.find(_.isInstanceOf[Repr.CompilerInternal])
+      internal.foreach { e =>
+        throw new IllegalStateException(
+          s"compiled UDF has compiler internal expression $e: $expr")
+      }
+      logDebug(s"[CatalystExpressionBuilder] compiled expression: $expr")
     }
 
     compiled


### PR DESCRIPTION
Fixes #9167.  Adds a check for compiler internal nodes remaining after compiling a UDF into an equivalent Catalyst expression.  If any internal expressions are found, the code will throw an illegal state exception which will be caught by the try/catch in GpuScalaUDF and cause a fallback to the original CPU UDF function.