### PR TITLE
Add multiple expression tier regression test for AST

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -380,3 +380,9 @@ def test_or(data_gen):
                        f.col('a') | f.lit(True),
                        f.lit(False) | f.col('b'),
                        f.col('a') | f.col('b')))
+
+def test_multi_tier_ast():
+    assert_gpu_ast(
+        is_supported=True,
+        func=lambda spark: spark.range(10).withColumn("x", f.col("id")).repartition(1)\
+            .selectExpr("(id < x) == (id < (id + x))"))


### PR DESCRIPTION
Closes #9733.  cudf has fixed the issue with data type mismatch on multiple expression tiers, so this adds a regression test to verify the functionality.