### PR TITLE
Bloop updates - require JDK11 in buildall + docs, build bloop for all targets.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,7 @@ interested in. For example, to generate the Bloop projects for the Spark 3.2.0 d
 just for the production code run:
 
 ```shell script
-mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall -am \
+mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall \
   -DdownloadSources=true \
   -Dbuildver=320 \
   -DskipTests \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,13 +353,10 @@ interested in. For example, to generate the Bloop projects for the Spark 3.2.0 d
 just for the production code run:
 
 ```shell script
-mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall \
-  -DdownloadSources=true \
-  -Dbuildver=320 \
-  -DskipTests \
-  -Dskip \
-  -Dmaven.scalastyle.skip=true \
-  -Dmaven.updateconfig.skip=true
+mvn -B clean install \
+    -DbloopInstall \
+    -DdownloadSources=true \
+    -Dbuildver=320
 ```
 
 With `--generate-bloop` we integrated Bloop project generation into `buildall`. It makes it easier
@@ -436,18 +433,11 @@ jps -l
 ###### java.lang.RuntimeException: boom
 
 Metals background compilation process status appears to be resetting to 0% after reaching 99%
-and you see a peculiar error message [`java.lang.RuntimeException: boom`][1]. You can work around
-it by making sure Metals Server (Bloop client) and Bloop Server are both running on Java 11+.
+and you see a peculiar error message [`java.lang.RuntimeException: boom`][1]. This is a known issue
+when running Metals/Bloop on Java 8. To work around it, ensure Metals and Bloop are both running on
+Java 11+.
 
-1. To this end make sure that Bloop projects are generated using Java 11+
-
-    ```bash
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
-      mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall \
-      -DdownloadSources=true \
-      -Dbuildver=331 \
-      -Dskip -DskipTests
-    ```
+1. The `-DbloopInstall` profile will enforce Java 11+ compliance.
 
 1. Add [`metals.javaHome`][2] to VSCode preferences to point to Java 11+.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,7 @@ interested in. For example, to generate the Bloop projects for the Spark 3.2.0 d
 just for the production code run:
 
 ```shell script
-mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall -pl aggregator -am \
+mvn install ch.epfl.scala:bloop-maven-plugin:bloopInstall -am \
   -DdownloadSources=true \
   -Dbuildver=320 \
   -DskipTests \
