### PR TITLE
Ignore failing Parquet filter test to unblock CI

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
@@ -224,7 +224,8 @@ class ParquetFilterSuite extends SparkQueryCompareTestSuite {
     })
   }
 
-  test("Parquet filter pushdown - timestamp") {
+  // https://github.com/NVIDIA/spark-rapids/issues/9507
+  ignore("Parquet filter pushdown - timestamp") {
     withCpuSparkSession(spark => {
       import spark.implicits._
       val df = (1 to 1024).map(i => new Timestamp(i)).toDF("a")


### PR DESCRIPTION
Relates to #9507.  Ignoring failing test to unblock CI while waiting for the fix.