### PR TITLE
Fix Spark 3.5.0 shell classloader issue with the plugin

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -149,7 +149,10 @@ object ShimLoader extends Logging {
         // fast path
         logInfo(s"findURLClassLoader found a URLClassLoader $urlCl")
         Option(urlCl)
-      case replCl if replCl.getClass.getName == "org.apache.spark.repl.ExecutorClassLoader" =>
+      case replCl if replCl.getClass.getName == "org.apache.spark.repl.ExecutorClassLoader" ||
+          replCl.getClass.getName == "org.apache.spark.executor.ExecutorClassLoader" =>
+        // Spark 3.5.0 changed the package of ExecutorClassLoader so we check for it being
+        // either old package name or new one.
         // https://issues.apache.org/jira/browse/SPARK-18646
         val parentLoader = MethodUtils.invokeMethod(replCl, true, "parentLoader")
           .asInstanceOf[ClassLoader]


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/9498

Spark 3.5.0 (https://github.com/apache/spark/commit/14868355b862bdfbfa4ca16e7b367eba1f9cd277) changed the package name of the ExecutorClassLoader.  Our ShimLoader code explicitly looks for it by the old package name so we have to update our ShimLoader to look for either name.

Manually tested with spark-shell on Spark 3.5.0 and older 3.3.0 and both worked.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
