### PR TITLE
Add FullOuter support to GpuShuffledSymmetricHashJoinExec

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -28,7 +28,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.{Inner, InnerLike, JoinType, LeftAnti, LeftSemi}
+import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, InnerLike, JoinType, LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.plans.physical.Distribution
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.joins.ShuffledHashJoinExec
@@ -70,8 +70,9 @@ class GpuShuffledHashJoinMeta(
     }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
     val joinExec = join.joinType match {
-      case Inner if conf.useShuffledSymmetricHashJoin =>
+      case Inner | FullOuter if conf.useShuffledSymmetricHashJoin =>
         GpuShuffledSymmetricHashJoinExec(
+          join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
           joinCondition,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark.rapids
 
-import org.apache.spark.sql.catalyst.plans.Inner
+import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
 import org.apache.spark.sql.rapids.execution.{GpuHashJoin, JoinTypeChecks}
@@ -83,8 +83,9 @@ class GpuSortMergeJoinMeta(
     }
     val Seq(left, right) = childPlans.map(_.convertIfNeeded())
     val joinExec = join.joinType match {
-      case Inner if conf.useShuffledSymmetricHashJoin =>
+      case Inner | FullOuter if conf.useShuffledSymmetricHashJoin =>
         GpuShuffledSymmetricHashJoinExec(
+          join.joinType,
           leftKeys.map(_.convertToGpu()),
           rightKeys.map(_.convertToGpu()),
           joinCondition,


### PR DESCRIPTION
Closes #9442.  Adds support for full outer joins to GpuShuffledSymmetricHashJoinExec.  As with inner joins, this was measured to be around 50% faster that the existing GpuShuffledHashJoinExec logic on my machine where the left side is only 10 rows and the right side is 2 billion rows and there's only 2 shuffle partitions.