### PR TITLE
Add spark350emr shim layer [EMR]

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -762,5 +762,22 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.nvidia</groupId>
+                    <artifactId>rapids-4-spark-delta-stub_${scala.binary.version}</artifactId>
+                    <version>${project.version}</version>
+                    <classifier>${spark.version.classifier}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/datagen/src/main/spark320/scala/org/apache/spark/sql/tests/datagen/datagen/DataGenExprBase.scala
+++ b/datagen/src/main/spark320/scala/org/apache/spark/sql/tests/datagen/datagen/DataGenExprBase.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.tests.datagen

--- a/integration_tests/src/main/python/arithmetic_ops_test.py
+++ b/integration_tests/src/main/python/arithmetic_ops_test.py
@@ -160,6 +160,8 @@ def test_subtraction_ansi_no_overflow(data_gen):
     _decimal_gen_38_10,
     _decimal_gen_38_neg10
     ], ids=idfn)
+@pytest.mark.xfail(condition=is_spark_350emr(),
+                   reason='EMR back-ported https://issues.apache.org/jira/browse/SPARK-45786 in spark350emr')
 def test_multiplication(data_gen):
     data_type = data_gen.data_type
     assert_gpu_and_cpu_are_equal_collect(
@@ -203,6 +205,8 @@ def test_multiplication_ansi_overflow():
 @pytest.mark.parametrize('rhs', [byte_gen, short_gen, int_gen, long_gen, DecimalGen(6, 3),
     DecimalGen(10, -2), DecimalGen(15, 3), DecimalGen(30, 12), DecimalGen(3, -3),
     DecimalGen(27, 7), DecimalGen(20, -3)], ids=idfn)
+@pytest.mark.xfail(condition=is_spark_350emr(),
+                   reason='EMR back-ported https://issues.apache.org/jira/browse/SPARK-45786 in spark350emr')
 def test_multiplication_mixed(lhs, rhs):
     assert_gpu_and_cpu_are_equal_collect(
             lambda spark : two_col_df(spark, lhs, rhs).select(

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -241,6 +241,9 @@ def is_spark_332cdh():
 def is_spark_cdh():
     return is_spark_321cdh() or is_spark_330cdh() or is_spark_332cdh()
 
+def is_spark_emr():
+    return is_spark350emr()
+
 def is_spark_350emr():
     return "3.5.0-amzn" in spark_version()
 

--- a/integration_tests/src/main/python/spark_session.py
+++ b/integration_tests/src/main/python/spark_session.py
@@ -241,6 +241,9 @@ def is_spark_332cdh():
 def is_spark_cdh():
     return is_spark_321cdh() or is_spark_330cdh() or is_spark_332cdh()
 
+def is_spark_350emr():
+    return "3.5.0-amzn" in spark_version()
+
 def is_databricks_version_or_later(major, minor):
     spark = get_spark_i_know_what_i_am_doing()
     version = spark.conf.get("spark.databricks.clusterUsageTags.sparkVersion", "0.0")

--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,27 @@
             </modules>
         </profile>
         <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>350emr</buildver>
+                <spark.version>${spark350emr.version}</spark.version>
+                <spark.test.version>${spark350emr.version}</spark.test.version>
+                <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
+                <iceberg.version>${spark330.iceberg.version}</iceberg.version>
+                <slf4j.version>2.0.7</slf4j.version>
+            </properties>
+            <modules>
+                <module>shim-deps/emr</module>
+                <module>delta-lake/delta-stub</module>
+            </modules>
+        </profile>
+        <profile>
             <id>release351</id>
             <activation>
                 <property>
@@ -782,6 +803,7 @@
         <spark332db.version>3.3.2-databricks</spark332db.version>
         <spark341db.version>3.4.1-databricks</spark341db.version>
         <spark350.version>3.5.0</spark350.version>
+        <spark350emr.version>3.5.0-amzn-0</spark350emr.version>
         <spark351.version>3.5.1-SNAPSHOT</spark351.version>
         <mockito.version>3.12.4</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
@@ -791,6 +813,7 @@
         <guava.cdh.version>30.0-jre</guava.cdh.version>
         <arrow.cdh.version>2.0.0</arrow.cdh.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <flatbuffers.java.version>1.11.0</flatbuffers.java.version>
         <hadoop.client.version>3.3.1</hadoop.client.version>
         <iceberg.version>0.13.2</iceberg.version>
@@ -831,7 +854,8 @@
             340,
             341,
             342,
-            350
+            350,
+            350emr
         </noSnapshot.buildvers>
         <snapshot.buildvers>
             351
@@ -933,6 +957,34 @@
                 <artifactId>jucx</artifactId>
                 <version>${ucx.version}</version>
             </dependency>
+            <!-- -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <!-- API bridge between log4j 1 and 2 -->
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- -->
             <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>jul-to-slf4j</artifactId>

--- a/scala2.13/aggregator/pom.xml
+++ b/scala2.13/aggregator/pom.xml
@@ -762,5 +762,22 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.nvidia</groupId>
+                    <artifactId>rapids-4-spark-delta-stub_${scala.binary.version}</artifactId>
+                    <version>${project.version}</version>
+                    <classifier>${spark.version.classifier}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -596,6 +596,27 @@
             </modules>
         </profile>
         <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <properties>
+                <buildver>350emr</buildver>
+                <spark.version>${spark350emr.version}</spark.version>
+                <spark.test.version>${spark350emr.version}</spark.test.version>
+                <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
+                <iceberg.version>${spark330.iceberg.version}</iceberg.version>
+                <slf4j.version>2.0.7</slf4j.version>
+            </properties>
+            <modules>
+                <module>shim-deps/emr</module>
+                <module>delta-lake/delta-stub</module>
+            </modules>
+        </profile>
+        <profile>
             <id>release351</id>
             <activation>
                 <property>
@@ -782,6 +803,7 @@
         <spark332db.version>3.3.2-databricks</spark332db.version>
         <spark341db.version>3.4.1-databricks</spark341db.version>
         <spark350.version>3.5.0</spark350.version>
+        <spark350emr.version>3.5.0-amzn-0</spark350emr.version>
         <spark351.version>3.5.1-SNAPSHOT</spark351.version>
         <mockito.version>3.12.4</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>

--- a/scala2.13/shim-deps/emr/pom.xml
+++ b/scala2.13/shim-deps/emr/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2023, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nvidia</groupId>
+        <artifactId>rapids-4-spark-parent_2.12</artifactId>
+        <version>24.02.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>rapids-4-spark-emr-bom</artifactId>
+    <packaging>pom</packaging>
+    <description>EMR Shim Dependencies</description>
+    <version>24.02.0-SNAPSHOT</version>
+
+    <properties>
+        <rapids.module>../shim-deps/emr</rapids.module>
+    </properties>
+
+    <!--
+        This module is going to be used as a provided dependency.
+        The dependencies below are compile-scope so that they are propagated to dependents as provided.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/scala2.13/shim-deps/pom.xml
+++ b/scala2.13/shim-deps/pom.xml
@@ -176,6 +176,24 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.nvidia</groupId>
+                    <artifactId>rapids-4-spark-emr-bom</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
 
         <profile>
             <id>with-classifier</id>

--- a/shim-deps/emr/pom.xml
+++ b/shim-deps/emr/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2023, NVIDIA CORPORATION.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nvidia</groupId>
+        <artifactId>rapids-4-spark-parent_2.12</artifactId>
+        <version>24.02.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>rapids-4-spark-emr-bom</artifactId>
+    <packaging>pom</packaging>
+    <description>EMR Shim Dependencies</description>
+    <version>24.02.0-SNAPSHOT</version>
+
+    <properties>
+        <rapids.module>../shim-deps/emr</rapids.module>
+    </properties>
+
+    <!--
+       This module is going to be used as a provided dependency.
+       The dependencies below are compile-scope so that they are propagated to dependents as provided.
+   -->
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/shim-deps/pom.xml
+++ b/shim-deps/pom.xml
@@ -176,6 +176,24 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>release350emr</id>
+            <activation>
+                <property>
+                    <name>buildver</name>
+                    <value>350emr</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.nvidia</groupId>
+                    <artifactId>rapids-4-spark-emr-bom</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
 
         <profile>
             <id>with-classifier</id>

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/AQEUtils.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/AggregationTagging.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/AggregationTagging.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/DecimalMultiply128.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/DecimalMultiply128.scala
@@ -38,6 +38,7 @@
 {"spark": "341"}
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/DeltaLakeUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/DeltaLakeUtils.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GetSequenceSize.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GetSequenceSize.scala
@@ -37,6 +37,7 @@
 {"spark": "341"}
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuFileFormatDataWriterShim.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuFileFormatDataWriterShim.scala
@@ -37,6 +37,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuWindowInPandasExec.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ReaderUtils.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ReaderUtils.scala
@@ -36,6 +36,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ShimLeafExecNode.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/ShimLeafExecNode.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/extractValueShims.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/extractValueShims.scala
@@ -36,6 +36,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/rapids/shims/GpuShuffleExchangeExec.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.rapids.shims

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
@@ -14,6 +14,32 @@
  * limitations under the License.
  */
 
+/*** spark-rapids-shim-json-lines
+{"spark": "311"}
+{"spark": "312"}
+{"spark": "313"}
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "321db"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "350"}
+{"spark": "351"}
+spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution
 
 import java.util.concurrent.{Future => JFuture}

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuArrowPythonRunner.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuArrowPythonRunner.scala
@@ -38,6 +38,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuCoGroupedArrowPythonRunner.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuCoGroupedArrowPythonRunner.scala
@@ -38,6 +38,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuGroupedPythonRunnerFactory.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuGroupedPythonRunnerFactory.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims

--- a/sql-plugin/src/main/spark320/java/com/nvidia/spark/rapids/shims/ShimSupportsRuntimeFiltering.java
+++ b/sql-plugin/src/main/spark320/java/com/nvidia/spark/rapids/shims/ShimSupportsRuntimeFiltering.java
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+ {"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims;

--- a/sql-plugin/src/main/spark320/java/com/nvidia/spark/rapids/shims/XxHash64Shims.scala
+++ b/sql-plugin/src/main/spark320/java/com/nvidia/spark/rapids/shims/XxHash64Shims.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/FileSourceScanExecMeta.scala
@@ -32,6 +32,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecBase.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExecBase.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuOrcDataReader.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuOrcDataReader.scala
@@ -32,6 +32,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuOrcDataReaderBase.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuOrcDataReaderBase.scala
@@ -35,6 +35,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuParquetCrypto.scala
@@ -32,6 +32,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/HashUtils.scala
@@ -35,6 +35,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OffsetWindowFunctionMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OffsetWindowFunctionMeta.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OrcCastingShims.scala
@@ -33,6 +33,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OrcShims320untilAllBase.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/OrcShims320untilAllBase.scala
@@ -33,6 +33,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/PlanShimsImpl.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RapidsCsvScanMeta.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RebaseShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/RebaseShims.scala
@@ -35,6 +35,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimAQEShuffleReadExec.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimAQEShuffleReadExec.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimBroadcastExchangeLike.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimBroadcastExchangeLike.scala
@@ -32,6 +32,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimPredicateHelper.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/ShimPredicateHelper.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusNonDBShims.scala
@@ -31,6 +31,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/TreeNode.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/TreeNode.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/TypeSigUtil.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/TypeSigUtil.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/YearParseUtil.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/YearParseUtil.scala
@@ -35,6 +35,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/gpuWindows.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/gpuWindows.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/v1FallbackWriters.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/v1FallbackWriters.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/GpuShuffleBlockResolver.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/GpuShuffleBlockResolver.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/ShuffledBatchRDDUtil.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/storage/ShimDiskBlockManager.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/rapids/shims/storage/ShimDiskBlockManager.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.rapids.shims.storage

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuArrowPythonOutput.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuArrowPythonOutput.scala
@@ -35,6 +35,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/AvroUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/AvroUtils.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedWriter.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedWriter.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/Spark32XShimsUtils.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/Spark32XShimsUtils.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/shims/datetimeExpressions.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/storage/RapidsPushBasedFetchHelper.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.storage

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/storage/RapidsShuffleBlockFetcherIterator.scala
@@ -36,6 +36,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.storage

--- a/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/Spark321PlusShims.scala
+++ b/sql-plugin/src/main/spark321/scala/com/nvidia/spark/rapids/shims/Spark321PlusShims.scala
@@ -35,6 +35,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
+++ b/sql-plugin/src/main/spark321db/scala/org/apache/spark/sql/rapids/shims/GpuAscii.scala
@@ -30,6 +30,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilter.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilter.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuBloomFilterMightContain.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuInSubqueryExec.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/GpuInSubqueryExec.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/AnsiUtil.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/AnsiUtil.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/BloomFilterShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/CharVarcharUtilsShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/DayTimeIntervalShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/DayTimeIntervalShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/DistributionUtil.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/DistributionUtil.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/FilteredPartitions.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/FilteredPartitions.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuDataSourceRDD.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuHashPartitioning.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtilsBase.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtilsBase.scala
@@ -28,6 +28,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuRangePartitioning.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/GpuTypeShims.scala
@@ -28,6 +28,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/InSubqueryShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/InSubqueryShims.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/OrcReadingShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/OrcReadingShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/OrcShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/OrcShims.scala
@@ -26,6 +26,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetFieldIdShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetFieldIdShims.scala
@@ -28,6 +28,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetSchemaClipShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ParquetSchemaClipShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsFileSourceMetaUtils.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsFileSourceMetaUtils.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsOrcScanMeta.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RapidsParquetScanMeta.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RoundingShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/RoundingShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ScanExecShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/ScanExecShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusNonDBShims.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala
+++ b/sql-plugin/src/main/spark330/scala/com/nvidia/spark/rapids/shims/Spark330PlusShims.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/execution/datasources/parquet/ShimCurrentBatchIterator.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/aggregate/GpuBloomFilterAggregate.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.aggregate

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuPythonMapInArrowExec.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/GpuPythonMapInArrowExec.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtilsFor330plus.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/RapidsShuffleThreadedReader.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/rapids/shims/intervalExpressions.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/types/shims/PartitionValueCastShims.scala
+++ b/sql-plugin/src/main/spark330/scala/org/apache/spark/sql/types/shims/PartitionValueCastShims.scala
@@ -29,6 +29,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.types.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/AnsiCastShim.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/AnsiCastShim.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/CastingConfigShim.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ColumnDefaultValuesShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/DecimalArithmeticOverrides.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GetMapValueMeta.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuCastShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/GpuCastShims.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ParquetStringPredShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ParquetStringPredShims.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ShimFilePartitionReaderFactory.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/ShimFilePartitionReaderFactory.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/TypeUtilsShims.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/rapids/DataSourceStrategyUtils.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/execution/datasources/rapids/DataSourceStrategyUtils.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.rapids

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/GpuCheckOverflowInTableInsert.scala
@@ -27,6 +27,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/aggregate/aggregateFunctions.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.aggregate

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/sql-plugin/src/main/spark331/scala/com/nvidia/spark/rapids/shims/Spark331PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark331/scala/com/nvidia/spark/rapids/shims/Spark331PlusNonDBShims.scala
@@ -24,6 +24,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/CreateDataSourceTableAsSelectCommandMetaShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/CreateDataSourceTableAsSelectCommandMetaShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/FileIndexOptionsShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/FileIndexOptionsShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuInsertIntoHiveTable.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuInsertIntoHiveTable.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuKnownNullable.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuOptimizedCreateHiveTableAsSelectCommandShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuOptimizedCreateHiveTableAsSelectCommandShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/execution/datasources/GpuWriteFiles.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/GpuRowBasedHiveGenericUDFShim.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/GpuRowBasedHiveGenericUDFShim.scala
@@ -18,6 +18,7 @@
 {"spark": "332db"}
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/HiveFileUtil.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/HiveFileUtil.scala
@@ -22,6 +22,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/HiveProviderCmdShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/hive/rapids/shims/HiveProviderCmdShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuDataSource.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuDataSource.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SchemaUtilsShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SchemaUtilsShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SparkDateTimeExceptionShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SparkDateTimeExceptionShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SparkUpgradeExceptionShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/SparkUpgradeExceptionShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/CastCheckShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/CastCheckShims.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GlobalLimitShims.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuBatchScanExec.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuBroadcastJoinMeta.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuBroadcastJoinMeta.scala
@@ -18,6 +18,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -19,6 +19,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/OrcProtoWriterShim.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/OrcProtoWriterShim.scala
@@ -21,6 +21,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetLegacyNanoAsLongShims.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetTimestampAnnotationShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetTimestampAnnotationShims.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetTimestampNTZShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ParquetTimestampNTZShims.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/PartitionedFileUtilsShim.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/PartitionedFileUtilsShim.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ShuffleOriginUtil.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/ShuffleOriginUtil.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusNonDBShims.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/TagScanForRuntimeFiltering.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/TagScanForRuntimeFiltering.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleIterator.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shuffle

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/catalyst/csv/GpuCsvUtils.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/catalyst/csv/GpuCsvUtils.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.catalyst.csv

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/catalyst/json/GpuJsonUtils.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/catalyst/json/GpuJsonUtils.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.catalyst.json

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/RapidsCachingReader.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastHashJoinExec.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/ShimTrampolineUtil.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/ShimTrampolineUtil.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/shims/RapidsErrorUtils.scala
@@ -19,6 +19,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuAggregateInPandasExecMeta.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuAggregateInPandasExecMeta.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuToPrettyString.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/GpuToPrettyString.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/PythonUDFShim.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/PythonUDFShim.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/execution/rapids/shims/SplitFiles.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/execution/rapids/shims/SplitFiles.scala
@@ -18,6 +18,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/CreateFunctions.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/CreateFunctions.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/FileSinkDescShim.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/FileSinkDescShim.scala
@@ -18,6 +18,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/HiveInspectorsShim.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/hive/rapids/shims/HiveInspectorsShim.scala
@@ -18,6 +18,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.hive.rapids.shims

--- a/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuBasePythonRunner.scala
+++ b/sql-plugin/src/main/spark341db/scala/org/apache/spark/sql/rapids/execution/python/shims/GpuBasePythonRunner.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution.python.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/BatchScanExecMeta.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/BatchScanExecMeta.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/GpuIntervalUtils.scala
@@ -15,6 +15,7 @@
  */
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/KeyGroupedPartitioningShim.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/KeyGroupedPartitioningShim.scala
@@ -15,6 +15,7 @@
  */
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/LegacyBehaviorPolicyShim.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/NullOutputStreamShim.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/NullOutputStreamShim.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/PythonMapInArrowExecShims.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
+++ b/sql-plugin/src/main/spark350/scala/com/nvidia/spark/rapids/shims/SparkShims.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ParquetCVShims.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/shims/ShimVectorizedColumnReader.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.parquet.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicCreateTableAsSelectExec.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2.rapids

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicReplaceTableAsSelectExec.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/datasources/v2/rapids/GpuAtomicReplaceTableAsSelectExec.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.datasources.v2.rapids

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/execution/rapids/shims/FilePartitionShims.scala
@@ -17,6 +17,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.execution.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/execution/GpuShuffleMeta.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/execution/GpuShuffleMeta.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.execution

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/ArrowUtilsShim.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/DataTypeUtilsShim.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/shims/DataTypeUtilsShim.scala
@@ -16,6 +16,7 @@
 
 /*** spark-rapids-shim-json-lines
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids.shims

--- a/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/GpuOutputAdapterExec.scala
+++ b/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/GpuOutputAdapterExec.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350emr"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.shims.ShimUnaryExecNode
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.exchange.BaseOutputAdapterExec
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Trivial GPU implementation of Spark's [[OutputAdapterExec]] to extend [[GpuExec]]
+ */
+case class GpuOutputAdapterExec(
+    override val output: Seq[Attribute],
+    override val child: SparkPlan) extends ShimUnaryExecNode
+    with BaseOutputAdapterExec with GpuExec {
+
+  // The adapter effectively produces new attributes that are not found in input attributes
+  override def producedAttributes: AttributeSet = outputSet -- inputSet
+
+  override def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  override def doCanonicalize(): SparkPlan = child.canonicalized
+
+  override def outputBatching: CoalesceGoal = GpuExec.outputBatching(child)
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
+    throw new IllegalStateException(s"Internal Error ${this.getClass} has column support" +
+      s" mismatch:\n$this")
+  }
+}

--- a/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/shims/spark350emr/SparkShimServiceProvider.scala
+++ b/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/shims/spark350emr/SparkShimServiceProvider.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350emr"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.shims.spark350emr
+
+import com.nvidia.spark.rapids.SparkShimVersion
+
+object SparkShimServiceProvider {
+  val VERSION = SparkShimVersion(3, 5, 0)
+  val VERSIONNAMES = Seq(s"$VERSION")
+}
+
+class SparkShimServiceProvider extends com.nvidia.spark.rapids.SparkShimServiceProvider {
+
+  override def getShimVersion: SparkShimVersion = SparkShimServiceProvider.VERSION
+
+  override def matchesVersion(version: String): Boolean = {
+    val shortenedVersion = if (version != null) version.split("-")(0) else null
+    SparkShimServiceProvider.VERSIONNAMES.contains(shortenedVersion)
+  }
+}

--- a/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/spark350/RapidsShuffleManager.scala
+++ b/sql-plugin/src/main/spark350emr/scala/com/nvidia/spark/rapids/spark350/RapidsShuffleManager.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350emr"}
+spark-rapids-shim-json-lines ***/
+package com.nvidia.spark.rapids.spark350emr
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.rapids.ProxyRapidsShuffleInternalManagerBase
+
+/** A shuffle manager optimized for the RAPIDS Plugin for Apache Spark. */
+sealed class RapidsShuffleManager(
+    conf: SparkConf,
+    isDriver: Boolean
+) extends ProxyRapidsShuffleInternalManagerBase(conf, isDriver)

--- a/sql-plugin/src/main/spark350emr/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
+++ b/sql-plugin/src/main/spark350emr/scala/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExec.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350emr"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.execution
+
+import scala.collection.JavaConverters.asScalaIteratorConverter
+
+import com.nvidia.spark.rapids.{BaseExprMeta, DataFromReplacementRule, GpuColumnarToRowExec, GpuExec, GpuMetric, GpuOutputAdapterExec, RapidsConf, RapidsMeta, SparkPlanMeta, TargetSize}
+import com.nvidia.spark.rapids.Arm.withResource
+import com.nvidia.spark.rapids.GpuMetric.{COLLECT_TIME, DESCRIPTION_COLLECT_TIME, ESSENTIAL_LEVEL}
+import com.nvidia.spark.rapids.shims.{ShimUnaryExecNode, SparkShimImpl}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Cast, Expression, NamedExpression, UnsafeProjection}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastMode, IdentityBroadcastMode}
+import org.apache.spark.sql.execution.{AsyncSubqueryExec, OutputAdapterExec, SparkPlan, SubqueryBroadcastExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
+import org.apache.spark.sql.execution.joins.{HashedRelationBroadcastMode, HashJoin}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+
+class GpuSubqueryBroadcastMeta(
+    s: SubqueryBroadcastExec,
+    conf: RapidsConf,
+    p: Option[RapidsMeta[_, _, _]],
+    r: DataFromReplacementRule) extends
+    SparkPlanMeta[SubqueryBroadcastExec](s, conf, p, r) {
+
+  private var broadcastBuilder: () => SparkPlan = _
+
+  override val childExprs: Seq[BaseExprMeta[_]] = Nil
+
+  override val childPlans: Seq[SparkPlanMeta[SparkPlan]] = Nil
+
+  override def tagPlanForGpu(): Unit = s.child match {
+
+    // For AQE off:
+    //
+    // The rule PlanDynamicPruningFilters will insert SubqueryBroadcast if there exists
+    // available broadcast exchange for reuse. The plan stack of SubqueryBroadcast:
+    //
+    // +- SubqueryBroadcast
+    //    +- BroadcastExchange (can be reused)
+    //       +- [executed subquery...]
+    //
+    // Since the GPU overrides rule has been applied on executedSubQuery, if the
+    // executedSubQuery can be replaced by GPU overrides, the plan stack becomes:
+    //
+    // +- SubqueryBroadcast
+    //    +- BroadcastExchange
+    //       +- GpuColumnarToRow
+    //          +- [GPU overrides of executed subquery...]
+    //
+    // To reuse BroadcastExchange on the GPU, we shall transform above pattern into:
+    //
+    // +- GpuSubqueryBroadcast
+    //    +- GpuBroadcastExchange (can be reused)
+    //       +- [GPU overrides of executed subquery...]
+    //
+    case ex @ BroadcastExchangeExec(_, c2r: GpuColumnarToRowExec) =>
+      val exMeta = new GpuBroadcastMeta(ex.copy(child = c2r.child), conf, p, r)
+      exMeta.tagForGpu()
+      if (exMeta.canThisBeReplaced) {
+        broadcastBuilder = () => exMeta.convertToGpu()
+      } else {
+        willNotWorkOnGpu("underlying BroadcastExchange can not run in the GPU.")
+      }
+
+    // For AQE on:
+    //
+    // In Spark 320+, DPP can cooperate with AQE. The insertion of SubqueryBroadcast is
+    // similar with non-AQE circumstance. During the creation of AdaptiveSparkPlan, the
+    // rule PlanAdaptiveSubqueries insert an intermediate plan SubqueryAdaptiveBroadcast to
+    // preserve the initial physical plan of DPP subquery filters. During the optimization,
+    // the rule PlanAdaptiveDynamicPruningFilters inserts the SubqueryBroadcast as the parent
+    // of adaptive subqueries:
+    //
+    // +- SubqueryBroadcast
+    //    +- AdaptiveSparkPlan (supportColumnar=false)
+    //    +- == Initial Plan ==
+    //       BroadcastExchange
+    //       +- [executed subquery...]
+    //
+    // Since AdaptiveSparkPlan can be explicitly set as a columnar plan from Spark 320+,
+    // we can simply build GpuSubqueryBroadcast on the base of columnar adaptive plans
+    // whose root plan are GpuBroadcastExchange:
+    //
+    // +- GpuSubqueryBroadcast
+    //    +- AdaptiveSparkPlan (supportColumnar=true)
+    //    +- == Final Plan ==
+    //       BroadcastQueryStage
+    //       +- GpuBroadcastExchange (can be reused)
+    //          +- [GPU overrides of executed subquery...]
+    //
+    case a: AdaptiveSparkPlanExec =>
+      tagAdaptivePlanForGpu(a, () =>
+        SparkShimImpl.columnarAdaptivePlan(
+          a, TargetSize(conf.gpuTargetBatchSizeBytes)))
+
+    case outputAdapter: OutputAdapterExec =>
+      outputAdapter.child match {
+        case a: AdaptiveSparkPlanExec =>
+          tagAdaptivePlanForGpu(a, () =>
+            GpuOutputAdapterExec(outputAdapter.output,
+              SparkShimImpl.columnarAdaptivePlan(a,
+                TargetSize(conf.gpuTargetBatchSizeBytes))))
+        case _ =>
+          willNotWorkOnGpu("the subquery to broadcast can not entirely run in the GPU.")
+      }
+
+    case _ =>
+      willNotWorkOnGpu("the subquery to broadcast can not entirely run in the GPU.")
+  }
+
+  def tagAdaptivePlanForGpu(adaptivePlan: AdaptiveSparkPlanExec,
+                            buildBroadcast: () => SparkPlan): Unit = {
+    SparkShimImpl.getAdaptiveInputPlan(adaptivePlan) match {
+      case ex: BroadcastExchangeExec =>
+        val exMeta = new GpuBroadcastMeta(ex, conf, p, r)
+        exMeta.tagForGpu()
+        if (exMeta.canThisBeReplaced) {
+          broadcastBuilder = buildBroadcast
+        } else {
+          willNotWorkOnGpu("underlying BroadcastExchange can not run in the GPU.")
+        }
+      case _ =>
+        throw new AssertionError("should not reach here")
+    }
+  }
+
+  /**
+   * Simply returns the original plan. Because its only child, BroadcastExchange, doesn't
+   * need to change if SubqueryBroadcastExec falls back to the CPU.
+   */
+  override def convertToCpu(): SparkPlan = s
+
+  override def convertToGpu(): GpuExec = {
+    GpuSubqueryBroadcastExec(s.name, s.index, s.buildKeys, broadcastBuilder())(
+      getBroadcastModeKeyExprs)
+  }
+
+  /** Extract the broadcast mode key expressions if there are any. */
+  private def getBroadcastModeKeyExprs: Option[Seq[Expression]] = {
+    val broadcastMode = s.child match {
+      case b: BroadcastExchangeExec =>
+        b.mode
+      case a: AdaptiveSparkPlanExec =>
+        getBroadcastModeFromAdaptivePlan(a)
+      case adapter: OutputAdapterExec =>
+        getBroadcastModeFromOutputAdapter(adapter)
+      case _ =>
+        throw new UnsupportedOperationException("Unknown SparkPlan")
+    }
+
+    broadcastMode match {
+      case HashedRelationBroadcastMode(keys, _) => Some(keys)
+      case IdentityBroadcastMode => None
+      case m => throw new UnsupportedOperationException(s"Unknown broadcast mode $m")
+    }
+  }
+
+  private def getBroadcastModeFromAdaptivePlan(plan: AdaptiveSparkPlanExec): BroadcastMode = {
+    SparkShimImpl.getAdaptiveInputPlan(plan) match {
+      case b: BroadcastExchangeExec =>
+        b.mode
+      case _ =>
+        throw new AssertionError("should not reach here")
+    }
+  }
+
+  private def getBroadcastModeFromOutputAdapter(adapter: OutputAdapterExec): BroadcastMode = {
+    adapter.child match {
+      case a: AdaptiveSparkPlanExec =>
+        getBroadcastModeFromAdaptivePlan(a)
+      case _ =>
+        throw new AssertionError("should not reach here")
+    }
+  }
+}
+
+
+case class GpuSubqueryBroadcastExec(
+    name: String,
+    index: Int,
+    buildKeys: Seq[Expression],
+    child: SparkPlan)(modeKeys: Option[Seq[Expression]])
+    extends AsyncSubqueryExec with GpuExec with ShimUnaryExecNode {
+
+  override def otherCopyArgs: Seq[AnyRef] = modeKeys :: Nil
+
+  // As `SubqueryBroadcastExec`, `GpuSubqueryBroadcastExec` is only used with `InSubqueryExec`.
+  // No one would reference this output, so the exprId doesn't matter here. But it's important to
+  // correctly report the output length, so that `InSubqueryExec` can know it's the single-column
+  // execution mode, not multi-column.
+  override def output: Seq[Attribute] = {
+    val key = buildKeys(index)
+    val name = key match {
+      case n: NamedExpression =>
+        n.name
+      case cast: Cast if cast.child.isInstanceOf[NamedExpression] =>
+        cast.child.asInstanceOf[NamedExpression].name
+      case _ =>
+        "key"
+    }
+    Seq(AttributeReference(name, key.dataType, key.nullable)())
+  }
+
+  override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
+    "dataSize" -> createSizeMetric(ESSENTIAL_LEVEL, "data size"),
+    COLLECT_TIME -> createNanoTimingMetric(ESSENTIAL_LEVEL, DESCRIPTION_COLLECT_TIME))
+
+  override def doCanonicalize(): SparkPlan = {
+    val keys = buildKeys.map(k => QueryPlan.normalizeExpressions(k, child.output))
+    GpuSubqueryBroadcastExec("dpp", index, keys, child.canonicalized)(modeKeys)
+  }
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    throw new UnsupportedOperationException(
+      "GpuSubqueryBroadcastExec does not support the execute() code path.")
+  }
+
+  override protected def doExecuteCollect(): Array[InternalRow] = {
+    val broadcastBatch = child.executeBroadcast[Any]()
+    val result: Array[InternalRow] = broadcastBatch.value match {
+      case b: SerializeConcatHostBuffersDeserializeBatch => projectSerializedBatchToRows(b)
+      case b if SparkShimImpl.isEmptyRelation(b) => Array.empty
+      case b => throw new IllegalStateException(s"Unexpected broadcast type: ${b.getClass}")
+    }
+
+    result
+  }
+
+  override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
+    throw new IllegalStateException(s"Internal Error ${this.getClass} has column support" +
+      s" mismatch:\n$this")
+  }
+
+  private def projectSerializedBatchToRows(
+      serBatch: SerializeConcatHostBuffersDeserializeBatch): Array[InternalRow] = {
+    val beforeCollect = System.nanoTime()
+
+    // Creates projection to extract target field from Row, as what Spark does.
+    // Note that unlike Spark, the GPU broadcast data has not applied the key expressions from
+    // the HashedRelation, so that is applied here if necessary to ensure the proper values
+    // are being extracted. The CPU already has the key projections applied in the broadcast
+    // data and thus does not have similar logic here.
+    val broadcastModeProject = modeKeys.map { keyExprs =>
+      val keyExpr = if (GpuHashJoin.canRewriteAsLongType(buildKeys)) {
+        // in this case, there is only 1 key expression since it's a packed version that encompasses
+        // multiple integral values into a single long using bit logic. In CPU Spark, the broadcast
+        // would create a LongHashedRelation instead of a standard HashedRelation.
+        keyExprs.head
+      } else {
+        keyExprs(index)
+      }
+      UnsafeProjection.create(keyExpr)
+    }
+
+    // Use the single output of the broadcast mode projection if it exists
+    val rowProjectIndex = if (broadcastModeProject.isDefined) 0 else index
+    val rowExpr = if (GpuHashJoin.canRewriteAsLongType(buildKeys)) {
+      // Since this is the expected output for a LongHashedRelation, we can extract the key from the
+      // long packed key using bit logic, using this method available in HashJoin to give us the
+      // correct key expression.
+      HashJoin.extractKeyExprAt(buildKeys, index)
+    } else {
+      BoundReference(rowProjectIndex, buildKeys(index).dataType, buildKeys(index).nullable)
+    }
+    val rowProject = UnsafeProjection.create(rowExpr)
+
+    // Deserializes the batch on the host. Then, transforms it to rows and performs row-wise
+    // projection. We should NOT run any device operation on the driver node.
+    val result = withResource(serBatch.hostBatch) { hostBatch =>
+      hostBatch.rowIterator().asScala.map { row =>
+        val broadcastRow = broadcastModeProject.map(_(row)).getOrElse(row)
+        rowProject(broadcastRow).copy().asInstanceOf[InternalRow]
+      }.toArray // force evaluation so we don't close hostBatch too soon
+    }
+
+    gpuLongMetric("dataSize") += serBatch.dataSize
+    gpuLongMetric(COLLECT_TIME) += System.nanoTime() - beforeCollect
+
+    result
+  }
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/StringFunctionSuite.scala
@@ -272,13 +272,13 @@ class StringOperatorsDiagnostics extends SparkQueryCompareTestSuite {
 
         val codepoint = TestCodepoints.validCodepointIndices(i)
         print(f"(${codepoint.toChar.toString} $codepoint[$codepoint%04x]) ($cpu_str ")
-        print(f"${cpu_str.map(_.toInt.formatted("%d")).mkString(",")}")
+        print(f"${cpu_str.map(c => "%d".format(c.toInt)).mkString(",")}")
         print("[")
-        print(f"${cpu_str.map(_.toInt.formatted("%04x")).mkString(",")}")
+        print(f"${cpu_str.map(c => "%04x".format(c.toInt)).mkString(",")}")
         print(f"]) ($gpu_str ")
-        print(f"${gpu_str.map(_.toInt.formatted("%d")).mkString(",")}")
+        print(f"${gpu_str.map(c => "%d".format(c.toInt)).mkString(",")}")
         print("[");
-        print(f"${gpu_str.map(_.toInt.formatted("%04x")).mkString(",")}")
+        print(f"${gpu_str.map(c => "%04x".format(c.toInt)).mkString(",")}")
         println("])");
       }
     }

