### PR TITLE
Fix typo in spark-tests.sh [skip ci]

### DIFF
--- a/jenkins/spark-tests.sh
+++ b/jenkins/spark-tests.sh
@@ -314,7 +314,7 @@ if [[ $TEST_MODE == "DEFAULT" ]]; then
     PYSP_TEST_spark_jars_packages=com.nvidia:rapids-4-spark_${SCALA_BINARY_VER}:${PROJECT_VER} \
     PYSP_TEST_spark_jars_repositories=${PROJECT_REPO} \
       ./run_pyspark_from_build.sh
-  if
+  fi
 
   # ParquetCachedBatchSerializer cache_test
   PYSP_TEST_spark_sql_cache_serializer=com.nvidia.spark.ParquetCachedBatchSerializer \


### PR DESCRIPTION
Fix typo in spark-tests.sh for '--packages' test

Follow up: https://github.com/NVIDIA/spark-rapids/pull/10279/files#r1471168516


Signed-off-by: Tim Liu <timl@nvidia.com>