### PR TITLE
 Improve configuration handling in BatchWithPartitionData

### DIFF
--- a/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
+++ b/integration_tests/src/main/python/col_size_exceeding_cudf_limit_test.py
@@ -69,7 +69,7 @@ if os.environ.get('INCLUDE_SPARK_AVRO_JAR', 'false') == 'true':
     file_formats = file_formats + ['avro']
 
 conf = {
-    'spark.rapids.cudfColumnSizeLimit': 1000,
+    'spark.rapids.sql.columnSizeBytes': 1000,
     'spark.sql.orc.impl': 'hive',  # null type column is not supported on native
     'spark.rapids.sql.format.avro.enabled': 'true',
     'spark.rapids.sql.format.avro.read.enabled': 'true'

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
@@ -65,6 +65,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
   private final int maxBatchSizeRows;
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
+  private final long maxGpuColumnSizeBytes;
 
   private final boolean useChunkedReader;
   private final scala.Option<String> parquetDebugDumpPrefix;
@@ -84,7 +85,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
 
   GpuMultiFileBatchReader(CombinedScanTask task, Table table, Schema expectedSchema,
       boolean caseSensitive, Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
-      long targetBatchSizeBytes,
+      long targetBatchSizeBytes, long maxGpuColumnSizeBytes,
       boolean useChunkedReader,
       scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
       int numThreads, int maxNumFileProcessed,
@@ -98,6 +99,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     this.maxBatchSizeRows = maxBatchSizeRows;
     this.maxBatchSizeBytes = maxBatchSizeBytes;
     this.targetBatchSizeBytes = targetBatchSizeBytes;
+    this.maxGpuColumnSizeBytes = maxGpuColumnSizeBytes;
     this.useChunkedReader = useChunkedReader;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
     this.parquetDebugDumpAlways = parquetDebugDumpAlways;
@@ -333,8 +335,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
         StructType partitionSchema) {
       return new MultiFileCloudParquetPartitionReader(conf, pFiles,
           this::filterParquetBlocks, caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways,
-          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, useChunkedReader,
-          metrics, partitionSchema,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
+          useChunkedReader, metrics, partitionSchema,
           numThreads, maxNumFileProcessed,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
@@ -407,8 +409,8 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
       return new MultiFileParquetPartitionReader(conf, pFiles,
           JavaConverters.asScalaBuffer(clippedBlocks).toSeq(),
           caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways, useChunkedReader,
-          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema,
-          numThreads,
+          maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
+          metrics, partitionSchema, numThreads,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
           false // useFieldId

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
@@ -282,7 +282,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
                          boolean queryUsesInputFile) {
       super(task.task, task.table(), task.expectedSchema(), task.isCaseSensitive(),
           task.getConfiguration(), task.getMaxBatchSizeRows(), task.getMaxBatchSizeBytes(),
-          task.getTargetBatchSizeBytes(), task.useChunkedReader(),
+          task.getTargetBatchSizeBytes(), task.getMaxBatchSizeBytes(), task.useChunkedReader(),
           task.getParquetDebugDumpPrefix(), task.getParquetDebugDumpAlways(),
           task.getNumThreads(), task.getMaxNumFileProcessed(),
           useMultiThread, ff, metrics, queryUsesInputFile);
@@ -309,6 +309,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
     private final long maxBatchSizeBytes;
 
     private final long targetBatchSizeBytes;
+    private final long maxGpuColumnSizeBytes;
     private final scala.Option<String> parquetDebugDumpPrefix;
     private final boolean parquetDebugDumpAlways;
     private final int numThreads;
@@ -334,6 +335,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
       this.maxBatchSizeRows = rapidsConf.maxReadBatchSizeRows();
       this.maxBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes();
       this.targetBatchSizeBytes = rapidsConf.gpuTargetBatchSizeBytes();
+      this.maxGpuColumnSizeBytes = rapidsConf.maxGpuColumnSizeBytes();
       this.parquetDebugDumpPrefix = rapidsConf.parquetDebugDumpPrefix();
       this.parquetDebugDumpAlways = rapidsConf.parquetDebugDumpAlways();
       this.numThreads = rapidsConf.multiThreadReadNumThreads();
@@ -372,6 +374,10 @@ abstract class GpuSparkScan extends GpuScanWrapper
 
     public long getTargetBatchSizeBytes() {
       return targetBatchSizeBytes;
+    }
+
+    public long getMaxGpuColumnSizeBytes() {
+      return maxGpuColumnSizeBytes;
     }
 
     public scala.Option<String> getParquetDebugDumpPrefix() {

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuSparkScan.java
@@ -282,7 +282,7 @@ abstract class GpuSparkScan extends GpuScanWrapper
                          boolean queryUsesInputFile) {
       super(task.task, task.table(), task.expectedSchema(), task.isCaseSensitive(),
           task.getConfiguration(), task.getMaxBatchSizeRows(), task.getMaxBatchSizeBytes(),
-          task.getTargetBatchSizeBytes(), task.getMaxBatchSizeBytes(), task.useChunkedReader(),
+          task.getTargetBatchSizeBytes(), task.getMaxGpuColumnSizeBytes(), task.useChunkedReader(),
           task.getParquetDebugDumpPrefix(), task.getParquetDebugDumpAlways(),
           task.getNumThreads(), task.getMaxNumFileProcessed(),
           useMultiThread, ff, metrics, queryUsesInputFile);

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
@@ -156,7 +156,7 @@ class BatchWithPartitionDataIterator(batchesWithPartitionData: Seq[BatchWithPart
 object BatchWithPartitionDataUtils {
   /**
    * Splits partition data (values and row counts) into smaller batches, ensuring that
-   * size of batch is less than the maximum batch size. Then, it utilizes these smaller
+   * size of column is less than the maximum column size. Then, it utilizes these smaller
    * partitioned batches to split the input batch and merges them to generate
    * an Iterator of split ColumnarBatches.
    *
@@ -195,7 +195,7 @@ object BatchWithPartitionDataUtils {
 
   /**
    * Adds a single set of partition values to all rows in a ColumnarBatch ensuring that
-   * size of batch is less than the maximum batch size.
+   * size of column is less than the maximum column size.
    *
    * @return a new columnar batch iterator with partition values
    * @see [[com.nvidia.spark.rapids.BatchWithPartitionDataUtils.addPartitionValuesToBatch]]
@@ -211,7 +211,7 @@ object BatchWithPartitionDataUtils {
 
   /**
    * Splits partitions into smaller batches, ensuring that the batch size
-   * for each column does not exceed the maximum batch size limit.
+   * for each column does not exceed the maximum column size limit.
    *
    * Data structures:
    *  - sizeOfBatch:   Array that stores the size of batches for each column.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/BatchWithPartitionData.scala
@@ -25,7 +25,6 @@ import com.nvidia.spark.rapids.RmmRapidsRetryIterator.withRetry
 import com.nvidia.spark.rapids.jni.SplitAndRetryOOM
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -157,31 +156,34 @@ class BatchWithPartitionDataIterator(batchesWithPartitionData: Seq[BatchWithPart
 object BatchWithPartitionDataUtils {
   /**
    * Splits partition data (values and row counts) into smaller batches, ensuring that
-   * size of batch is less than cuDF size limit. Then, it utilizes these smaller
+   * size of batch is less than the maximum batch size. Then, it utilizes these smaller
    * partitioned batches to split the input batch and merges them to generate
    * an Iterator of split ColumnarBatches.
    *
    * Using an Iterator ensures that the actual merging does not happen until
    * the batch is required, thus avoiding GPU memory wastage.
    *
-   * @param batch           Input batch, will be closed after the call returns
-   * @param partitionValues Partition values collected from the batch
-   * @param partitionRows   Row numbers collected from the batch, and it should have
-   *                        the same size with "partitionValues"
-   * @param partitionSchema Partition schema
+   * @param batch                 Input batch, will be closed after the call returns
+   * @param partitionValues       Partition values collected from the batch
+   * @param partitionRows         Row numbers collected from the batch, and it should have
+   *                              the same size with "partitionValues"
+   * @param partitionSchema       Partition schema
+   * @param maxGpuColumnSizeBytes Maximum number of bytes for a GPU column
    * @return a new columnar batch iterator with partition values
    */
   def addPartitionValuesToBatch(
       batch: ColumnarBatch,
       partitionRows: Array[Long],
       partitionValues: Array[InternalRow],
-      partitionSchema: StructType): GpuColumnarBatchIterator = {
+      partitionSchema: StructType,
+      maxGpuColumnSizeBytes: Long): GpuColumnarBatchIterator = {
     if (partitionSchema.nonEmpty) {
       withResource(batch) { _ =>
         require(partitionRows.length == partitionValues.length, "Partition rows and values must" +
           " be of same length")
         val partitionRowData = PartitionRowData.from(partitionValues, partitionRows)
-        val partitionedGroups = splitPartitionDataIntoGroups(partitionRowData, partitionSchema)
+        val partitionedGroups = splitPartitionDataIntoGroups(partitionRowData, partitionSchema,
+          maxGpuColumnSizeBytes)
         val splitBatches = splitAndCombineBatchWithPartitionData(batch, partitionedGroups,
           partitionSchema)
         new BatchWithPartitionDataIterator(splitBatches)
@@ -192,19 +194,24 @@ object BatchWithPartitionDataUtils {
   }
 
   /**
-   * Adds a single set of partition values to all rows in a ColumnarBatch.
+   * Adds a single set of partition values to all rows in a ColumnarBatch ensuring that
+   * size of batch is less than the maximum batch size.
+   *
    * @return a new columnar batch iterator with partition values
+   * @see [[com.nvidia.spark.rapids.BatchWithPartitionDataUtils.addPartitionValuesToBatch]]
    */
   def addSinglePartitionValueToBatch(
       batch: ColumnarBatch,
       partitionValues: InternalRow,
-      partitionSchema: StructType): GpuColumnarBatchIterator = {
-    addPartitionValuesToBatch(batch, Array(batch.numRows), Array(partitionValues), partitionSchema)
+      partitionSchema: StructType,
+      maxGpuColumnSizeBytes: Long): GpuColumnarBatchIterator = {
+    addPartitionValuesToBatch(batch, Array(batch.numRows), Array(partitionValues), partitionSchema,
+      maxGpuColumnSizeBytes)
   }
 
   /**
    * Splits partitions into smaller batches, ensuring that the batch size
-   * for each column does not exceed the maximum column size limit.
+   * for each column does not exceed the maximum batch size limit.
    *
    * Data structures:
    *  - sizeOfBatch:   Array that stores the size of batches for each column.
@@ -245,8 +252,8 @@ object BatchWithPartitionDataUtils {
    */
   def splitPartitionDataIntoGroups(
       partitionRowData: Array[PartitionRowData],
-      partSchema: StructType): Array[Array[PartitionRowData]] = {
-    val maxColumnSize = getMaxColumnSize
+      partSchema: StructType,
+      maxGpuColumnSizeBytes: Long): Array[Array[PartitionRowData]] = {
     val resultBatches = ArrayBuffer[Array[PartitionRowData]]()
     val currentBatch = ArrayBuffer[PartitionRowData]()
     val sizeOfBatch = Array.fill(partSchema.length)(0L)
@@ -261,7 +268,7 @@ object BatchWithPartitionDataUtils {
       val valuesInPartition = partitionRowData(partIndex).rowValue
       // Calculate the maximum number of rows that can fit in current batch.
       val maxRows = calculateMaxRows(rowsInPartition, valuesInPartition, partSchema,
-        sizeOfBatch, maxColumnSize)
+        sizeOfBatch, maxGpuColumnSizeBytes)
       // Splitting occurs if for any column, maximum rows we can fit is less than rows in partition.
       splitOccurred = maxRows < rowsInPartition
       if (splitOccurred) {
@@ -292,13 +299,6 @@ object BatchWithPartitionDataUtils {
   }
 
   /**
-   * Retrieves the maximum size for cuDF column vector from the configuration.
-   */
-  private def getMaxColumnSize: Long = {
-    new RapidsConf(SQLConf.get).cudfColumnSizeLimit
-  }
-
-  /**
    * Calculates the partition size for each column as 'size of single value * number of rows'
    */
   private def calculatePartitionSizes(rowNum: Int, values: InternalRow,
@@ -318,7 +318,7 @@ object BatchWithPartitionDataUtils {
    * This value is capped at row numbers in the partition.
    */
   private def calculateMaxRows(rowNum: Int, values: InternalRow, partSchema: StructType,
-      sizeOfBatch: Array[Long], maxColumnSize: Long): Int = {
+      sizeOfBatch: Array[Long], maxGpuColumnSizeBytes: Long): Int = {
     partSchema.zipWithIndex.map {
       case (field, colIndex) if field.dataType == StringType
         && !values.isNullAt(colIndex) =>
@@ -327,7 +327,7 @@ object BatchWithPartitionDataUtils {
           // All rows can fit
           rowNum
         } else {
-          val availableSpace = maxColumnSize - sizeOfBatch(colIndex)
+          val availableSpace = maxGpuColumnSizeBytes - sizeOfBatch(colIndex)
           val maxRows = (availableSpace / sizeOfSingleValue).toInt
           // Cap it at rowNum to ensure it doesn't exceed the available rows in the partition
           Math.min(maxRows, rowNum)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnarBatchIterator.scala
@@ -97,12 +97,14 @@ class SingleGpuColumnarBatchIterator(private var batch: ColumnarBatch)
  * @param partRowNums row numbers collected from all the batches in the input iterator, it
  *                    should have the same size with "partValues".
  * @param partSchema the partition schema
+ * @param maxGpuColumnSizeBytes maximum number of bytes for a GPU column
  */
 class GpuColumnarBatchWithPartitionValuesIterator(
     inputIter: Iterator[ColumnarBatch],
     partValues: Array[InternalRow],
     partRowNums: Array[Long],
-    partSchema: StructType) extends Iterator[ColumnarBatch] {
+    partSchema: StructType,
+    maxGpuColumnSizeBytes: Long) extends Iterator[ColumnarBatch] {
   assert(partValues.length == partRowNums.length)
 
   private var leftValues: Array[InternalRow] = partValues
@@ -123,7 +125,7 @@ class GpuColumnarBatchWithPartitionValuesIterator(
           computeValuesAndRowNumsForBatch(batch.numRows())
         }
         outputIter = BatchWithPartitionDataUtils.addPartitionValuesToBatch(batch, readPartRows,
-          readPartValues, partSchema)
+          readPartValues, partSchema, maxGpuColumnSizeBytes)
         outputIter.next()
       } else {
         batch

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3649,7 +3649,8 @@ object GpuOverrides extends Logging {
             a.partitionFilters,
             a.dataFilters,
             conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
+            conf.maxReadBatchSizeBytes,
+            conf.maxGpuColumnSizeBytes)
       }),
     GpuOverrides.scan[JsonScan](
       "Json parsing",
@@ -3666,7 +3667,8 @@ object GpuOverrides extends Logging {
             a.partitionFilters,
             a.dataFilters,
             conf.maxReadBatchSizeRows,
-            conf.maxReadBatchSizeBytes)
+            conf.maxReadBatchSizeBytes,
+            conf.maxGpuColumnSizeBytes)
       })).map(r => (r.getClassFor.asSubclass(classOf[Scan]), r)).toMap
 
   val scans: Map[Class[_ <: Scan], ScanRule[_ <: Scan]] =

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1198,8 +1198,8 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     val combineConf = CombineConf(combineThresholdSize, combineWaitTime)
     new MultiFileCloudParquetPartitionReader(conf, files, filterFunc, isCaseSensitive,
       debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
-      targetBatchSizeBytes, useChunkedReader, metrics, partitionSchema, numThreads,
-      maxNumFileProcessed, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId,
+      targetBatchSizeBytes, maxGpuColumnSizeBytes, useChunkedReader, metrics, partitionSchema,
+      numThreads, maxNumFileProcessed, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId,
       alluxioPathReplacementMap.getOrElse(Map.empty), alluxioReplacementTaskTime,
       queryUsesInputFile, keepReadsInOrderFromConf, combineConf)
   }
@@ -1312,8 +1312,8 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     }
     new MultiFileParquetPartitionReader(conf, files, clippedBlocks, isCaseSensitive,
       debugDumpPrefix, debugDumpAlways, useChunkedReader, maxReadBatchSizeRows,
-      maxReadBatchSizeBytes, targetBatchSizeBytes, metrics, partitionSchema, numThreads,
-      ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId)
+      maxReadBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes, metrics, partitionSchema,
+      numThreads, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId)
   }
 
   /**
@@ -1345,6 +1345,7 @@ case class GpuParquetPartitionReaderFactory(
   private val maxReadBatchSizeRows = rapidsConf.maxReadBatchSizeRows
   private val maxReadBatchSizeBytes = rapidsConf.maxReadBatchSizeBytes
   private val targetSizeBytes = rapidsConf.gpuTargetBatchSizeBytes
+  private val maxGpuColumnSizeBytes = rapidsConf.maxGpuColumnSizeBytes
   private val useChunkedReader = rapidsConf.chunkedReaderEnabled
   private val filterHandler = GpuParquetFileFilterHandler(sqlConf, metrics)
   private val readUseFieldId = ParquetSchemaClipShims.useFieldId(sqlConf)
@@ -1360,7 +1361,8 @@ case class GpuParquetPartitionReaderFactory(
   override def buildColumnarReader(
       partitionedFile: PartitionedFile): PartitionReader[ColumnarBatch] = {
     val reader = new PartitionReaderWithBytesRead(buildBaseColumnarParquetReader(partitionedFile))
-    ColumnarPartitionReaderWithPartitionValues.newReader(partitionedFile, reader, partitionSchema)
+    ColumnarPartitionReaderWithPartitionValues.newReader(partitionedFile, reader, partitionSchema,
+      maxGpuColumnSizeBytes)
   }
 
   private def buildBaseColumnarParquetReader(
@@ -1902,6 +1904,7 @@ class MultiFileParquetPartitionReader(
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     override val execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
     numThreads: Int,
@@ -1909,7 +1912,8 @@ class MultiFileParquetPartitionReader(
     ignoreCorruptFiles: Boolean,
     useFieldId: Boolean)
   extends MultiFileCoalescingPartitionReaderBase(conf, clippedBlocks,
-    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, numThreads, execMetrics)
+    partitionSchema, maxReadBatchSizeRows, maxReadBatchSizeBytes, maxGpuColumnSizeBytes,
+    numThreads, execMetrics)
   with ParquetPartitionReaderBase {
 
   // Some implicits to convert the base class to the sub-class and vice versa
@@ -2094,6 +2098,7 @@ class MultiFileCloudParquetPartitionReader(
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
+    maxGpuColumnSizeBytes: Long,
     useChunkedReader: Boolean,
     override val execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
@@ -2535,10 +2540,10 @@ class MultiFileCloudParquetPartitionReader(
         case Some(partRowsAndValues) =>
           val (rowsPerPart, partValues) = partRowsAndValues.unzip
           BatchWithPartitionDataUtils.addPartitionValuesToBatch(origBatch, rowsPerPart,
-            partValues, partitionSchema)
+            partValues, partitionSchema, maxGpuColumnSizeBytes)
         case None =>
           BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(origBatch,
-            meta.partitionedFile.partitionValues, partitionSchema)
+            meta.partitionedFile.partitionValues, partitionSchema, maxGpuColumnSizeBytes)
       }
 
     case buffer: HostMemoryBuffersWithMetaData =>
@@ -2601,7 +2606,7 @@ class MultiFileCloudParquetPartitionReader(
         val allPartInternalRows = allPartValues.get.map(_._2)
         val rowsPerPartition = allPartValues.get.map(_._1)
         new GpuColumnarBatchWithPartitionValuesIterator(batchIter, allPartInternalRows,
-          rowsPerPartition, partitionSchema)
+          rowsPerPartition, partitionSchema, maxGpuColumnSizeBytes)
       } else {
         // this is a bit weird, we don't have number of rows when allPartValues isn't
         // filled in so can't use GpuColumnarBatchWithPartitionValuesIterator
@@ -2609,7 +2614,7 @@ class MultiFileCloudParquetPartitionReader(
           // we have to add partition values here for this batch, we already verified that
           // its not different for all the blocks in this batch
           BatchWithPartitionDataUtils.addSinglePartitionValueToBatch(batch,
-            partedFile.partitionValues, partitionSchema)
+            partedFile.partitionValues, partitionSchema, maxGpuColumnSizeBytes)
         }
       }
     }.flatten

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuReadCSVFileFormat.scala
@@ -65,6 +65,7 @@ class GpuReadCSVFileFormat extends CSVFileFormat with GpuReadFileFormatWithMetri
       csvOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
+      rapidsConf.maxGpuColumnSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -557,6 +557,16 @@ object RapidsConf {
       s"Batch size must be positive and not exceed ${Integer.MAX_VALUE} bytes.")
     .createWithDefault(1 * 1024 * 1024 * 1024) // 1 GiB is the default
 
+  val MAX_GPU_COLUMN_SIZE_BYTES = conf("spark.rapids.sql.columnSizeBytes")
+    .doc("Limit the max number of bytes for a GPU column. It is same as the cudf " +
+      "row count limit of a column. It is used by the multi-file readers. " +
+      "See com.nvidia.spark.rapids.BatchWithPartitionDataUtils.")
+    .internal()
+    .bytesConf(ByteUnit.BYTE)
+    .checkValue(v => v >= 0 && v <= Integer.MAX_VALUE,
+      s"Column size must be positive and not exceed ${Integer.MAX_VALUE} bytes.")
+    .createWithDefault(Integer.MAX_VALUE) // 2 GiB is the default
+
   val MAX_READER_BATCH_SIZE_ROWS = conf("spark.rapids.sql.reader.batchSizeRows")
     .doc("Soft limit on the maximum number of rows the reader will read per batch. " +
       "The orc and parquet readers will read row groups until this limit is met or exceeded. " +
@@ -1829,12 +1839,6 @@ object RapidsConf {
     .booleanConf
     .createWithDefault(false)
 
-  val CUDF_COLUMN_SIZE_LIMIT = conf("spark.rapids.cudfColumnSizeLimit")
-    .internal()
-    .doc("Maximum size for cuDF column vector set to 2^31 - 1")
-    .longConf
-    .createWithDefault((1L << 31) - 1)
-
   val ALLOW_DISABLE_ENTIRE_PLAN = conf("spark.rapids.allowDisableEntirePlan")
     .internal()
     .doc("The plugin has the ability to detect possibe incompatibility with some specific " +
@@ -2353,6 +2357,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val maxReadBatchSizeBytes: Long = get(MAX_READER_BATCH_SIZE_BYTES)
 
+  lazy val maxGpuColumnSizeBytes: Long = get(MAX_GPU_COLUMN_SIZE_BYTES)
+
   lazy val parquetDebugDumpPrefix: Option[String] = get(PARQUET_DEBUG_DUMP_PREFIX)
 
   lazy val parquetDebugDumpAlways: Boolean = get(PARQUET_DEBUG_DUMP_ALWAYS)
@@ -2621,8 +2627,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val shimsProviderOverride: Option[String] = get(SHIMS_PROVIDER_OVERRIDE)
 
   lazy val cudfVersionOverride: Boolean = get(CUDF_VERSION_OVERRIDE)
-
-  lazy val cudfColumnSizeLimit: Long = get(CUDF_COLUMN_SIZE_LIMIT)
 
   lazy val allowDisableEntirePlan: Boolean = get(ALLOW_DISABLE_ENTIRE_PLAN)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuReadJsonFileFormat.scala
@@ -65,6 +65,7 @@ class GpuReadJsonFileFormat extends JsonFileFormat with GpuReadFileFormatWithMet
       jsonOpts,
       rapidsConf.maxReadBatchSizeRows,
       rapidsConf.maxReadBatchSizeBytes,
+      rapidsConf.maxGpuColumnSizeBytes,
       metrics,
       options)
     PartitionReaderIterator.buildReader(factory)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuAvroScan.scala
@@ -633,7 +633,7 @@ class GpuAvroPartitionReader(
  * @param partitionSchema Schema of partitions.
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows to be read per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes to be read per batch
- * @param maxGpuColumnSizeBytes target number of bytes for a GPU batch
+ * @param maxGpuColumnSizeBytes maximum number of bytes for a GPU column
  */
 class GpuMultiFileCloudAvroPartitionReader(
     override val conf: Configuration,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
@@ -63,5 +63,6 @@ class RapidsCsvScanMeta(
       cScan.partitionFilters,
       cScan.dataFilters,
       conf.maxReadBatchSizeRows,
-      conf.maxReadBatchSizeBytes)
+      conf.maxReadBatchSizeBytes,
+      conf.maxGpuColumnSizeBytes)
 }


### PR DESCRIPTION
Fixes #9467. 

#### Changes:
1. Create a new config  `spark.rapids.sql.columnSizeBytes` that stores maximum size of column in bytes. 
     - This aligns with other similar configurations and ensures consistency.
2. Modified all callers to the method `addPartitionValuesToBatch()` to accept `maxGpuColumnSizeBytes` as a parameter and pass it along.

#### Testing:
- Existing unit tests and integration tests have been updated for these changes.

