### PR TITLE
Add retry support to `HostToGpuCoalesceIterator.concatAllAndPutOnGPU`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/HostColumnarToGpu.scala
@@ -270,7 +270,9 @@ class HostToGpuCoalesceIterator(iter: Iterator[ColumnarBatch],
     // About to place data back on the GPU
     GpuSemaphore.acquireIfNecessary(TaskContext.get())
 
-    val ret = batchBuilder.build(totalRows)
+    val ret = RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch]{
+      batchBuilder.tryBuild(totalRows)
+    }
     val maxDeviceMemory = GpuColumnVector.getTotalDeviceMemoryUsed(ret)
 
     // refine the estimate for number of rows based on this batch

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
@@ -20,7 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.jni.{RetryOOM, RmmSpark, SplitAndRetryOOM}
+import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
+import org.mockito.Mockito._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -118,15 +119,10 @@ class GpuCoalesceBatchesRetrySuite
     }
   }
 
-  // this is a placeholder test. The HostToGpuCoalesceIterator is going to
-  // need a change in cuDF to make it retriable, so we are asserting here
-  // that the exception we could handle `RetryOOM` is being thrown.
   test("coalesce gpu batches with retry host iter") {
     val iter = getHostIter(injectRetry = 1)
-    assertThrows[RetryOOM] {
-      withResource(iter.next()) { coalesced =>
-        assertResult(10)(coalesced.numRows())
-      }
+    withResource(iter.next()) { coalesced =>
+      assertResult(10)(coalesced.numRows())
     }
     // ensure that this iterator _did not close_ the incoming batches
     // as that is the semantics of the HostToGpuCoalesceIterator

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
@@ -22,7 +22,6 @@ import ai.rapids.cudf.Table
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.jni.{RmmSpark, SplitAndRetryOOM}
 import org.mockito.Mockito._
-import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.sql.types.{DataType, LongType, StructField, StructType}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnToGpuRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnToGpuRetrySuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuColumnVector.GpuArrowColumnarBatchBuilder
+import com.nvidia.spark.rapids.jni.RmmSpark
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.IntVector
+
+import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+
+class HostColumnToGpuRetrySuite extends RmmSparkRetrySuiteBase {
+
+  private val schema = StructType(Seq(StructField("a", IntegerType)))
+  private val NUM_ROWS = 50
+
+  private def buildArrowIntColumn(): ColumnVector = {
+    val intVector = new IntVector("intVector", new RootAllocator())
+    intVector.allocateNew(NUM_ROWS)
+    (0 until NUM_ROWS).foreach { pos =>
+      intVector.set(pos, pos * 10)
+    }
+    new ArrowColumnVector(intVector)
+  }
+
+  test("Arrow column builder with retry OOM") {
+    val batch = withResource(new GpuArrowColumnarBatchBuilder(schema)) { builder =>
+      withResource(buildArrowIntColumn()) { arrowColumn =>
+        builder.copyColumnar(arrowColumn, 0, NUM_ROWS)
+      }
+      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+      RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch] {
+        builder.tryBuild(NUM_ROWS)
+      }
+    }
+    withResource(batch) { _ =>
+      assertResult(NUM_ROWS)(batch.numRows())
+      assertResult(1)(batch.numCols())
+      withResource(batch.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hostCol =>
+        withResource(buildArrowIntColumn()) { arrowCol =>
+          (0 until NUM_ROWS).foreach { pos =>
+            assert(hostCol.getInt(pos) == arrowCol.getInt(pos))
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnToGpuRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HostColumnToGpuRetrySuite.scala
@@ -19,7 +19,7 @@ package com.nvidia.spark.rapids
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuColumnVector.GpuArrowColumnarBatchBuilder
 import com.nvidia.spark.rapids.jni.RmmSpark
-import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
 import org.apache.arrow.vector.IntVector
 
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -30,32 +30,35 @@ class HostColumnToGpuRetrySuite extends RmmSparkRetrySuiteBase {
   private val schema = StructType(Seq(StructField("a", IntegerType)))
   private val NUM_ROWS = 50
 
-  private def buildArrowIntColumn(): ColumnVector = {
-    val intVector = new IntVector("intVector", new RootAllocator())
+  private def buildArrowIntColumn(allocator: BufferAllocator): ColumnVector = {
+    val intVector = new IntVector("intVector", allocator)
     intVector.allocateNew(NUM_ROWS)
     (0 until NUM_ROWS).foreach { pos =>
       intVector.set(pos, pos * 10)
     }
+    intVector.setValueCount(NUM_ROWS)
     new ArrowColumnVector(intVector)
   }
 
   test("Arrow column builder with retry OOM") {
-    val batch = withResource(new GpuArrowColumnarBatchBuilder(schema)) { builder =>
-      withResource(buildArrowIntColumn()) { arrowColumn =>
-        builder.copyColumnar(arrowColumn, 0, NUM_ROWS)
+    withResource(new RootAllocator()) { allocator =>
+      val batch = withResource(new GpuArrowColumnarBatchBuilder(schema)) { builder =>
+        withResource(buildArrowIntColumn(allocator)) { arrowColumn =>
+          builder.copyColumnar(arrowColumn, 0, NUM_ROWS)
+        }
+        RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
+        RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch] {
+          builder.tryBuild(NUM_ROWS)
+        }
       }
-      RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId)
-      RmmRapidsRetryIterator.withRetryNoSplit[ColumnarBatch] {
-        builder.tryBuild(NUM_ROWS)
-      }
-    }
-    withResource(batch) { _ =>
-      assertResult(NUM_ROWS)(batch.numRows())
-      assertResult(1)(batch.numCols())
-      withResource(batch.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hostCol =>
-        withResource(buildArrowIntColumn()) { arrowCol =>
-          (0 until NUM_ROWS).foreach { pos =>
-            assert(hostCol.getInt(pos) == arrowCol.getInt(pos))
+      withResource(batch) { _ =>
+        assertResult(NUM_ROWS)(batch.numRows())
+        assertResult(1)(batch.numCols())
+        withResource(batch.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hostCol =>
+          withResource(buildArrowIntColumn(allocator)) { arrowCol =>
+            (0 until NUM_ROWS).foreach { pos =>
+              assert(hostCol.getInt(pos) == arrowCol.getInt(pos))
+            }
           }
         }
       }


### PR DESCRIPTION
close https://github.com/NVIDIA/spark-rapids/issues/8326

This PR adds the retry support to `HostToGpuCoalesceIterator.concatAllAndPutOnGPU` for HostColumnToGpu by implementing the `tryBuild` method in builders.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
