### PR TITLE
Fix 332cdh build [skip ci]

### DIFF
--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -19,6 +19,7 @@
 {"spark": "330cdh"}
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332cdh"}
 {"spark": "333"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2.rapids


### PR DESCRIPTION
Premerge for #9425 ran before #9396 was merged, so it didn't catch the missing shimplify directive needed for that PR.  Adding it here to fix the 332cdh build.