### PR TITLE
Skip redundant steps in nightly build [skip ci]

### DIFF
--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -102,7 +102,7 @@ function distWithReducedPom {
 
 # option to skip unit tests. Used in our CI to separate test runs in parallel stages
 SKIP_TESTS=${SKIP_TESTS:-"false"}
-DEPLOY_SUBMODULES=${DEPLOY_SUBMODULES:-'sql-plugin-api,aggregator,integration-tests'}
+DEPLOY_SUBMODULES=${DEPLOY_SUBMODULES:-"!${DIST_PL}"} # TODO: deploy only required submodules to save time
 for buildver in "${SPARK_SHIM_VERSIONS[@]:1}"; do
     $MVN -U -B clean install $MVN_URM_MIRROR -Dmaven.repo.local=$M2DIR \
         -Dcuda.version=$DEFAULT_CUDA_CLASSIFIER \


### PR DESCRIPTION
As we currently have 22 shims in nightly build,  the entire build+deploy (not including tests) time is close to 7 hours now.
To reduce the time cost, this change is trying to skip redundant scala style + scala doc (vary from 30s to 5mins per submodule build) steps while deploy commands.

Internally its now ~ 5hours (saved 2 hours)
Also added TODO to not deploy all non-dist submodules to try save more deploying time.
(could be `aggregator,sql-plugin-api,integration-tests`, please correct me if I miss any)

Verified internally. [skip ci] as it would not be covered in pre-merge.