### PR TITLE
Fix broken #endif scala comments [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1096,7 +1096,7 @@
                         <!-- #if scala-2.13 --><!--
                         <compilerPlugins combine.self="override">
                         </compilerPlugins>
-                        --><!-- #endif -->
+                        --><!-- #endif scala-2.13 -->
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1234,7 +1234,13 @@
                           <message>Minimum Maven version 3.6.x required</message>
                           <version>[3.6,)</version>
                         </requireMavenVersion>
-                        <!-- TODO add buildver validation -->
+                        <!-- #if scala-2.13 --><!--
+                        <requireProperty>
+                            <regexMessage>Unexpected buildver value ${buildver} for a Scala 2.13 build, only Apache Spark versions 3.3.0 (330) and higher are supported, no vendor builds such as 330db</regexMessage>
+                            <property>buildver</property>
+                            <regex>[3-9][3-9][0-9]</regex>
+                        </requireProperty>
+                        --><!-- #endif scala-2.13 -->
                       </rules>
                     </configuration>
                   </execution>
@@ -1346,13 +1352,13 @@
                             <skip>${maven.cleanall.skip}</skip>
                             <target>
                                 <!-- #if scala-2.12 -->
-                                <dirset dir="${project.basedir}" 
+                                <dirset dir="${project.basedir}"
                                     includes="**/target"
                                     excludes="scala2.13/**"
                                     id="target.dirs.for.clean"/>
                                 <!-- #endif scala-2.12 -->
                                 <!-- #if scala-2.13 --><!--
-                                <dirset dir="${project.basedir}" 
+                                <dirset dir="${project.basedir}"
                                     includes="**/target"
                                     id="target.dirs.for.clean"/>
                                 --><!-- #endif scala-2.13 -->

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1096,7 +1096,7 @@
                         <!-- #if scala-2.13 -->
                         <compilerPlugins combine.self="override">
                         </compilerPlugins>
-                        --><!-- #endif -->
+                        <!-- #endif scala-2.13 -->
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1234,7 +1234,13 @@
                           <message>Minimum Maven version 3.6.x required</message>
                           <version>[3.6,)</version>
                         </requireMavenVersion>
-                        <!-- TODO add buildver validation -->
+                        <!-- #if scala-2.13 -->
+                        <requireProperty>
+                            <regexMessage>Unexpected buildver value ${buildver} for a Scala 2.13 build, only Apache Spark versions 3.3.0 (330) and higher are supported, no vendor builds such as 330db</regexMessage>
+                            <property>buildver</property>
+                            <regex>[3-9][3-9][0-9]</regex>
+                        </requireProperty>
+                        <!-- #endif scala-2.13 -->
                       </rules>
                     </configuration>
                   </execution>
@@ -1346,13 +1352,13 @@
                             <skip>${maven.cleanall.skip}</skip>
                             <target>
                                 <!-- #if scala-2.12 --><!--
-                                <dirset dir="${project.basedir}" 
+                                <dirset dir="${project.basedir}"
                                     includes="**/target"
                                     excludes="scala2.13/**"
                                     id="target.dirs.for.clean"/>
                                 --><!-- #endif scala-2.12 -->
                                 <!-- #if scala-2.13 -->
-                                <dirset dir="${project.basedir}" 
+                                <dirset dir="${project.basedir}"
                                     includes="**/target"
                                     id="target.dirs.for.clean"/>
                                 <!-- #endif scala-2.13 -->


### PR DESCRIPTION
Correct two instances of incomplete `#endif` comments that are not properly [replaced](https://github.com/NVIDIA/spark-rapids/blob/2cc202ad8e226823e6e5f448878732601d7c6698/build/make-scala-version-build-files.sh#L76) when generating the scala2.13 pom. It does not break the build because the broken comment becomes an ignored text fragment

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
