### PR TITLE
xfail fixed_length_byte_array.parquet test due to rapidsai/cudf#14104 [databricks]

### DIFF
--- a/integration_tests/src/main/python/parquet_testing_test.py
+++ b/integration_tests/src/main/python/parquet_testing_test.py
@@ -39,7 +39,6 @@ _java_reader_confs = copy_and_update(
 # When the association is a pair rather than a string, it's a way to xfail the test
 # by providing the error string and xfail reason.
 _error_files = {
-    "fixed_length_byte_array.parquet": "Exception",
     "large_string_map.brotli.parquet": "Exception",
     "nation.dict-malformed.parquet": ("Exception", "https://github.com/NVIDIA/spark-rapids/issues/8644"),
     "non_hadoop_lz4_compressed.parquet": "Exception",
@@ -50,6 +49,7 @@ _error_files = {
 # xfail reason message.
 _xfail_files = {
     "byte_array_decimal.parquet": "https://github.com/NVIDIA/spark-rapids/issues/8629",
+    "fixed_length_byte_array.parquet": "https://github.com/rapidsai/cudf/issues/14104",
     "datapage_v2.snappy.parquet": "datapage v2 not supported by cudf",
     "delta_binary_packed.parquet": "https://github.com/rapidsai/cudf/issues/13501",
     "delta_byte_array.parquet": "https://github.com/rapidsai/cudf/issues/13501",


### PR DESCRIPTION
Fixes #9233.  xfailing the test since libcudf is loading corrupted data after enabling fixed length byte array loading in the plugin.  Tracked by rapidsai/cudf#14104.