### PR TITLE
Put back in full decimal support for format_number

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -803,7 +803,8 @@ format_number_gens = integral_gens + [DecimalGen(precision=7, scale=7), DecimalG
                                       DecimalGen(precision=36, scale=-5), DecimalGen(precision=38, scale=10), 
                                       DecimalGen(precision=38, scale=-10), 
                                       DecimalGen(precision=38, scale=30, special_cases=[Decimal('0.000125')]),
-                                      DecimalGen(precision=38, scale=32, special_cases=[Decimal('0.000125')])]
+                                      DecimalGen(precision=38, scale=32, special_cases=[Decimal('0.000125')]),
+                                      DecimalGen(precision=38, scale=37, special_cases=[Decimal('0.000125')])]
 
 @pytest.mark.parametrize('data_gen', format_number_gens, ids=idfn)
 def test_format_number_supported(data_gen):
@@ -815,6 +816,8 @@ def test_format_number_supported(data_gen):
             'format_number(a, 1)',
             'format_number(a, 5)',
             'format_number(a, 10)',
+            'format_number(a, 13)',
+            'format_number(a, 30)',
             'format_number(a, 100)')
     )
 
@@ -835,17 +838,6 @@ def test_format_number_float_limited(data_gen):
 @allow_non_gpu('ProjectExec')
 @pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
 def test_format_number_float_fallback(data_gen):
-    assert_gpu_fallback_collect(
-        lambda spark: unary_op_df(spark, data_gen).selectExpr(
-            'format_number(a, 5)'),
-        'FormatNumber'
-    )
-
-# fallback due to https://github.com/NVIDIA/spark-rapids/issues/9309
-@allow_non_gpu('ProjectExec')
-@pytest.mark.parametrize('data_gen', [float_gen, double_gen], ids=idfn)
-def test_format_number_decimal_big_scale_fallback(data_gen):
-    data_gen = DecimalGen(precision=38, scale=37) 
     assert_gpu_fallback_collect(
         lambda spark: unary_op_df(spark, data_gen).selectExpr(
             'format_number(a, 5)'),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3093,20 +3093,11 @@ object GpuOverrides extends Logging {
       (in, conf, p, r) => new BinaryExprMeta[FormatNumber](in, conf, p, r) {
         override def tagExprForGpu(): Unit = {
           in.children.head.dataType match {
-            case _: FloatType | DoubleType => {
-              if (!conf.isFloatFormatNumberEnabled) {
-                willNotWorkOnGpu("format_number with floating point types on the GPU returns " +
+            case FloatType | DoubleType if !conf.isFloatFormatNumberEnabled =>
+              willNotWorkOnGpu("format_number with floating point types on the GPU returns " +
                   "results that have a different precision than the default results of Spark. " +
                   "To enable this operation on the GPU, set" +
                   s" ${RapidsConf.ENABLE_FLOAT_FORMAT_NUMBER} to true.")
-              }
-            }
-            case dt: DecimalType => {
-              if (dt.scale > 32) {
-                willNotWorkOnGpu("format_number will generate results mismatched from Spark " +
-                  "when the scale is larger than 32.")
-              }
-            }
             case _ =>
           }
         }


### PR DESCRIPTION
This is dependent on https://github.com/rapidsai/cudf/pull/14233

This fixes https://github.com/NVIDIA/spark-rapids/issues/9309

or at least opens up format_number after CUDF actually fixed the issue.