### PR TITLE
Preparation for non-UTC nightly CI [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -263,6 +263,20 @@ run_pyarrow_tests() {
   ./run_pyspark_from_build.sh -m pyarrow_test --pyarrow_test
 }
 
+run_non_utc_time_zone_tests() {
+  # select one time zone according to date
+  non_utc_time_zones=("Asia/Shanghai" "Iran")
+  time_zones_length=${#non_utc_time_zones[@]}
+  current_date=$(date +%Y%m%d)
+  echo "Current date is: ${current_date}"
+  time_zone_index=$((current_date % time_zones_length))
+  time_zone="${non_utc_time_zones[${time_zone_index}]}"
+  echo "Run Non-UTC tests, time zone is ${time_zone}"
+
+  # run tests
+  TZ=${time_zone} ./run_pyspark_from_build.sh
+}
+
 # TEST_MODE
 # - DEFAULT: all tests except cudf_udf tests
 # - DELTA_LAKE_ONLY: Delta Lake tests only
@@ -319,6 +333,11 @@ fi
 # Pyarrow tests
 if [[ "$TEST_MODE" == "DEFAULT" || "$TEST_MODE" == "PYARROW_ONLY" ]]; then
   run_pyarrow_tests
+fi
+
+# Non-UTC time zone tests
+if [[ "$TEST_MODE" == "NON_UTC_TZ" ]]; then
+  run_non_utc_time_zone_tests
 fi
 
 popd

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -284,6 +284,7 @@ run_non_utc_time_zone_tests() {
 # - AVRO_ONLY: avro tests only (with --packages option instead of --jars)
 # - CUDF_UDF_ONLY: cudf_udf tests only, requires extra conda cudf-py lib
 # - MULTITHREADED_SHUFFLE: shuffle tests only
+# - NON_UTC_TZ: test all tests in a non-UTC time zone which is selected according to current date.
 TEST_MODE=${TEST_MODE:-'DEFAULT'}
 if [[ $TEST_MODE == "DEFAULT" ]]; then
   ./run_pyspark_from_build.sh

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -269,7 +269,7 @@ run_non_utc_time_zone_tests() {
   time_zones_length=${#non_utc_time_zones[@]}
   # get day of week, Sunday is represented by 0 and Saturday by 6
   current_date=$(date +%w)
-  echo "Current date is: ${current_date}"
+  echo "Current day of week is: ${current_date}"
   time_zone_index=$((current_date % time_zones_length))
   time_zone="${non_utc_time_zones[${time_zone_index}]}"
   echo "Run Non-UTC tests, time zone is ${time_zone}"

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -264,10 +264,11 @@ run_pyarrow_tests() {
 }
 
 run_non_utc_time_zone_tests() {
-  # select one time zone according to date
+  # select one time zone according to current day of week
   non_utc_time_zones=("Asia/Shanghai" "Iran")
   time_zones_length=${#non_utc_time_zones[@]}
-  current_date=$(date +%Y%m%d)
+  # get day of week, Sunday is represented by 0 and Saturday by 6
+  current_date=$(date +%w)
   echo "Current date is: ${current_date}"
   time_zone_index=$((current_date % time_zones_length))
   time_zone="${non_utc_time_zones[${time_zone_index}]}"
@@ -284,7 +285,7 @@ run_non_utc_time_zone_tests() {
 # - AVRO_ONLY: avro tests only (with --packages option instead of --jars)
 # - CUDF_UDF_ONLY: cudf_udf tests only, requires extra conda cudf-py lib
 # - MULTITHREADED_SHUFFLE: shuffle tests only
-# - NON_UTC_TZ: test all tests in a non-UTC time zone which is selected according to current date.
+# - NON_UTC_TZ: test all tests in a non-UTC time zone which is selected according to current day of week.
 TEST_MODE=${TEST_MODE:-'DEFAULT'}
 if [[ $TEST_MODE == "DEFAULT" ]]; then
   ./run_pyspark_from_build.sh


### PR DESCRIPTION
Preparation for non-UTC nightly CI

Select a non-UTC time zone according to current date, then test.
Depending on https://github.com/NVIDIA/spark-rapids/pull/9719