### PR TITLE
Use Spark 3.3.3 instead of 3.3.2 for Scala 2.13 premerge builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
             320
         </premergeUTF8.buildvers>
         <premergeScala213.buildvers>
-            332,
+            333,
             340
         </premergeScala213.buildvers>
         <jdk11.buildvers>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -791,7 +791,7 @@
             320
         </premergeUTF8.buildvers>
         <premergeScala213.buildvers>
-            332,
+            333,
             340
         </premergeScala213.buildvers>
         <jdk11.buildvers>


### PR DESCRIPTION
Relates to #9659.  Updates the premerge build versions for Scala 2.13 to use Spark 3.3.3 instead of Spark 3.3.2 due to the known issues with Spark 3.3.2 + Scala 2.13, see [SPARK-39696](https://issues.apache.org/jira/browse/SPARK-39696).