### PR TITLE
Add support for AtomicCreateTableAsSelect with Delta Lake [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalogBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalogBase.scala
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import java.util
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import com.databricks.sql.transaction.tahoe.{DeltaErrors, DeltaLog, DeltaOptions}
+import com.databricks.sql.transaction.tahoe.catalog.BucketTransform
+import com.databricks.sql.transaction.tahoe.commands.{TableCreationModes, WriteIntoDelta}
+import com.databricks.sql.transaction.tahoe.sources.{DeltaSourceUtils, DeltaSQLConf}
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, V1Write, WriteBuilder}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.InsertableRelation
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+trait GpuDeltaCatalogBase extends StagingTableCatalog {
+  val spark: SparkSession = SparkSession.active
+
+  val cpuCatalog: StagingTableCatalog
+
+  val rapidsConf: RapidsConf
+
+  protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand
+
+  protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable]
+
+  protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable
+
+  protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  protected def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode): Table = {
+    // These two keys are tableProperties in data source v2 but not in v1, so we have to filter
+    // them out. Otherwise property consistency checks will fail.
+    val tableProperties = allTableProperties.asScala.filterKeys {
+      case TableCatalog.PROP_LOCATION => false
+      case TableCatalog.PROP_PROVIDER => false
+      case TableCatalog.PROP_COMMENT => false
+      case TableCatalog.PROP_OWNER => false
+      case TableCatalog.PROP_EXTERNAL => false
+      case "path" => false
+      case "option.path" => false
+      case _ => true
+    }.toMap
+    val (partitionColumns, maybeBucketSpec) = convertTransforms(partitions)
+    val newSchema = schema
+    val newPartitionColumns = partitionColumns
+    val newBucketSpec = maybeBucketSpec
+    val conf = spark.sessionState.conf
+
+    val isByPath = isPathIdentifier(ident)
+    if (isByPath && !conf.getConf(DeltaSQLConf.DELTA_LEGACY_ALLOW_AMBIGUOUS_PATHS)
+      && allTableProperties.containsKey("location")
+      // The location property can be qualified and different from the path in the identifier, so
+      // we check `endsWith` here.
+      && Option(allTableProperties.get("location")).exists(!_.endsWith(ident.name()))
+    ) {
+      throw DeltaErrors.ambiguousPathsInCreateTableException(
+        ident.name(), allTableProperties.get("location"))
+    }
+    val location = if (isByPath) {
+      Option(ident.name())
+    } else {
+      Option(allTableProperties.get("location"))
+    }
+    val id = {
+      TableIdentifier(ident.name(), ident.namespace().lastOption)
+    }
+    val locUriOpt = location.map(CatalogUtils.stringToURI)
+    val existingTableOpt = getExistingTableIfExists(id)
+    val loc = locUriOpt
+      .orElse(existingTableOpt.flatMap(_.storage.locationUri))
+      .getOrElse(spark.sessionState.catalog.defaultTablePath(id))
+    val storage = DataSource.buildStorageFormatFromOptions(writeOptions)
+      .copy(locationUri = Option(loc))
+    val tableType =
+      if (location.isDefined) CatalogTableType.EXTERNAL else CatalogTableType.MANAGED
+    val commentOpt = Option(allTableProperties.get("comment"))
+
+
+    val tableDesc = new CatalogTable(
+      identifier = id,
+      tableType = tableType,
+      storage = storage,
+      schema = newSchema,
+      provider = Some(DeltaSourceUtils.ALT_NAME),
+      partitionColumnNames = newPartitionColumns,
+      bucketSpec = newBucketSpec,
+      properties = tableProperties,
+      comment = commentOpt
+    )
+
+    val withDb = verifyTableAndSolidify(tableDesc, None)
+
+    val writer = sourceQuery.map { df =>
+      WriteIntoDelta(
+        DeltaLog.forTable(spark, new Path(loc)),
+        operation.mode,
+        new DeltaOptions(withDb.storage.properties, spark.sessionState.conf),
+        withDb.partitionColumnNames,
+        withDb.properties ++ commentOpt.map("comment" -> _),
+        df,
+        schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
+    }
+
+    val gpuCreateTableCommand = buildGpuCreateDeltaTableCommand(
+      rapidsConf,
+      withDb,
+      existingTableOpt,
+      operation.mode,
+      writer,
+      operation,
+      tableByPath = isByPath)
+    gpuCreateTableCommand.run(spark)
+
+    cpuCatalog.loadTable(ident)
+  }
+
+  override def loadTable(ident: Identifier): Table = cpuCatalog.loadTable(ident)
+
+  private def getProvider(properties: util.Map[String, String]): String = {
+    Option(properties.get("provider"))
+      .getOrElse(spark.sessionState.conf.getConf(SQLConf.DEFAULT_DATA_SOURCE_NAME))
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createDeltaTable(
+        ident,
+        schema,
+        partitions,
+        properties,
+        Map.empty,
+        sourceQuery = None,
+        TableCreationModes.Create
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.Replace
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.CreateOrReplace
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.Create
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  // Copy of V2SessionCatalog.convertTransforms, which is private.
+  private def convertTransforms(partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
+    val identityCols = new mutable.ArrayBuffer[String]
+    var bucketSpec = Option.empty[BucketSpec]
+
+    partitions.map {
+      case IdentityTransform(FieldReference(Seq(col))) =>
+        identityCols += col
+
+      case BucketTransform(numBuckets, bucketCols, sortCols) =>
+        bucketSpec = Some(BucketSpec(
+          numBuckets, bucketCols.map(_.fieldNames.head), sortCols.map(_.fieldNames.head)))
+
+      case _ =>
+        throw DeltaErrors.operationNotSupportedException(s"Partitioning by expressions")
+    }
+
+    (identityCols.toSeq, bucketSpec)
+  }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2(
+      ident: Identifier,
+      override val schema: StructType,
+      val partitions: Array[Transform],
+      override val properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode
+  ) extends StagedTable with SupportsWrite {
+
+    private var asSelectQuery: Option[DataFrame] = None
+    private var writeOptions: Map[String, String] = Map.empty
+
+    override def partitioning(): Array[Transform] = partitions
+
+    override def commitStagedChanges(): Unit = {
+      val conf = spark.sessionState.conf
+      val props = new util.HashMap[String, String]()
+      // Options passed in through the SQL API will show up both with an "option." prefix and
+      // without in Spark 3.1, so we need to remove those from the properties
+      val optionsThroughProperties = properties.asScala.collect {
+        case (k, _) if k.startsWith("option.") => k.stripPrefix("option.")
+      }.toSet
+      val sqlWriteOptions = new util.HashMap[String, String]()
+      properties.asScala.foreach { case (k, v) =>
+        if (!k.startsWith("option.") && !optionsThroughProperties.contains(k)) {
+          // Do not add to properties
+          props.put(k, v)
+        } else if (optionsThroughProperties.contains(k)) {
+          sqlWriteOptions.put(k, v)
+        }
+      }
+      if (writeOptions.isEmpty && !sqlWriteOptions.isEmpty) {
+        writeOptions = sqlWriteOptions.asScala.toMap
+      }
+      if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+        // Legacy behavior
+        writeOptions.foreach { case (k, v) => props.put(k, v) }
+      } else {
+        writeOptions.foreach { case (k, v) =>
+          // Continue putting in Delta prefixed options to avoid breaking workloads
+          if (k.toLowerCase(Locale.ROOT).startsWith("delta.")) {
+            props.put(k, v)
+          }
+        }
+      }
+      createDeltaTable(
+        ident,
+        schema,
+        partitions,
+        props,
+        writeOptions,
+        asSelectQuery,
+        operation
+      )
+    }
+
+    override def name(): String = ident.name()
+
+    override def abortStagedChanges(): Unit = {}
+
+    override def capabilities(): util.Set[TableCapability] = Set(V1_BATCH_WRITE).asJava
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+      writeOptions = info.options.asCaseSensitiveMap().asScala.toMap
+      new DeltaV1WriteBuilder
+    }
+
+    /*
+     * WriteBuilder for creating a Delta table.
+     */
+    private class DeltaV1WriteBuilder extends WriteBuilder {
+      override def build(): V1Write = new V1Write {
+        override def toInsertableRelation(): InsertableRelation = {
+          new InsertableRelation {
+            override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+              asSelectQuery = Option(data)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    cpuCatalog.alterTable(ident, changes: _*)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = cpuCatalog.dropTable(ident)
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    cpuCatalog.renameTable(oldIdent, newIdent)
+  }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    throw new IllegalStateException("should not be called")
+  }
+
+  override def tableExists(ident: Identifier): Boolean = cpuCatalog.tableExists(ident)
+
+  override def initialize(s: String, caseInsensitiveStringMap: CaseInsensitiveStringMap): Unit = {
+    throw new IllegalStateException("should not be called")
+  }
+
+  override def name(): String = cpuCatalog.name()
+
+  private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
+
+  private def hasDeltaNamespace(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 && DeltaSourceUtils.isDeltaDataSourceName(ident.namespace().head)
+  }
+
+  private def isPathIdentifier(ident: Identifier): Boolean = {
+    // Should be a simple check of a special PathIdentifier class in the future
+    try {
+      supportSQLOnFile && hasDeltaNamespace(ident) && new Path(ident.name()).isAbsolute
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+  }
+}
+
+
+/**
+ * A trait for handling table access through delta.`/some/path`. This is a stop-gap solution
+ * until PathIdentifiers are implemented in Apache Spark.
+ */
+trait SupportsPathIdentifier extends TableCatalog { self: GpuDeltaCatalogBase =>
+
+  private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
+
+  protected lazy val catalog: SessionCatalog = spark.sessionState.catalog
+
+  private def hasDeltaNamespace(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 && DeltaSourceUtils.isDeltaDataSourceName(ident.namespace().head)
+  }
+
+  protected def isPathIdentifier(ident: Identifier): Boolean = {
+    // Should be a simple check of a special PathIdentifier class in the future
+    try {
+      supportSQLOnFile && hasDeltaNamespace(ident) && new Path(ident.name()).isAbsolute
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+  }
+
+  protected def isPathIdentifier(table: CatalogTable): Boolean = {
+    isPathIdentifier(table.identifier)
+  }
+
+  protected def isPathIdentifier(tableIdentifier: TableIdentifier) : Boolean = {
+    isPathIdentifier(Identifier.of(tableIdentifier.database.toArray, tableIdentifier.table))
+  }
+}

--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaLog.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaLog.scala
@@ -18,6 +18,7 @@ package com.databricks.sql.transaction.tahoe.rapids
 
 import com.databricks.sql.transaction.tahoe.{DeltaLog, OptimisticTransaction}
 import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.Clock
@@ -68,6 +69,14 @@ object GpuDeltaLog {
       options: Map[String, String],
       rapidsConf: RapidsConf): GpuDeltaLog = {
     val deltaLog = DeltaLog.forTable(spark, dataPath, options)
+    new GpuDeltaLog(deltaLog, rapidsConf)
+  }
+
+  def forTable(
+      spark: SparkSession,
+      tableLocation: Path,
+      rapidsConf: RapidsConf): GpuDeltaLog = {
+    val deltaLog = DeltaLog.forTable(spark, tableLocation)
     new GpuDeltaLog(deltaLog, rapidsConf)
   }
 }

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeleteCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DeleteCommandMeta.scala
@@ -37,7 +37,7 @@ class DeleteCommandMeta(
         s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     DeleteCommandMetaShim.tagForGpu(this)
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 
@@ -62,7 +62,7 @@ class DeleteCommandEdgeMeta(
         s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     DeleteCommandMetaShim.tagForGpu(this)
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/MergeIntoCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/MergeIntoCommandMeta.scala
@@ -38,7 +38,8 @@ class MergeIntoCommandMeta(
     MergeIntoCommandMetaShim.tagForGpu(this, mergeCmd)
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog), Map.empty,
+      SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand =
@@ -60,7 +61,8 @@ class MergeIntoCommandEdgeMeta(
     MergeIntoCommandMetaShim.tagForGpu(this, mergeCmd)
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog), Map.empty,
+      SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand =

--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/UpdateCommandMeta.scala
@@ -35,7 +35,7 @@ class UpdateCommandMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {
@@ -62,7 +62,7 @@ class UpdateCommandEdgeMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShim.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/DeltaRuntimeShim.scala
@@ -22,7 +22,9 @@ import com.nvidia.spark.rapids.{RapidsConf, ShimReflectionUtils, VersionUtils}
 import com.nvidia.spark.rapids.delta.DeltaProvider
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.util.Clock
@@ -35,6 +37,8 @@ trait DeltaRuntimeShim {
   def fileFormatFromLog(deltaLog: DeltaLog): FileFormat
 
   def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean
+
+  def getGpuDeltaCatalog(cpuCatalog: DeltaCatalog, rapidsConf: RapidsConf): StagingTableCatalog
 }
 
 object DeltaRuntimeShim {
@@ -81,4 +85,8 @@ object DeltaRuntimeShim {
 
   def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean =
     shimInstance.getTightBoundColumnOnFileInitDisabled(spark)
+
+  def getGpuDeltaCatalog(cpuCatalog: DeltaCatalog, rapidsConf: RapidsConf): StagingTableCatalog = {
+    shimInstance.getGpuDeltaCatalog(cpuCatalog, rapidsConf)
+  }
 }

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaCatalogBase.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaCatalogBase.scala
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids
+
+import java.util
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, V1Write, WriteBuilder}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions}
+import org.apache.spark.sql.delta.catalog.{BucketTransform, DeltaCatalog}
+import org.apache.spark.sql.delta.commands.{TableCreationModes, WriteIntoDelta}
+import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.InsertableRelation
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+trait GpuDeltaCatalogBase extends StagingTableCatalog {
+  val spark: SparkSession
+
+  val cpuCatalog: DeltaCatalog
+
+  val rapidsConf: RapidsConf
+
+  protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand
+
+  protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable]
+
+  protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable
+
+  protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  protected def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode): Table = {
+    // These two keys are tableProperties in data source v2 but not in v1, so we have to filter
+    // them out. Otherwise property consistency checks will fail.
+    val tableProperties = allTableProperties.asScala.filterKeys {
+      case TableCatalog.PROP_LOCATION => false
+      case TableCatalog.PROP_PROVIDER => false
+      case TableCatalog.PROP_COMMENT => false
+      case TableCatalog.PROP_OWNER => false
+      case TableCatalog.PROP_EXTERNAL => false
+      case "path" => false
+      case "option.path" => false
+      case _ => true
+    }.toMap
+    val (partitionColumns, maybeBucketSpec) = convertTransforms(partitions)
+    val newSchema = schema
+    val newPartitionColumns = partitionColumns
+    val newBucketSpec = maybeBucketSpec
+    val conf = spark.sessionState.conf
+
+    val isByPath = isPathIdentifier(ident)
+    if (isByPath && !conf.getConf(DeltaSQLConf.DELTA_LEGACY_ALLOW_AMBIGUOUS_PATHS)
+      && allTableProperties.containsKey("location")
+      // The location property can be qualified and different from the path in the identifier, so
+      // we check `endsWith` here.
+      && Option(allTableProperties.get("location")).exists(!_.endsWith(ident.name()))
+    ) {
+      throw DeltaErrors.ambiguousPathsInCreateTableException(
+        ident.name(), allTableProperties.get("location"))
+    }
+    val location = if (isByPath) {
+      Option(ident.name())
+    } else {
+      Option(allTableProperties.get("location"))
+    }
+    val id = {
+      TableIdentifier(ident.name(), ident.namespace().lastOption)
+    }
+    val locUriOpt = location.map(CatalogUtils.stringToURI)
+    val existingTableOpt = getExistingTableIfExists(id)
+    val loc = locUriOpt
+      .orElse(existingTableOpt.flatMap(_.storage.locationUri))
+      .getOrElse(spark.sessionState.catalog.defaultTablePath(id))
+    val storage = DataSource.buildStorageFormatFromOptions(writeOptions)
+      .copy(locationUri = Option(loc))
+    val tableType =
+      if (location.isDefined) CatalogTableType.EXTERNAL else CatalogTableType.MANAGED
+    val commentOpt = Option(allTableProperties.get("comment"))
+
+
+    val tableDesc = new CatalogTable(
+      identifier = id,
+      tableType = tableType,
+      storage = storage,
+      schema = newSchema,
+      provider = Some(DeltaSourceUtils.ALT_NAME),
+      partitionColumnNames = newPartitionColumns,
+      bucketSpec = newBucketSpec,
+      properties = tableProperties,
+      comment = commentOpt
+    )
+
+    val withDb = verifyTableAndSolidify(tableDesc, None)
+
+    val writer = sourceQuery.map { df =>
+      WriteIntoDelta(
+        DeltaLog.forTable(spark, new Path(loc)),
+        operation.mode,
+        new DeltaOptions(withDb.storage.properties, spark.sessionState.conf),
+        withDb.partitionColumnNames,
+        withDb.properties ++ commentOpt.map("comment" -> _),
+        df,
+        schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
+    }
+
+    val gpuCreateTableCommand = buildGpuCreateDeltaTableCommand(
+      rapidsConf,
+      withDb,
+      existingTableOpt,
+      operation.mode,
+      writer,
+      operation,
+      tableByPath = isByPath)
+    gpuCreateTableCommand.run(spark)
+
+    cpuCatalog.loadTable(ident)
+  }
+
+  override def loadTable(ident: Identifier): Table = cpuCatalog.loadTable(ident)
+
+  private def getProvider(properties: util.Map[String, String]): String = {
+    Option(properties.get("provider"))
+      .getOrElse(spark.sessionState.conf.getConf(SQLConf.DEFAULT_DATA_SOURCE_NAME))
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createDeltaTable(
+        ident,
+        schema,
+        partitions,
+        properties,
+        Map.empty,
+        sourceQuery = None,
+        TableCreationModes.Create
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.Replace
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.CreateOrReplace
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable = {
+    if (DeltaSourceUtils.isDeltaDataSourceName(getProvider(properties))) {
+      createGpuStagedDeltaTableV2(
+        ident,
+        schema,
+        partitions,
+        properties,
+        TableCreationModes.Create
+      )
+    } else {
+      throw new IllegalStateException(s"Cannot create non-Delta tables")
+    }
+  }
+
+// Copy of V2SessionCatalog.convertTransforms, which is private.
+  private def convertTransforms(partitions: Seq[Transform]): (Seq[String], Option[BucketSpec]) = {
+    val identityCols = new mutable.ArrayBuffer[String]
+    var bucketSpec = Option.empty[BucketSpec]
+
+    partitions.map {
+      case IdentityTransform(FieldReference(Seq(col))) =>
+        identityCols += col
+
+      case BucketTransform(numBuckets, bucketCols, sortCols) =>
+        bucketSpec = Some(BucketSpec(
+          numBuckets, bucketCols.map(_.fieldNames.head), sortCols.map(_.fieldNames.head)))
+
+      case _ =>
+        throw DeltaErrors.operationNotSupportedException(s"Partitioning by expressions")
+    }
+
+    (identityCols.toSeq, bucketSpec)
+  }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2(
+      ident: Identifier,
+      override val schema: StructType,
+      val partitions: Array[Transform],
+      override val properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode
+  ) extends StagedTable with SupportsWrite {
+
+    private var asSelectQuery: Option[DataFrame] = None
+    private var writeOptions: Map[String, String] = Map.empty
+
+    override def partitioning(): Array[Transform] = partitions
+
+    override def commitStagedChanges(): Unit = {
+      val conf = spark.sessionState.conf
+      val props = new util.HashMap[String, String]()
+      // Options passed in through the SQL API will show up both with an "option." prefix and
+      // without in Spark 3.1, so we need to remove those from the properties
+      val optionsThroughProperties = properties.asScala.collect {
+        case (k, _) if k.startsWith("option.") => k.stripPrefix("option.")
+      }.toSet
+      val sqlWriteOptions = new util.HashMap[String, String]()
+      properties.asScala.foreach { case (k, v) =>
+        if (!k.startsWith("option.") && !optionsThroughProperties.contains(k)) {
+          // Do not add to properties
+          props.put(k, v)
+        } else if (optionsThroughProperties.contains(k)) {
+          sqlWriteOptions.put(k, v)
+        }
+      }
+      if (writeOptions.isEmpty && !sqlWriteOptions.isEmpty) {
+        writeOptions = sqlWriteOptions.asScala.toMap
+      }
+      if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+        // Legacy behavior
+        writeOptions.foreach { case (k, v) => props.put(k, v) }
+      } else {
+        writeOptions.foreach { case (k, v) =>
+          // Continue putting in Delta prefixed options to avoid breaking workloads
+          if (k.toLowerCase(Locale.ROOT).startsWith("delta.")) {
+            props.put(k, v)
+          }
+        }
+      }
+      createDeltaTable(
+        ident,
+        schema,
+        partitions,
+        props,
+        writeOptions,
+        asSelectQuery,
+        operation
+      )
+    }
+
+    override def name(): String = ident.name()
+
+    override def abortStagedChanges(): Unit = {}
+
+    override def capabilities(): util.Set[TableCapability] = Set(V1_BATCH_WRITE).asJava
+
+    override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+      writeOptions = info.options.asCaseSensitiveMap().asScala.toMap
+      new DeltaV1WriteBuilder
+    }
+
+    /*
+     * WriteBuilder for creating a Delta table.
+     */
+    private class DeltaV1WriteBuilder extends WriteBuilder {
+      override def build(): V1Write = new V1Write {
+        override def toInsertableRelation(): InsertableRelation = {
+          new InsertableRelation {
+            override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+              asSelectQuery = Option(data)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    cpuCatalog.alterTable(ident, changes: _*)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = cpuCatalog.dropTable(ident)
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    cpuCatalog.renameTable(oldIdent, newIdent)
+  }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    throw new IllegalStateException("should not be called")
+  }
+
+  override def tableExists(ident: Identifier): Boolean = cpuCatalog.tableExists(ident)
+
+  override def initialize(s: String, caseInsensitiveStringMap: CaseInsensitiveStringMap): Unit = {
+    throw new IllegalStateException("should not be called")
+  }
+
+  override def name(): String = cpuCatalog.name()
+
+  private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
+
+  private def hasDeltaNamespace(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 && DeltaSourceUtils.isDeltaDataSourceName(ident.namespace().head)
+  }
+
+  private def isPathIdentifier(ident: Identifier): Boolean = {
+    // Should be a simple check of a special PathIdentifier class in the future
+    try {
+      supportSQLOnFile && hasDeltaNamespace(ident) && new Path(ident.name()).isAbsolute
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+  }
+}
+
+
+/**
+ * A trait for handling table access through delta.`/some/path`. This is a stop-gap solution
+ * until PathIdentifiers are implemented in Apache Spark.
+ */
+trait SupportsPathIdentifier extends TableCatalog { self: GpuDeltaCatalogBase =>
+
+  private def supportSQLOnFile: Boolean = spark.sessionState.conf.runSQLonFile
+
+  protected lazy val catalog: SessionCatalog = spark.sessionState.catalog
+
+  private def hasDeltaNamespace(ident: Identifier): Boolean = {
+    ident.namespace().length == 1 && DeltaSourceUtils.isDeltaDataSourceName(ident.namespace().head)
+  }
+
+  protected def isPathIdentifier(ident: Identifier): Boolean = {
+    // Should be a simple check of a special PathIdentifier class in the future
+    try {
+      supportSQLOnFile && hasDeltaNamespace(ident) && new Path(ident.name()).isAbsolute
+    } catch {
+      case _: IllegalArgumentException => false
+    }
+  }
+
+  protected def isPathIdentifier(table: CatalogTable): Boolean = {
+    isPathIdentifier(table.identifier)
+  }
+
+  protected def isPathIdentifier(tableIdentifier: TableIdentifier) : Boolean = {
+    isPathIdentifier(Identifier.of(tableIdentifier.database.toArray, tableIdentifier.table))
+  }
+}

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaLog.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuDeltaLog.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.rapids
 
 import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction}
@@ -68,6 +69,14 @@ object GpuDeltaLog {
       options: Map[String, String],
       rapidsConf: RapidsConf): GpuDeltaLog = {
     val deltaLog = DeltaLog.forTable(spark, dataPath, options)
+    new GpuDeltaLog(deltaLog, rapidsConf)
+  }
+
+  def forTable(
+      spark: SparkSession,
+      tableLocation: Path,
+      rapidsConf: RapidsConf): GpuDeltaLog = {
+    val deltaLog = DeltaLog.forTable(spark, tableLocation)
     new GpuDeltaLog(deltaLog, rapidsConf)
   }
 }

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/DeleteCommandMeta.scala
@@ -37,7 +37,7 @@ class DeleteCommandMeta(
       willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/Delta20xProvider.scala
@@ -16,14 +16,18 @@
 
 package com.nvidia.spark.rapids.delta.delta20x
 
-import com.nvidia.spark.rapids.{GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, GpuExec, GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
 import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
+import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
+import org.apache.spark.sql.execution.datasources.v2.rapids.GpuAtomicCreateTableAsSelectExec
 
 object Delta20xProvider extends DeltaIOProvider {
 
@@ -57,5 +61,20 @@ object Delta20xProvider extends DeltaIOProvider {
   override def getReadFileFormat(format: FileFormat): FileFormat = {
     val cpuFormat = format.asInstanceOf[DeltaParquetFileFormat]
     GpuDelta20xParquetFileFormat(cpuFormat.columnMappingMode, cpuFormat.referenceSchema)
+  }
+
+  override def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
+    GpuAtomicCreateTableAsSelectExec(
+      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
+      cpuExec.ident,
+      cpuExec.partitioning,
+      cpuExec.plan,
+      meta.childPlans.head.convertIfNeeded(),
+      cpuExec.properties,
+      cpuExec.writeOptions,
+      cpuExec.ifNotExists)
   }
 }

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/MergeIntoCommandMeta.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/MergeIntoCommandMeta.scala
@@ -39,7 +39,8 @@ class MergeIntoCommandMeta(
     }
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog), Map.empty,
+      SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-20x/src/main/scala/com/nvidia/spark/rapids/delta/delta20x/UpdateCommandMeta.scala
@@ -37,7 +37,7 @@ class UpdateCommandMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/Delta20xRuntimeShim.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/Delta20xRuntimeShim.scala
@@ -21,7 +21,9 @@ import com.nvidia.spark.rapids.delta.DeltaProvider
 import com.nvidia.spark.rapids.delta.delta20x.Delta20xProvider
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.rapids.{DeltaRuntimeShim, GpuOptimisticTransactionBase}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -54,4 +56,10 @@ class Delta20xRuntimeShim extends DeltaRuntimeShim {
     deltaLog.fileFormat()
 
   override def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean = false
+
+  override def getGpuDeltaCatalog(
+      cpuCatalog: DeltaCatalog,
+      rapidsConf: RapidsConf): StagingTableCatalog = {
+    new GpuDeltaCatalog(cpuCatalog, rapidsConf)
+  }
 }

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta20x
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.commands.{TableCreationModes, WriteIntoDelta}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          val tableName = table.identifier.quotedString
+          throw new AnalysisException(
+            s"The location of the existing table $tableName is " +
+              s"`${existingTable.location}`. It doesn't match the specified location " +
+              s"`${table.location}`.")
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(sparkSession, tableWithLocation, gpuDeltaLog.deltaLog.snapshot, txn)
+
+      result
+    }
+  }
+
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw new CannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-20x/src/main/scala/org/apache/spark/sql/delta/rapids/delta20x/GpuDeltaCatalog.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta20x
+
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.rapids.{GpuDeltaCatalogBase, SupportsPathIdentifier}
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: DeltaCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with Logging {
+
+  override val spark: SparkSession = cpuCatalog.spark
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw DeltaErrors.notADeltaTable(table.table)
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/DeleteCommandMeta.scala
@@ -37,7 +37,7 @@ class DeleteCommandMeta(
       willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/Delta21xProvider.scala
@@ -16,14 +16,18 @@
 
 package com.nvidia.spark.rapids.delta.delta21x
 
-import com.nvidia.spark.rapids.{GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, GpuExec, GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
 import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
+import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
+import org.apache.spark.sql.execution.datasources.v2.rapids.GpuAtomicCreateTableAsSelectExec
 
 object Delta21xProvider extends DeltaIOProvider {
 
@@ -57,5 +61,20 @@ object Delta21xProvider extends DeltaIOProvider {
   override def getReadFileFormat(format: FileFormat): FileFormat = {
     val cpuFormat = format.asInstanceOf[DeltaParquetFileFormat]
     GpuDelta21xParquetFileFormat(cpuFormat.columnMappingMode, cpuFormat.referenceSchema)
+  }
+
+  override def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
+    GpuAtomicCreateTableAsSelectExec(
+      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
+      cpuExec.ident,
+      cpuExec.partitioning,
+      cpuExec.plan,
+      meta.childPlans.head.convertIfNeeded(),
+      cpuExec.tableSpec,
+      cpuExec.writeOptions,
+      cpuExec.ifNotExists)
   }
 }

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/MergeIntoCommandMeta.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/MergeIntoCommandMeta.scala
@@ -39,7 +39,8 @@ class MergeIntoCommandMeta(
     }
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog), Map.empty,
+      SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-21x/src/main/scala/com/nvidia/spark/rapids/delta/delta21x/UpdateCommandMeta.scala
@@ -37,7 +37,7 @@ class UpdateCommandMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/Delta21xRuntimeShim.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/Delta21xRuntimeShim.scala
@@ -21,7 +21,9 @@ import com.nvidia.spark.rapids.delta.DeltaProvider
 import com.nvidia.spark.rapids.delta.delta21x.Delta21xProvider
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.rapids.{DeltaRuntimeShim, GpuOptimisticTransactionBase}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -54,4 +56,9 @@ class Delta21xRuntimeShim extends DeltaRuntimeShim {
 
   override def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean = false
 
+  override def getGpuDeltaCatalog(
+      cpuCatalog: DeltaCatalog,
+      rapidsConf: RapidsConf): StagingTableCatalog = {
+    new GpuDeltaCatalog(cpuCatalog, rapidsConf)
+  }
 }

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from CreateDeltaTableCommand.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta21x
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.commands.{TableCreationModes, WriteIntoDelta}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          val tableName = table.identifier.quotedString
+          throw new AnalysisException(
+            s"The location of the existing table $tableName is " +
+              s"`${existingTable.location}`. It doesn't match the specified location " +
+              s"`${table.location}`.")
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+              txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(sparkSession, tableWithLocation, gpuDeltaLog.deltaLog.snapshot, txn)
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw new CannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-21x/src/main/scala/org/apache/spark/sql/delta/rapids/delta21x/GpuDeltaCatalog.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta21x
+
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.rapids.{GpuDeltaCatalogBase, SupportsPathIdentifier}
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: DeltaCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with Logging {
+
+  override val spark: SparkSession = cpuCatalog.spark
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw DeltaErrors.notADeltaTable(table.table)
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+
+  override def loadTable(ident: Identifier, timestamp: Long): Table = {
+    cpuCatalog.loadTable(ident, timestamp)
+  }
+
+  override def loadTable(ident: Identifier, version: String): Table = {
+    cpuCatalog.loadTable(ident, version)
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/DeleteCommandMeta.scala
@@ -37,7 +37,7 @@ class DeleteCommandMeta(
       willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
         s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/Delta22xProvider.scala
@@ -16,14 +16,18 @@
 
 package com.nvidia.spark.rapids.delta.delta22x
 
-import com.nvidia.spark.rapids.{GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, GpuExec, GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
 import org.apache.spark.sql.delta.DeltaParquetFileFormat
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
+import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
+import org.apache.spark.sql.execution.datasources.v2.rapids.GpuAtomicCreateTableAsSelectExec
 
 object Delta22xProvider extends DeltaIOProvider {
 
@@ -57,5 +61,20 @@ object Delta22xProvider extends DeltaIOProvider {
   override def getReadFileFormat(format: FileFormat): FileFormat = {
     val cpuFormat = format.asInstanceOf[DeltaParquetFileFormat]
     GpuDelta22xParquetFileFormat(cpuFormat.columnMappingMode, cpuFormat.referenceSchema)
+  }
+
+  override def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
+    GpuAtomicCreateTableAsSelectExec(
+      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
+      cpuExec.ident,
+      cpuExec.partitioning,
+      cpuExec.plan,
+      meta.childPlans.head.convertIfNeeded(),
+      cpuExec.tableSpec,
+      cpuExec.writeOptions,
+      cpuExec.ifNotExists)
   }
 }

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/MergeIntoCommandMeta.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/MergeIntoCommandMeta.scala
@@ -39,7 +39,8 @@ class MergeIntoCommandMeta(
     }
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog), Map.empty,
+      SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-22x/src/main/scala/com/nvidia/spark/rapids/delta/delta22x/UpdateCommandMeta.scala
@@ -37,7 +37,7 @@ class UpdateCommandMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/Delta22xRuntimeShim.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/Delta22xRuntimeShim.scala
@@ -21,7 +21,9 @@ import com.nvidia.spark.rapids.delta.DeltaProvider
 import com.nvidia.spark.rapids.delta.delta22x.Delta22xProvider
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.rapids.{DeltaRuntimeShim, GpuOptimisticTransactionBase}
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.expressions.UserDefinedFunction
@@ -49,4 +51,10 @@ class Delta22xRuntimeShim extends DeltaRuntimeShim {
     deltaLog.fileFormat()
 
   override def getTightBoundColumnOnFileInitDisabled(spark: SparkSession): Boolean = false
+
+  override def getGpuDeltaCatalog(
+      cpuCatalog: DeltaCatalog,
+      rapidsConf: RapidsConf): StagingTableCatalog = {
+    new GpuDeltaCatalog(cpuCatalog, rapidsConf)
+  }
 }

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from CreateDeltaTableCommand.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta22x
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.commands.{TableCreationModes, WriteIntoDelta}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          throw DeltaErrors.tableLocationMismatch(table, existingTable)
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      val opStartTs = System.currentTimeMillis()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+              txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(
+        sparkSession,
+        tableWithLocation,
+        gpuDeltaLog.deltaLog.update(checkIfUpdatedSinceTs = Some(opStartTs)),
+        txn)
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw DeltaErrors.cannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-22x/src/main/scala/org/apache/spark/sql/delta/rapids/delta22x/GpuDeltaCatalog.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta22x
+
+import com.nvidia.spark.rapids.RapidsConf
+import java.util
+
+import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.{GpuDeltaCatalogBase, SupportsPathIdentifier}
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+import org.apache.spark.sql.types.StructType
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: DeltaCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with DeltaLogging {
+
+  override val spark: SparkSession = cpuCatalog.spark
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw DeltaErrors.notADeltaTable(table.table)
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+
+  override protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2WithLogging(ident, schema, partitions, properties, operation)
+  }
+
+  override def loadTable(ident: Identifier, timestamp: Long): Table = {
+    cpuCatalog.loadTable(ident, timestamp)
+  }
+
+  override def loadTable(ident: Identifier, version: String): Table = {
+    cpuCatalog.loadTable(ident, version)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  override def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode
+  ): Table = recordFrameProfile(
+    "DeltaCatalog", "createDeltaTable") {
+    super.createDeltaTable(
+      ident,
+      schema,
+      partitions,
+      allTableProperties,
+      writeOptions,
+      sourceQuery,
+      operation)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table =
+    recordFrameProfile("DeltaCatalog", "createTable") {
+      super.createTable(ident, schema, partitions, properties)
+    }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageReplace") {
+      super.stageReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
+      super.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreate") {
+      super.stageCreate(ident, schema, partitions, properties)
+    }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2WithLogging(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode)
+    extends GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation) {
+
+    override def commitStagedChanges(): Unit = recordFrameProfile(
+      "DeltaCatalog", "commitStagedChanges") {
+      super.commitStagedChanges()
+    }
+  }
+}

--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/DeleteCommandMeta.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/DeleteCommandMeta.scala
@@ -45,7 +45,7 @@ class DeleteCommandMeta(
       // https://github.com/NVIDIA/spark-rapids/issues/8554
       willNotWorkOnGpu("Deletion vectors are not supported on GPU")
     }
-    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, deleteCmd.deltaLog,
+    RapidsDeltaUtils.tagForDeltaWrite(this, deleteCmd.target.schema, Some(deleteCmd.deltaLog),
       Map.empty, SparkSession.active)
   }
 

--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/Delta24xProvider.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/Delta24xProvider.scala
@@ -16,15 +16,19 @@
 
 package com.nvidia.spark.rapids.delta.delta24x
 
-import com.nvidia.spark.rapids.{GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, GpuExec, GpuOverrides, GpuReadParquetFileFormat, RunnableCommandRule, SparkPlanMeta}
 import com.nvidia.spark.rapids.delta.DeltaIOProvider
 
 import org.apache.spark.sql.delta.DeltaParquetFileFormat
 import org.apache.spark.sql.delta.DeltaParquetFileFormat.{IS_ROW_DELETED_COLUMN_NAME, ROW_INDEX_COLUMN_NAME}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.{DeleteCommand, MergeIntoCommand, UpdateCommand}
+import org.apache.spark.sql.delta.rapids.DeltaRuntimeShim
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
+import org.apache.spark.sql.execution.datasources.v2.rapids.GpuAtomicCreateTableAsSelectExec
 
 object Delta24xProvider extends DeltaIOProvider {
 
@@ -71,5 +75,20 @@ object Delta24xProvider extends DeltaIOProvider {
   override def getReadFileFormat(format: FileFormat): FileFormat = {
     val cpuFormat = format.asInstanceOf[DeltaParquetFileFormat]
     GpuDelta24xParquetFileFormat(cpuFormat.metadata, cpuFormat.isSplittable)
+  }
+
+  override def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    val cpuCatalog = cpuExec.catalog.asInstanceOf[DeltaCatalog]
+    GpuAtomicCreateTableAsSelectExec(
+      DeltaRuntimeShim.getGpuDeltaCatalog(cpuCatalog, meta.conf),
+      cpuExec.ident,
+      cpuExec.partitioning,
+      cpuExec.plan,
+      meta.childPlans.head.convertIfNeeded(),
+      cpuExec.tableSpec,
+      cpuExec.writeOptions,
+      cpuExec.ifNotExists)
   }
 }

--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/GpuDeltaCatalog.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.delta.delta24x
+
+import com.nvidia.spark.rapids.RapidsConf
+import java.util
+
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.commands.TableCreationModes
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.GpuDeltaCatalogBase
+import org.apache.spark.sql.delta.rapids.delta24x.GpuCreateDeltaTableCommand
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.rapids.execution.ShimTrampolineUtil
+import org.apache.spark.sql.types.StructType
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: DeltaCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with DeltaLogging {
+
+  override val spark: SparkSession = cpuCatalog.spark
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    cpuCatalog.getExistingTableIfExists(table)
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+    cpuCatalog.verifyTableAndSolidify(tableDesc, query)
+  }
+
+  override protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2WithLogging(ident, schema, partitions, properties, operation)
+  }
+
+  override def loadTable(ident: Identifier, timestamp: Long): Table = {
+    cpuCatalog.loadTable(ident, timestamp)
+  }
+
+  override def loadTable(ident: Identifier, version: String): Table = {
+    cpuCatalog.loadTable(ident, version)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  override def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode
+  ): Table = recordFrameProfile(
+    "DeltaCatalog", "createDeltaTable") {
+    super.createDeltaTable(
+      ident,
+      schema,
+      partitions,
+      allTableProperties,
+      writeOptions,
+      sourceQuery,
+      operation)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      columns: Array[org.apache.spark.sql.connector.catalog.Column],
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    createTable(
+      ident,
+      ShimTrampolineUtil.v2ColumnsToStructType(columns),
+      partitions,
+      properties)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table =
+    recordFrameProfile("DeltaCatalog", "createTable") {
+      super.createTable(ident, schema, partitions, properties)
+    }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageReplace") {
+      super.stageReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
+      super.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreate") {
+      super.stageCreate(ident, schema, partitions, properties)
+    }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2WithLogging(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode)
+    extends GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation) {
+
+    override def commitStagedChanges(): Unit = recordFrameProfile(
+      "DeltaCatalog", "commitStagedChanges") {
+      super.commitStagedChanges()
+    }
+  }
+}

--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/MergeIntoCommandMeta.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/MergeIntoCommandMeta.scala
@@ -43,7 +43,8 @@ class MergeIntoCommandMeta(
     }
     val targetSchema = mergeCmd.migratedSchema.getOrElse(mergeCmd.target.schema)
     val deltaLog = mergeCmd.targetFileIndex.deltaLog
-    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, deltaLog, Map.empty, SparkSession.active)
+    RapidsDeltaUtils.tagForDeltaWrite(this, targetSchema, Some(deltaLog),
+      Map.empty, SparkSession.active)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/UpdateCommandMeta.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/UpdateCommandMeta.scala
@@ -37,7 +37,7 @@ class UpdateCommandMeta(
           s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
     }
     RapidsDeltaUtils.tagForDeltaWrite(this, updateCmd.target.schema,
-      updateCmd.tahoeFileIndex.deltaLog, Map.empty, updateCmd.tahoeFileIndex.spark)
+      Some(updateCmd.tahoeFileIndex.deltaLog), Map.empty, updateCmd.tahoeFileIndex.spark)
   }
 
   override def convertToGpu(): RunnableCommand = {

--- a/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/Delta24xRuntimeShim.scala
+++ b/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/Delta24xRuntimeShim.scala
@@ -18,10 +18,12 @@ package org.apache.spark.sql.delta.rapids.delta24x
 
 import com.nvidia.spark.rapids.RapidsConf
 import com.nvidia.spark.rapids.delta.DeltaProvider
-import com.nvidia.spark.rapids.delta.delta24x.Delta24xProvider
+import com.nvidia.spark.rapids.delta.delta24x.{Delta24xProvider, GpuDeltaCatalog}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.delta.{DeltaLog, DeltaUDF, Snapshot}
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.rapids.{DeltaRuntimeShim, GpuOptimisticTransactionBase}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.execution.datasources.FileFormat
@@ -54,4 +56,9 @@ class Delta24xRuntimeShim extends DeltaRuntimeShim {
     spark.sessionState.conf.getConf(DeltaSQLConf.TIGHT_BOUND_COLUMN_ON_FILE_INIT_DISABLED)
   }
 
+  override def getGpuDeltaCatalog(
+      cpuCatalog: DeltaCatalog,
+      rapidsConf: RapidsConf): StagingTableCatalog = {
+    new GpuDeltaCatalog(cpuCatalog, rapidsConf)
+  }
 }

--- a/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-24x/src/main/scala/org/apache/spark/sql/delta/rapids/delta24x/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from CreateDeltaTableCommand.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rapids.delta24x
+
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaColumnMapping.{dropColumnMappingMetadata, filterColumnMappingProperties}
+import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
+import org.apache.spark.sql.delta.commands.{DeltaCommand, TableCreationModes, WriteIntoDelta}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.rapids.GpuDeltaLog
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ * @param protocol This is used to create a table with specific protocol version
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil,
+    protocol: Option[Protocol] = None)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+    with DeltaCommand
+    with DeltaLogging {
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          throw DeltaErrors.tableLocationMismatch(table, existingTable)
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      val opStartTs = System.currentTimeMillis()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+
+        // Execute write command for `deltaWriter` by
+        //   - replacing the metadata new target table for DataFrameWriterV2 writer if it is a
+        //     REPLACE or CREATE_OR_REPLACE command,
+        //   - running the write procedure of DataFrameWriter command and returning the
+        //     new created actions,
+        //   - returning the Delta Operation type of this DataFrameWriter
+        def doDeltaWrite(
+            deltaWriter: WriteIntoDelta,
+            schema: StructType): (Seq[Action], DeltaOperations.Operation) = {
+          // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+          // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+          if (!isV1Writer) {
+            replaceMetadataIfNecessary(
+              txn, tableWithLocation, options, schema)
+          }
+          val actions = deltaWriter.write(txn, sparkSession)
+          val op = getOperation(txn.metadata, isManagedTable, Some(options))
+          (actions, op)
+        }
+
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case deltaWriter: WriteIntoDelta =>
+              if (!hasBeenExecuted(txn, sparkSession, Some(options))) {
+                val (actions, op) = doDeltaWrite(deltaWriter, deltaWriter.data.schema.asNullable)
+                txn.commit(actions, op)
+              }
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+            val deltaWriter = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data)
+            if (!hasBeenExecuted(txn, sparkSession, Some(options))) {
+              val (actions, op) = doDeltaWrite(deltaWriter, other.schema.asNullable)
+              txn.commit(actions, op)
+            }
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+            protocol.foreach { protocol =>
+              txn.updateProtocol(protocol)
+            }
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(
+        sparkSession,
+        tableWithLocation,
+        gpuDeltaLog.deltaLog.update(checkIfUpdatedSinceTs = Some(opStartTs)),
+        txn)
+
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+
+        // If schema is specified, we must make sure the partitioning matches, even the partitioning
+        // is not specified.
+        if (tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+          throw DeltaErrors.createTableWithDifferentPartitioningException(
+            path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+        }
+      }
+
+      if (tableDesc.properties.nonEmpty) {
+        // When comparing properties of the existing table and the new table, remove some
+        // internal column mapping properties for the sake of comparison.
+        val filteredTableProperties = filterColumnMappingProperties(tableDesc.properties)
+        val filteredExistingProperties = filterColumnMappingProperties(
+          existingMetadata.configuration)
+        if (filteredTableProperties != filteredExistingProperties) {
+          throw DeltaErrors.createTableWithDifferentPropertiesException(
+            path, filteredTableProperties, filteredExistingProperties)
+        }
+        // If column mapping properties are present in both configs, verify they're the same value.
+        if (!DeltaColumnMapping.verifyInternalProperties(
+            tableDesc.properties, existingMetadata.configuration)) {
+          throw DeltaErrors.createTableWithDifferentPropertiesException(
+            path, tableDesc.properties, existingMetadata.configuration)
+        }
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(spark, table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw DeltaErrors.cannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(spark: SparkSession, table: CatalogTable, snapshot: Snapshot)
+      : CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe._
+import com.databricks.sql.transaction.tahoe.actions.Metadata
+import com.databricks.sql.transaction.tahoe.commands.{TableCreationModes, WriteIntoDelta}
+import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
+import com.databricks.sql.transaction.tahoe.schema.SchemaUtils
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw new AnalysisException(s"DTable ${table.identifier.quotedString} already exists.")
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          val tableName = table.identifier.quotedString
+          throw new AnalysisException(
+            s"The location of the existing table $tableName is " +
+              s"`${existingTable.location}`. It doesn't match the specified location " +
+              s"`${table.location}`.")
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(sparkSession, tableWithLocation, gpuDeltaLog.deltaLog.snapshot, txn)
+
+      result
+    }
+  }
+
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw new AnalysisException(s"Cannot create table ('${tableWithLocation.identifier}')." +
+        s" The associated location ('${tableWithLocation.location}') is not empty but " +
+        s"it's not a Delta table")
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw new CannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-spark321db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaErrors}
+import com.databricks.sql.transaction.tahoe.commands.TableCreationModes
+import com.databricks.sql.transaction.tahoe.sources.DeltaSourceUtils
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{AnalysisException, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: StagingTableCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with Logging {
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw new AnalysisException(s"$table is not a Delta table. Please drop this " +
+          "table first if you would like to recreate it with Delta Lake.")
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+}

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from CreateDeltaTableCommand.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe._
+import com.databricks.sql.transaction.tahoe.actions.Metadata
+import com.databricks.sql.transaction.tahoe.commands.{TableCreationModes, WriteIntoDelta}
+import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
+import com.databricks.sql.transaction.tahoe.schema.SchemaUtils
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          throw DeltaErrors.tableLocationMismatch(table, existingTable)
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      val opStartTs = System.currentTimeMillis()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+              txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(
+        sparkSession,
+        tableWithLocation,
+        gpuDeltaLog.deltaLog.update(checkIfUpdatedSinceTs = Some(opStartTs)),
+        txn)
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw DeltaErrors.cannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-spark330db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import java.util
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaErrors}
+import com.databricks.sql.transaction.tahoe.commands.TableCreationModes
+import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
+import com.databricks.sql.transaction.tahoe.sources.DeltaSourceUtils
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, StagingTableCatalog, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+import org.apache.spark.sql.types.StructType
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: StagingTableCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with DeltaLogging {
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw new AnalysisException(s"$table is not a Delta table. Please drop this " +
+          "table first if you would like to recreate it with Delta Lake.")
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+
+  override protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2WithLogging(ident, schema, partitions, properties, operation)
+  }
+
+  override def loadTable(ident: Identifier, timestamp: Long): Table = {
+    cpuCatalog.loadTable(ident, timestamp)
+  }
+
+  override def loadTable(ident: Identifier, version: String): Table = {
+    cpuCatalog.loadTable(ident, version)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  override def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode
+  ): Table = recordFrameProfile(
+    "DeltaCatalog", "createDeltaTable") {
+    super.createDeltaTable(
+      ident,
+      schema,
+      partitions,
+      allTableProperties,
+      writeOptions,
+      sourceQuery,
+      operation)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table =
+    recordFrameProfile("DeltaCatalog", "createTable") {
+      super.createTable(ident, schema, partitions, properties)
+    }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageReplace") {
+      super.stageReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
+      super.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreate") {
+      super.stageCreate(ident, schema, partitions, properties)
+    }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2WithLogging(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode)
+    extends GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation) {
+
+    override def commitStagedChanges(): Unit = recordFrameProfile(
+      "DeltaCatalog", "commitStagedChanges") {
+      super.commitStagedChanges()
+    }
+  }
+}

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuCreateDeltaTableCommand.scala
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from CreateDeltaTableCommand.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import com.databricks.sql.transaction.tahoe._
+import com.databricks.sql.transaction.tahoe.actions.Metadata
+import com.databricks.sql.transaction.tahoe.commands.{TableCreationModes, WriteIntoDelta}
+import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
+import com.databricks.sql.transaction.tahoe.schema.SchemaUtils
+import com.databricks.sql.transaction.tahoe.sources.DeltaSQLConf
+import com.nvidia.spark.rapids.RapidsConf
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Single entry point for all write or declaration operations for Delta tables accessed through
+ * the table name.
+ *
+ * @param table The table identifier for the Delta table
+ * @param existingTableOpt The existing table for the same identifier if exists
+ * @param mode The save mode when writing data. Relevant when the query is empty or set to Ignore
+ *             with `CREATE TABLE IF NOT EXISTS`.
+ * @param query The query to commit into the Delta table if it exist. This can come from
+ *                - CTAS
+ *                - saveAsTable
+ */
+case class GpuCreateDeltaTableCommand(
+    table: CatalogTable,
+    existingTableOpt: Option[CatalogTable],
+    mode: SaveMode,
+    query: Option[LogicalPlan],
+    operation: TableCreationModes.CreationMode = TableCreationModes.Create,
+    tableByPath: Boolean = false,
+    override val output: Seq[Attribute] = Nil)(@transient rapidsConf: RapidsConf)
+  extends LeafRunnableCommand
+  with DeltaLogging {
+
+  override def otherCopyArgs: Seq[AnyRef] = Seq(rapidsConf)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val table = this.table
+
+    assert(table.tableType != CatalogTableType.VIEW)
+    assert(table.identifier.database.isDefined, "Database should've been fixed at analysis")
+    // There is a subtle race condition here, where the table can be created by someone else
+    // while this command is running. Nothing we can do about that though :(
+    val tableExists = existingTableOpt.isDefined
+    if (mode == SaveMode.Ignore && tableExists) {
+      // Early exit on ignore
+      return Nil
+    } else if (mode == SaveMode.ErrorIfExists && tableExists) {
+      throw DeltaErrors.tableAlreadyExists(table)
+    }
+
+    val tableWithLocation = if (tableExists) {
+      val existingTable = existingTableOpt.get
+      table.storage.locationUri match {
+        case Some(location) if location.getPath != existingTable.location.getPath =>
+          throw DeltaErrors.tableLocationMismatch(table, existingTable)
+        case _ =>
+      }
+      table.copy(
+        storage = existingTable.storage,
+        tableType = existingTable.tableType)
+    } else if (table.storage.locationUri.isEmpty) {
+      // We are defining a new managed table
+      assert(table.tableType == CatalogTableType.MANAGED)
+      val loc = sparkSession.sessionState.catalog.defaultTablePath(table.identifier)
+      table.copy(storage = table.storage.copy(locationUri = Some(loc)))
+    } else {
+      // 1. We are defining a new external table
+      // 2. It's a managed table which already has the location populated. This can happen in DSV2
+      //    CTAS flow.
+      table
+    }
+
+    val isManagedTable = tableWithLocation.tableType == CatalogTableType.MANAGED
+    val tableLocation = new Path(tableWithLocation.location)
+    val gpuDeltaLog = GpuDeltaLog.forTable(sparkSession, tableLocation, rapidsConf)
+    val hadoopConf = gpuDeltaLog.deltaLog.newDeltaHadoopConf()
+    val fs = tableLocation.getFileSystem(hadoopConf)
+    val options = new DeltaOptions(table.storage.properties, sparkSession.sessionState.conf)
+    var result: Seq[Row] = Nil
+
+    recordDeltaOperation(gpuDeltaLog.deltaLog, "delta.ddl.createTable") {
+      val txn = gpuDeltaLog.startTransaction()
+      val opStartTs = System.currentTimeMillis()
+      if (query.isDefined) {
+        // If the mode is Ignore or ErrorIfExists, the table must not exist, or we would return
+        // earlier. And the data should not exist either, to match the behavior of
+        // Ignore/ErrorIfExists mode. This means the table path should not exist or is empty.
+        if (mode == SaveMode.Ignore || mode == SaveMode.ErrorIfExists) {
+          assert(!tableExists)
+          // We may have failed a previous write. The retry should still succeed even if we have
+          // garbage data
+          if (txn.readVersion > -1 || !fs.exists(gpuDeltaLog.deltaLog.logPath)) {
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+        }
+        // We are either appending/overwriting with saveAsTable or creating a new table with CTAS or
+        // we are creating a table as part of a RunnableCommand
+        query.get match {
+          case writer: WriteIntoDelta =>
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, writer.data.schema.asNullable)
+            }
+            val actions = writer.write(txn, sparkSession)
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+              txn.commit(actions, op)
+          case cmd: RunnableCommand =>
+            result = cmd.run(sparkSession)
+          case other =>
+            // When using V1 APIs, the `other` plan is not yet optimized, therefore, it is safe
+            // to once again go through analysis
+            val data = Dataset.ofRows(sparkSession, other)
+
+            // In the V2 Writer, methods like "replace" and "createOrReplace" implicitly mean that
+            // the metadata should be changed. This wasn't the behavior for DataFrameWriterV1.
+            if (!isV1Writer) {
+              replaceMetadataIfNecessary(
+                txn, tableWithLocation, options, other.schema.asNullable)
+            }
+
+            val actions = WriteIntoDelta(
+              deltaLog = gpuDeltaLog.deltaLog,
+              mode = mode,
+              options,
+              partitionColumns = table.partitionColumnNames,
+              configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
+              data = data).write(txn, sparkSession)
+
+            val op = getOperation(txn.metadata, isManagedTable, Some(options))
+            txn.commit(actions, op)
+        }
+      } else {
+        def createTransactionLogOrVerify(): Unit = {
+          if (isManagedTable) {
+            // When creating a managed table, the table path should not exist or is empty, or
+            // users would be surprised to see the data, or see the data directory being dropped
+            // after the table is dropped.
+            assertPathEmpty(hadoopConf, tableWithLocation)
+          }
+
+          // This is either a new table, or, we never defined the schema of the table. While it is
+          // unexpected that `txn.metadata.schema` to be empty when txn.readVersion >= 0, we still
+          // guard against it, in case of checkpoint corruption bugs.
+          val noExistingMetadata = txn.readVersion == -1 || txn.metadata.schema.isEmpty
+          if (noExistingMetadata) {
+            assertTableSchemaDefined(fs, tableLocation, tableWithLocation, txn, sparkSession)
+            assertPathEmpty(hadoopConf, tableWithLocation)
+            // This is a user provided schema.
+            // Doesn't come from a query, Follow nullability invariants.
+            val newMetadata = getProvidedMetadata(tableWithLocation, table.schema.json)
+            txn.updateMetadataForNewTable(newMetadata)
+
+            val op = getOperation(newMetadata, isManagedTable, None)
+            txn.commit(Nil, op)
+          } else {
+            verifyTableMetadata(txn, tableWithLocation)
+          }
+        }
+        // We are defining a table using the Create or Replace Table statements.
+        operation match {
+          case TableCreationModes.Create =>
+            require(!tableExists, "Can't recreate a table when it exists")
+            createTransactionLogOrVerify()
+
+          case TableCreationModes.CreateOrReplace if !tableExists =>
+            // If the table doesn't exist, CREATE OR REPLACE must provide a schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            createTransactionLogOrVerify()
+          case _ =>
+            // When the operation is a REPLACE or CREATE OR REPLACE, then the schema shouldn't be
+            // empty, since we'll use the entry to replace the schema
+            if (tableWithLocation.schema.isEmpty) {
+              throw DeltaErrors.schemaNotProvidedException
+            }
+            // We need to replace
+            replaceMetadataIfNecessary(txn, tableWithLocation, options, tableWithLocation.schema)
+            // Truncate the table
+            val operationTimestamp = System.currentTimeMillis()
+            val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
+            val op = getOperation(txn.metadata, isManagedTable, None)
+            txn.commit(removes, op)
+        }
+      }
+
+      // We would have failed earlier on if we couldn't ignore the existence of the table
+      // In addition, we just might using saveAsTable to append to the table, so ignore the creation
+      // if it already exists.
+      // Note that someone may have dropped and recreated the table in a separate location in the
+      // meantime... Unfortunately we can't do anything there at the moment, because Hive sucks.
+      logInfo(s"Table is path-based table: $tableByPath. Update catalog with mode: $operation")
+      updateCatalog(
+        sparkSession,
+        tableWithLocation,
+        gpuDeltaLog.deltaLog.update(checkIfUpdatedSinceTs = Some(opStartTs)),
+        txn)
+
+      result
+    }
+  }
+
+  private def getProvidedMetadata(table: CatalogTable, schemaString: String): Metadata = {
+    Metadata(
+      description = table.comment.orNull,
+      schemaString = schemaString,
+      partitionColumns = table.partitionColumnNames,
+      configuration = table.properties,
+      createdTime = Some(System.currentTimeMillis()))
+  }
+
+  private def assertPathEmpty(
+      hadoopConf: Configuration,
+      tableWithLocation: CatalogTable): Unit = {
+    val path = new Path(tableWithLocation.location)
+    val fs = path.getFileSystem(hadoopConf)
+    // Verify that the table location associated with CREATE TABLE doesn't have any data. Note that
+    // we intentionally diverge from this behavior w.r.t regular datasource tables (that silently
+    // overwrite any previous data)
+    if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+      throw DeltaErrors.createTableWithNonEmptyLocation(
+        tableWithLocation.identifier.toString,
+        tableWithLocation.location.toString)
+    }
+  }
+
+  private def assertTableSchemaDefined(
+      fs: FileSystem,
+      path: Path,
+      table: CatalogTable,
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession): Unit = {
+    // If we allow creating an empty schema table and indeed the table is new, we just need to
+    // make sure:
+    // 1. txn.readVersion == -1 to read a new table
+    // 2. for external tables: path must either doesn't exist or is completely empty
+    val allowCreatingTableWithEmptySchema = sparkSession.sessionState
+      .conf.getConf(DeltaSQLConf.DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE) && txn.readVersion == -1
+
+    // Users did not specify the schema. We expect the schema exists in Delta.
+    if (table.schema.isEmpty) {
+      if (table.tableType == CatalogTableType.EXTERNAL) {
+        if (fs.exists(path) && fs.listStatus(path).nonEmpty) {
+          throw DeltaErrors.createExternalTableWithoutLogException(
+            path, table.identifier.quotedString, sparkSession)
+        } else {
+          if (allowCreatingTableWithEmptySchema) return
+          throw DeltaErrors.createExternalTableWithoutSchemaException(
+            path, table.identifier.quotedString, sparkSession)
+        }
+      } else {
+        if (allowCreatingTableWithEmptySchema) return
+        throw DeltaErrors.createManagedTableWithoutSchemaException(
+          table.identifier.quotedString, sparkSession)
+      }
+    }
+  }
+
+  /**
+   * Verify against our transaction metadata that the user specified the right metadata for the
+   * table.
+   */
+  private def verifyTableMetadata(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable): Unit = {
+    val existingMetadata = txn.metadata
+    val path = new Path(tableDesc.location)
+
+    // The delta log already exists. If they give any configuration, we'll make sure it all matches.
+    // Otherwise we'll just go with the metadata already present in the log.
+    // The schema compatibility checks will be made in `WriteIntoDelta` for CreateTable
+    // with a query
+    if (txn.readVersion > -1) {
+      if (tableDesc.schema.nonEmpty) {
+        // We check exact alignment on create table if everything is provided
+        // However, if in column mapping mode, we can safely ignore the related metadata fields in
+        // existing metadata because new table desc will not have related metadata assigned yet
+        val differences = SchemaUtils.reportDifferences(
+          DeltaColumnMapping.dropColumnMappingMetadata(existingMetadata.schema),
+          tableDesc.schema)
+        if (differences.nonEmpty) {
+          throw DeltaErrors.createTableWithDifferentSchemaException(
+            path, tableDesc.schema, existingMetadata.schema, differences)
+        }
+      }
+
+      // If schema is specified, we must make sure the partitioning matches, even the partitioning
+      // is not specified.
+      if (tableDesc.schema.nonEmpty &&
+        tableDesc.partitionColumnNames != existingMetadata.partitionColumns) {
+        throw DeltaErrors.createTableWithDifferentPartitioningException(
+          path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
+      }
+
+      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+        throw DeltaErrors.createTableWithDifferentPropertiesException(
+          path, tableDesc.properties, existingMetadata.configuration)
+      }
+    }
+  }
+
+  /**
+   * Based on the table creation operation, and parameters, we can resolve to different operations.
+   * A lot of this is needed for legacy reasons in Databricks Runtime.
+   * @param metadata The table metadata, which we are creating or replacing
+   * @param isManagedTable Whether we are creating or replacing a managed table
+   * @param options Write options, if this was a CTAS/RTAS
+   */
+  private def getOperation(
+      metadata: Metadata,
+      isManagedTable: Boolean,
+      options: Option[DeltaOptions]): DeltaOperations.Operation = operation match {
+    // This is legacy saveAsTable behavior in Databricks Runtime
+    case TableCreationModes.Create if existingTableOpt.isDefined && query.isDefined =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // DataSourceV2 table creation
+    // CREATE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Create =>
+      DeltaOperations.CreateTable(metadata, isManagedTable, query.isDefined)
+
+    // DataSourceV2 table replace
+    // REPLACE TABLE (non-DataFrameWriter API) doesn't have options syntax
+    // (userMetadata uses SQLConf in this case)
+    case TableCreationModes.Replace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = false, query.isDefined)
+
+    // Legacy saveAsTable with Overwrite mode
+    case TableCreationModes.CreateOrReplace if options.exists(_.replaceWhere.isDefined) =>
+      DeltaOperations.Write(mode, Option(table.partitionColumnNames), options.get.replaceWhere,
+        options.flatMap(_.userMetadata))
+
+    // New DataSourceV2 saveAsTable with overwrite mode behavior
+    case TableCreationModes.CreateOrReplace =>
+      DeltaOperations.ReplaceTable(metadata, isManagedTable, orCreate = true, query.isDefined,
+        options.flatMap(_.userMetadata))
+  }
+
+  /**
+   * Similar to getOperation, here we disambiguate the catalog alterations we need to do based
+   * on the table operation, and whether we have reached here through legacy code or DataSourceV2
+   * code paths.
+   */
+  private def updateCatalog(
+      spark: SparkSession,
+      table: CatalogTable,
+      snapshot: Snapshot,
+      txn: OptimisticTransaction): Unit = {
+    val cleaned = cleanupTableDefinition(table, snapshot)
+    operation match {
+      case _ if tableByPath => // do nothing with the metastore if this is by path
+      case TableCreationModes.Create =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = existingTableOpt.isDefined,
+          validateLocation = false)
+      case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
+          if existingTableOpt.isDefined =>
+        spark.sessionState.catalog.alterTable(table)
+      case TableCreationModes.Replace =>
+        val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
+        throw DeltaErrors.cannotReplaceMissingTableException(ident)
+      case TableCreationModes.CreateOrReplace =>
+        spark.sessionState.catalog.createTable(
+          cleaned,
+          ignoreIfExists = false,
+          validateLocation = false)
+    }
+  }
+
+  /** Clean up the information we pass on to store in the catalog. */
+  private def cleanupTableDefinition(table: CatalogTable, snapshot: Snapshot): CatalogTable = {
+    // These actually have no effect on the usability of Delta, but feature flagging legacy
+    // behavior for now
+    val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
+      // Legacy behavior
+      table.storage
+    } else {
+      table.storage.copy(properties = Map.empty)
+    }
+
+    table.copy(
+      schema = new StructType(),
+      properties = Map.empty,
+      partitionColumnNames = Nil,
+      // Remove write specific options when updating the catalog
+      storage = storageProps,
+      tracksPartitionsInCatalog = true)
+  }
+
+  /**
+   * With DataFrameWriterV2, methods like `replace()` or `createOrReplace()` mean that the
+   * metadata of the table should be replaced. If overwriteSchema=false is provided with these
+   * methods, then we will verify that the metadata match exactly.
+   */
+  private def replaceMetadataIfNecessary(
+      txn: OptimisticTransaction,
+      tableDesc: CatalogTable,
+      options: DeltaOptions,
+      schema: StructType): Unit = {
+    val isReplace = (operation == TableCreationModes.CreateOrReplace ||
+        operation == TableCreationModes.Replace)
+    // If a user explicitly specifies not to overwrite the schema, during a replace, we should
+    // tell them that it's not supported
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
+    if (isReplace && dontOverwriteSchema) {
+      throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
+    }
+    if (txn.readVersion > -1L && isReplace && !dontOverwriteSchema) {
+      // When a table already exists, and we're using the DataFrameWriterV2 API to replace
+      // or createOrReplace a table, we blindly overwrite the metadata.
+      txn.updateMetadataForNewTable(getProvidedMetadata(table, schema.json))
+    }
+  }
+
+  /**
+   * Horrible hack to differentiate between DataFrameWriterV1 and V2 so that we can decide
+   * what to do with table metadata. In DataFrameWriterV1, mode("overwrite").saveAsTable,
+   * behaves as a CreateOrReplace table, but we have asked for "overwriteSchema" as an
+   * explicit option to overwrite partitioning or schema information. With DataFrameWriterV2,
+   * the behavior asked for by the user is clearer: .createOrReplace(), which means that we
+   * should overwrite schema and/or partitioning. Therefore we have this hack.
+   */
+  private def isV1Writer: Boolean = {
+    Thread.currentThread().getStackTrace.exists(_.toString.contains(
+      classOf[DataFrameWriter[_]].getCanonicalName + "."))
+  }
+}

