### PR TITLE
Add gerashegalov to CODEOWNERS [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-#  Copyright (c) 2020-2023, NVIDIA CORPORATION.
+#  Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 
-/jenkins/  @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu
-pom.xml    @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu
-/dist/     @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu
-/.github/  @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu
+/jenkins/  @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu @gerashegalov
+pom.xml    @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu @gerashegalov
+/dist/     @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu @gerashegalov
+/.github/  @jlowe @revans2 @tgravescs @GaryShen2008 @NvTimLiu @gerashegalov


### PR DESCRIPTION
This adds @gerashegalov as a code owner since he is one of the team experts on our build setup.