### PR TITLE
Override the seed for `test_map_scalars_supported_key_types ` for version of Spark before 3.4.0 [Databricks]

### DIFF
--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -154,9 +154,14 @@ def pytest_runtest_setup(item):
     _inject_oom = item.get_closest_marker('inject_oom')
     datagen_overrides = item.get_closest_marker('datagen_overrides')
     if datagen_overrides:
+        try:
+            seed = datagen_overrides.kwargs["seed"]
+        except KeyError:
+            raise Exception("datagen_overrides requires an override seed value")
+
         override_seed = datagen_overrides.kwargs.get('condition', True)
         if override_seed:
-            _test_datagen_random_seed = datagen_overrides.kwargs.get('seed', _test_datagen_random_seed)
+            _test_datagen_random_seed = seed
 
     order = item.get_closest_marker('ignore_order')
     if order:

--- a/integration_tests/src/main/python/conftest.py
+++ b/integration_tests/src/main/python/conftest.py
@@ -154,7 +154,9 @@ def pytest_runtest_setup(item):
     _inject_oom = item.get_closest_marker('inject_oom')
     datagen_overrides = item.get_closest_marker('datagen_overrides')
     if datagen_overrides:
-        _test_datagen_random_seed = datagen_overrides.kwargs.get('seed', _test_datagen_random_seed)
+        override_seed = datagen_overrides.kwargs.get('condition', True)
+        if override_seed:
+            _test_datagen_random_seed = datagen_overrides.kwargs.get('seed', _test_datagen_random_seed)
 
     order = item.get_closest_marker('ignore_order')
     if order:

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -192,9 +192,9 @@ def test_basic_scalar_map_get_map_value(key_gen):
 
 
 @allow_non_gpu('WindowLocalExec')
-@datagen_overrides(condition=is_before_spark_314()
+@datagen_overrides(seed=0, condition=is_before_spark_314()
                              or (not is_before_spark_320() and is_before_spark_323())
-                             or (not is_before_spark_330() and is_before_spark_331()), seed=0, reason="https://issues.apache.org/jira/browse/SPARK-40089")
+                             or (not is_before_spark_330() and is_before_spark_331()), reason="https://issues.apache.org/jira/browse/SPARK-40089")
 @pytest.mark.parametrize('data_gen', supported_key_map_gens, ids=idfn)
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 def test_map_scalars_supported_key_types(data_gen):

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -192,7 +192,7 @@ def test_basic_scalar_map_get_map_value(key_gen):
 
 
 @allow_non_gpu('WindowLocalExec')
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9683')
+@datagen_overrides(condition=is_before_spark_340(), seed=0, reason="https://issues.apache.org/jira/browse/SPARK-40089")
 @pytest.mark.parametrize('data_gen', supported_key_map_gens, ids=idfn)
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 def test_map_scalars_supported_key_types(data_gen):

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -192,7 +192,9 @@ def test_basic_scalar_map_get_map_value(key_gen):
 
 
 @allow_non_gpu('WindowLocalExec')
-@datagen_overrides(condition=is_before_spark_340(), seed=0, reason="https://issues.apache.org/jira/browse/SPARK-40089")
+@datagen_overrides(condition=is_before_spark_314()
+                             or (not is_before_spark_320() and is_before_spark_323())
+                             or (not is_before_spark_330() and is_before_spark_331()), seed=0, reason="https://issues.apache.org/jira/browse/SPARK-40089")
 @pytest.mark.parametrize('data_gen', supported_key_map_gens, ids=idfn)
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 def test_map_scalars_supported_key_types(data_gen):

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -128,11 +128,17 @@ def is_before_spark_312():
 def is_before_spark_313():
     return spark_version() < "3.1.3"
 
+def is_before_spark_314():
+    return spark_version() < "3.1.4"
+
 def is_before_spark_320():
     return spark_version() < "3.2.0"
 
 def is_before_spark_322():
     return spark_version() < "3.2.2"
+
+def is_before_spark_323():
+    return spark_version() < "3.2.3"
 
 def is_before_spark_330():
     return spark_version() < "3.3.0"


### PR DESCRIPTION
This PR adds a `condition` parameter based on which we should override the `datagen_overrides` if it's provided. If no condition is provided then we apply the override unconditionally. 

Based on the findings, the bug stems from an old [bug](https://issues.apache.org/jira/browse/SPARK-40089) in Spark decimal sort. 

fixes #9683 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
