### PR TITLE
Fix a few minor things with scale test

### DIFF
--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/QuerySpecs.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/QuerySpecs.scala
@@ -45,7 +45,6 @@ class QuerySpecs(config: Config, spark: SparkSession) {
 
   private val random = new Random(config.seed)
 
-
   /**
    * To get numeric columns in a dataframe.
    * Now numeric columns are limited to [byte, int, long, decimal]
@@ -72,6 +71,32 @@ class QuerySpecs(config: Config, spark: SparkSession) {
     }
     numericColumns
   }
+
+  /**
+   * To get columns in a dataframe that work with min/max.
+   * Now numeric columns are limited to [byte, int, long, decimal, string]
+   *
+   * @param table table name
+   * @return min/max type column names
+   */
+  private def getMinMaxColumns(table: String): Seq[String] = {
+    assert(tables.contains(table), s"Invalid table: $table, candidate tables are ${
+      tables
+          .mkString(",")
+    }")
+    val df = spark.read.format(config.format).load(s"$baseInputPath/$table")
+    // Get the data types of all columns
+
+    df.dtypes.filter {
+      case (_, dataType) =>
+        dataType == "ByteType" || dataType == "IntegerType" || dataType == "LongType" ||
+            dataType.startsWith("DecimalType") || dataType == "StringType" ||
+            dataType == "TimestampType" || dataType == "DateType"
+    }.map {
+      case (columnName, _) => columnName
+    }
+  }
+
 
   /**
    * To get numeric columns in a dataframe and also in candidate columns
@@ -138,7 +163,7 @@ class QuerySpecs(config: Config, spark: SparkSession) {
   = {
     // Current Agg functions are MIN MAX which doesn't apply to MapType, so filter first.
     getNumericColumns(table, (1 to complexity).map(i => s"${prefix}_$i")).map(
-      i => s"${aggFunc}($i)"
+      i => s"${aggFunc}($i) as ${aggFunc}_$i"
     ).mkString(",")
   }
 
@@ -186,50 +211,58 @@ class QuerySpecs(config: Config, spark: SparkSession) {
       (1 to 10).map(i => s"b_data_small_value_range_$i").mkString(", ")
   }
 
-
   /**
-   * generate a string that contains multiple SUM oprations for numeric data columns
+   * generate multiple SUM operations for numeric data columns
    * e.g. when table b contains numeric columns as ["b_1", "b_2", "b_3", "b_4"]
    * it will produce "SUM(b_1 * b_2), SUM(b_1 * b3), SUM(b_1 * b_4)....." according to complexity.
    * Note it's not only limited to 2 columns multiplied, when complexity goes large, it may contains
-   * more columns.
-   *
-   * @param table
-   * @param complexity
-   * @return
+   * more columns. The returned value is of the form Seq[("SUM(b_1 * b2)", unique_column_name)].
+   * so the data can be processed to name the resulting column appropriately.
    */
-  private def expandSumForDataColumnsByComplexity(table: String, complexity: Int)
-  : String = {
+  private def expandSumForDataColumnsByComplexityInternal(table: String,
+      complexity: Int): Seq[(String, String)] = {
     val numericColumns = getNumericColumns(table)
-    (2 until numericColumns.length).map(numericColumns.combinations).reduce(_ ++ _).take(
-      complexity).map(f => f.mkString("SUM(", " * ", ")")).mkString(", ")
+    val allSums = (2 until numericColumns.length).map(numericColumns.combinations)
+        .reduce(_ ++ _).zipWithIndex
+    allSums.take(complexity).map {
+      case (cols, index) =>
+        (cols.mkString("SUM(", " * ", ")"), s"EXPAND_SUM_$index")
+    }.toSeq
   }
 
-  private def randomMinMax(random: Random): String = {
-    if (random.nextBoolean()) {
-      "MAX"
-    } else {
-      "MIN"
-    }
+  private def expandMinMaxForDataColumnsByComplexityInternal(columns: Seq[String],
+      complexity: Int): Seq[(String, String)] = {
+    val allPossible = for {
+      column <- columns
+      min_or_max <- Seq("MIN", "MAX")
+    } yield (s"$min_or_max($column)", s"${min_or_max}_$column")
+
+    random.shuffle(allPossible).take(complexity)
   }
 
-  private def expandMinMaxForDataColumnsByComplexity(table: String, complexity: Int): String = {
-    val numericColumns = getNumericColumns(table)
-    numericColumns.take(complexity).map(i => i.mkString(s"${randomMinMax(random)}(", "", ")"))
-      .mkString(",")
+  private def mixedSumMinMaxColumnsByComplexityInternal(table: String,
+      complexity: Int): Seq[(String, String)] = {
+    val minMaxColumns = getMinMaxColumns(table)
+    val maxPossibleMinMax = minMaxColumns.length * 2 // one for min and another for max
+    val numMinMax = math.min(maxPossibleMinMax, complexity / 2)
+    val numSums = complexity - numMinMax
+    expandSumForDataColumnsByComplexityInternal(table, numSums) ++
+      expandMinMaxForDataColumnsByComplexityInternal(minMaxColumns, numMinMax)
   }
 
-  private def MixedSumMinMaxColumnsByComplexity(table: String, complexity: Int): String = {
-    val numSums = random.nextInt(complexity)
-    val numMinMax = complexity - numSums
-    Seq(expandSumForDataColumnsByComplexity(table, numSums),
-      expandMinMaxForDataColumnsByComplexity(table, numMinMax)).filter(_.nonEmpty).mkString(",")
+  private def mixedSumMinMaxColumnsByComplexity(table: String, complexity: Int): String = {
+    val initial = mixedSumMinMaxColumnsByComplexityInternal(table, complexity)
+    initial.map {
+      case (query, name) => s"$query AS $name"
+    }.mkString(",")
   }
 
-  private def WindowMixedSumMinMaxColumnsByComplexity(table: String, complexity: Int): String = {
-    val withoutWindow = MixedSumMinMaxColumnsByComplexity(table, complexity)
-    withoutWindow.split(",").filter(_.nonEmpty)
-      .map(i => s"$i over w").mkString(", ")
+  private def windowMixedSumMinMaxColumnsByComplexity(table: String,
+      complexity: Int, window: String): String = {
+    val initial = mixedSumMinMaxColumnsByComplexityInternal(table, complexity)
+    initial.map {
+      case (query, name) => s"$query over $window AS $name"
+    }.mkString(",")
   }
 
   /**
@@ -243,516 +276,515 @@ class QuerySpecs(config: Config, spark: SparkSession) {
     }
   }
 
-  def getCandidateQueries(): ListMap[String, TestQuery] = {
+  def getCandidateQueries: Map[String, TestQuery] = {
     /*
     All queries are defined here
      */
-    val allQueries = ListMap[String, TestQuery](
-      "q1" -> TestQuery("q1",
+    val allQueries = ListMap(Seq(
+      TestQuery("q1",
         "SELECT a_facts.*, " +
-          expandColumnWithRange("b_data", 1, 10) +
-          " FROM b_data JOIN a_facts WHERE " +
-          "primary_a = b_foreign_a",
+            expandColumnWithRange("b_data", 1, 10) +
+            " FROM b_data JOIN a_facts WHERE " +
+            "primary_a = b_foreign_a",
         config.iterations,
         config.timeout,
         "Inner join with lots of ride along columns"),
-
-      "q2" -> TestQuery("q2",
+      TestQuery("q2",
         "SELECT a_facts.*," +
-          expandColumnWithRange("b_data", 1, 10) +
-          " FROM b_data FULL OUTER JOIN a_facts WHERE primary_a = b_foreign_a",
+            expandColumnWithRange("b_data", 1, 10) +
+            " FROM b_data FULL OUTER JOIN a_facts WHERE primary_a = b_foreign_a",
         config.iterations,
         config.timeout,
         "Full outer join with lots of ride along columns"),
-
-      "q3" -> TestQuery("q3",
+      TestQuery("q3",
         "SELECT a_facts.*," +
-          expandColumnWithRange("b_data", 1, 10) +
-          " FROM b_data LEFT OUTER JOIN a_facts WHERE primary_a = b_foreign_a",
+            expandColumnWithRange("b_data", 1, 10) +
+            " FROM b_data LEFT OUTER JOIN a_facts WHERE primary_a = b_foreign_a",
         config.iterations,
         config.timeout,
         "Left outer join with lots of ride along columns"),
-
-      "q4" -> TestQuery("q4",
+      TestQuery("q4",
         "SELECT c_data.* FROM c_data LEFT ANTI JOIN a_facts on primary_a = c_foreign_a",
         config.iterations,
         config.timeout,
         "Left anti-join lots of ride along columns."),
-      "q5" -> TestQuery("q5",
+      TestQuery("q5",
         "SELECT c_data.* FROM c_data LEFT SEMI JOIN a_facts on primary_a = c_foreign_a",
         config.iterations,
         config.timeout,
         "Left semi-join lots of ride along columns."),
-
-      "q6" -> TestQuery("q6",
+      TestQuery("q6",
         s"SELECT " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1), " +
-          s"${expandAggColumnByComplexity(
-            "c_data", "c_data", "MIN", 5)}," +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data_numeric", "MIN", 5)
-          }," +
-          s"${expandAggColumnByComplexity("d_data", "d_data", "MAX", 10)} " +
-          s"FROM c_data JOIN d_data WHERE " +
-          s"${
-            expandWhereClauseWithAndByComplexity(
-              "c_key2", "d_key2", config.complexity)
-          } GROUP BY " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1) as rn, " +
+            s"${expandAggColumnByComplexity(
+              "c_data", "c_data", "MIN", 5)}," +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data_numeric", "MIN", 5)
+            }," +
+            s"${expandAggColumnByComplexity("d_data", "d_data", "MAX", 10)} " +
+            s"FROM c_data JOIN d_data WHERE " +
+            s"${
+              expandWhereClauseWithAndByComplexity(
+                "c_key2", "d_key2", config.complexity)
+            } GROUP BY " +
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
         config.iterations,
         config.timeout,
         "Exploding inner large key count equi-join followed by min/max agg."),
-      "q7" -> TestQuery("q7",
+      TestQuery("q7",
         s"SELECT " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1), " +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data", "MIN", 5)
-          }," +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data_numeric", "MIN", 5)
-          }," +
-          s"${expandAggColumnByComplexity(
-            "d_data", "d_data", "MAX", 10)} " +
-          s"FROM c_data FULL OUTER JOIN d_data WHERE " +
-          s"${
-            expandWhereClauseWithAndByComplexity(
-              "c_key2", "d_key2", config.complexity)
-          } GROUP BY " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1) as rn, " +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data", "MIN", 5)
+            }," +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data_numeric", "MIN", 5)
+            }," +
+            s"${expandAggColumnByComplexity(
+              "d_data", "d_data", "MAX", 10)} " +
+            s"FROM c_data FULL OUTER JOIN d_data WHERE " +
+            s"${
+              expandWhereClauseWithAndByComplexity(
+                "c_key2", "d_key2", config.complexity)
+            } GROUP BY " +
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
         config.iterations,
         config.timeout,
         "Exploding full outer large key count equi-join followed by min/max agg."),
