### PR TITLE
Remove forced seed from Delta Lake part_write_round_trip_unmanaged tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -93,7 +93,6 @@ def test_delta_write_round_trip_unmanaged(spark_tmp_path):
 @ignore_order
 @pytest.mark.parametrize("gens", parquet_part_write_gens, ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9738')
 def test_delta_part_write_round_trip_unmanaged(spark_tmp_path, gens):
     gen_list = [("a", RepeatSeqGen(gens, 10)), ("b", gens)]
     data_path = spark_tmp_path + "/DELTA_DATA"
@@ -115,7 +114,6 @@ def test_delta_part_write_round_trip_unmanaged(spark_tmp_path, gens):
 @ignore_order
 @pytest.mark.parametrize("gens", parquet_part_write_gens, ids=idfn)
 @pytest.mark.skipif(is_before_spark_320(), reason="Delta Lake writes are not supported before Spark 3.2.x")
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9738')
 def test_delta_multi_part_write_round_trip_unmanaged(spark_tmp_path, gens):
     gen_list = [("a", RepeatSeqGen(gens, 10)), ("b", gens), ("c", SetValuesGen(StringType(), ["x", "y", "z"]))]
     data_path = spark_tmp_path + "/DELTA_DATA"


### PR DESCRIPTION
#9741 and #9748 crossed paths such that #9748 didn't remove the forced seed added in #9741.  This fixes that oversight.