### PR TITLE
Fix 332db build failure [databricks]

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
@@ -66,7 +66,7 @@ class MockTaskContext(taskAttemptId: Long, partitionId: Int) extends TaskContext
 
   override private[spark] def killTaskIfInterrupted(): Unit = {}
 
-  override private[spark] def getKillReason() = None
+  override def getKillReason() = None
 
   override def taskMemoryManager() = null
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10063

Builds were failing with:

```
[ERROR] /home/ubuntu/spark-rapids/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala:69: 

method getKillReason has weaker access privileges; it should be public

overriding method getKillReason in class TaskContext of type ()Option[String];
```

This PR makes the method public to fix the compilation error.