### PR TITLE
Avoid generating null filter values in test_delta_dfp_reuse_broadcast_exchange [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_zorder_test.py
+++ b/integration_tests/src/main/python/delta_zorder_test.py
@@ -144,7 +144,8 @@ def test_delta_dfp_reuse_broadcast_exchange(spark_tmp_table_factory, s_index, aq
             ('ex_skey', IntegerGen(nullable=False, min_val=0, max_val=1000, special_cases=[])),
             ('value', int_gen),
             ('filter', RepeatSeqGen(
-                IntegerGen(min_val=0, max_val=2000, special_cases=[]), length=2000 // 20))
+                IntegerGen(nullable=False, min_val=0, max_val=2000, special_cases=[]),
+                length=2000 // 20))
         ], 2000)
         df.write.format("delta") \
             .mode("overwrite") \


### PR DESCRIPTION
After #9441 test_delta_dfp_reuse_broadcast_exchange can sometimes fail with a query analysis error like this:
```
AnalysisException("Column 'None' does not exist. Did you mean one of the following? [dim.key, fact.key, dim.skey, fact...
```
The problem is that a query is run on the CPU to determine a filter value, but since the column of filter values can contain nulls, it's possible for the query to return None rather than an integer value.  When "None" is plugged into the query template, it results in an invalid query.

This fixes the test to never generate nulls for the filter values.