### PR TITLE
Fix Cloudera 3.3.2 shim for handling CheckOverflowInTableInsert and orc zstd support

### DIFF
--- a/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/Spark33cdhShims.scala
+++ b/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/Spark33cdhShims.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "330cdh"}
+{"spark": "332cdh"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
+
+trait Spark33cdhShims extends Spark330PlusNonDBShims with AnsiCastRuleShims {
+  override def getDataWriteCmds: Map[Class[_ <: DataWritingCommand],
+      DataWritingCommandRule[_ <: DataWritingCommand]] = {
+    Seq(GpuOverrides.dataWriteCmd[CreateDataSourceTableAsSelectCommand](
+    "Create table with select command",
+    (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r))
+    ).map(r => (r.getClassFor.asSubclass(classOf[DataWritingCommand]), r)).toMap
+  }
+
+  override def getRunnableCmds: Map[Class[_ <: RunnableCommand],
+      RunnableCommandRule[_ <: RunnableCommand]] = {
+    Map.empty
+  }
+
+ override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
+    val newRule = org.apache.spark.sql.hive.cdh.HiveOverrides.getHiveTableExecRule()
+    // scala compiler gets confused if we don't give an explicit type to the class here.
+    // ... perhaps there is a cleaner way to do this
+    val ruleClass: Class[_ <: SparkPlan] = newRule.getClassFor.asSubclass(classOf[SparkPlan])
+    super.getExecs ++ Seq(ruleClass -> newRule).toMap
+  }
+}

--- a/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -19,32 +19,4 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids._
-
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
-
-object SparkShimImpl extends Spark330PlusNonDBShims with AnsiCastRuleShims {
-  override def getDataWriteCmds: Map[Class[_ <: DataWritingCommand],
-      DataWritingCommandRule[_ <: DataWritingCommand]] = {
-    Seq(GpuOverrides.dataWriteCmd[CreateDataSourceTableAsSelectCommand](
-    "Create table with select command",
-    (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r))
-    ).map(r => (r.getClassFor.asSubclass(classOf[DataWritingCommand]), r)).toMap
-  }
-
-  override def getRunnableCmds: Map[Class[_ <: RunnableCommand],
-      RunnableCommandRule[_ <: RunnableCommand]] = {
-    Map.empty
-  }
-
-  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
-
-    val newRule = org.apache.spark.sql.hive.cdh.HiveOverrides.getHiveTableExecRule()
-    // scala compiler gets confused if we don't give an explicit type to the class here.
-    // ... perhaps there is a cleaner way to do this
-    val ruleClass: Class[_ <: SparkPlan] = newRule.getClassFor.asSubclass(classOf[SparkPlan])
-    super.getExecs ++ Seq(ruleClass -> newRule).toMap
-  }
-
-}
+object SparkShimImpl extends Spark33cdhShims {}

--- a/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark330cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -16,7 +16,6 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "330cdh"}
-{"spark": "332cdh"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 

--- a/sql-plugin/src/main/spark331/scala/com/nvidia/spark/rapids/shims/Spark331PlusShims.scala
+++ b/sql-plugin/src/main/spark331/scala/com/nvidia/spark/rapids/shims/Spark331PlusShims.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332cdh"}
 {"spark": "333"}
 {"spark": "340"}
 {"spark": "341"}

--- a/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
+++ b/sql-plugin/src/main/spark331/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "331"}
 {"spark": "332"}
+{"spark": "332cdh"}
 {"spark": "333"}
 {"spark": "340"}
 {"spark": "341"}

