### PR TITLE
Prevent a degenerative join in test_dpp_reuse_broadcast_exchange [databricks]

### DIFF
--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -347,13 +347,14 @@ class RepeatSeqGen(DataGen):
             self.nullable = nullable
             assert (length is None or length < len(child))
             self._length = length if length is not None else len(child)
+            self._child = child[:length] if length is not None else child
         else:
             super().__init__(child.data_type, nullable=False)
             self.nullable = child.nullable
             assert(data_type is None or data_type != child.data_type)
             assert(length is not None)
             self._length = length
-        self._child = child
+            self._child = child
         self._vals = []
         self._index = 0
 

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -335,16 +335,14 @@ class RepeatSeqGen(DataGen):
     When child is a list:
         data_type must be specified
         length must be <= length of child
-        nullable is honored
     When child is a DataGen:
         length must be specified
         data_type must be None or match child's
-        nullable is set child's nullable attribute
     """
-    def __init__(self, child, length=None, data_type=None, nullable=False):
+    def __init__(self, child, length=None, data_type=None):
         if isinstance(child, list):
             super().__init__(data_type, nullable=False)
-            self.nullable = nullable
+            self.nullable = None in child
             assert (length is None or length < len(child))
             self._length = length if length is not None else len(child)
             self._child = child[:length] if length is not None else child

--- a/integration_tests/src/main/python/data_gen.py
+++ b/integration_tests/src/main/python/data_gen.py
@@ -329,15 +329,28 @@ class UniqueLongGen(DataGen):
         self._start(rand, lambda: self.next_val())
 
 class RepeatSeqGen(DataGen):
-    """Generate Repeated seq of `length` random items"""
+    """Generate Repeated seq of `length` random items if child is a DataGen,
+    otherwise repeat the provided seq when child is a list.
+
+    When child is a list:
+        data_type must be specified
+        length must be <= length of child
+        nullable is honored
+    When child is a DataGen:
+        length must be specified
+        data_type must be None or match child's
+        nullable is set child's nullable attribute
+    """
     def __init__(self, child, length=None, data_type=None, nullable=False):
         if isinstance(child, list):
             super().__init__(data_type, nullable=False)
             self.nullable = nullable
-            self._length = len(child)
+            assert (length is None or length < len(child))
+            self._length = length if length is not None else len(child)
         else:
             super().__init__(child.data_type, nullable=False)
             self.nullable = child.nullable
+            assert(data_type is None or data_type != child.data_type)
             assert(length is not None)
             self._length = length
         self._child = child

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -20,9 +20,9 @@ from data_gen import *
 from marks import ignore_order, allow_non_gpu
 from spark_session import is_before_spark_320, with_cpu_session, is_before_spark_312, is_databricks_runtime, is_databricks113_or_later
 
-# non-positive values here can produce a degenerative join, so we want a filter value associated
-# with only positive values. See https://github.com/NVIDIA/spark-rapids/issues/10147
-value_gen = RepeatSeqGen(int_gen, length=100) 
+# non-positive values here can produce a degenerative join, so here we ensure that most values are
+# positive to ensure the join will produce rows. See https://github.com/NVIDIA/spark-rapids/issues/10147
+value_gen = RepeatSeqGen(IntegerGen(nullable=True, min_val=1, max_val=100, special_cases=[0,-1]), length=100)
 
 def create_dim_table(table_name, table_format, length=500):
     def fn(spark):

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -27,7 +27,9 @@ def create_dim_table(table_name, table_format, length=500):
             ('key', IntegerGen(nullable=False, min_val=0, max_val=9, special_cases=[])),
             ('skey', IntegerGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
             ('ex_key', IntegerGen(nullable=False, min_val=0, max_val=3, special_cases=[])),
-            ('value', int_gen),
+            # non-positive values here can produce a degenerative join, so we want a filter value associated
+            # with only positive values. See https://github.com/NVIDIA/spark-rapids/issues/10147
+            ('value', IntegerGen(min_val=1, special_cases=[1, INT_MAX])),
             # specify nullable=False for `filter` to avoid generating invalid SQL with
             # expression `filter = None` (https://github.com/NVIDIA/spark-rapids/issues/9817)
             ('filter', RepeatSeqGen(

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ from data_gen import *
 from marks import ignore_order, allow_non_gpu
 from spark_session import is_before_spark_320, with_cpu_session, is_before_spark_312, is_databricks_runtime, is_databricks113_or_later
 
+# non-positive values here can produce a degenerative join, so we want a filter value associated
+# with only positive values. See https://github.com/NVIDIA/spark-rapids/issues/10147
+value_gen = RepeatSeqGen(int_gen, length=100) 
 
 def create_dim_table(table_name, table_format, length=500):
     def fn(spark):
@@ -27,9 +30,7 @@ def create_dim_table(table_name, table_format, length=500):
             ('key', IntegerGen(nullable=False, min_val=0, max_val=9, special_cases=[])),
             ('skey', IntegerGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
             ('ex_key', IntegerGen(nullable=False, min_val=0, max_val=3, special_cases=[])),
-            # non-positive values here can produce a degenerative join, so we want a filter value associated
-            # with only positive values. See https://github.com/NVIDIA/spark-rapids/issues/10147
-            ('value', IntegerGen(min_val=1, special_cases=[1, INT_MAX])),
+            ('value', value_gen),
             # specify nullable=False for `filter` to avoid generating invalid SQL with
             # expression `filter = None` (https://github.com/NVIDIA/spark-rapids/issues/9817)
             ('filter', RepeatSeqGen(
@@ -51,7 +52,7 @@ def create_fact_table(table_name, table_format, length=2000):
             ('skey', IntegerGen(nullable=False, min_val=0, max_val=4, special_cases=[])),
             # ex_key is not a partition column
             ('ex_key', IntegerGen(nullable=False, min_val=0, max_val=3, special_cases=[])),
-            ('value', int_gen)], length)
+            ('value', value_gen)], length)
         df.write.format(table_format) \
             .mode("overwrite") \
             .partitionBy('key', 'skey') \

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+from pyspark.sql.types import IntegerType
+
 from asserts import assert_cpu_and_gpu_are_equal_collect_with_capture, assert_gpu_and_cpu_are_equal_collect
 from conftest import spark_tmp_table_factory
 from data_gen import *
@@ -22,7 +24,7 @@ from spark_session import is_before_spark_320, with_cpu_session, is_before_spark
 
 # non-positive values here can produce a degenerative join, so here we ensure that most values are
 # positive to ensure the join will produce rows. See https://github.com/NVIDIA/spark-rapids/issues/10147
-value_gen = RepeatSeqGen(IntegerGen(nullable=True, min_val=1, max_val=100, special_cases=[0,-1]), length=100)
+value_gen = RepeatSeqGen([None, INT_MIN, -1, 0, 1, INT_MAX], data_type=IntegerType(), nullable=True)
 
 def create_dim_table(table_name, table_format, length=500):
     def fn(spark):

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -24,7 +24,7 @@ from spark_session import is_before_spark_320, with_cpu_session, is_before_spark
 
 # non-positive values here can produce a degenerative join, so here we ensure that most values are
 # positive to ensure the join will produce rows. See https://github.com/NVIDIA/spark-rapids/issues/10147
-value_gen = RepeatSeqGen([None, INT_MIN, -1, 0, 1, INT_MAX], data_type=IntegerType(), nullable=False)
+value_gen = RepeatSeqGen([None, INT_MIN, -1, 0, 1, INT_MAX], data_type=IntegerType())
 
 def create_dim_table(table_name, table_format, length=500):
     def fn(spark):

--- a/integration_tests/src/main/python/dpp_test.py
+++ b/integration_tests/src/main/python/dpp_test.py
@@ -24,7 +24,7 @@ from spark_session import is_before_spark_320, with_cpu_session, is_before_spark
 
 # non-positive values here can produce a degenerative join, so here we ensure that most values are
 # positive to ensure the join will produce rows. See https://github.com/NVIDIA/spark-rapids/issues/10147
-value_gen = RepeatSeqGen([None, INT_MIN, -1, 0, 1, INT_MAX], data_type=IntegerType(), nullable=True)
+value_gen = RepeatSeqGen([None, INT_MIN, -1, 0, 1, INT_MAX], data_type=IntegerType(), nullable=False)
 
 def create_dim_table(table_name, table_format, length=500):
     def fn(spark):


### PR DESCRIPTION
Fixes #10147

This ensures that dim table here produces only positive values in the `value` column, so that the filter included in the join does not result in a degenerative join.  There is an existing `test_dpp_empty_relation` which should be testing the scenario that involves DPP+AQE with empty relations from degenerative joins. 


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
