### PR TITLE
Enforce Scala method syntax over deprecated procedure syntax

### DIFF
--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuOptimisticTransaction.scala
@@ -71,7 +71,7 @@ class GpuOptimisticTransaction
    * @param deltaLog The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuOptimisticTransaction.scala
@@ -71,7 +71,7 @@ class GpuOptimisticTransaction
    * @param deltaLog The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuOptimisticTransaction.scala
@@ -71,7 +71,7 @@ class GpuOptimisticTransaction
    * @param deltaLog The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuOptimisticTransaction.scala
@@ -71,7 +71,7 @@ class GpuOptimisticTransaction
    * @param deltaLog The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -62,7 +62,7 @@ class GpuOptimisticTransaction(
    * @param deltaLog   The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -72,7 +72,7 @@ class GpuOptimisticTransaction(
    * @param deltaLog   The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransaction.scala
@@ -72,7 +72,7 @@ class GpuOptimisticTransaction(
    * @param deltaLog   The Delta Log for the table this transaction is modifying.
    * @param rapidsConf RAPIDS Accelerator config settings
    */
-  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) {
+  def this(deltaLog: DeltaLog, rapidsConf: RapidsConf)(implicit clock: Clock) = {
     this(deltaLog, deltaLog.update(), rapidsConf)
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1321,9 +1321,9 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.scalastyle</groupId>
+                        <groupId>com.beautiful-scala</groupId>
                         <artifactId>scalastyle_${scala.binary.version}</artifactId>
-                        <version>1.0.0</version>
+                        <version>1.5.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -104,6 +104,23 @@ You can also disable only one rule, by specifying its rule id, as specified in:
         <customMessage>Use Javadoc style indentation for multiline comments</customMessage>
     </check>
 
+    
+    <!-- ================================================================================ -->
+    <!--       rules for enforcing cross-build between Scala 2.12 and 2.13                -->
+    <!-- ================================================================================ -->
+
+    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">def this\((.*)\) \{</parameter>
+            <parameter name="line">false</parameter>
+        </parameters>
+        <customMessage>procedure syntax is deprecated for constructors in Scala 2.13: add `=`, as in method definition</customMessage>
+    </check>
+
+    <check level="error" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true">
+        <customMessage>procedure syntax is deprecated in Scala 2.13: add return type `: Unit` and `=`</customMessage>
+    </check>
+
     <!-- ================================================================================ -->
     <!--       rules we'd like to enforce, but haven't cleaned up the codebase yet        -->
     <!-- ================================================================================ -->

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -393,7 +393,7 @@ trait GpuOverridesListener {
   def optimizedPlan(
       plan: SparkPlanMeta[SparkPlan],
       sparkPlan: SparkPlan,
-      costOptimizations: Seq[Optimization])
+      costOptimizations: Seq[Optimization]): Unit
 }
 
 sealed trait FileFormatType

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRunnableCommandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuRunnableCommandExec.scala
@@ -75,7 +75,7 @@ object GpuRunnableCommand {
     }
   }
 
-  def assertEmptyRootPath(tablePath: URI, saveMode: SaveMode, hadoopConf: Configuration) {
+  def assertEmptyRootPath(tablePath: URI, saveMode: SaveMode, hadoopConf: Configuration): Unit = {
     if (saveMode == SaveMode.ErrorIfExists && !getAllowNonEmptyLocationInCTAS) {
       val filePath = new org.apache.hadoop.fs.Path(tablePath)
       val fs = filePath.getFileSystem(hadoopConf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBuffer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsBuffer.scala
@@ -304,7 +304,7 @@ trait RapidsBuffer extends AutoCloseable {
    * @param stream CUDA stream to use
    */
   def copyToMemoryBuffer(
-      srcOffset: Long, dst: MemoryBuffer, dstOffset: Long, length: Long, stream: Cuda.Stream)
+      srcOffset: Long, dst: MemoryBuffer, dstOffset: Long, length: Long, stream: Cuda.Stream): Unit
 
   /**
    * Get the device memory buffer from the underlying storage. If the buffer currently resides

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -1735,14 +1735,14 @@ sealed case class RegexSequence(parts: ListBuffer[RegexAST]) extends RegexAST {
 sealed case class RegexGroup(capture: Boolean, term: RegexAST,
     val lookahead: Option[RegexLookahead])
     extends RegexAST {
-  def this(capture: Boolean, term: RegexAST) {
+  def this(capture: Boolean, term: RegexAST) = {
     this(capture, term, None)
   }
-  def this(capture: Boolean, term: RegexAST, position: Int) {
+  def this(capture: Boolean, term: RegexAST, position: Int) = {
     this(capture, term, None)
     this.position = Some(position)
   }
-  def this(capture: Boolean, term: RegexAST, position: Int, lookahead: Option[RegexLookahead]) {
+  def this(capture: Boolean, term: RegexAST, position: Int, lookahead: Option[RegexLookahead]) = {
     this(capture, term, lookahead)
     this.position = Some(position)
   }
@@ -1761,7 +1761,7 @@ sealed case class RegexGroup(capture: Boolean, term: RegexAST,
 }
 
 sealed case class RegexChoice(a: RegexAST, b: RegexAST) extends RegexAST {
-  def this(a: RegexAST, b: RegexAST, position: Int) {
+  def this(a: RegexAST, b: RegexAST, position: Int) = {
     this(a, b)
     this.position = Some(position)
   }
@@ -1770,7 +1770,7 @@ sealed case class RegexChoice(a: RegexAST, b: RegexAST) extends RegexAST {
 }
 
 sealed case class RegexRepetition(a: RegexAST, quantifier: RegexQuantifier) extends RegexAST {
-  def this(a: RegexAST, quantifier: RegexQuantifier, position: Int) {
+  def this(a: RegexAST, quantifier: RegexQuantifier, position: Int) = {
     this(a, quantifier)
     this.position = Some(position)
   }
@@ -1781,7 +1781,7 @@ sealed case class RegexRepetition(a: RegexAST, quantifier: RegexQuantifier) exte
 sealed trait RegexQuantifier extends RegexAST
 
 sealed case class SimpleQuantifier(ch: Char) extends RegexQuantifier {
-  def this(ch: Char, position: Int) {
+  def this(ch: Char, position: Int) = {
     this(ch)
     this.position = Some(position)
   }
@@ -1791,7 +1791,7 @@ sealed case class SimpleQuantifier(ch: Char) extends RegexQuantifier {
 
 sealed case class QuantifierFixedLength(length: Int)
     extends RegexQuantifier {
-  def this(length: Int, position: Int) {
+  def this(length: Int, position: Int) = {
     this(length)
     this.position = Some(position)
   }
@@ -1803,7 +1803,7 @@ sealed case class QuantifierFixedLength(length: Int)
 
 sealed case class QuantifierVariableLength(minLength: Int, maxLength: Option[Int])
     extends RegexQuantifier{
-  def this(minLength: Int, maxLength: Option[Int], position: Int) {
+  def this(minLength: Int, maxLength: Option[Int], position: Int) = {
     this(minLength, maxLength)
     this.position = Some(position)
   }
@@ -1821,7 +1821,7 @@ sealed case class QuantifierVariableLength(minLength: Int, maxLength: Option[Int
 sealed trait RegexCharacterClassComponent extends RegexAST
 
 sealed case class RegexHexDigit(a: String) extends RegexCharacterClassComponent {
-  def this(a: String, position: Int) {
+  def this(a: String, position: Int) = {
     this(a)
     this.position = Some(position)
   }
@@ -1838,7 +1838,7 @@ sealed case class RegexHexDigit(a: String) extends RegexCharacterClassComponent 
 }
 
 sealed case class RegexOctalChar(a: String) extends RegexCharacterClassComponent {
-  def this(a: String, position: Int) {
+  def this(a: String, position: Int) = {
     this(a)
     this.position = Some(position)
   }
@@ -1849,7 +1849,7 @@ sealed case class RegexOctalChar(a: String) extends RegexCharacterClassComponent
 }
 
 sealed case class RegexChar(ch: Char) extends RegexCharacterClassComponent {
-  def this(ch: Char, position: Int) {
+  def this(ch: Char, position: Int) = {
     this(ch)
     this.position = Some(position)
   }
@@ -1858,7 +1858,7 @@ sealed case class RegexChar(ch: Char) extends RegexCharacterClassComponent {
 }
 
 sealed case class RegexEscaped(a: Char) extends RegexCharacterClassComponent{
-  def this(a: Char, position: Int) {
+  def this(a: Char, position: Int) = {
     this(a)
     this.position = Some(position)
   }
@@ -1869,7 +1869,9 @@ sealed case class RegexEscaped(a: Char) extends RegexCharacterClassComponent{
 sealed case class RegexCharacterRange(start: RegexCharacterClassComponent,
     end: RegexCharacterClassComponent)
   extends RegexCharacterClassComponent{
-  def this(start: RegexCharacterClassComponent, end: RegexCharacterClassComponent, position: Int) {
+  def this(start: RegexCharacterClassComponent,
+           end: RegexCharacterClassComponent,
+           position: Int) = {
     this(start, end)
     this.position = Some(position)
   }
@@ -1885,7 +1887,7 @@ sealed case class RegexCharacterClass(
   def this (
       negated: Boolean,
       characters: ListBuffer[RegexCharacterClassComponent],
-      position: Int) {
+      position: Int) = {
     this(negated, characters)
     this.position = Some(position)
   }
@@ -1942,7 +1944,7 @@ sealed case class RegexCharacterClass(
 }
 
 sealed case class RegexBackref(num: Int, isNew: Boolean = false) extends RegexAST {
-  def this(num: Int, isNew: Boolean, position: Int) {
+  def this(num: Int, isNew: Boolean, position: Int) = {
     this(num, isNew)
     this.position = Some(position)
   }
@@ -1952,7 +1954,7 @@ sealed case class RegexBackref(num: Int, isNew: Boolean = false) extends RegexAS
 
 sealed case class RegexReplacement(parts: ListBuffer[RegexAST],
     var numCaptureGroups: Int = 0) extends RegexAST {
-  def this(parts: ListBuffer[RegexAST], numCaptureGroups: Int, position: Int) {
+  def this(parts: ListBuffer[RegexAST], numCaptureGroups: Int, position: Int) = {
     this(parts, numCaptureGroups)
     this.position = Some(position)
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SamplingUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SamplingUtils.scala
@@ -271,7 +271,7 @@ private[spark] class XORShiftRandom(init: Long) extends JavaRandom(init) {
     (nextSeed & ((1L << bits) -1)).asInstanceOf[Int]
   }
 
-  override def setSeed(s: Long) {
+  override def setSeed(s: Long): Unit = {
     seed = XORShiftRandom.hashSeed(s)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TypeChecks.scala
@@ -2235,7 +2235,7 @@ object SupportedOpsForTools {
     }
   }
 
-  private def outputSupportIO() {
+  private def outputSupportIO(): Unit = {
     // Look at what we have for defaults for some configs because if the configs are off
     // it likely means something isn't completely compatible.
     val conf = new RapidsConf(Map.empty[String, String])

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTransport.scala
@@ -32,7 +32,7 @@ trait TransactionCallback {
 }
 
 trait MemoryRegistrationCallback {
-  def apply(error: Option[Throwable] = None)
+  def apply(error: Option[Throwable] = None): Unit
 }
 
 /**
@@ -344,7 +344,7 @@ trait RapidsShuffleTransport extends AutoCloseable {
    * (throttle) Adds a set of requests to be throttled as limits allowed.
    * @param reqs requests to add to the throttle queue
    */
-  def queuePending(reqs: Seq[PendingTransferRequest])
+  def queuePending(reqs: Seq[PendingTransferRequest]): Unit
 
   /**
    * Cancel requests that are waiting in the queue (not in-flight) for a specific

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
@@ -44,7 +44,7 @@ trait ShuffleMetricsUpdater {
     fetchWaitTimeInMs: Long,
     remoteBlocksFetched: Long,
     remoteBytesRead: Long,
-    rowsFetched: Long)
+    rowsFetched: Long): Unit
 }
 
 class RapidsCachingReader[K, C](

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
@@ -38,7 +38,7 @@ object PythonMapInArrowExecShims {
         ExecChecks((TypeSig.commonCudfTypes + TypeSig.ARRAY + TypeSig.STRUCT).nested(),
           TypeSig.all),
         (mapPy, conf, p, r) => new GpuPythonMapInArrowExecMeta(mapPy, conf, p, r) {
-          override def tagPlanForGpu() {
+          override def tagPlanForGpu(): Unit = {
             super.tagPlanForGpu()
             if (SQLConf.get.getConf(SQLConf.ARROW_EXECUTION_USE_LARGE_VAR_TYPES)) {
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -632,7 +632,7 @@ class AdaptiveQueryExecSuite
     numLocalReaders.length
   }
 
-  def skewJoinTest(fun: SparkSession => Unit) {
+  def skewJoinTest(fun: SparkSession => Unit): Unit = {
     val conf = new SparkConf()
       .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
@@ -699,7 +699,7 @@ class AdaptiveQueryExecSuite
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData(spark: SparkSession) {
+  private def testData(spark: SparkSession): Unit = {
     import spark.implicits._
     val data: Seq[(Int, String)] = (1 to 100).map(i => (i, i.toString))
     val df = data.toDF("key", "value")
@@ -707,7 +707,7 @@ class AdaptiveQueryExecSuite
     registerAsParquetTable(spark, df, "testData")  }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData2(spark: SparkSession) {
+  private def testData2(spark: SparkSession): Unit = {
     import spark.implicits._
     val df = Seq[(Int, Int)]((1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2))
       .toDF("a", "b")
@@ -716,7 +716,7 @@ class AdaptiveQueryExecSuite
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def testData3(spark: SparkSession) {
+  private def testData3(spark: SparkSession): Unit = {
     import spark.implicits._
     val df = Seq[(Int, Option[Int])]((1, None), (2, Some(2)))
       .toDF("a", "b")
@@ -725,7 +725,7 @@ class AdaptiveQueryExecSuite
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def uncommonTypeTestData(spark: SparkSession) {
+  private def uncommonTypeTestData(spark: SparkSession): Unit = {
     import scala.collection.JavaConverters._
     val df = spark.createDataFrame(
       List.tabulate(20)(i => Row(i % 3, BigDecimal(i), Array(i, i), Row(i))).asJava,
@@ -740,7 +740,7 @@ class AdaptiveQueryExecSuite
   }
 
   /** Ported from org.apache.spark.sql.test.SQLTestData */
-  private def lowerCaseData(spark: SparkSession) {
+  private def lowerCaseData(spark: SparkSession): Unit = {
     import spark.implicits._
     // note that this differs from the original Spark test by generating a larger data set so that
     // we can trigger larger stats in the logical mode, preventing BHJ, and then our queries filter
@@ -753,7 +753,7 @@ class AdaptiveQueryExecSuite
     registerAsParquetTable(spark, df, "lowercaseData")
   }
 
-  private def registerAsParquetTable(spark: SparkSession, df: Dataset[Row], name: String) {
+  private def registerAsParquetTable(spark: SparkSession, df: Dataset[Row], name: String): Unit = {
     val path = new File(TEST_FILES_ROOT, s"$name.parquet").getAbsolutePath
     df.write
         .mode(SaveMode.Overwrite)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ApproximatePercentileSuite.scala
@@ -102,7 +102,7 @@ class ApproximatePercentileSuite extends SparkQueryCompareTestSuite {
     df.sparkSession.sql("SELECT approx_percentile(salary, array(0.5)) FROM salaries")
   }
 
-  def sqlFallbackTest(sql: String) {
+  def sqlFallbackTest(sql: String): Unit = {
 
     val conf = new SparkConf()
       .set("spark.rapids.sql.incompatibleOps.enabled", "true")
@@ -126,7 +126,7 @@ class ApproximatePercentileSuite extends SparkQueryCompareTestSuite {
   private def doTest(
     func: SparkSession => DataFrame,
     percentileArg: Either[Double, Array[Double]] = Right(DEFAULT_PERCENTILES),
-    delta: Option[Int]) {
+    delta: Option[Int]): Unit = {
 
     val percentiles = withCpuSparkSession { spark =>
       calcPercentiles(spark, func, percentileArg, delta,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuBatchUtilsSuite.scala
@@ -158,7 +158,7 @@ class GpuBatchUtilsSuite extends AnyFunSuite {
     assert(GpuBatchUtils.estimateRowCount(200, 0, 1) == 1)
   }
 
-  private def compareEstimateWithActual(schema: StructType, rowCount: Int) {
+  private def compareEstimateWithActual(schema: StructType, rowCount: Int): Unit = {
     val rows = GpuBatchUtilsSuite.createRows(schema, rowCount)
     val estimate = GpuBatchUtils.estimateGpuMemory(schema, rows.length)
     val actual = calculateGpuMemory(schema, rows)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesSuite.scala
@@ -487,7 +487,7 @@ class GpuCoalesceBatchesSuite extends SparkQueryCompareTestSuite {
     }, conf)
   }
 
-  def testCompressedBatches(maxCompressedBatchMemoryLimit: Long) {
+  def testCompressedBatches(maxCompressedBatchMemoryLimit: Long): Unit = {
     val coalesceTargetBytes = 8000
     val stop = 10000
     var start = 0

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregatesSuite.scala
@@ -61,7 +61,7 @@ class HashAggregatesSuite extends SparkQueryCompareTestSuite {
     batchSize: Int = 0,
     repart: Int = 1,
     maxFloatDiff: Double = 0.0)
-    (fn: DataFrame => DataFrame) {
+    (fn: DataFrame => DataFrame): Unit = {
     if (batchSize > 0) {
       makeBatchedBytes(batchSize, conf)
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParseDateTimeSuite.scala
@@ -39,11 +39,11 @@ class ParseDateTimeSuite extends SparkQueryCompareTestSuite with BeforeAndAfterE
     .set(SQLConf.LEGACY_TIME_PARSER_POLICY.key, "LEGACY")
     .set(RapidsConf.INCOMPATIBLE_DATE_FORMATS.key, "true")
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     GpuOverrides.removeAllListeners()
   }
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     GpuOverrides.removeAllListeners()
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionTranspilerSuite.scala
@@ -672,7 +672,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     doFuzzTest(None, RegexFindMode)
   }
 
-  private def doFuzzTest(validChars: Option[String], mode: RegexMode) {
+  private def doFuzzTest(validChars: Option[String], mode: RegexMode): Unit = {
 
     val r = new EnhancedRandom(new Random(seed = 0L),
       options = FuzzerOptions(validChars, maxStringLen = 12))
@@ -826,7 +826,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     doStringSplitTest(patterns, data, -1)
   }
 
-  def assertTranspileToSplittableString(patterns: Set[String]) {
+  def assertTranspileToSplittableString(patterns: Set[String]): Unit = {
     for (pattern <- patterns) {
       val transpiler = new CudfRegexTranspiler(RegexSplitMode)
       transpiler.transpileToSplittableString(pattern) match {
@@ -839,7 +839,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     }
   }
 
-  def assertNoTranspileToSplittableString(patterns: Set[String]) {
+  def assertNoTranspileToSplittableString(patterns: Set[String]): Unit = {
     for (pattern <- patterns) {
       val transpiler = new CudfRegexTranspiler(RegexSplitMode)
       transpiler.transpileToSplittableString(pattern) match {
@@ -853,7 +853,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     }
   }
 
-  def doStringSplitTest(patterns: Set[String], data: Seq[String], limit: Int) {
+  def doStringSplitTest(patterns: Set[String], data: Seq[String], limit: Int): Unit = {
     for (pattern <- patterns) {
       val cpu = cpuSplit(pattern, data, limit)
       val transpiler = new CudfRegexTranspiler(RegexSplitMode)
@@ -883,7 +883,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
   }
 
   private def doAstFuzzTest(validDataChars: Option[String], validPatternChars: String,
-      mode: RegexMode) {
+      mode: RegexMode): Unit = {
     val (data, patterns) = generateDataAndPatterns(validDataChars, validPatternChars, mode)
     if (mode == RegexReplaceMode) {
       assertCpuGpuMatchesRegexpReplace(patterns.toSeq, data)
@@ -922,7 +922,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     (data, patterns.toSet)
   }
 
-  private def assertCpuGpuMatchesRegexpFind(javaPatterns: Seq[String], input: Seq[String]) = {
+  private def assertCpuGpuMatchesRegexpFind(javaPatterns: Seq[String], input: Seq[String]): Unit = {
     for ((javaPattern, patternIndex) <- javaPatterns.zipWithIndex) {
       val cpu = cpuContains(javaPattern, input)
       val (cudfPattern, _) =
@@ -946,7 +946,7 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
 
   private def assertCpuGpuMatchesRegexpReplace(
       javaPatterns: Seq[String],
-      input: Seq[String]) = {
+      input: Seq[String]): Unit = {
     for ((javaPattern, patternIndex) <- javaPatterns.zipWithIndex) {
       val cpu = cpuReplace(javaPattern, input)
       val (cudfPattern, replaceString) =
@@ -1048,12 +1048,12 @@ class RegularExpressionTranspilerSuite extends AnyFunSuite {
     }
   }
 
-  private def doTranspileTest(pattern: String, expected: String) {
+  private def doTranspileTest(pattern: String, expected: String): Unit = {
     val transpiled: String = transpile(pattern, RegexFindMode)
     assert(toReadableString(transpiled) === toReadableString(expected))
   }
 
-  private def doTranspileTest(pattern: String, expected: String, groupIdx: Int) {
+  private def doTranspileTest(pattern: String, expected: String, groupIdx: Int): Unit = {
     val transpiled: String = transpile(pattern, groupIdx)
     assert(toReadableString(transpiled) === toReadableString(expected))
   }

--- a/tests/src/test/spark321/scala/com/nvidia/spark/rapids/DynamicPruningSuite.scala
+++ b/tests/src/test/spark321/scala/com/nvidia/spark/rapids/DynamicPruningSuite.scala
@@ -190,7 +190,7 @@ class DynamicPruningSuite
     factData(spark)
   }
 
-  private def dimData(spark: SparkSession) {
+  private def dimData(spark: SparkSession): Unit = {
     val schema = StructType(Seq(
       StructField("key", DataTypes.IntegerType, false),
       StructField("skey", DataTypes.IntegerType, false),
@@ -204,7 +204,7 @@ class DynamicPruningSuite
     ))
     registerAsParquetTable(spark, df, "dim", None)  }
 
-  private def factData(spark: SparkSession) {
+  private def factData(spark: SparkSession): Unit = {
     val schema = StructType(Seq(
       StructField("key", DataTypes.IntegerType, false),
       StructField("skey", DataTypes.IntegerType, false),
@@ -218,7 +218,7 @@ class DynamicPruningSuite
     registerAsParquetTable(spark, df, "fact", Some(List("key", "skey")))  }
 
   private def registerAsParquetTable(spark: SparkSession, df: Dataset[Row], name: String,
-      partitionBy: Option[Seq[String]]) {
+      partitionBy: Option[Seq[String]]): Unit = {
     val path = new File(TEST_FILES_ROOT, s"$name.parquet").getAbsolutePath
 
     partitionBy match {


### PR DESCRIPTION
This is one of a sequence of PRs to address Scala 2.13 (see #1525) support for the spark-rapids codebase. This will enforce method syntax as opposed to procedure syntax for Scala methods in the codebase. The procedure syntax was deprecated and the Scala 2.13 compiler enforces this by returning compiler errors when it sees this in code.  This PR is designed to address this by adding a couple of scalastyle rules to detect instances of this (one for methods and the other for constructors). This PR also contains current fixes to the existing code.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
