### PR TITLE
Add arm64 profile to build arm artifacts

### DIFF
--- a/api_validation/pom.xml
+++ b/api_validation/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
             <scope>provided</scope>
         </dependency>
         <!-- use aggregator jar because accessing internal classes -->
@@ -115,7 +115,7 @@
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <target.classifier/>
-        <dist.jar.name>${project.build.directory}/${project.build.finalName}-${cuda.version}.jar</dist.jar.name>
+        <dist.jar.name>${project.build.directory}/${project.build.finalName}-${jni.classifier}.jar</dist.jar.name>
         <dist.jar.pom.url>jar:file:${dist.jar.name}!/META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml</dist.jar.pom.url>
         <rapids.default.jar.phase>none</rapids.default.jar.phase>
     </properties>
@@ -223,7 +223,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <classifier>${cuda.version}</classifier>
+                    <classifier>${jni.classifier}</classifier>
                 </configuration>
                 <executions>
                     <execution>
@@ -235,7 +235,7 @@
                         <configuration>
                             <archive><compress>${dist.jar.compress}</compress></archive>
                             <classesDirectory>${project.build.directory}/parallel-world</classesDirectory>
-                            <classifier>${cuda.version}</classifier>
+                            <classifier>${jni.classifier}</classifier>
                         </configuration>
                     </execution>
                 </executions>
@@ -412,7 +412,7 @@ self.log("... OK")
                                 <artifactItem>
                                     <groupId>com.nvidia</groupId>
                                     <artifactId>spark-rapids-jni</artifactId>
-                                    <classifier>${cuda.version}</classifier>
+                                    <classifier>${jni.classifier}</classifier>
                                     <excludes>META-INF/**</excludes>
                                     <outputDirectory>${project.build.directory}/parallel-world</outputDirectory>
                                     <overWrite>true</overWrite>
@@ -447,7 +447,7 @@ self.log("... OK")
                         <configuration>
                             <file>${dist.jar.name}</file>
                             <artifactId>${project.artifactId}</artifactId>
-                            <classifier>${cuda.version}</classifier>
+                            <classifier>${jni.classifier}</classifier>
                             <groupId>${project.groupId}</groupId>
                             <version>${project.version}</version>
                             <packaging>jar</packaging>
@@ -477,7 +477,7 @@ self.log("... OK")
                             <file>${dist.jar.name}</file>
                             <url>file://${java.io.tmpdir}/m2-repo</url>
                             <artifactId>${project.artifactId}</artifactId>
-                            <classifier>${cuda.version}</classifier>
+                            <classifier>${jni.classifier}</classifier>
                             <groupId>${project.groupId}</groupId>
                             <packaging>jar</packaging>
                             <!-- pomFile will be taken from META-INF in jar

--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -54,7 +54,7 @@
             <groupId>com.nvidia</groupId>
             <artifactId>rapids-4-spark_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,12 @@
                 <maven.compiler.target>17</maven.compiler.target>
             </properties>
         </profile>
+        <profile>
+            <id>arm64</id>
+            <properties>
+                <jni.classifier>${cuda.version}-arm64</jni.classifier>
+            </properties>
+        </profile>
     </profiles>
 
     <properties>
@@ -593,6 +599,7 @@
         <parquet.hadoop.version>1.10.1</parquet.hadoop.version>
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
+        <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>23.10.0-SNAPSHOT</spark-rapids-jni.version>
         <spark-rapids-private.version>23.10.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -768,7 +775,7 @@
               <groupId>com.nvidia</groupId>
               <artifactId>spark-rapids-jni</artifactId>
               <version>${spark-rapids-jni.version}</version>
-              <classifier>${cuda.version}</classifier>
+              <classifier>${jni.classifier}</classifier>
             </dependency>
             <dependency>
                 <groupId>org.openucx</groupId>

--- a/shuffle-plugin/pom.xml
+++ b/shuffle-plugin/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/sql-plugin-api/pom.xml
+++ b/sql-plugin-api/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
         </dependency>
     </dependencies>
     <profiles>

--- a/sql-plugin/pom.xml
+++ b/sql-plugin/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>com.nvidia</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
         </dependency>
         <!-- use aggregator jar because accessing internal classes -->
         <dependency>

--- a/udf-compiler/pom.xml
+++ b/udf-compiler/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.nvidia</groupId>
             <artifactId>spark-rapids-jni</artifactId>
-            <classifier>${cuda.version}</classifier>
+            <classifier>${jni.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
follow-up of https://github.com/NVIDIA/spark-rapids-jni/pull/1385 to add arm64 profile to support build and test against arm experimentally

This change would,
1. Add arm64 profile to build new plugin artifacts with arm-based JNI artifact (currently only available on URM internally)
2. Do not change the deployment process for now to avoid affecting existing development and release (x86). 

When we decide to officially support arm in plugin, and we will have some updates for build and deploy setup to include arm artifacts as part of regular deploy&release. Filed a ticket to track in 23.12 or later https://github.com/NVIDIA/spark-rapids/issues/9274

e.g. command like
```
mvn -Dmaven.wagon.http.retryHandler.count=3 -U -B -s jenkins/settings.xml -P mirror-apache-to-urm,arm64 -Dbuildver=311 package -Drat.skip=true -Dskip -Dmaven.scalastyle.skip=true -Dcuda.version=cuda11 -DskipTests
```
would produce
```
 % ll dist/target/*.jar
-rw-rw-r-- 1 peixinl peixinl 449M Sep 20 05:27 dist/target/rapids-4-spark_2.12-23.10.0-SNAPSHOT-cuda11-arm64.jar
```

in the artifact it would include the arm64-based JNI objects
```
% ll -R aarch64
aarch64:
total 4.0K
drwxrwxr-x 2 peixinl peixinl 4.0K Sep 20 05:50 Linux

aarch64/Linux:
total 690M
-rw-r--r-- 1 peixinl peixinl  68K Sep 20 05:26 libcudfjni.so
-rw-r--r-- 1 peixinl peixinl 646M Sep 20 05:26 libcudf.so
-rw-r--r-- 1 peixinl peixinl  21M Sep 20 05:26 libnvcomp_bitcomp.so
-rw-r--r-- 1 peixinl peixinl  11M Sep 20 05:26 libnvcomp_gdeflate.so
-rw-r--r-- 1 peixinl peixinl  14M Sep 20 05:26 libnvcomp.so
```