### PR TITLE
Fix array_transform to not recompute the argument

### DIFF
--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -337,6 +337,11 @@ def test_array_transform_non_deterministic():
             lambda spark : spark.range(1).selectExpr("transform(sequence(0, cast(rand(5)*10 as int) + 1), x -> x * 22) as t"),
             conf={'spark.rapids.sql.castFloatToIntegralTypes.enabled': True})
 
+def test_array_transform_non_deterministic_second_param():
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : debug_df(spark.range(1).selectExpr("transform(sequence(0, cast(rand(5)*10 as int) + 1), (x, i) -> x + i) as t")),
+            conf={'spark.rapids.sql.castFloatToIntegralTypes.enabled': True})
+
 # TODO add back in string_gen when https://github.com/rapidsai/cudf/issues/9156 is fixed
 array_min_max_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
         string_gen, boolean_gen, date_gen, timestamp_gen, null_gen] + decimal_gens

--- a/integration_tests/src/main/python/array_test.py
+++ b/integration_tests/src/main/python/array_test.py
@@ -332,6 +332,11 @@ def test_array_transform(data_gen):
 
     assert_gpu_and_cpu_are_equal_collect(do_it)
 
+def test_array_transform_non_deterministic():
+    assert_gpu_and_cpu_are_equal_collect(
+            lambda spark : spark.range(1).selectExpr("transform(sequence(0, cast(rand(5)*10 as int) + 1), x -> x * 22) as t"),
+            conf={'spark.rapids.sql.castFloatToIntegralTypes.enabled': True})
+
 # TODO add back in string_gen when https://github.com/rapidsai/cudf/issues/9156 is fixed
 array_min_max_gens = [byte_gen, short_gen, int_gen, long_gen, float_gen, double_gen,
         string_gen, boolean_gen, date_gen, timestamp_gen, null_gen] + decimal_gens

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -895,6 +895,22 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     return incRefCounts(ret);
   }
 
+  public static ColumnarBatch combineColumns(ColumnarBatch cb, GpuColumnVector ... vectors) {
+    final int numRows = cb.numRows();
+    ArrayList<ColumnVector> columns = new ArrayList<>();
+    int numColumns = cb.numCols();
+    for (int i = 0; i < numColumns; i++) {
+      columns.add(cb.column(i));
+    }
+    for (GpuColumnVector cv: vectors) {
+      assert cv.getBase().getRowCount() == numRows : "Rows do not match expected " + numRows + " found " +
+          cv.getBase().getRowCount();
+      columns.add(cv);
+    }
+    ColumnarBatch ret = new ColumnarBatch(columns.toArray(new ColumnVector[columns.size()]), numRows);
+    return incRefCounts(ret);
+  }
+
   /**
    * Remove columns from the batch.  The order of the remaining columns is preserved.
    * dropList[] has an entry for each column in the batch which indicates whether the column should

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/GpuColumnVector.java
@@ -895,11 +895,11 @@ public class GpuColumnVector extends GpuColumnVectorBase {
     return incRefCounts(ret);
   }
 
-  public static ColumnarBatch combineColumns(ColumnarBatch cb, GpuColumnVector ... vectors) {
+  public static ColumnarBatch appendColumns(ColumnarBatch cb, GpuColumnVector ... vectors) {
     final int numRows = cb.numRows();
-    ArrayList<ColumnVector> columns = new ArrayList<>();
-    int numColumns = cb.numCols();
-    for (int i = 0; i < numColumns; i++) {
+    final int numCbColumns = cb.numCols();
+    ArrayList<ColumnVector> columns = new ArrayList<>(numCbColumns + vectors.length);
+    for (int i = 0; i < numCbColumns; i++) {
       columns.add(cb.column(i));
     }
     for (GpuColumnVector cv: vectors) {


### PR DESCRIPTION
This fixes https://github.com/NVIDIA/spark-rapids/issues/9472

Thanks to @razajafri for doing the majority of the debugging on this.