### PR TITLE
Fix Delta Lake atomic table operations on spark341db [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalogBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuDeltaCatalogBase.scala
@@ -44,6 +44,12 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
+/** A trait used to identify Delta tables that are GPU-aware. */
+trait GpuDeltaSupportsWrite extends SupportsWrite
+
+/** A trait used to identify Delta V1Write that is GPU-aware */
+trait GpuDeltaV1Write extends V1Write
+
 trait GpuDeltaCatalogBase extends StagingTableCatalog {
   val spark: SparkSession = SparkSession.active
 
@@ -294,7 +300,7 @@ trait GpuDeltaCatalogBase extends StagingTableCatalog {
       val partitions: Array[Transform],
       override val properties: util.Map[String, String],
       operation: TableCreationModes.CreationMode
-  ) extends StagedTable with SupportsWrite {
+  ) extends StagedTable with GpuDeltaSupportsWrite {
 
     private var asSelectQuery: Option[DataFrame] = None
     private var writeOptions: Map[String, String] = Map.empty
@@ -358,7 +364,7 @@ trait GpuDeltaCatalogBase extends StagingTableCatalog {
      * WriteBuilder for creating a Delta table.
      */
     private class DeltaV1WriteBuilder extends WriteBuilder {
-      override def build(): V1Write = new V1Write {
+      override def build(): V1Write = new GpuDeltaV1Write {
         override def toInsertableRelation(): InsertableRelation = {
           new InsertableRelation {
             override def insert(data: DataFrame, overwrite: Boolean): Unit = {

--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -178,7 +178,6 @@ def _atomic_write_table_as_select(gens, spark_tmp_table_factory, spark_tmp_path,
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(condition=is_spark_340_or_later() and is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/9676")
 def test_delta_atomic_create_table_as_select(spark_tmp_table_factory, spark_tmp_path):
     _atomic_write_table_as_select(delta_write_gens, spark_tmp_table_factory, spark_tmp_path, overwrite=False)
 
@@ -186,7 +185,6 @@ def test_delta_atomic_create_table_as_select(spark_tmp_table_factory, spark_tmp_
 @delta_lake
 @ignore_order(local=True)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@pytest.mark.xfail(condition=is_spark_340_or_later() and is_databricks_runtime(), reason="https://github.com/NVIDIA/spark-rapids/issues/9676")
 def test_delta_atomic_replace_table_as_select(spark_tmp_table_factory, spark_tmp_path):
     _atomic_write_table_as_select(delta_write_gens, spark_tmp_table_factory, spark_tmp_path, overwrite=True)
 


### PR DESCRIPTION
Fixes #9676.  Databricks 13.3 includes the changes from [SPARK-43088](https://issues.apache.org/jira/browse/SPARK-43088) where atomic operations do not include the query at the point where the staged table is created but instead create then append the data.  For Delta Lake, this manifests as a subplan being executed which contains an AppendDataExecV1 using the table and WriteBuilder created to handle the original atomic table operation.  That explains why the issue reported seeing a tagging attempt on a RAPIDS Accelerator class.

The fix is relatively straightforward.  We go ahead and let the AppendDataExecV1 use the RAPIDS Accelerator classes, but we recognize these classes in the tagging code and skip the CPU extraction code when that is the case.  This keeps the append operation on the GPU because we're already using a table and writer geared to the GPU.