### PR TITLE
WIP: Refactor text partition reader to move CSV logic into CSV subclass

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala
@@ -18,13 +18,16 @@ package com.nvidia.spark.rapids
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+
 import scala.collection.JavaConverters._
+
 import ai.rapids.cudf
 import ai.rapids.cudf.{ColumnVector, DType, NvtxColor, Scalar, Schema, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.shims.{ColumnDefaultValuesShims, GpuTypeShims, ShimFilePartitionReaderFactory}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow


### PR DESCRIPTION
`GpuTextBasedPartitionReader` is the base class for CSV, JSON, and Hive readers, but it currently contains some CSV-specific logic.

This PR is a refactor to move the CSV-specific logic into the appropriate CSV subclass and also make some of the JSON logic accessible from `GpuJsonToStructs` in a future PR.