### PR TITLE
Document problem with handling of invalid characters in CSV reader

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -106,6 +106,10 @@ it and they should be avoided.
 Escaped quote characters `'\"'` are not supported well as described by this
 [issue](https://github.com/NVIDIA/spark-rapids/issues/129).
 
+The GPU accelerated CSV parser does not replace invalid UTF-8 characters with the Unicode
+replacement character �.  Instead it just passes them through as described in this
+[issue](https://github.com/NVIDIA/spark-rapids/issues/9560).
+
 ### CSV Dates
 
 Only a limited set of formats are supported when parsing dates.


### PR DESCRIPTION
Adding a note to the compatibility guide to document the problem with handling invalid UTF-8 characters in the CSV reader as described in https://github.com/NVIDIA/spark-rapids/issues/9560.
