### PR TITLE
Deploy release candidates to local maven repo for dependency check[skip ci]

### DIFF
--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Argument(s):
+#   ARTIFACT_FILE :  Artifact(groupId:artifactId:version:[[packaging]:classifier]) list file
+#
+# Used environment(s):
+#   SERVER_ID:      The repository id for this deployment.
+#   SERVER_URL:     The url where to deploy artifacts.
+#   M2_CACHE:       Maven local repo
+###
+
+set -ex
+
+ARTIFACT_FILE=${1:-"/tmp/artifacts-list"}
+SERVER_ID=${SERVER_ID:-"snapshots"}
+SERVER_URL=${SERVER_URL:-"file:/tmp/local-release-repo"}
+M2_CACHE=${M2_CACHE:-"/tmp/m2-cache"}
+
+remote_maven_repo=$SERVER_ID::default::$SERVER_URL
+# Get the spark-rapids-jni and spark-rapids-private jars from OSS Snapshot maven repo
+if [ "$SERVER_ID" == "snapshots" ]; then
+    oss_snapshot_url="https://oss.sonatype.org/content/repositories/snapshots"
+    remote_maven_repo="$remote_maven_repo,$SERVER_ID::default::$oss_snapshot_url"
+fi
+while read line; do
+    artifact=$line # artifact=groupId:artifactId:version:[[packaging]:classifier]
+    mvn dependency:get -DremoteRepositories=$remote_maven_repo -Dmaven.repo.local=$M2_CACHE -Dartifact=$artifact
+done < $ARTIFACT_FILE

--- a/jenkins/dependency-check.sh
+++ b/jenkins/dependency-check.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# This file checks whether all the dependency jar or pom files for the specified
+# artifacts defined in the file "$ARTIFACT_FILE" are available
+# in the "$SERVER_ID::default::$SERVER_URL" maven repo
+
 
 # Argument(s):
 #   ARTIFACT_FILE :  Artifact(groupId:artifactId:version:[[packaging]:classifier]) list file

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -116,7 +116,6 @@ $DEPLOY_CMD -DpomFile=$POM_FILE \
             -Dtypes=$DEPLOY_TYPES \
             -Dclassifiers=$CLASSIFIERS
 
-echo "$ART_GROUP_ID:$ART_ID:$ART_VER:pom" >> $ARTIFACT_FILE
 echo "$ART_GROUP_ID:$ART_ID:$ART_VER:jar" >> $ARTIFACT_FILE
 CLASSLIST="$CLASSIFIERS,sources,javadoc"
 CLASSLIST=(${CLASSLIST//','/' '})

--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -102,14 +102,10 @@ echo "Deploy CMD: $DEPLOY_CMD"
 
 ###### Deploy the parent pom file ######
 $DEPLOY_CMD -Dfile=./pom.xml -DpomFile=./pom.xml
-PARENT_ART_ID=$(mvnEval "./" project.artifactId)
-echo "$ART_GROUP_ID:$PARENT_ART_ID:$ART_VER:pom" >> $ARTIFACT_FILE
 
 ###### Deploy the jdk-profile pom file ######
 JDK_PROFILES=${JDK_PROFILES:-"jdk-profiles"}
 $DEPLOY_CMD -Dfile=$JDK_PROFILES/pom.xml -DpomFile=$JDK_PROFILES/pom.xml
-JDK_PROFILES_ART_ID=$(mvnEval "$JDK_PROFILES" project.artifactId)
-echo "$ART_GROUP_ID:$JDK_PROFILES_ART_ID:$ART_VER:pom" >> $ARTIFACT_FILE
 
 ###### Deploy the artifact jar(s) ######
 $DEPLOY_CMD -DpomFile=$POM_FILE \

--- a/jenkins/spark-nightly-build.sh
+++ b/jenkins/spark-nightly-build.sh
@@ -30,7 +30,7 @@ WORKSPACE=${WORKSPACE:-$(pwd)}
 export M2DIR=${M2DIR:-"$WORKSPACE/.m2"}
 
 ## MVN_OPT : maven options environment, e.g. MVN_OPT='-Dspark-rapids-jni.version=xxx' to specify spark-rapids-jni dependency's version.
-MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT}"
+MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 -DretryFailedDeploymentCount=3 ${MVN_OPT} -Psource-javadoc"
 
 DIST_PL="dist"
 function mvnEval {


### PR DESCRIPTION
Deploy release candidates to local maven repo for dependency check
  
To fix : https://github.com/NVIDIA/spark-rapids/issues/10164

Deploy release candidates to local maven repo leveraging the release deploy script.

Instead of using internal snapshots maven repo(having all the intermediate artifacts),
    we check dependencies for the release candidates using the local maven repo,
    which only contains release candidates.


Signed-off-by: Tim Liu <timl@nvidia.com>

