### PR TITLE
Fix RMM crash in FileCacheIntegrationSuite with ARENA memory allocator

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/filecache/FileCacheIntegrationSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/filecache/FileCacheIntegrationSuite.scala
@@ -16,33 +16,21 @@
 
 package org.apache.spark.sql.rapids.filecache
 
-import com.nvidia.spark.rapids.{RapidsBufferCatalog, RapidsDeviceMemoryStore, SparkQueryCompareTestSuite}
+import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
 import com.nvidia.spark.rapids.shims.GpuBatchScanExec
-import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.rapids.GpuFileSourceScanExec
 
-class FileCacheIntegrationSuite extends SparkQueryCompareTestSuite with BeforeAndAfterEach {
+class FileCacheIntegrationSuite extends SparkQueryCompareTestSuite {
   import com.nvidia.spark.rapids.GpuMetric._
 
   private val FILE_SPLITS_PARQUET = "file-splits.parquet"
   private val FILE_SPLITS_ORC = "file-splits.orc"
   private val MAP_OF_STRINGS_PARQUET = "map_of_strings.snappy.parquet"
   private val SCHEMA_CANT_PRUNE_ORC = "schema-cant-prune.orc"
-
-  override def beforeEach(): Unit = {
-    val deviceStorage = new RapidsDeviceMemoryStore()
-    val catalog = new RapidsBufferCatalog(deviceStorage)
-    RapidsBufferCatalog.setDeviceStorage(deviceStorage)
-    RapidsBufferCatalog.setCatalog(catalog)
-  }
-
-  override def afterEach(): Unit = {
-    RapidsBufferCatalog.close()
-  }
 
   def isFileCacheEnabled(conf: SparkConf): Boolean = {
     // File cache only supported on Spark 3.2+


### PR DESCRIPTION
This reverts the FileCacheIntegrationSuite change added in #8667 which was causing a crash in RMM with the ARENA memory allocator.