### PR TITLE
Add a fallback Cloudera Maven repo URL [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -844,7 +844,8 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
-        <cloudera.repo.url>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url>
+        <cloudera.repo.url>https://repository.cloudera.com/artifactory/cloudera-repos</cloudera.repo.url>
+        <cloudera.repo.url.fallback>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url.fallback>
         <bloop.installPhase>install</bloop.installPhase>
         <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <build.info.path>${project.build.outputDirectory}/rapids4spark-version-info.properties</build.info.path>
@@ -1740,6 +1741,16 @@ This will force full Scala code rebuild in downstream modules.
                 <enabled>${cloudera.repo.enabled}</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>cloudera-repo-fallback</id>
+            <url>${cloudera.repo.url.fallback}</url>
+            <releases>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -1752,6 +1763,16 @@ This will force full Scala code rebuild in downstream modules.
         <pluginRepository>
             <id>cloudera-repo</id>
             <url>${cloudera.repo.url}</url>
+            <releases>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>cloudera-repo-fallback</id>
+            <url>${cloudera.repo.url.fallback}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -844,6 +844,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <cloudera.repo.url>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url>
         <bloop.installPhase>install</bloop.installPhase>
         <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <build.info.path>${project.build.outputDirectory}/rapids4spark-version-info.properties</build.info.path>
@@ -1731,7 +1732,7 @@ This will force full Scala code rebuild in downstream modules.
         </repository>
         <repository>
             <id>cloudera-repo</id>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+            <url>${cloudera.repo.url}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>
@@ -1750,7 +1751,7 @@ This will force full Scala code rebuild in downstream modules.
         </pluginRepository>
         <pluginRepository>
             <id>cloudera-repo</id>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+            <url>${cloudera.repo.url}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -844,7 +844,8 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
-        <cloudera.repo.url>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url>
+        <cloudera.repo.url>https://repository.cloudera.com/artifactory/cloudera-repos</cloudera.repo.url>
+        <cloudera.repo.url.fallback>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url.fallback>
         <bloop.installPhase>install</bloop.installPhase>
         <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <build.info.path>${project.build.outputDirectory}/rapids4spark-version-info.properties</build.info.path>
@@ -1740,6 +1741,16 @@ This will force full Scala code rebuild in downstream modules.
                 <enabled>${cloudera.repo.enabled}</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>cloudera-repo-fallback</id>
+            <url>${cloudera.repo.url.fallback}</url>
+            <releases>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -1752,6 +1763,16 @@ This will force full Scala code rebuild in downstream modules.
         <pluginRepository>
             <id>cloudera-repo</id>
             <url>${cloudera.repo.url}</url>
+            <releases>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${cloudera.repo.enabled}</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>cloudera-repo-fallback</id>
+            <url>${cloudera.repo.url.fallback}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -844,6 +844,7 @@
             -Djdk.reflect.useDirectMethodHandle=false
         </extraJavaTestArgs>
         <cloudera.repo.enabled>false</cloudera.repo.enabled>
+        <cloudera.repo.url>https://repository.cloudera.com/repository/cloudera-repos</cloudera.repo.url>
         <bloop.installPhase>install</bloop.installPhase>
         <bloop.configDirectory>${spark.rapids.source.basedir}/.bloop</bloop.configDirectory>
         <build.info.path>${project.build.outputDirectory}/rapids4spark-version-info.properties</build.info.path>
@@ -1731,7 +1732,7 @@ This will force full Scala code rebuild in downstream modules.
         </repository>
         <repository>
             <id>cloudera-repo</id>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+            <url>${cloudera.repo.url}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>
@@ -1750,7 +1751,7 @@ This will force full Scala code rebuild in downstream modules.
         </pluginRepository>
         <pluginRepository>
             <id>cloudera-repo</id>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+            <url>${cloudera.repo.url}</url>
             <releases>
                 <enabled>${cloudera.repo.enabled}</enabled>
             </releases>


### PR DESCRIPTION
Builds against Cloudera artifacts are failing with various with the [documented URL](https://docs.cloudera.com/cdp-private-cloud-base/7.1.9/cds-3/topics/spark-spark-3-maven-repo.html) https://repository.cloudera.com/artifactory/cloudera-repos. 

However, there seems to be another path working https://repository.cloudera.com/repository/cloudera-repos found via a HTTP redirect

Add a secondary URL as a fallback to unblock builds

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
