### PR TITLE
Update timezone test framework to support both GPU and CPU POC

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -24,7 +24,6 @@ import scala.sys.process._
 import scala.util.Try
 import ai.rapids.cudf.{Cuda, CudaException, CudaFatalException, CudfException, MemoryCleaner}
 import com.nvidia.spark.rapids.filecache.{FileCache, FileCacheLocalityManager, FileCacheLocalityMsg}
-import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskFailedReason}
@@ -379,7 +378,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
               s"Driver timezone is $driverTimezone and executor timezone is " +
               s"$executorTimezone. Set executor timezone to $driverTimezone.")
         }
-        GpuTimeZoneDB.cacheDatabase()
       }
 
       GpuCoreDumpHandler.executorInit(conf, pluginContext)
@@ -502,7 +500,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def shutdown(): Unit = {
-    GpuTimeZoneDB.shutdown()
     GpuSemaphore.shutdown()
     PythonWorkerSemaphore.shutdown()
     GpuDeviceManager.shutdown()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids
 import java.lang.reflect.InvocationTargetException
 import java.time.ZoneId
 import java.util.Properties
+
 import scala.collection.JavaConverters._
 import scala.sys.process._
 import scala.util.Try

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -19,16 +19,14 @@ package com.nvidia.spark.rapids
 import java.lang.reflect.InvocationTargetException
 import java.time.ZoneId
 import java.util.Properties
-
 import scala.collection.JavaConverters._
 import scala.sys.process._
 import scala.util.Try
-
 import ai.rapids.cudf.{Cuda, CudaException, CudaFatalException, CudfException, MemoryCleaner}
 import com.nvidia.spark.rapids.filecache.{FileCache, FileCacheLocalityManager, FileCacheLocalityMsg}
+import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.Logging
@@ -381,6 +379,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
               s"Driver timezone is $driverTimezone and executor timezone is " +
               s"$executorTimezone. Set executor timezone to $driverTimezone.")
         }
+        GpuTimeZoneDB.cacheDatabase()
       }
 
       GpuCoreDumpHandler.executorInit(conf, pluginContext)
