### PR TITLE
[Doc]Remove CUDA related requirement from download page.[Skip CI]

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -29,7 +29,7 @@ The plugin is tested on the following architectures:
 
 	OS: Ubuntu 20.04, Ubuntu 22.04, CentOS 7, or Rocky Linux 8
 
-	NVIDIA Driver*: 470+
+	NVIDIA Driver*: R470+
 
 	Runtime: 
 		Scala 2.12
@@ -55,7 +55,7 @@ The plugin is tested on the following architectures:
 		GCP Dataproc 2.0
 		GCP Dataproc 2.1
 
-*Some hardware may have a minimum driver version greater than v450.80.02+.  Check the GPU spec sheet
+*Some hardware may have a minimum driver version greater than R470. Check the GPU spec sheet
 for your hardware's minimum driver version.
 
 *For Cloudera and EMR support, please refer to the
@@ -65,10 +65,8 @@ for your hardware's minimum driver version.
 * Download the [RAPIDS
   Accelerator for Apache Spark 23.08.1 jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/23.08.1/rapids-4-spark_2.12-23.08.1.jar)
 
-This package is built against CUDA 11.8, all CUDA 11.x and 12.x versions are supported through [CUDA forward
-compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html). It is tested
-on V100, T4, A10, A100, L4 and H100 GPUs with CUDA 11.8-12.0.  For those using other types of GPUs 
-which do not have CUDA forward compatibility (for example, GeForce), CUDA 11.8 or later is required.
+This package is built against CUDA 11.8. It is tested on V100, T4, A10, A100, L4 and H100 GPUs with 
+CUDA 11.8-12.0.
 
 Note that v23.08.0 is deprecated.
 


### PR DESCRIPTION
Since we do not require CUDA to be installed and we only require NVIDIA driver to be installed, this PR is to make it clear and remove the CUDA related requirements from download page.