### PR TITLE
Add Delta Lake support for Spark 3.4.1 and Delta Lake tests on Spark 3.4.x

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -534,7 +534,7 @@
             <dependencies>
                 <dependency>
                     <groupId>com.nvidia</groupId>
-                    <artifactId>rapids-4-spark-delta-stub_${scala.binary.version}</artifactId>
+                    <artifactId>rapids-4-spark-delta-24x_${scala.binary.version}</artifactId>
                     <version>${project.version}</version>
                     <classifier>${spark.version.classifier}</classifier>
                 </dependency>

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -186,6 +186,7 @@ run_delta_lake_tests() {
   echo "run_delta_lake_tests SPARK_VER = $SPARK_VER"
   SPARK_32X_PATTERN="(3\.2\.[0-9])"
   SPARK_33X_PATTERN="(3\.3\.[0-9])"
+  SPARK_34X_PATTERN="(3\.4\.[0-9])"
 
   if [[ $SPARK_VER =~ $SPARK_32X_PATTERN ]]; then
     # There are multiple versions of deltalake that support SPARK 3.2.X
@@ -195,6 +196,10 @@ run_delta_lake_tests() {
 
   if [[ $SPARK_VER =~ $SPARK_33X_PATTERN ]]; then
     DELTA_LAKE_VERSIONS="2.1.1 2.2.0"
+  fi
+
+  if [[ $SPARK_VER =~ $SPARK_34X_PATTERN ]]; then
+    DELTA_LAKE_VERSIONS="2.4.0"
   fi
 
   if [ -z "$DELTA_LAKE_VERSIONS" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,7 @@
                 <slf4j.version>2.0.6</slf4j.version>
             </properties>
             <modules>
-                <module>delta-lake/delta-stub</module>
+                <module>delta-lake/delta-24x</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Delta Lake support was missing from the Spark 3.4.1, so this PR corrects that by adding the same Delta Lake support that is used for Spark 3.4.0.  In addition there were no Delta Lake tests being run against Spark 3.4.x, so this updates the jenkins test scripts to test Delta Lake support for Spark 3.4.x.