### PR TITLE
Building different Cuda versions section profile does not take effect [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,8 @@ specifying the environment variable `BUILD_PARALLEL=<n>`.
 ### Building against different CUDA Toolkit versions
 
 You can build against different versions of the CUDA Toolkit by modifying the variable `cuda.version`:
-* `-Dcuda.version=cuda11` (CUDA 11.0/11.1/11.2, default)
+* `-Dcuda.version=cuda11` (CUDA 11.x, default)
+* `-Dcuda.version=cuda12` (CUDA 12.x)
 
 ### Building a Distribution for a Single Spark Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,8 @@ specifying the environment variable `BUILD_PARALLEL=<n>`.
 
 ### Building against different CUDA Toolkit versions
 
-You can build against different versions of the CUDA Toolkit by using one of the following profiles:
-* `-Pcuda11` (CUDA 11.0/11.1/11.2, default)
+You can build against different versions of the CUDA Toolkit by modifying the variable `cuda.version`:
+* `-Dcuda.version=cuda11` (CUDA 11.0/11.1/11.2, default)
 
 ### Building a Distribution for a Single Spark Release
 


### PR DESCRIPTION
Fixes #9327 
No unit tests needed as it is a minor doc change.

I have one question regarding this change , whether we did intend having or had cuda versions as profiles in maven pom settings and if that is preferred over current change? CC: @gerashegalov 

