### PR TITLE
Improve `GpuExpand` by pre-projecting some columns[databricks]

### DIFF
--- a/integration_tests/src/main/python/expand_exec_test.py
+++ b/integration_tests/src/main/python/expand_exec_test.py
@@ -38,4 +38,5 @@ def test_expand_pre_project():
 
     assert_gpu_and_cpu_are_equal_sql(get_df,
         "pre_pro",
-        "select count(distinct (a+b)), count(distinct if((a+b)>100, c, null)) from pre_pro group by a")
+        "select count(distinct (a+b)), count(distinct if((a+b)>100, c, null)) from pre_pro group by a",
+        {"spark.rapids.sql.expandPreproject.enabled": "true"})

--- a/integration_tests/src/main/python/expand_exec_test.py
+++ b/integration_tests/src/main/python/expand_exec_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pytest
 
-from asserts import assert_gpu_and_cpu_are_equal_collect, assert_equal
+from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_and_cpu_are_equal_sql
 from data_gen import *
 import pyspark.sql.functions as f
 from marks import ignore_order
@@ -29,3 +29,13 @@ def test_expand_exec(data_gen):
             ('b', IntegerGen())], nullable=False), length=length).rollup(f.col("a"), f.col("b")).agg(f.col("b"))
 
     assert_gpu_and_cpu_are_equal_collect(op_df)
+
+
+@ignore_order(local=True)
+def test_expand_pre_project():
+    def get_df(spark):
+        return three_col_df(spark, short_gen, int_gen, string_gen)
+
+    assert_gpu_and_cpu_are_equal_sql(get_df,
+        "pre_pro",
+        "select count(distinct (a+b)), count(distinct if((a+b)>100, c, null)) from pre_pro group by a")

--- a/integration_tests/src/main/python/expand_exec_test.py
+++ b/integration_tests/src/main/python/expand_exec_test.py
@@ -31,6 +31,8 @@ def test_expand_exec(data_gen):
     assert_gpu_and_cpu_are_equal_collect(op_df)
 
 
+# "cube" and "rollup" will not run into the pre-projection because of different
+# planning by Spark. But it is still good to test them to make sure no regressions.
 pre_pro_sqls = [
     "select count(distinct (a+b)), count(distinct if((a+b)>100, c, null)) from pre_pro group by a",
     "select count(b), count(c) from pre_pro group by cube((a+b), if((a+b)>100, c, null))",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package com.nvidia.spark.rapids
+
+import scala.collection.mutable
+import scala.util.Random
 
 import ai.rapids.cudf.NvtxColor
 import com.nvidia.spark.rapids.Arm.withResource
@@ -88,15 +91,34 @@ case class GpuExpandExec(
     AttributeSet(projections.flatten.flatMap(_.references))
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
-    val boundProjections = projections.map { pl =>
-      GpuBindReferences.bindGpuReferencesTiered(pl, child.output, useTieredProject)
+    var projectionsForBind = projections
+    var attributesForBind = child.output
+    var preprojectIter = identity[Iterator[ColumnarBatch]] _
+    if (useTieredProject) {
+      // Tiered projection is enabled, check if pre-projection is needed.
+      val boundPreprojections = GpuBindReferences.bindGpuReferencesTiered(
+        preprojectionList, child.output, useTieredProject)
+      if (boundPreprojections.exprTiers.size > 1) {
+        logDebug("GPU expanding with pre-projection.")
+        // We got some nested expressions, so pre-projection is good to enable.
+        projectionsForBind = preprojectedProjections
+        attributesForBind = preprojectionList.map(_.toAttribute)
+        preprojectIter = (iter: Iterator[ColumnarBatch]) => iter.map(cb =>
+          boundPreprojections.projectAndCloseWithRetrySingleBatch(
+            SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
+        )
+      }
+    }
+
+    val boundProjections = projectionsForBind.map { pl =>
+      GpuBindReferences.bindGpuReferencesTiered(pl, attributesForBind, useTieredProject)
     }
 
     // cache in a local to avoid serializing the plan
     val metricsMap = allMetrics
 
     child.executeColumnar().mapPartitions { it =>
-      new GpuExpandIterator(boundProjections, metricsMap, it)
+      new GpuExpandIterator(boundProjections, metricsMap, preprojectIter(it))
     }
   }
 
@@ -104,6 +126,57 @@ case class GpuExpandExec(
     throw new IllegalStateException("ROW BASED PROCESSING IS NOT SUPPORTED")
   }
 
+  /**
+   * The expressions that need to be pre-projected, and the corresponding projections
+   * for expanding.
+   *
+   * Some rules (e.g. RewriteDistinctAggregates) in Spark will put non-leaf expressions
+   * into Expand projections, then it can not leverage the GPU tiered projection across
+   * the projection lists.
+   * So here tries to factor out these expressions for the pre-projection before
+   * expanding to avoid duplicate evaluation of semantic-equal (sub) expressions.
+   *
+   * e.g. projections:
+   *     [if((a+b)>0) 1 else 0, null], [null, if((a+b)=0 "no" else "yes")];
+   * without pre-projection, "a+b" will be evaluated twice.
+   * while with pre-projection, it has
+   *    preprojectionList:
+   *            [if((a+b)>0) 1 else 0, if((a+b)=0 "no" else "yes")]
+   *    preprojectedProjections:
+   *            [_pre-project-c1#0, null], [null, _pre-project-c3#1]
+   * and
+   *    "_pre-project-c1#0" refers to "if((a+b)>0) 1 else 0",
+   *    "_pre-project-c3#1" refers to "if((a+b)=0 "no" else "yes"
+   * By leveraging the tiered projection, "a+b" will be evaluated only once.
+   */
+  private[this] lazy val (preprojectionList, preprojectedProjections) = {
+    val projectListSet = mutable.Set[NamedExpression]()
+    val newProjections = projections.map { proList =>
+      proList.map {
+        case attr: AttributeReference if child.outputSet.contains(attr) =>
+          // A ref to child output, add it to pre-projection for passthrough.
+          projectListSet += attr
+          attr
+        case leaf if leaf.children.isEmpty =>
+          // A leaf expression is simple enough, not necessary for pre-projection.
+          // e.g. GpuLiteral.
+          leaf
+        case notLeafNamed: NamedExpression =>
+          logDebug(s"Got a named non-leaf expression: $notLeafNamed for pre-projection")
+          // A named non-leaf expression, e.g. GpuAlias. Add it for pre-projection and
+          // replace with its attribute.
+          projectListSet += notLeafNamed
+          notLeafNamed.toAttribute
+        case notLeaf =>
+          logDebug(s"Got a non-leaf expression: $notLeaf for pre-projection")
+          // Wrap it by a new "GpuAlias", and replace with the "GpuAlias"'s attribute.
+          val alias = GpuAlias(notLeaf, s"_pre-project-c${Random.nextInt}")()
+          projectListSet += alias
+          alias.toAttribute
+      }
+    }
+    (projectListSet.toList, newProjections)
+  }
 }
 
 class GpuExpandIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -79,7 +79,8 @@ class GpuGenerateExecSparkPlanMeta(
     }
     val output: Seq[Attribute] = gen.requiredChildOutput ++ gen.generatorOutput.take(numFields)
     GpuExpandExec(projections, output, childPlans.head.convertIfNeeded())(
-        useTieredProject = conf.isTieredProjectEnabled)
+        useTieredProject = conf.isTieredProjectEnabled,
+        preprojectEnabled = conf.isExpandPreprojectEnabled)
   }
 
   override def convertToGpu(): GpuExec = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1078,6 +1078,17 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .doc("When set to false disables orc output acceleration")
     .booleanConf
     .createWithDefault(true)
