### PR TITLE
Add developer documentation about working with data sources [skip ci]

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -13,6 +13,7 @@ following topics:
   * [How Spark Executes the Physical Plan](#how-spark-executes-the-physical-plan)
 * [How the Plugin Works](#how-the-rapids-plugin-works)
   * [Plugin Replacement Rules](#plugin-replacement-rules)
+  * [Working with Data Sources](#working-with-data-sources)
 * [Guidelines for Replacing Catalyst Executors and Expressions](#guidelines-for-replacing-catalyst-executors-and-expressions)
   * [Setting Up the Class](#setting-up-the-class)
   * [Expressions](#expressions)
@@ -130,6 +131,11 @@ executor, expression, etc.), and applying the rule that matches.  See the
 
 There is a separate guide for working with
 [Adaptive Query Execution](adaptive-query.md).
+
+### Working with Data Sources
+
+The plugin supports v1 and v2 data sources for file formats such as CSV,
+Orc, JSON, and Parquet. See the [data source guide](data-sources.md) for more information.
 
 ## Guidelines for Replacing Catalyst Executors and Expressions
 Most development work in the plugin involves translating various Catalyst

--- a/docs/dev/data-sources.md
+++ b/docs/dev/data-sources.md
@@ -1,3 +1,10 @@
+---
+layout: page
+title: Working with Spark Data Sources
+nav_order: 2
+parent: Developer Overview
+---
+
 # Working with Spark Data Sources
 
 ## Data Source API Versions

--- a/docs/dev/data-sources.md
+++ b/docs/dev/data-sources.md
@@ -1,0 +1,61 @@
+# Working with Spark Data Sources
+
+## Data Source API Versions
+
+Spark has two major versions of its data source APIs, simply known as "v1" and "v2". There is a configuration
+property `spark.sql.sources.useV1SourceList` which determines which API version is used when reading from data
+sources such as CSV, Orc, and Parquet. The default value for this configuration option (as of Spark 3.4.0)
+is `"avro,csv,json,kafka,orc,parquet,text"`, meaning that all of these data sources fall back to v1 by default.
+
+When using Spark SQL (including the DataFrame API), the representation of a read in the physical plan will be
+different depending on the API version being used, and in the plugin we therefore have different code paths
+for tagging and replacing these operations.
+
+## V1 API
+
+In the v1 API, a read from a file-based data source is represented by a `FileSourceScanExec`, which wraps
+a `HadoopFsRelation`.
+
+`HadoopFsRelation` is an important component in Apache Spark. It represents a relation based on data stored in the
+Hadoop FileSystem. When we talk about the Hadoop FileSystem in this context, it encompasses various distributed
+storage systems that are Hadoop-compatible, such as HDFS (Hadoop Distributed FileSystem), Amazon S3, and others.
+
+`HadoopFsRelation` is not tied to a specific file format. Instead, it relies on implementations of the `FileFormat`
+interface to read and write data.
+
+This means that various file formats like CSV, Parquet, and ORC can have their implementations of the `FileFormat`
+interface, and `HadoopFsRelation` will be able to work with any of them.
+
+When overriding `FileSourceScanExec` in the plugin, there are a number of different places where tagging code can be
+placed, depending on the file format. We start in GpuOverrides with a map entry `GpuOverrides.exec[FileSourceScanExec]`,
+and then the hierarchical flow is typically as follows, although it may vary between shim versions:
+
+```
+FileSourceScanExecMeta.tagPlanForGpu
+  ScanExecShims.tagGpuFileSourceScanExecSupport
+    GpuFileSourceScanExec.tagSupport
+```
+
+`GpuFileSourceScanExec.tagSupport` will inspect the `FileFormat` and then call into one of the following:
+
+- `GpuReadCSVFileFormat.tagSupport`, which calls `GpuCSVScan.tagSupport`
+- `GpuReadOrcFileFormat.tagSupport`, which calls `GpuOrcScan.tagSupport`
+- `GpuReadParquetFileFormat.tagSupport`, which calls `GpuParquetScan.tagSupport`
+
+The classes `GpuCSVScan`, `GpuParquetScan`, `GpuOrcScan`, and `GpuJsonScan` are also called
+from the v2 API, so this is a good place to put code that is not specific to either API
+version. These scan classes also call into `FileFormatChecks.tag`.
+
+## v2 API
+
+When using the v2 API, the physical plan will contain a `BatchScanExec`, which wraps a scan that implements
+the `org.apache.spark.sql.connector.read.Scan` trait. The scan implementations include `CsvScan`, `ParquetScan`,
+and `OrcScan`. These are the same scan implementations used in the v1 API, and the plugin tagging code can be
+placed in one of the following methods:
+
+- `GpuCSVScan.tagSupport`
+- `GpuOrcScan.tagSupport`
+- `GpuParquetScan.tagSupport`
+
+When overriding v2 operators in the plugin, we can override both `BatchScanExec` and the individual scans, such
+as `CsvScanExec`.

--- a/docs/dev/data-sources.md
+++ b/docs/dev/data-sources.md
@@ -53,7 +53,7 @@ The classes `GpuCSVScan`, `GpuParquetScan`, `GpuOrcScan`, and `GpuJsonScan` are 
 from the v2 API, so this is a good place to put code that is not specific to either API
 version. These scan classes also call into `FileFormatChecks.tag`.
 
-## v2 API
+## V2 API
 
 When using the v2 API, the physical plan will contain a `BatchScanExec`, which wraps a scan that implements
 the `org.apache.spark.sql.connector.read.Scan` trait. The scan implementations include `CsvScan`, `ParquetScan`,


### PR DESCRIPTION
This PR adds some developer documentation about working with v1 and v2 data sources in the plugin. I sometimes forget where everything is and what the code paths are, so this would help me in the future.