### PR TITLE
Update rapids JNI and private version to release 24.02.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020-2023, NVIDIA CORPORATION.
+  Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -722,8 +722,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <spark-rapids-jni.version>24.02.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.02.0</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.02.0</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020-2023, NVIDIA CORPORATION.
+  Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -722,8 +722,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <spark-rapids-jni.version>24.02.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.02.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.02.0</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.02.0</spark-rapids-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
Update dependencies version to 24.02.0

Will re-trigger all CIs after those artifacts are available on maven central


Signed-off-by: Tim Liu <timl@nvidia.com>