### PR TITLE
Specify nullable=False when generating filter values in dpp tests

### DIFF
--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -28,6 +28,8 @@ def create_dim_table(table_name, table_format, length=500):
             ('skey', IntegerGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
             ('ex_key', IntegerGen(nullable=False, min_val=0, max_val=3, special_cases=[])),
             ('value', int_gen),
+            # specify nullable=False for `filter` to avoid generating invalid SQL with
+            # expression `filter = None` (https://github.com/NVIDIA/spark-rapids/issues/9817)
             ('filter', RepeatSeqGen(
                 IntegerGen(min_val=0, max_val=length, special_cases=[], nullable=False), length=length // 20))
         ], length)

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -29,7 +29,7 @@ def create_dim_table(table_name, table_format, length=500):
             ('ex_key', IntegerGen(nullable=False, min_val=0, max_val=3, special_cases=[])),
             ('value', int_gen),
             ('filter', RepeatSeqGen(
-                IntegerGen(min_val=0, max_val=length, special_cases=[]), length=length // 20))
+                IntegerGen(min_val=0, max_val=length, special_cases=[], nullable=False), length=length // 20))
         ], length)
         df.cache()
         df.write.format(table_format) \


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/9817

The dpp tests fail if we generate a null filter value because it gets translated to `None` literal in the SQL, resulting in the following error:

```
A column or function parameter with name `None` cannot be resolved. 
Did you mean one of the following? [`dim`.`key`, `fact`.`key`, `dim`.`skey`, `fact`.`skey`, `dim`.`value`]
```

I tested this manually using the seed value from the issue.