--- a/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -19,33 +19,4 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import com.nvidia.spark.rapids._
-
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
-
-object SparkShimImpl extends Spark331PlusShims with AnsiCastRuleShims {
-
-  override def getDataWriteCmds: Map[Class[_ <: DataWritingCommand],
-      DataWritingCommandRule[_ <: DataWritingCommand]] = {
-    Seq(GpuOverrides.dataWriteCmd[CreateDataSourceTableAsSelectCommand](
-    "Create table with select command",
-    (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r))
-    ).map(r => (r.getClassFor.asSubclass(classOf[DataWritingCommand]), r)).toMap
-  }
-
-  override def getRunnableCmds: Map[Class[_ <: RunnableCommand],
-      RunnableCommandRule[_ <: RunnableCommand]] = {
-    Map.empty
-  }
-
-  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
-
-    val newRule = org.apache.spark.sql.hive.cdh.HiveOverrides.getHiveTableExecRule()
-    // scala compiler gets confused if we don't give an explicit type to the class here.
-    // ... perhaps there is a cleaner way to do this
-    val ruleClass: Class[_ <: SparkPlan] = newRule.getClassFor.asSubclass(classOf[SparkPlan])
-    super.getExecs ++ Seq(ruleClass -> newRule).toMap
-  }
-
-}
+object SparkShimImpl extends Spark33cdhShims with Spark331PlusShims {}

--- a/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark332cdh/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "332cdh"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import com.nvidia.spark.rapids._
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.command.{CreateDataSourceTableAsSelectCommand, DataWritingCommand, RunnableCommand}
+
+object SparkShimImpl extends Spark331PlusShims with AnsiCastRuleShims {
+
+  override def getDataWriteCmds: Map[Class[_ <: DataWritingCommand],
+      DataWritingCommandRule[_ <: DataWritingCommand]] = {
+    Seq(GpuOverrides.dataWriteCmd[CreateDataSourceTableAsSelectCommand](
+    "Create table with select command",
+    (a, conf, p, r) => new CreateDataSourceTableAsSelectCommandMeta(a, conf, p, r))
+    ).map(r => (r.getClassFor.asSubclass(classOf[DataWritingCommand]), r)).toMap
+  }
+
+  override def getRunnableCmds: Map[Class[_ <: RunnableCommand],
+      RunnableCommandRule[_ <: RunnableCommand]] = {
+    Map.empty
+  }
+
+  override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] = {
+
+    val newRule = org.apache.spark.sql.hive.cdh.HiveOverrides.getHiveTableExecRule()
+    // scala compiler gets confused if we don't give an explicit type to the class here.
+    // ... perhaps there is a cleaner way to do this
+    val ruleClass: Class[_ <: SparkPlan] = newRule.getClassFor.asSubclass(classOf[SparkPlan])
+    super.getExecs ++ Seq(ruleClass -> newRule).toMap
+  }
+
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/OrcQuerySuite.scala
@@ -219,7 +219,7 @@ class OrcQuerySuite extends SparkQueryCompareTestSuite {
     // Cdh321, Cdh330 does not support ZSTD, refer to the Cdh Class:
     // org.apache.spark.sql.execution.datasources.orc.OrcOptions
     // Spark 31x do not support lz4, zstd
-    if (isCdh321 || isCdh330 || !VersionUtils.isSpark320OrLater) {
+    if (isCdh321 || isCdh330 || isCdh332 || !VersionUtils.isSpark320OrLater) {
       supportedWriteCompressType -= "ZSTD"
     }
     supportedWriteCompressType

--- a/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/SparkQueryCompareTestSuite.scala
@@ -2271,4 +2271,6 @@ trait SparkQueryCompareTestSuite extends AnyFunSuite with BeforeAndAfterAll {
   def isCdh321: Boolean = VersionUtils.isCloudera && cmpSparkVersion(3, 2, 1) == 0
 
   def isCdh330: Boolean = VersionUtils.isCloudera && cmpSparkVersion(3, 3, 0) == 0
+
+  def isCdh332: Boolean = VersionUtils.isCloudera && cmpSparkVersion(3, 3, 2) == 0
 }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/9457

We had some unit tests failing on 3.3.2 CDH. It looks like there are 2 issues:

1) Update test to skip the orc zstd because Cloudera doesn't support
2) The shim was based on 3.3.0 CDH instead of 3.3.1.  This is 3.3.2 CDH so it should have been based on 3.3.1.  Spark 3.3.1  adds handling for CheckOverflowInTableInsert, so the tests for this were failing as they should have.



<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
