### PR TITLE
Fix test_initcap to use the intended limited character set

### DIFF
--- a/integration_tests/src/main/python/string_test.py
+++ b/integration_tests/src/main/python/string_test.py
@@ -653,10 +653,10 @@ def test_byte_length():
 @incompat
 def test_initcap():
     # Because we don't use the same unicode version we need to limit
-    # the charicter set to something more reasonable
+    # the character set to something more reasonable
     # upper and lower should cover the corner cases, this is mostly to
     # see if there are issues with spaces
-    gen = mk_str_gen('([aAbB1357ȺéŸ_@%-]{0,15}[ \r\n\t]{1,2}){1,5}')
+    gen = StringGen('([aAbB1357ȺéŸ_@%-]{0,15}[ \r\n\t]{1,2}){1,5}')
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark: unary_op_df(spark, gen).select(
                 f.initcap(f.col('a'))))


### PR DESCRIPTION
Relates to #9247.  The initcap test was written with the intent to limit the datagen character set to characters that should not have capitalization issues, but `mk_str_gen` is used which allows any character to be generated, defeating the point of testing with the limited character set.  This updates the test to use only the limited character set.
