### PR TITLE
Add SplitAndRetry to GpuRunningWindowIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -1520,11 +1520,6 @@ class GpuRunningWindowIterator(
       fixerIndexMap.values.foreach(_.close())
       saveLastParts(Array.empty)
       saveLastOrder(Array.empty)
-      maybeSplitIter match {
-        case closeable: AutoCloseable => closeable.close()
-        case _ => // noop
-      }
-      maybeSplitIter = Iterator.empty
       cachedBatch.foreach(_.close())
       cachedBatch = None
     }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuWindowExec.scala
@@ -28,6 +28,7 @@ import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRow
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.shims.{GpuWindowUtil, ShimUnaryExecNode}
 
+import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeReference, AttributeSeq, AttributeSet, CurrentRow, Expression, FrameType, NamedExpression, RangeFrame, RowFrame, SortOrder, UnboundedFollowing, UnboundedPreceding}
@@ -1495,12 +1496,13 @@ class GpuRunningWindowIterator(
   // This should only ever be cached in between calls to `hasNext` and `next`. This is just
   // to let us filter out empty batches.
   private val boundOrderColumns = boundOrderSpec.map(_.child)
-  private var cachedBatch: Option[ColumnarBatch] = None
+  private var cachedBatch: Option[SpillableColumnarBatch] = None
   private var lastParts: Array[Scalar] = Array.empty
   private var lastOrder: Array[Scalar] = Array.empty
   private var isClosed: Boolean = false
+  private var maybeSplitIter: Iterator[ColumnarBatch] = Iterator.empty
 
-  onTaskCompletion(close())
+  Option(TaskContext.get()).foreach(tc => onTaskCompletion(tc)(close()))
 
   private def saveLastParts(newLastParts: Array[Scalar]): Unit = {
     lastParts.foreach(_.close())
@@ -1518,6 +1520,10 @@ class GpuRunningWindowIterator(
       fixerIndexMap.values.foreach(_.close())
       saveLastParts(Array.empty)
       saveLastOrder(Array.empty)
+      maybeSplitIter.foreach(_.close())
+      maybeSplitIter = Iterator.empty
+      cachedBatch.foreach(_.close())
+      cachedBatch = None
     }
   }
 
@@ -1556,25 +1562,22 @@ class GpuRunningWindowIterator(
     }
   }
 
