### PR TITLE
Add retry for CrossJoinIterator and ConditionalNestedLoopJoinIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/AbstractGpuJoinIterator.scala
@@ -198,7 +198,7 @@ abstract class SplittableJoinIterator(
   // If the join explodes this holds batches from the stream side split into smaller pieces.
   private val pendingSplits = scala.collection.mutable.Queue[LazySpillableColumnarBatch]()
 
-  protected def computeNumJoinRows(cb: ColumnarBatch): Long
+  protected def computeNumJoinRows(cb: LazySpillableColumnarBatch): Long
 
   /**
    * Create a join gatherer.
@@ -225,7 +225,7 @@ abstract class SplittableJoinIterator(
       }
       opTime.ns {
         withResource(scb) { scb =>
-          val numJoinRows = computeNumJoinRows(scb.getBatch)
+          val numJoinRows = computeNumJoinRows(scb)
 
           // We want the gather maps size to be around the target size. There are two gather maps
           // that are made up of ints, so compute how many rows on the stream side will produce the

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuHashJoin.scala
@@ -292,14 +292,14 @@ abstract class BaseHashJoinIterator(
       1.0
   }
 
-  override def computeNumJoinRows(cb: ColumnarBatch): Long = {
+  override def computeNumJoinRows(cb: LazySpillableColumnarBatch): Long = {
     // TODO: Replace this estimate with exact join row counts using the corresponding cudf APIs
     //       being added in https://github.com/rapidsai/cudf/issues/9053.
     joinType match {
       // Full Outer join is implemented via LeftOuter/RightOuter, so use same estimate.
       case _: InnerLike | LeftOuter | RightOuter | FullOuter =>
-        Math.ceil(cb.numRows() * streamMagnificationFactor).toLong
-      case _ => cb.numRows()
+        Math.ceil(cb.numRows * streamMagnificationFactor).toLong
+      case _ => cb.numRows
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/8344
fixes https://github.com/NVIDIA/spark-rapids/issues/8345

This PR adds retry support to creating the gather maps for CrossJoinIterator and the `computeNumJoinRows` method 
 of `ConditionalNestedLoopJoinIterator`.

This is simple enough so I don't add tests. If you prefer I am happy to try to add some.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
