### PR TITLE
Roll our own BufferedIterator so we can close cleanly

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/CloseableBufferedIterator.scala
@@ -21,14 +21,15 @@ import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import org.apache.spark.TaskContext
 
 /**
- * Helper iterator that wraps a BufferedIterator of AutoCloseable subclasses.
+ * Helper iterator that wraps an Iterator of AutoCloseable subclasses.
  * This iterator also implements AutoCloseable, so it can be closed in case
- * of exceptions.
+ * of exceptions and when close is called on it, its buffered item will be
+ * closed as well.
  *
- * @param wrapped the buffered iterator
+ * @param wrapped the iterator we are wrapping for buffering
  * @tparam T an AutoCloseable subclass
  */
-class CloseableBufferedIterator[T <: AutoCloseable](wrapped: BufferedIterator[T])
+class CloseableBufferedIterator[T <: AutoCloseable](wrapped: Iterator[T])
   extends BufferedIterator[T] with AutoCloseable {
   // Don't install the callback if in a unit test
   Option(TaskContext.get()).foreach { tc =>
@@ -38,13 +39,38 @@ class CloseableBufferedIterator[T <: AutoCloseable](wrapped: BufferedIterator[T]
   }
 
   private[this] var isClosed = false
-  override def head: T = wrapped.head
-  override def headOption: Option[T] = wrapped.headOption
-  override def next: T = wrapped.next
-  override def hasNext: Boolean = wrapped.hasNext
+
+  private var hd: Option[T] = None
+
+  def head: T = {
+    if (hd.isEmpty) {
+      hd = Some(next())
+    }
+    hd.get
+  }
+
+  override def headOption: Option[T] = {
+    if (hasNext) {
+      Some(head)
+    } else {
+      None
+    }
+  }
+
+  override def next: T = if (hd.isDefined) {
+    val res = hd.get
+    hd = None
+    res
+  } else {
+    wrapped.next
+  }
+
+  override def hasNext: Boolean = !isClosed && (hd.isDefined || wrapped.hasNext)
+
   override def close(): Unit = {
     if (!isClosed) {
-      headOption.foreach(_.close())
+      hd.foreach(_.close()) // close a buffered head item
+      hd = None
       isClosed = true
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -253,7 +253,7 @@ object GpuShuffledHashJoinExec extends Logging {
   (Either[ColumnarBatch, Iterator[ColumnarBatch]], Iterator[ColumnarBatch]) = {
     val buildTime = coalesceMetrics(GpuMetric.BUILD_TIME)
     val buildTypes = buildOutput.map(_.dataType).toArray
-    closeOnExcept(new CloseableBufferedIterator(buildIter.buffered)) { bufBuildIter =>
+    closeOnExcept(new CloseableBufferedIterator(buildIter)) { bufBuildIter =>
       val startTime = System.nanoTime()
       // Batches type detection
       val isBuildSerialized = bufBuildIter.hasNext && isBatchSerialized(bufBuildIter.head)
@@ -401,7 +401,7 @@ object GpuShuffledHashJoinExec extends Logging {
     // will grab the semaphore when putting the first stream batch on the GPU, and
     // then we bring the build batch to the GPU and return.
     withResource(hostConcatResult) { _ =>
-      closeOnExcept(new CloseableBufferedIterator(streamIter.buffered)) { bufStreamIter =>
+      closeOnExcept(new CloseableBufferedIterator(streamIter)) { bufStreamIter =>
         withResource(new NvtxRange("first stream batch", NvtxColor.RED)) { _ =>
           if (bufStreamIter.hasNext) {
             bufStreamIter.head

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExecBase.scala
@@ -142,7 +142,7 @@ abstract class GpuBroadcastHashJoinExecBase(
       streamIter: Iterator[ColumnarBatch],
       coalesceMetricsMap: Map[String, GpuMetric]): (ColumnarBatch, Iterator[ColumnarBatch]) = {
 
-    val bufferedStreamIter = new CloseableBufferedIterator(streamIter.buffered)
+    val bufferedStreamIter = new CloseableBufferedIterator(streamIter)
     closeOnExcept(bufferedStreamIter) { _ =>
       withResource(new NvtxRange("first stream batch", NvtxColor.RED)) { _ =>
         if (bufferedStreamIter.hasNext) {

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -131,7 +131,7 @@ case class GpuBroadcastHashJoinExec(
     val targetSize = RapidsConf.GPU_BATCH_SIZE_BYTES.get(conf)
     val metricsMap = allMetrics
 
-    val bufferedStreamIter = new CloseableBufferedIterator(streamIter.buffered)
+    val bufferedStreamIter = new CloseableBufferedIterator(streamIter)
     closeOnExcept(bufferedStreamIter) { _ =>
       withResource(new NvtxRange("first stream batch", NvtxColor.RED)) { _ =>
         if (bufferedStreamIter.hasNext) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExecSuite.scala
@@ -55,9 +55,7 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
       optimalCase: Boolean = false)
       (verifyBuiltData: Either[ColumnarBatch, Iterator[ColumnarBatch]] => Unit): Unit = {
     val mockStreamIter = mock[Iterator[ColumnarBatch]]
-    val mockBufferedStreamIterator = mock[BufferedIterator[ColumnarBatch]]
-    when(mockStreamIter.buffered).thenReturn(mockBufferedStreamIterator)
-    when(mockBufferedStreamIterator.hasNext).thenReturn(true)
+    when(mockStreamIter.hasNext).thenReturn(true)
     val (builtData, _) = GpuShuffledHashJoinExec.prepareBuildBatchesForJoin(
       buildIter,
       mockStreamIter,
@@ -68,11 +66,12 @@ class GpuShuffledHashJoinExecSuite extends AnyFunSuite with MockitoSugar {
     verifyBuiltData(builtData)
     // build iterator should be drained
     assertResult(expected = false)(buildIter.hasNext)
-    verify(mockStreamIter, times(0)).hasNext
     if (optimalCase) {
-      verify(mockStreamIter, times(1)).buffered
-      verify(mockBufferedStreamIterator, times(1)).hasNext
-      verify(mockBufferedStreamIterator, times(1)).head
+      verify(mockStreamIter, times(1)).hasNext
+      verify(mockStreamIter, times(1)).next
+    } else {
+      verify(mockStreamIter, times(0)).hasNext
+      verify(mockStreamIter, times(0)).next
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ScalableTaskCompletionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ScalableTaskCompletionSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import org.apache.spark.TaskContext
+
+class ScalableTaskCompletionSuite extends AnyFunSuite {
+  test("ScalableTaskCompletion prevents registering callbacks from a running callback") {
+    val tc = mock[TaskContext]
+    var doFail = true
+    ScalableTaskCompletion.onTaskCompletion(tc, _ => {
+      if (doFail) {
+        ScalableTaskCompletion.onTaskCompletion(tc, _ => {
+        })
+      }
+    })
+    assertThrows[IllegalStateException] {
+      ScalableTaskCompletion.reset()
+    }
+    doFail = false
+    ScalableTaskCompletion.reset()
+  }
+
+  test("ScalableTaskCompletion prevents calling callbacks from a running callback") {
+    val tc = mock[TaskContext]
+    var doFail = true
+    ScalableTaskCompletion.onTaskCompletion(tc, _ => {
+      if (doFail) {
+        ScalableTaskCompletion.reset()
+      }
+    })
+    assertThrows[IllegalStateException] {
+      ScalableTaskCompletion.reset()
+    }
+    doFail = false
+    ScalableTaskCompletion.reset()
+  }
+
+  test("ScalableTaskCompletion succeeds in the good case") {
+    val tc = mock[TaskContext]
+    var called = false
+    ScalableTaskCompletion.onTaskCompletion(tc, _ => {
+      called = true
+    })
+    ScalableTaskCompletion.reset()
+    assert(called)
+  }
+}


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9131

This removes an issue we had in the `CloseableBufferedIterator` where it would call `next` on its wrapped iterator while closing. This could register a task completion callback, as we are handling another task completion callback, which leads to a `ConcurrentModificationException`.