### PR TITLE
Allow checkpoint and restore on non-deterministic expressions in GpuFilter and GpuProject

### DIFF
--- a/dist/unshimmed-common-from-spark311.txt
+++ b/dist/unshimmed-common-from-spark311.txt
@@ -5,6 +5,7 @@ com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin*
 com/nvidia/spark/GpuCachedBatchSerializer*
 com/nvidia/spark/ParquetCachedBatchSerializer*
 com/nvidia/spark/RapidsUDF*
+com/nvidia/spark/Retryable*
 com/nvidia/spark/SQLPlugin*
 com/nvidia/spark/rapids/ColumnarRdd*
 com/nvidia/spark/rapids/GpuColumnVectorUtils*

--- a/sql-plugin/src/main/java/com/nvidia/spark/Retryable.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/Retryable.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark;
+
+/**
+ * An interface that can be used by Retry framework of RAPIDS Plugin to handle the GPU OOMs.
+ *
+ * GPU memory is a limited resource, so OOM can happen if too many tasks run in parallel.
+ * Retry framework is introduced to improve the stability by retrying the work when it
+ * meets OOMs. The overall process of Retry framework is similar as the below.
+ *    ```
+ *      Retryable retryable
+ *      retryable.checkpoint()
+ *      boolean hasOOM = false
+ *      do {
+ *        try {
+ *          runWorkOnGpu(retryable) // May lead to GPU OOM
+ *          hasOOM = false
+ *        } catch (OOMError oom) {
+ *          hasOOM = true
+ *          tryToReleaseSomeGpuMemoryFromLowPriorityTasks()
+ *          retryable.restore()
+ *        }
+ *      } while(hasOOM)
+ *    ```
+ * In a retry, "checkpoint" will be called first and only once, which is used to save the
+ * state for later loops. When OOM happens, "restore" will be called to restore the
+ * state that saved by "checkpoint". After that, it will try the same work again. And
+ * the whole process runs on Spark executors.
+ *
+ * Retry framework expects the "runWorkOnGpu" always outputs the same result when running
+ * it multiple times in a retry. So if "runWorkOnGpu" is non-deterministic, it can not be
+ * used by Retry framework.
+ * The "Retryable" is designed for this kind of cases. By implementing this interface,
+ * "runWorkOnGpu" can become deterministic inside a retry process, making it usable for
+ * Retry framework to improve the stability.
+ */
+public interface Retryable {
+  /**
+   * Save the state, so it can be restored in case of an OOM Retry.
+   * This is called inside a Spark task context on executors.
+   */
+  void checkpoint();
+
+  /**
+   * Restore the state that was saved by calling to "checkpoint".
+   * This is called inside a Spark task context on executors.
+   */
+  void restore();
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ColumnarOutputWriter.scala
@@ -21,6 +21,7 @@ import java.io.OutputStream
 import scala.collection.mutable
 
 import ai.rapids.cudf.{HostBufferConsumer, HostMemoryBuffer, NvtxColor, NvtxRange, TableWriter}
+import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRestoreOnRetry, withRetry, withRetryNoSplit}
@@ -186,7 +187,7 @@ abstract class ColumnarOutputWriter(context: TaskAttemptContext,
   /** Apply any necessary casts before writing batch out */
   def transformAndClose(cb: ColumnarBatch): ColumnarBatch = cb
 
-  private val checkpointRestore = new CheckpointRestore {
+  private val checkpointRestore = new Retryable {
     override def checkpoint(): Unit = ()
     override def restore(): Unit = dropBufferedData()
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -101,8 +101,6 @@ object GpuExpressionsUtils {
     expressions.flatMap { expr =>
       expr.collect {
         case r: Retryable => r
-        case udf: GpuUserDefinedFunction if udf.retryable && udf.selfNonDeterministic =>
-          udf.function.asInstanceOf[Retryable]
       }
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -187,6 +187,9 @@ trait GpuExpression extends Expression {
   /**
    * Whether an expression itself is non-deterministic when its "deterministic" is false,
    * no matter whether it has any non-deterministic children.
+   * An expression is actually a tree, and deterministic being false means there is at
+   * least one tree node is non-deterministic, but we need to know the exact nodes which
+   * are non-deterministic to check if it implements the Retryable.
    *
    * Default to false because Spark checks only children by default in Expression. So it
    * is non-deterministic iff it has non-deterministic children.
@@ -200,9 +203,6 @@ trait GpuExpression extends Expression {
    * An expression is retryable when
    *   - it is deterministic, or
    *   - when being non-deterministic, it is a Retryable and its children are all retryable.
-   *
-   * One exception is the UDF. The UDF expression will be retryable when its
-   * "function" is a Retryable, even itself is not a Retryable.
    */
   lazy val retryable: Boolean = deterministic || {
     val childrenAllRetryable = children.forall(_.asInstanceOf[GpuExpression].retryable)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
@@ -46,14 +46,6 @@ trait GpuUserDefinedFunction extends GpuExpression
 
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
   override val selfNonDeterministic: Boolean = !udfDeterministic
-  override lazy val retryable: Boolean = deterministic || {
-    val childrenAllRetryable = children.forall(_.asInstanceOf[GpuExpression].retryable)
-    if (selfNonDeterministic) {
-      function.isInstanceOf[Retryable] && childrenAllRetryable
-    } else {
-      childrenAllRetryable
-    }
-  }
 
   private[this] val nvtxRangeName = s"UDF: $name"
   private[this] lazy val funcCls = TrampolineUtil.getSimpleName(function.getClass)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuUserDefinedFunction.scala
@@ -17,7 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{HostColumnVector, HostColumnVectorCore, NvtxColor, NvtxRange}
-import com.nvidia.spark.{RapidsUDF, Retryable}
+import com.nvidia.spark.RapidsUDF
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.ShimExpression

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExpression.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 import ai.rapids.cudf
 import ai.rapids.cudf.{BinaryOp, ColumnVector, DType, GroupByScanAggregation, RollingAggregation, RollingAggregationOnColumn, Scalar, ScanAggregation}
+import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuOverrides.wrapExpr
 import com.nvidia.spark.rapids.shims.{GpuWindowUtil, ShimExpression}
@@ -814,7 +815,7 @@ trait GpuRunningWindowFunction extends GpuWindowFunction {
  * </code>
  * which can be output.
  */
-trait BatchedRunningWindowFixer extends AutoCloseable with CheckpointRestore {
+trait BatchedRunningWindowFixer extends AutoCloseable with Retryable {
   /**
    * Fix up `windowedColumnOutput` with any stored state from previous batches.
    * Like all window operations the input data will have been sorted by the partition

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/JoinGatherer.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{ColumnVector, ColumnView, DeviceMemoryBuffer, DType, GatherMap, NvtxColor, NvtxRange, OrderByArg, OutOfBoundsPolicy, Scalar, Table}
+import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 
 import org.apache.spark.TaskContext
@@ -34,7 +35,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
  * If the data is needed after `allowSpilling` is called the implementations should get the data
  * back and cache it again until allowSpilling is called once more.
  */
-trait LazySpillable extends AutoCloseable with CheckpointRestore {
+trait LazySpillable extends AutoCloseable with Retryable {
 
   /**
    * Indicate that we are done using the data for now and it can be spilled.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.rapids.catalyst.expressions
 
 import ai.rapids.cudf.{DType, HostColumnVector, NvtxColor, NvtxRange}
+import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids.{GpuColumnVector, GpuExpression, GpuLiteral}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.ShimUnaryExpression
@@ -27,11 +28,11 @@ import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression,
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.Utils
-import org.apache.spark.util.random.XORShiftRandom
+import org.apache.spark.util.random.rapids.RapidsXORShiftRandom
 
 /** Generate a random column with i.i.d. uniformly distributed values in [0, 1). */
 case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpression
-  with ExpectsInputTypes with ExpressionWithRandomSeed {
+  with ExpectsInputTypes with ExpressionWithRandomSeed with Retryable {
 
   def this() = this(GpuLiteral(Utils.random.nextLong(), LongType))
 
@@ -40,12 +41,13 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
   def seedExpression: Expression = child
 
   override lazy val deterministic: Boolean = false
+  override val selfNonDeterministic: Boolean = true
 
   /**
    * Record ID within each partition. By being transient, the Random Number Generator is
    * reset every time we serialize and deserialize and initialize it.
    */
-  @transient protected var rng: XORShiftRandom = _
+  @transient protected var rng: RapidsXORShiftRandom = _
 
   @transient protected lazy val seed: Long = child match {
     case GpuLiteral(s, IntegerType) => s.asInstanceOf[Int]
@@ -55,6 +57,9 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
   }
 
   @transient protected var previousPartition: Int = 0
+
+  @transient private var curXORShiftRandomSeed: Long = 0
+
   private def wasInitialized: Boolean = rng != null
 
   override def nullable: Boolean = false
@@ -64,17 +69,33 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
   override def inputTypes: Seq[AbstractDataType] = Seq(TypeCollection(IntegerType, LongType))
 
   override def columnarEval(batch: ColumnarBatch): GpuColumnVector = {
+    println(s"columnarEval for part ${TaskContext.getPartitionId()}")
+    assert(wasInitialized)
     withResource(new NvtxRange("GpuRand", NvtxColor.RED)) { _ =>
-      val partId = TaskContext.getPartitionId()
-      if (partId != previousPartition || !wasInitialized) {
-        rng = new XORShiftRandom(seed + partId)
-        previousPartition = partId
-      }
       val numRows = batch.numRows()
       withResource(HostColumnVector.builder(DType.FLOAT64, numRows)) { builder =>
         (0 until numRows).foreach(_ => builder.append(rng.nextDouble()))
         GpuColumnVector.from(builder.buildAndPutOnDevice(), dataType)
       }
     }
+  }
+
+  override def checkpoint(): Unit = {
+    // In a task, checkpoint is called before columnarEval, so init the random
+    // generator here.
+    val partId = TaskContext.getPartitionId()
+    println(s"====> checkpoint for part $partId, inited ? $wasInitialized," +
+      s" previous part: $previousPartition")
+    if (partId != previousPartition || !wasInitialized) {
+      rng = new RapidsXORShiftRandom(seed + partId)
+      previousPartition = partId
+    }
+    curXORShiftRandomSeed = rng.currentSeed
+  }
+
+  override def restore(): Unit = {
+    println(s"restore for part ${TaskContext.getPartitionId()}")
+    assert(wasInitialized)
+    rng.setHashedSeed(curXORShiftRandomSeed)
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuPythonUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuPythonUDF.scala
@@ -68,6 +68,7 @@ abstract class GpuPythonFunction(
     with UserDefinedExpression with GpuAggregateWindowFunction with Serializable {
 
   override lazy val deterministic: Boolean = udfDeterministic && children.forall(_.deterministic)
+  override val selfNonDeterministic: Boolean = !udfDeterministic
 
   override def toString: String = s"$name(${children.mkString(", ")})"
 

--- a/sql-plugin/src/main/scala/org/apache/spark/util/random/rapids/XORShiftRandom.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/util/random/rapids/XORShiftRandom.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.random.rapids
+
+import org.apache.spark.util.random.XORShiftRandom
+
+/** RAPIDS version of the Spark XORShiftRandom providing access to the internal seed. */
+class RapidsXORShiftRandom(init: Long) extends XORShiftRandom(init) {
+
+  private var curSeed = XORShiftRandom.hashSeed(init)
+
+  // Only override "next", since it will be called by other nextXXX.
+  override protected def next(bits: Int): Int = {
+    var nextSeed = curSeed ^ (curSeed << 21)
+    nextSeed ^= (nextSeed >>> 35)
+    nextSeed ^= (nextSeed << 4)
+    curSeed = nextSeed
+    (nextSeed & ((1L << bits) - 1)).asInstanceOf[Int]
+  }
+
+  override def setSeed(s: Long): Unit = {
+    curSeed = XORShiftRandom.hashSeed(s)
+  }
+
+  /* Set the hashed seed directly. (Not thread-safe) */
+  def setHashedSeed(hashedSeed: Long): Unit = {
+    curSeed = hashedSeed
+  }
+
+  /* Get the current internal seed. (Not thread-safe) */
+  def currentSeed: Long = curSeed
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/NonDeterministicRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/NonDeterministicRetrySuite.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.jni.RmmSpark
+
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, NamedExpression}
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
 import org.apache.spark.sql.types.IntegerType

--- a/tests/src/test/scala/com/nvidia/spark/rapids/NonDeterministicRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/NonDeterministicRetrySuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.ColumnVector
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.jni.RmmSpark
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, NamedExpression}
+import org.apache.spark.sql.rapids.catalyst.expressions.GpuRand
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class NonDeterministicRetrySuite extends RmmSparkRetrySuiteBase {
+  private val NUM_ROWS = 500
+  private val RAND_SEED = 10
+
+  private def buildBatch(ints: Seq[Int] = 0 until NUM_ROWS): ColumnarBatch = {
+    new ColumnarBatch(
+      Array(GpuColumnVector.from(ColumnVector.fromInts(ints: _*), IntegerType)), ints.length)
+  }
+
+  test("GPU rand outputs the same sequence with checkpoint and restore") {
+    val gpuRand = GpuRand(GpuLiteral(RAND_SEED, IntegerType))
+    withResource(buildBatch()) { inputCB =>
+      // checkpoint the state
+      gpuRand.checkpoint()
+      val randHCol1 = withResource(gpuRand.columnarEval(inputCB)) { randCol1 =>
+        randCol1.copyToHost()
+      }
+      withResource(randHCol1) { _ =>
+        // store the state, and generate data again
+        gpuRand.restore()
+        val randHCol2 = withResource(gpuRand.columnarEval(inputCB)) { randCol2 =>
+          randCol2.copyToHost()
+        }
+        withResource(randHCol2) { _ =>
+          // check the two random columns are equal.
+          assert(randHCol1.getRowCount.toInt == NUM_ROWS)
+          assert(randHCol1.getRowCount == randHCol2.getRowCount)
+          (0 until randHCol1.getRowCount.toInt).foreach { pos =>
+            assert(randHCol1.getDouble(pos) == randHCol2.getDouble(pos))
+          }
+        }
+      }
+    }
+  }
+
+  test("GPU project retry with GPU rand") {
+    val childOutput = Seq(AttributeReference("int", IntegerType)(NamedExpression.newExprId))
+    val projectRandOnly = Seq(
+      GpuAlias(GpuRand(GpuLiteral(RAND_SEED)), "rand")(NamedExpression.newExprId))
+    val projectList = projectRandOnly ++ childOutput
+    Seq(true, false).foreach { useTieredProject =>
+      // expression should be retryable
+      val randOnlyProjectList = GpuBindReferences.bindGpuReferencesTiered(projectRandOnly,
+        childOutput, useTieredProject)
+      assert(randOnlyProjectList.areAllRetryable)
+      val boundProjectList = GpuBindReferences.bindGpuReferencesTiered(projectList,
+        childOutput, useTieredProject)
+      assert(boundProjectList.areAllRetryable)
+
+      // project with retry
+      val sb = closeOnExcept(buildBatch()) { cb =>
+        SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
+      }
+      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+      withResource(boundProjectList.projectAndCloseWithRetrySingleBatch(sb)) { outCB =>
+        // We can not verify the data, so only rows number here
+        assertResult(NUM_ROWS)(outCB.numRows())
+      }
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WithRetrySuite.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids
 
 import ai.rapids.cudf.{Rmm, RmmAllocationMode, RmmEventHandler, Table}
+import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitTargetSizeInHalf, withRestoreOnRetry, withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
@@ -297,7 +298,7 @@ class WithRetrySuite
       false
     }
   }
-  private class SimpleCheckpointRestore(var value:Int) extends CheckpointRestore {
+  private class SimpleCheckpointRestore(var value:Int) extends Retryable {
     private var lastValue:Int = value
     def setValue(newVal: Int) = {
       value = newVal


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/7865

This PR is to support `checkpoint` and `restore` on non-deterministic expressions in `GpuFilter` and `GpuProject`.

- Introduce a new interface named `Retryable` in Java to supprt Java UDF in the future for end users. A non-deterministic expression can implement this interface to make it retryable.
- Introduce a new class named `RapidsXORShiftRandom` to provide access to the internal hashed seed. This is used by `GpuRand` to implement the `Retryable` interface.
- Removed the useless `CheckpointRestore` trait, replaced by the new `Retryable` interface.
- Update `GpuRand` to support `checkpoint` and `restore`.
- Introduce two new memebers in `GpuExpression`, they are `selfNonDeterministic` and `retryable`. `retryable` is used to tell whether an expression is retryable. It will cover its children. While `selfNonDeterministic` indicates whether an expression itself is non-deterministic when its "deterministic" is false, excluding its children. An expression is actually a tree, and `deterministic` being false means there is at least one tree node is non-deterministic, but we need to know the exact nodes which are non-deterministic to check if it implements the `Retryable`. So `selfNonDeterministic` is created.

TODO
- [x] add tests


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
