### PR TITLE
[auto-merge] branch-23.12 to branch-24.02 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -18,7 +18,7 @@ name: auto-merge HEAD to BASE
 on:
   pull_request_target:
     branches:
-    - branch-23.10
+    - branch-23.12
     types: [closed]
 
 jobs:
@@ -29,13 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: branch-23.10 # force to fetch from latest upstream instead of PR ref
+          ref: branch-23.12 # force to fetch from latest upstream instead of PR ref
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge
         env:
           OWNER: NVIDIA
           REPO_NAME: spark-rapids
-          HEAD: branch-23.10
-          BASE: branch-23.12
+          HEAD: branch-23.12
+          BASE: branch-24.02
           AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }} # use to merge PR

--- a/docs/download.md
+++ b/docs/download.md
@@ -16,7 +16,7 @@ The RAPIDS Accelerator For Apache Spark requires each worker node in the cluster
 The RAPIDS Accelerator For Apache Spark consists of two jars: a plugin jar along with the RAPIDS
 cuDF jar, that is either preinstalled in the Spark classpath on all nodes or submitted with each job
 that uses the RAPIDS Accelerator For Apache Spark. See the [getting-started
-guide](https://nvidia.github.io/spark-rapids/Getting-Started/) for more details.
+guide](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/overview.html) for more details.
 
 ## Release v23.10.0
 ### Hardware Requirements:


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-23.12` to create a PR keeping `branch-24.02` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.