### PR TITLE
Improve JSON empty row fix to use less memory

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -37,7 +37,7 @@ case class GpuJsonToStructs(
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
       case struct: StructType if struct.fields.nonEmpty =>
-        s"{${escapeFieldName(struct.head.name)}:null}"
+        s"{\"${escapeFieldName(struct.head.name)}\":null}"
       case other =>
         throw new IllegalArgumentException(s"$other is not supported as a top level type")    }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -23,6 +23,7 @@ import com.nvidia.spark.rapids.GpuCast.doCast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.MapUtils
 
+import org.apache.commons.text.StringEscapeUtils
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant, TimeZoneAwareExpression}
 import org.apache.spark.sql.types._
 
@@ -37,12 +38,10 @@ case class GpuJsonToStructs(
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
       case struct: StructType if struct.fields.nonEmpty =>
-        s"""{"${escapeFieldName(struct.head.name)}":null}"""
+        s"""{"${StringEscapeUtils.escapeJson(struct.head.name)}":null}"""
       case other =>
         throw new IllegalArgumentException(s"$other is not supported as a top level type")    }
   }
-
-  private def escapeFieldName(fieldName: String): String = fieldName.replace("\"", "\\\"")
 
   lazy val emptyRowStr = constructEmptyRow(schema)
   

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -22,8 +22,8 @@ import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuCast.doCast
 import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
 import com.nvidia.spark.rapids.jni.MapUtils
-
 import org.apache.commons.text.StringEscapeUtils
+
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, NullIntolerant, TimeZoneAwareExpression}
 import org.apache.spark.sql.types._
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -37,7 +37,7 @@ case class GpuJsonToStructs(
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
       case struct: StructType if struct.fields.nonEmpty =>
-        s"${escapeFieldName(struct.head.name)}:null"
+        s"{${escapeFieldName(struct.head.name)}:null}"
       case other =>
         throw new IllegalArgumentException(s"$other is not supported as a top level type")    }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -37,7 +37,7 @@ case class GpuJsonToStructs(
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
       case struct: StructType if struct.fields.nonEmpty =>
-        s"{\"${escapeFieldName(struct.head.name)}\":null}"
+        s"""{"${escapeFieldName(struct.head.name)}":null}"""
       case other =>
         throw new IllegalArgumentException(s"$other is not supported as a top level type")    }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -36,23 +36,13 @@ case class GpuJsonToStructs(
 
   private def constructEmptyRow(schema: DataType): String = {
     schema match {
-      case struct: StructType if (struct.fields.length > 0) => {
-        val jsonFields: Array[String] = struct.fields.map { field => 
-          field.dataType match {
-            case IntegerType => s""""${field.name}": 0"""
-            case StringType => s""""${field.name}": """""
-            case s: StructType => s""""${field.name}": ${constructEmptyRow(s)}"""
-            case a: ArrayType => s""""${field.name}": ${constructEmptyRow(a)}"""
-            case t => throw new IllegalArgumentException("GpuJsonToStructs currently" +
-              s"does not support input schema with type $t.")
-          }
-        }
-        jsonFields.mkString("{", ", ", "}")
-      }
-      case array: ArrayType => s"[${constructEmptyRow(array.elementType)}]"
-      case _ => "{}"
-    }
+      case struct: StructType if struct.fields.nonEmpty =>
+        s"${escapeFieldName(struct.head.name)}:null"
+      case other =>
+        throw new IllegalArgumentException(s"$other is not supported as a top level type")    }
   }
+
+  private def escapeFieldName(fieldName: String): String = fieldName.replace("\"", "\\\"")
 
   lazy val emptyRowStr = constructEmptyRow(schema)
   


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/8542

Change representation of empty JSON row to just specify a single column instead of specifying all columns in the schema.

This reduces memory overhead without affecting the functionality.