### PR TITLE
Support SplitAndRetry for GpuRangeExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -984,6 +984,97 @@ case class GpuFastSampleExec(
   }
 }
 
+class GpuRangeIterator(
+    partitionStart: BigInt,
+    partitionEnd: BigInt,
+    step: Long,
+    maxRowCountPerBatch: Long,
+    taskContext: TaskContext,
+    opTime: GpuMetric) extends Iterator[ColumnarBatch] with Logging {
+
+  private def getSafeMargin(bi: BigInt): Long = {
+    if (bi.isValidLong) {
+      bi.toLong
+    } else if (bi > 0) {
+      Long.MaxValue
+    } else {
+      Long.MinValue
+    }
+  }
+
+  private val safePartitionStart = getSafeMargin(partitionStart) // inclusive
+  private val safePartitionEnd = getSafeMargin(partitionEnd) // exclusive, unless start == this
+  private[this] var number: Long = safePartitionStart
+  private[this] var done: Boolean = false
+
+  override def hasNext: Boolean = {
+    if (!done) {
+      if (step > 0) {
+        number < safePartitionEnd
+      } else {
+        number > safePartitionEnd
+      }
+    } else false
+  }
+
+  override def next(): ColumnarBatch = {
+    GpuSemaphore.acquireIfNecessary(taskContext)
+    withResource(new NvtxWithMetrics("GpuRange", NvtxColor.DARK_GREEN, opTime)) { _ =>
+      val start = number
+      val remainingRows = (safePartitionEnd - start) / step
+      // Start is inclusive so we need to produce at least one row
+      val rowsExpected = Math.max(1, Math.min(remainingRows, maxRowCountPerBatch))
+      val iter = withRetry(AutoCloseableLong(rowsExpected), splitRowsNumberInHalf) { rows =>
+        withResource(Scalar.fromLong(start)) { startScalar =>
+          withResource(Scalar.fromLong(step)) { stepScalar =>
+            withResource(
+                cudf.ColumnVector.sequence(startScalar, stepScalar, rows.value.toInt)) { vec =>
+              withResource(new Table(vec)) { tab =>
+                GpuColumnVector.from(tab, Array[DataType](LongType))
+              }
+            }
+          }
+        }
+      }
+      assert(iter.hasNext)
+      closeOnExcept(iter.next()) { batch =>
+        // it should has only one batch
+        assert(iter.isEmpty)
+        val endInclusive = start + ((batch.numRows() - 1) * step)
+        number = endInclusive + step
+        if (number < endInclusive ^ step < 0) {
+          // we have Long.MaxValue + Long.MaxValue < Long.MaxValue
+          // and Long.MinValue + Long.MinValue > Long.MinValue, so iff the step causes a
+          // step back, we are pretty sure that we have an overflow.
+          done = true
+        }
+        if (batch.numRows() < rowsExpected) {
+          logDebug(s"Retried with ${batch.numRows()} rows when expected $rowsExpected rows")
+        }
+        batch
+      }
+    }
+  }
+
+  /**
+   * Reduce the input rows number by half, and it returns a Seq with only one element,
+   * that is the half value.
+   */
+  private def splitRowsNumberInHalf: AutoCloseableLong => Seq[AutoCloseableLong] =
+    (rowsNumber) => {
+      withResource(rowsNumber) { _ =>
+        assert(rowsNumber.value > 0)
+        val firstHalf = math.max(1L, rowsNumber.value / 2)
+        Seq(AutoCloseableLong(firstHalf))
+      }
+    }
+
+  /** A bridge class between Long and AutoCloseable for retry */
+  case class AutoCloseableLong(value: Long) extends AutoCloseable {
+    override def close(): Unit = { /* Nothing to be closed */ }
+  }
+}
+
 /**
  * Physical plan for range (generating a range of 64 bit numbers).
  */
@@ -994,7 +1085,7 @@ case class GpuRangeExec(
     numSlices: Int,
     output: Seq[Attribute],
     targetSizeBytes: Long)
