### PR TITLE
UCX 1.15 upgrade

### DIFF
--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_no_rdma
@@ -17,23 +17,26 @@
 #
 # The parameters are: 
 #   - CUDA_VER: 11.8.0 by default
-#   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
-#                               CUDA runtime from the UCX github repo.
-#                               See: https://github.com/openucx/ucx/releases/
+#   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
+#       Used to pick a package matching a specific UCX version and
+#       CUDA runtime from the UCX github repo.
+#       See: https://github.com/openucx/ucx/releases/
 #   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=11.8.0
-ARG UCX_VER=1.14.0
+ARG UCX_VER=1.15.0
 ARG UCX_CUDA_VER=11
+ARG UCX_ARCH=x86_64
 ARG ROCKY_VER=8
 FROM nvidia/cuda:${CUDA_VER}-runtime-rockylinux${ROCKY_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
+ARG UCX_ARCH
 
 RUN yum update -y && yum install -y wget bzip2 numactl-libs libgomp
 RUN ls /usr/lib
 RUN mkdir /tmp/ucx_install && cd /tmp/ucx_install && \
-  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
+  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf *.bz2 && \
   rpm -i ucx-$UCX_VER*.rpm && \
   rpm -i ucx-cuda-$UCX_VER*.rpm --nodeps && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.rocky_rdma
@@ -17,22 +17,25 @@
 #
 # The parameters are: 
 #   - CUDA_VER: 11.8.0 by default
-#   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
-#                               CUDA runtime from the UCX github repo.
-#                               See: https://github.com/openucx/ucx/releases/
+#   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
+#       Used to pick a package matching a specific UCX version and
+#       CUDA runtime from the UCX github repo.
+#       See: https://github.com/openucx/ucx/releases/
 #   - ROCKY_VER: Rocky Linux OS version
 
 ARG CUDA_VER=11.8.0
-ARG UCX_VER=1.14.0
+ARG UCX_VER=1.15.0
 ARG UCX_CUDA_VER=11
+ARG UCX_ARCH=x86_64
 ARG ROCKY_VER=8
 FROM nvidia/cuda:${CUDA_VER}-runtime-rockylinux${ROCKY_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
+ARG UCX_ARCH
 
 RUN yum update -y && yum install -y wget bzip2 rdma-core numactl-libs libgomp libibverbs librdmacm
 RUN mkdir /tmp/ucx_install && cd /tmp/ucx_install && \
-  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
+  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-centos8-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   tar -xvf *.bz2 && \
   rpm -i ucx-$UCX_VER*.rpm && \
   rpm -i ucx-cuda-$UCX_VER*.rpm --nodeps && \

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -17,21 +17,24 @@
 #
 # The parameters are: 
 #   - CUDA_VER: 11.8.0 by default
-#   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and 
-#                               CUDA runtime from the UCX github repo.
-#                               See: https://github.com/openucx/ucx/releases/
+#   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
+#       Used to pick a package matching a specific UCX version and
+#       CUDA runtime from the UCX github repo.
+#       See: https://github.com/openucx/ucx/releases/
 #   - UBUNTU_VER: 20.04 by default
 #
 
 ARG CUDA_VER=11.8.0
-ARG UCX_VER=1.14.0
+ARG UCX_VER=1.15.0
 ARG UCX_CUDA_VER=11
+ARG UCX_ARCH=x86_64
 ARG UBUNTU_VER=20.04
 
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
 ARG UBUNTU_VER
+ARG UCX_ARCH
 
 RUN apt-get update && apt-get install -y gnupg2
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
@@ -41,7 +44,7 @@ RUN CUDA_UBUNTU_VER=`echo "$UBUNTU_VER"| sed -s 's/\.//'` && \
 RUN apt update
 RUN apt-get install -y wget
 RUN mkdir /tmp/ucx_install && cd /tmp/ucx_install && \
-  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
-  tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
+  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
+  tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   apt install -y /tmp/ucx_install/*.deb && \
   rm -rf /tmp/ucx_install

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -20,9 +20,10 @@
 #   - RDMA_CORE_VERSION: Set to 32.1 to match the rdma-core line in the latest 
 #                        released MLNX_OFED 5.x driver
 #   - CUDA_VER: 11.8.0 by default
-#   - UCX_VER and UCX_CUDA_VER: these are used to pick a package matching a specific UCX version and
-#                               CUDA runtime from the UCX github repo.
-#                               See: https://github.com/openucx/ucx/releases/
+#   - UCX_VER, UCX_CUDA_VER, and UCX_ARCH: 
+#       Used to pick a package matching a specific UCX version and
+#       CUDA runtime from the UCX github repo.
+#       See: https://github.com/openucx/ucx/releases/
 #   - UBUNTU_VER: 20.04 by default
 #
 # The Dockerfile first fetches and builds `rdma-core` to satisfy requirements for
@@ -34,8 +35,9 @@
 
 ARG RDMA_CORE_VERSION=32.1
 ARG CUDA_VER=11.8.0
-ARG UCX_VER=1.14.0
+ARG UCX_VER=1.15.0
 ARG UCX_CUDA_VER=11
+ARG UCX_ARCH=x86_64
 ARG UBUNTU_VER=20.04
 
 # Throw away image to build rdma_core
@@ -43,6 +45,7 @@ FROM ubuntu:${UBUNTU_VER} as rdma_core
 ARG RDMA_CORE_VERSION
 ARG UBUNTU_VER
 ARG CUDA_VER
+ARG UCX_ARCH
 
 RUN apt-get update && apt-get install -y gnupg2
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
@@ -61,6 +64,7 @@ RUN tar -xvf *.tar.gz && cd rdma-core*/ && dpkg-buildpackage -b -d
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG UCX_VER
 ARG UCX_CUDA_VER
+ARG UCX_ARCH
 ARG UBUNTU_VER
 
 RUN mkdir /tmp/ucx_install
@@ -70,7 +74,7 @@ COPY --from=rdma_core /*.deb /tmp/ucx_install/
 RUN apt update
 RUN apt-get install -y wget
 RUN cd /tmp/ucx_install && \
-  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
-  tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER.tar.bz2 && \
+  wget https://github.com/openucx/ucx/releases/download/v$UCX_VER/ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
+  tar -xvf ucx-$UCX_VER-ubuntu$UBUNTU_VER-mofed5-cuda$UCX_CUDA_VER-$UCX_ARCH.tar.bz2 && \
   apt install -y /tmp/ucx_install/*.deb && \
   rm -rf /tmp/ucx_install

--- a/jenkins/Dockerfile-blossom.multi
+++ b/jenkins/Dockerfile-blossom.multi
@@ -26,7 +26,7 @@
 
 ARG CUDA_VER=11.8.0
 ARG UBUNTU_VER=20.04
-ARG UCX_VER=1.15.0-rc6
+ARG UCX_VER=1.15.0
 # multi-platform build with: docker buildx build --platform linux/arm64,linux/amd64 <ARGS> on either amd64 or arm64 host
 # check available official arm-based docker images at https://hub.docker.com/r/nvidia/cuda/tags (OS/ARCH)
 FROM --platform=$TARGETPLATFORM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -27,13 +27,14 @@
 
 ARG CUDA_VER=11.0.3
 ARG UBUNTU_VER=20.04
-ARG UCX_VER=1.14.0
+ARG UCX_VER=1.15.0
 ARG UCX_CUDA_VER=11
 FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu${UBUNTU_VER}
 ARG CUDA_VER
 ARG UBUNTU_VER
 ARG UCX_VER
 ARG UCX_CUDA_VER
+ARG UCX_ARCH=x86_64
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN UB_VER=$(echo ${UBUNTU_VER} | tr -d '.') && \
@@ -65,7 +66,7 @@ RUN apt install -y inetutils-ping expect wget libnuma1 libgomp1
 
 RUN mkdir -p /tmp/ucx && \
     cd /tmp/ucx && \
-    wget https://github.com/openucx/ucx/releases/download/v${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5-cuda${UCX_CUDA_VER}.tar.bz2 && \
+    wget https://github.com/openucx/ucx/releases/download/v${UCX_VER}/ucx-${UCX_VER}-ubuntu${UBUNTU_VER}-mofed5-cuda${UCX_CUDA_VER}-${UCX_ARCH}.tar.bz2 && \
     tar -xvf *.bz2 && \
     dpkg -i *.deb && \
     rm -rf /tmp/ucx

--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
         https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties#L1993-L1994
         -->
         <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing|-Werror</scala.javac.args>
-        <ucx.version>1.14</ucx.version>
+        <ucx.version>1.15.0</ucx.version>
         <rapids.compressed.artifact>true</rapids.compressed.artifact>
         <rapids.default.jar.excludePattern/>
         <rapids.default.jar.phase>package</rapids.default.jar.phase>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -648,7 +648,7 @@
         https://github.com/openjdk/jdk17/blob/4afbcaf55383ec2f5da53282a1547bac3d099e9d/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties#L1993-L1994
         -->
         <scala.javac.args>-Xlint:all,-serial,-path,-try,-processing|-Werror</scala.javac.args>
-        <ucx.version>1.14</ucx.version>
+        <ucx.version>1.15.0</ucx.version>
         <rapids.compressed.artifact>true</rapids.compressed.artifact>
         <rapids.default.jar.excludePattern/>
         <rapids.default.jar.phase>package</rapids.default.jar.phase>


### PR DESCRIPTION
Closes #8137 

This updates JUCX to 1.15, updating the example and CI dockerfiles.

The Dockerfile.multi is using `aarch64` but the rest are using `x86_64`.

I will test with cuda12 locally. 

Note: I am not able to get rocky8 to work with the packages we have in openucx with cuda12. There is a cuda11 + centos8 package, but not a cuda12 + centos8. I also don't see consistency with the architectures supported, so we would need to work with the UCX team to get those releases populated (perhaps UCX 1.16?)

For now, if a user wants one of these combinations in RockyOS, they would have to build from source. Ubuntu 20 and 22 have all combinations: cuda11 and cuda12, aarch64 and x86_64. 

I had to make a table of the releases for 1.15 over at https://github.com/openucx/ucx/releases, here it is:

OS | CUDA11+ARM | CUDA12+ARM | CUDA11+x86 | CUDA12+x86
-- | -- | -- | -- | --
centos7 |   |   | YES | YES
centos8 | YES |   | YES |  
ubuntu16 |   |   | YES |  
ubuntu18 | YES |   | YES | YES
ubuntu20 | YES | YES | YES | YES
ubuntu22 | YES | YES | YES | YES

Update: I am able to install the centos7/cuda12 binary on rocky8, so that would be one approach while we get the support matrix figured out.

