### PR TITLE
Fix to_utc_timestamp and from_utc_timestamp fallback when TZ is supported time zone

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -291,7 +291,6 @@ supported_timezones = ["Asia/Shanghai", "UTC", "UTC+0", "UTC-0", "GMT", "GMT+0",
 unsupported_timezones = ["PST", "NST", "AST", "America/Los_Angeles", "America/New_York", "America/Chicago"]
 
 @pytest.mark.parametrize('time_zone', supported_timezones, ids=idfn)
-@allow_non_gpu(*non_utc_allow)
 def test_from_utc_timestamp(time_zone):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: unary_op_df(spark, timestamp_gen).select(f.from_utc_timestamp(f.col('a'), time_zone)))
@@ -311,7 +310,6 @@ def test_unsupported_fallback_from_utc_timestamp():
             "from_utc_timestamp(a, tzone)"),
         'FromUTCTimestamp')
 
-@allow_non_gpu(*non_utc_allow)
 @pytest.mark.parametrize('time_zone', supported_timezones, ids=idfn)
 def test_to_utc_timestamp(time_zone):
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsMeta.scala
@@ -1154,7 +1154,6 @@ abstract class BaseExprMeta[INPUT <: Expression](
   //|         Value          | needTimeZoneCheck |           isTimeZoneSupported           |
   //+------------------------+-------------------+-----------------------------------------+
   //| TimezoneAwareExpression| True              | False by default, True when implemented |
-  //| UTCTimestamp           | True              | False by default, True when implemented |
   //| Others                 | False             | N/A (will not be checked)               |
   //+------------------------+-------------------+-----------------------------------------+
   lazy val needTimeZoneCheck: Boolean = {
@@ -1171,7 +1170,6 @@ abstract class BaseExprMeta[INPUT <: Expression](
         } else{
           true
         }
-      case _: UTCTimestamp => true
       case _ => false
     }
   }


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/10222

to_utc_timestamp and from_utc_timestamp are not time zone aware.  It means they are not related to session time zone.
They both take a timezone parameter, usage:
- from_utc_timestamp(ts_col, tz)
- to_utc_timestamp(ts_col, tz)
So should not check the session time zone, only check time zone in the parameter is enough.

Signed-off-by: Chong Gao <res_life@163.com>
