### PR TITLE
Add CastOptions to make GpuCast extendible to handle more options [databricks]

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuIcebergReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuIcebergReader.java
@@ -26,6 +26,7 @@ import ai.rapids.cudf.Scalar;
 import com.nvidia.spark.rapids.GpuCast;
 import com.nvidia.spark.rapids.GpuColumnVector;
 import com.nvidia.spark.rapids.GpuScalar;
+import com.nvidia.spark.rapids.SparkConfCastOptions;
 import com.nvidia.spark.rapids.iceberg.data.GpuDeleteFilter;
 import com.nvidia.spark.rapids.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.Schema;
@@ -158,7 +159,7 @@ public class GpuIcebergReader implements CloseableIterator<ColumnarBatch> {
         GpuColumnVector oldColumn = columns[i];
         columns[i] = GpuColumnVector.from(
             GpuCast.doCast(oldColumn.getBase(), oldColumn.dataType(), expectedSparkType,
-            false, false, false), expectedSparkType);
+            new SparkConfCastOptions(false, false, false)), expectedSparkType);
       }
       ColumnarBatch newBatch = new ColumnarBatch(columns, batch.numRows());
       columns = null;

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuIcebergReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuIcebergReader.java
@@ -23,10 +23,10 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import ai.rapids.cudf.Scalar;
+import com.nvidia.spark.rapids.CastOptions$;
 import com.nvidia.spark.rapids.GpuCast;
 import com.nvidia.spark.rapids.GpuColumnVector;
 import com.nvidia.spark.rapids.GpuScalar;
-import com.nvidia.spark.rapids.SparkConfCastOptions;
 import com.nvidia.spark.rapids.iceberg.data.GpuDeleteFilter;
 import com.nvidia.spark.rapids.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.Schema;
