### PR TITLE
Use POSIX mode in assembly plugin to avoid issues with large UID/GID

### DIFF
--- a/integration_tests/pom.xml
+++ b/integration_tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020-2023, NVIDIA CORPORATION.
+  Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -80,7 +80,9 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <finalName>rapids-4-spark-integration-tests_${scala.binary.version}-${project.version}-${spark.version.classifier}</finalName>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
@pmattione-nvidia noted a build error where the Maven assembly plugin was complaining about IDs being too large.  It's a known issue where the assembly plugin uses the GNU tar format by default which has relatively low limits on user or group IDs.

This fixes the issue by requesting the assembly plugin use the POSIX tar format which can accept long UID/GIDs.  It also specifies a specific assembly plugin version which was not being done previously.