### PR TITLE
Support OverwriteByExpressionExecV1 for Delta Lake tables [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DatabricksDeltaProvider.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/nvidia/spark/rapids/delta/DatabricksDeltaProvider.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{FileFormat, LogicalRelation, SaveIntoDataSourceCommand}
-import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
 import org.apache.spark.sql.execution.datasources.v2.rapids.{GpuAtomicCreateTableAsSelectExec, GpuAtomicReplaceTableAsSelectExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.ExternalSource
@@ -263,34 +263,71 @@ object DatabricksDeltaProvider extends DeltaProviderImplBase {
       case Some(c: DeltaWriteV1Config) => c
       case _ => throw new IllegalStateException("Missing Delta write config from tagging pass")
     }
-    val deltaLog = writeConfig.deltaLog
-    val gpuWrite = new V1Write {
-      override def toInsertableRelation(): InsertableRelation = {
-        new InsertableRelation {
-          override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-            val session = data.sparkSession
+    val gpuWrite = toGpuWrite(writeConfig, meta.conf)
+    GpuAppendDataExecV1(cpuExec.table, cpuExec.plan, cpuExec.refreshCache, gpuWrite)
+  }
 
-            // TODO: Get the config from WriteIntoDelta's txn.
-            val cpuWrite = WriteIntoDelta(
-              deltaLog,
-              if (writeConfig.forceOverwrite) SaveMode.Overwrite else SaveMode.Append,
-              new DeltaOptions(writeConfig.options.toMap, session.sessionState.conf),
-              Nil,
-              DeltaLogShim.getMetadata(deltaLog).configuration,
-              data)
-            val gpuWrite = GpuWriteIntoDelta(new GpuDeltaLog(deltaLog, meta.conf), cpuWrite)
-            gpuWrite.run(session)
+  override def tagForGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): Unit = {
+    if (!meta.conf.isDeltaWriteEnabled) {
+      meta.willNotWorkOnGpu("Delta Lake output acceleration has been disabled. To enable set " +
+          s"${RapidsConf.ENABLE_DELTA_WRITE} to true")
+    }
+    val deltaTable = cpuExec.table.asInstanceOf[DeltaTableV2]
+    val tablePath = if (deltaTable.catalogTable.isDefined) {
+      new Path(deltaTable.catalogTable.get.location)
+    } else {
+      DeltaDataSource.parsePathIdentifier(cpuExec.session, deltaTable.path.toString,
+        deltaTable.options)._1
+    }
+    val deltaLog = DeltaLog.forTable(cpuExec.session, tablePath, deltaTable.options)
+    RapidsDeltaUtils.tagForDeltaWrite(meta, cpuExec.plan.schema, Some(deltaLog),
+      deltaTable.options, cpuExec.session)
+    extractWriteV1Config(meta, deltaLog, cpuExec.write).foreach { writeConfig =>
+      meta.setCustomTaggingData(writeConfig)
+    }
+  }
 
-            // TODO: Push this to Apache Spark
-            // Re-cache all cached plans(including this relation itself, if it's cached) that refer
-            // to this data source relation. This is the behavior for InsertInto
-            session.sharedState.cacheManager.recacheByPlan(
-              session, LogicalRelation(deltaLog.createRelation()))
-          }
+  override def convertToGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): GpuExec = {
+    val writeConfig = meta.getCustomTaggingData match {
+      case Some(c: DeltaWriteV1Config) => c
+      case _ => throw new IllegalStateException("Missing Delta write config from tagging pass")
+    }
+    val gpuWrite = toGpuWrite(writeConfig, meta.conf)
+    GpuOverwriteByExpressionExecV1(cpuExec.table, cpuExec.plan, cpuExec.refreshCache, gpuWrite)
+  }
+
+  private def toGpuWrite(
+      writeConfig: DeltaWriteV1Config,
+      rapidsConf: RapidsConf): V1Write = new V1Write {
+    override def toInsertableRelation(): InsertableRelation = {
+      new InsertableRelation {
+        override def insert(data: DataFrame, overwrite: Boolean): Unit = {
+          val session = data.sparkSession
+          val deltaLog = writeConfig.deltaLog
+
+          // TODO: Get the config from WriteIntoDelta's txn.
+          val cpuWrite = WriteIntoDelta(
+            deltaLog,
+            if (writeConfig.forceOverwrite) SaveMode.Overwrite else SaveMode.Append,
+            new DeltaOptions(writeConfig.options.toMap, session.sessionState.conf),
+            Nil,
+            DeltaLogShim.getMetadata(deltaLog).configuration,
+            data)
+          val gpuWrite = GpuWriteIntoDelta(new GpuDeltaLog(deltaLog, rapidsConf), cpuWrite)
+          gpuWrite.run(session)
+
+          // TODO: Push this to Apache Spark
+          // Re-cache all cached plans(including this relation itself, if it's cached) that refer
+          // to this data source relation. This is the behavior for InsertInto
+          session.sharedState.cacheManager.recacheByPlan(
+            session, LogicalRelation(deltaLog.createRelation()))
         }
       }
     }
-    GpuAppendDataExecV1(cpuExec.table, cpuExec.plan, cpuExec.refreshCache, gpuWrite)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/delta/DeltaProvider.scala
@@ -16,14 +16,14 @@
 
 package com.nvidia.spark.rapids.delta
 
-import com.nvidia.spark.rapids.{AppendDataExecV1Meta, AtomicCreateTableAsSelectExecMeta, AtomicReplaceTableAsSelectExecMeta, CreatableRelationProviderRule, ExecRule, GpuExec, RunnableCommandRule, ShimLoaderTemp, SparkPlanMeta}
+import com.nvidia.spark.rapids.{AppendDataExecV1Meta, AtomicCreateTableAsSelectExecMeta, AtomicReplaceTableAsSelectExecMeta, CreatableRelationProviderRule, ExecRule, GpuExec, OverwriteByExpressionExecV1Meta, RunnableCommandRule, ShimLoaderTemp, SparkPlanMeta}
 
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.connector.catalog.{StagingTableCatalog, SupportsWrite}
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
 import org.apache.spark.sql.sources.CreatableRelationProvider
 
 /** Probe interface to determine which Delta Lake provider to use. */
@@ -72,6 +72,12 @@ trait DeltaProvider {
   def tagForGpu(cpuExec: AppendDataExecV1,meta: AppendDataExecV1Meta): Unit
 
   def convertToGpu(cpuExec: AppendDataExecV1, meta: AppendDataExecV1Meta): GpuExec
+
+  def tagForGpu(cpuExec: OverwriteByExpressionExecV1, meta: OverwriteByExpressionExecV1Meta): Unit
+
+  def convertToGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): GpuExec
 }
 
 object DeltaProvider {
@@ -134,6 +140,18 @@ object NoDeltaProvider extends DeltaProvider {
   }
 
   override def convertToGpu(cpuExec: AppendDataExecV1, meta: AppendDataExecV1Meta): GpuExec = {
+    throw new IllegalStateException("write not supported, should not be called")
+  }
+
+  override def tagForGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): Unit = {
+    throw new IllegalStateException("write not supported, should not be called")
+  }
+
+  override def convertToGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): GpuExec = {
     throw new IllegalStateException("write not supported, should not be called")
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExternalSource.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
 import org.apache.spark.sql.sources.CreatableRelationProvider
 import org.apache.spark.util.Utils
 
@@ -201,6 +201,28 @@ object ExternalSource extends Logging {
   def convertToGpu(
       cpuExec: AppendDataExecV1,
       meta: AppendDataExecV1Meta): GpuExec = {
+    val writeClass = cpuExec.table.getClass
+    if (deltaProvider.isSupportedWrite(writeClass)) {
+      deltaProvider.convertToGpu(cpuExec, meta)
+    } else {
+      throw new IllegalStateException("No GPU conversion")
+    }
+  }
+
+  def tagForGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): Unit = {
+    val writeClass = cpuExec.table.getClass
+    if (deltaProvider.isSupportedWrite(writeClass)) {
+      deltaProvider.tagForGpu(cpuExec, meta)
+    } else {
+      meta.willNotWorkOnGpu(s"catalog $writeClass is not supported")
+    }
+  }
+
+  def convertToGpu(
+      cpuExec: OverwriteByExpressionExecV1,
+      meta: OverwriteByExpressionExecV1Meta): GpuExec = {
     val writeClass = cpuExec.table.getClass
     if (deltaProvider.isSupportedWrite(writeClass)) {
       deltaProvider.convertToGpu(cpuExec, meta)

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -54,7 +54,7 @@ import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec}
+import org.apache.spark.sql.execution.datasources.v2.{AppendDataExecV1, AtomicCreateTableAsSelectExec, AtomicReplaceTableAsSelectExec, OverwriteByExpressionExecV1}
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVScan
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcScan
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
@@ -276,7 +276,14 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
           GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
           TypeSig.all),
         (e, conf, p, r) => new AtomicReplaceTableAsSelectExecMeta(e, conf, p, r)),
