### PR TITLE
Add CPU POC of TimeZoneDB; Test some time zones by comparing CPU POC and Spark

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/CpuTimeZoneDB.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/CpuTimeZoneDB.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.timezone
+
+import java.time.ZoneId
+
+import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.daysToLocalDate
+
+object CpuTimeZoneDB {
+
+  def cacheDatabase(): Unit = {}
+
+  /**
+   * convert date or timestamp vector in a time zone to UTC timestamp
+   *
+   * @return
+   */
+  def convertToUTC(inputVector: ColumnVector, currentTimeZone: ZoneId): ColumnVector = {
+    if (inputVector.getType == DType.TIMESTAMP_DAYS) {
+      val rowCount = inputVector.getRowCount.toInt
+      withResource(inputVector.copyToHost()) { input =>
+        withResource(HostColumnVector.builder(DType.TIMESTAMP_MICROSECONDS, rowCount)) { builder =>
+          var currRow = 0
+          while (currRow < rowCount) {
+            val origin = input.getLong(currRow)
+
+            // copied from Spark ToTimestamp
+            val instant = daysToLocalDate(origin.toInt).atStartOfDay(currentTimeZone).toInstant
+            val dist = DateTimeUtils.instantToMicros(instant)
+            builder.append(dist)
+            currRow += 1
+          }
+          withResource(builder.build()) { b =>
+            b.copyToDevice()
+          }
+          }
+      }
+    } else if (inputVector.getType == DType.TIMESTAMP_MICROSECONDS) {
+      // Spark always save UTC time, refer to Spark TimestampType
+      inputVector.incRefCount()
+    } else {
+      throw new IllegalArgumentException("Unsupported vector type: " + inputVector.getType)
+    }
+  }
+
+  /**
+   * Convert timestamp in UTC to timestamp in the `desiredTimeZone`
+   *
+   * @param inputVector     UTC timestamp
+   * @param desiredTimeZone desired time zone
+   * @return timestamp in the `desiredTimeZone`
+   */
+  def convertFromUTC(inputVector: ColumnVector, desiredTimeZone: ZoneId): ColumnVector = {
+    // only test UTC timestamp to timestamp within desiredTimeZone
+    assert(inputVector.getType == DType.TIMESTAMP_MICROSECONDS)
+    val zoneStr = desiredTimeZone.getId
+    val rowCount = inputVector.getRowCount.toInt
+    withResource(inputVector.copyToHost()) { input =>
+      withResource(HostColumnVector.builder(DType.TIMESTAMP_MICROSECONDS, rowCount)) { builder =>
+        var currRow = 0
+        while (currRow < rowCount) {
+          val origin = input.getLong(currRow)
+          val dist = DateTimeUtils.fromUTCTime(origin, zoneStr)
+          builder.append(dist)
+          currRow += 1
+        }
+        withResource(builder.build()) { b =>
+          b.copyToDevice()
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
@@ -23,16 +23,18 @@ import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
-object CpuTimeZoneDB {
+object TimeZoneDB {
 
   def cacheDatabase(): Unit = {}
 
   /**
-   * Interprate a timestamp as a time in the given time zone, and renders that time as a timestamp in UTC
+   * Interpret a timestamp as a time in the given time zone,
+   * and renders that time as a timestamp in UTC
    *
-   * @return
    */
-  def fromTimestampToUtcTimestamp(inputVector: ColumnVector, currentTimeZone: ZoneId): ColumnVector = {
+  def fromTimestampToUtcTimestamp(
+      inputVector: ColumnVector,
+      currentTimeZone: ZoneId): ColumnVector = {
     assert(inputVector.getType == DType.TIMESTAMP_MICROSECONDS)
     val zoneStr = currentTimeZone.getId
     val rowCount = inputVector.getRowCount.toInt
@@ -60,7 +62,9 @@ object CpuTimeZoneDB {
    * @param desiredTimeZone desired time zone
    * @return timestamp in the `desiredTimeZone`
    */
-  def fromUtcTimestampToTimestamp(inputVector: ColumnVector, desiredTimeZone: ZoneId): ColumnVector = {
+  def fromUtcTimestampToTimestamp(
+      inputVector: ColumnVector,
+      desiredTimeZone: ZoneId): ColumnVector = {
     assert(inputVector.getType == DType.TIMESTAMP_MICROSECONDS)
     val zoneStr = desiredTimeZone.getId
     val rowCount = inputVector.getRowCount.toInt
@@ -82,7 +86,7 @@ object CpuTimeZoneDB {
   }
 
   /**
-   * Converts timesamp to date since 1970-01-01 at the given zone ID.
+   * Converts timestamp to date since 1970-01-01 at the given zone ID.
    *
    * @return
    */
@@ -113,7 +117,7 @@ object CpuTimeZoneDB {
    * @param desiredTimeZone desired time zone
    * @return timestamp in the `desiredTimeZone`
    */
-  def fromDateToTimestap(inputVector: ColumnVector, desiredTimeZone: ZoneId): ColumnVector = {
+  def fromDateToTimestamp(inputVector: ColumnVector, desiredTimeZone: ZoneId): ColumnVector = {
     assert(inputVector.getType == DType.TIMESTAMP_DAYS)
     val rowCount = inputVector.getRowCount.toInt
     withResource(inputVector.copyToHost()) { input =>

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -147,7 +147,7 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
   }
 
   test("test all time zones") {
-    assume(true,
+    assume(false,
       "It's time consuming for test all time zones, by default it's disabled")
     //    val zones = ZoneId.getAvailableZoneIds.asScala.toList.map(z => ZoneId.of(z)).filter { z =>
     //      val rules = z.getRules

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -27,7 +27,6 @@ import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.functions.to_timestamp
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 
 class TimeZoneSuite extends SparkQueryCompareTestSuite {
@@ -39,7 +38,7 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
     withResource(HostColumnVector.builder(DType.TIMESTAMP_MICROSECONDS, rows)) { builder =>
       var idx = 0
       while (idx < rows) {
-        // change seconds to micro seconds
+        // convert seconds to micro seconds
         builder.append(epochSeconds(idx) * 1000000L)
         idx += 1
       }
@@ -50,86 +49,121 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
   }
 
   /**
-   * create Spark data frame with a timestamp with name ts
+   * create Spark data frame, schema is [(ts_long: long)]
    * @return
    */
   def createDF(spark: SparkSession, epochSeconds: Array[Long]): DataFrame = {
     val data = epochSeconds.indices.map(i => Row(epochSeconds(i)))
     val schema = StructType(Array(StructField("ts_long", LongType)))
-    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
-    // to_timestamp cast UTC seconds to timestamp
-    df.withColumn("ts", to_timestamp(df.col("ts_long")))
+    spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
   }
 
   /**
-   * Use spark to generate parquet file that will be tested
+   * assert result with Spark result
    */
-  def writeTimestampToParquet(longs: Array[Long], path: String): Unit = {
-    withCpuSparkSession(
-      spark => createDF(spark, longs).write.mode("overwrite").parquet(path),
-      // write in UTC time zone
-      new SparkConf().set("spark.sql.session.timeZone", "UTC")
-          .set("spark.sql.parquet.int96RebaseModeInWrite", "CORRECTED"))
-  }
-
-  /**
-   * assert result from CpuTimeZoneDB and Spark
-   */
-  def assertRet(cpuPocRetCv: ColumnVector, sparkRet: Seq[Row]): Unit = {
-    withResource(cpuPocRetCv.copyToHost()) { host =>
-      assert(cpuPocRetCv.getRowCount == sparkRet.length)
-      for (i <- 0 until cpuPocRetCv.getRowCount.toInt) {
-        val sparkInstant = sparkRet(i).getTimestamp(0).toInstant
+  def assertRet(actualRet: ColumnVector, sparkRet: Seq[Row]): Unit = {
+    withResource(actualRet.copyToHost()) { host =>
+      assert(actualRet.getRowCount == sparkRet.length)
+      for (i <- 0 until actualRet.getRowCount.toInt) {
+        val sparkInstant = sparkRet(i).getInstant(0)
         val sparkMicro = sparkInstant.getEpochSecond * 1000000L + sparkInstant.getNano / 1000L
         assert(host.getLong(i) == sparkMicro)
       }
     }
   }
 
+  /**
+  * Get all epoch seconds every 15 minutes in [startYear, endYear].
+  */
+  def getEpochSeconds(startYear: Int, endYear: Int): Array[Long] = {
+    val s = Instant.parse("%04d-01-01T00:00:00z".format(startYear)).getEpochSecond
+    val e = Instant.parse("%04d-01-01T00:00:00z".format(endYear)).getEpochSecond
+    val epochSeconds = mutable.ArrayBuffer[Long]()
+    for (epoch <- s until e by TimeUnit.MINUTES.toSeconds(15)) {
+      epochSeconds += epoch
+    }
+    // Note: in seconds, not micro seconds
+    epochSeconds.toArray
+  }
+
+  def testFromUTC(epochSeconds: Array[Long], zoneStr: String): Unit = {
+    // get result from Spark
+    val sparkRet = withCpuSparkSession(
+      spark => {
+        createDF(spark, epochSeconds).createOrReplaceTempView("tab")
+        // refer to https://spark.apache.org/docs/latest/api/sql/#from_utc_timestamp
+        // convert from UTC timestamp
+        // first cast long value as timestamp
+        spark.sql(s"select from_utc_timestamp(cast(ts_long as timestamp), '$zoneStr') from tab").collect()
+      },
+      new SparkConf()
+        // use UTC time zone to create date frame
+        .set("spark.sql.session.timeZone", "UTC")
+        // by setting this, the Spark output for datetime type is java.time.Instant instead
+        // of java.sql.Timestamp, it's convenient to compare result via java.time.Instant
+        .set("spark.sql.datetime.java8API.enabled", "true"))
+
+    // get result from TimeZoneDB
+    val actualRet = withResource(createColumnVector(epochSeconds)) { inputCv =>
+      // convert time zone from UTC to specific timezone
+      CpuTimeZoneDB.convertFromUTC(
+        inputCv,
+        ZoneId.of(zoneStr))
+    }
+
+    withResource(actualRet) { _ =>
+      assertRet(actualRet, sparkRet)
+    }
+  }
+
+  def testToUTC(epochSeconds: Array[Long], zoneStr: String): Unit = {
+    // get result from Spark
+    val sparkRet = withCpuSparkSession(
+      spark => {
+        createDF(spark, epochSeconds).createOrReplaceTempView("tab")
+        // refer to https://spark.apache.org/docs/latest/api/sql/#to_utc_timestamp
+        // convert to UTC timezone
+        // first cast long value as timestamp
+        spark.sql(s"select to_utc_timestamp(cast(ts_long as timestamp), '$zoneStr') from tab").collect()
+      },
+      new SparkConf()
+        // use UTC time zone to create date frame
+        .set("spark.sql.session.timeZone", "UTC")
+        // by setting this, the Spark output for datetime type is java.time.Instant instead
+        // of java.sql.Timestamp, it's convenient to compare result via java.time.Instant
+        .set("spark.sql.datetime.java8API.enabled", "true"))
+
+    // get result from TimeZoneDB
+    val actualRet = withResource(createColumnVector(epochSeconds)) { inputCv =>
+      // convert time zone from UTC to specific timezone
+      CpuTimeZoneDB.convertToUTC(
+        inputCv,
+        ZoneId.of(zoneStr))
+    }
+
+    withResource(actualRet) { _ =>
+      assertRet(actualRet, sparkRet)
+    }
+  }
+
   test("test all time zones") {
-    assume(false,
+    assume(true,
       "It's time consuming for test all time zones, by default it's disabled")
     //    val zones = ZoneId.getAvailableZoneIds.asScala.toList.map(z => ZoneId.of(z)).filter { z =>
     //      val rules = z.getRules
     //      // remove this line when we support repeat rules
-    //      rules.isFixedOffset && rules.getTransitionRules.isEmpty
+    //      rules.isFixedOffset || rules.getTransitionRules.isEmpty
     //    }
 
-    // Currently only test China time zone
-    val zones = Array[ZoneId](ZoneId.of("Asia/Shanghai"))
-    // iterate zone, year and seconds every 15 minutes
-    for (zone <- zones) {
-      // For the years before 1900, there are diffs, need to investigate
-      for (year <- 1900 until 9999 by 10) {
-        val s = Instant.parse("%04d-01-01T00:00:00z".format(year)).getEpochSecond
-        val e = Instant.parse("%04d-01-01T00:00:00z".format(year + 1)).getEpochSecond
-        val longs = mutable.ArrayBuffer[Long]()
-        for (v <- s until e by TimeUnit.MINUTES.toSeconds(15)) {
-          longs += v
-        }
-        // data saves epoch seconds
-        val data = longs.toArray
-
-        withTempPath { file =>
-          writeTimestampToParquet(data, file.getAbsolutePath)
-          val sparkRet = withCpuSparkSession(
-            spark => {
-              spark.read.parquet(file.getAbsolutePath).createOrReplaceTempView("tab")
-              // refer to https://spark.apache.org/docs/latest/api/sql/#from_utc_timestamp
-              // convert timestamp to Shanghai timezone
-              spark.sql("select from_utc_timestamp(ts, 'Asia/Shanghai') from tab").collect()
-            },
-            new SparkConf().set("spark.sql.parquet.int96RebaseModeInRead", "CORRECTED"))
-
-          withResource(createColumnVector(data)) { inputCv =>
-            // convert time zone from UTC to Shanghai
-            withResource(CpuTimeZoneDB.convertFromUTC(
-              inputCv,
-              ZoneId.of("Asia/Shanghai"))) { cpuPocRetCv =>
-              assertRet(cpuPocRetCv, sparkRet)
-            }
-          }
-        }
+    // Currently only test one zone
+    val zones = Array[String]("Asia/Shanghai")
+    // iterate zones
+    for (zoneStr <- zones) {
+      // iterate years
+      for (year <- 1 until 9999) {
+        val epochSeconds = getEpochSeconds(year, year + 1)
+        testFromUTC(epochSeconds, zoneStr)
+        testToUTC(epochSeconds, zoneStr)
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.timezone
+
+import java.time.{Instant, ZoneId}
+import java.util.concurrent.TimeUnit
+
+import scala.collection.mutable
+
+import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.functions.to_timestamp
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+
+class TimeZoneSuite extends SparkQueryCompareTestSuite {
+  /**
+   * create timestamp column vector
+   */
+  def createColumnVector(epochSeconds: Array[Long]): ColumnVector = {
+    val rows = epochSeconds.length
+    withResource(HostColumnVector.builder(DType.TIMESTAMP_MICROSECONDS, rows)) { builder =>
+      var idx = 0
+      while (idx < rows) {
+        // change seconds to micro seconds
+        builder.append(epochSeconds(idx) * 1000000L)
+        idx += 1
+      }
+      withResource(builder.build()) { b =>
+        b.copyToDevice()
+      }
+    }
+  }
+
+  /**
+   * create Spark data frame with a timestamp with name ts
+   * @return
+   */
+  def createDF(spark: SparkSession, epochSeconds: Array[Long]): DataFrame = {
+    val data = epochSeconds.indices.map(i => Row(epochSeconds(i)))
+    val schema = StructType(Array(StructField("ts_long", LongType)))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+    // to_timestamp cast UTC seconds to timestamp
+    df.withColumn("ts", to_timestamp(df.col("ts_long")))
+  }
+
+  /**
+   * Use spark to generate parquet file that will be tested
+   */
+  def writeTimestampToParquet(longs: Array[Long], path: String): Unit = {
+    withCpuSparkSession(
+      spark => createDF(spark, longs).write.mode("overwrite").parquet(path),
+      // write in UTC time zone
+      new SparkConf().set("spark.sql.session.timeZone", "UTC")
+          .set("spark.sql.parquet.int96RebaseModeInWrite", "CORRECTED"))
+  }
+
+  /**
+   * assert result from CpuTimeZoneDB and Spark
+   */
+  def assertRet(cpuPocRetCv: ColumnVector, sparkRet: Seq[Row]): Unit = {
+    withResource(cpuPocRetCv.copyToHost()) { host =>
+      assert(cpuPocRetCv.getRowCount == sparkRet.length)
+      for (i <- 0 until cpuPocRetCv.getRowCount.toInt) {
+        val sparkInstant = sparkRet(i).getTimestamp(0).toInstant
+        val sparkMicro = sparkInstant.getEpochSecond * 1000000L + sparkInstant.getNano / 1000L
+        assert(host.getLong(i) == sparkMicro)
+      }
+    }
+  }
+
+  test("test all time zones") {
+    assume(false,
+      "It's time consuming for test all time zones, by default it's disabled")
+    //    val zones = ZoneId.getAvailableZoneIds.asScala.toList.map(z => ZoneId.of(z)).filter { z =>
+    //      val rules = z.getRules
+    //      // remove this line when we support repeat rules
+    //      rules.isFixedOffset && rules.getTransitionRules.isEmpty
+    //    }
+
+    // Currently only test China time zone
+    val zones = Array[ZoneId](ZoneId.of("Asia/Shanghai"))
+    // iterate zone, year and seconds every 15 minutes
+    for (zone <- zones) {
+      // For the years before 1900, there are diffs, need to investigate
+      for (year <- 1900 until 9999 by 10) {
+        val s = Instant.parse("%04d-01-01T00:00:00z".format(year)).getEpochSecond
+        val e = Instant.parse("%04d-01-01T00:00:00z".format(year + 1)).getEpochSecond
+        val longs = mutable.ArrayBuffer[Long]()
+        for (v <- s until e by TimeUnit.MINUTES.toSeconds(15)) {
+          longs += v
+        }
+        // data saves epoch seconds
+        val data = longs.toArray
+
+        withTempPath { file =>
+          writeTimestampToParquet(data, file.getAbsolutePath)
+          val sparkRet = withCpuSparkSession(
+            spark => {
+              spark.read.parquet(file.getAbsolutePath).createOrReplaceTempView("tab")
+              // refer to https://spark.apache.org/docs/latest/api/sql/#from_utc_timestamp
+              // convert timestamp to Shanghai timezone
+              spark.sql("select from_utc_timestamp(ts, 'Asia/Shanghai') from tab").collect()
+            },
+            new SparkConf().set("spark.sql.parquet.int96RebaseModeInRead", "CORRECTED"))
+
+          withResource(createColumnVector(data)) { inputCv =>
+            // convert time zone from UTC to Shanghai
+            withResource(CpuTimeZoneDB.convertFromUTC(
+              inputCv,
+              ZoneId.of("Asia/Shanghai"))) { cpuPocRetCv =>
+              assertRet(cpuPocRetCv, sparkRet)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
contributes #6832

In order to test GPUTimeZoneDB, we first implement a `CPU`TimeZoneDB, and test CPU POC against Spark.
When GPU version kernel is ready, it's easy to shift to test GPU kernel.
And here we want to test every time zone and every time point(every 15 mins from 0001 year to 9999 year) 

- Add CPU POC of TimeZoneDB
- Test Shanghai time zone and other 2 random time zones  by comparing CPU POC and Spark

Now this PR is testing Shanghai timezone from 1 year to 9999 year step by 7 years.

Signed-off-by: Chong Gao <res_life@163.com>