@@ -383,6 +383,11 @@ You can now open the spark-rapids as a
 [BSP project in IDEA](https://www.jetbrains.com/help/idea/bsp-support.html)
 
 Read on for VS Code Scala Metals instructions.
+
+##### JDK 11 Requirement
+
+It is known that Bloop's SemanticDB generation with JDK 8 is broken for spark-rapids. Please use JDK
+11 or later for Bloop builds.
 
 #### Bloop, Scala Metals, and Visual Studio Code
 

--- a/build/buildall
+++ b/build/buildall
@@ -57,7 +57,14 @@ function bloopInstall() {
 
   [[ "$BUILD_ALL_DEBUG" == "1" ]] && set -x
 
-  local javaVersion=$(java -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
+  if [ -z $JAVA_HOME ]
+  then
+    local java=java
+  else
+    local java=$JAVA_HOME/bin/java
+  fi
+
+  local javaVersion=$($java -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
   if [ $javaVersion -lt 11 ]
   then
     echo "Bloop install requires JDK >= 11"
@@ -73,7 +80,6 @@ function bloopInstall() {
       mkdir -p $bloopTmpConfigDir
       $MVN -B clean install \
         ch.epfl.scala:bloop-maven-plugin:bloopInstall \
-        -am \
         -Dbloop.configDirectory="$bloopTmpConfigDir" \
         -DdownloadSources=true \
         -Dbuildver="$bv" \

--- a/build/buildall
+++ b/build/buildall
@@ -57,6 +57,13 @@ function bloopInstall() {
 
   [[ "$BUILD_ALL_DEBUG" == "1" ]] && set -x
 
+  local javaVersion=$(java -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
+  if [ $javaVersion -lt 11 ]
+  then
+    echo "Bloop install requires JDK >= 11"
+    exit 1
+  fi
+
   local bloopTmpDir=$(mktemp -d /tmp/tmp.bloop.XXXXXX)
 
   time (
@@ -66,7 +73,7 @@ function bloopInstall() {
       mkdir -p $bloopTmpConfigDir
       $MVN -B clean install \
         ch.epfl.scala:bloop-maven-plugin:bloopInstall \
-        -pl aggregator -am \
+        -am \
         -Dbloop.configDirectory="$bloopTmpConfigDir" \
         -DdownloadSources=true \
         -Dbuildver="$bv" \

--- a/build/buildall
+++ b/build/buildall
@@ -57,20 +57,6 @@ function bloopInstall() {
 
   [[ "$BUILD_ALL_DEBUG" == "1" ]] && set -x
 
-  if [ -z $JAVA_HOME ]
-  then
-    local java=java
-  else
-    local java=$JAVA_HOME/bin/java
-  fi
-
-  local javaVersion=$($java -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p' | cut -d' ' -f1)
-  if [ $javaVersion -lt 11 ]
-  then
-    echo "Bloop install requires JDK >= 11"
-    exit 1
-  fi
-
   local bloopTmpDir=$(mktemp -d /tmp/tmp.bloop.XXXXXX)
 
   time (
@@ -79,14 +65,10 @@ function bloopInstall() {
       bloopTmpConfigDir="$bloopTmpDir/.bloop$bv"
       mkdir -p $bloopTmpConfigDir
       $MVN -B clean install \
-        ch.epfl.scala:bloop-maven-plugin:bloopInstall \
+        -DbloopInstall \
         -Dbloop.configDirectory="$bloopTmpConfigDir" \
         -DdownloadSources=true \
-        -Dbuildver="$bv" \
-        -DskipTests \
-        -Dskip \
-        -Dmaven.scalastyle.skip=true \
-        -Dmaven.updateconfig.skip=true
+        -Dbuildver="$bv"
 
       specifier="spark$bv"
       bloopDir=$PWD/.bloop-$specifier

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,57 @@
                 <jni.classifier>${cuda.version}-arm64</jni.classifier>
             </properties>
         </profile>
+        <profile>
+            <id>bloopInstall</id>
+            <activation>
+                <property>
+                    <name>bloopInstall</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <maven.scaladoc.skip>true</maven.scaladoc.skip>
+                <maven.scalastyle.skip>true</maven.scalastyle.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-bloop-rules</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <message>Metals semantic database requires JAVA_HOME pointing to JDK 11+, actual Java version: ${java.version}</message>
+                                            <version>[11,)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>ch.epfl.scala</groupId>
+                        <artifactId>bloop-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-bloop-projects</id>
+                                <goals><goal>bloopInstall</goal></goals>
+                                <phase>${bloopInstallPhase}</phase>
+                                <configuration>
+                                    <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <properties>
@@ -655,6 +706,7 @@
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <spark330.iceberg.version>0.14.1</spark330.iceberg.version>
@@ -765,6 +817,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <bloopInstallPhase>install</bloopInstallPhase>
     </properties>
 
     <dependencyManagement>
@@ -1043,6 +1096,7 @@
                                     <arg>-doc-external-doc:${settings.localRepository}/${scala.local-lib.path}#https://scala-lang.org/api/${scala.version}/</arg>
                                     <arg>-doc-external-doc:${settings.localRepository}/org/apache/spark/spark-sql_${scala.binary.version}/${spark.version}/spark-sql_${scala.binary.version}-${spark.version}.jar#https://spark.apache.org/docs/${spark.version}/api/scala/index.html</arg>
                                 </args>
+                                <skip>${maven.scaladoc.skip}</skip>
                             </configuration>
                         </execution>
                     </executions>
@@ -1212,6 +1266,21 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>ch.epfl.scala</groupId>
+                <artifactId>bloop-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <skip>true</skip>
+                            <!-- workaround: skip is not skipping -->
+                            <bloopConfigDir>/dev/null/ERROR: Do not specify the bloop-maven-plugin on the command line. Instead invoke `mvn install -DbloopInstall ...`</bloopConfigDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -609,7 +609,7 @@
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
-                                <phase>${bloopInstallPhase}</phase>
+                                <phase>${bloop.installPhase}</phase>
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
@@ -641,7 +641,6 @@
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.15</scala.version>
-        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <!--
         -processing
         to suppress unactionable "No processor claimed any of these annotations"
@@ -818,7 +817,8 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
-        <bloopInstallPhase>install</bloopInstallPhase>
+        <bloop.installPhase>install</bloop.installPhase>
+        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@
                                 <phase>${bloopInstallPhase}</phase>
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
-                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                    <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
                                 </configuration>
                             </execution>
                         </executions>
@@ -641,6 +641,7 @@
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.12.15</scala.version>
+        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <!--
         -processing
         to suppress unactionable "No processor claimed any of these annotations"

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -569,6 +569,57 @@
                 <jni.classifier>${cuda.version}-arm64</jni.classifier>
             </properties>
         </profile>
+        <profile>
+            <id>bloopInstall</id>
+            <activation>
+                <property>
+                    <name>bloopInstall</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <skipTests>true</skipTests>
+                <maven.scaladoc.skip>true</maven.scaladoc.skip>
+                <maven.scalastyle.skip>true</maven.scalastyle.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-bloop-rules</id>
+                                <goals><goal>enforce</goal></goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <message>Metals semantic database requires JAVA_HOME pointing to JDK 11+, actual Java version: ${java.version}</message>
+                                            <version>[11,)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>ch.epfl.scala</groupId>
+                        <artifactId>bloop-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-bloop-projects</id>
+                                <goals><goal>bloopInstall</goal></goals>
+                                <phase>${bloopInstallPhase}</phase>
+                                <configuration>
+                                    <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
+                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <properties>
@@ -655,6 +706,7 @@
         <scala.local-lib.path>org/scala-lang/scala-library/${scala.version}/scala-library-${scala.version}.jar</scala.local-lib.path>
         <target.classifier>${spark.version.classifier}</target.classifier>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
+        <maven.scaladoc.skip>false</maven.scaladoc.skip>
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <dist.jar.compress>true</dist.jar.compress>
         <spark330.iceberg.version>0.14.1</spark330.iceberg.version>
@@ -765,6 +817,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <bloopInstallPhase>install</bloopInstallPhase>
     </properties>
 
     <dependencyManagement>
@@ -1043,6 +1096,7 @@
                                     <arg>-doc-external-doc:${settings.localRepository}/${scala.local-lib.path}#https://scala-lang.org/api/${scala.version}/</arg>
                                     <arg>-doc-external-doc:${settings.localRepository}/org/apache/spark/spark-sql_${scala.binary.version}/${spark.version}/spark-sql_${scala.binary.version}-${spark.version}.jar#https://spark.apache.org/docs/${spark.version}/api/scala/index.html</arg>
                                 </args>
+                                <skip>${maven.scaladoc.skip}</skip>
                             </configuration>
                         </execution>
                     </executions>
@@ -1212,6 +1266,21 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>ch.epfl.scala</groupId>
+                <artifactId>bloop-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <skip>true</skip>
+                            <!-- workaround: skip is not skipping -->
+                            <bloopConfigDir>/dev/null/ERROR: Do not specify the bloop-maven-plugin on the command line. Instead invoke `mvn install -DbloopInstall ...`</bloopConfigDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -609,7 +609,7 @@
                             <execution>
                                 <id>generate-bloop-projects</id>
                                 <goals><goal>bloopInstall</goal></goals>
-                                <phase>${bloopInstallPhase}</phase>
+                                <phase>${bloop.installPhase}</phase>
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
                                     <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
@@ -641,7 +641,6 @@
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.8</scala.version>
-        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <!--
         -processing
         to suppress unactionable "No processor claimed any of these annotations"
@@ -818,7 +817,8 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
-        <bloopInstallPhase>install</bloopInstallPhase>
+        <bloop.installPhase>install</bloop.installPhase>
+        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
     </properties>
 
     <dependencyManagement>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -612,7 +612,7 @@
                                 <phase>${bloopInstallPhase}</phase>
                                 <configuration>
                                     <!-- Metals looks at the repo root. so to accomodate scala 2.13  define -->
-                                    <bloopConfigDir>${spark.rapids.source.basedir}/.bloop</bloopConfigDir>
+                                    <bloopConfigDir>${bloop.configDirectory}</bloopConfigDir>
                                 </configuration>
                             </execution>
                         </executions>
@@ -641,6 +641,7 @@
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>
         <scala.version>2.13.8</scala.version>
+        <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <!--
         -processing
         to suppress unactionable "No processor claimed any of these annotations"


### PR DESCRIPTION
Enforces JDK11+ for Bloop builds, and builds Bloop for all targets per https://github.com/NVIDIA/spark-rapids/issues/9547.