--- a/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
+++ b/delta-lake/delta-spark332db/src/main/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalog.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * This file was derived from DeltaDataSource.scala in the
+ * Delta Lake project at https://github.com/delta-io/delta.
+ *
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.databricks.sql.transaction.tahoe.rapids
+
+import java.util
+
+import com.databricks.sql.transaction.tahoe.{DeltaConfigs, DeltaErrors}
+import com.databricks.sql.transaction.tahoe.commands.TableCreationModes
+import com.databricks.sql.transaction.tahoe.metering.DeltaLogging
+import com.databricks.sql.transaction.tahoe.sources.DeltaSourceUtils
+import com.nvidia.spark.rapids.RapidsConf
+
+import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, StagedTable, StagingTableCatalog, Table}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.datasources.PartitioningUtils
+import org.apache.spark.sql.types.StructType
+
+class GpuDeltaCatalog(
+    override val cpuCatalog: StagingTableCatalog,
+    override val rapidsConf: RapidsConf)
+  extends GpuDeltaCatalogBase with SupportsPathIdentifier with DeltaLogging {
+
+  override protected def buildGpuCreateDeltaTableCommand(
+      rapidsConf: RapidsConf,
+      table: CatalogTable,
+      existingTableOpt: Option[CatalogTable],
+      mode: SaveMode,
+      query: Option[LogicalPlan],
+      operation: TableCreationModes.CreationMode,
+      tableByPath: Boolean): LeafRunnableCommand = {
+    GpuCreateDeltaTableCommand(
+      table,
+      existingTableOpt,
+      mode,
+      query,
+      operation,
+      tableByPath = tableByPath
+    )(rapidsConf)
+  }
+
+  override protected def getExistingTableIfExists(table: TableIdentifier): Option[CatalogTable] = {
+    // If this is a path identifier, we cannot return an existing CatalogTable. The Create command
+    // will check the file system itself
+    if (isPathIdentifier(table)) return None
+    val tableExists = catalog.tableExists(table)
+    if (tableExists) {
+      val oldTable = catalog.getTableMetadata(table)
+      if (oldTable.tableType == CatalogTableType.VIEW) {
+        throw new AnalysisException(
+          s"$table is a view. You may not write data into a view.")
+      }
+      if (!DeltaSourceUtils.isDeltaTable(oldTable.provider)) {
+        throw new AnalysisException(s"$table is not a Delta table. Please drop this " +
+          "table first if you would like to recreate it with Delta Lake.")
+      }
+      Some(oldTable)
+    } else {
+      None
+    }
+  }
+
+  override protected def verifyTableAndSolidify(
+      tableDesc: CatalogTable,
+      query: Option[LogicalPlan]): CatalogTable = {
+
+    if (tableDesc.bucketSpec.isDefined) {
+      throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
+    }
+
+    val schema = query.map { plan =>
+      assert(tableDesc.schema.isEmpty, "Can't specify table schema in CTAS.")
+      plan.schema.asNullable
+    }.getOrElse(tableDesc.schema)
+
+    PartitioningUtils.validatePartitionColumn(
+      schema,
+      tableDesc.partitionColumnNames,
+      caseSensitive = false) // Delta is case insensitive
+
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tableDesc.properties)
+
+    val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
+    val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))
+    tableDesc.copy(
+      identifier = tableIdentWithDB,
+      schema = schema,
+      properties = validatedConfigurations)
+  }
+
+  override protected def createGpuStagedDeltaTableV2(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode): StagedTable = {
+    new GpuStagedDeltaTableV2WithLogging(ident, schema, partitions, properties, operation)
+  }
+
+  override def loadTable(ident: Identifier, timestamp: Long): Table = {
+    cpuCatalog.loadTable(ident, timestamp)
+  }
+
+  override def loadTable(ident: Identifier, version: String): Table = {
+    cpuCatalog.loadTable(ident, version)
+  }
+
+  /**
+   * Creates a Delta table using GPU for writing the data
+   *
+   * @param ident              The identifier of the table
+   * @param schema             The schema of the table
+   * @param partitions         The partition transforms for the table
+   * @param allTableProperties The table properties that configure the behavior of the table or
+   *                           provide information about the table
+   * @param writeOptions       Options specific to the write during table creation or replacement
+   * @param sourceQuery        A query if this CREATE request came from a CTAS or RTAS
+   * @param operation          The specific table creation mode, whether this is a
+   *                           Create/Replace/Create or Replace
+   */
+  override def createDeltaTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      allTableProperties: util.Map[String, String],
+      writeOptions: Map[String, String],
+      sourceQuery: Option[DataFrame],
+      operation: TableCreationModes.CreationMode
+  ): Table = recordFrameProfile(
+    "DeltaCatalog", "createDeltaTable") {
+    super.createDeltaTable(
+      ident,
+      schema,
+      partitions,
+      allTableProperties,
+      writeOptions,
+      sourceQuery,
+      operation)
+  }
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): Table =
+    recordFrameProfile("DeltaCatalog", "createTable") {
+      super.createTable(ident, schema, partitions, properties)
+    }
+
+  override def stageReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageReplace") {
+      super.stageReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreateOrReplace(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreateOrReplace") {
+      super.stageCreateOrReplace(ident, schema, partitions, properties)
+    }
+
+  override def stageCreate(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String]): StagedTable =
+    recordFrameProfile("DeltaCatalog", "stageCreate") {
+      super.stageCreate(ident, schema, partitions, properties)
+    }
+
+  /**
+   * A staged Delta table, which creates a HiveMetaStore entry and appends data if this was a
+   * CTAS/RTAS command. We have a ugly way of using this API right now, but it's the best way to
+   * maintain old behavior compatibility between Databricks Runtime and OSS Delta Lake.
+   */
+  protected class GpuStagedDeltaTableV2WithLogging(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: util.Map[String, String],
+      operation: TableCreationModes.CreationMode)
+    extends GpuStagedDeltaTableV2(ident, schema, partitions, properties, operation) {
+
+    override def commitStagedChanges(): Unit = recordFrameProfile(
+      "DeltaCatalog", "commitStagedChanges") {
+      super.commitStagedChanges()
+    }
+  }
+}

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -258,6 +258,26 @@ def test_delta_append_round_trip_unmanaged(spark_tmp_path):
 
 @allow_non_gpu(*delta_meta_allow)
 @delta_lake
