### PR TITLE
Temporarily fix date format failed cases for non-UTC time zone.

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -458,7 +458,8 @@ def test_date_format_for_date(data_gen, date_format):
         lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)))
 
 @pytest.mark.parametrize('date_format', supported_date_formats, ids=idfn)
-@pytest.mark.parametrize('data_gen', [timestamp_gen], ids=idfn)
+# use 9999-12-30 instead of 9999-12-31 to avoid the issue: https://github.com/NVIDIA/spark-rapids/issues/10083
+@pytest.mark.parametrize('data_gen', [TimestampGen(end=datetime(9999, 12, 30, 23, 59, 59, 999999, tzinfo=timezone.utc))], ids=idfn)
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 def test_date_format_for_time(data_gen, date_format):
     assert_gpu_and_cpu_are_equal_collect(
@@ -519,7 +520,11 @@ def test_date_format_maybe(data_gen, date_format):
         'DateFormatClass')
 
 @pytest.mark.parametrize('date_format', maybe_supported_date_formats, ids=idfn)
-@pytest.mark.parametrize('data_gen', date_n_time_gens, ids=idfn)
+
+@pytest.mark.parametrize('data_gen', [date_gen,
+                                      # use 9999-12-30 instead of 9999-12-31 to avoid the issue: https://github.com/NVIDIA/spark-rapids/issues/10083
+                                      TimestampGen(end=datetime(9999, 12, 30, 23, 59, 59, 999999, tzinfo=timezone.utc))
+                                      ], ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_date_format_maybe_incompat(data_gen, date_format):
     conf = {"spark.rapids.sql.incompatibleDateFormats.enabled": "true"}


### PR DESCRIPTION
Related to https://github.com/NVIDIA/spark-rapids/issues/10083

When time zone is non-UTC, formating timestamp column which contains `9999-12-31` time will do the following:
- step1: rebase from microseconds of `9999-12-31` to the microseconds of `10000-01-01` according to non-UTC tz.
- step2: use cuDF to format `10000` years to get the strings.
In the above step 2, cuDF has limitation, it truncate `10000` to `0000`
Refer to [link](https://github.com/rapidsai/cudf/blob/branch-24.02/cpp/src/strings/convert/convert_datetime.cu#L114), cuDF supports `%Y` has a 4 digits length.
```
specifier_map specifiers = {
    {'Y', 4}, {'y', 2}, {'m', 2}, {'d', 2}, {'H', 2}, {'I', 2}, {'M', 2},
```

```scala
// will truncate `10000` to `0000`
cv.asStrings("%Y-%m-%d")
```

This PR is a workaround to temporarily fix this issue.
After we have a new kernel to handle Java time format, we then revert this PR.

Signed-off-by: Chong Gao <res_life@163.com>
