### PR TITLE
Add Spark 3.5.0 to list of supported Spark versions [skip ci]

### DIFF
--- a/docs/additional-functionality/rapids-shuffle.md
+++ b/docs/additional-functionality/rapids-shuffle.md
@@ -31,6 +31,7 @@ in our plugin:
 | 3.3.3           | com.nvidia.spark.rapids.spark333.RapidsShuffleManager    |
 | 3.4.0           | com.nvidia.spark.rapids.spark340.RapidsShuffleManager    |
 | 3.4.1           | com.nvidia.spark.rapids.spark341.RapidsShuffleManager    |
+| 3.5.0           | com.nvidia.spark.rapids.spark350.RapidsShuffleManager    |
 | Databricks 10.4 | com.nvidia.spark.rapids.spark321db.RapidsShuffleManager  |
 | Databricks 11.3 | com.nvidia.spark.rapids.spark330db.RapidsShuffleManager  |
 | Databricks 12.2 | com.nvidia.spark.rapids.spark332db.RapidsShuffleManager  |

--- a/docs/download.md
+++ b/docs/download.md
@@ -44,6 +44,7 @@ The plugin is tested on the following architectures:
 		Apache Spark 3.2.0, 3.2.1, 3.2.2, 3.2.3, 3.2.4
 		Apache Spark 3.3.0, 3.3.1, 3.3.2
 		Apache Spark 3.4.0, 3.4.1
+		Apache Spark 3.5.0
 	
 	Supported Databricks runtime versions for Azure and AWS:
 		Databricks 10.4 ML LTS (GPU, Scala 2.12, Spark 3.2.1)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8121

Spark 3.5.0 support was already merged into branch-23.10, but we did not update the docs to say we support it. This PR has the docs update.