### PR TITLE
Params for build and test CI scripts on Databricks

### DIFF
--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -112,6 +112,7 @@ initialize()
     echo "Build Version                                 : ${BUILDVER}"
     echo "Skip Dependencies                             : ${SKIP_DEP_INSTALL}"
     echo "Include Default Spark Shim                    : ${WITH_DEFAULT_UPSTREAM_SHIM}"
+    echo "Extra environments                            : ${EXTRA_ENVS}"
     printf '+ %*s +\n' 100 '' | tr ' ' =
 }
 

--- a/jenkins/databricks/build.sh
+++ b/jenkins/databricks/build.sh
@@ -130,6 +130,10 @@ install_dependencies()
 ##########################
 # Main script starts here
 ##########################
+## 'foo=abc,bar=123,...' to 'export foo=abc bar=123 ...'
+if [ -n "$EXTRA_ENVS" ]; then
+    export ${EXTRA_ENVS//','/' '}
+fi
 
 initialize
 if [[ $SKIP_DEP_INSTALL == "1" ]]

--- a/jenkins/databricks/common_vars.sh
+++ b/jenkins/databricks/common_vars.sh
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+## 'foo=abc,bar=123,...' to 'export foo=abc bar=123 ...'
+if [ -n "$EXTRA_ENVS" ]; then
+    export ${EXTRA_ENVS//','/' '}
+fi
+
 SPARK_VER=${SPARK_VER:-$(< /databricks/spark/VERSION)}
 export SPARK_SHIM_VER=${SPARK_SHIM_VER:-spark${SPARK_VER//.}db}
 

--- a/jenkins/databricks/params.py
+++ b/jenkins/databricks/params.py
@@ -26,11 +26,13 @@ tgz_dest = '/home/ubuntu/spark-rapids-ci.tgz'
 base_spark_pom_version = '3.2.1'
 base_spark_version_to_install_databricks_jars = base_spark_pom_version
 clusterid = ''
-# can take comma seperated maven options, e.g., -Pfoo=1,-Dbar=2,...
+# can take comma separated maven options, e.g., -Pfoo=1,-Dbar=2,...
 mvn_opt = ''
 jar_path = ''
-# `spark_conf` can take comma seperated multiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
+# can take comma separated multiple spark configurations, e.g., spark.foo=1,spark.bar=2,...'
 spark_conf = ''
+# can take comma separated environments, e.g., foo=abc,bar=123,...'
+extra_envs = ''
 
 
 def usage():
@@ -48,11 +50,12 @@ def usage():
           ' -j <jarpath>'
           ' -n <skipstartingcluster>'
           ' -f <sparkconf>'
-          ' -i <sparkinstallver>')
+          ' -i <sparkinstallver>'
+          ' -e <extraenvs>')
 
 
 try:
-    opts, script_args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:i:',
+    opts, script_args = getopt.getopt(sys.argv[1:], 'hw:t:c:p:l:d:z:m:v:b:j:f:i:e:',
                                       ['workspace=',
                                        'token=',
                                        'clusterid=',
@@ -62,9 +65,10 @@ try:
                                        'sparktgz=',
                                        'basesparkpomversion=',
                                        'mvnoptions=',
-                                       'jarpath',
-                                       'sparkconf',
-                                       'sparkinstallver='])
+                                       'jarpath=',
+                                       'sparkconf=',
+                                       'sparkinstallver=',
+                                       'extraenvs='])
 except getopt.GetoptError:
     usage()
     sys.exit(2)
@@ -97,6 +101,8 @@ for opt, arg in opts:
         spark_conf = arg
     elif opt in ('-i', '--sparkinstallver'):
         base_spark_version_to_install_databricks_jars = arg
+    elif opt in ('-e', '--extraenvs'):
+        extra_envs = arg
 
 print('-w is ' + workspace)
 print('-c is ' + clusterid)
@@ -109,3 +115,4 @@ print('-v is ' + base_spark_pom_version)
 print('-j is ' + jar_path)
 print('-f is ' + spark_conf)
 print('-i is ' + base_spark_version_to_install_databricks_jars)
+print('-e is ' + extra_envs)


### PR DESCRIPTION
Params for build and test CI scripts on Databricks
 
To fix https://github.com/NVIDIA/spark-rapids/issues/9903

Add params to support specify build, test args on Databricks for CI scripts, e.g.

   `python jenkins/databricks/run-build.py -e SKIP_DEP_INSTALL=1` : Run maven build on Databricks and skip installing dependencies into maven repo

   `python jenkins/databricks/run-test.py -e TEST_MODE=DELTA_LAKE_ONLY` : only run Delta Lake  test cases on Databricks

Signed-off-by: timl@nvidia.com