-      GpuOverrides.exec[WindowInPandasExec](
+      exec[OverwriteByExpressionExecV1](
+        "Overwrite into a datasource V2 table using the V1 write interface",
+        ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 +
+          TypeSig.STRUCT + TypeSig.MAP + TypeSig.ARRAY + TypeSig.BINARY +
+          GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
+          TypeSig.all),
+        (p, conf, parent, r) => new OverwriteByExpressionExecV1Meta(p, conf, parent, r)),
+      exec[WindowInPandasExec](
         "The backend for Window Aggregation Pandas UDF, Accelerates the data transfer between" +
           " the Java process and the Python process. It also supports scheduling GPU resources" +
           " for the Python process when enabled. For now it only supports row based window frame.",

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/v1FallbackWriters.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/v1FallbackWriters.scala
@@ -58,6 +58,25 @@ case class GpuAppendDataExecV1(
     refreshCache: () => Unit,
     write: V1Write) extends GpuV1FallbackWriters
 
+/**
+ * GPU version of OverwriteByExpressionExecV1
+ *
+ * Physical plan node for overwrite into a v2 table with V1 write interfaces. Note that when this
+ * interface is used, the atomicity of the operation depends solely on the target data source.
+ *
+ * Overwrites data in a table matched by a set of filters. Rows matching all of the filters will be
+ * deleted and rows in the output data set are appended.
+ *
+ * This plan is used to implement SaveMode.Overwrite. The behavior of SaveMode.Overwrite is to
+ * truncate the table -- delete all rows -- and append the output data set. This uses the filter
+ * AlwaysTrue to delete all rows.
+ */
+case class GpuOverwriteByExpressionExecV1(
+    table: SupportsWrite,
+    plan: LogicalPlan,
+    refreshCache: () => Unit,
+    write: V1Write) extends GpuV1FallbackWriters
+
 /** GPU version of V1FallbackWriters */
 trait GpuV1FallbackWriters extends LeafV2CommandExec with SupportsV1Write with GpuExec {
   override def supportsColumnar: Boolean = false


### PR DESCRIPTION
Fixes #7279.

Adds GpuOverwriteByExpressionExecV1 and support for the V1 Write instance provided by Delta Lake.  Ported some of the tests over from the Delta Lake project which helped discover that, unlike Apache Spark, Databricks will use a different node for dynamic partition overwrite. Filed #9543 to track handling that new node and xfailed the affected tests on Databricks in the interim.