-    extends ShimLeafExecNode with GpuExec {
+  extends ShimLeafExecNode with GpuExec {
 
   val numElements: BigInt = {
     val safeStart = BigInt(start)
@@ -1049,78 +1140,23 @@ case class GpuRangeExec(
       sparkContext.emptyRDD[ColumnarBatch]
     } else {
       sparkSession
-          .sparkContext
-          .parallelize(0 until numSlices, numSlices)
-          .mapPartitionsWithIndex { (i, _) =>
-            val partitionStart = (i * numElements) / numSlices * step + start
-            val partitionEnd = (((i + 1) * numElements) / numSlices) * step + start
+        .sparkContext
+        .parallelize(0 until numSlices, numSlices)
+        .mapPartitionsWithIndex { (i, _) =>
+          val partitionStart = (i * numElements) / numSlices * step + start
+          val partitionEnd = (((i + 1) * numElements) / numSlices) * step + start
+          val taskContext = TaskContext.get()
+          val inputMetrics = taskContext.taskMetrics().inputMetrics
 
-            def getSafeMargin(bi: BigInt): Long =
-              if (bi.isValidLong) {
-                bi.toLong
-              } else if (bi > 0) {
-                Long.MaxValue
-              } else {
-                Long.MinValue
-              }
-
-            val safePartitionStart = getSafeMargin(partitionStart) // inclusive
-            val safePartitionEnd = getSafeMargin(partitionEnd) // exclusive, unless start == this
-            val taskContext = TaskContext.get()
-
-            val iter: Iterator[ColumnarBatch] = new Iterator[ColumnarBatch] {
-              private[this] var number: Long = safePartitionStart
-              private[this] var done: Boolean = false
-              private[this] val inputMetrics = taskContext.taskMetrics().inputMetrics
-
-              override def hasNext: Boolean =
-                if (!done) {
-                  if (step > 0) {
-                    number < safePartitionEnd
-                  } else {
-                    number > safePartitionEnd
-                  }
-                } else false
-
-              override def next(): ColumnarBatch = {
-                GpuSemaphore.acquireIfNecessary(taskContext)
-                withResource(
-                  new NvtxWithMetrics("GpuRange", NvtxColor.DARK_GREEN, opTime)) { _ =>
-                    val start = number
-                    val remainingSteps = (safePartitionEnd - start) / step
-                    // Start is inclusive so we need to produce at least one row
-                    val rowsThisBatch = Math.max(1, Math.min(remainingSteps, maxRowCountPerBatch))
-                    val endInclusive = start + ((rowsThisBatch - 1) * step)
-                    number = endInclusive + step
-                    if (number < endInclusive ^ step < 0) {
-                      // we have Long.MaxValue + Long.MaxValue < Long.MaxValue
-                      // and Long.MinValue + Long.MinValue > Long.MinValue, so iff the step causes a
-                      // step back, we are pretty sure that we have an overflow.
-                      done = true
-                    }
-
-                    val ret = withResource(Scalar.fromLong(start)) { startScalar =>
-                      withResource(Scalar.fromLong(step)) { stepScalar =>
-                        withResource(
-                          cudf.ColumnVector.sequence(
-                            startScalar, stepScalar, rowsThisBatch.toInt)) { vec =>
-                          withResource(new Table(vec)) { tab =>
-                            GpuColumnVector.from(tab, Array[DataType](LongType))
-                          }
-                        }
-                      }
-                    }
-
-                    assert(rowsThisBatch == ret.numRows())
-                    numOutputRows += rowsThisBatch
-                    TrampolineUtil.incInputRecordsRows(inputMetrics, rowsThisBatch)
-                    numOutputBatches += 1
-                    ret
-                }
-              }
-            }
-            new InterruptibleIterator(taskContext, iter)
+          val rangeIter = new GpuRangeIterator(partitionStart, partitionEnd, step,
+              maxRowCountPerBatch, taskContext, opTime).map { batch =>
+            numOutputRows += batch.numRows()
+            TrampolineUtil.incInputRecordsRows(inputMetrics, batch.numRows())
+            numOutputBatches += 1
+            batch
           }
+          new InterruptibleIterator(taskContext, rangeIter)
+        }
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RangeRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RangeRetrySuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.jni.RmmSpark
+
+class RangeRetrySuite extends RmmSparkRetrySuiteBase {
+
+  test("Gpu range with split and retry OOM") {
+    val start = BigInt(0)
+    val end = BigInt(50)
+    val step = 2
+    val maxRows = 20
+    val rangeIter = new GpuRangeIterator(start, end, step, maxRows, null, NoopMetric)
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+    var actualTotalRows = 0L
+    var batchesNum = 0
+    var curValue = start.toLong
+    rangeIter.foreach { batch =>
+      withResource(batch) { _ =>
+        withResource(batch.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hCol =>
+          (0 until hCol.getRowCount.toInt).foreach { pos =>
+            assertResult(curValue)(hCol.getLong(pos))
+            curValue += step
+          }
+        }
+        actualTotalRows += batch.numRows()
+        batchesNum += 1
+      }
+    }
+    assertResult((end - start) / step)(actualTotalRows)
+    // It should have (50/2/20 + 1) batches
+    assertResult(2)(batchesNum)
+  }
+
+}


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/8314

This PR adds the `SplitAndRetry` support for `GpuRangeExec`. 

It adds the retry block to the generating of the sequence on GPU, and also does some refactor by moving the core code into a new iterator called `GpuRangeIterator`.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