-      "q8" -> TestQuery("q8",
+      TestQuery("q8",
         s"SELECT " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1), " +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data", "MIN", 5)
-          }," +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data_numeric", "MIN", 5)
-          }," +
-          s"${expandAggColumnByComplexity("d_data", "d_data", "MAX", 10)} " +
-          s"FROM c_data LEFT OUTER JOIN d_data WHERE " +
-          s"${
-            expandWhereClauseWithAndByComplexity(
-              "c_key2", "d_key2", config.complexity)
-          } " +
-          s"GROUP BY " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, COUNT(1) as rn, " +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data", "MIN", 5)
+            }," +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data_numeric", "MIN", 5)
+            }," +
+            s"${expandAggColumnByComplexity("d_data", "d_data", "MAX", 10)} " +
+            s"FROM c_data LEFT OUTER JOIN d_data WHERE " +
+            s"${
+              expandWhereClauseWithAndByComplexity(
+                "c_key2", "d_key2", config.complexity)
+            } " +
+            s"GROUP BY " +
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
         config.iterations,
         config.timeout,
         "Exploding left outer large key count equi-join followed by min/max agg."),
-      "q9" -> TestQuery("q9",
+      TestQuery("q9",
         s"SELECT " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, " +
-          s"COUNT(1), " +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data", "MIN", 5)
-          }," +
-          s"${
-            expandAggColumnByComplexity(
-              "c_data", "c_data_numeric", "MIN", 5)
-          } " +
-          s"FROM c_data LEFT SEMI JOIN d_data on " +
-          s"${
-            expandWhereClauseWithAndByComplexity(
-              "c_key2", "d_key2", config.complexity)
-          }" +
-          s" GROUP BY " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}, " +
+            s"COUNT(1) as rn, " +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data", "MIN", 5)
+            }," +
+            s"${
+              expandAggColumnByComplexity(
+                "c_data", "c_data_numeric", "MIN", 5)
+            } " +
+            s"FROM c_data LEFT SEMI JOIN d_data on " +
+            s"${
+              expandWhereClauseWithAndByComplexity(
+                "c_key2", "d_key2", config.complexity)
+            }" +
+            s" GROUP BY " +
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
         config.iterations,
         config.timeout,
         "Left semi large key count equi-join followed by min/max agg."),
