### PR TITLE
Support hour minute second for non-UTC time zone

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -130,48 +130,20 @@ def test_datediff(data_gen):
             'datediff(a, date(null))',
             'datediff(a, \'2016-03-02\')'))
 
-@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+@allow_non_gpu(*non_utc_allow)
 def test_hour():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'),
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'))
 
-@allow_non_gpu('ProjectExec')
-@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-def test_hour_fallback():
-    assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'),
-        'ProjectExec',
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
-
-@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+@allow_non_gpu(*non_utc_allow)
 def test_minute():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'),
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
-    
-@allow_non_gpu('ProjectExec')
-@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-def test_minute_fallback():
-    assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'),
-        'ProjectExec',
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'))
 
-@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+@allow_non_gpu(*non_utc_allow)
 def test_second():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'),
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
-    
-@allow_non_gpu('ProjectExec')
-@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
-def test_second_fallback():
-    assert_gpu_fallback_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'),
-        'ProjectExec',
-        conf = {'spark.rapids.sql.nonUTC.enabled': True})
-
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'))
 
 def test_quarter():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -130,20 +130,48 @@ def test_datediff(data_gen):
             'datediff(a, date(null))',
             'datediff(a, \'2016-03-02\')'))
 
-@allow_non_gpu(*non_utc_allow)
+@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 def test_hour():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
 
-@allow_non_gpu(*non_utc_allow)
+@allow_non_gpu('ProjectExec')
+@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+def test_hour_fallback():
+    assert_gpu_fallback_collect(
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'),
+        'ProjectExec',
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+
+@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 def test_minute():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+    
+@allow_non_gpu('ProjectExec')
+@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+def test_minute_fallback():
+    assert_gpu_fallback_collect(
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'),
+        'ProjectExec',
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
 
-@allow_non_gpu(*non_utc_allow)
+@pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 def test_second():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+    
+@allow_non_gpu('ProjectExec')
+@pytest.mark.skipif(is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
+def test_second_fallback():
+    assert_gpu_fallback_collect(
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'),
+        'ProjectExec',
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
+
 
 def test_quarter():
     assert_gpu_and_cpu_are_equal_collect(

--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -130,20 +130,25 @@ def test_datediff(data_gen):
             'datediff(a, date(null))',
             'datediff(a, \'2016-03-02\')'))
 
-@allow_non_gpu(*non_utc_allow)
+hms_fallback = ['ProjectExec'] if not is_supported_time_zone() else []
+
+@allow_non_gpu(*hms_fallback)
 def test_hour():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('hour(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
 
-@allow_non_gpu(*non_utc_allow)
+@allow_non_gpu(*hms_fallback)
 def test_minute():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('minute(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
 
-@allow_non_gpu(*non_utc_allow)
+@allow_non_gpu(*hms_fallback)
 def test_second():
     assert_gpu_and_cpu_are_equal_collect(
-        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'))
+        lambda spark : unary_op_df(spark, timestamp_gen).selectExpr('second(a)'),
+        conf = {'spark.rapids.sql.nonUTC.enabled': True})
 
 def test_quarter():
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -1728,26 +1728,26 @@ object GpuOverrides extends Logging {
       ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (hour, conf, p, r) => new UnaryExprMeta[Hour](hour, conf, p, r) {
-
-        override def convertToGpu(expr: Expression): GpuExpression = GpuHour(expr)
+        override def isTimeZoneSupported = true
+        override def convertToGpu(expr: Expression): GpuExpression = GpuHour(expr, hour.timeZoneId)
       }),
     expr[Minute](
       "Returns the minute component of the string/timestamp",
       ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (minute, conf, p, r) => new UnaryExprMeta[Minute](minute, conf, p, r) {
-
+        override def isTimeZoneSupported = true
         override def convertToGpu(expr: Expression): GpuExpression =
-          GpuMinute(expr)
+          GpuMinute(expr, minute.timeZoneId)
       }),
     expr[Second](
       "Returns the second component of the string/timestamp",
       ExprChecks.unaryProject(TypeSig.INT, TypeSig.INT,
         TypeSig.TIMESTAMP, TypeSig.TIMESTAMP),
       (second, conf, p, r) => new UnaryExprMeta[Second](second, conf, p, r) {
-
+        override def isTimeZoneSupported = true
         override def convertToGpu(expr: Expression): GpuExpression =
-          GpuSecond(expr)
+          GpuSecond(expr, second.timeZoneId)
       }),
     expr[WeekDay](
       "Returns the day of the week (0 = Monday...6=Sunday)",

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -91,7 +91,14 @@ case class GpuMinute(child: Expression, timeZoneId: Option[String] = None)
     copy(timeZoneId = Option(timeZoneId))
 
   override protected def doColumnar(input: GpuColumnVector): ColumnVector =
-    input.getBase.minute()
+    if (GpuOverrides.isUTCTimezone(zoneId)) {
+      input.getBase.minute()
+    } else {
+      // Non-UTC time zone
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+        shifted => shifted.minute()
+      }
+    }
 }
 
 case class GpuSecond(child: Expression, timeZoneId: Option[String] = None)
@@ -101,7 +108,14 @@ case class GpuSecond(child: Expression, timeZoneId: Option[String] = None)
     copy(timeZoneId = Option(timeZoneId))
 
   override protected def doColumnar(input: GpuColumnVector): ColumnVector =
-    input.getBase.second()
+    if (GpuOverrides.isUTCTimezone(zoneId)) {
+      input.getBase.second()
+    } else {
+      // Non-UTC time zone
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+        shifted => shifted.second()
+      }
+    }
 }
 
 case class GpuHour(child: Expression, timeZoneId: Option[String] = None)
@@ -111,7 +125,14 @@ case class GpuHour(child: Expression, timeZoneId: Option[String] = None)
     copy(timeZoneId = Option(timeZoneId))
 
   override protected def doColumnar(input: GpuColumnVector): ColumnVector =
-    input.getBase.hour()
+    if (GpuOverrides.isUTCTimezone(zoneId)) {
+      input.getBase.hour()
+    } else {
+      // Non-UTC time zone
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+        shifted => shifted.hour()
+      }
+    }
 }
 
 case class GpuYear(child: Expression) extends GpuDateUnaryExpression {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -95,7 +95,7 @@ case class GpuMinute(child: Expression, timeZoneId: Option[String] = None)
       input.getBase.minute()
     } else {
       // Non-UTC time zone
-      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId)) {
         shifted => shifted.minute()
       }
     }
@@ -112,7 +112,7 @@ case class GpuSecond(child: Expression, timeZoneId: Option[String] = None)
       input.getBase.second()
     } else {
       // Non-UTC time zone
-      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId)) {
         shifted => shifted.second()
       }
     }
@@ -129,7 +129,7 @@ case class GpuHour(child: Expression, timeZoneId: Option[String] = None)
       input.getBase.hour()
     } else {
       // Non-UTC time zone
-      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId.normalized())) {
+      withResource(GpuTimeZoneDB.fromUtcTimestampToTimestamp(input.getBase, zoneId)) {
         shifted => shifted.hour()
       }
     }


### PR DESCRIPTION
This PR supports `hour` `minute` and `second` for non-UTC time zone.

Closes #6834 
Closes #6842

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
