### PR TITLE
Remove using mamba before they fix the incompatibility issue [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -45,8 +45,9 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda init && \
-    conda config --set solver libmamba
+RUN conda init
+# TODO: re-enable mamba solver after https://github.com/NVIDIA/spark-rapids/issues/9393
+# conda config --set solver libmamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -57,8 +57,9 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm -f ~/miniconda.sh
 ENV PATH="/opt/conda/bin:$MAVEN_HOME/bin:${PATH}"
-RUN conda init && \
-    conda config --set solver libmamba
+RUN conda init
+# TODO: re-enable mamba solver after https://github.com/NVIDIA/spark-rapids/issues/9393
+# conda config --set solver libmamba
 
 # 'pyarrow' and 'pandas' will be installed as the dependencies of cudf below
 RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \


### PR DESCRIPTION
workaround before https://github.com/NVIDIA/spark-rapids/issues/9393 is resolved

currently, the nightly image build fails 100% while building integration images due to the incompatible libarchive issue with mamba when enable non-default channel, and we did not find any easy way to continue resolving the issue (it requires to keep binding pkgs to specific versions, but it would fail again if conda/mamba did any upgrade)

Verified disabling mamba would solve the issue (increase ~5-10 mins building time)