### PR TITLE
Mark hash reduction decimal overflow test as a permanent seed override

### DIFF
--- a/integration_tests/src/main/python/hash_aggregate_test.py
+++ b/integration_tests/src/main/python/hash_aggregate_test.py
@@ -396,7 +396,7 @@ def test_hash_reduction_sum(data_gen, conf):
 @pytest.mark.parametrize('data_gen', numeric_gens + decimal_gens + [
     DecimalGen(precision=38, scale=0), DecimalGen(precision=38, scale=-10)], ids=idfn)
 @pytest.mark.parametrize('conf', get_params(_confs, params_markers_for_confs), ids=idfn)
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/9779')
+@datagen_overrides(seed=0, permanent=True, reason='https://github.com/NVIDIA/spark-rapids/issues/9779')
 def test_hash_reduction_sum_full_decimal(data_gen, conf):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, data_gen, length=100).selectExpr("SUM(a)"),


### PR DESCRIPTION
Closes #9779.

Per the documentation on decimal support in the compatibility guide, the RAPIDS Accelerator will not always match decimal overflow detection semantics with Apache Spark (and Spark itself uses different approaches even on the CPU).  This marks the datagen seed override as permanent, as we will not always detect overflows for all combinations of inputs in the same way the CPU does.