### PR TITLE
Fix 340+(including DB341+) does not support casting date to integral/float [databricks]

### DIFF
--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -694,4 +694,4 @@ def test_cast_fallback_not_UTC(from_gen, to_type):
 def test_cast_date_integral_and_fp():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, date_gen).selectExpr(
-            "cast(a as byte)", "cast(a as short)", "cast(a as int)", "cast(a as long)", "cast(a as float)", "cast(a as double)"))
+            "cast(a as boolean)", "cast(a as byte)", "cast(a as short)", "cast(a as int)", "cast(a as long)", "cast(a as float)", "cast(a as double)"))

--- a/integration_tests/src/main/python/cast_test.py
+++ b/integration_tests/src/main/python/cast_test.py
@@ -691,7 +691,7 @@ def test_cast_fallback_not_UTC(from_gen, to_type):
         {"spark.sql.session.timeZone": "+08",
          "spark.rapids.sql.castStringToTimestamp.enabled": "true"})
 
-def test_cast_date_integral():
+def test_cast_date_integral_and_fp():
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, date_gen).selectExpr(
-            "cast(a as byte)", "cast(a as short)", "cast(a as int)", "cast(a as long)"))
+            "cast(a as byte)", "cast(a as short)", "cast(a as int)", "cast(a as long)", "cast(a as float)", "cast(a as double)"))

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/CastCheckShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/CastCheckShims.scala
@@ -52,7 +52,7 @@ object CastCheckShims {
   def additionalTypesDateCanCastTo: TypeSig = if (SQLConf.get.ansiEnabled) {
     TypeSig.none
   } else {
-    TypeSig.BOOLEAN
+    TypeSig.BOOLEAN + TypeSig.integral + TypeSig.fp
   }
 
   def additionalTypesTimestampCanCastTo: TypeSig = if (SQLConf.get.ansiEnabled) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/CastOpSuite.scala
@@ -527,16 +527,7 @@ class CastOpSuite extends GpuExpressionTestSuite {
       col("bools").cast(DoubleType))
   }
 
-  def before3_4_0(s: SparkSession): (Boolean, String) = {
-    (s.version < "3.4.0", s"Spark version must be prior to 3.4.0")
-  }
-
-  def since3_4_0(s: SparkSession): (Boolean, String) = {
-    (s.version >= "3.4.0", s"Spark version must be at least 3.4.0")
-  }
-
-  testSparkResultsAreEqual("Test cast from date", timestampDatesMsecParquet,
-    assumeCondition = before3_4_0) {
+  testSparkResultsAreEqual("Test cast from date", timestampDatesMsecParquet) {
     frame => frame.select(
       col("date"),
       col("date").cast(BooleanType),
@@ -549,14 +540,6 @@ class CastOpSuite extends GpuExpressionTestSuite {
       col("date").cast(LongType),
       col("date").cast(TimestampType))
    }
-
-  testSparkResultsAreEqual("Test cast from date Spark 3.4.0+", timestampDatesMsecParquet,
-    assumeCondition = since3_4_0) {
-    frame =>
-      frame.select(
-        col("date"),
-        col("date").cast(TimestampType))
-  }
 
   testSparkResultsAreEqual("Test cast from string to bool", maybeBoolStrings) {
     frame => frame.select(col("maybe_bool").cast(BooleanType))


### PR DESCRIPTION
closes #9977

Fix 340+(including DB341+) does not support casting date to integral/float

Casting date to other type just generates null in non-ansi mode.
In ansi mode, casting date to other type is not allowed (analysis exception).