### PR TITLE
Fix Java OOM caused by incorrect state of shouldCapture when exception occurred

### DIFF
--- a/integration_tests/src/main/python/asserts.py
+++ b/integration_tests/src/main/python/asserts.py
@@ -351,24 +351,31 @@ def assert_gpu_fallback_write(write_func,
     jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.startCapture()
     gpu_start = time.time()
     gpu_path = base_path + '/GPU'
-    with_gpu_session(lambda spark : write_func(spark, gpu_path), conf=conf)
-    gpu_end = time.time()
-    jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name_list, 10000)
-    print('### WRITE: GPU TOOK {} CPU TOOK {} ###'.format(
-        gpu_end - gpu_start, cpu_end - cpu_start))
+    try:
+        with_gpu_session(lambda spark : write_func(spark, gpu_path), conf=conf)
+        gpu_end = time.time()
+        jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.assertCapturedAndGpuFellBack(cpu_fallback_class_name_list, 10000)
+        print('### WRITE: GPU TOOK {} CPU TOOK {} ###'.format(
+            gpu_end - gpu_start, cpu_end - cpu_start))
 
-    (cpu_bring_back, cpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, cpu_path), 'COLLECT')
-    (gpu_bring_back, gpu_collect_type) = _prep_func_for_compare(
-            lambda spark: read_func(spark, gpu_path), 'COLLECT')
+        (cpu_bring_back, cpu_collect_type) = _prep_func_for_compare(
+                lambda spark: read_func(spark, cpu_path), 'COLLECT')
+        (gpu_bring_back, gpu_collect_type) = _prep_func_for_compare(
+                lambda spark: read_func(spark, gpu_path), 'COLLECT')
 
-    from_cpu = with_cpu_session(cpu_bring_back, conf=conf)
-    from_gpu = with_cpu_session(gpu_bring_back, conf=conf)
-    if should_sort_locally():
-        from_cpu.sort(key=_RowCmp)
-        from_gpu.sort(key=_RowCmp)
+        from_cpu = with_cpu_session(cpu_bring_back, conf=conf)
+        from_gpu = with_cpu_session(gpu_bring_back, conf=conf)
+        if should_sort_locally():
+            from_cpu.sort(key=_RowCmp)
+            from_gpu.sort(key=_RowCmp)
 
-    assert_equal(from_cpu, from_gpu)
+        assert_equal(from_cpu, from_gpu)
+    finally:
+        # Ensure `shouldCapture` state is restored. This may happen when GpuPlan is failed to be executed,
+        # then `shouldCapture` state is failed to restore in `assertCapturedAndGpuFellBack` method.
+        # This mostly happen within a xfail case where error may be ignored.
+        jvm.org.apache.spark.sql.rapids.ExecutionPlanCaptureCallback.endCapture()
+
 
 def assert_cpu_and_gpu_are_equal_collect_with_capture(func,
         exist_classes='',

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ExecutionPlanCaptureCallback.scala
@@ -26,6 +26,8 @@ trait ExecutionPlanCaptureCallbackBase {
   def captureIfNeeded(qe: QueryExecution): Unit
   def startCapture(): Unit
   def startCapture(timeoutMillis: Long): Unit
+  def endCapture(): Unit
+  def endCapture(timeoutMillis: Long): Unit
   def getResultsWithTimeout(timeoutMs: Long = 10000): Array[SparkPlan]
   def extractExecutedPlan(plan: SparkPlan): SparkPlan
   def assertContains(gpuPlan: SparkPlan, className: String): Unit
@@ -56,6 +58,10 @@ object ExecutionPlanCaptureCallback extends ExecutionPlanCaptureCallbackBase {
 
   override def startCapture(timeoutMillis: Long): Unit =
     impl.startCapture(timeoutMillis)
+
+  override def endCapture(): Unit = impl.endCapture()
+
+  override def endCapture(timeoutMillis: Long): Unit = impl.endCapture(timeoutMillis)
 
   override def getResultsWithTimeout(timeoutMs: Long = 10000): Array[SparkPlan] =
     impl.getResultsWithTimeout(timeoutMs)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ShimmedExecutionPlanCaptureCallbackImpl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/ShimmedExecutionPlanCaptureCallbackImpl.scala
@@ -57,6 +57,15 @@ class ShimmedExecutionPlanCaptureCallbackImpl extends ExecutionPlanCaptureCallba
     }
   }
 
+  override def endCapture(): Unit = endCapture(10000)
+
+  override def endCapture(timeoutMillis: Long): Unit = synchronized {
+    if (shouldCapture) {
+      shouldCapture = false
+      execPlans.clear()
+    }
+  }
+
   override def getResultsWithTimeout(timeoutMs: Long = 10000): Array[SparkPlan] = {
     try {
       val spark = SparkSession.active


### PR DESCRIPTION
This closes https://github.com/NVIDIA/spark-rapids/issues/9829.

Typically, ```shouldCapture``` in ```ShimmedExecutionPlanCaptureCallbackImpl``` should work as pair of ```startCapture``` and ```getResultsWithTimeout```. But it may fail to be restored when exception happens in Gpu run sesssion. In #9829 case, it missed to add a non-GPU operator resulting in an ```IllegalArgumentException```. Then ```getResultsWithTimeout``` was failed to be updated.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
