### PR TITLE
Remove unused dataTypes argument from HostShuffleCoalesceIterator

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffleCoalesceExec.scala
@@ -69,7 +69,7 @@ case class GpuShuffleCoalesceExec(child: SparkPlan, targetBatchByteSize: Long)
 
     child.executeColumnar().mapPartitions { iter =>
       new GpuShuffleCoalesceIterator(
-        new HostShuffleCoalesceIterator(iter, targetSize, dataTypes, metricsMap),
+        new HostShuffleCoalesceIterator(iter, targetSize, metricsMap),
         dataTypes, metricsMap)
     }
   }
@@ -84,7 +84,6 @@ case class GpuShuffleCoalesceExec(child: SparkPlan, targetBatchByteSize: Long)
 class HostShuffleCoalesceIterator(
     iter: Iterator[ColumnarBatch],
     targetBatchByteSize: Long,
-    dataTypes: Array[DataType],
     metricsMap: Map[String, GpuMetric])
       extends Iterator[HostConcatResult] with AutoCloseable {
   private[this] val concatTimeMetric = metricsMap(GpuMetric.CONCAT_TIME)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -260,7 +260,7 @@ object GpuShuffledHashJoinExec extends Logging {
 
       // Let batches coalesce for size overflow check
       val coalesceBuiltIter = if (isBuildSerialized) {
-        new HostShuffleCoalesceIterator(bufBuildIter, targetSize, buildTypes, coalesceMetrics)
+        new HostShuffleCoalesceIterator(bufBuildIter, targetSize, coalesceMetrics)
       } else { // Batches on GPU have already coalesced to the target size by the given goal.
         bufBuildIter
       }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuExecutorBroadcastHelper.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuExecutorBroadcastHelper.scala
@@ -68,8 +68,8 @@ object GpuExecutorBroadcastHelper {
     // grab and release the semaphore while doing I/O
     val iter = shuffleDataIterator(shuffleData)
     new GpuShuffleCoalesceIterator(
-      new HostShuffleCoalesceIterator(iter, targetSize, dataTypes, metricsMap),
-        dataTypes, metricsMap).asInstanceOf[Iterator[ColumnarBatch]]
+      new HostShuffleCoalesceIterator(iter, targetSize, metricsMap),
+      dataTypes, metricsMap).asInstanceOf[Iterator[ColumnarBatch]]
   }
 
   /**


### PR DESCRIPTION
This removes the unused `dataTypes` parameter of `HostShuffleCoalesceIterator` and updates the callers accordingly.