### PR TITLE
Fix 'year 0 is out of range' by setting a fix seed

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -650,7 +650,7 @@ def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser
         .with_special_case('null')
     options = { 'timestampFormat': timestamp_format } if len(timestamp_format) > 0 else { }
     assert_gpu_and_cpu_are_equal_collect(
-        # Use zero seed to workaround for the branch-23.12 relase
+        # Remove the fix seed when fix https://github.com/NVIDIA/spark-rapids/issues/9747
         lambda spark : unary_op_df(spark, json_string_gen, seed = 0) \
             .select(f.col('a'), f.from_json('a', 'struct<a:timestamp>', options)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True,

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -20,7 +20,7 @@ from data_gen import *
 from conftest import is_not_utc
 from datetime import timezone
 from conftest import is_databricks_runtime
-from marks import approximate_float, allow_non_gpu, ignore_order
+from marks import approximate_float, allow_non_gpu, ignore_order, datagen_overrides
 from spark_session import *
 
 json_supported_gens = [

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -650,7 +650,8 @@ def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser
         .with_special_case('null')
     options = { 'timestampFormat': timestamp_format } if len(timestamp_format) > 0 else { }
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, json_string_gen) \
+        # Use zero seed to workaround for the branch-23.12 relase
+        lambda spark : unary_op_df(spark, json_string_gen, seed = 0) \
             .select(f.col('a'), f.from_json('a', 'struct<a:timestamp>', options)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True,
               'spark.sql.legacy.timeParserPolicy': time_parser_policy,

--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -642,6 +642,7 @@ def test_from_json_struct_date_fallback_non_default_format(date_gen, date_format
     pytest.param("LEGACY", marks=pytest.mark.allow_non_gpu('ProjectExec')),
     "CORRECTED"
 ])
+@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9747')
 @pytest.mark.parametrize('ansi_enabled', [ True, False ])
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser_policy, ansi_enabled):
@@ -650,8 +651,7 @@ def test_from_json_struct_timestamp(timestamp_gen, timestamp_format, time_parser
         .with_special_case('null')
     options = { 'timestampFormat': timestamp_format } if len(timestamp_format) > 0 else { }
     assert_gpu_and_cpu_are_equal_collect(
-        # Remove the fix seed when fix https://github.com/NVIDIA/spark-rapids/issues/9747
-        lambda spark : unary_op_df(spark, json_string_gen, seed = 0) \
+        lambda spark : unary_op_df(spark, json_string_gen) \
             .select(f.col('a'), f.from_json('a', 'struct<a:timestamp>', options)),
         conf={"spark.rapids.sql.expression.JsonToStructs": True,
               'spark.sql.legacy.timeParserPolicy': time_parser_policy,


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/9936

Workaroud to fix 'year 0 is out of range' 

Signed-off-by: Chong Gao <res_life@163.com>