### PR TITLE
xfail AST string tests

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -42,7 +42,8 @@ ast_comparable_descrs = [
     (double_gen, False),
     (timestamp_gen, True),
     (date_gen, True),
-    (string_gen, True)
+    pytest.param((string_gen, True),
+                 marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/9771"))
 ]
 
 ast_boolean_descr = [(boolean_gen, True)]


### PR DESCRIPTION
Relates to #9771.  Marking the AST string tests as xfail until that issue is resolved to unblock nightly CI runs.