### PR TITLE
Fix leak in aggregate when there are retries

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/aggregate.scala
@@ -526,7 +526,7 @@ object GpuAggregateIterator extends Logging {
         withResource(
           new NvtxWithMetrics("concatenateBatches", NvtxColor.BLUE, concatTime,
             opTime)) { _ =>
-          val batchesToConcat = attempt.map(_.getColumnarBatch())
+          val batchesToConcat = attempt.safeMap(_.getColumnarBatch())
           withResource(batchesToConcat) { _ =>
             val numCols = batchesToConcat.head.numCols()
             val dataTypes = (0 until numCols).map {


### PR DESCRIPTION
This likely fixes https://github.com/NVIDIA/spark-rapids/issues/9204.

I need to run this a few more times, but looks like because we didn't use `safeMap`, we were leaking some batches if we had a retry during agg. This was seen in query78 at 100TB.