### PR TITLE
Implement Math.round using floor on GPU

### DIFF
--- a/integration_tests/src/main/python/orc_cast_test.py
+++ b/integration_tests/src/main/python/orc_cast_test.py
@@ -102,8 +102,6 @@ def test_casting_from_float_and_double(spark_tmp_path, to_type):
         lambda spark: spark.read.schema(schema_str).orc(orc_path)
     )
 
-
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/10017')
 @pytest.mark.parametrize('data_gen', [DoubleGen(max_exp=32, special_cases=None),
                                       DoubleGen(max_exp=32, special_cases=[8.88e9, 9.99e10, 1.314e11])])
 @allow_non_gpu(*non_utc_allow_orc_scan)


### PR DESCRIPTION
Spark and libcudf round are more like rould half away from zero

Reimplementing `Math.round(x)` for Orc Timestamp-from-Double conversion using `floor(x+0.5)`

Fixes #10017

Signed-off-by: Gera Shegalov <gera@apache.org>
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
