### PR TITLE
Support integration test against scala2.13 spark binaries[skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -96,7 +96,7 @@ fi
 
 tar xzf "$RAPIDS_INT_TESTS_TGZ" -C $ARTF_ROOT && rm -f "$RAPIDS_INT_TESTS_TGZ"
 
-. jenkins/hadoop-def.sh $SPARK_VER
+. jenkins/hadoop-def.sh $SPARK_VER ${SCALA_BINARY_VER}
 wget -P $ARTF_ROOT $SPARK_REPO/org/apache/spark/$SPARK_VER/spark-$SPARK_VER-$BIN_HADOOP_VER.tgz
 
 # Download parquet-hadoop jar for parquet-read encryption tests


### PR DESCRIPTION
Support integration test against scala2.13 spark binaries in CI test scripts


Signed-off-by: Tim Liu <timl@nvidia.com>