### PR TITLE
Fix Databricks 13.3 BroadcastHashJoin using executor side broadcast fed by ColumnarToRow [Databricks]

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -252,7 +252,7 @@ db_133_cpu_bnlj_join_allow=["ShuffleExchangeExec"] if is_databricks113_or_later(
 @ignore_order(local=True)
 @pytest.mark.skipif(not (is_databricks_runtime()), \
     reason="Executor side broadcast only supported on Databricks")
-@allow_non_gpu('BroadcastHashJoinExec', 'ColumnartoRowExec', *db_113_cpu_bnlj_join_allow)
+@allow_non_gpu('BroadcastHashJoinExec', 'ColumnarToRowExec', *db_113_cpu_bnlj_join_allow)
 def test_aqe_join_executor_broadcast_not_single_partition(spark_tmp_path):
     data_path = spark_tmp_path + '/PARQUET_DATA'
     bhj_disable_conf = copy_and_update(_adaptive_conf,

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -266,18 +266,7 @@ def test_aqe_join_executor_broadcast(spark_tmp_path):
                   .add("gender", StringType())
                   .add("salary", IntegerType()))
 
-        data_school= [
-            ("1", "school1"),
-            ("2", "school1"),
-            ("3", "school2")
-        ]
-        schema_school = (StructType()
-                  .add("id", StringType())
-                  .add("school", IntegerType()))
-
         df = spark.createDataFrame(spark.sparkContext.parallelize(data),schema)
-        df_school = spark.createDataFrame(spark.sparkContext.parallelize(data_school),schema_school)
-
         df.write.format("parquet").mode("overwrite").save(data_path)
 
     with_cpu_session(prep)
@@ -285,6 +274,16 @@ def test_aqe_join_executor_broadcast(spark_tmp_path):
     def do_it(spark):
         newdf = spark.read.parquet(data_path)
         newdf.createOrReplaceTempView("df")
+        data_school= [
+            ("1", "school1"),
+            ("2", "school1"),
+            ("3", "school2")
+        ]
+        schema_school = (StructType()
+                  .add("id", StringType())
+                  .add("school", StringType()))
+        df_school = spark.createDataFrame(spark.sparkContext.parallelize(data_school),schema_school)
+        df_school.createOrReplaceTempView("df_school")
 
         return spark.sql(
             """

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -16,7 +16,7 @@ import pytest
 from pyspark.sql.functions import when, col, current_date, current_timestamp
 from pyspark.sql.types import *
 from asserts import assert_gpu_and_cpu_are_equal_collect, assert_cpu_and_gpu_are_equal_collect_with_capture
-from conftest import is_not_utc
+from conftest import is_databricks_runtime, is_not_utc
 from data_gen import *
 from marks import ignore_order, allow_non_gpu
 from spark_session import with_cpu_session, is_databricks113_or_later

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -184,11 +184,11 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, e)
 
     case c2re @ ColumnarToRowExec(aqese @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
-      logWarning("columnar to row with AQEShuffleReadExec " + c2re)
+      logWarning("columnar to row with AQEShuffleReadExec " + c2re + " entire plan is: " + plan)
       val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(s, Some(plan)))
       val res = SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, s)
-      logWarning("spark plan after is: " + res)
       aqese.withNewChildren(Seq(res))
+      logWarning("spark plan after is: " + aqese)
       aqese
 
     case ColumnarToRowExec(e: BroadcastQueryStageExec) =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -184,6 +184,13 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, e)
 
     case c2re @ ColumnarToRowExec(aqesr @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
+      parent match {
+        case bhje: BroadcastHashJoinExec=>
+          logWarning("parent is broadcast hash join, specifics: " + bhje +
+            " is executor broadcast " + bhje.isExecutorBroadcast)
+        case _ =>
+          logWarning("not bhj")
+      }
       logWarning("tgraves aqe read is: " + aqesr + " coalesced: " + aqesr.isCoalescedRead +
         " spec: " + aqesr.partitionSpecs.mkString(",") + " parent is: " + parent)
       logWarning("columnar to row with AQEShuffleReadExec " + c2re + " entire plan is: " + plan)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -185,7 +185,10 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
 
     case c2re @ ColumnarToRowExec(aqese @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
       logWarning("columnar to row with AQEShuffleReadExec " + c2re + " entire plan is: " + plan)
-      val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(s, Some(plan)))
+      val planopt = optimizeAdaptiveTransitions(s, Some(plan))
+      val c2r = GpuColumnarToRowExec(planopt)
+      logWarning("tom planopt is " + planopt + " ctor: " + c2r)
+
       val res = SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, s)
       aqese.withNewChildren(Seq(res))
       logWarning("spark plan after is: " + aqese)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Attribut
 import org.apache.spark.sql.catalyst.plans.physical.IdentityBroadcastMode
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, AdaptiveSparkPlanExec, BroadcastQueryStageExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanExecBase, DropTableExec, ShowTablesExec}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -810,7 +810,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
             plan.conf.adaptiveExecutionEnabled && plan.conf.exchangeReuseEnabled) {
           updatedPlan = fixupAdaptiveExchangeReuse(updatedPlan)
         }
-        
+
         if (rapidsConf.logQueryTransformations) {
           logWarning(s"Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -186,7 +186,9 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
     case c2re @ ColumnarToRowExec(AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
       logWarning("columnar to row with AQEShuffleReadExec " + c2re)
       val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(s, Some(plan)))
-      SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, s)
+      val res = SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, s)
+      logWarning("spark plan after is: " + res)
+      res
 
     case ColumnarToRowExec(e: BroadcastQueryStageExec) =>
       logWarning("columnar to row with BroadcastQueryStageExec")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -183,12 +183,13 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
       val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(e, Some(plan)))
       SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, e)
 
-    case c2re @ ColumnarToRowExec(AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
+    case c2re @ ColumnarToRowExec(aqese @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
       logWarning("columnar to row with AQEShuffleReadExec " + c2re)
       val c2r = GpuColumnarToRowExec(optimizeAdaptiveTransitions(s, Some(plan)))
       val res = SparkShimImpl.addRowShuffleToQueryStageTransitionIfNeeded(c2r, s)
       logWarning("spark plan after is: " + res)
-      res
+      aqese.withNewChildren(Seq(res))
+      aqese
 
     case ColumnarToRowExec(e: BroadcastQueryStageExec) =>
       logWarning("columnar to row with BroadcastQueryStageExec")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -185,7 +185,7 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
 
     case c2re @ ColumnarToRowExec(aqesr @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
       logWarning("tgraves aqe read is: " + aqesr + " coalesced: " + aqesr.isCoalescedRead +
-        " spec: " + aqesr.partitionSpecs.mkString(","))
+        " spec: " + aqesr.partitionSpecs.mkString(",") + " parent is: " + parent)
       logWarning("columnar to row with AQEShuffleReadExec " + c2re + " entire plan is: " + plan)
       val planopt = optimizeAdaptiveTransitions(s, Some(plan))
       val c2r = GpuColumnarToRowExec(planopt)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -149,6 +149,7 @@ trait SparkShims {
    */
   def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan,
       parent: Option[SparkPlan]): Boolean = false
+
   def getShuffleFromCToRWithExecBroadcastAQECoalPart(p: SparkPlan): Option[SparkPlan] = None
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -155,8 +155,7 @@ trait SparkShims {
    * If the shim doesn't support executor broadcast, just return the plan passed in
    */
   def addExecBroadcastShuffle(p: SparkPlan): SparkPlan = p
-
-
+  
   /**
    * Walk the plan recursively and return a list of operators that match the predicate
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -143,7 +143,10 @@ trait SparkShims {
 
   def checkColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): Boolean = false
 
-  def convertColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): SparkPlan = p
+  def convertColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan],
+      c2r: SparkPlan): SparkPlan = p
+
+  def getShuffleFromColumnarToRowWithExecBroadcast(p: SparkPlan): Option[SparkPlan] = None
 
   /**
    * Walk the plan recursively and return a list of operators that match the predicate

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -139,7 +139,11 @@ trait SparkShims {
    * that consumes rows
    */
   def addRowShuffleToQueryStageTransitionIfNeeded(c2r: ColumnarToRowTransition,
-      sqse: ShuffleQueryStageExec): SparkPlan = c2r
+      sqse: ShuffleQueryStageExec, fromBHJExecutorBroadcast: Boolean = false): SparkPlan = c2r
+
+  def checkColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): Boolean = false
+
+  def convertColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): SparkPlan = p
 
   /**
    * Walk the plan recursively and return a list of operators that match the predicate

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -143,9 +143,9 @@ trait SparkShims {
 
   /*
    * The following two functions are used to recognize when an executor broadcast
-   * is being used to feed into a join but a columnar to row get inserted between
+   * is being used to feed into a join but a columnar to row gets inserted between
    * the exchange and the join. This causes issues on some versions of Spark so we
-   *  have to shim it.
+   * have to shim it.
    */
   def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan,
       parent: Option[SparkPlan]): Boolean = false
@@ -155,7 +155,7 @@ trait SparkShims {
    * If the shim doesn't support executor broadcast, just return the plan passed in
    */
   def addExecBroadcastShuffle(p: SparkPlan): SparkPlan = p
-  
+
   /**
    * Walk the plan recursively and return a list of operators that match the predicate
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -139,14 +139,23 @@ trait SparkShims {
    * that consumes rows
    */
   def addRowShuffleToQueryStageTransitionIfNeeded(c2r: ColumnarToRowTransition,
-      sqse: ShuffleQueryStageExec, fromBHJExecutorBroadcast: Boolean = false): SparkPlan = c2r
+      sqse: ShuffleQueryStageExec): SparkPlan = c2r
 
-  def checkColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): Boolean = false
+  /*
+   * The following two functions are used to recognize when an executor broadcast
+   * is being used to feed into a join but a columnar to row get inserted between
+   * the exchange and the join. This causes issues on some versions of Spark so we
+   *  have to shim it.
+   */
+  def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan,
+      parent: Option[SparkPlan]): Boolean = false
+  def getShuffleFromCToRWithExecBroadcastAQECoalPart(p: SparkPlan): Option[SparkPlan] = None
 
-  def convertColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan],
-      c2r: ColumnarToRowTransition): SparkPlan = p
+  /**
+   * If the shim doesn't support executor broadcast, just return the plan passed in
+   */
+  def addExecBroadcastShuffle(p: SparkPlan): SparkPlan = p
 
-  def getShuffleFromColumnarToRowWithExecBroadcast(p: SparkPlan): Option[SparkPlan] = None
 
   /**
    * Walk the plan recursively and return a list of operators that match the predicate

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SparkShims.scala
@@ -144,7 +144,7 @@ trait SparkShims {
   def checkColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan]): Boolean = false
 
   def convertColumnarToRowWithExecBroadcast(p: SparkPlan, parent: Option[SparkPlan],
-      c2r: SparkPlan): SparkPlan = p
+      c2r: ColumnarToRowTransition): SparkPlan = p
 
   def getShuffleFromColumnarToRowWithExecBroadcast(p: SparkPlan): Option[SparkPlan] = None
 

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -23,7 +23,6 @@ package com.nvidia.spark.rapids.shims
 
 import com.nvidia.spark.rapids._
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
@@ -33,7 +32,7 @@ import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.rapids.{GpuCheckOverflowInTableInsert, GpuElementAtMeta}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec, GpuBroadcastNestedLoopJoinExec}
 
-trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
+trait Spark330PlusDBShims extends Spark321PlusDBShims {
   override def getExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = {
     val shimExprs: Map[Class[_ <: Expression], ExprRule[_ <: Expression]] = Seq(
       GpuOverrides.expr[CheckOverflowInTableInsert](
@@ -76,8 +75,8 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
   }
 
   /*
-   * We are looking for the below pattern. We end up with a ColumnarToRow that feeds into
-   * a CPU broadcasthash join which is using Executor broadcast. This pattern fails on
+   * We are looking for the pattern describe below. We end up with a ColumnarToRow that feeds
+   * into a CPU broadcasthash join which is using Executor broadcast. This pattern fails on
    * Databricks because it doesn't like the ColumnarToRow feeding into the BroadcastHashJoin.
    * Note, in most other cases we see executor broadcast, the Exchange would be CPU
    * single partition exchange explicitly marked with type EXECUTOR_BROADCAST.

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -93,15 +93,11 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
     p match {
       case ColumnarToRowExec(AQEShuffleReadExec(_: ShuffleQueryStageExec, _, _)) =>
         parent match {
-          case Some(bhje: BroadcastHashJoinExec) if bhje.isExecutorBroadcast =>
-            true
-          case Some(bhnlj: GpuBroadcastNestedLoopJoinExec) if bhnlj.isExecutorBroadcast =>
-            true
-          case _ =>
-            false
+          case Some(bhje: BroadcastHashJoinExec) if bhje.isExecutorBroadcast => true
+          case Some(bhnlj: GpuBroadcastNestedLoopJoinExec) if bhnlj.isExecutorBroadcast => true
+          case _ => false
         }
-      case _ =>
-        false
+      case _ => false
     }
   }
 
@@ -113,10 +109,8 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
    */
   override def getShuffleFromCToRWithExecBroadcastAQECoalPart(p: SparkPlan): Option[SparkPlan] = {
     p match {
-      case ColumnarToRowExec(AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) =>
-        Some(s)
-      case _ =>
-        None
+      case ColumnarToRowExec(AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) => Some(s)
+      case _ => None
     }
   }
 
@@ -133,10 +127,9 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
       sqse: ShuffleQueryStageExec): SparkPlan = {
     val plan = GpuTransitionOverrides.getNonQueryStagePlan(sqse)
     plan match {
-      case shuffle: ShuffleExchangeLike if shuffle.shuffleOrigin.equals(EXECUTOR_BROADCAST)
+      case shuffle: ShuffleExchangeLike if shuffle.shuffleOrigin.equals(EXECUTOR_BROADCAST) =>
         addExecBroadcastShuffle(c2r)
-      case _ =>
-        c2r
+      case _ => c2r
     }
   }
 }

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -89,7 +89,8 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
    *        +- ShuffleQueryStage
    *            +- GpuColumnarExchange gpuhashpartitioning
    */
-  override def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan, parent: Option[SparkPlan]): Boolean = {
+  override def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan,
+      parent: Option[SparkPlan]): Boolean = {
     p match {
       case ColumnarToRowExec(AQEShuffleReadExec(_: ShuffleQueryStageExec, _, _)) =>
         parent match {

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -26,9 +26,10 @@ import com.nvidia.spark.rapids._
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
-import org.apache.spark.sql.execution.{ColumnarToRowTransition, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.ShuffleQueryStageExec
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.exchange.{EXECUTOR_BROADCAST, ShuffleExchangeExec, ShuffleExchangeLike}
+import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.rapids.{GpuCheckOverflowInTableInsert, GpuElementAtMeta}
 import org.apache.spark.sql.rapids.execution.{GpuBroadcastHashJoinExec, GpuBroadcastNestedLoopJoinExec}
 

--- a/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
+++ b/sql-plugin/src/main/spark330db/scala/com/nvidia/spark/rapids/shims/Spark330PlusDBShims.scala
@@ -83,8 +83,10 @@ trait Spark330PlusDBShims extends Spark321PlusDBShims with Logging {
         logInfo("in executor broadcast handling, creating new shuffle exchange")
         ShuffleExchangeExec(SinglePartition, c2r, EXECUTOR_BROADCAST)
       case shuffleOther: ShuffleExchangeLike =>
-        logInfo("shuffle not executor broadcast: " +  shuffleOther)
-        shuffleOther
+        logInfo("shuffle not executor broadcast: " + shuffleOther)
+        val res = ShuffleExchangeExec(SinglePartition, c2r, EXECUTOR_BROADCAST)
+        logInfo("adding shuffle with c2r : " + res)
+        res
       case _ =>
         c2r
     }

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/Spark341PlusDBShims.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/Spark341PlusDBShims.scala
@@ -25,8 +25,10 @@ import com.nvidia.spark.rapids.GpuOverrides.pluginSupportedOrderableSig
 import org.apache.spark.rapids.shims.GpuShuffleExchangeExec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
-import org.apache.spark.sql.execution.{CollectLimitExec, GlobalLimitExec, SparkPlan, TakeOrderedAndProjectExec}
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.exchange.ENSURE_REQUIREMENTS
+import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDAF
 import org.apache.spark.sql.types.StringType
@@ -171,4 +173,43 @@ trait Spark341PlusDBShims extends Spark332PlusDBShims {
   override def getExecs: Map[Class[_ <: SparkPlan], ExecRule[_ <: SparkPlan]] =
     super.getExecs ++ shimExecs
 
+  /*
+   * We are looking for the pattern describe below. We end up with a ColumnarToRow that feeds
+   * into a CPU broadcasthash join which is using Executor broadcast. This pattern fails on
+   * Databricks because it doesn't like the ColumnarToRow feeding into the BroadcastHashJoin.
+   * Note, in most other cases we see executor broadcast, the Exchange would be CPU
+   * single partition exchange explicitly marked with type EXECUTOR_BROADCAST.
+   *
+   *  +- BroadcastHashJoin || BroadcastNestedLoopJoin (using executor broadcast)
+   *  ^
+   *  +- ColumnarToRow
+   *      +- AQEShuffleRead ebj (uses coalesce partitions to go to 1 partition)
+   *        +- ShuffleQueryStage
+   *            +- GpuColumnarExchange gpuhashpartitioning
+   */
+  override def checkCToRWithExecBroadcastAQECoalPart(p: SparkPlan,
+      parent: Option[SparkPlan]): Boolean = {
+    p match {
+      case ColumnarToRowExec(AQEShuffleReadExec(_: ShuffleQueryStageExec, _, _)) =>
+        parent match {
+          case Some(bhje: BroadcastHashJoinExec) if bhje.isExecutorBroadcast => true
+          case Some(bhnlj: GpuBroadcastNestedLoopJoinExec) if bhnlj.isExecutorBroadcast => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  /*
+   * If this plan matches the checkCToRWithExecBroadcastCoalPart() then get the shuffle
+   * plan out so we can wrap it. This function does not check that the parent is
+   * BroadcastHashJoin doing executor broadcast, so is expected to be called only
+   * after checkCToRWithExecBroadcastCoalPart().
+   */
+  override def getShuffleFromCToRWithExecBroadcastAQECoalPart(p: SparkPlan): Option[SparkPlan] = {
+    p match {
+      case ColumnarToRowExec(AQEShuffleReadExec(s: ShuffleQueryStageExec, _, _)) => Some(s)
+      case _ => None
+    }
+  }
 }

--- a/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/Spark341PlusDBShims.scala
+++ b/sql-plugin/src/main/spark341db/scala/com/nvidia/spark/rapids/shims/Spark341PlusDBShims.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.exchange.ENSURE_REQUIREMENTS
-import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec}
 import org.apache.spark.sql.rapids.GpuV1WriteUtils.GpuEmpty2Null
 import org.apache.spark.sql.rapids.execution.python.GpuPythonUDAF
 import org.apache.spark.sql.types.StringType
@@ -193,7 +193,7 @@ trait Spark341PlusDBShims extends Spark332PlusDBShims {
       case ColumnarToRowExec(AQEShuffleReadExec(_: ShuffleQueryStageExec, _, _)) =>
         parent match {
           case Some(bhje: BroadcastHashJoinExec) if bhje.isExecutorBroadcast => true
-          case Some(bhnlj: GpuBroadcastNestedLoopJoinExec) if bhnlj.isExecutorBroadcast => true
+          case Some(bhnlj: BroadcastNestedLoopJoinExec) if bhnlj.isExecutorBroadcast => true
           case _ => false
         }
       case _ => false


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/10165

Here the issue is that Databricks supports a special executor side broadcast in BroadcastHashJoin and in this case the BroadcastHashJoin ended up being on the CPU. The BroadcastHashJoin can't be fed by a ColumnarToRow.  It expects to be fed by an exchange that specifically handles going to a single partition.
There is a similar issue in Databricks 12.2 that we fixed by inserting an extra GpuColumnarToRow and then an Exchange.  I use similar logic here to fix this and filed a followup to investigate the performance of now having 2 exchanges (https://github.com/NVIDIA/spark-rapids/issues/10229).

The beginning plan looks like:
```
Caused by: org.apache.spark.SparkException: Unexpected build plan for Executor Side Broadcast Join: 
ColumnarToRow
+- AQEShuffleRead ebj
   +- ShuffleQueryStage 132, Statistics(sizeInBytes=7.8 MiB, rowCount=2.74E+5, ColumnStat: N/A, isRuntime=true)
      +- GpuColumnarExchange gpuhashpartitioning(cast(user_id#83458 as int), 200), ENSURE_REQUIREMENTS, [plan_id=394739]
         +- GpuProject [gpucoalesce(user_id#84619, cast(user_id#84639 as string)) AS user_id#83458, if ((gpucoalesce(is_deleted#84640, true) AND NOT (cast(user_id#84619 as int) = 117563))) gdpr-deleted else gpucoalesce(email_address#84631, email_address#84646) AS email_address#83462]
            +- GpuRowToColumnar targetsize(268435456)
```

After this fix the plan looks like:

```
 +- Exchange (SinglePartition, EXECUTOR_BROADCAST)
             *     +- GpuColumnarToRow
             *         +- GpuShuffleCoalesce
             *             +- ShuffleQueryStage
             *                 +- GpuColumnarExchange
```

Added an integration test for databricks.  The test throws an exception without the fix and then passes with the fix.  This new logic only occurs on Databricks 13.3 and the parameters to AQEShuffleReadExec changed between 12.2 and 13.3 so the shim code went into a specific Databricks 13.3 file.


<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