+
+  val ENABLE_EXPAND_PREPROJECT = conf("spark.rapids.sql.expandPreproject.enabled")
+    .doc("When set to true enables the pre-projection for GPU Expand. " +
+      "Pre-projection leverages the tiered projection to evaluate expressions that " +
+      "semantically equal across Expand projection lists before expanding, to avoid " +
+      "duplicate evaluations. Usually it increases the GPU memory pressure, so disable " +
+      s"it by default. '${ENABLE_TIERED_PROJECT.key}' should also set to true to " +
+      s"enable this.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
 
   val ENABLE_ORC_FLOAT_TYPES_TO_STRING =
     conf("spark.rapids.sql.format.orc.floatTypesToString.enable")
@@ -2508,6 +2519,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isProjectAstEnabled: Boolean = get(ENABLE_PROJECT_AST)
 
   lazy val isTieredProjectEnabled: Boolean = get(ENABLE_TIERED_PROJECT)
+
+  lazy val isExpandPreprojectEnabled: Boolean = get(ENABLE_EXPAND_PREPROJECT)
 
   lazy val multiThreadReadNumThreads: Int = {
     // Use the largest value set among all the options.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1080,15 +1080,14 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .createWithDefault(true)
 
   val ENABLE_EXPAND_PREPROJECT = conf("spark.rapids.sql.expandPreproject.enabled")
-    .doc("When set to true enables the pre-projection for GPU Expand. " +
+    .doc("When set to false disables the pre-projection for GPU Expand. " +
       "Pre-projection leverages the tiered projection to evaluate expressions that " +
       "semantically equal across Expand projection lists before expanding, to avoid " +
-      "duplicate evaluations. Usually it increases the GPU memory pressure, so disable " +
-      s"it by default. '${ENABLE_TIERED_PROJECT.key}' should also set to true to " +
-      s"enable this.")
+      s"duplicate evaluations. '${ENABLE_TIERED_PROJECT.key}' should also set to true " +
+      "to enable this.")
     .internal()
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
   val ENABLE_ORC_FLOAT_TYPES_TO_STRING =
     conf("spark.rapids.sql.format.orc.floatTypesToString.enable")


### PR DESCRIPTION
closes https://github.com/NVIDIA/spark-rapids/issues/10249

Some rules (e.g. RewriteDistinctAggregates) in Spark will put non-leaf expressions into Expand projections, then it can not leverage the GPU tiered projection across  the projection lists.

So this PR tries to factor out these expressions and evaluate them before expanding to avoid duplicate evaluations of semantic-equal (sub) expressions.

e.g. given projections:
```
      [if((a+b)>0) 1 else 0, null],
      [null, if((a+b)=0 "no" else "yes")]
```
without pre-projection, `a+b` will be evaluated twice. While with pre-projection, it has
```
   # preprojection list:
            [if((a+b)>0) 1 else 0, if((a+b)=0 "no" else "yes")]
   # preprojected projections for expanding:
            [_pre-project-c1#0, null], [null, _pre-project-c3#1]
   # and
           "_pre-project-c1#0" refers to "if((a+b)>0) 1 else 0",
           "_pre-project-c3#1" refers to "if((a+b)=0 "no" else "yes"
```

By leveraging the tiered projection on the preprojection list, `a+b` will be evaluated only once.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
