### PR TITLE
Replace deprecated class scala.Proxy

### DIFF
--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/RapidsProxy.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/RapidsProxy.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,37 +16,11 @@
 
 package com.nvidia.spark.rapids
 
-import scala.collection.mutable.Stack
-
-class RapidsStack[T] extends RapidsProxy {
-  override val self = Stack.empty[T]
-
-  def push(elem1: T): RapidsStack[T] = {
-    self.push(elem1)
-    this
-  }
-
-  def pop(): T = {
-    self.pop()
-  }
-
-  def isEmpty: Boolean = {
-    self.isEmpty
-  }
-
-  def nonEmpty: Boolean = {
-    self.nonEmpty
-  }
-
-  def size(): Int = {
-    self.size
-  }
-
-  def toSeq(): Seq[T] = {
-    self.toSeq
-  }
-
-  def clear(): Unit = {
-    self.clear()
-  }
+/**
+ * Trait to replace usage of deprecated scala.Proxy. If the purpose is to delay
+ * initialization of the underlying implementation, self is overriden as a
+ * lazy val
+ */
+trait RapidsProxy extends Any {
+  def self: Any
 }

--- a/sql-plugin-api/src/main/scala/org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin-api/src/main/scala/org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase.scala
@@ -46,7 +46,7 @@ class ProxyRapidsShuffleInternalManagerBase(
 
   // touched in the plugin code after the shim initialization
   // is complete
-  lazy val self: ShuffleManager = ShimLoader.newInternalShuffleManager(conf, isDriver)
+  override lazy val self: ShuffleManager = ShimLoader.newInternalShuffleManager(conf, isDriver)
       .asInstanceOf[ShuffleManager]
 
   // This function touches the lazy val `self` so we actually instantiate

--- a/sql-plugin-api/src/main/scala/org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin-api/src/main/scala/org/apache/spark/sql/rapids/ProxyRapidsShuffleInternalManagerBase.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.rapids
 
-import com.nvidia.spark.rapids.ShimLoader
+import com.nvidia.spark.rapids.{RapidsProxy, ShimLoader}
 
 import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
 import org.apache.spark.shuffle._
@@ -42,7 +42,7 @@ trait RapidsShuffleManagerLike {
 class ProxyRapidsShuffleInternalManagerBase(
     conf: SparkConf,
     override val isDriver: Boolean
-) extends RapidsShuffleManagerLike with Proxy with ShuffleManager {
+) extends RapidsShuffleManagerLike with RapidsProxy with ShuffleManager {
 
   // touched in the plugin code after the shim initialization
   // is complete

--- a/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
+++ b/sql-plugin/src/main/scala-2.12/com/nvidia/spark/rapids/RapidsStack.scala
@@ -18,10 +18,8 @@ package com.nvidia.spark.rapids
 
 import scala.collection.mutable.ArrayStack
 
-class RapidsStack[T] extends Proxy {
-  private val stack = new ArrayStack[T]()
-
-  override def self = stack
+class RapidsStack[T] extends RapidsProxy {
+  override val self: ArrayStack[T] = new ArrayStack[T]()
 
   def push(elem1: T): Unit = {
     self.push(elem1)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/ExclusiveModeGpuDiscoveryPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.nvidia.spark
 
 import java.util.Optional
 
-import com.nvidia.spark.rapids.ShimLoader
+import com.nvidia.spark.rapids.{RapidsProxy, ShimLoader}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.api.resource.ResourceDiscoveryPlugin
@@ -35,7 +35,7 @@ import org.apache.spark.resource.{ResourceInformation, ResourceRequest}
  *  This plugin can be activated in spark with the configuration:
  *  `--conf spark.resources.discoveryPlugin=com.nvidia.spark.ExclusiveModeGpuDiscoveryPlugin`
  */
-class ExclusiveModeGpuDiscoveryPlugin extends ResourceDiscoveryPlugin with Proxy {
+class ExclusiveModeGpuDiscoveryPlugin extends ResourceDiscoveryPlugin with RapidsProxy {
   override def discoverResource(
     request: ResourceRequest,
     sparkConf: SparkConf

--- a/sql-plugin/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark
 
-import com.nvidia.spark.rapids.ShimLoaderTemp
+import com.nvidia.spark.rapids.{RapidsProxy, ShimLoaderTemp}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -39,7 +39,7 @@ trait GpuCachedBatchSerializer extends CachedBatchSerializer {
 /**
  * User facing wrapper class that calls into the internal version.
  */
-class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer with Proxy {
+class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer with RapidsProxy {
 
   override lazy val self: GpuCachedBatchSerializer =
     ShimLoaderTemp.newParquetCachedBatchSerializer()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsShuffleHeartbeatManager.scala
@@ -217,7 +217,7 @@ class RapidsShuffleHeartbeatEndpoint(pluginContext: PluginContext, conf: RapidsC
   }
 
   def registerShuffleHeartbeat(): Unit = {
-    val rapidsShuffleManager = SparkEnv.get.shuffleManager.asInstanceOf[Proxy].self
+    val rapidsShuffleManager = SparkEnv.get.shuffleManager.asInstanceOf[RapidsProxy].self
         .asInstanceOf[RapidsShuffleInternalManagerBase]
     if (rapidsShuffleManager.isDriver) {
       logDebug("Local mode detected. Skipping shuffle heartbeat registration.")


### PR DESCRIPTION
This PR replaces the usage of the deprecated class `scala.Proxy` whose sole purpose in this project was to tag delegation proxy classes routing all methods to `self` referencing the real implementation.

This PR does not introduce any semantics changes

Derived classes are expected to override `def self` either as  `override val self` or `override lazy val self`

Closes #9577

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
