### PR TITLE
Fix reading partition value columns larger than cudf column size limit

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -2174,14 +2174,15 @@ class MultiFileCloudOrcPartitionReader(
             GpuColumnVector.fromNull(rows, f.dataType).asInstanceOf[SparkVector])
           new ColumnarBatch(nullColumns, rows)
         }
-        val tmp = meta.allPartValues.map { partRowsAndValues =>
-          val (rowsPerPart, partValues) = partRowsAndValues.unzip
-          MultiFileReaderUtils.addMultiplePartitionValuesAndClose(batch,
-            partValues, rowsPerPart, partitionSchema)
-        }.getOrElse {
-          addPartitionValues(batch, meta.partitionedFile.partitionValues, partitionSchema)
+        meta.allPartValues match {
+          case Some(partRowsAndValues) =>
+            val (rowsPerPart, partValues) = partRowsAndValues.unzip
+            MultiFileReaderUtils.addMultiplePartitionValuesAndCloseIter(batch,
+              partValues, rowsPerPart, partitionSchema)
+          case None =>
+            val newBatch = addPartitionValues(batch, meta.partitionedFile.partitionValues, partitionSchema)
+            new SingleGpuColumnarBatchIterator(newBatch)
         }
-        new SingleGpuColumnarBatchIterator(tmp)
 
       case buffer: HostMemoryBuffersWithMetaData =>
         val memBuffersAndSize = buffer.memBuffersAndSizes
@@ -2189,14 +2190,15 @@ class MultiFileCloudOrcPartitionReader(
         val batchReader = decodeToBatch(hmbInfo.hmb, hmbInfo.bytes, buffer.updatedReadSchema,
             buffer.requestedMapping, filterHandler.isCaseSensitive, files) match {
           case Some(batch) =>
-            val tmp = buffer.allPartValues.map { partRowsAndValues =>
-              val (rowsPerPart, partValues) = partRowsAndValues.unzip
-              MultiFileReaderUtils.addMultiplePartitionValuesAndClose(batch,
-                partValues, rowsPerPart, partitionSchema)
-            }.getOrElse {
-              addPartitionValues(batch, buffer.partitionedFile.partitionValues, partitionSchema)
+            buffer.allPartValues match {
+              case Some(partRowsAndValues) =>
+                val (rowsPerPart, partValues) = partRowsAndValues.unzip
+                MultiFileReaderUtils.addMultiplePartitionValuesAndCloseIter(batch,
+                  partValues, rowsPerPart, partitionSchema)
+              case None =>
+                val newBatch = addPartitionValues(batch, buffer.partitionedFile.partitionValues, partitionSchema)
+                new SingleGpuColumnarBatchIterator(newBatch)
             }
-            new SingleGpuColumnarBatchIterator(tmp)
           case _ =>
             EmptyGpuColumnarBatchIterator
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -2528,16 +2528,16 @@ class MultiFileCloudParquetPartitionReader(
 
       // we have to add partition values here for this batch, we already verified that
       // its not different for all the blocks in this batch
-      val batch = if (meta.allPartValues.isDefined) {
+      if (meta.allPartValues.isDefined) {
         val rowsPerPartition = meta.allPartValues.get.map(_._1).toArray
         val allPartInternalRows = meta.allPartValues.get.map(_._2).toArray
-        MultiFileReaderUtils.addMultiplePartitionValuesAndClose(origBatch, allPartInternalRows,
+        MultiFileReaderUtils.addMultiplePartitionValuesAndCloseIter(origBatch, allPartInternalRows,
           rowsPerPartition, partitionSchema)
       } else {
-        addPartitionValues(origBatch, meta.partitionedFile.partitionValues, partitionSchema)
+        val batch = addPartitionValues(origBatch, meta.partitionedFile.partitionValues, partitionSchema)
+        new SingleGpuColumnarBatchIterator(batch)
       }
 
-      new SingleGpuColumnarBatchIterator(batch)
     case buffer: HostMemoryBuffersWithMetaData =>
       val memBuffersAndSize = buffer.memBuffersAndSizes
       val hmbAndInfo = memBuffersAndSize.head


### PR DESCRIPTION
Fixes #9110.

This PR fixes the issue when readers create partition value column that exceeds the cudf column size limit. This is fixed by checking size and creating multiple batches.

### Tasks:

- [x] Convert methods in MultiFileReaderUtils to an Iterator based API. 
- [x] Update `hasNext` of `GpuColumnarBatchWithPartitionValuesIterator`
- [ ] Find smallest column that exceeds the cudf limit.
- [ ] Return an Iterator of ColumnarBatch by splitting using the value above.
- [ ] Include retry framework.