@@ -159,7 +159,7 @@ public class GpuIcebergReader implements CloseableIterator<ColumnarBatch> {
         GpuColumnVector oldColumn = columns[i];
         columns[i] = GpuColumnVector.from(
             GpuCast.doCast(oldColumn.getBase(), oldColumn.dataType(), expectedSparkType,
-            new SparkConfCastOptions(false, false, false)), expectedSparkType);
+            CastOptions$.MODULE$.DEFAULT_CAST_OPTIONS()), expectedSparkType);
       }
       ColumnarBatch newBatch = new ColumnarBatch(columns, batch.numRows());
       columns = null;

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuApproximatePercentile.scala
@@ -144,9 +144,7 @@ case class ApproxPercentileFromTDigestExpr(
           // array and return that (after converting from Double to finalDataType)
           withResource(cv.getBase.approxPercentile(Array(p))) { percentiles =>
             withResource(percentiles.extractListElement(0)) { childView =>
-              withResource(doCast(childView, DataTypes.DoubleType, finalDataType,
-                  ansiMode = false, legacyCastToString = false,
-                  stringToDateAnsiModeEnabled = false)) { childCv =>
+              withResource(doCast(childView, DataTypes.DoubleType, finalDataType)) { childCv =>
                 GpuColumnVector.from(childCv.copyToColumnVector(), dataType)
               }
             }
@@ -159,9 +157,7 @@ case class ApproxPercentileFromTDigestExpr(
               GpuColumnVector.from(percentiles.incRefCount(), dataType)
             } else {
               withResource(percentiles.getChildColumnView(0)) { childView =>
-                withResource(doCast(childView, DataTypes.DoubleType, finalDataType,
-                    ansiMode = false, legacyCastToString = false,
-                    stringToDateAnsiModeEnabled = false)) { childCv =>
+                withResource(doCast(childView, DataTypes.DoubleType, finalDataType)) { childCv =>
                   withResource(percentiles.replaceListChild(childCv)) { x =>
                     GpuColumnVector.from(x.copyToColumnVector(), dataType)
                   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -787,6 +787,7 @@ object GpuCast {
       elementType: DataType,
       options: CastOptions): ColumnVector = {
 
+    // We use square brackets for arrays regardless 
     val (leftStr, rightStr) = ("[", "]")
     val emptyStr = ""
     val numRows = input.getRowCount.toInt

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -381,8 +381,7 @@ object GpuOrcScan {
       case (f: DType, t: DType) if f.isDecimalType && t.isDecimalType =>
         val fromDataType = DecimalType(f.getDecimalMaxPrecision, -f.getScale)
         val toDataType = DecimalType(t.getDecimalMaxPrecision, -t.getScale)
-        GpuCast.doCast(col, fromDataType, toDataType, ansiMode=false, legacyCastToString = false,
-          stringToDateAnsiModeEnabled = false)
+        GpuCast.doCast(col, fromDataType, toDataType)
 
       case (DType.STRING, DType.STRING) if originalFromDt.isInstanceOf[CharType] =>
         // Trim trailing whitespace off of output strings, to match CPU output.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -197,7 +197,7 @@ case class GpuJsonToStructs(
               } else {
                 val col = rawTable.getColumn(i)
                 // getSparkType is only used to get the from type for cast
-                doCast(col, getSparkType(col), dtype, false, false, false)
+                doCast(col, getSparkType(col), dtype)
               }
             }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -405,12 +405,12 @@ trait GpuDecimalMultiplyBase extends GpuExpression {
         lhs.getBase,
         lhs.dataType(),
         intermediateLhsType,
-        ArithmeticCastOptions(failOnError))
+        CastOptions.getArithmeticCastOptions(failOnError))
     }
     val ret = withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         GpuCast.doCast(rhs.getBase, rhs.dataType(), intermediateRhsType,
-          ArithmeticCastOptions(failOnError))
+          CastOptions.getArithmeticCastOptions(failOnError))
       }
       withResource(castRhs) { castRhs =>
         withResource(castLhs.mul(castRhs,
@@ -439,7 +439,7 @@ trait GpuDecimalMultiplyBase extends GpuExpression {
     }
     withResource(ret) { ret =>
       GpuColumnVector.from(GpuCast.doCast(ret, intermediateResultType, dataType,
-        ArithmeticCastOptions(failOnError)),
+        CastOptions.getArithmeticCastOptions(failOnError)),
         dataType)
     }
   }
@@ -858,14 +858,14 @@ trait GpuDecimalDivideBase extends GpuExpression {
         lhs.getBase,
         lhs.dataType(),
         intermediateLhsType,
-        ArithmeticCastOptions(failOnError))
+        CastOptions.getArithmeticCastOptions(failOnError))
 
     }
     val ret = withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
           GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType,
-            ArithmeticCastOptions(failOnError))
+            CastOptions.getArithmeticCastOptions(failOnError))
         }
       }
       withResource(castRhs) { castRhs =>
@@ -878,7 +878,7 @@ trait GpuDecimalDivideBase extends GpuExpression {
       // in the common case with us. It will also handle rounding the result to the final scale
       // to match what Spark does.
       GpuColumnVector.from(GpuCast.doCast(ret, intermediateResultType, dataType,
-        ArithmeticCastOptions(failOnError)),
+        CastOptions.getArithmeticCastOptions(failOnError)),
         dataType)
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -401,13 +401,16 @@ trait GpuDecimalMultiplyBase extends GpuExpression {
 
   def regularMultiply(batch: ColumnarBatch): GpuColumnVector = {
     val castLhs = withResource(left.columnarEval(batch)) { lhs =>
-      GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType, ansiMode = failOnError,
-        legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+      GpuCast.doCast(
+        lhs.getBase,
+        lhs.dataType(),
+        intermediateLhsType,
+        ArithmeticCastOptions(failOnError))
     }
     val ret = withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
-        GpuCast.doCast(rhs.getBase, rhs.dataType(), intermediateRhsType, ansiMode = failOnError,
-          legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+        GpuCast.doCast(rhs.getBase, rhs.dataType(), intermediateRhsType,
+          ArithmeticCastOptions(failOnError))
       }
       withResource(castRhs) { castRhs =>
         withResource(castLhs.mul(castRhs,
@@ -436,7 +439,7 @@ trait GpuDecimalMultiplyBase extends GpuExpression {
     }
     withResource(ret) { ret =>
       GpuColumnVector.from(GpuCast.doCast(ret, intermediateResultType, dataType,
-        ansiMode = failOnError, legacyCastToString = false, stringToDateAnsiModeEnabled = false),
+        ArithmeticCastOptions(failOnError)),
         dataType)
     }
   }
@@ -851,14 +854,18 @@ trait GpuDecimalDivideBase extends GpuExpression {
 
   def regularDivide(batch: ColumnarBatch): GpuColumnVector = {
     val castLhs = withResource(left.columnarEval(batch)) { lhs =>
-      GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType, ansiMode = failOnError,
-        legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+      GpuCast.doCast(
+        lhs.getBase,
+        lhs.dataType(),
+        intermediateLhsType,
+        ArithmeticCastOptions(failOnError))
+
     }
     val ret = withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
-          GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType, ansiMode = failOnError,
-            legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+          GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType,
+            ArithmeticCastOptions(failOnError))
         }
       }
       withResource(castRhs) { castRhs =>
@@ -871,7 +878,7 @@ trait GpuDecimalDivideBase extends GpuExpression {
       // in the common case with us. It will also handle rounding the result to the final scale
       // to match what Spark does.
       GpuColumnVector.from(GpuCast.doCast(ret, intermediateResultType, dataType,
-        ansiMode = failOnError, legacyCastToString = false, stringToDateAnsiModeEnabled = false),
+        ArithmeticCastOptions(failOnError)),
         dataType)
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -460,7 +460,7 @@ case class GpuSecondsToTimestamp(child: Expression) extends GpuNumberToTimestamp
       }
     case DoubleType | FloatType =>
       (input: GpuColumnVector) => {
-        GpuCast.doCast(input.getBase, input.dataType, TimestampType, false, false, false)
+        GpuCast.doCast(input.getBase, input.dataType, TimestampType)
       }
     case dt: DecimalType =>
       (input: GpuColumnVector) => {

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -343,13 +343,13 @@ case class GpuDecimalRemainder(left: Expression, right: Expression)
   private def regularRemainder(batch: ColumnarBatch): GpuColumnVector = {
     val castLhs = withResource(left.columnarEval(batch)) { lhs =>
       GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType,
-        ArithmeticCastOptions(failOnError))
+        CastOptions.getArithmeticCastOptions(failOnError))
     }
     withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
           GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType,
-            ArithmeticCastOptions(failOnError))
+            CastOptions.getArithmeticCastOptions(failOnError))
         }
       }
       withResource(castRhs) { castRhs =>

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -95,11 +95,11 @@ trait GpuAddSub extends CudfBinaryArithmetic {
             } else {
               // eval operands using the output precision
               val castLhs = withResource(left.columnarEval(batch)) { lhs =>
-                GpuCast.doCast(lhs.getBase(), leftInputType, resultType, false, false, false)
+                GpuCast.doCast(lhs.getBase(), leftInputType, resultType)
               }
               val castRhs = closeOnExcept(castLhs){ _ =>
                 withResource(right.columnarEval(batch)) { rhs =>
-                  GpuCast.doCast(rhs.getBase(), rightInputType, resultType, false, false, false)
+                  GpuCast.doCast(rhs.getBase(), rightInputType, resultType)
                 }
               }
 
@@ -342,14 +342,14 @@ case class GpuDecimalRemainder(left: Expression, right: Expression)
 
   private def regularRemainder(batch: ColumnarBatch): GpuColumnVector = {
     val castLhs = withResource(left.columnarEval(batch)) { lhs =>
-      GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType, ansiMode = failOnError,
-        legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+      GpuCast.doCast(lhs.getBase, lhs.dataType(), intermediateLhsType,
+        ArithmeticCastOptions(failOnError))
     }
     withResource(castLhs) { castLhs =>
       val castRhs = withResource(right.columnarEval(batch)) { rhs =>
         withResource(divByZeroFixes(rhs.getBase)) { fixed =>
-          GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType, ansiMode = failOnError,
-            legacyCastToString = false, stringToDateAnsiModeEnabled = false)
+          GpuCast.doCast(fixed, rhs.dataType(), intermediateRhsType,
+            ArithmeticCastOptions(failOnError))
         }
       }
       withResource(castRhs) { castRhs =>


### PR DESCRIPTION
This PR is addressing a problem where GpuCast is taking params as part of the `doCast` function but as we add more options as part of adding `GpuToPrettyString` the code gets messy 

The cast_test tests pass for Spark 311 and Spark 340. No new tests were added as there is no new functionality added

fixes #9284 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
