### PR TITLE
Update string to float compatibility doc[skip ci]

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -722,9 +722,16 @@ This configuration is enabled by default. To disable this operation on the GPU s
 
 ### String to Float
 
-Casting from string to double on the GPU could sometimes return incorrect results if the string 
-contains high precision values. In Apache Spark, the values are rounded to the nearest double, 
-whereas the Rapids accelerator truncates the values directly.
+Casting from string to double on the GPU returns incorrect results when the string represents any 
+number in the following ranges. In both cases the GPU returns `Double.MaxValue`. The default behavior 
+in Apache Spark is to return `+Infinity` and `-Infinity`, respectively.
+
+- `1.7976931348623158E308 <= x < 1.7976931348623159E308`
+- `-1.7976931348623159E308 < x <= -1.7976931348623158E308`
+
+Casting from string to double on the GPU could also sometimes return incorrect results if the string 
+contains high precision values. Apache Spark rounds the values to the nearest double, while the GPU 
+truncates the values directly.
 
 Also, the GPU does not support casting from strings containing hex values to floating-point types.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -722,14 +722,11 @@ This configuration is enabled by default. To disable this operation on the GPU s
 
 ### String to Float
 
-Casting from string to floating-point types on the GPU returns incorrect results when the string
-represents any number in the following ranges. In both cases the GPU returns `Double.MaxValue`. The
-default behavior in Apache Spark is to return `+Infinity` and `-Infinity`, respectively.
+Casting from string to double on the GPU could sometimes return incorrect results if the string 
+contains high precision values. In Apache Spark, the values are rounded to the nearest double, 
+whereas the Rapids accelerator truncates the values directly.
 
-- `1.7976931348623158E308 <= x < 1.7976931348623159E308`
-- `-1.7976931348623159E308 < x <= -1.7976931348623158E308`
-
-Also, the GPU does not support casting from strings containing hex values.
+Also, the GPU does not support casting from strings containing hex values to floating-point types.
 
 This configuration is enabled by default. To disable this operation on the GPU set
 [`spark.rapids.sql.castStringToFloat.enabled`](additional-functionality/advanced_configs.md#sql.castStringToFloat.enabled) to `false`.


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10037

Casting from string to double on the GPU could sometimes return incorrect results if the string contains high precision values. In Apache Spark, the values are rounded to the nearest double, whereas the Rapids accelerator truncates the values directly.

There are some tests in the issue. It looks like not an easy fix, so I think we can update the compatibility doc first.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