--- a/tests/src/test/spark320/scala/com/nvidia/spark/rapids/shims/OrcStatisticShim.scala
+++ b/tests/src/test/spark320/scala/com/nvidia/spark/rapids/shims/OrcStatisticShim.scala
@@ -33,6 +33,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuInSubqueryExecSuite.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/GpuInSubqueryExecSuite.scala
@@ -26,6 +26,7 @@
 {"spark": "341"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package org.apache.spark.sql.rapids

--- a/tests/src/test/spark340/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
+++ b/tests/src/test/spark340/scala/com/nvidia/spark/rapids/shuffle/RapidsShuffleTestHelper.scala
@@ -20,6 +20,7 @@
 {"spark": "341db"}
 {"spark": "342"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shuffle

--- a/tests/src/test/spark341db/scala/com/nvidia/spark/rapids/ToPrettyStringSuite.scala
+++ b/tests/src/test/spark341db/scala/com/nvidia/spark/rapids/ToPrettyStringSuite.scala
@@ -17,6 +17,7 @@
 /*** spark-rapids-shim-json-lines
 {"spark": "341db"}
 {"spark": "350"}
+{"spark": "350emr"}
 {"spark": "351"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids

--- a/tests/src/test/spark350emr/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExecSuite.scala
+++ b/tests/src/test/spark350emr/org/apache/spark/sql/rapids/execution/GpuSubqueryBroadcastExecSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350emr"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.execution
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+
+import com.nvidia.spark.rapids.SparkSessionHolder
+import org.mockito.Mockito
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkException
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.LeafExecNode
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class GpuSubqueryBroadcastExecSuite extends AnyFunSuite with BeforeAndAfter with Matchers {
+
+  before {
+    SparkSessionHolder // Ensure we have an active SparkSession
+  }
+
+  test("executeCollect") {
+    val batch1 = createLongBatch(1, 2, 3)
+    val batch2 = createLongBatch(4, 5, 6)
+    val subqueryBroadcast = createIntGpuSubqueryBroadcast(batch1, batch2)
+    subqueryBroadcast.executeCollect().map(_.getInt(0)) shouldBe Seq(1, 2, 3, 4, 5, 6)
+  }
+
+  test("materialize") {
+    val batch1 = createLongBatch(1, 2, 3)
+    val subqueryBroadcast = createIntGpuSubqueryBroadcast(batch1)
+
+    val future = subqueryBroadcast.materialize()
+    val result = Await.result(future, Duration.Inf)
+    result shouldBe an [Array[InternalRow]]
+    result.asInstanceOf[Array[InternalRow]].map(_.getInt(0)) shouldBe Seq(1, 2, 3)
+  }
+
+  test("cancel") {
+    val batch1 = createLongBatch(1, 2, 3)
+    val subqueryBroadcast = createIntGpuSubqueryBroadcast(batch1)
+
+    subqueryBroadcast.cancel()
+    val future = subqueryBroadcast.materialize()
+    val thrown = the [SparkException] thrownBy Await.result(future, Duration.Inf)
+    thrown.getMessage should include ("was cancelled")
+  }
+
+  private def createIntGpuSubqueryBroadcast(batches: ColumnarBatch*): GpuSubqueryBroadcastExec = {
+    val output = Seq('key.int)
+    val broadcast = MockGpuBroadcastExchangeExec(output, batches)
+    GpuSubqueryBroadcastExec("ddp", 0, output, broadcast)(None)
+  }
+
+  private def createLongBatch(values: Long*): ColumnarBatch = {
+    val vector = new OnHeapColumnVector(values.length, LongType)
+    vector.putLongs(0, values.length, values.toArray, 0)
+    new ColumnarBatch(Array(vector), values.length)
+  }
+}
+
+case class MockGpuBroadcastExchangeExec(
+    output: Seq[Attribute], data: Seq[ColumnarBatch]) extends LeafExecNode {
+
+  override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException
+
+  override protected[sql] def doExecuteBroadcast[T](): Broadcast[T] = {
+    val batch = MockitoSugar.mock[SerializeConcatHostBuffersDeserializeBatch]
+    Mockito.doReturn(data.toArray, Nil: _*).when(batch).hostBatch
+    new MockBroadcast[SerializeConcatHostBuffersDeserializeBatch](id = 0, batch)
+        .asInstanceOf[Broadcast[T]]
+  }
+}
+
+class MockBroadcast[T: ClassTag](id: Long, value: T) extends Broadcast[T](id) {
+
+  override protected def getValue(): T = value
+
+  override protected def doUnpersist(blocking: Boolean): Unit =
+    throw new UnsupportedOperationException
+
+  override protected def doDestroy(blocking: Boolean): Unit =
+    throw new UnsupportedOperationException
+}


### PR DESCRIPTION
## Summary

This PR targets to add a new shim layer `spark350emr` which supports running Spark RAPIDS on AWS EMR Spark 3.5.0.

## Testing

### Unit Testing
I ran full suite of unit tests with example command as below:
```
mvn clean install
```
and got the following results:
```
Run completed in 30 minutes, 23 seconds.
Total number of tests run: 1214
Suites: completed 123, aborted 0
Tests: succeeded 1205, failed 9, canceled 54, ignored 16, pending 0
```
After some investigation and analysis, I found the following:
```
AdaptiveQueryExecSuite
- Join partitioned tables DPP fallback *** FAILED ***
- Exchange reuse *** FAILED ***

NOTE: Below exception is found from the log.
Part of the plan is not columnar class org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
Part of the plan is not columnar class org.apache.spark.sql.execution.FilterExec
```
```
SortExecSuite
- IGNORE ORDER: join longs *** FAILED ***
- IGNORE ORDER: join longs multiple batches *** FAILED ***

NOTE: Below exception is found from the log.
Part of the plan is not columnar class org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
```
```
CostBasedOptimizerSuite
- Force section of plan back onto CPU, AQE off *** FAILED ***
- keep CustomShuffleReaderExec on GPU *** FAILED ***
- Compute estimated row count nested joins no broadcast *** FAILED ***

NOTE: Below exception is found from the log.
Part of the plan is not columnar class org.apache.spark.sql.execution.FilterExec
```
```
JoinsSuite
- IGNORE ORDER: IGNORE ORDER: Test hash join *** FAILED ***
- INCOMPAT, IGNORE ORDER: Test replace sort merge join with hash join *** FAILED ***

[NOTE:]([url]()) Below exception is found from the log.
Part of the plan is not columnar class org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
```

We started an email-thread before to discuss these unit test failures but we still don't fix these test failures yet and need some help on these ones.

### Integration Testing
I ran full suite of integration tests and found some test failures we've discussed before as follows:
```
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication[Decimal(38,10)][DATAGEN_SEED=0, INJECT_OOM]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Integer-Decimal(30,10)][DATAGEN_SEED=0]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Decimal(10,-2)-Decimal(30,10)][DATAGEN_SEED=0]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Decimal(15,3)-Decimal(30,10)][DATAGEN_SEED=0, INJECT_OOM]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Decimal(30,12)-Integer][DATAGEN_SEED=0, INJECT_OOM]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Decimal(30,12)-Decimal(16,7)][DATAGEN_SEED=0]
FAILED src/main/python/arithmetic_ops_test.py::test_multiplication_mixed[Decimal(27,7)-Decimal(16,7)][DATAGEN_SEED=0, INJECT_OOM]
```
The failed reason is that AWS EMR back-ported the fix about [this issue](https://issues.apache.org/jira/browse/SPARK-45786) in Spark 3.5.0. Thus, I mark them as xfail in this change.

### Reproduction
To reproduce my test results, you can use the following environment:
1. This PR as a patch based on `branch-24.02`.
2. AWS EMR Spark: `3.5.0-amzn-0`. You can get it from AWS EMR cluster with release `emr-7.0.0`.

Also, for your convenience, I've already attached this patch and `scala-test-detailed-output.log` as here: [unit_tests.zip](https://github.com/NVIDIA/spark-rapids/files/13947779/unit_tests.zip)


## Others
For this change to build successfully, we also need the following change:
```
# before
<dependency>
            <groupId>com.nvidia</groupId>
            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
            <version>${spark-rapids-private.version}</version>
            <classifier>${spark.version.classifier}</classifier>
 </dependency>
# after
<dependency>
            <groupId>com.nvidia</groupId>
            <artifactId>rapids-4-spark-private_${scala.binary.version}</artifactId>
            <version>${spark-rapids-private.version}</version>
            <classifier>spark350</classifier>
 </dependency>
```
I think this is because that there is no such a private artifact for `spark350emr`. Do we need additional change for this or will the NVIDIA take care of it?