### PR TITLE
fix test_hash_agg_with_nan_keys floating point sum failure

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -159,7 +159,7 @@ _nan_zero_double_special_cases = [
 
 _grpkey_doubles_with_nan_zero_grouping_keys = [
     ('a', RepeatSeqGen(DoubleGen(nullable=(True, 10.0), special_cases=_nan_zero_double_special_cases), length=50)),
-    ('b', FloatGen(nullable=(True, 10.0))),
+    ('b', IntegerGen(nullable=(True, 10.0))),
     ('c', LongGen())]
 
 # Schema for xfail cases
@@ -1154,7 +1154,6 @@ def test_hash_multiple_filters(data_gen, conf):
         'min(a), max(b) filter (where c > 250) from hash_agg_table group by a',
         conf)
 
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/10026')
 @approximate_float
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grpkey_floats_with_nan_zero_grouping_keys,
@@ -1222,7 +1221,7 @@ def test_hash_agg_with_struct_of_array_fallback(data_gen):
 
 @approximate_float
 @ignore_order
-@pytest.mark.parametrize('data_gen', [ _grpkey_doubles_with_nan_zero_grouping_keys], ids=idfn)
+@pytest.mark.parametrize('data_gen', [ _grpkey_floats_with_nulls_and_nans ], ids=idfn)
 def test_count_distinct_with_nan_floats(data_gen):
     assert_gpu_and_cpu_are_equal_sql(
         lambda spark : gen_df(spark, data_gen, length=1024),


### PR DESCRIPTION
Fixes #10026.

This fixes the failures for `test_hash_agg_with_nan_keys` by changing the test to sum a column of Integers instead of Floats.  The summing of floating point values is not the aim of this unit test.  See [this comment](https://github.com/NVIDIA/spark-rapids/issues/10026#issuecomment-1875479522).

This also changes `test_count_distinct_with_nan_floats` to use `_grpkey_floats_with_nulls_and_nans` instead of `_grpkey_doubles_with_nan_zero_grouping_keys`, because the latter was changed so that the b column is Integers instead of Floats, and this test needs a column of Floats (with nans).

My proposal is to use this pr to fix #10026, and continue investigating the floating point sum differences in #9822.