### PR TITLE
Install procps tools for rocky docker images [skip ci]

### DIFF
--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ ARG URM_URL
 # Install jdk-8, jdk-11, maven, docker image
 RUN yum update -y && \
     yum install epel-release -y && \
-    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect rsync zip unzip
+    yum install -y java-1.8.0-openjdk-devel java-11-openjdk-devel wget expect rsync zip unzip procps
 
 # The plugin: net.alchim31.maven requires a higher mvn version.
 ENV MAVEN_HOME "/usr/local/apache-maven-3.6.3"


### PR DESCRIPTION
To fix issue: https://github.com/NVIDIA/spark-rapids/issues/10154

Install 'procps' to fix 'ps: command not found' in nvidia Rocky9 Docker containers,

when runing integration tests with jenkins/spark-test.sh

'procps' is required for rocky docker containers to run spark standalone cluster, see:

https://github.com/apache/spark/blob/v3.3.2/bin/load-spark-env.sh#L68

Signed-off-by: Tim Liu <timl@nvidia.com>