### PR TITLE
Test Parquet double column stat without NaN [databricks]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScaleTestUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScaleTestUtils.scala
@@ -22,7 +22,7 @@ case class NonNaNFloatGenFunc(mapping: LocationToSeedMapping = null) extends Gen
   override def apply(rowLoc: RowLocation): Any = {
     val v = java.lang.Float.intBitsToFloat(DataGen.getRandomFor(mapping(rowLoc)).nextInt())
     if (v.isNaN) {
-      1.toFloat // ust use 1.0
+      1.toFloat // just use 1.0
     } else {
       v
     }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScaleTestUtils.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ParquetScaleTestUtils.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.tests.datagen.{DataGen, GeneratorFunction, LocationToSeedMapping, RowLocation}
+
+case class NonNaNFloatGenFunc(mapping: LocationToSeedMapping = null) extends GeneratorFunction {
+  override def apply(rowLoc: RowLocation): Any = {
+    val v = java.lang.Float.intBitsToFloat(DataGen.getRandomFor(mapping(rowLoc)).nextInt())
+    if (v.isNaN) {
+      1.toFloat // ust use 1.0
+    } else {
+      v
+    }
+  }
+
+  override def withLocationToSeedMapping(mapping: LocationToSeedMapping): GeneratorFunction =
+    NonNaNFloatGenFunc(mapping)
+
+  override def withValueRange(min: Any, max: Any): GeneratorFunction =
+    throw new IllegalStateException("value ranges are not supported for Float yet")
+}
+
+case class NonNaNDoubleGenFunc(mapping: LocationToSeedMapping = null) extends GeneratorFunction {
+  override def apply(rowLoc: RowLocation): Any = {
+    val v = java.lang.Double.longBitsToDouble(DataGen.nextLong(rowLoc, mapping))
+    if (v.isNaN) {
+      1.toDouble // just use 1.0
+    } else {
+      v
+    }
+  }
+
+  override def withLocationToSeedMapping(mapping: LocationToSeedMapping): GeneratorFunction =
+    NonNaNDoubleGenFunc(mapping)
+
+  override def withValueRange(min: Any, max: Any): GeneratorFunction =
+    throw new IllegalStateException("value ranges are not supported for Double yet")
+}


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/8762
This PR is a follow up from: https://github.com/NVIDIA/spark-rapids/pull/9090#discussion_r1324568528

Add a test case for float/double without NaN values.