### PR TITLE
Fix test_multi_tier_ast to ignore ordering of output rows

### DIFF
--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -385,5 +385,6 @@ def test_or(data_gen):
 def test_multi_tier_ast():
     assert_gpu_ast(
         is_supported=True,
+        # repartition is here to avoid Spark simplifying the expression
         func=lambda spark: spark.range(10).withColumn("x", f.col("id")).repartition(1)\
             .selectExpr("x", "(id < x) == (id < (id + x))"))

--- a/integration_tests/src/main/python/ast_test.py
+++ b/integration_tests/src/main/python/ast_test.py
@@ -17,7 +17,7 @@ import pytest
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture
 from conftest import is_not_utc
 from data_gen import *
-from marks import approximate_float, datagen_overrides
+from marks import approximate_float, datagen_overrides, ignore_order
 from spark_session import with_cpu_session, is_before_spark_330
 import pyspark.sql.functions as f
 
@@ -381,8 +381,9 @@ def test_or(data_gen):
                        f.lit(False) | f.col('b'),
                        f.col('a') | f.col('b')))
 
+@ignore_order
 def test_multi_tier_ast():
     assert_gpu_ast(
         is_supported=True,
         func=lambda spark: spark.range(10).withColumn("x", f.col("id")).repartition(1)\
-            .selectExpr("(id < x) == (id < (id + x))"))
+            .selectExpr("x", "(id < x) == (id < (id + x))"))


### PR DESCRIPTION
Fixes #9932.  Update the test to include the input value and ignore the output ordering to resolve issues with non-deterministic task completion sequencing.