### PR TITLE
Move Stack classes to wrapper classes to fix non-deterministic build issue

### DIFF
--- a/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
@@ -16,6 +16,37 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.mutable.Stack
+import scala.collection.mutable.ArrayStack
 
-class ScalaStack[T] extends Stack[T]
+class RapidsStack[T] {
+  private val innerStack = new ArrayStack[T]()
+
+  def push(elem1: T): RapidsStack[T] = {
+    innerStack.push(elem1)
+    this
+  }
+
+  def pop(): T = {
+    innerStack.pop()
+  }
+
+  def isEmpty: Boolean = {
+    innerStack.isEmpty
+  }
+
+  def nonEmpty: Boolean = {
+    innerStack.nonEmpty
+  }
+
+  def size(): Int = {
+    innerStack.size
+  }
+
+  def toSeq(): Seq[T] = {
+    innerStack.toSeq
+  }
+
+  def clear(): Unit = {
+    innerStack.clear()
+  }
+}

--- a/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
@@ -19,11 +19,12 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.ArrayStack
 
 class RapidsStack[T] extends Proxy {
-  override def self = new ArrayStack[T]()
+  private val stack = new ArrayStack[T]()
 
-  def push(elem1: T): RapidsStack[T] = {
+  override def self = stack
+
+  def push(elem1: T): Unit = {
     self.push(elem1)
-    this
   }
 
   def pop(): T = {
@@ -38,11 +39,11 @@ class RapidsStack[T] extends Proxy {
     self.nonEmpty
   }
 
-  def size(): Int = {
+  def size: Int = {
     self.size
   }
 
-  def toSeq(): Seq[T] = {
+  def toSeq: Seq[T] = {
     self.toSeq
   }
 

--- a/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
@@ -18,35 +18,35 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayStack
 
-class RapidsStack[T] {
-  private val innerStack = new ArrayStack[T]()
+class RapidsStack[T] extends Proxy {
+  override def self = new ArrayStack[T]()
 
   def push(elem1: T): RapidsStack[T] = {
-    innerStack.push(elem1)
+    self.push(elem1)
     this
   }
 
   def pop(): T = {
-    innerStack.pop()
+    self.pop()
   }
 
   def isEmpty: Boolean = {
-    innerStack.isEmpty
+    self.isEmpty
   }
 
   def nonEmpty: Boolean = {
-    innerStack.nonEmpty
+    self.nonEmpty
   }
 
   def size(): Int = {
-    innerStack.size
+    self.size
   }
 
   def toSeq(): Seq[T] = {
-    innerStack.toSeq
+    self.toSeq
   }
 
   def clear(): Unit = {
-    innerStack.clear()
+    self.clear()
   }
 }

--- a/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
@@ -18,35 +18,35 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.Stack
 
-class RapidsStack[T] {
-  private val innerStack = new Stack[T]()
+class RapidsStack[T] extends scala.Proxy {
+  override def self = new Stack[T]()
 
   def push(elem1: T): RapidsStack[T] = {
-    innerStack.push(elem1)
+    self.push(elem1)
     this
   }
 
   def pop(): T = {
-    innerStack.pop()
+    self.pop()
   }
 
   def isEmpty: Boolean = {
-    innerStack.isEmpty
+    self.isEmpty
   }
 
   def nonEmpty: Boolean = {
-    innerStack.nonEmpty
+    self.nonEmpty
   }
 
   def size(): Int = {
-    innerStack.size
+    self.size
   }
 
   def toSeq(): Seq[T] = {
-    innerStack.toSeq
+    self.toSeq
   }
 
   def clear(): Unit = {
-    innerStack.clear()
+    self.clear()
   }
 }

--- a/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
@@ -16,6 +16,37 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.mutable.ArrayStack
+import scala.collection.mutable.Stack
 
-class ScalaStack[T] extends ArrayStack[T]
+class RapidsStack[T] {
+  private val innerStack = new Stack[T]()
+
+  def push(elem1: T): RapidsStack[T] = {
+    innerStack.push(elem1)
+    this
+  }
+
+  def pop(): T = {
+    innerStack.pop()
+  }
+
+  def isEmpty: Boolean = {
+    innerStack.isEmpty
+  }
+
+  def nonEmpty: Boolean = {
+    innerStack.nonEmpty
+  }
+
+  def size(): Int = {
+    innerStack.size
+  }
+
+  def toSeq(): Seq[T] = {
+    innerStack.toSeq
+  }
+
+  def clear(): Unit = {
+    innerStack.clear()
+  }
+}

--- a/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
@@ -19,7 +19,8 @@ package com.nvidia.spark.rapids
 import scala.collection.mutable.Stack
 
 class RapidsStack[T] extends Proxy {
-  override def self = new Stack[T]()
+  private val stack = new Stack[T]()
+  override def self = stack
 
   def push(elem1: T): RapidsStack[T] = {
     self.push(elem1)

--- a/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.13/com/nvidia/spark/rapids/RapidsStack.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.Stack
 
-class RapidsStack[T] extends scala.Proxy {
+class RapidsStack[T] extends Proxy {
   override def self = new Stack[T]()
 
   def push(elem1: T): RapidsStack[T] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortExec.scala
@@ -450,8 +450,8 @@ case class GpuOutOfCoreSortIterator(
     while (!pending.isEmpty && sortedSize < targetSize) {
       // Keep going until we have enough data to return
       var bytesLeftToFetch = targetSize
-      val pendingSort = new ScalaStack[SpillableColumnarBatch]()
-      closeOnExcept(pendingSort) { _ =>
+      val pendingSort = new RapidsStack[SpillableColumnarBatch]()
+      closeOnExcept(pendingSort.toSeq) { _ =>
         while (!pending.isEmpty &&
             (bytesLeftToFetch - pending.peek().buffer.sizeInBytes >= 0 || pendingSort.isEmpty)) {
           val buffer = pending.poll().buffer


### PR DESCRIPTION
Fixes #9571.

This wraps the Scala 2.12/2.13 specific Stack classes in a class called `RapidsStack`, which is then used like the other classes. Previously, we extended the Spark specific classes with `ScalaStack`, but that created issues in the build due to the bytecode dependencies that linked back to SQLExecPlugin.class.  

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
