### PR TITLE
Specify correct dependency versions for 350 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,9 +534,10 @@
                 <buildver>350</buildver>
                 <spark.version>${spark350.version}</spark.version>
                 <spark.test.version>${spark350.version}</spark.test.version>
-                <parquet.hadoop.version>1.12.2</parquet.hadoop.version>
+                <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <spark.shim.sources>${spark350.sources}</spark.shim.sources>
                 <iceberg.version>${spark330.iceberg.version}</iceberg.version>
+                <slf4j.version>2.0.7</slf4j.version>
             </properties>
             <modules>
                 <module>delta-lake/delta-stub</module>


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9263

We need to specify the slf4j version per shim, otherwise we can get duplicate versions and that breaks logging in the unit tests.

I also noticed that the parquet-hadoop version needed updating.

