### PR TITLE
Delete pre-merge workspace content if success [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -202,6 +202,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         common.publishPytestResult(this, "${STAGE_NAME}")
                                         common.printJVMCoreDumps(this)
                                     }
+                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }
@@ -233,6 +234,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         common.publishPytestResult(this, "${STAGE_NAME}")
                                         common.printJVMCoreDumps(this)
                                     }
+                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }
@@ -264,6 +266,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                         common.publishPytestResult(this, "${STAGE_NAME}")
                                         common.printJVMCoreDumps(this)
                                     }
+                                    deleteDir() // cleanup content if no error
                                 }
                             }
                         }

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -112,6 +112,7 @@ pipeline {
                             script {
                                 unstash('source_tree')
                                 databricksBuild()
+                                deleteDir() // cleanup content if no error
                             }
                         }
                     }


### PR DESCRIPTION
Our persistency storage is closed to be out of space even with cleanup service (only keep 3 days records).

Update pre-merge CI to only keep failed workspace for debugging, if success then just cleanup content in stage workspaces