### PR TITLE
Revert "Ignore failing Parquet filter test to unblock CI (#9519)"

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/ParquetFilterSuite.scala
@@ -224,8 +224,7 @@ class ParquetFilterSuite extends SparkQueryCompareTestSuite {
     })
   }
 
-  // https://github.com/NVIDIA/spark-rapids/issues/9507
-  ignore("Parquet filter pushdown - timestamp") {
+  test("Parquet filter pushdown - timestamp") {
     withCpuSparkSession(spark => {
       import spark.implicits._
       val df = (1 to 1024).map(i => new Timestamp(i)).toDF("a")


### PR DESCRIPTION
Issue https://github.com/rapidsai/cudf/issues/14315 is closed with PR https://github.com/rapidsai/cudf/pull/14322 

This PR adds back tests for "Parquet filter pushdown - timestamp" by reverting commit eeb4168382c63a00201a1dbc833abca76a7d9828.

Closes https://github.com/NVIDIA/spark-rapids/issues/9507