### PR TITLE
Fix performance regression in from_json

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -87,7 +87,11 @@ case class GpuJsonToStructs(
                   }
                 }
 
-                (isNullOrEmptyInput, withNewline.joinStrings(null, emptyRow))
+                val joined = withResource(Scalar.fromString("")) { emptyString =>
+                  withNewline.joinStrings(emptyString, emptyRow)
+                }
+
+                (isNullOrEmptyInput, joined)
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -80,10 +80,12 @@ case class GpuJsonToStructs(
                 checkForNewline(cleaned, "\r", "carriage return")
 
                 // add a newline to each JSON line and then join all the JSON lines into one string
-                val withNewline = withResource(cudf.Scalar.fromString("\n")) { lineSep =>
-                  withResource(ColumnVector.fromScalar(lineSep, cleaned.getRowCount.toInt)) {
+                val withNewline = withResource(cleaned) { _ =>
+                  withResource(cudf.Scalar.fromString("\n")) { lineSep =>
+                    withResource(ColumnVector.fromScalar(lineSep, cleaned.getRowCount.toInt)) {
                       newLineCol =>
-                    ColumnVector.stringConcatenate(Array[ColumnView](cleaned, newLineCol))
+                        ColumnVector.stringConcatenate(Array[ColumnView](cleaned, newLineCol))
+                    }
                   }
                 }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -78,19 +78,16 @@ case class GpuJsonToStructs(
               withResource(isLiteralNull.ifElse(emptyRow, nullsReplaced)) { cleaned =>
                 checkForNewline(cleaned, "\n", "line separator")
                 checkForNewline(cleaned, "\r", "carriage return")
-                // if the last entry in a column is incomplete or invalid, then cuDF
-                // will drop the row rather than replace with null if there is no newline, so we
-                // add a newline here to prevent that
-                val joined = withResource(cudf.Scalar.fromString("\n")) { lineSep =>
-                  cleaned.joinStrings(lineSep, emptyRow)
-                }
-                val concat = withResource(joined) { _ =>
-                  withResource(ColumnVector.fromStrings("\n")) { newline =>
-                    ColumnVector.stringConcatenate(Array[ColumnView](joined, newline))
+
+                // add a newline to each JSON line and then join all the JSON lines into one string
+                val withNewline = withResource(cudf.Scalar.fromString("\n")) { lineSep =>
+                  withResource(ColumnVector.fromScalar(lineSep, cleaned.getRowCount.toInt)) {
+                      newLineCol =>
+                    ColumnVector.stringConcatenate(Array[ColumnView](cleaned, newLineCol))
                   }
                 }
 
-                (isNullOrEmptyInput, concat)
+                (isNullOrEmptyInput, withNewline.joinStrings(null, emptyRow))
               }
             }
           }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10301

## Old Approach

- joinStrings with newline separator
- stringConcat to add one more newline at the end, but this was operating on a column with a single string, so not parallelizable

## New Approach

- stringConcat to append newline to each entry
- joinStrings with empty string as separator

This fixes the performance regression and we are now slightly faster than CPU for the benchmark I have been using (instead of 4x slower)