### PR TITLE
Use withGpuSparkSession to customize SparkConf

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -18,8 +18,11 @@ package com.nvidia.spark.rapids
 
 import java.sql.Timestamp
 import java.time.DateTimeException
+
 import scala.util.Random
+
 import com.nvidia.spark.rapids.shims.{CastingConfigShim, SparkShimImpl}
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AnsiCastOpSuite.scala
@@ -18,11 +18,8 @@ package com.nvidia.spark.rapids
 
 import java.sql.Timestamp
 import java.time.DateTimeException
-
 import scala.util.Random
-
 import com.nvidia.spark.rapids.shims.{CastingConfigShim, SparkShimImpl}
-
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, NamedExpression}
@@ -458,14 +455,14 @@ class AnsiCastOpSuite extends GpuExpressionTestSuite {
   }
 
   test("ansi_cast decimal to string") {
-    val sqlCtx = SparkSession.getActiveSession.get.sqlContext
-    sqlCtx.setConf("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
-
-    Seq(10, 15, 18).foreach { precision =>
-      Seq(-precision, -5, 0, 5, precision).foreach { scale =>
-        testCastToString(DataTypes.createDecimalType(precision, scale),
-          ansiMode = true,
-          comparisonFunc = None)
+    withGpuSparkSession { spark =>
+      spark.conf.set("spark.sql.legacy.allowNegativeScaleOfDecimal", true.toString)
+      Seq(10, 15, 18).foreach { precision =>
+        Seq(-precision, -5, 0, 5, precision).foreach { scale =>
+          testCastToString(DataTypes.createDecimalType(precision, scale),
+            ansiMode = true,
+            comparisonFunc = None)
+        }
       }
     }
   }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -445,13 +445,13 @@ class CastOpSuite extends GpuExpressionTestSuite {
   }
 
   test("cast decimal to string") {
-    val sqlCtx = SparkSession.getActiveSession.get.sqlContext
-    sqlCtx.setConf("spark.sql.legacy.allowNegativeScaleOfDecimal", "true")
-
-    Seq(10, 15, 28).foreach { precision =>
-      Seq(-precision, -5, 0, 5, precision).foreach { scale =>
-        testCastToString(DataTypes.createDecimalType(precision, scale),
-          comparisonFunc = None)
+    withGpuSparkSession { spark =>
+      spark.conf.set("spark.sql.legacy.allowNegativeScaleOfDecimal", true.toString)
+      Seq(10, 15, 28).foreach { precision =>
+        Seq(-precision, -5, 0, 5, precision).foreach { scale =>
+          testCastToString(DataTypes.createDecimalType(precision, scale),
+            comparisonFunc = None)
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #9768 

(Ansi)CastOpSuite @ (ansi) cast decimal to string

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
