### PR TITLE
Enable Spark 350 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,11 +699,10 @@
             333,
             330cdh,
             340,
-            341
+            341,
+            350
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            <!--TODO: re-enable https://github.com/NVIDIA/spark-rapids/issues/9116-->
-            <!--350-->
         </snapshot.buildvers>
         <databricks.buildvers>
             321db,


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9116

Spark 3.5.0 jars are now available on Maven Central, so we can now re-enable the build.

Note that there is no official distro available yet, but it should be available in the next few days.