### PR TITLE
Avoid leading and trailing zeros in test_timestamp_seconds_rounding_necessary

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -244,7 +244,7 @@ class IntegerGen(DataGen):
 
 class DecimalGen(DataGen):
     """Generate Decimals, with some built in corner cases."""
-    def __init__(self, precision=None, scale=None, nullable=True, special_cases=None, avoid_positive_values=False):
+    def __init__(self, precision=None, scale=None, nullable=True, special_cases=None, avoid_positive_values=False, full_precision=False):
         if precision is None:
             #Maximum number of decimal digits a Long can represent is 18
             precision = 18
@@ -259,12 +259,14 @@ class DecimalGen(DataGen):
         self.scale = scale
         self.precision = precision
         self.avoid_positive_values = avoid_positive_values
+        self.full_precision = full_precision
 
     def __repr__(self):
         return super().__repr__() + '(' + str(self.precision) + ',' + str(self.scale) + ')'
 
     def _cache_repr(self):
-        return super()._cache_repr() + '(' + str(self.precision) + ',' + str(self.scale) + ',' + str(self.avoid_positive_values) + ')'
+        return super()._cache_repr() + '(' + str(self.precision) + ',' + str(self.scale) + ',' +\
+              str(self.avoid_positive_values) + ',' + str(self.full_precision) + ')'
 
     def start(self, rand):
         def random_decimal(rand):
@@ -272,7 +274,15 @@ class DecimalGen(DataGen):
                 sign = "-"
             else:
                 sign = rand.choice(["-", ""])
-            int_part = "".join([rand.choice("0123456789") for _ in range(self.precision)]) 
+            if self.full_precision:
+                if self.precision == 1:
+                    int_part = rand.choice("123456789")
+                else:
+                    int_part = rand.choice("123456789") + \
+                        "".join([rand.choice("0123456789") for _ in range(self.precision - 2)]) + \
+                        rand.choice("123456789")
+            else:
+                int_part = "".join([rand.choice("0123456789") for _ in range(self.precision)]) 
             result = f"{sign}{int_part}e{str(-self.scale)}" 
             return Decimal(result)
 

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -245,6 +245,7 @@ class IntegerGen(DataGen):
 class DecimalGen(DataGen):
     """Generate Decimals, with some built in corner cases."""
     def __init__(self, precision=None, scale=None, nullable=True, special_cases=None, avoid_positive_values=False, full_precision=False):
+        """full_precision: If True, generate decimals with full precision without leading and trailing zeros."""
         if precision is None:
             #Maximum number of decimal digits a Long can represent is 18
             precision = 18

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -573,9 +573,11 @@ def test_timestamp_seconds_long_overflow():
         lambda spark : unary_op_df(spark, long_gen).selectExpr("timestamp_seconds(a)").collect(),
         conf={},
         error_message='long overflow')
-    
-@pytest.mark.parametrize('data_gen', [DecimalGen(7, 7), DecimalGen(20, 7)], ids=idfn)
+
+# Make sure every decimal value in test data is rounding necessary by set full_precision=True to
+# avoid leading and trailing zeros
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
+@pytest.mark.parametrize('data_gen', [DecimalGen(7, 7, full_precision=True), DecimalGen(20, 7, full_precision=True)], ids=idfn)
 def test_timestamp_seconds_rounding_necessary(data_gen):
     assert_gpu_and_cpu_error(
         lambda spark : unary_op_df(spark, data_gen).selectExpr("timestamp_seconds(a)").collect(),

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -574,8 +574,10 @@ def test_timestamp_seconds_long_overflow():
         conf={},
         error_message='long overflow')
 
-# Make sure every decimal value in test data is 'Rounding necessary' by set full_precision=True to
-# avoid leading and trailing zeros
+# For Decimal(20, 7) case, the data is both 'Overflow' and 'Rounding necessary', this case is to verify
+# that 'Rounding necessary' check is before 'Overflow' check. So we should make sure that every decimal 
+# value in test data is 'Rounding necessary' by setting full_precision=True to avoid leading and trailing zeros.
+# Otherwise, the test data will bypass the 'Rounding necessary' check and throw an 'Overflow' error.
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 @pytest.mark.parametrize('data_gen', [DecimalGen(7, 7, full_precision=True), DecimalGen(20, 7, full_precision=True)], ids=idfn)
 def test_timestamp_seconds_rounding_necessary(data_gen):

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -574,7 +574,7 @@ def test_timestamp_seconds_long_overflow():
         conf={},
         error_message='long overflow')
 
-# Make sure every decimal value in test data is rounding necessary by set full_precision=True to
+# Make sure every decimal value in test data is 'Rounding necessary' by set full_precision=True to
 # avoid leading and trailing zeros
 @pytest.mark.xfail(condition = is_not_utc(), reason = 'xfail non-UTC time zone tests because of https://github.com/NVIDIA/spark-rapids/issues/9653')
 @pytest.mark.parametrize('data_gen', [DecimalGen(7, 7, full_precision=True), DecimalGen(20, 7, full_precision=True)], ids=idfn)


### PR DESCRIPTION
Fixes #9923 

`timestamp_seconds` will check for rounding necessary before overflow, the Decimal(20,7) case satisfies both rounding necessary and overflow, so it should complain about rounding necessary. The first element in the df with the failed seed is 1793879511158.1649100, so it bypasses the rounding necessary check and passes the overflow check next.

This PR adds a new parameter `full_precision` in integration test `DecimalGen` to avoid it generating data with leading and tailing zeros, and sets it to True in test_timestamp_seconds_rounding_necessary.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
