### PR TITLE
WIP: Add support for reading structs in GpuJsonScan

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -894,7 +894,8 @@ object GpuOverrides extends Logging {
       sparkSig = (TypeSig.cpuAtomics + TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP +
           TypeSig.UDT).nested())),
     (JsonFormatType, FileFormatChecks(
-      cudfRead = TypeSig.commonCudfTypes + TypeSig.DECIMAL_128,
+      cudfRead = (TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 +
+          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
       cudfWrite = TypeSig.none,
       sparkSig = (TypeSig.cpuAtomics + TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP +
         TypeSig.UDT).nested())),


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10241

Creating this draft PR for discussion.

Pros:
- Allows us to read JSON files containing structs on the GPU, making it consistent with GpuJsonToStruct, which already supports this

Cons:
- cuDF will infer the types of fields in the nested structs and this is different to the behavior of how we read top-level primitive fields, where we specify to cuDF that they should be read as strings, and then we cast to the specific type in the plugin. To be able to make this all consistent we will need https://github.com/rapidsai/cudf/issues/14830

