### PR TITLE
Fix a potential data corruption for Pandas UDF

### DIFF
--- a/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark321db/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -25,7 +25,7 @@ package com.nvidia.spark.rapids.shims
 import scala.collection.mutable.ArrayBuffer
 
 import com.nvidia.spark.rapids._
-import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.python.PythonWorkerSemaphore
 
 import org.apache.spark.TaskContext
@@ -33,7 +33,7 @@ import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.rapids.execution.python.{BatchProducer, BatchQueue, CombiningIterator, GpuPythonHelper, GpuWindowInPandasExecBase, GroupingIterator}
+import org.apache.spark.sql.rapids.execution.python.{BatchProducer, CombiningIterator, GpuPythonHelper, GpuWindowInPandasExecBase, GroupingIterator}
 import org.apache.spark.sql.rapids.execution.python.shims.GpuArrowPythonRunner
 import org.apache.spark.sql.rapids.shims.{ArrowUtilsShim, DataTypeUtilsShim}
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
@@ -199,24 +199,13 @@ case class GpuWindowInPandasExec(
       val boundPartitionRefs = GpuBindReferences.bindGpuReferences(gpuPartitionSpec, childOutput)
       val batchProducer = new BatchProducer(
         new GroupingIterator(inputIter, boundPartitionRefs, numInputRows, numInputBatches))
-      val queue = new BatchQueue(batchProducer)
-      val pyInputIterator = batchProducer.asIterator.map { case (batch, isForPeek) =>
-        // We have to do the project before we add the batch because the batch might be closed
-        // when it is added
-        val inputBatch = closeOnExcept(batch) { _ =>
+      val pyInputIterator = batchProducer.asIterator.map { batch =>
+        withResource(batch) { _ =>
           withResource(GpuProjectExec.project(batch, boundDataRefs)) { projectedCb =>
             // Compute the window bounds and insert to the head of each row for one batch
             insertWindowBounds(projectedCb)
           }
         }
-        if (isForPeek) {
-          batch.close()
-        } else {
-          // We only add the batch that is not for peek, because the batch for peek is already
-          // added by the reader when peeking the next rows number.
-          queue.add(batch)
-        }
-        inputBatch
       }
 
       if (isPythonOnGpuEnabled) {
@@ -237,8 +226,8 @@ case class GpuWindowInPandasExec(
           pythonOutputSchema)
 
         val outputIterator = pyRunner.compute(pyInputIterator, context.partitionId(), context)
-        new CombiningIterator(queue, outputIterator, pyRunner, numOutputRows,
-          numOutputBatches).map(projectResult)
+        new CombiningIterator(batchProducer.getBatchQueue, outputIterator, pyRunner,
+            numOutputRows, numOutputBatches).map(projectResult)
       } else {
         // Empty partition, return the input iterator directly
         inputIter


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/9941

This PR moves the `BatchQueue` into the `DataProducer` to share the same lock as the output iterator returned by `asIterator`, and make the batch movement from the input iterator to the batch queue be an atomic operation to eliminate the race when appending the batches to the queue.