### PR TITLE
Refactor ExternalSource to move some APIs to converted GPU format or scan [databricks]

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkBatchQueryScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkBatchQueryScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -368,7 +368,7 @@ public class GpuSparkBatchQueryScan extends GpuSparkScan implements ShimSupports
   }
 
   /** Return a copy of "this" but with "queryUsesInputFile = true" */
-  public GpuSparkBatchQueryScan copyWithInputFileTrue() {
+  public GpuSparkBatchQueryScan withInputFile() {
     return new GpuSparkBatchQueryScan(SparkSession.active(), table(), this.scan, readConf(),
         expectedSchema(), filterExpressions(), rapidsConf(),
         true // queryUsesInputFile

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.nvidia.spark.rapids.GpuMetric;
+import com.nvidia.spark.rapids.GpuScanWrapper;
 import com.nvidia.spark.rapids.MultiFileReaderUtils;
 import com.nvidia.spark.rapids.RapidsConf;
-import com.nvidia.spark.rapids.ScanWithMetricsWrapper;
 import com.nvidia.spark.rapids.iceberg.spark.Spark3Util;
 import com.nvidia.spark.rapids.iceberg.spark.SparkReadConf;
 import com.nvidia.spark.rapids.iceberg.spark.SparkSchemaUtil;
@@ -67,7 +67,7 @@ import org.apache.spark.util.SerializableConfiguration;
  * GPU-accelerated Iceberg Scan.
  * This is derived from Apache Iceberg's SparkScan class.
  */
-abstract class GpuSparkScan extends ScanWithMetricsWrapper
+abstract class GpuSparkScan extends GpuScanWrapper
     implements Scan, SupportsReportStatistics {
   private static final Logger LOG = LoggerFactory.getLogger(GpuSparkScan.class);
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AvroProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,13 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.connector.read.{PartitionReaderFactory, Scan}
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.rapids.GpuFileSourceScanExec
-import org.apache.spark.sql.sources.Filter
-import org.apache.spark.util.SerializableConfiguration
 
 trait AvroProvider {
   /** If the file format is supported as an external source */
   def isSupportedFormat(format: FileFormat): Boolean
-
-  def isPerFileReadEnabledForFormat(format: FileFormat, conf: RapidsConf): Boolean
 
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit
 
@@ -38,19 +32,5 @@ trait AvroProvider {
    */
   def getReadFileFormat(format: FileFormat): FileFormat
 
-  /**
-   * Create a multi-file reader factory for the input format.
-   * Better to check if the format is supported first by calling 'isSupportedFormat'
-   */
-  def createMultiFileReaderFactory(
-      format: FileFormat,
-      broadcastedConf: Broadcast[SerializableConfiguration],
-      pushedFilters: Array[Filter],
-      fileScan: GpuFileSourceScanExec): PartitionReaderFactory
-
   def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]]
-
-  def isSupportedScan(scan: Scan): Boolean
-
-  def copyScanWithInputFileTrue(scan: Scan): Scan
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -51,9 +51,6 @@ trait ScanWithMetrics {
   var metrics : Map[String, GpuMetric] = Map.empty
 }
 
-// Allows use of ScanWithMetrics from Java code
-class ScanWithMetricsWrapper extends ScanWithMetrics
-
 object GpuCSVScan {
   def tagSupport(scanMeta: ScanMeta[CSVScan]) : Unit = {
     val scan = scanMeta.wrapped
@@ -213,7 +210,7 @@ case class GpuCSVScan(
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long)
-  extends TextBasedFileScan(sparkSession, options) with ScanWithMetrics {
+  extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: CSVOptions = new CSVOptions(
     options.asScala.toMap,
@@ -250,6 +247,8 @@ case class GpuCSVScan(
   def withFilters(
       partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
     this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+
+  override def withInputFile(): GpuScan = this
 
   override def equals(obj: Any): Boolean = obj match {
     case c: GpuCSVScan =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -84,7 +84,7 @@ case class GpuOrcScan(
     dataFilters: Seq[Expression],
     rapidsConf: RapidsConf,
     queryUsesInputFile: Boolean = false)
-  extends ScanWithMetrics with FileScan with Logging {
+  extends FileScan with GpuScan with Logging {
 
   override def isSplitable(path: Path): Boolean = true
 
@@ -124,6 +124,8 @@ case class GpuOrcScan(
   def withFilters(
       partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
     this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+
+  override def withInputFile(): GpuScan = copy(queryUsesInputFile = true)
 }
 
 object GpuOrcScan {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3619,7 +3619,7 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new ScanMeta[CSVScan](a, conf, p, r) {
         override def tagSelfForGpu(): Unit = GpuCSVScan.tagSupport(this)
 
-        override def convertToGpu(): Scan =
+        override def convertToGpu(): GpuScan =
           GpuCSVScan(a.sparkSession,
             a.fileIndex,
             a.dataSchema,
@@ -3636,7 +3636,7 @@ object GpuOverrides extends Logging {
       (a, conf, p, r) => new ScanMeta[JsonScan](a, conf, p, r) {
         override def tagSelfForGpu(): Unit = GpuJsonScan.tagSupport(this)
 
-        override def convertToGpu(): Scan =
+        override def convertToGpu(): GpuScan =
           GpuJsonScan(a.sparkSession,
             a.fileIndex,
             a.dataSchema,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -108,7 +108,7 @@ case class GpuParquetScan(
     dataFilters: Seq[Expression],
     rapidsConf: RapidsConf,
     queryUsesInputFile: Boolean = false)
-  extends ScanWithMetrics with FileScan with Logging {
+  extends FileScan with GpuScan with Logging {
 
   override def isSplitable(path: Path): Boolean = true
 
@@ -146,6 +146,8 @@ case class GpuParquetScan(
   def withFilters(
       partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): FileScan =
     this.copy(partitionFilters = partitionFilters, dataFilters = dataFilters)
+
+  override def withInputFile(): GpuScan = copy(queryUsesInputFile = true)
 }
 
 object GpuParquetScan {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,15 @@ package com.nvidia.spark.rapids
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.csv.CSVOptions
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -65,6 +68,15 @@ class GpuReadCSVFileFormat extends CSVFileFormat with GpuReadFileFormatWithMetri
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)
+  }
+
+  override def isPerFileReadEnabled(conf: RapidsConf): Boolean = true
+
+  override def createMultiFileReaderFactory(
+      broadcastedConf: Broadcast[SerializableConfiguration],
+      pushedFilters: Array[Filter],
+      fileScan: GpuFileSourceScanExec): PartitionReaderFactory = {
+    throw new IllegalStateException("CSV format does not support multifile reads")
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadFileFormatWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadFileFormatWithMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,11 +22,15 @@ package com.nvidia.spark.rapids
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.{FileFormat, OutputWriterFactory, PartitionedFile}
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
 
 trait GpuReadFileFormatWithMetrics extends FileFormat {
   final override def supportBatch(spark: SparkSession, dataSchema: StructType): Boolean = true
@@ -62,4 +66,11 @@ trait GpuReadFileFormatWithMetrics extends FileFormat {
       metrics: Map[String, GpuMetric],
       alluxioPathReplacementMap: Option[Map[String, String]])
   : PartitionedFile => Iterator[InternalRow]
+
+  def isPerFileReadEnabled(conf: RapidsConf): Boolean
+
+  def createMultiFileReaderFactory(
+      broadcastedConf: Broadcast[SerializableConfiguration],
+      pushedFilters: Array[Filter],
+      fileScan: GpuFileSourceScanExec): PartitionReaderFactory
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadOrcFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ package com.nvidia.spark.rapids
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -57,6 +60,24 @@ class GpuReadOrcFileFormat extends OrcFileFormat with GpuReadFileFormatWithMetri
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)
+  }
+
+  override def isPerFileReadEnabled(conf: RapidsConf): Boolean = conf.isOrcPerFileReadEnabled
+
+  override def createMultiFileReaderFactory(
+      broadcastedConf: Broadcast[SerializableConfiguration],
+      pushedFilters: Array[Filter],
+      fileScan: GpuFileSourceScanExec): PartitionReaderFactory = {
+    GpuOrcMultiFilePartitionReaderFactory(
+      fileScan.conf,
+      broadcastedConf,
+      fileScan.relation.dataSchema,
+      fileScan.requiredSchema,
+      fileScan.readPartitionSchema,
+      pushedFilters,
+      fileScan.rapidsConf,
+      fileScan.allMetrics,
+      fileScan.queryUsesInputFile)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuScan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-package com.nvidia.spark.rapids.iceberg
-
-import com.nvidia.spark.rapids.{ScanRule, ShimLoader}
+package com.nvidia.spark.rapids
 
 import org.apache.spark.sql.connector.read.Scan
 
-/** Interfaces to avoid accessing the optional Apache Iceberg jars directly in common code. */
-trait IcebergProvider {
-  def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]]
+trait GpuScan extends Scan with ScanWithMetrics {
+  /** Create a version of this scan with input file name support */
+  def withInputFile(): GpuScan
 }
 
-object IcebergProvider {
-  def apply(): IcebergProvider = ShimLoader.newIcebergProvider()
-
-  val cpuScanClassName: String = "org.apache.iceberg.spark.source.SparkBatchQueryScan"
-}
+// Allows use of GpuScan from Java code
+abstract class GpuScanWrapper extends GpuScan

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedC
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanExecBase, DropTableExec, ShowTablesExec}
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, Exchange, ReusedExchangeExec, ShuffleExchangeLike}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, HashedRelationBroadcastMode}
-import org.apache.spark.sql.rapids.{ExternalSource, GpuDataSourceScanExec, GpuFileSourceScanExec, GpuInputFileBlockLength, GpuInputFileBlockStart, GpuInputFileName, GpuShuffleEnv, GpuTaskMetrics}
+import org.apache.spark.sql.rapids.{GpuDataSourceScanExec, GpuFileSourceScanExec, GpuInputFileBlockLength, GpuInputFileBlockStart, GpuInputFileName, GpuShuffleEnv, GpuTaskMetrics}
 import org.apache.spark.sql.rapids.execution.{ExchangeMappingCache, GpuBroadcastExchangeExec, GpuBroadcastExchangeExecBase, GpuBroadcastToRowExec, GpuCustomShuffleReaderExec, GpuHashJoin, GpuShuffleExchangeExecBase}
 import org.apache.spark.sql.types.StructType
 
@@ -362,20 +362,13 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       disableUntilInput: Boolean = false): SparkPlan = {
     plan match {
       case batchScan: GpuBatchScanExec =>
-        if ((batchScan.scan.isInstanceOf[GpuParquetScan] ||
-          batchScan.scan.isInstanceOf[GpuOrcScan] ||
-          ExternalSource.isSupportedScan(batchScan.scan)) &&
-          (disableUntilInput || disableScanUntilInput(batchScan))) {
-          val scanCopy = batchScan.scan match {
-            case parquetScan: GpuParquetScan =>
-              parquetScan.copy(queryUsesInputFile = true)
-            case orcScan: GpuOrcScan =>
-              orcScan.copy(queryUsesInputFile = true)
-            case eScan if ExternalSource.isSupportedScan(eScan) =>
-              ExternalSource.copyScanWithInputFileTrue(eScan)
-            case _ => throw new RuntimeException("Wrong format") // never reach here
+        if (disableUntilInput || disableScanUntilInput(batchScan)) {
+          val newScan = batchScan.scan.withInputFile()
+          if (newScan ne batchScan.scan) {
+            batchScan.copy(scan = newScan)
+          } else {
+            batchScan
           }
-          batchScan.copy(scan = scanCopy)
         } else {
           batchScan
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -503,7 +503,7 @@ abstract class ScanMeta[INPUT <: Scan](scan: INPUT,
     conf: RapidsConf,
     parent: Option[RapidsMeta[_, _, _]],
     rule: DataFromReplacementRule)
-  extends RapidsMeta[INPUT, Scan, Scan](scan, conf, parent, rule) {
+  extends RapidsMeta[INPUT, Scan, GpuScan](scan, conf, parent, rule) {
 
   override val childPlans: Seq[SparkPlanMeta[_]] = Seq.empty
   override val childExprs: Seq[BaseExprMeta[_]] = Seq.empty
@@ -529,7 +529,7 @@ final class RuleNotFoundScanMeta[INPUT <: Scan](
     willNotWorkOnGpu(s"GPU does not currently support the operator ${scan.getClass}")
   }
 
-  override def convertToGpu(): Scan =
+  override def convertToGpu(): GpuScan =
     throw new IllegalStateException("Cannot be converted to GPU")
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -198,7 +198,7 @@ case class GpuJsonScan(
     dataFilters: Seq[Expression],
     maxReaderBatchSizeRows: Integer,
     maxReaderBatchSizeBytes: Long)
-  extends TextBasedFileScan(sparkSession, options) with ScanWithMetrics {
+  extends TextBasedFileScan(sparkSession, options) with GpuScan {
 
   private lazy val parsedOptions: JSONOptions = new JSONOptions(
     options.asScala.toMap,
@@ -222,6 +222,8 @@ case class GpuJsonScan(
       dataSchema, readDataSchema, readPartitionSchema, parsedOptions, maxReaderBatchSizeRows,
       maxReaderBatchSizeBytes, metrics, options.asScala.toMap)
   }
+
+  override def withInputFile(): GpuScan = this
 }
 
 case class GpuJsonPartitionReaderFactory(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,15 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 import org.apache.hadoop.conf.Configuration
 
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.json.JSONOptionsInRead
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
+import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -65,6 +68,15 @@ class GpuReadJsonFileFormat extends JsonFileFormat with GpuReadFileFormatWithMet
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)
+  }
+
+  override def isPerFileReadEnabled(conf: RapidsConf): Boolean = true
+
+  override def createMultiFileReaderFactory(
+      broadcastedConf: Broadcast[SerializableConfiguration],
+      pushedFilters: Array[Filter],
+      fileScan: GpuFileSourceScanExec): PartitionReaderFactory = {
+    throw new IllegalStateException("JSON format does not support multifile reads")
   }
 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ class AvroProviderImpl extends AvroProvider {
         (a, conf, p, r) => new ScanMeta[AvroScan](a, conf, p, r) {
           override def tagSelfForGpu(): Unit = GpuAvroScan.tagSupport(this)
 
-          override def convertToGpu(): Scan =
+          override def convertToGpu(): GpuScan =
             GpuAvroScan(a.sparkSession,
               a.fileIndex,
               a.dataSchema,
@@ -112,14 +112,5 @@ class AvroProviderImpl extends AvroProvider {
               a.dataFilters)
         })
     ).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
-  }
-
-  def isSupportedScan(scan: Scan): Boolean = scan.isInstanceOf[GpuAvroScan]
-
-  def copyScanWithInputFileTrue(scan: Scan): Scan = scan match {
-    case avroScan: GpuAvroScan =>
-      avroScan.copy(queryUsesInputFile=true)
-    case _ =>
-      throw new RuntimeException(s"Unsupported scan type: ${scan.getClass.getSimpleName}")
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
@@ -23,14 +23,13 @@ import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.delta.DeltaProvider
 import com.nvidia.spark.rapids.iceberg.IcebergProvider
 
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connector.read.{PartitionReaderFactory, Scan}
+import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.sources.{CreatableRelationProvider, Filter}
-import org.apache.spark.util.{SerializableConfiguration, Utils}
+import org.apache.spark.sql.sources.CreatableRelationProvider
+import org.apache.spark.util.Utils
 
 /**
  * The subclass of AvroProvider imports spark-avro classes. This file should not imports
@@ -79,12 +78,6 @@ object ExternalSource extends Logging {
     } else false
   }
 
-  def isPerFileReadEnabledForFormat(format: FileFormat, conf: RapidsConf): Boolean = {
-    if (hasSparkAvroJar) {
-      avroProvider.isPerFileReadEnabledForFormat(format, conf)
-    } else false
-  }
-
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit = {
     if (hasSparkAvroJar) {
       avroProvider.tagSupportForGpuFileSourceScan(meta)
@@ -103,23 +96,6 @@ object ExternalSource extends Logging {
     }
   }
 
-  /**
-   * Create a multi-file reader factory for the input format.
-   * Better to check if the format is supported first by calling 'isSupportedFormat'
-   */
-  def createMultiFileReaderFactory(
-      format: FileFormat,
-      broadcastedConf: Broadcast[SerializableConfiguration],
-      pushedFilters: Array[Filter],
-      fileScan: GpuFileSourceScanExec): PartitionReaderFactory = {
-    if (hasSparkAvroJar) {
-      avroProvider.createMultiFileReaderFactory(format, broadcastedConf, pushedFilters,
-        fileScan)
-    } else {
-      throw new RuntimeException(s"File format $format is not supported yet")
-    }
-  }
-
   def getScans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = {
     var scans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] = Map.empty
     if (hasSparkAvroJar) {
@@ -129,31 +105,6 @@ object ExternalSource extends Logging {
       scans = scans ++ icebergProvider.getScans
     }
     scans
-  }
-
-  /** If the scan is supported as an external source */
-  def isSupportedScan(scan: Scan): Boolean = {
-    if (hasSparkAvroJar && avroProvider.isSupportedScan(scan)) {
-      true
-    } else if (hasIcebergJar && icebergProvider.isSupportedScan(scan)) {
-      true
-    } else {
-      false
-    }
-  }
-
-  /**
-   * Clone the input scan with setting 'true' to the 'queryUsesInputFile'.
-   * Better to check if the scan is supported first by calling 'isSupportedScan'.
-   */
-  def copyScanWithInputFileTrue(scan: Scan): Scan = {
-    if (hasSparkAvroJar && avroProvider.isSupportedScan(scan)) {
-      avroProvider.copyScanWithInputFileTrue(scan)
-    } else if (hasIcebergJar && icebergProvider.isSupportedScan(scan)) {
-      icebergProvider.copyScanWithInputFileTrue(scan)
-    } else {
-      throw new RuntimeException(s"Unsupported scan type: ${scan.getClass.getSimpleName}")
-    }
   }
 
   def wrapCreatableRelationProvider[INPUT <: CreatableRelationProvider](

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -104,7 +104,7 @@ case class GpuAvroScan(
     rapidsConf: RapidsConf,
     partitionFilters: Seq[Expression] = Seq.empty,
     dataFilters: Seq[Expression] = Seq.empty,
-    queryUsesInputFile: Boolean = false) extends FileScan with ScanWithMetrics {
+    queryUsesInputFile: Boolean = false) extends FileScan with GpuScan {
   override def isSplitable(path: Path): Boolean = true
 
   override def createReaderFactory(): PartitionReaderFactory = {
@@ -144,6 +144,8 @@ case class GpuAvroScan(
   override def description(): String = {
     super.description() + ", PushedFilters: " + seqToString(pushedFilters)
   }
+
+  override def withInputFile(): GpuScan = copy(queryUsesInputFile = true)
 }
 
 /** Avro partition reader factory to build columnar reader */

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
@@ -21,9 +21,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 
 class RapidsOrcScanMeta(
@@ -37,7 +36,7 @@ class RapidsOrcScanMeta(
     GpuOrcScan.tagSupport(this)
   }
 
-  override def convertToGpu(): Scan =
+  override def convertToGpu(): GpuScan =
     GpuOrcScan(oScan.sparkSession,
       oScan.hadoopConf,
       oScan.fileIndex,

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -21,9 +21,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 
 class RapidsParquetScanMeta(
@@ -37,7 +36,7 @@ class RapidsParquetScanMeta(
     GpuParquetScan.tagSupport(this)
   }
 
-  override def convertToGpu(): Scan = {
+  override def convertToGpu(): GpuScan = {
     GpuParquetScan(pScan.sparkSession,
       pScan.hadoopConf,
       pScan.fileIndex,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -26,7 +26,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.google.common.base.Objects
-import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, ScanWithMetrics}
+import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, GpuScan}
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -42,7 +42,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GpuBatchScanExec(
     output: Seq[AttributeReference],
-    @transient scan: Scan,
+    @transient scan: GpuScan,
     runtimeFilters: Seq[Expression] = Seq.empty)
     extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
   @transient lazy val batch: Batch = scan.toBatch
@@ -97,11 +97,7 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
-    scan match {
-      case s: ScanWithMetrics => s.metrics = allMetrics
-      case _ =>
-    }
-
+    scan.metrics = allMetrics
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
@@ -35,9 +35,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuCSVScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuCSVScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 
 class RapidsCsvScanMeta(
@@ -53,7 +52,7 @@ class RapidsCsvScanMeta(
     TagScanForRuntimeFiltering.tagScanForRuntimeFiltering(this, cScan)
   }
 
-  override def convertToGpu(): Scan =
+  override def convertToGpu(): GpuScan =
     GpuCSVScan(cScan.sparkSession,
       cScan.fileIndex,
       cScan.dataSchema,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
@@ -25,9 +25,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 
 class RapidsOrcScanMeta(
@@ -43,7 +42,7 @@ class RapidsOrcScanMeta(
     TagScanForRuntimeFiltering.tagScanForRuntimeFiltering(this, oScan)
   }
 
-  override def convertToGpu(): Scan =
+  override def convertToGpu(): GpuScan =
     GpuOrcScan(oScan.sparkSession,
       oScan.hadoopConf,
       oScan.fileIndex,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -25,9 +25,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 
 class RapidsParquetScanMeta(
@@ -43,7 +42,7 @@ class RapidsParquetScanMeta(
     TagScanForRuntimeFiltering.tagScanForRuntimeFiltering(this, pScan)
   }
 
-  override def convertToGpu(): Scan = {
+  override def convertToGpu(): GpuScan = {
     GpuParquetScan(pScan.sparkSession,
       pScan.hadoopConf,
       pScan.fileIndex,

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -24,7 +24,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.google.common.base.Objects
-import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, ScanWithMetrics}
+import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, GpuScan}
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -40,7 +40,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GpuBatchScanExec(
     output: Seq[AttributeReference],
-    @transient scan: Scan,
+    @transient scan: GpuScan,
     runtimeFilters: Seq[Expression] = Seq.empty,
     keyGroupedPartitioning: Option[Seq[Expression]] = None)
     extends DataSourceV2ScanExecBase with GpuBatchScanExecMetrics {
@@ -116,11 +116,7 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
-    scan match {
-      case s: ScanWithMetrics => s.metrics = allMetrics
-      case _ =>
-    }
-
+    scan.metrics = allMetrics
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
@@ -28,9 +28,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuOrcScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 
 class RapidsOrcScanMeta(
@@ -50,7 +49,7 @@ class RapidsOrcScanMeta(
     }
   }
 
-  override def convertToGpu(): Scan =
+  override def convertToGpu(): GpuScan =
     GpuOrcScan(oScan.sparkSession,
       oScan.hadoopConf,
       oScan.fileIndex,

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -28,9 +28,8 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, RapidsConf, RapidsMeta, ScanMeta}
+import com.nvidia.spark.rapids.{DataFromReplacementRule, GpuParquetScan, GpuScan, RapidsConf, RapidsMeta, ScanMeta}
 
-import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 
 class RapidsParquetScanMeta(
@@ -51,7 +50,7 @@ class RapidsParquetScanMeta(
     }
   }
 
-  override def convertToGpu(): Scan = {
+  override def convertToGpu(): GpuScan = {
     GpuParquetScan(pScan.sparkSession,
       pScan.hadoopConf,
       pScan.fileIndex,

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -20,7 +20,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.google.common.base.Objects
-import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, ScanWithMetrics}
+import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, GpuScan}
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -37,7 +37,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GpuBatchScanExec(
     output: Seq[AttributeReference],
-    @transient scan: Scan,
+    @transient scan: GpuScan,
     runtimeFilters: Seq[Expression],
     keyGroupedPartitioning: Option[Seq[Expression]],
     ordering: Option[Seq[SortOrder]], 
@@ -116,11 +116,7 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
-    scan match {
-      case s: ScanWithMetrics => s.metrics = allMetrics
-      case _ =>
-    }
-
+    scan.metrics = allMetrics
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -20,7 +20,7 @@ spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import com.google.common.base.Objects
-import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, ScanWithMetrics}
+import com.nvidia.spark.rapids.{GpuBatchScanExecMetrics, GpuScan}
 
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
@@ -37,7 +37,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 case class GpuBatchScanExec(
     output: Seq[AttributeReference],
-    @transient scan: Scan,
+    @transient scan: GpuScan,
     runtimeFilters: Seq[Expression],
     keyGroupedPartitioning: Option[Seq[Expression]],
     ordering: Option[Seq[SortOrder]], 
@@ -116,11 +116,7 @@ case class GpuBatchScanExec(
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {
-    scan match {
-      case s: ScanWithMetrics => s.metrics = allMetrics
-      case _ =>
-    }
-
+    scan.metrics = allMetrics
     if (filteredPartitions.isEmpty && outputPartitioning == SinglePartition) {
       // return an empty RDD with 1 partition if dynamic filtering removed the only split
       sparkContext.parallelize(Array.empty[InternalRow], 1)


### PR DESCRIPTION
GpuFileSourceScanExec and ExternalSource were doing pattern matching on GPU file formats or scans to implement features.  This refactors the interfaces so the GPU format can directly provide the required APIs, eliminating the need to do pattern matching before invoking GPU format-related APIs.