### PR TITLE
Re-enable AST string integration cases

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -225,7 +225,6 @@ else
 
     # time zone will be tested; use export TZ=time_zone_name before run this script
     TZ=${TZ:-UTC}
-    LC_ALL=C # TODO: remove this before commit
 
     # Set the Delta log cache size to prevent the driver from caching every Delta log indefinitely
     export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=10 $COVERAGE_SUBMIT_FLAGS"

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -225,6 +225,7 @@ else
 
     # time zone will be tested; use export TZ=time_zone_name before run this script
     TZ=${TZ:-UTC}
+    LC_ALL=C # TODO: remove this before commit
 
     # Set the Delta log cache size to prevent the driver from caching every Delta log indefinitely
     export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=10 $COVERAGE_SUBMIT_FLAGS"

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture
 from data_gen import *
 from marks import approximate_float, datagen_overrides
-from spark_session import with_cpu_session, is_before_spark_330, is_jvm_charset_utf8
+from spark_session import with_cpu_session, is_before_spark_330
 import pyspark.sql.functions as f
 
 # Each descriptor contains a list of data generators and a corresponding boolean

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -42,8 +42,7 @@ ast_comparable_descrs = [
     (double_gen, False),
     (timestamp_gen, True),
     (date_gen, True),
-    pytest.param((string_gen, True),
-                 marks=pytest.mark.skipif(not is_jvm_charset_utf8(), reason="AST string requires UTF-8"))
+    (string_gen, True)
 ]
 
 ast_boolean_descr = [(boolean_gen, True)]

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture
 from data_gen import *
 from marks import approximate_float, datagen_overrides
-from spark_session import with_cpu_session, is_before_spark_330
+from spark_session import with_cpu_session, is_before_spark_330, is_jvm_charset_utf8
 import pyspark.sql.functions as f
 
 # Each descriptor contains a list of data generators and a corresponding boolean
@@ -43,7 +43,7 @@ ast_comparable_descrs = [
     (timestamp_gen, True),
     (date_gen, True),
     pytest.param((string_gen, True),
-                 marks=pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/9771"))
+                 marks=pytest.mark.skipif(not is_jvm_charset_utf8(), reason="AST string requires UTF-8"))
 ]
 
 ast_boolean_descr = [(boolean_gen, True)]


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/9771.

AST string needs to be UTF8. But in some test cases, locale default is not.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