@@ -503,6 +502,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
   }
 
   override def shutdown(): Unit = {
+    GpuTimeZoneDB.shutdown()
     GpuSemaphore.shutdown()
     PythonWorkerSemaphore.shutdown()
     GpuDeviceManager.shutdown()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -22,10 +22,12 @@ import java.util.Properties
 import scala.collection.JavaConverters._
 import scala.sys.process._
 import scala.util.Try
+
 import ai.rapids.cudf.{Cuda, CudaException, CudaFatalException, CudfException, MemoryCleaner}
 import com.nvidia.spark.rapids.filecache.{FileCache, FileCacheLocalityManager, FileCacheLocalityMsg}
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 import org.apache.commons.lang3.exception.ExceptionUtils
+
 import org.apache.spark.{ExceptionFailure, SparkConf, SparkContext, TaskFailedReason}
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.Logging

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids.timezone
 
 import java.time.ZoneId
+import java.util.concurrent.Executor
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.Arm.withResource
@@ -25,7 +26,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 object TimeZoneDB {
 
-  def cacheDatabase(): Unit = {}
+  def cacheDatabase(e: Executor): Unit = {}
 
   /**
    * Interpret a timestamp as a time in the given time zone,
@@ -121,7 +122,7 @@ object TimeZoneDB {
     assert(inputVector.getType == DType.TIMESTAMP_DAYS)
     val rowCount = inputVector.getRowCount.toInt
     withResource(inputVector.copyToHost()) { input =>
-      withResource(HostColumnVector.builder(DType.INT64, rowCount)) { builder =>
+      withResource(HostColumnVector.builder(DType.TIMESTAMP_MICROSECONDS, rowCount)) { builder =>
         var currRow = 0
         while (currRow < rowCount) {
           val origin = input.getInt(currRow)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneDB.scala
@@ -17,7 +17,6 @@
 package com.nvidia.spark.rapids.timezone
 
 import java.time.ZoneId
-import java.util.concurrent.Executor
 
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.Arm.withResource
@@ -26,7 +25,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 object TimeZoneDB {
 
-  def cacheDatabase(e: Executor): Unit = {}
+  def cacheDatabase(): Unit = {}
 
   /**
    * Interpret a timestamp as a time in the given time zone,

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -317,7 +317,13 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAll {
   override def beforeAll(): Unit = {
     zones = selectTimeZones
     if (useGPU) {
-      withGpuSparkSession(_ => { })
+      GpuTimeZoneDB.cacheDatabase()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    if (useGPU) {
+      GpuTimeZoneDB.shutdown()
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -18,19 +18,20 @@ package com.nvidia.spark.rapids.timezone
 
 import java.time._
 import java.util.concurrent.TimeUnit
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
 import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
+import org.scalatest.BeforeAndAfterAll
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToInstant
 import org.apache.spark.sql.types._
-import org.scalatest.BeforeAndAfterAll
-
-import java.util.concurrent.Executors
 
 class TimeZoneSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAll {
   private val useGPU = true
@@ -313,17 +314,9 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAll {
   }
 
   override def beforeAll(): Unit = {
-    if (useGPU) {
-      GpuTimeZoneDB.cacheDatabase(Executors.newCachedThreadPool())
-    } else {
-      TimeZoneDB.cacheDatabase(Executors.newCachedThreadPool())
-    }
     zones = selectTimeZones
-  }
-
-  override def afterAll(): Unit = {
     if (useGPU) {
-      GpuTimeZoneDB.unload()
+      withGpuSparkSession(_ => { })
     }
   }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/timezone/TimeZoneSuite.scala
@@ -18,19 +18,27 @@ package com.nvidia.spark.rapids.timezone
 
 import java.time._
 import java.util.concurrent.TimeUnit
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
 import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.SparkQueryCompareTestSuite
-
+import com.nvidia.spark.rapids.jni.GpuTimeZoneDB
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToInstant
 import org.apache.spark.sql.types._
+import org.scalatest.BeforeAndAfterAll
 
-class TimeZoneSuite extends SparkQueryCompareTestSuite {
+import java.util.concurrent.Executors
+
+class TimeZoneSuite extends SparkQueryCompareTestSuite with BeforeAndAfterAll {
+  private val useGPU = true
+  private val testAllTimezones = false
+  private val testAllYears = false
+
+  private var zones = Seq.empty[String]
+
   /**
    * create timestamp column vector
    */
@@ -91,13 +99,24 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
   /**
    * assert timestamp result with Spark result
    */
-  def assertTimestampRet(actualRet: ColumnVector, sparkRet: Seq[Row]): Unit = {
+  def assertTimestampRet(actualRet: ColumnVector, sparkRet: Seq[Row], input: ColumnVector): Unit = {
     withResource(actualRet.copyToHost()) { host =>
-      assert(actualRet.getRowCount == sparkRet.length)
-      for (i <- 0 until actualRet.getRowCount.toInt) {
-        val sparkInstant = sparkRet(i).getInstant(0)
-        val sparkMicro = sparkInstant.getEpochSecond * 1000000L + sparkInstant.getNano / 1000L
-        assert(host.getLong(i) == sparkMicro)
+      withResource(input.copyToHost()) { hostInput =>
+        assert(actualRet.getRowCount == sparkRet.length)
+        for (i <- 0 until actualRet.getRowCount.toInt) {
+          val sparkInstant = sparkRet(i).getInstant(0)
+          val sparkMicro = sparkInstant.getEpochSecond * 1000000L + sparkInstant.getNano / 1000L
+          if (hostInput.getType == DType.TIMESTAMP_DAYS) {
+            assert(host.getLong(i) == sparkMicro,
+              s"for ${hostInput.getInt(i)} " +
+                s"${microsToInstant(host.getLong(i))} != ${microsToInstant(sparkMicro)}")
+
+          } else {
+            assert(host.getLong(i) == sparkMicro,
+              s"for ${hostInput.getLong(i)} (${microsToInstant(hostInput.getLong(i))}) " +
+                s"${microsToInstant(host.getLong(i))} != ${microsToInstant(sparkMicro)}")
+          }
+        }
       }
     }
   }
@@ -160,18 +179,24 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
           .set("spark.sql.datetime.java8API.enabled", "true"))
 
     // get result from TimeZoneDB
-    val actualRet = withResource(createColumnVector(epochSeconds)) { inputCv =>
-      TimeZoneDB.fromUtcTimestampToTimestamp(
-        inputCv,
-        ZoneId.of(zoneStr))
+    withResource(createColumnVector(epochSeconds)) { inputCv =>
+      val actualRet = if (useGPU) {
+        GpuTimeZoneDB.fromUtcTimestampToTimestamp(
+          inputCv,
+          ZoneId.of(zoneStr))
+      } else {
+        TimeZoneDB.fromUtcTimestampToTimestamp(
+          inputCv,
+          ZoneId.of(zoneStr))
+      }
+      withResource(actualRet) { _ =>
+        assertTimestampRet(actualRet, sparkRet, inputCv)
+      }
     }
 
-    withResource(actualRet) { _ =>
-      assertTimestampRet(actualRet, sparkRet)
-    }
   }
 
-  def testFromTimestampToUTCTimestamp(epochSeconds: Array[Long], zoneStr: String): Unit = {
+  def testFromTimestampToUtcTimestamp(epochSeconds: Array[Long], zoneStr: String): Unit = {
     // get result from Spark
     val sparkRet = withCpuSparkSession(
       spark => {
@@ -189,15 +214,21 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
           .set("spark.sql.datetime.java8API.enabled", "true"))
 
     // get result from TimeZoneDB
-    val actualRet = withResource(createColumnVector(epochSeconds)) { inputCv =>
-      TimeZoneDB.fromTimestampToUtcTimestamp(
-        inputCv,
-        ZoneId.of(zoneStr))
+    withResource(createColumnVector(epochSeconds)) { inputCv =>
+      val actualRet = if (useGPU) {
+        GpuTimeZoneDB.fromTimestampToUtcTimestamp(
+          inputCv,
+          ZoneId.of(zoneStr))
+      } else {
+        TimeZoneDB.fromTimestampToUtcTimestamp(
+          inputCv,
+          ZoneId.of(zoneStr))
+      }
+      withResource(actualRet) { _ =>
+        assertTimestampRet(actualRet, sparkRet, inputCv)
+      }
     }
 
-    withResource(actualRet) { _ =>
-      assertTimestampRet(actualRet, sparkRet)
-    }
   }
 
   def testFromTimestampToDate(epochSeconds: Array[Long], zoneStr: String): Unit = {
@@ -245,15 +276,15 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
           .set("spark.sql.datetime.java8API.enabled", "true"))
 
     // get result from TimeZoneDB
-    val actualRet = withResource(createDateColumnVector(epochDays)) { inputCv =>
-      TimeZoneDB.fromDateToTimestamp(
+    withResource(createDateColumnVector(epochDays)) { inputCv =>
+      val actualRet = TimeZoneDB.fromDateToTimestamp(
         inputCv,
         ZoneId.of(zoneStr))
+      withResource(actualRet) { _ =>
+        assertTimestampRet(actualRet, sparkRet, inputCv)
+      }
     }
 
-    withResource(actualRet) { _ =>
-      assertTimestampRet(actualRet, sparkRet)
-    }
   }
 
   def selectWithRepeatZones: Seq[String] = {
@@ -266,36 +297,80 @@ class TimeZoneSuite extends SparkQueryCompareTestSuite {
     repeatZones.slice(0, 2) ++ mustZones
   }
 
-  def selectNonRepeatZones: Seq[String] = {
+  def selectTimeZones: Seq[String] = {
     val mustZones = Array[String]("Asia/Shanghai", "America/Sao_Paulo")
-    val nonRepeatZones = ZoneId.getAvailableZoneIds.asScala.toList.filter { z =>
-      val rules = ZoneId.of(z).getRules
-      // remove this line when we support repeat rules
-      (rules.isFixedOffset || rules.getTransitionRules.isEmpty) && !mustZones.contains(z)
+    if (testAllTimezones) {
+      val nonRepeatZones = ZoneId.getAvailableZoneIds.asScala.toList.filter { z =>
+        val rules = ZoneId.of(z).getRules
+        // remove this line when we support repeat rules
+        (rules.isFixedOffset || rules.getTransitionRules.isEmpty) && !mustZones.contains(z)
+      }
+      scala.util.Random.shuffle(nonRepeatZones)
+      nonRepeatZones.slice(0, 2) ++ mustZones
+    } else {
+      mustZones
     }
-    scala.util.Random.shuffle(nonRepeatZones)
-    nonRepeatZones.slice(0, 2) ++ mustZones
   }
 
-  test("test all time zones") {
-    assume(false,
-      "It's time consuming for test all time zones, by default it's disabled")
+  override def beforeAll(): Unit = {
+    if (useGPU) {
+      GpuTimeZoneDB.cacheDatabase(Executors.newCachedThreadPool())
+    } else {
+      TimeZoneDB.cacheDatabase(Executors.newCachedThreadPool())
+    }
+    zones = selectTimeZones
+  }
 
-    val zones = selectNonRepeatZones
-    // iterate zones
+  override def afterAll(): Unit = {
+    if (useGPU) {
+      GpuTimeZoneDB.unload()
+    }
+  }
+
+  test("test timestamp to utc timestamp") {
     for (zoneStr <- zones) {
       // iterate years
-      val startYear = 1
-      val endYear = 9999
+      val startYear = if (testAllYears) 1 else 1899
+      val endYear = if (testAllYears) 9999 else 2030
+      for (year <- startYear until endYear by 7) {
+        val epochSeconds = getEpochSeconds(year, year + 1)
+        testFromTimestampToUtcTimestamp(epochSeconds, zoneStr)
+      }
+    }
+  }
+
+  test("test utc timestamp to timestamp") {
+    for (zoneStr <- zones) {
+      // iterate years
+      val startYear = if (testAllYears) 1 else 1899
+      val endYear = if (testAllYears) 9999 else 2030
       for (year <- startYear until endYear by 7) {
         val epochSeconds = getEpochSeconds(year, year + 1)
         testFromUtcTimeStampToTimestamp(epochSeconds, zoneStr)
-        testFromTimestampToUTCTimestamp(epochSeconds, zoneStr)
-        testFromTimestampToDate(epochSeconds, zoneStr)
       }
+    }
+  }
 
+  test("test timestamp to date") {
+    for (zoneStr <- zones) {
+      // iterate years
+      val startYear = if (testAllYears) 1 else 1899
+      val endYear = if (testAllYears) 9999 else 2030
+      for (year <- startYear until endYear by 7) {
+        val epochSeconds = getEpochSeconds(year, year + 1)
+         testFromTimestampToDate(epochSeconds, zoneStr)
+      }
+    }
+  }
+
+  test("test date to timestamp") {
+    for (zoneStr <- zones) {
+      // iterate years
+      val startYear = if (testAllYears) 1 else 1899
+      val endYear = if (testAllYears) 9999 else 2030
       val epochDays = getEpochDays(startYear, endYear)
       testFromDateToTimestamp(epochDays, zoneStr)
     }
   }
+
 }


### PR DESCRIPTION
Fixes #6831 . Depends on https://github.com/NVIDIA/spark-rapids-jni/pull/1553 being merged first.

This adds the GpuTimeZoneDB to the TimeZoneSuite used to test the CPU POC concept. This enables testing all possible times and multiple timezones on the GPU.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
