### PR TITLE
Avoid using floating point for partition values in Delta Lake tests

### DIFF
--- a/integration_tests/src/main/python/delta_lake_write_test.py
+++ b/integration_tests/src/main/python/delta_lake_write_test.py
@@ -32,9 +32,6 @@ delta_part_write_gens = [
     short_gen,
     int_gen,
     long_gen,
-    # Avoid NaNs since it falsely triggers switch to new file when checking if partition changed
-    FloatGen(no_nans=True),
-    DoubleGen(no_nans=True),
     # Some file systems have issues with UTF8 strings so to help the test pass even there
     StringGen('(\\w| ){0,50}'),
     boolean_gen,


### PR DESCRIPTION
Fixes #9934.  This updates the Delta Lake partition write tests to avoid using floating point values.  It's clear from the recent woes with floating point partition values that it isn't a well tested path in Apache Spark, and it's a dubious use case.  #9934 failures were because the CPU was producing single-digit rows per file which is clearly not the desired behavior and causes the metadata comparisons to fail because the CPU produces far more files than the GPU does.