### PR TITLE
Use conda libmamba solver to resolve intermittent libarchive issue [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -45,13 +45,15 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
+RUN conda init && \
+    conda config --set solver libmamba
+
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
-    mamba install -y spacy && python -m spacy download en_core_web_sm && \
-    mamba install -y -c anaconda pytest requests && \
-    mamba install -y -c conda-forge sre_yield && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
+    conda install -y spacy && python -m spacy download en_core_web_sm && \
+    conda install -y -c anaconda pytest requests && \
+    conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 # install pytest plugins for xdist parallel run
 RUN python -m pip install findspark pytest-xdist pytest-order

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -57,13 +57,15 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
+RUN conda init && \
+    conda config --set solver libmamba
+
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
-    conda install -y -c conda-forge mamba=1.4.9 libarchive && \
-    mamba install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
-    mamba install -y spacy && python -m spacy download en_core_web_sm && \
-    mamba install -y -c anaconda pytest requests && \
-    mamba install -y -c conda-forge sre_yield && \
+    conda install -y -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge -c defaults cudf=${CUDF_VER} python=3.9 cuda-version=${CUDA_VER} && \
+    conda install -y spacy && python -m spacy download en_core_web_sm && \
+    conda install -y -c anaconda pytest requests && \
+    conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 # install pytest plugins for xdist parallel run
 RUN python -m pip install findspark pytest-xdist pytest-order


### PR DESCRIPTION
To fix an intermittent issue while using mamba to download conda pkgs
```
[2023-09-12T19:23:51.693Z] Traceback (most recent call last):
[2023-09-12T19:23:51.693Z]   File "/opt/conda/bin/mamba", line 7, in <module>
[2023-09-12T19:23:51.693Z]     from mamba.mamba import main
[2023-09-12T19:23:51.693Z]   File "/opt/conda/lib/python3.11/site-packages/mamba/mamba.py", line 49, in <module>
[2023-09-12T19:23:51.693Z]     import libmambapy as api
[2023-09-12T19:23:51.693Z]   File "/opt/conda/lib/python3.11/site-packages/libmambapy/__init__.py", line 7, in <module>
[2023-09-12T19:23:51.693Z]     raise e
[2023-09-12T19:23:51.693Z]   File "/opt/conda/lib/python3.11/site-packages/libmambapy/__init__.py", line 4, in <module>
[2023-09-12T19:23:51.693Z]     from libmambapy.bindings import *  # noqa: F401,F403
[2023-09-12T19:23:51.693Z]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2023-09-12T19:23:51.693Z] ImportError: libarchive.so.13: cannot open shared object file: No such file or directory
```


Previously we fixed the same issue in https://github.com/NVIDIA/spark-rapids/pull/8728 by hardcode mamba version,
But it started again recently. It should still be related to the mamba being incompatible w/ newer conda,
so as suggested by conda team, we decided to use conda-libmamba-solver which should be guaranteed w/o any compatibility issue.

Verified in internal ENVs