-  def computeRunning(input: ColumnarBatch): ColumnarBatch = {
+  def computeRunningAndClose(sb: SpillableColumnarBatch): Iterator[ColumnarBatch] = {
     val fixers = fixerIndexMap
-    val numRows = input.numRows()
-    val cbSpillable = SpillableColumnarBatch(input, SpillPriorities.ACTIVE_ON_DECK_PRIORITY)
-    withRetryNoSplit(cbSpillable) { _ =>
-      withResource(cbSpillable.getColumnarBatch()) { cb =>
+    withRetry(sb, splitSpillableInHalfByRows) { maybeSplitSb =>
+      val numRows = maybeSplitSb.numRows()
+      withResource(maybeSplitSb.getColumnarBatch()) { cb =>
         withResource(computeBasicWindow(cb)) { basic =>
           var newOrder: Option[Array[Scalar]] = None
           var newParts: Option[Array[Scalar]] = None
           val fixedUp = try {
             // we backup the fixers state and restore it in the event of a retry
             withRestoreOnRetry(fixers.values.toSeq) {
-              withResource(GpuProjectExec.project(cb,
-                boundPartitionSpec)) { parts =>
+              withResource(GpuProjectExec.project(cb, boundPartitionSpec)) { parts =>
                 val partColumns = GpuColumnVector.extractBases(parts)
                 withResourceIfAllowed(arePartsEqual(lastParts, partColumns)) { partsEqual =>
                   val fixedUp = if (fixerNeedsOrderMask) {
-                    withResource(GpuProjectExec.project(cb,
-                      boundOrderColumns)) { order =>
+                    withResource(GpuProjectExec.project(cb, boundOrderColumns)) { order =>
                       val orderColumns = GpuColumnVector.extractBases(order)
                       // We need to fix up the rows that are part of the same batch as the end of
                       // the last batch
@@ -1603,15 +1606,17 @@ class GpuRunningWindowIterator(
               newParts.foreach(_.foreach(_.close()))
               throw t
           }
-          // this section is outside of the retry logic because the calls to saveLastParts
-          // and saveLastOrders can potentially close GPU resources
           withResource(fixedUp) { _ =>
-            newOrder.foreach(saveLastOrder)
-            newParts.foreach(saveLastParts)
-            convertToBatch(outputTypes, fixedUp)
+            (convertToBatch(outputTypes, fixedUp), newParts, newOrder)
           }
         }
       }
+    }.map { case (batch, newParts, newOrder) =>
+      // this section is outside of the retry logic because the calls to saveLastParts
+      // and saveLastOrders can potentially close GPU resources
+      newParts.foreach(saveLastParts)
+      newOrder.foreach(saveLastOrder)
+      batch
     }
   }
 
@@ -1619,7 +1624,7 @@ class GpuRunningWindowIterator(
     while (cachedBatch.isEmpty && input.hasNext) {
       closeOnExcept(input.next()) { cb =>
         if (cb.numRows() > 0) {
-          cachedBatch = Some(cb)
+          cachedBatch = Some(SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
         } else {
           cb.close()
         }
@@ -1627,7 +1632,7 @@ class GpuRunningWindowIterator(
     }
   }
 
-  def readNextInputBatch(): ColumnarBatch = {
+  def readNextInputBatch(): SpillableColumnarBatch = {
     cacheBatchIfNeeded()
     val ret = cachedBatch.getOrElse {
       throw new NoSuchElementException()
@@ -1636,15 +1641,18 @@ class GpuRunningWindowIterator(
     ret
   }
 
-  override def hasNext: Boolean = {
+  override def hasNext: Boolean = maybeSplitIter.hasNext || {
     cacheBatchIfNeeded()
     cachedBatch.isDefined
   }
 
   override def next(): ColumnarBatch = {
-    val cb = readNextInputBatch()
+    if (!maybeSplitIter.hasNext) {
+      maybeSplitIter = computeRunningAndClose(readNextInputBatch())
+      assert(maybeSplitIter.hasNext)
+    }
     withResource(new NvtxWithMetrics("RunningWindow", NvtxColor.CYAN, opTime)) { _ =>
-      val ret = computeRunning(cb) // takes ownership of cb
+      val ret = maybeSplitIter.next()
       numOutputBatches += 1
       numOutputRows += ret.numRows()
       ret

--- a/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/WindowRetrySuite.scala
@@ -171,4 +171,43 @@ class WindowRetrySuite
       verify(inputBatch, times(1)).close()
     }
   }
+
+  test("row-based group by running window handles SplitAndRetryOOM") {
+    val runningFrame = GpuSpecifiedWindowFrame(RowFrame,
+      GpuSpecialFrameBoundary(UnboundedPreceding), GpuSpecialFrameBoundary(CurrentRow))
+    val boundOrderSpec = SortOrder(
+      GpuBoundReference(0, IntegerType, nullable = true)(ExprId(0), "int"), Ascending) :: Nil
+    val boundPartSpec = Seq(
+      GpuBoundReference(1, LongType, nullable = true)(ExprId(1), "long"))
+    val spec = GpuWindowSpecDefinition(boundPartSpec, boundOrderSpec, runningFrame)
+    val count = GpuWindowExpression(GpuCount(Seq(GpuLiteral.create(1, IntegerType))), spec)
+    val cb = buildInputBatch()
+
+    val runningIter = new GpuRunningWindowIterator(
+      Seq(cb).iterator, Seq(GpuAlias(count, "count")()), boundPartSpec, boundOrderSpec,
+      Array(LongType), NoopMetric, NoopMetric, NoopMetric)
+    RmmSpark.forceSplitAndRetryOOM(RmmSpark.getCurrentThreadId)
+    // there should be two batches, each has two rows
+    withResource(runningIter.next()) { first =>
+      assertResult(1)(first.numCols())
+      assertResult(2)(first.numRows())
+      withResource(first.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hc =>
+        // one row one partition
+        Seq(1L, 1L).zipWithIndex.foreach { case (cnt, pos) =>
+          assert(cnt == hc.getLong(pos))
+        }
+      }
+    }
+    withResource(runningIter.next()) { second =>
+      assertResult(1)(second.numCols())
+      assertResult(2)(second.numRows())
+      withResource(second.column(0).asInstanceOf[GpuColumnVector].copyToHost()) { hc =>
+        // count for partition [3, 3] are [1L, 2L] by running frame.
+        Seq(1L, 2L).zipWithIndex.foreach { case (cnt, pos) =>
+          assert(cnt == hc.getLong(pos))
+        }
+      }
+    }
+    assert(runningIter.isEmpty)
+  }
 }


### PR DESCRIPTION
fixes #8343

This PR updates GpuRunningWindowIterator to support handling the `SplitAndRetryOOM` instead of only RetryOOM.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
