### PR TITLE
Adding BUFFER_TIME for ORC multifile reader

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -2067,7 +2067,9 @@ class MultiFileCloudOrcPartitionReader(
               while (blockChunkIter.hasNext) {
                 val blocksToRead = populateCurrentBlockChunk(blockChunkIter, maxReadBatchSizeRows,
                   maxReadBatchSizeBytes)
-                val (hostBuf, bufSize) = readPartFile(ctx, blocksToRead)
+                val (hostBuf, bufSize) = metrics(BUFFER_TIME).ns {
+                  readPartFile(ctx, blocksToRead)
+                }
                 val numRows = blocksToRead.map(_.infoBuilder.getNumberOfRows).sum
                 val metas = blocksToRead.map(b => OrcDataStripe(OrcStripeWithMeta(b, ctx)))
                 hostBuffers += SingleHMBAndMeta(hostBuf, bufSize, numRows, metas)


### PR DESCRIPTION
Closes #9210

BUFFER_TIME wasn't being logged for the multifile ORC reader path so it caused confusion with readFsTime > bufferTime
