### PR TITLE
Fix format_number NaN symbol in high jdk version

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2298,9 +2298,9 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     x.dataType match {
       case FloatType | DoubleType => {
         val nanSymbol = DecimalFormatSymbols.getInstance(Locale.US).getNaN
-        // JDK 8's nan symbol is "�", which is also the jni kernel's nan symbol
+        // JDK 8's nan symbol is "�" ('\uFFFD'), which is also the jni kernel's nan symbol
         // In higher JDK version, nan symbol is "NaN", so we need to handle it here.
-        if (nanSymbol == "�") {
+        if (nanSymbol == String.valueOf('\uFFFD')) {
           CastStrings.fromFloatWithFormat(lhs.getBase, d)
         } else {
           withResource(Scalar.fromString(nanSymbol)) { nan =>

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package org.apache.spark.sql.rapids
 
 import java.nio.charset.Charset
-import java.util.Optional
+import java.text.DecimalFormatSymbols
+import java.util.{Locale, Optional}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -2296,7 +2297,20 @@ case class GpuFormatNumber(x: Expression, d: Expression)
     val d = rhs.getValue.asInstanceOf[Int]
     x.dataType match {
       case FloatType | DoubleType => {
-        CastStrings.fromFloatWithFormat(lhs.getBase, d)
+        val nanSymbol = DecimalFormatSymbols.getInstance(Locale.US).getNaN
+        // JDK 8's nan symbol is "�", which is also the jni kernel's nan symbol
+        // In higher JDK version, nan symbol is "NaN", so we need to handle it here.
+        if (nanSymbol == "�") {
+          CastStrings.fromFloatWithFormat(lhs.getBase, d)
+        } else {
+          withResource(Scalar.fromString(nanSymbol)) { nan =>
+            withResource(lhs.getBase.isNan) { isNan =>
+              withResource(CastStrings.fromFloatWithFormat(lhs.getBase, d)) { res =>
+                isNan.ifElse(nan, res)
+              }
+            }
+          }
+        }
       }
       case _ => {
         formatNumberNonKernel(lhs.getBase, d) 


### PR DESCRIPTION
Fix https://github.com/NVIDIA/spark-rapids/issues/10175

In format_number, the symbol representing NaN is from `DecimalFormatSymbols.getInstance(Locale.US).getNaN` in Spark, but is hardcoded in the kernel in the plugin. So it will mismatch for NaN in different JDK versions.

This PR will check the NaN symbol when running format_number, if it is different from the one we use in the kernel, then find the NaNs in the results and replace them with the correct symbol. 

Tested locally with jdk 11 and verified that the code doesn't go into the replace nan branch under jdk 8.

perf test results:

| Data Type | jdk 11 GPU Time (ms) | jdk 8 GPU Time (ms) | jdk 11 CPU Time (ms) | jdk 11 Speed up |
|-|-|-|-|-|
| double | 633 | 321 | 10641 | 16.81x |
| float | 247 | 230 | 4602 |  18.63x |

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
