### PR TITLE
Install Dependencies Needed For Databricks 13.3

### DIFF
--- a/jenkins/databricks/install_deps.py
+++ b/jenkins/databricks/install_deps.py
@@ -39,6 +39,9 @@ def define_deps(spark_version, scala_version):
     elif spark_version.startswith('3.3'):
         spark_prefix = '----ws_3_3'
         mvn_prefix = '--mvn'
+    elif spark_version.startswith('3.4'):
+        spark_prefix = '----ws_3_4'
+        mvn_prefix = '--mvn'
 
     spark_suffix = f'hive-{hive_version}__hadoop-{hadoop_version}_{scala_version}'
 
@@ -79,16 +82,6 @@ def define_deps(spark_version, scala_version):
                  f'{prefix_ws_sp_mvn_hadoop}--org.apache.hive--hive-serde--org.apache.hive__hive-serde__*.jar'),
         Artifact('org.apache.hive', 'hive-storage-api',
                  f'{prefix_ws_sp_mvn_hadoop}--org.apache.hive--hive-storage-api--org.apache.hive__hive-storage-api__*.jar'),
-
-        # Parquet
-        Artifact('org.apache.parquet', 'parquet-hadoop',
-                 f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-hadoop--org.apache.parquet__parquet-hadoop__*-databricks*.jar'),
-        Artifact('org.apache.parquet', 'parquet-common',
-                 f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-common--org.apache.parquet__parquet-common__*-databricks*.jar'),
-        Artifact('org.apache.parquet', 'parquet-column',
-                 f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-column--org.apache.parquet__parquet-column__*-databricks*.jar'),
-        Artifact('org.apache.parquet', 'parquet-format',
-                 f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-format-structures--org.apache.parquet__parquet-format-structures__*-databricks*.jar'),
 
         # Orc
         Artifact('org.apache.orc', 'orc-core',
@@ -134,10 +127,48 @@ def define_deps(spark_version, scala_version):
                  f'{prefix_ws_sp_mvn_hadoop}--org.apache.avro--avro--org.apache.avro__avro__*.jar'),
     ]
 
+    # Parquet
+    if spark_version.startswith('3.4'):
+        deps += [
+        Artifact('org.apache.parquet', 'parquet-hadoop', 
+             f'{spark_prefix}--third_party--parquet-mr--parquet-hadoop--parquet-hadoop-shaded--*--libparquet-hadoop-internal.jar'),
+        Artifact('org.apache.parquet', 'parquet-common', 
+             f'{spark_prefix}--third_party--parquet-mr--parquet-common--parquet-common-shaded--*--libparquet-common-internal.jar'),
+        Artifact('org.apache.parquet', 'parquet-column',
+             f'{spark_prefix}--third_party--parquet-mr--parquet-column--parquet-column-shaded--*--libparquet-column-internal.jar'),
+        Artifact('org.apache.parquet', 'parquet-format',
+             f'{spark_prefix}--third_party--parquet-mr--parquet-format-structures--parquet-format-structures-shaded--*--libparquet-format-structures-internal.jar'),
+        Artifact('shaded.parquet.org.apache.thrift', f'shaded-parquet-thrift_{scala_version}', 
+            f'{spark_prefix}--third_party--parquet-mr--parquet-format-structures--parquet-format-structures-shaded--*--org.apache.thrift__libthrift__0.16.0.jar'),
+        Artifact('org.apache.parquet', f'parquet-format-internal_{scala_version}', 
+            f'{spark_prefix}--third_party--parquet-mr--parquet-format-structures--parquet-format-structures-shaded--*--libparquet-thrift.jar')
+        ]
+    else:
+        deps += [
+        Artifact('org.apache.parquet', 'parquet-hadoop',
+             f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-hadoop--org.apache.parquet__parquet-hadoop__*-databricks*.jar'),
+        Artifact('org.apache.parquet', 'parquet-common',
+             f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-common--org.apache.parquet__parquet-common__*-databricks*.jar'),
+        Artifact('org.apache.parquet', 'parquet-column',
+             f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-column--org.apache.parquet__parquet-column__*-databricks*.jar'),
+        Artifact('org.apache.parquet', 'parquet-format',
+             f'{prefix_ws_sp_mvn_hadoop}--org.apache.parquet--parquet-format-structures--org.apache.parquet__parquet-format-structures__*-databricks*.jar')
+        ]
+
+
     # log4j-core
-    if spark_version.startswith('3.3'):
+    if spark_version.startswith('3.3') or spark_version.startswith('3.4'):
         deps += Artifact('org.apache.logging.log4j', 'log4j-core',
                          f'{prefix_ws_sp_mvn_hadoop}--org.apache.logging.log4j--log4j-core--org.apache.logging.log4j__log4j-core__*.jar'),
+
+    if spark_version.startswith('3.4'):
+        deps += [
+        # Spark Internal Logging
+        Artifact('org.apache.spark', f'spark-common-utils_{scala_version}', f'{spark_prefix}--common--utils--common-utils-hive-2.3__hadoop-3.2_2.12_deploy.jar'),
+        # Spark SQL API
+        Artifact('org.apache.spark', f'spark-sql-api_{scala_version}', f'{spark_prefix}--sql--api--sql-api-hive-2.3__hadoop-3.2_2.12_deploy.jar')
+        ]
+
 
     return deps
 


### PR DESCRIPTION
This pull request adds incremental support for Databricks 13.3. The primary focus of this PR is to address dependency resolution failures caused by changes introduced in the new Databricks version.

**Changes Made:** 

Parquet Dependencies have been renamed and are now shaded versions
`org.apache.spark.internal.Logging` has moved to a separate jar from spark-core
sql-api jar is also introduced

**Testing:**

Tests will be addressed in future PRs

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
