### PR TITLE
Revert "Remove Databricks 13.3 from release 23.12 [databricks] (#9890)" [databricks]

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -88,7 +88,7 @@ pipeline {
                         // 'name' and 'value' only supprt literal string in the declarative Jenkins
                         // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
                         name 'DB_RUNTIME'
-                        values '10.4', '11.3', '12.2'
+                        values '10.4', '11.3', '12.2', '13.3'
                     }
                 }
                 stages {

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -144,12 +144,6 @@ if [[ "$WITH_BLOOP" == "1" ]]; then
     MVN_OPT="ch.epfl.scala:bloop-maven-plugin:bloopInstall $MVN_OPT"
 fi
 
-# Disabling build for 341db until 24.02
-if [[ "$BUILDVER" == "341db" ]]; then
-    echo "Databricks 341 is not supported as of release 23.12\n"
-    exit 1
-fi 
-
 # Build the RAPIDS plugin by running package command for databricks
 $MVN_CMD -B -Ddatabricks -Dbuildver=$BUILDVER clean package -DskipTests $MVN_OPT
 

--- a/pom.xml
+++ b/pom.xml
@@ -771,7 +771,8 @@
         <databricks.buildvers>
             321db,
             330db,
-            332db
+            332db,
+            341db
         </databricks.buildvers>
         <!--
           Build and run unit tests on one specific version for each sub-version (e.g. 311, 320, 330)

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -771,7 +771,8 @@
         <databricks.buildvers>
             321db,
             330db,
-            332db
+            332db,
+            341db
         </databricks.buildvers>
         <!--
           Build and run unit tests on one specific version for each sub-version (e.g. 311, 320, 330)


### PR DESCRIPTION
This reverts commit c59b0a2c0712b42fb4c0d169608e1a967e7b9147 and adds back Databricks 13.3 to the release

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
