### PR TITLE
Fix LongGen accidentally using special cases when none are desired

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -280,10 +280,13 @@ class DecimalGen(DataGen):
 
 LONG_MIN = -(1 << 63)
 LONG_MAX = (1 << 63) - 1
+_MISSING_ARG = object()
+
 class LongGen(DataGen):
     """Generate Longs, which some built in corner cases."""
-    def __init__(self, nullable=True, min_val = LONG_MIN, max_val = LONG_MAX, special_cases = []):
-        _special_cases = [min_val, max_val, 0, 1, -1] if not special_cases else special_cases
+    def __init__(self, nullable=True, min_val = LONG_MIN, max_val = LONG_MAX,
+                 special_cases = _MISSING_ARG):
+        _special_cases = [min_val, max_val, 0, 1, -1] if special_cases is _MISSING_ARG else special_cases
         super().__init__(LongType(), nullable=nullable, special_cases=_special_cases)
         self._min_val = min_val
         self._max_val = max_val


### PR DESCRIPTION
Fixes #9933.

LongGen had a bug where callers passing an empty list or None for the special cases (i.e.: meaning they do not want any special cases) were actually getting the default special case list.  This fixes the issue by using a hidden sentinel value as the default argument and only using the default special cases when that default sentinel argument is the argument that is seen during init.