### PR TITLE
Temporarily force `datagen_seed=0` for `test_re_replace_all` to unblock CI

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -1054,6 +1054,7 @@ def test_regexp_memory_ok():
         }
     )
 
+@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9731')
 def test_re_replace_all():
     """
     regression test for https://github.com/NVIDIA/spark-rapids/issues/8323


### PR DESCRIPTION
This temporarily modifies `test_re_replace_all` with `seed = 0` to unblock CI due to a bug in regex (https://github.com/NVIDIA/spark-rapids/issues/9731).