### PR TITLE
Add jenkins-level retry for pre-merge build in databricks runtimes [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -160,7 +160,12 @@ void databricksBuild() {
                         def BUILD_PARAMS = " -w $DATABRICKS_HOST -t $DATABRICKS_TOKEN -c $CLUSTER_ID -z ./spark-rapids-ci.tgz" +
                                 " -p $DATABRICKS_PRIVKEY -l ./jenkins/databricks/build.sh -d /home/ubuntu/build.sh" +
                                 " -v $BASE_SPARK_VERSION -i $BASE_SPARK_VERSION_TO_INSTALL_DATABRICKS_JARS"
-                        sh "python3 ./jenkins/databricks/run-build.py $BUILD_PARAMS"
+
+                        //  add retry for build step to try
+                        //  mitigate the issue of downloading dependencies while maven/sonatype is quite unstable
+                        retry(3) {
+                            sh "python3 ./jenkins/databricks/run-build.py $BUILD_PARAMS"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We got more and more build failures while downloading dependencies since apache repos (central&sonatype) are quite unstable recently.

For CI running internally, we have URM artifactory but for external runs (like databricks) we can only try to add more retries and pray this could help mitigate the issue (we already have maven retry args but did not help too much). Managed cache on shared CSP storage could also be an option as long-term goal

This change only touches the build step. (internal pipeline has applied the same change)