### PR TITLE
Fix CI: can't find script when there is pushd in script [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -20,6 +20,8 @@ set -ex
 nvidia-smi
 
 . jenkins/version-def.sh
+# if run in jenkins WORKSPACE refers to rapids root path; if not run in jenkins just use current pwd(contains jenkins dirs)
+WORKSPACE=${WORKSPACE:-`pwd`}
 
 ARTF_ROOT="$WORKSPACE/jars"
 MVN_GET_CMD="mvn -Dmaven.wagon.http.retryHandler.count=3 org.apache.maven.plugins:maven-dependency-plugin:2.8:get -B \
@@ -273,7 +275,7 @@ run_pyarrow_tests() {
 
 run_non_utc_time_zone_tests() {
   # select one time zone according to current day of week
-  source "$(dirname "$0")"/test-timezones.sh
+  source "${WORKSPACE}/jenkins/test-timezones.sh"
   time_zones_length=${#time_zones_test_cases[@]}
   # get day of week, Sunday is represented by 0 and Saturday by 6
   current_date=$(date +%w)

--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
closes #10118

pushd will impact $(dirname $0), so first backup the workspace virable.

Signed-off-by: Chong Gao <res_life@163.com>