### PR TITLE
Fix failed cases for non-utc time zone

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -343,6 +343,24 @@ integration tests. For example:
 $ DATAGEN_SEED=1702166057 SPARK_HOME=~/spark-3.4.0-bin-hadoop3 integration_tests/run_pyspark_from_build.sh
 ```
 
+### Running with non-UTC time zone
+For the new added cases, we should check non-UTC time zone is working, or the non-UTC nightly CIs will fail.
+The non-UTC nightly CIs are verifing all cases with non-UTC time zone.
+But only a small amout of cases are verifing with non-UTC time zone in pre-merge CI due to limited GPU resources.
+When adding cases, should also check non-UTC is working besides the default UTC time zone.
+To run with non-UTC time zone, set TZ environment variable,
+For example:
+```shell
+$ TZ=Iran ./integration_tests/run_pyspark_from_build.sh
+```
+If the new added cases failed with non-UTC, then should allow the operator(does not support non-UTC) fallback,
+For example, add the following annotation to the case:
+```python
+non_utc_allow_for_sequence = ['ProjectExec'] # Update after non-utc time zone is supported for sequence
+@allow_non_gpu(*non_utc_allow_for_sequence)
+test_my_new_added_case_for_sequence_operator()
+```
+
 ### Reviewing integration tests in Spark History Server
 
 If the integration tests are run using [run_pyspark_from_build.sh](run_pyspark_from_build.sh) we have

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -346,13 +346,15 @@ $ DATAGEN_SEED=1702166057 SPARK_HOME=~/spark-3.4.0-bin-hadoop3 integration_tests
 ### Running with non-UTC time zone
 For the new added cases, we should check non-UTC time zone is working, or the non-UTC nightly CIs will fail.
 The non-UTC nightly CIs are verifing all cases with non-UTC time zone.
-But only a small amout of cases are verifing with non-UTC time zone in pre-merge CI due to limited GPU resources.
+But only a small amout of cases are verifing with non-UTC time zone in the pre-merge CI due to limited GPU resources.
 When adding cases, should also check non-UTC is working besides the default UTC time zone.
-To run with non-UTC time zone, set TZ environment variable,
-For example:
+Please test the following time zones:
 ```shell
 $ TZ=Iran ./integration_tests/run_pyspark_from_build.sh
+$ TZ=America/Los_Angeles ./integration_tests/run_pyspark_from_build.sh
 ```
+`Iran` is non-DST(Daylight Savings Time) time zone and `America/Los_Angeles` is DST time zone.
+
 If the new added cases failed with non-UTC, then should allow the operator(does not support non-UTC) fallback,
 For example, add the following annotation to the case:
 ```python


### PR DESCRIPTION
closes #10055

The 2 failed cases were added recently. 
Because premerge does not cover all the cases for non-utc, so it passed in premerge, but failed in nightly CI.
Add `ProjectExec` to `non_utc_allow` to fix.

Signed-off-by: Chong Gao <res_life@163.com>