### PR TITLE
Shim MockTaskContext to fix Spark 3.5.1 build

### DIFF
--- a/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
+++ b/tests/src/test/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.spark.scheduler.TaskLocality
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.util.{AccumulatorV2, TaskCompletionListener, TaskFailureListener}
 
-class MockTaskContext(taskAttemptId: Long, partitionId: Int) extends TaskContext {
+class MockTaskContext(taskAttemptId: Long, partitionId: Int) extends MockTaskContextBase {
 
   val listeners = new ListBuffer[TaskCompletionListener]
 

--- a/tests/src/test/spark311/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContextBase.scala
+++ b/tests/src/test/spark311/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContextBase.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "321db"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "350"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.metrics.source
+
+import org.apache.spark.TaskContext
+
+abstract class MockTaskContextBase extends TaskContext {
+}

--- a/tests/src/test/spark351/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContextBase.scala
+++ b/tests/src/test/spark351/scala/org/apache/spark/sql/rapids/metrics/source/MockTaskContextBase.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "351"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.metrics.source
+
+import org.apache.spark.TaskContext
+
+abstract class MockTaskContextBase extends TaskContext {
+  override def isFailed(): Boolean = false
+}


### PR DESCRIPTION
Fixes #10094.  Spark 3.5.1 incorporates [SPARK-46480](https://issues.apache.org/jira/browse/SPARK-46480) which adds a new `isFailed` method to the abstract TaskContext class.  A new MockTaskContextBase shim is used to override this new method on Spark 3.5.1.