### PR TITLE
Merge metrics and file format fixes to Delta 2.4 support

### DIFF
--- a/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/GpuDelta24xParquetFileFormat.scala
+++ b/delta-lake/delta-24x/src/main/scala/com/nvidia/spark/rapids/delta/delta24x/GpuDelta24xParquetFileFormat.scala
@@ -45,4 +45,20 @@ case class GpuDelta24xParquetFileFormat(
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = isSplittable
+
+  /**
+   * We sometimes need to replace FileFormat within LogicalPlans, so we have to override
+   * `equals` to ensure file format changes are captured
+   */
+  override def equals(other: Any): Boolean = {
+    other match {
+      case ff: GpuDelta24xParquetFileFormat =>
+        ff.columnMappingMode == columnMappingMode &&
+          ff.referenceSchema == referenceSchema &&
+          ff.isSplittable == isSplittable
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = getClass.getCanonicalName.hashCode()
 }


### PR DESCRIPTION
Fixes #9581.  Updated GpuMergeIntoCommand for Delta Lake 2.4 to significantly reduce the diffs between it and the Delta Lake 2.4 MergeIntoCommand reference and the Delta Lake 2.3 GPU support.  Also fixed the missing equals/hashCode methods on the Delta Parquet file format class.