### PR TITLE
Fix leak in test and double free in corner case

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -410,6 +410,26 @@ abstract class AbstractGpuCoalesceIterator(
   }
 
   /**
+   * A Simple wrapper around a ColumnarBatch to let us avoid closing it in some cases.
+   */
+  private class BatchWrapper(var cb: ColumnarBatch) extends AutoCloseable {
+    def get: ColumnarBatch = cb
+
+    def release: ColumnarBatch = {
+      val tmp = cb
+      cb = null
+      tmp
+    }
+
+    override def close(): Unit = {
+      if (cb != null) {
+        cb.close()
+        cb = null
+      }
+    }
+  }
+
+  /**
    * Add input batches to the `batches` collection up to the limit specified
    * by the goal. Note: for a size goal, if any incoming batch is greater than this size
    * it will be passed through unmodified.
@@ -447,13 +467,13 @@ abstract class AbstractGpuCoalesceIterator(
       }
 
       while(maybeFilteredIter.hasNext) {
-        var cb = maybeFilteredIter.next()
+        val cb = new BatchWrapper(maybeFilteredIter.next())
         closeOnExcept(cb) { _ =>
-          val nextRows = cb.numRows()
+          val nextRows = cb.get.numRows()
           // filter out empty batches
           if (nextRows > 0) {
             numInputRows += nextRows
-            val nextBytes = getBatchDataSize(cb)
+            val nextBytes = getBatchDataSize(cb.get)
 
             // calculate the new sizes based on this input batch being added to the current
             // output batch
@@ -488,9 +508,10 @@ abstract class AbstractGpuCoalesceIterator(
                       }
                     }
                     // 2) Filter the incoming batch.
-                    val filteredCbIter = GpuFilter.filterAndClose(cb, filterTier,
+                    // filterAndClose takes ownership of CB so we should not close it on a failure
+                    // anymore...
+                    val filteredCbIter = GpuFilter.filterAndClose(cb.release, filterTier,
                       NoopMetric, NoopMetric, opTime)
-                    cb = null // null out `cb` to prevent multiple close calls
                     while (filteredCbIter.hasNext) {
                       closeOnExcept(filteredCbIter.next()) { filteredCb =>
                         val filteredWouldBeRows = filteredNumRows + filteredCb.numRows()
@@ -521,23 +542,23 @@ abstract class AbstractGpuCoalesceIterator(
                       s"At least $wouldBeRows are in this partition, even after filtering " +
                       s"nulls. Please try increasing your partition count.")
                   }
-                case _ => saveOnDeck(cb) // not a single batch requirement
+                case _ => saveOnDeck(cb.get) // not a single batch requirement
               }
             } else if (batchRowLimit > 0 && wouldBeRows > batchRowLimit) {
-              saveOnDeck(cb)
+              saveOnDeck(cb.get)
             } else if (wouldBeBytes > goal.targetSizeBytes && numBytes > 0) {
               // There are no explicit checks for the concatenate result exceeding the cudf 2^31
               // row count limit for any column. We are relying on cudf's concatenate to throw
               // an exception if this occurs and limiting performance-oriented goals to under
               // 2GB data total to avoid hitting that error.
-              saveOnDeck(cb)
+              saveOnDeck(cb.get)
             } else {
-              addBatch(cb)
+              addBatch(cb.get)
               numRows = wouldBeRows
               numBytes = wouldBeBytes
             }
           } else {
-            cleanupInputBatch(cb)
+            cleanupInputBatch(cb.get)
           }
         } // end of closeOnExcept(cb)
       } // end of while(maybeFilteredIter.hasNext)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarToRowExec.scala
@@ -223,7 +223,7 @@ class ColumnarToRowIterator(batches: Iterator[ColumnarBatch],
     opTime: GpuMetric,
     streamTime: GpuMetric,
     nullSafe: Boolean = false,
-    releaseSemaphore: Boolean = true) extends Iterator[InternalRow] {
+    releaseSemaphore: Boolean = true) extends Iterator[InternalRow] with AutoCloseable {
   // GPU batches read in must be closed by the receiver (us)
   @transient private var cb: ColumnarBatch = null
   private var it: java.util.Iterator[InternalRow] = null
@@ -240,6 +240,8 @@ class ColumnarToRowIterator(batches: Iterator[ColumnarBatch],
       closeCurrentBatch()
     }
   }
+
+  override def close(): Unit = closeCurrentBatch()
 
   private def closeCurrentBatch(): Unit = {
     if (cb != null) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GeneratedInternalRowToCudfRowIteratorRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GeneratedInternalRowToCudfRowIteratorRetrySuite.scala
@@ -48,23 +48,24 @@ class GeneratedInternalRowToCudfRowIteratorRetrySuite
 
   test("a retry when copying to device is handled") {
     val batch = buildBatch()
-    val ctriter = new ColumnarToRowIterator(
-      Seq(batch).iterator,
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
-    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
-    val myIter = GeneratedInternalRowToCudfRowIterator(
-      ctriter, schema, TargetSize(Int.MaxValue),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
-    // this forces a retry on the copy of the host column to a device column
-    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
-    withResource(myIter.next()) { devBatch =>
-      withResource(buildBatch()) { expected =>
-        TestUtils.compareBatches(expected, devBatch)
+    val batchIter = Seq(batch).iterator
+    withResource(new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric)) { ctriter =>
+      val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+      val myIter = GeneratedInternalRowToCudfRowIterator(
+        ctriter, schema, TargetSize(Int.MaxValue),
+        NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+      // this forces a retry on the copy of the host column to a device column
+      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+      withResource(myIter.next()) { devBatch =>
+        withResource(buildBatch()) { expected =>
+          TestUtils.compareBatches(expected, devBatch)
+        }
       }
+      assert(!GpuColumnVector.extractBases(batch).exists(_.getRefCount > 0))
+      assert(!myIter.hasNext)
+      assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
     }
-    assert(!GpuColumnVector.extractBases(batch).exists(_.getRefCount > 0))
-    assert(!myIter.hasNext)
-    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
   }
 
   test("a retry when converting to a table is handled") {
@@ -83,28 +84,29 @@ class GeneratedInternalRowToCudfRowIteratorRetrySuite
     }).when(deviceStorage)
         .addTable(any(), any(), any(), any())
 
-    val ctriter = new ColumnarToRowIterator(batchIter,
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
-    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
-    val myIter = spy(GeneratedInternalRowToCudfRowIterator(
-      ctriter, schema, TargetSize(Int.MaxValue),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
-    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
-    assertResult(0)(getAndResetNumRetryThrowCurrentTask)
-    withResource(myIter.next()) { devBatch =>
-      withResource(buildBatch()) { expected =>
-        TestUtils.compareBatches(expected, devBatch)
+    withResource(new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric)) { ctriter =>
+      val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+      val myIter = spy(GeneratedInternalRowToCudfRowIterator(
+        ctriter, schema, TargetSize(Int.MaxValue),
+        NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
+      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
+      assertResult(0)(getAndResetNumRetryThrowCurrentTask)
+      withResource(myIter.next()) { devBatch =>
+        withResource(buildBatch()) { expected =>
+          TestUtils.compareBatches(expected, devBatch)
+        }
       }
+      assertResult(5)(getAndResetNumRetryThrowCurrentTask)
+      assert(!myIter.hasNext)
+      assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+      // This is my wrap around of checking that we did retry the last part
+      // where we are converting the device column of rows into an actual column.
+      // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
+      // a batch.
+      verify(rapidsBufferSpy, times(4))
+          .getColumnarBatch(any())
     }
-    assertResult(5)(getAndResetNumRetryThrowCurrentTask)
-    assert(!myIter.hasNext)
-    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
-    // This is my wrap around of checking that we did retry the last part
-    // where we are converting the device column of rows into an actual column.
-    // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
-    // a batch.
-    verify(rapidsBufferSpy, times(4))
-        .getColumnarBatch(any())
   }
 
   test("spilling the device column of rows works") {
@@ -126,44 +128,46 @@ class GeneratedInternalRowToCudfRowIteratorRetrySuite
     }).when(deviceStorage)
         .addTable(any(), any(), any(), any())
 
-    val ctriter = new ColumnarToRowIterator(batchIter,
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric)
-    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
-    val myIter = spy(GeneratedInternalRowToCudfRowIterator(
-      ctriter, schema, TargetSize(Int.MaxValue),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
-    RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
-    assertResult(0)(getAndResetNumRetryThrowCurrentTask)
-    withResource(myIter.next()) { devBatch =>
-      withResource(buildBatch()) { expected =>
-        TestUtils.compareBatches(expected, devBatch)
+    withResource(new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric)) { ctriter =>
+      val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+      val myIter = spy(GeneratedInternalRowToCudfRowIterator(
+        ctriter, schema, TargetSize(Int.MaxValue),
+        NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric))
+      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 2)
+      assertResult(0)(getAndResetNumRetryThrowCurrentTask)
+      withResource(myIter.next()) { devBatch =>
+        withResource(buildBatch()) { expected =>
+          TestUtils.compareBatches(expected, devBatch)
+        }
       }
+      assertResult(5)(getAndResetNumRetryThrowCurrentTask)
+      assert(!myIter.hasNext)
+      assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
+      // This is my wrap around of checking that we did retry the last part
+      // where we are converting the device column of rows into an actual column.
+      // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
+      // a batch.
+      verify(rapidsBufferSpy, times(4))
+          .getColumnarBatch(any())
     }
-    assertResult(5)(getAndResetNumRetryThrowCurrentTask)
-    assert(!myIter.hasNext)
-    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
-    // This is my wrap around of checking that we did retry the last part
-    // where we are converting the device column of rows into an actual column.
-    // Because we asked for 3 retries, we would ask the spill framework 4 times to materialize
-    // a batch.
-    verify(rapidsBufferSpy, times(4))
-        .getColumnarBatch(any())
   }
 
   test("a split and retry when copying to device is not handled, and we throw") {
     val batch = buildBatch()
     val batchIter = Seq(batch).iterator
 
-    val ctriter = new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
-      NoopMetric)
-    val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
-    val myIter = GeneratedInternalRowToCudfRowIterator(
-      ctriter, schema, TargetSize(1),
-      NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
-    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
-    assertThrows[SplitAndRetryOOM] {
-      myIter.next()
+    withResource(new ColumnarToRowIterator(batchIter, NoopMetric, NoopMetric, NoopMetric,
+      NoopMetric)) { ctriter =>
+      val schema = Array(AttributeReference("longcol", LongType)().toAttribute)
+      val myIter = GeneratedInternalRowToCudfRowIterator(
+        ctriter, schema, TargetSize(1),
+        NoopMetric, NoopMetric, NoopMetric, NoopMetric, NoopMetric)
+      RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+      assertThrows[SplitAndRetryOOM] {
+        myIter.next()
+      }
+      assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
     }
-    assertResult(0)(RapidsBufferCatalog.getDeviceStorage.currentSize)
   }
 }


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/9261

assuming that the fix from https://github.com/NVIDIA/spark-rapids/pull/9257 also goes in.

The leak was in a test and I added a withResource and AutoCloseable for an iterator to make it work.

The double free was in a really rare corner case where we are already going to throw an exception that would bring down the task, so it is not too critical.  It is not really a use after free in this case. It is a little bit ugly because I had to add in a layer of indirection to make the code work without refactoring a huge chunk of code.