### PR TITLE
Normalize file timezone and handle missing file timezone in datetimeRebaseUtils

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/datetimeRebaseUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/datetimeRebaseUtils.scala
@@ -16,11 +16,13 @@
 
 package com.nvidia.spark.rapids
 
+import java.util.TimeZone
+
 import ai.rapids.cudf.{ColumnVector, DType, Scalar}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.shims.SparkShimImpl
 
-import org.apache.spark.sql.catalyst.util.RebaseDateTime
+import org.apache.spark.sql.catalyst.util.{DateTimeUtils, RebaseDateTime}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 
 /**
@@ -87,11 +89,16 @@ object DateTimeRebaseUtils {
 
     // Check the timezone of the file if the mode is LEGACY.
     if (mode == DateTimeRebaseLegacy) {
-      val fileTimeZone = lookupFileMeta(SPARK_TIMEZONE_METADATA_KEY)
-      if (fileTimeZone != null && fileTimeZone != "UTC") {
+      val fileTimeZoneId = Option(lookupFileMeta(SPARK_TIMEZONE_METADATA_KEY)).map { str =>
+        DateTimeUtils.getZoneId(str)
+      }.getOrElse {
+        // Use the default JVM time zone for backward compatibility
+        TimeZone.getDefault.toZoneId
+      }
+      if (fileTimeZoneId.normalized() != GpuOverrides.UTC_TIMEZONE_ID) {
         throw new UnsupportedOperationException(
           "LEGACY datetime rebase mode is only supported for files written in UTC timezone. " +
-            s"Actual file timezone: $fileTimeZone")
+            s"Actual file timezone: $fileTimeZoneId")
       }
     }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RebaseHelperSuite.scala
@@ -16,6 +16,10 @@
 
 package com.nvidia.spark.rapids
 
+import java.util.TimeZone
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
 import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm.withResource
 import org.scalatest.funsuite.AnyFunSuite
@@ -32,6 +36,36 @@ class RebaseHelperSuite extends AnyFunSuite {
     withResource(ColumnVector.timestampMicroSecondsFromBoxedLongs(null, null, null)) { c =>
       assertResult(false)(DateTimeRebaseUtils.isTimeRebaseNeededInWrite(c))
       assertResult(false)(DateTimeRebaseUtils.isTimeRebaseNeededInRead(c))
+    }
+  }
+
+  test("time zone IDs are normalized") {
+    for (tz <- Seq("Etc/UTC", "Z", "UTC")) {
+      val metadata = Map(
+        "org.apache.spark.version" -> "3.0.0",
+        "org.apache.spark.legacyDateTime" -> "",
+        "org.apache.spark.legacyINT96" -> "",
+        "org.apache.spark.timeZone" -> tz)
+      assertResult(DateTimeRebaseLegacy) {
+        DateTimeRebaseUtils.datetimeRebaseMode(metadata.asJava.get, "LEGACY")
+      }
+    }
+  }
+
+  test("missing time zone") {
+    val shouldThrow = TimeZone.getDefault.toZoneId.normalized() != GpuOverrides.UTC_TIMEZONE_ID
+    val metadata = Map(
+      "org.apache.spark.version" -> "3.0.0",
+      "org.apache.spark.legacyDateTime" -> "",
+      "org.apache.spark.legacyINT96" -> "")
+    if (shouldThrow) {
+      assertThrows[UnsupportedOperationException] {
+        DateTimeRebaseUtils.datetimeRebaseMode(metadata.asJava.get, "LEGACY")
+      }
+    } else {
+      assertResult(DateTimeRebaseLegacy) {
+        DateTimeRebaseUtils.datetimeRebaseMode(metadata.asJava.get, "LEGACY")
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #9669.  Timezone is now normalized before checking if it is supported, and handling of missing timezones is updated to reflect the behavior from Apache Spark where the default timezone is assumed.