### PR TITLE
Init changelog for v23.12.1 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change log
-Generated on 2023-12-12
+Generated on 2023-12-29
 
 ## Release 23.12
 
@@ -118,6 +118,9 @@ Generated on 2023-12-12
 ### PRs
 |||
 |:---|:---|
+|[#10121](https://github.com/NVIDIA/spark-rapids/pull/10121)|[DOC] update download page for db hot fix  [skip ci]|
+|[#10116](https://github.com/NVIDIA/spark-rapids/pull/10116)|Upgrade to 23.12.1-SNAPSHOT|
+|[#9935](https://github.com/NVIDIA/spark-rapids/pull/9935)|Init 23.12 changelog [skip ci]|
 |[#9943](https://github.com/NVIDIA/spark-rapids/pull/9943)|[DOC] Update docs for 23.12.0 release [skip ci]|
 |[#10014](https://github.com/NVIDIA/spark-rapids/pull/10014)|Add documentation for how to run tests with a fixed datagen seed [skip ci]|
 |[#9954](https://github.com/NVIDIA/spark-rapids/pull/9954)|Update private and JNI version to released 23.12.0|


### PR DESCRIPTION
1, Init changelog with

```
GITHUB_TOKEN=<> scripts/generate-changelog --releases=23.10,23.12
```

2, move 23.08 content to archives folder


Signed-off-by: Tim Liu <timl@nvidia.com>