-      "q10" -> TestQuery("q10",
+      TestQuery("q10",
         s"SELECT " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}," +
-          s" COUNT(1)," +
-          s" ${expandAggColumnByComplexity(
-            "c_data", "c_data", "MIN", config.complexity)}" +
-          s" FROM c_data LEFT ANTI JOIN d_data on " +
-          s"${
-            expandWhereClauseWithAndByComplexity(
-              "c_key2", "d_key2", config.complexity)
-          } " +
-          s"GROUP BY " +
-          s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}," +
+            s" COUNT(1) as rn," +
+            s" ${expandAggColumnByComplexity(
+              "c_data", "c_data", "MIN", config.complexity)}" +
+            s" FROM c_data LEFT ANTI JOIN d_data on " +
+            s"${
+              expandWhereClauseWithAndByComplexity(
+                "c_key2", "d_key2", config.complexity)
+            } " +
+            s"GROUP BY " +
+            s"${expandKeyColumnByComplexity("c_key2", config.complexity)}",
         config.iterations,
         config.timeout,
         "Left anti large key count equi-join followed by min/max agg."),
-      "q11" -> TestQuery("q11",
+      TestQuery("q11",
         s"SELECT " +
-          s"${expandKeyGroup3("b_key3")}, " +
-          s"${expandColumnWithRange("e_data", 1, 10)}, " +
-          s"${expandBDataColumns()} " +
-          s"FROM b_data JOIN e_data on " +
-          s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
+            s"${expandKeyGroup3("b_key3")}, " +
+            s"${expandColumnWithRange("e_data", 1, 10)}, " +
+            s"${expandBDataColumns()} " +
+            s"FROM b_data JOIN e_data on " +
+            s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
         config.iterations,
         config.timeout,
-        "No obvious build side inner equi-join. (Shuffle partitions should be set to 10)",
+        "No obvious build side inner equi-join. (few shuffle partitions)",
         shufflePartitions = Math.ceil(config.scaleFactor/50.0).toInt),
-      "q12" -> TestQuery("q12",
+      TestQuery("q12",
         s"SELECT " +
-          s"${expandKeyGroup3("b_key3")}, " +
-          s"${expandColumnWithRange("e_data", 1, 10)}, " +
-          s"${expandBDataColumns()} " +
-          s"FROM b_data FULL OUTER JOIN e_data on " +
-          s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
+            s"${expandKeyGroup3("b_key3")}, " +
+            s"${expandColumnWithRange("e_data", 1, 10)}, " +
+            s"${expandBDataColumns()} " +
+            s"FROM b_data FULL OUTER JOIN e_data on " +
+            s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
         config.iterations,
         config.timeout,
-        " No obvious build side full outer equi-join. (Shuffle partitions should be set to 10)",
+        " No obvious build side full outer equi-join. (few shuffle partitions)",
         shufflePartitions = Math.ceil(config.scaleFactor/50.0).toInt),
-      "q13" -> TestQuery("q13",
+      TestQuery("q13",
         s"SELECT " +
-          s"${expandKeyGroup3("b_key3")}, " +
-          s"${expandColumnWithRange("e_data", 1, 10)}, " +
-          s"${expandBDataColumns()} " +
-          s"FROM b_data LEFT OUTER JOIN e_data WHERE " +
-          s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
+            s"${expandKeyGroup3("b_key3")}, " +
+            s"${expandColumnWithRange("e_data", 1, 10)}, " +
+            s"${expandBDataColumns()} " +
+            s"FROM b_data LEFT OUTER JOIN e_data WHERE " +
+            s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
         config.iterations,
         config.timeout,
-        "No obvious build side left outer equi-join. (Shuffle partitions should be set to 10)",
+        "No obvious build side left outer equi-join. (few shuffle partitions)",
         shufflePartitions = Math.ceil(config.scaleFactor/50.0).toInt),
-      "q14" -> TestQuery("q14",
+      TestQuery("q14",
         s"SELECT " +
-          s"${expandKeyGroup3("b_key3")}, " +
-          s"${expandBDataColumns()} " +
-          s"FROM " +
-          s"b_data LEFT SEMI JOIN e_data on " +
-          s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
+            s"${expandKeyGroup3("b_key3")}, " +
+            s"${expandBDataColumns()} " +
+            s"FROM " +
+            s"b_data LEFT SEMI JOIN e_data on " +
+            s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
         config.iterations,
         config.timeout,
-        "both sides large left semi equi-join. (Shuffle partitions should be set to 10)",
+        "both sides large left semi equi-join. (few shuffle partitions)",
         shufflePartitions = Math.ceil(config.scaleFactor/50.0).toInt),
-      "q15" -> TestQuery("q15",
+      TestQuery("q15",
         s"SELECT " +
-          s"${expandKeyGroup3("b_key3")}, " +
-          s"${expandBDataColumns()} " +
-          s"FROM " +
-          s"b_data LEFT ANTI JOIN e_data on " +
-          s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
+            s"${expandKeyGroup3("b_key3")}, " +
+            s"${expandBDataColumns()} " +
+            s"FROM " +
+            s"b_data LEFT ANTI JOIN e_data on " +
+            s"${expandWhereClauseWithAndKeyGroup3("b_key3", "e_key3")}",
         config.iterations,
         config.timeout,
-        "Both sides large left anti equi-join. (Shuffle partitions should be set to 10)",
+        "Both sides large left anti equi-join. (few shuffle partitions)",
         shufflePartitions = Math.ceil(config.scaleFactor/50.0).toInt),
-      "q16" -> TestQuery("q16",
+      TestQuery("q16",
         s"SELECT a_key4_1, " +
-          s"${
-            expandColumnWithRange("a_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          }, " +
-          s"${
-            expandColumnWithRange("f_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"FROM a_facts JOIN f_facts " +
-          s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
+            s"${
+              expandColumnWithRange("a_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            }, " +
+            s"${
+              expandColumnWithRange("f_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"FROM a_facts JOIN f_facts " +
+            s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional AST inner join."),
-      "q17" -> TestQuery("q17",
+      TestQuery("q17",
         s"SELECT a_key4_1, " +
-          s"${
-            expandColumnWithRange("a_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          }, " +
-          s"${
-            expandColumnWithRange("f_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"FROM a_facts FULL OUTER JOIN f_facts " +
-          s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
+            s"${
+              expandColumnWithRange("a_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            }, " +
+            s"${
+              expandColumnWithRange("f_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"FROM a_facts FULL OUTER JOIN f_facts " +
+            s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional AST full outer join."),
-      "q18" -> TestQuery("q18",
+      TestQuery("q18",
         s"SELECT a_key4_1, " +
-          s"${
-            expandColumnWithRange("a_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          }, " +
-          s"${
-            expandColumnWithRange("f_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"FROM a_facts LEFT OUTER JOIN f_facts " +
-          s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
+            s"${
+              expandColumnWithRange("a_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            }, " +
+            s"${
+              expandColumnWithRange("f_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"FROM a_facts LEFT OUTER JOIN f_facts " +
+            s"on a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional AST left anti join."),
-      "q19" -> TestQuery("q19",
+      TestQuery("q19",
         s"SELECT " +
-          s"a_key4_1, " +
-          s"${expandADataColumns()} " +
-          s"FROM a_facts " +
-          s"LEFT ANTI JOIN f_facts on " +
-          s"a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) != 2",
+            s"a_key4_1, " +
+            s"${expandADataColumns()} " +
+            s"FROM a_facts " +
+            s"LEFT ANTI JOIN f_facts on " +
+            s"a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) != 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional AST left anti join."),
-      "q20" -> TestQuery("q20",
+      TestQuery("q20",
         s"SELECT " +
-          s"a_key4_1, " +
-          s"${expandADataColumns()} " +
-          s"FROM a_facts LEFT SEMI JOIN f_facts on " +
-          s"a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
+            s"a_key4_1, " +
+            s"${expandADataColumns()} " +
+            s"FROM a_facts LEFT SEMI JOIN f_facts on " +
+            s"a_key4_1 = f_key4_1 AND (a_data_low_unique_1 + f_data_low_unique_1) = 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional AST left semi join."),
-      "q21" -> TestQuery("q21",
+      TestQuery("q21",
         s"SELECT " +
-          s"a_key4_1, " +
-          s"${
-            expandColumnWithRange("a_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          }, " +
-          s"${
-            expandColumnWithRange("f_data",
-              1,
-              Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"FROM a_facts JOIN f_facts " +
-          s"on a_key4_1 = f_key4_1 AND " +
-          s"(length(concat(a_data_low_unique_len_1, f_data_low_unique_len_1))) = 2",
+            s"a_key4_1, " +
+            s"${
+              expandColumnWithRange("a_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            }, " +
+            s"${
+              expandColumnWithRange("f_data",
+                1,
+                Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"FROM a_facts JOIN f_facts " +
+            s"on a_key4_1 = f_key4_1 AND " +
+            s"(length(concat(a_data_low_unique_len_1, f_data_low_unique_len_1))) = 2",
         config.iterations,
         config.timeout,
         "Extreme skew conditional NON-AST inner join."),
-      "q22" -> TestQuery("q22",
+      TestQuery("q22",
         s"SELECT ${expandKeyGroup3("b_key3")}, " +
-          s"${MixedSumMinMaxColumnsByComplexity("b_data", config.complexity)} " +
-          s"FROM b_data GROUP BY " +
-          s"${expandKeyGroup3("b_key3")}",
+            s"${mixedSumMinMaxColumnsByComplexity("b_data", config.complexity)} " +
+            s"FROM b_data GROUP BY " +
+            s"${expandKeyGroup3("b_key3")}",
         config.iterations,
         config.timeout,
         "Group by aggregation, not a lot of combining, but lots of aggregations, " +
-          "and CUDF does sort agg internally."),
-      "q23" -> TestQuery("q23",
-        s"SELECT ${MixedSumMinMaxColumnsByComplexity("b_data", config.complexity)} " +
-          s"FROM b_data",
+            "and CUDF does sort agg internally."),
+      TestQuery("q23",
+        s"SELECT ${mixedSumMinMaxColumnsByComplexity("b_data", config.complexity)} " +
+            s"FROM b_data",
         config.iterations,
         config.timeout,
-        "Reduction with with lots of aggregations"),
-      "q24" -> TestQuery("q24",
+        "Reduction with lots of aggregations"),
+      TestQuery("q24",
         s"SELECT ${expandKeyGroup3("g_key3")}, " +
-          s"${MixedSumMinMaxColumnsByComplexity("g_data", config.complexity)} " +
-          s"FROM g_data " +
-          s"GROUP BY ${expandKeyGroup3("g_key3")}",
+            s"${mixedSumMinMaxColumnsByComplexity("g_data", config.complexity)} " +
+            s"FROM g_data " +
+            s"GROUP BY ${expandKeyGroup3("g_key3")}",
         config.iterations,
         config.timeout,
         "Group by aggregation with lots of combining, lots of aggs, and CUDF does hash agg" +
-          " internally"),
-      "q25" -> TestQuery("q25",
+            " internally"),
+      TestQuery("q25",
         s"select ${expandKeyGroup3("g_key3")}, " +
-          s"collect_set(g_data_enum_1) FROM g_data GROUP BY " +
-          s"${expandKeyGroup3("g_key3")}",
+            s"collect_set(g_data_enum_1) as g_data_emnum_1_set FROM g_data GROUP BY " +
+            s"${expandKeyGroup3("g_key3")}",
         config.iterations,
         config.timeout,
         "collect set group by agg"),
-      "q26" -> TestQuery("q26",
-        s"select b_foreign_a, collect_list(b_data_1) FROM b_data GROUP BY b_foreign_a",
+      TestQuery("q26",
+        s"select b_foreign_a, collect_list(b_data_1) b_data_1_list " +
+            s"FROM b_data GROUP BY b_foreign_a",
         config.iterations,
         config.timeout,
         "collect list group by agg with some hope of succeeding."),
-      "q27" -> TestQuery("q27",
+      TestQuery("q27",
         s"select " +
-          s"min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w, " +
-          s"row_number() over w " +
-          s"from g_data " +
-          s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} ORDER BY " +
-          s"g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+            s"min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4, " +
+            s"row_number() over w as rn " +
+            s"from g_data " +
+            s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} ORDER BY " +
+            s"g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
         config.iterations,
         config.timeout,
         "Running Window with skewed partition by columns, and single order by column with small " +
-          "number of basic window ops (min, max, sum, count, average, row_number)"),
-      "q28" -> TestQuery("q28",
-        s"select min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w " +
-          "from g_data " +
-          s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} " +
-          s"ORDER BY g_data_row_num_1 RANGE BETWEEN 1000 * ${config.scaleFactor}" +
-          s" PRECEDING AND 5000 * ${config.scaleFactor} " +
-          s"FOLLOWING)",
+            "number of basic window ops (min, max, sum, count, average, row_number)"),
+      TestQuery("q28",
+        s"select min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4 " +
+            "from g_data " +
+            s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} " +
+            s"ORDER BY g_data_row_num_1 RANGE BETWEEN ${1000 * config.scaleFactor}" +
+            s" PRECEDING AND ${5000 * config.scaleFactor} " +
+            s"FOLLOWING)",
         config.iterations,
         config.timeout,
         "Ranged Window with large range (lots of rows preceding and following) skewed partition" +
-          " by columns and single order by column with small number of basic window ops (min, " +
-          "max, sum, count, average)"),
-      "q29" -> TestQuery("q29",
-        s"select min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w " +
-          s"from g_data " +
-          s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} ORDER BY " +
-          s"g_data_row_num_1 ROWS BETWEEN " +
-          s"UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
+            " by columns and single order by column with small number of basic window ops (min, " +
+            "max, sum, count, average)"),
+      TestQuery("q29",
+        s"select min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4 " +
+            s"from g_data " +
+            s"WINDOW w AS (PARTITION BY ${expandKeyGroup3("g_key3")} ORDER BY " +
+            s"g_data_row_num_1 ROWS BETWEEN " +
+            s"UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
         config.iterations,
         config.timeout,
         "unbounded preceding and following window with skewed partition by columns and single " +
-          "order by column with small number of basic window op (min, max, sum, count, average)"),
-      "q30" -> TestQuery("q30",
-        s"select " +
-          s"min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w " +
-          s"from g_data " +
-          s"WINDOW w AS (ORDER BY g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING AND " +
-          s"CURRENT ROW)",
+            "order by column with small number of basic window op (min, max, sum, count, average)"),
+      TestQuery("q30",
+        s"select min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4 " +
+            s"from g_data " +
+            s"WINDOW w AS (ORDER BY g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING AND " +
+            s"CURRENT ROW)",
         config.iterations,
         config.timeout,
         " running window with no partition by columns and single order by column with small " +
-          "number of basic window ops (min, max, sum, count, average, row_number)"),
-      "q31" -> TestQuery("q31",
-        s"select min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w " +
-          s"from g_data " +
-          s"WINDOW w AS (ORDER BY g_data_row_num_1 RANGE BETWEEN 1000 * ${config.scaleFactor}" +
-          s" PRECEDING AND 5000 * ${config.scaleFactor} FOLLOWING)",
+            "number of basic window ops (min, max, sum, count, average, row_number)"),
+      TestQuery("q31",
+        s"select min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4 " +
+            s"from g_data " +
+            s"WINDOW w AS (ORDER BY g_data_row_num_1 RANGE BETWEEN ${1000 * config.scaleFactor}" +
+            s" PRECEDING AND ${5000 * config.scaleFactor} FOLLOWING)",
         config.iterations,
         config.timeout,
         " ranged window with large range (lots of rows preceding and following) no partition by " +
-          "columns and single order by column with small number of basic window ops (min, max, " +
-          "sum, count, average)"),
-      "q32" -> TestQuery("q32",
-        s"select  min(g_data_byte_1) over w, " +
-          s"max(g_data_byte_1) over w, " +
-          s"sum(g_data_byte_2) over w, " +
-          s"count(g_data_byte_3) over w, " +
-          s"avg(g_data_byte_4) over w " +
-          s"from g_data " +
-          s"WINDOW w AS (ORDER BY g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED" +
-          s" FOLLOWING)",
+            "columns and single order by column with small number of basic window ops (min, max, " +
+            "sum, count, average)"),
+      TestQuery("q32",
+        s"select min(g_data_byte_1) over w as MIN_g_data_byte_1, " +
+            s"max(g_data_byte_1) over w as MAX_g_data_byte_1, " +
+            s"sum(g_data_byte_2) over w as SUM_g_data_byte_2, " +
+            s"count(g_data_byte_3) over w as COUNT_g_data_byte_3, " +
+            s"avg(g_data_byte_4) over w as AVG_g_data_byte_4 " +
+            s"from g_data " +
+            s"WINDOW w AS (ORDER BY g_data_row_num_1 ROWS BETWEEN UNBOUNDED PRECEDING " +
+            s"AND UNBOUNDED FOLLOWING)",
         config.iterations,
         config.timeout,
         "unbounded preceding and following window with no partition by columns and single order" +
-          " by column with small number of basic window ops (min, max, sum, count, average)"),
-      "q33" -> TestQuery("q33",
-        s"select lag(g_data_byte_1, 10 * ${config.scaleFactor}) OVER w, " +
-          s"lead(g_data_byte_2, 10 * ${config.scaleFactor}) OVER w " +
-          s"from g_data " +
-          s"WINDOW w as (PARTITION BY ${expandKeyGroup3("g_key3")} " +
-          s"ORDER BY g_data_row_num_1)",
+            " by column with small number of basic window ops (min, max, sum, count, average)"),
+      TestQuery("q33",
+        s"select lag(g_data_byte_1, ${10 * config.scaleFactor}) OVER w as LAG_g_data_byte_1, " +
+            s"lead(g_data_byte_2, ${10 * config.scaleFactor}) OVER w as LEAD_g_data_byte_2 " +
+            s"from g_data " +
+            s"WINDOW w as (PARTITION BY ${expandKeyGroup3("g_key3")} " +
+            s"ORDER BY g_data_row_num_1)",
         config.iterations,
         config.timeout,
         "Lead/Lag window with skewed partition by columns and single order by column"),
-      "q34" -> TestQuery("q34",
-        s"select lag(g_data_byte_1, 10 * ${config.scaleFactor}) over w, " +
-          s"lead(g_data_byte_2, 10 * ${config.scaleFactor}) over w " +
-          s"from g_data " +
-          s"WINDOW w as (ORDER BY g_data_row_num_1)",
+      TestQuery("q34",
+        s"select lag(g_data_byte_1, ${10 * config.scaleFactor}) OVER w as LAG_g_data_byte_1, " +
+            s"lead(g_data_byte_2, ${10 * config.scaleFactor}) OVER w as LEAD_g_data_byte_2 " +
+            s"from g_data " +
+            s"WINDOW w as (ORDER BY g_data_row_num_1)",
         config.iterations,
         config.timeout,
         "Lead/Lag window with no partition by columns and single order by column."),
-      "q35" -> TestQuery("q35",
-        s"select min(c_data_numeric_1) over w, " +
-          s"max(c_data_numeric_2) over w " +
-          s"from c_data " +
-          s"WINDOW w AS " +
-          s"( " +
-          s"PARTITION BY ${
-            expandColumnWithRange("c_key2",
-              1, Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"ORDER BY ${
-            expandColumnWithRange("c_key2",
-              1, Math.round(config.complexity / 2.0).toInt)
-          } " +
-          s"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+      TestQuery("q35",
+        s"select min(c_data_numeric_1) over w as MIN_c_data_numeric_1, " +
+            s"max(c_data_numeric_2) over w as MAX_c_data_numeric_2 " +
+            s"from c_data " +
+            s"WINDOW w AS " +
+            s"( " +
+            s"PARTITION BY ${
+              expandColumnWithRange("c_key2",
+                1, Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"ORDER BY ${
+              expandColumnWithRange("c_key2",
+                1, Math.round(config.complexity / 2.0).toInt)
+            } " +
+            s"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
         config.iterations,
         config.timeout,
         "Running window with complexity/2 in partition by columns and complexity/2 in order" +
-          " by columns."),
-      "q36" -> TestQuery("q36",
-        s"select min(c_data_numeric_1) over w, max(c_data_numeric_2) over w from c_data " +
-          s"WINDOW w AS " +
-          s"(PARTITION BY ${
-            expandColumnWithRange("c_key2",
-              1, Math.round(config.complexity / 2.0).toInt)
-          }" +
-          s" ORDER BY ${
-            expandColumnWithRange("c_key2",
-              Math.round(config.complexity / 2.0).toInt, config.complexity)
-          } " +
-          s"ROWS BETWEEN UNBOUNDED PRECEDING " +
-          s"AND UNBOUNDED FOLLOWING)",
+            " by columns."),
+      TestQuery("q36",
+        s"select min(c_data_numeric_1) over w as MIN_c_data_numeric_1, " +
+            s"max(c_data_numeric_2) over w as MAX_c_data_numeric_2 " +
+            s"from c_data " +
+            s"WINDOW w AS " +
+            s"(PARTITION BY ${
+              expandColumnWithRange("c_key2",
+                1, Math.round(config.complexity / 2.0).toInt)
+            }" +
+            s" ORDER BY ${
+              expandColumnWithRange("c_key2",
+                Math.round(config.complexity / 2.0).toInt, config.complexity)
+            } " +
+            s"ROWS BETWEEN UNBOUNDED PRECEDING " +
+            s"AND UNBOUNDED FOLLOWING)",
         config.iterations,
         config.timeout,
         "unbounded to unbounded window with complexity/2 in partition by columns and complexity/2" +
-          " in order by columns."),
-            "q37" -> TestQuery("q37",
-              s"select ${WindowMixedSumMinMaxColumnsByComplexity("c_data",
-                config.complexity)} " +
-                s" from c_data " +
-                s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 ROWS BETWEEN " +
-                s"UNBOUNDED PRECEDING AND CURRENT ROW)",
-              config.iterations,
-              config.timeout,
-              "Running window with simple partition by and order by columns, but complexity " +
-                "window operations as combinations of a few input columns"),
-            "q38" -> TestQuery("q38",
-              s"select ${
-                WindowMixedSumMinMaxColumnsByComplexity("c_data", config.complexity)} " +
-                s"from c_data " +
-                s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 RANGE BETWEEN " +
-                s"10 PRECEDING AND 10 FOLLOWING)",
-              config.iterations,
-              config.timeout,
-              "Ranged window with simple partition by and order by columns, but complexity " +
-                "window operations as combinations of a few input columns"),
-            "q39" -> TestQuery("q39",
-              s"select ${
-                WindowMixedSumMinMaxColumnsByComplexity("c_data", config.complexity)} " +
-                s"from c_data " +
-                s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 ROWS BETWEEN " +
-                s"UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING )",
-              config.iterations,
-              config.timeout,
-              "unbounded window with simple partition by and order by columns, but complexity " +
-                "window operations as combinations of a few input columns"),
-      "q40" -> TestQuery("q40",
+            " in order by columns."),
+      TestQuery("q37",
+        s"select ${windowMixedSumMinMaxColumnsByComplexity("c_data", config.complexity, "w")} " +
+            s" from c_data " +
+            s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 ROWS BETWEEN " +
+            s"UNBOUNDED PRECEDING AND CURRENT ROW)",
+        config.iterations,
+        config.timeout,
+        "Running window with simple partition by and order by columns, but complexity " +
+            "window operations as combinations of a few input columns"),
+      TestQuery("q38",
+        s"select ${
+          windowMixedSumMinMaxColumnsByComplexity("c_data", config.complexity, "w")} " +
+            s"from c_data " +
+            s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 RANGE BETWEEN " +
+            s"10 PRECEDING AND 10 FOLLOWING)",
+        config.iterations,
+        config.timeout,
+        "Ranged window with simple partition by and order by columns, but complexity " +
+            "window operations as combinations of a few input columns"),
+      TestQuery("q39",
+        s"select ${
+          windowMixedSumMinMaxColumnsByComplexity("c_data", config.complexity, "w")} " +
+            s"from c_data " +
+            s"WINDOW w AS (PARTITION BY c_foreign_a ORDER BY c_data_row_num_1 ROWS BETWEEN " +
+            s"UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING )",
+        config.iterations,
+        config.timeout,
+        "unbounded window with simple partition by and order by columns, but complexity " +
+            "window operations as combinations of a few input columns"),
+      TestQuery("q40",
         s"select " +
-          s"array_sort(collect_set(f_data_low_unique_1) " +
-          s"OVER (PARTITION BY f_key4_1 order by f_data_row_num_1 ROWS BETWEEN UNBOUNDED " +
-          s"PRECEDING AND CURRENT ROW)) " +
-          s"from f_facts",
+            s"array_sort(collect_set(f_data_low_unique_1) " +
+            s"OVER (PARTITION BY f_key4_1 order by f_data_row_num_1 ROWS BETWEEN UNBOUNDED " +
+            s"PRECEDING AND CURRENT ROW)) as f_data_low_unique_1_set " +
+            s"from f_facts",
         config.iterations,
         config.timeout,
         "COLLECT SET WINDOW (We may never really be able to do this well)"),
-      "q41" -> TestQuery("q41",
+      TestQuery("q41",
         s"select " +
-          s"collect_list(f_data_low_unique_1) " +
-          s"OVER (PARTITION BY f_key4_1 order by f_data_row_num_1 " +
-          s"ROWS BETWEEN ${config.complexity} PRECEDING and CURRENT ROW ) " +
-          s"from f_facts",
+            s"collect_list(f_data_low_unique_1) " +
+            s"OVER (PARTITION BY f_key4_1 order by f_data_row_num_1 " +
+            s"ROWS BETWEEN ${config.complexity} PRECEDING and CURRENT ROW ) " +
+            s"as f_data_low_unique_1_list " +
+            s"from f_facts",
         config.iterations,
         config.timeout,
-        "COLLECT LIST WINDOW (We may never really be able to do this well)")
-    )
+        "COLLECT LIST WINDOW (We may never really be able to do this well)")).map { tc =>
+      (tc.name, tc)
+    }: _*)
     if (config.queries.isEmpty) {
       allQueries
     } else {

--- a/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/ScaleTest.scala
+++ b/integration_tests/src/main/scala/com/nvidia/spark/rapids/tests/scaletest/ScaleTest.scala
@@ -19,7 +19,6 @@ package com.nvidia.spark.rapids.tests.scaletest
 import java.util.concurrent._
 
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-import scala.collection.immutable.ListMap
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.NANOSECONDS
@@ -78,8 +77,6 @@ object ScaleTest {
     val status = ListBuffer[String]()
 
     (1 to query.iterations).foreach(i => {
-      spark.sparkContext.setJobGroup(s"query=${query.name}", s"iteration=$i")
-      println(s"Iteration: $i")
       while (idleSessionListener.isBusy()){
         // Scala Test aims for stability not performance. And the sleep time will not be calculated
         // into execution time.
@@ -89,9 +86,13 @@ object ScaleTest {
       }
       val taskFailureListener = new TaskFailureListener
       try {
-        spark.conf.set("spark.sql.shuffle.partitions", query.shufflePartitions)
-        spark.sparkContext.addSparkListener(taskFailureListener)
         val future = scala.concurrent.Future {
+          spark.sparkContext.setJobGroup(query.name, s"query=${query.name},iteration=$i")
+          println(s"Iteration: $i")
+
+          spark.conf.set("spark.sql.shuffle.partitions", query.shufflePartitions)
+          spark.sparkContext.addSparkListener(taskFailureListener)
+
           val start = System.nanoTime()
           spark.sql(query.content).write.mode(mode).format(format).save(s"${baseOutputPath}_$i")
           val end = System.nanoTime()
@@ -132,7 +133,7 @@ object ScaleTest {
    * @param spark spark session
    * @param queryMap query map
    */
-  private def printQueries(spark: SparkSession, queryMap: ListMap[String, TestQuery]): Unit
+  private def printQueries(spark: SparkSession, queryMap: Map[String, TestQuery]): Unit
   = {
     for ((queryName, query) <- queryMap) {
       println("*"*80)
@@ -151,7 +152,7 @@ object ScaleTest {
     spark.sparkContext.addSparkListener(idleSessionListener)
     val querySpecs = new QuerySpecs(config, spark)
     querySpecs.initViews()
-    val queryMap = querySpecs.getCandidateQueries()
+    val queryMap = querySpecs.getCandidateQueries
     if (config.dry) {
       printQueries(spark, queryMap)
       sys.exit(1)


### PR DESCRIPTION
This fixes #9198

It also 
   * increases the types of columns that can be used for min/max operations
   * Adds a user readable column name for all output columns (so comparing results will be simpler)
   * Adjusts the ratio of SUM vs MIN/MAX columns to be even instead of random.
   * Removes duplication in the query names. The query names before were put into the map and also into the TestQuery. This moves them to only ever be in the TestQuery and the map is built from that.