+@ignore_order(local=True)
+@pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
+@pytest.mark.parametrize("gens", parquet_write_gens_list, ids=idfn)
+def test_delta_atomic_create_table_as_select(gens, spark_tmp_table_factory, spark_tmp_path):
+    gen_list = [("c" + str(i), gen) for i, gen in enumerate(gens)]
+    data_path = spark_tmp_path + "/DELTA_DATA"
+    confs = copy_and_update(writer_confs, delta_writes_enabled_conf)
+    path_to_table= {}
+    def do_write(spark, path):
+        table = spark_tmp_table_factory.get()
+        path_to_table[path] = table
+        gen_df(spark, gen_list).coalesce(1).write.format("delta").saveAsTable(table)
+    assert_gpu_and_cpu_writes_are_equal_collect(
+        do_write,
+        lambda spark, path: spark.read.format("delta").table(path_to_table[path]),
+        data_path,
+        conf = confs)
+
+@allow_non_gpu(*delta_meta_allow)
+@delta_lake
 @ignore_order
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
 @pytest.mark.skipif(is_databricks_runtime() and is_before_spark_330(),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AtomicCreateTableAsSelectExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AtomicCreateTableAsSelectExecMeta.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
+import org.apache.spark.sql.rapids.ExternalSource
+
+class AtomicCreateTableAsSelectExecMeta(
+    wrapped: AtomicCreateTableAsSelectExec,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule)
+  extends SparkPlanMeta[AtomicCreateTableAsSelectExec](wrapped, conf, parent, rule) {
+
+  override def tagPlanForGpu(): Unit = {
+    ExternalSource.tagForGpu(wrapped, this)
+  }
+
+  override def convertToGpu(): GpuExec = {
+    ExternalSource.convertToGpu(wrapped, this)
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -510,6 +510,8 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
   private def insertColumnarFromGpu(plan: SparkPlan): SparkPlan = {
     if (plan.supportsColumnar && plan.isInstanceOf[GpuExec]) {
       GpuBringBackToHost(insertColumnarToGpu(plan))
+    } else if (plan.isInstanceOf[ColumnarToRowTransition] && plan.isInstanceOf[GpuExec]) {
+      plan.withNewChildren(plan.children.map(insertColumnarToGpu))
     } else {
       plan.withNewChildren(plan.children.map(insertColumnarFromGpu))
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
@@ -16,12 +16,14 @@
 
 package com.nvidia.spark.rapids.delta
 
-import com.nvidia.spark.rapids.{CreatableRelationProviderRule, ExecRule, RunnableCommandRule, ShimLoader, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AtomicCreateTableAsSelectExecMeta, CreatableRelationProviderRule, ExecRule, GpuExec, RunnableCommandRule, ShimLoader, SparkPlanMeta}
 
 import org.apache.spark.sql.Strategy
+import org.apache.spark.sql.connector.catalog.StagingTableCatalog
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
 import org.apache.spark.sql.sources.CreatableRelationProvider
 
 /** Probe interface to determine which Delta Lake provider to use. */
@@ -46,6 +48,16 @@ trait DeltaProvider {
   def tagSupportForGpuFileSourceScan(meta: SparkPlanMeta[FileSourceScanExec]): Unit
 
   def getReadFileFormat(format: FileFormat): FileFormat
+
+  def isSupportedCatalog(catalogClass: Class[_ <: StagingTableCatalog]): Boolean
+
+  def tagForGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): Unit
+
+  def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec
 }
 
 object DeltaProvider {
@@ -74,4 +86,18 @@ object NoDeltaProvider extends DeltaProvider {
 
   override def getReadFileFormat(format: FileFormat): FileFormat =
     throw new IllegalStateException("unsupported format")
+
+  override def isSupportedCatalog(catalogClass: Class[_ <: StagingTableCatalog]): Boolean = false
+
+  override def tagForGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): Unit = {
+    throw new IllegalStateException("catalog not supported, should not be called")
+  }
+
+  override def convertToGpu(
+      cpuExec: AtomicCreateTableAsSelectExec,
+      meta: AtomicCreateTableAsSelectExecMeta): GpuExec = {
+    throw new IllegalStateException("catalog not supported, should not be called")
+  }
 }

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -52,6 +52,7 @@ import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
@@ -251,6 +252,13 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
 
   override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
     val maps: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = Seq(
+      exec[AtomicCreateTableAsSelectExec](
+        "Create table as select for datasource V2 tables that support staging table creation",
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.STRUCT +
+          TypeSig.MAP + TypeSig.ARRAY + TypeSig.BINARY +
+          GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
+          TypeSig.all),
+        (e, conf, p, r) => new AtomicCreateTableAsSelectExecMeta(e, conf, p, r)),
       GpuOverrides.exec[WindowInPandasExec](
         "The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between" +
           " the Java process and the Python process. It also supports scheduling GPU resources" +

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -59,7 +59,7 @@ case class GpuAtomicCreateTableAsSelectExec(
     query: SparkPlan,
     properties: Map[String, String],
     writeOptions: CaseInsensitiveStringMap,
-    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec with ColumnarToRowTransition {
 
   override def supportsColumnar: Boolean = false
 

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2.rapids
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.GpuExec
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.connector.catalog.{Identifier, StagingTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * GPU version of AtomicCreateTableAsSelectExec.
+ *
+ * Physical plan node for v2 create table as select, when the catalog is determined to support
+ * staging table creation.
+ *
+ * A new table will be created using the schema of the query, and rows from the query are appended.
+ * The CTAS operation is atomic. The creation of the table is staged and the commit of the write
+ * should bundle the commitment of the metadata and the table contents in a single unit. If the
+ * write fails, the table is instructed to roll back all staged changes.
+ */
+case class GpuAtomicCreateTableAsSelectExec(
+    catalog: StagingTableCatalog,
+    ident: Identifier,
+    partitioning: Seq[Transform],
+    plan: LogicalPlan,
+    query: SparkPlan,
+    properties: Map[String, String],
+    writeOptions: CaseInsensitiveStringMap,
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+
+  override def supportsColumnar: Boolean = false
+
+  override protected def run(): Seq[InternalRow] = {
+    if (catalog.tableExists(ident)) {
+      if (ifNotExists) {
+        return Nil
+      }
+
+      throw QueryCompilationErrors.tableAlreadyExistsError(ident)
+    }
+    val schema = CharVarcharUtils.getRawSchema(query.schema).asNullable
+    val stagedTable = catalog.stageCreate(
+      ident, schema, partitioning.toArray, properties.asJava)
+    writeToTable(catalog, stagedTable, writeOptions, ident)
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): GpuAtomicCreateTableAsSelectExec = copy(query = newChild)
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] =
+    throw new IllegalStateException("Columnar execution not supported")
+}

--- a/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -58,7 +58,7 @@ case class GpuAtomicCreateTableAsSelectExec(
     query: SparkPlan,
     tableSpec: TableSpec,
     writeOptions: CaseInsensitiveStringMap,
-    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec with ColumnarToRowTransition {
 
   val properties = CatalogV2Util.convertTableProperties(tableSpec)
 

--- a/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "321db"}
+{"spark": "330db"}
+{"spark": "332db"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2.rapids
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.GpuExec
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * GPU version of AtomicCreateTableAsSelectExec.
+ *
+ * Physical plan node for v2 create table as select, when the catalog is determined to support
+ * staging table creation.
+ *
+ * A new table will be created using the schema of the query, and rows from the query are appended.
+ * The CTAS operation is atomic. The creation of the table is staged and the commit of the write
+ * should bundle the commitment of the metadata and the table contents in a single unit. If the
+ * write fails, the table is instructed to roll back all staged changes.
+ */
+case class GpuAtomicCreateTableAsSelectExec(
+    override val output: Seq[Attribute],
+    catalog: StagingTableCatalog,
+    ident: Identifier,
+    partitioning: Seq[Transform],
+    plan: LogicalPlan,
+    query: SparkPlan,
+    tableSpec: TableSpec,
+    writeOptions: CaseInsensitiveStringMap,
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+
+  val properties = CatalogV2Util.convertTableProperties(tableSpec)
+
+  override def supportsColumnar: Boolean = false
+
+  override protected def run(): Seq[InternalRow] = {
+    if (catalog.tableExists(ident)) {
+      if (ifNotExists) {
+        return Nil
+      }
+
+      throw QueryCompilationErrors.tableAlreadyExistsError(ident)
+    }
+    val schema = CharVarcharUtils.getRawSchema(query.schema, conf).asNullable
+    val stagedTable = catalog.stageCreate(
+      ident, schema, partitioning.toArray, properties.asJava)
+    writeToTable(catalog, stagedTable, writeOptions, ident)
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): GpuAtomicCreateTableAsSelectExec = copy(query = newChild)
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] =
+    throw new IllegalStateException("Columnar execution not supported")
+}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "333"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2.rapids
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.GpuExec
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * GPU version of AtomicCreateTableAsSelectExec.
+ *
+ * Physical plan node for v2 create table as select, when the catalog is determined to support
+ * staging table creation.
+ *
+ * A new table will be created using the schema of the query, and rows from the query are appended.
+ * The CTAS operation is atomic. The creation of the table is staged and the commit of the write
+ * should bundle the commitment of the metadata and the table contents in a single unit. If the
+ * write fails, the table is instructed to roll back all staged changes.
+ */
+case class GpuAtomicCreateTableAsSelectExec(
+    catalog: StagingTableCatalog,
+    ident: Identifier,
+    partitioning: Seq[Transform],
+    plan: LogicalPlan,
+    query: SparkPlan,
+    tableSpec: TableSpec,
+    writeOptions: CaseInsensitiveStringMap,
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+
+  val properties = CatalogV2Util.convertTableProperties(tableSpec)
+
+  override def supportsColumnar: Boolean = false
+
+  override protected def run(): Seq[InternalRow] = {
+    if (catalog.tableExists(ident)) {
+      if (ifNotExists) {
+        return Nil
+      }
+
+      throw QueryCompilationErrors.tableAlreadyExistsError(ident)
+    }
+    val schema = CharVarcharUtils.getRawSchema(query.schema, conf).asNullable
+    val stagedTable = catalog.stageCreate(
+      ident, schema, partitioning.toArray, properties.asJava)
+    writeToTable(catalog, stagedTable, writeOptions, ident)
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): GpuAtomicCreateTableAsSelectExec = copy(query = newChild)
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] =
+    throw new IllegalStateException("Columnar execution not supported")
+}

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -58,7 +58,7 @@ case class GpuAtomicCreateTableAsSelectExec(
     query: SparkPlan,
     tableSpec: TableSpec,
     writeOptions: CaseInsensitiveStringMap,
-    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec with ColumnarToRowTransition {
 
   val properties = CatalogV2Util.convertTableProperties(tableSpec)
 

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "340"}
+{"spark": "341"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2.rapids
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.GpuExec
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * GPU version of AtomicCreateTableAsSelectExec.
+ *
+ * Physical plan node for v2 create table as select, when the catalog is determined to support
+ * staging table creation.
+ *
+ * A new table will be created using the schema of the query, and rows from the query are appended.
+ * The CTAS operation is atomic. The creation of the table is staged and the commit of the write
+ * should bundle the commitment of the metadata and the table contents in a single unit. If the
+ * write fails, the table is instructed to roll back all staged changes.
+ */
+case class GpuAtomicCreateTableAsSelectExec(
+    catalog: StagingTableCatalog,
+    ident: Identifier,
+    partitioning: Seq[Transform],
+    plan: LogicalPlan,
+    query: SparkPlan,
+    tableSpec: TableSpec,
+    writeOptions: CaseInsensitiveStringMap,
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+
+  val properties = CatalogV2Util.convertTableProperties(tableSpec)
+
+  override def supportsColumnar: Boolean = false
+
+  override protected def run(): Seq[InternalRow] = {
+    if (catalog.tableExists(ident)) {
+      if (ifNotExists) {
+        return Nil
+      }
+
+      throw QueryCompilationErrors.tableAlreadyExistsError(ident)
+    }
+    val columns = CatalogV2Util.structTypeToV2Columns(
+      CharVarcharUtils.getRawSchema(query.schema, conf).asNullable)
+    val stagedTable = catalog.stageCreate(
+      ident, columns, partitioning.toArray, properties.asJava)
+    writeToTable(catalog, stagedTable, writeOptions, ident)
+  }
+
+  override protected def withNewChildInternal(
+      newChild: SparkPlan): GpuAtomicCreateTableAsSelectExec = copy(query = newChild)
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] =
+    throw new IllegalStateException("Columnar execution not supported")
+}

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -55,7 +55,7 @@ case class GpuAtomicCreateTableAsSelectExec(
     query: SparkPlan,
     tableSpec: TableSpec,
     writeOptions: CaseInsensitiveStringMap,
-    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec {
+    ifNotExists: Boolean) extends TableWriteExecHelper with GpuExec with ColumnarToRowTransition {
 
   val properties = CatalogV2Util.convertTableProperties(tableSpec)
 

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/ShimTrampolineUtil.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/ShimTrampolineUtil.scala
@@ -22,6 +22,7 @@ spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution
 
 import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, IdentityBroadcastMode}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column}
 import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.types.{DataType, StructType}
 
@@ -34,5 +35,9 @@ object ShimTrampolineUtil {
     case _ : HashedRelationBroadcastMode => true
     case IdentityBroadcastMode => true
     case _ => false
+  }
+
+  def v2ColumnsToStructType(columns: Array[Column]): StructType = {
+    CatalogV2Util.v2ColumnsToStructType(columns)
   }
 }

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.ColumnarToRowTransition
 import org.apache.spark.sql.execution.datasources.v2.V2CreateTableAsSelectBaseExec
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -52,7 +51,7 @@ case class GpuAtomicCreateTableAsSelectExec(
     tableSpec: TableSpec,
     writeOptions: Map[String, String],
     ifNotExists: Boolean)
-  extends V2CreateTableAsSelectBaseExec with GpuExec with ColumnarToRowTransition {
+  extends V2CreateTableAsSelectBaseExec with GpuExec {
 
   val properties = CatalogV2Util.convertTableProperties(tableSpec)
 

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.ColumnarToRowTransition
 import org.apache.spark.sql.execution.datasources.v2.V2CreateTableAsSelectBaseExec
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -50,7 +51,8 @@ case class GpuAtomicCreateTableAsSelectExec(
     query: LogicalPlan,
     tableSpec: TableSpec,
     writeOptions: Map[String, String],
-    ifNotExists: Boolean) extends V2CreateTableAsSelectBaseExec with GpuExec {
+    ifNotExists: Boolean)
+  extends V2CreateTableAsSelectBaseExec with GpuExec with ColumnarToRowTransition {
 
   val properties = CatalogV2Util.convertTableProperties(tableSpec)
 

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.execution.datasources.v2.rapids
+
+import scala.collection.JavaConverters._
+
+import com.nvidia.spark.rapids.GpuExec
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, TableSpec}
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, StagingTableCatalog}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.v2.V2CreateTableAsSelectBaseExec
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * GPU version of AtomicCreateTableAsSelectExec.
+ *
+ * Physical plan node for v2 create table as select, when the catalog is determined to support
+ * staging table creation.
+ *
+ * A new table will be created using the schema of the query, and rows from the query are appended.
+ * The CTAS operation is atomic. The creation of the table is staged and the commit of the write
+ * should bundle the commitment of the metadata and the table contents in a single unit. If the
+ * write fails, the table is instructed to roll back all staged changes.
+ */
+case class GpuAtomicCreateTableAsSelectExec(
+    catalog: StagingTableCatalog,
+    ident: Identifier,
+    partitioning: Seq[Transform],
+    query: LogicalPlan,
+    tableSpec: TableSpec,
+    writeOptions: Map[String, String],
+    ifNotExists: Boolean) extends V2CreateTableAsSelectBaseExec with GpuExec {
+
+  val properties = CatalogV2Util.convertTableProperties(tableSpec)
+
+  override def supportsColumnar: Boolean = false
+
+  override protected def run(): Seq[InternalRow] = {
+    if (catalog.tableExists(ident)) {
+      if (ifNotExists) {
+        return Nil
+      }
+
+      throw QueryCompilationErrors.tableAlreadyExistsError(ident)
+    }
+    val stagedTable = catalog.stageCreate(
+      ident, getV2Columns(query.schema, catalog.useNullableQuerySchema),
+      partitioning.toArray, properties.asJava)
+    writeToTable(catalog, stagedTable, writeOptions, ident, query)
+  }
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] =
+    throw new IllegalStateException("Columnar execution not supported")
+}


### PR DESCRIPTION
Fixes #7276.  Extended ExternalSource to handle potential replacements for AtomicCreateTableAsSelect and added unit tests.  A significant amount of the code change comes from the various GpuCreateDeltaTableCommand files which are small changes from the original versions of CreateDeltaTableCommand sources needed to perform the operation on the GPU.  Rather than refactor these for commonality between the Delta Lake versions and make it hard to see the GPU diffs needed for each version, I added each separately to make diffing easier both for the current review and for auditing for changes in Delta Lake patch versions in the future.