### PR TITLE
Fix tests for datetime rebase in Databricks [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -501,7 +501,9 @@ def test_datetime_roundtrip_with_legacy_rebase(spark_tmp_path, ts_write, data_ge
     data_path = spark_tmp_path + '/PARQUET_DATA'
     all_confs = {'spark.sql.parquet.outputTimestampType': ts_write,
                  'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'LEGACY',
-                 'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED'}
+                 'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED',
+                 # set the int96 rebase mode values because its LEGACY in databricks which will preclude this op from running on GPU
+                 'spark.sql.legacy.parquet.int96RebaseModeInRead' : 'CORRECTED'}
     assert_gpu_and_cpu_writes_are_equal_collect(
         lambda spark, path: unary_op_df(spark, data_gen).coalesce(1).write.parquet(path),
         lambda spark, path: spark.read.parquet(path),

--- a/integration_tests/src/main/python/parquet_write_test.py
+++ b/integration_tests/src/main/python/parquet_write_test.py
@@ -503,6 +503,7 @@ def test_datetime_roundtrip_with_legacy_rebase(spark_tmp_path, ts_write, data_ge
                  'spark.sql.legacy.parquet.datetimeRebaseModeInWrite': 'LEGACY',
                  'spark.sql.legacy.parquet.datetimeRebaseModeInRead': 'CORRECTED',
                  # set the int96 rebase mode values because its LEGACY in databricks which will preclude this op from running on GPU
+                 'spark.sql.legacy.parquet.int96RebaseModeInWrite' : 'CORRECTED',
                  'spark.sql.legacy.parquet.int96RebaseModeInRead' : 'CORRECTED'}
     assert_gpu_and_cpu_writes_are_equal_collect(
         lambda spark, path: unary_op_df(spark, data_gen).coalesce(1).write.parquet(path),


### PR DESCRIPTION
This adds an irrelevant config but necessary to allow datatime rebase tests to run on Databricks.

Closes https://github.com/NVIDIA/spark-rapids/issues/9206.