### PR TITLE
Let GPU scans fall back when default values exist in schema[databricks]

### DIFF
--- a/integration_tests/src/main/python/scan_default_values_test.py
+++ b/integration_tests/src/main/python/scan_default_values_test.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from asserts import assert_gpu_fallback_collect
+from spark_session import is_support_default_values_in_schema, with_cpu_session
+from marks import allow_non_gpu
+
+
+# The `DEFAULT` keyword in SQL is not supported before Spark 340, so need to skip it.
+@pytest.mark.skipif(not is_support_default_values_in_schema(),
+                    reason="Default values in schema is supported from Spark 340")
+@allow_non_gpu('ColumnarToRowExec', 'FileSourceScanExec')
+@pytest.mark.parametrize('data_source', ['csv', 'json', 'parquet', 'orc'])
+def test_scan_fallback_by_default_value(data_source, spark_tmp_table_factory):
+    test_table = spark_tmp_table_factory.get()
+    def setup_table(spark):
+        spark.sql("create table {} (a string, i int default 10) using {}".format(
+            test_table, data_source))
+        spark.sql("insert into {} values ('s1', DEFAULT)".format(test_table))
+        spark.sql("insert into {} values ('s2', DEFAULT)".format(test_table))
+        spark.sql("insert into {} values (NULL, DEFAULT)".format(test_table))
+        spark.sql("insert into {} values ('s10', null)".format(test_table))
+        spark.sql("insert into {} values ('s10', 100)".format(test_table))
+    with_cpu_session(setup_table)
+
+    assert_gpu_fallback_collect(
+        lambda spark: spark.sql("select * from {}".format(test_table)),
+        'FileSourceScanExec',
+        conf={'spark.rapids.sql.format.json.enabled': 'true',
+              'spark.rapids.sql.format.json.read.enabled': 'true'})

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -214,6 +214,10 @@ def supports_delta_lake_deletion_vectors():
     else:
         return is_spark_340_or_later()
 
+def is_support_default_values_in_schema():
+    # Spark 340 + and Databricks 330 + support
+    return is_spark_340_or_later() or is_databricks113_or_later()
+
 def get_java_major_version():
     ver = _spark.sparkContext._jvm.System.getProperty("java.version")
     # Allow these formats:

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOrcScan.scala
@@ -37,7 +37,7 @@ import com.nvidia.spark.rapids.GpuMetric._
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.SchemaUtils._
 import com.nvidia.spark.rapids.filecache.FileCache
-import com.nvidia.spark.rapids.shims.{GpuOrcDataReader, NullOutputStreamShim, OrcCastingShims, OrcReadingShims, OrcShims, ShimFilePartitionReaderFactory}
+import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuOrcDataReader, NullOutputStreamShim, OrcCastingShims, OrcReadingShims, OrcShims, ShimFilePartitionReaderFactory}
 import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.CountingOutputStream
 import org.apache.hadoop.conf.Configuration
@@ -148,6 +148,10 @@ object GpuOrcScan {
     if (!meta.conf.isOrcReadEnabled) {
       meta.willNotWorkOnGpu("ORC input has been disabled. To enable set" +
         s"${RapidsConf.ENABLE_ORC_READ} to true")
+    }
+
+    if (ColumnDefaultValuesShims.hasExistenceDefaultValues(schema)) {
+      meta.willNotWorkOnGpu("GpuOrcScan does not support default values in schema")
     }
 
     FileFormatChecks.tag(meta, schema, OrcFormatType, ReadFileOp)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -38,7 +38,7 @@ import com.nvidia.spark.rapids.RapidsConf.ParquetFooterReaderType
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.filecache.FileCache
 import com.nvidia.spark.rapids.jni.{DateTimeRebase, ParquetFooter, SplitAndRetryOOM}
-import com.nvidia.spark.rapids.shims.{GpuParquetCrypto, GpuTypeShims, ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims, ReaderUtils, ShimFilePartitionReaderFactory, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuParquetCrypto, GpuTypeShims, ParquetLegacyNanoAsLongShims, ParquetSchemaClipShims, ParquetStringPredShims, ReaderUtils, ShimFilePartitionReaderFactory, SparkShimImpl}
 import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.{CountingOutputStream, NullOutputStream}
 import org.apache.hadoop.conf.Configuration
@@ -189,6 +189,11 @@ object GpuParquetScan {
     if (schemaHasTimestamps && sparkSession.sessionState.conf.isParquetINT96TimestampConversion) {
       meta.willNotWorkOnGpu("GpuParquetScan does not support int96 timestamp conversion")
     }
+
+    if (ColumnDefaultValuesShims.hasExistenceDefaultValues(readSchema)) {
+      meta.willNotWorkOnGpu("GpuParquetScan does not support default values in schema")
+    }
+
   }
 
   /**

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/catalyst/json/rapids/GpuJsonScan.scala
@@ -25,7 +25,7 @@ import ai.rapids.cudf
 import ai.rapids.cudf.{CaptureGroups, ColumnVector, DType, NvtxColor, RegexProgram, Scalar, Schema, Table}
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.shims.ShimFilePartitionReaderFactory
+import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, ShimFilePartitionReaderFactory}
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.broadcast.Broadcast
@@ -181,6 +181,10 @@ object GpuJsonScan {
       readSchema.head.name == parsedOptions.columnNameOfCorruptRecord) {
       // fallback to cpu to throw exception
       meta.willNotWorkOnGpu("GpuJsonScan does not support Corrupt Record")
+    }
+
+    if (ColumnDefaultValuesShims.hasExistenceDefaultValues(readSchema)) {
+      meta.willNotWorkOnGpu("GpuJsonScan does not support default values in schema")
     }
 
     FileFormatChecks.tag(meta, readSchema, JsonFormatType, ReadFileOp)

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "321db"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "333"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.types.StructType
+
+object ColumnDefaultValuesShims {
+
+  /** Whether there is any default value in the schema */
+  def hasExistenceDefaultValues(schema: StructType): Boolean = {
+    // Before Spark 340, default values in schema is not supported for scans.
+    false
+  }
+}

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*** spark-rapids-shim-json-lines
+{"spark": "330db"}
+{"spark": "332db"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "350"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims
+
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
+import org.apache.spark.sql.types.StructType
+
+object ColumnDefaultValuesShims {
+
+  /** Whether there is any default value in the schema */
+  def hasExistenceDefaultValues(schema: StructType): Boolean = {
+    ResolveDefaultColumns.getExistenceDefaultValues(schema).exists(_ != null)
+  }
+}


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/9648

Let GPU ORC, Parquet, CSV, JSON scans fall back to CPU when there are some default values existing in schema.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
