### PR TITLE
test needs marks for non-UTC and for non_supported timezones

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -1685,6 +1685,8 @@ def test_window_first_last_nth_ignore_nulls(data_gen):
         'FROM window_agg_table')
 
 
+@tz_sensitive_test
+@allow_non_gpu(*non_supported_tz_allow)
 @ignore_order(local=True)
 def test_to_date_with_window_functions():
     """


### PR DESCRIPTION
closes #10186

Add fallback mark when TZ is DST time zone(like America/New_York).
Currently do not support DST time zone.

Signed-off-by: Chong Gao <res_life@163.com>
