### PR TITLE
Support launching Map Pandas UDF on empty partitions

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowPythonRunner.scala
@@ -35,6 +35,7 @@ import org.apache.spark.api.python._
 import org.apache.spark.rapids.shims.api.python.ShimBasePythonRunner
 import org.apache.spark.sql.execution.python.PythonUDFRunner
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.rapids.shims.ArrowUtilsShim
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -298,7 +299,7 @@ abstract class GpuArrowPythonRunnerBase(
 
       private def writeEmptyIteratorOnCpu(dataOut: DataOutputStream): Unit = {
         // most code is copied from Spark
-        val arrowSchema = ArrowUtils.toArrowSchema(pythonInSchema, timeZoneId)
+        val arrowSchema = ArrowUtilsShim.toArrowSchema(pythonInSchema, timeZoneId)
         val allocator = ArrowUtils.rootAllocator.newChildAllocator(
           s"stdout writer for empty partition", 0, Long.MaxValue)
         val root = VectorSchemaRoot.create(arrowSchema, allocator)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuMapInBatchExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuMapInBatchExec.scala
@@ -87,31 +87,25 @@ trait GpuMapInBatchExec extends ShimUnaryExecNode with GpuPythonExecBase {
             }
           }
       }
-
-      if (pyInputIterator.hasNext) {
-        val pyRunner = new GpuArrowPythonRunnerBase(
-            chainedFunc,
-            pythonEvalType,
-            argOffsets,
-            pyInputSchema,
-            sessionLocalTimeZone,
-            pythonRunnerConf,
-            batchSize) {
-          override def toBatch(table: Table): ColumnarBatch = {
-            BatchGroupedIterator.extractChildren(table, localOutput)
-          }
+      val pyRunner = new GpuArrowPythonRunnerBase(
+          chainedFunc,
+          pythonEvalType,
+          argOffsets,
+          pyInputSchema,
+          sessionLocalTimeZone,
+          pythonRunnerConf,
+          batchSize) {
+        override def toBatch(table: Table): ColumnarBatch = {
+          BatchGroupedIterator.extractChildren(table, localOutput)
         }
-
-        pyRunner.compute(pyInputIterator, context.partitionId(), context)
-          .map { cb =>
-            numOutputBatches += 1
-            numOutputRows += cb.numRows
-            cb
-          }
-      } else {
-        // Empty partition, return it directly
-        inputIter
       }
+
+      pyRunner.compute(pyInputIterator, context.partitionId(), context)
+        .map { cb =>
+          numOutputBatches += 1
+          numOutputRows += cb.numRows
+          cb
+        }
     } // end of mapPartitionsInternal
   } // end of internalDoExecuteColumnar
 

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
@@ -39,10 +39,18 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.arrow.vector.types.pojo.Schema
+
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.ArrowUtils
 
 object ArrowUtilsShim {
   def getPythonRunnerConfMap(conf: SQLConf): Map[String, String] =
     ArrowUtils.getPythonRunnerConfMap(conf)
+
+  def toArrowSchema(schema: StructType, timeZoneId: String,
+      errorOnDuplicatedFieldNames: Boolean = true, largeVarTypes: Boolean = false): Schema = {
+    ArrowUtils.toArrowSchema(schema, timeZoneId)
+  }
 }

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
@@ -19,10 +19,19 @@
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims
 
+import org.apache.arrow.vector.types.pojo.Schema
+
 import org.apache.spark.sql.execution.python.ArrowPythonRunner
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.ArrowUtils
 
 object ArrowUtilsShim {
   def getPythonRunnerConfMap(conf: SQLConf): Map[String, String] =
     ArrowPythonRunner.getPythonRunnerConfMap(conf)
+
+  def toArrowSchema(schema: StructType, timeZoneId: String,
+      errorOnDuplicatedFieldNames: Boolean = true, largeVarTypes: Boolean = false): Schema = {
+    ArrowUtils.toArrowSchema(schema, timeZoneId, errorOnDuplicatedFieldNames, largeVarTypes)
+  }
 }


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/9480

This PR adds support of launching Map Pandas UDF on empty partitions to align with Spark's behavior.

So far I don't see other types of Pandas UDF will be called for empty partitions.

The test is copied from the example in the linked issue.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
