### PR TITLE
Fix NaN handling in GpuLessThanOrEqual and GpuGreaterThanOrEqual

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -258,7 +258,6 @@ def test_lt(data_descr):
             s2 < f.col('b'),
             f.col('a') < f.col('b')))
 
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9711')
 @pytest.mark.parametrize('data_descr', ast_comparable_descrs, ids=idfn)
 def test_lte(data_descr):
     (s1, s2) = with_cpu_session(lambda spark: gen_scalars(data_descr[0], 2))

--- a/integration_tests/src/main/python/cmp_test.py
+++ b/integration_tests/src/main/python/cmp_test.py
@@ -156,6 +156,7 @@ def test_lte(data_gen):
             lambda spark : binary_op_df(spark, data_gen).select(
                 f.col('a') <= s1,
                 s2 <= f.col('b'),
+                f.col('b') <= s2,
                 f.lit(None).cast(data_type) <= f.col('a'),
                 f.col('b') <= f.lit(None).cast(data_type),
                 f.col('a') <= f.col('b')))
@@ -189,6 +190,7 @@ def test_gt(data_gen):
             lambda spark : binary_op_df(spark, data_gen).select(
                 f.col('a') > s1,
                 s2 > f.col('b'),
+                f.col('b') > s2,
                 f.lit(None).cast(data_type) > f.col('a'),
                 f.col('b') > f.lit(None).cast(data_type),
                 f.col('a') > f.col('b')))
@@ -222,6 +224,7 @@ def test_gte(data_gen):
             lambda spark : binary_op_df(spark, data_gen).select(
                 f.col('a') >= s1,
                 s2 >= f.col('b'),
+                f.col('b') >= s2,
                 f.lit(None).cast(data_type) >= f.col('a'),
                 f.col('b') >= f.lit(None).cast(data_type),
                 f.col('a') >= f.col('b')))

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/predicates.scala
@@ -367,8 +367,8 @@ case class GpuGreaterThanOrEqual(left: Expression, right: Expression) extends Cu
          lhs.getBase.getType == DType.FLOAT64) && lhs.isNan) {
       withResource(Scalar.fromBool(true)) { trueScalar =>
         if (rhs.hasNull) {
-          withResource(rhs.getBase.isNotNull) { rhsIsNotNull =>
-            trueScalar.and(rhsIsNotNull)
+          withResource(ColumnVector.fromScalar(trueScalar, rhs.getRowCount.toInt)) { trueVec =>
+            trueVec.mergeAndSetValidity(BinaryOp.BITWISE_AND, rhs.getBase)
           }
         } else {
           ColumnVector.fromScalar(trueScalar, rhs.getRowCount.toInt)
@@ -464,8 +464,8 @@ case class GpuLessThanOrEqual(left: Expression, right: Expression) extends CudfB
          rhs.getBase.getType == DType.FLOAT64) && rhs.isNan) {
       withResource(Scalar.fromBool(true)) { trueScalar =>
         if (lhs.hasNull) {
-          withResource(lhs.getBase.isNotNull) { lhsIsNotNull =>
-            trueScalar.and(lhsIsNotNull)
+          withResource(ColumnVector.fromScalar(trueScalar, lhs.getRowCount.toInt)) { trueVec =>
+            trueVec.mergeAndSetValidity(BinaryOp.BITWISE_AND, lhs.getBase)
           }
         } else {
           ColumnVector.fromScalar(trueScalar, lhs.getRowCount.toInt)


### PR DESCRIPTION
Fixes #9751.  Fixes #9711.

`ColumnView.isNan` does not return any nulls (null input rows return false output rows), so the logic for handling a scalar NaN in GpuLessThanOrEqual and GpuGreaterThanOrEqual was accidentally clobbering nulls in the output.  Updated to simply apply the validity vector of the input to the column vector full of true rows to produce the proper result for this corner case.