### PR TITLE
Fix build regression against Spark 3.2.x [databricks]

### DIFF
--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -47,7 +47,7 @@ object GpuJsonToStructsShim {
   }
 
   def castJsonStringToDate(input: ColumnVector, options: Map[String, String]): ColumnVector = {
-    // dateFormat is ignored in from_json in Spark 3.2
+    // dateFormat is ignored in from_json in Spark 3.2.x and 3.3.x
     withResource(Scalar.fromString(" ")) { space =>
       withResource(input.strip(space)) { trimmed =>
         GpuCast.castStringToDate(trimmed)
@@ -56,8 +56,6 @@ object GpuJsonToStructsShim {
   }
 
   def tagDateFormatSupportFromScan(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
-    // dateFormat is ignored by JsonToStructs in Spark 3.2.x and 3.3.x because it just
-    // performs a regular cast from string to date
   }
 
   def castJsonStringToDateFromScan(input: ColumnVector, dt: DType,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -56,6 +56,8 @@ object GpuJsonToStructsShim {
   }
 
   def tagDateFormatSupportFromScan(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
+    // dateFormat is ignored by JsonToStructs in Spark 3.2.x and 3.3.x because it just
+    // performs a regular cast from string to date
   }
 
   def castJsonStringToDateFromScan(input: ColumnVector, dt: DType,
@@ -82,7 +84,8 @@ object GpuJsonToStructsShim {
 
   def tagTimestampFormatSupport(meta: RapidsMeta[_, _, _],
       timestampFormat: Option[String]): Unit = {
-    // timestampFormat is ignored
+    // timestampFormat is ignored by JsonToStructs in Spark 3.2.x and 3.3.x because it just
+    // performs a regular cast from string to timestamp
   }
 
   def castJsonStringToTimestamp(input: ColumnVector,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -82,8 +82,7 @@ object GpuJsonToStructsShim {
 
   def tagTimestampFormatSupport(meta: RapidsMeta[_, _, _],
       timestampFormat: Option[String]): Unit = {
-    // we only support the case where no format is specified
-    timestampFormat.foreach(f => meta.willNotWorkOnGpu(s"Unsupported timestampFormat: $f"))
+    // timestampFormat is ignored
   }
 
   def castJsonStringToTimestamp(input: ColumnVector,


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10174

The reason this code was failing against 3.2 and not against 3.3 is that 3.2 will populate `timestampFormat` with a default if none is supplied, whereas 3.3 does not.

Integration tests passed locally for me with this change against both 3.2.3 and 3.3.2