### PR TITLE
Fixed Failing ToPrettyStringSuite Test for 3.5.0

### DIFF
--- a/tests/src/test/spark341db/scala/com/nvidia/spark/rapids/ToPrettyStringSuite.scala
+++ b/tests/src/test/spark341db/scala/com/nvidia/spark/rapids/ToPrettyStringSuite.scala
@@ -24,7 +24,6 @@ import ai.rapids.cudf.ColumnVector
 import com.nvidia.spark.rapids.Arm._
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.shims.GpuToPrettyString
-import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, NamedExpression, ToPrettyString}
 import org.apache.spark.sql.types.{ArrayType, DataType, DataTypes, DecimalType, MapType, StructField, StructType}
@@ -78,15 +77,11 @@ class ToPrettyStringSuite extends GpuUnitTests {
   }
 
   test("test show() on floats") {
-    // This test is expected to fail until https://github.com/NVIDIA/spark-rapids/issues/4204
-    // is resolved
-    assertThrows[TestFailedException](testDataType(DataTypes.FloatType))
+    testDataType(DataTypes.FloatType)
   }
 
   test("test show() on doubles") {
-    // This test is expected to fail until https://github.com/NVIDIA/spark-rapids/issues/4204
-    // is resolved
-    assertThrows[TestFailedException](testDataType(DataTypes.DoubleType))
+    testDataType(DataTypes.DoubleType)
   }
 
   test("test show() on strings") {


### PR DESCRIPTION
After this [issue](https://github.com/NVIDIA/spark-rapids/issues/4204) was fixed regarding the double-to-string incompatibility, double => string and float => string tests which were expected to throw an exception because the GPU and CPU results did not match started not to throw an Exception which caused the test to fail. 

This PR addresses that issue since now we are compatible with the CPU. 

fixes #10056 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
