### PR TITLE
Fix ENV typo in pre-merge github actions [skip ci]

### DIFF
--- a/.github/workflows/mvn-verify-check.yml
+++ b/.github/workflows/mvn-verify-check.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           # https://github.com/NVIDIA/spark-rapids/issues/8847
           # specify expected versions
-          export JAVA_HOME=export JAVA_HOME=${JAVA_HOME_11_X64}
+          export JAVA_HOME=${JAVA_HOME_11_X64}
           export PATH=${JAVA_HOME}/bin:${PATH}
           java -version && mvn --version && echo "ENV JAVA_HOME: $JAVA_HOME, PATH: $PATH"
           # test command


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/9625

this did not affect the test cases but should be fixed. thanks @gerashegalov for pointing it out