### PR TITLE
Optimize from_unixtime

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -1009,13 +1009,13 @@ case class GpuFromUnixTime(
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
     // expressions map and passed down here as strfFormat
-    withResource(lhs.getBase.asTimestampSeconds) { secondsVector =>
+    withResource(lhs.getBase.asTimestampSeconds) { secondCV =>
       if (GpuOverrides.isUTCTimezone(zoneId)) {
         // UTC time zone
-        secondsVector.asStrings(strfFormat)
+        secondCV.asStrings(strfFormat)
       } else {
         // Non-UTC TZ
-        withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(secondsVector, zoneId.normalized())) {
+        withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(secondCV, zoneId.normalized())) {
           shifted => shifted.asStrings(strfFormat)
         }
       }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -1010,15 +1010,13 @@ case class GpuFromUnixTime(
     // we aren't using rhs as it was already converted in the GpuOverrides while creating the
     // expressions map and passed down here as strfFormat
     withResource(lhs.getBase.asTimestampSeconds) { secondsVector =>
-      withResource(secondsVector.asTimestampMicroseconds) { tsVector =>
-        if (GpuOverrides.isUTCTimezone(zoneId)) {
-          // UTC time zone
-          tsVector.asStrings(strfFormat)
-        } else {
-          // Non-UTC TZ
-          withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(tsVector, zoneId.normalized())) {
-            shifted => shifted.asStrings(strfFormat)
-          }
+      if (GpuOverrides.isUTCTimezone(zoneId)) {
+        // UTC time zone
+        secondsVector.asStrings(strfFormat)
+      } else {
+        // Non-UTC TZ
+        withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(secondsVector, zoneId.normalized())) {
+          shifted => shifted.asStrings(strfFormat)
         }
       }
     }


### PR DESCRIPTION
contributes to https://github.com/NVIDIA/spark-rapids/issues/9605

`GpuTimeZoneDB.fromUtcTimestampToTimestamp` supports second timestamp, no need to convert to microsecond timestamp first.

Signed-off-by: Chong Gao <res_life@163.com>