### PR TITLE
Skip fastparquet timestamp tests when plugin cannot read/write timestamps

### DIFF
--- a/integration_tests/src/main/python/fastparquet_compatibility_test.py
+++ b/integration_tests/src/main/python/fastparquet_compatibility_test.py
@@ -15,6 +15,7 @@
 import pytest
 
 from asserts import assert_gpu_and_cpu_are_equal_collect
+from conftest import is_not_utc
 from data_gen import *
 from fastparquet_utils import get_fastparquet_result_canonicalizer
 from spark_session import spark_version, with_cpu_session, with_gpu_session
@@ -94,13 +95,6 @@ def read_parquet(data_path, local_data_path):
     return read_with_fastparquet_or_plugin
 
 
-def is_timezone_utc():
-    from spark_init_internal import get_spark_i_know_what_i_am_doing
-    import time
-    spark = get_spark_i_know_what_i_am_doing()
-    return spark.conf.get("spark.sql.session.timeZone") == "UTC" and time.tzname[time.daylight] == "UTC"
-
-
 @pytest.mark.skipif(condition=fastparquet_unavailable(),
                     reason="fastparquet is required for testing fastparquet compatibility")
 @pytest.mark.skipif(condition=spark_version() < "3.4.0",
@@ -129,7 +123,7 @@ def is_timezone_utc():
     pytest.param(TimestampGen(nullable=False,
                               start=pandas_min_datetime,
                               end=pandas_max_datetime),
-                 marks=pytest.mark.skipif(condition=not is_timezone_utc(),
+                 marks=pytest.mark.skipif(condition=is_not_utc(),
                                           reason="fastparquet interprets timestamps in UTC timezone, regardless "
                                                  "of timezone settings")),  # Vanilla case.
     pytest.param(TimestampGen(nullable=False,
@@ -201,7 +195,7 @@ def test_reading_file_written_by_spark_cpu(data_gen, spark_tmp_path):
     pytest.param(TimestampGen(nullable=False,
                               start=pandas_min_datetime,
                               end=pandas_max_datetime),
-                 marks=pytest.mark.skipif(condition=not is_timezone_utc(),
+                 marks=pytest.mark.skipif(condition=is_not_utc(),
                                           reason="fastparquet interprets timestamps in UTC timezone, regardless "
                                                  "of timezone settings")),  # Vanilla case.
     pytest.param(TimestampGen(nullable=False,


### PR DESCRIPTION
Fixes #9776.

The tests in `fastparquet_compatibility_test.py` check for compatibility between Apache Spark, the Spark RAPIDS plugin, and fastparquet. In particular:
1. `test_reading_file_written_by_spark_cpu` checks if timestamp columns written with Apache Spark are read similarly with fastparquet and the plugin.
2. `test_reading_file_written_with_gpu` checks if timestamps written with the plugin are read the same on Apache Spark and fastparquet.

If the timezone is not set to `UTC`, and the system timezone isn't `UTC` either, the plugin falls back to CPU for read/write of Parquet timestamp columns. This would cause the above tests not to run: the plugin can neither read nor write timestamps on GPU.

Further, fastparquet seems to interpret timestamps written from Spark as being in `UTC`, regardless of the timezone settings. So on non-UTC timezones, Apache Spark and fastparquet get different results for the same input.

For the two reasons above, it is best to only run the three-way timestamp comparison tests in setups with `UTC` timezone.

This commit skips the timestamp tests described above, when a non-UTC timezone is detected.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
