### PR TITLE
Fix bug in tagging of JsonToStructs

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3576,7 +3576,7 @@ object GpuOverrides extends Logging {
         (TypeSig.STRUCT + TypeSig.MAP + TypeSig.ARRAY).nested(TypeSig.all),
         Seq(ParamCheck("jsonStr", TypeSig.STRING, TypeSig.STRING))),
       (a, conf, p, r) => new UnaryExprMeta[JsonToStructs](a, conf, p, r) {
-        override def tagExprForGpu(): Unit =
+        override def tagExprForGpu(): Unit = {
           a.schema match {
             case MapType(_: StringType, _: StringType, _) => ()
             case _: StructType => ()
@@ -3585,6 +3585,7 @@ object GpuOverrides extends Logging {
                 "or StructType schema")
           }
           GpuJsonScan.tagJsonToStructsSupport(a.options, this)
+        }
 
         override def convertToGpu(child: Expression): GpuExpression =
           // GPU implementation currently does not support duplicated json key names in input


### PR DESCRIPTION
I found this problem while working on https://github.com/NVIDIA/spark-rapids/pull/9666

The call to `GpuJsonScan.tagJsonToStructsSupport` looks like it is called from `tagExprForGpu`, but it is actually a standalone line of code after the method because there are no braces around the method. It was still getting called but not as part of the call to `tagExprForGpu`.