### PR TITLE
Dump tool for verifing get_json_object

### DIFF
--- a/docs/dev/get-json-object-dump-tool.md
+++ b/docs/dev/get-json-object-dump-tool.md
@@ -1,0 +1,69 @@
+---
+layout: page
+title: Dump tool for get json object
+nav_order: 12
+parent: Developer Overview
+---
+
+# Dump tool for get json object
+
+## Overview
+In order to track the issues caused by get json object function, RAPIDS Accelerator provides this
+dump tool to save the JSON and PATH to reproduce the issues. Note, the dumped data will be masked
+to protect the customer data.
+
+## How to enable
+Set the following configs:
+- enable GetJsonObject
+```
+'spark.rapids.sql.expression.GetJsonObject': 'true'
+```
+- enable verify GetJsonObject
+```
+'spark.rapids.sql.test.get_json_object': 'true'
+```
+
+- set diff save path
+e,g,:
+```
+'spark.rapids.sql.test.get_json_object.savePath': '/tmp/get-json-object_diffs_'
+```
+CSV file path is /tmp/get-json-object_diffs_yyyyMMdd.csv, yyyyMMdd is current
+date. Can skip this config, default value works, default value is: /tmp/get-json-object_diffs_.
+Currently only supports local path.
+
+- set max rows for each block in GetJsonObject operator when saving diffs.
+```
+'spark.rapids.sql.test.get_json_object.saveRows': '1024'
+```
+This config can be skipped, because default value works.
+This config can not control total rows, it only takes effective in GetJsonObject operator.
+
+## how to do mask
+It's enabled by default, and can not be disabled.
+RAPIDS Accelerator should not dump the original Customer data.
+This dump tool only care about the functionality of get-json-object, the masked data should
+reproduce issues if original data/path can reproduce issues. The mask is to find a way to
+mask data and reproduce issues by using masked data.
+Special/retain chars, the following chars will not be masked:
+```
+    ASCII chars [0, 31] including space char
+    { } [ ] , : " ' :  JSON structure chars, should not mask
+    \  :  escape char, should not mask
+    / b f n r t u : can follow \, should not mask
+    - :  used by number, should not mask
+    0-9  : used by number, should not mask
+    e E  : used by number, e.g.: 1.0E-3, should not mask
+    u A-F a-f : used by JSON string by unicode, e.g.: \u1e2F
+    true :  should not mask
+    false :  should not mask
+    null :  should not mask
+    $ [ ] . * '  : used by path, should not mask
+    ?  : json path supports although Spark does not support, adding this has no side effect
+```
+Above special/retain chars should not be masked, or the JSON will be invalid.  
+Mask logic:  
+  - Assume path only contains a-z, A-Z, '-' and [0-9]
+  - For char set [a-z, A-Z] minus special/retain chars like [eE1-9], create a random one to
+    one mapping to mask data. e.g.: a -> b, b -> c, ..., z -> a
+  - For other chars, e.g.: Chinese chars, map to a const char 's'

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3648,7 +3648,8 @@ object GpuOverrides extends Logging {
           ParamCheck("path", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
       (a, conf, p, r) => new BinaryExprMeta[GetJsonObject](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuGetJsonObject(lhs, rhs, conf.testGetJsonObject, conf.testGetJsonObjectSavePathPrefix)
+          GpuGetJsonObject(lhs, rhs,
+            conf.testGetJsonObject, conf.testGetJsonObjectSavePath, conf.testGetJsonObjectSaveRows)
       }
     ).disabledByDefault("escape sequences are not processed correctly, the input is not " +
         "validated, and the output is not normalized the same as Spark"),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3648,7 +3648,7 @@ object GpuOverrides extends Logging {
           ParamCheck("path", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
       (a, conf, p, r) => new BinaryExprMeta[GetJsonObject](a, conf, p, r) {
         override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuGetJsonObject(lhs, rhs)
+          GpuGetJsonObject(lhs, rhs, conf.testGetJsonObject, conf.testGetJsonObjectSavePathPrefix)
       }
     ).disabledByDefault("escape sequences are not processed correctly, the input is not " +
         "validated, and the output is not normalized the same as Spark"),

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2121,12 +2121,20 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .booleanConf
       .createWithDefault(false)
 
-  val TEST_GET_JSON_OBJECT_SAVE_PREFIX = conf("spark.rapids.sql.test.get_json_object.save.prefix")
-      .doc("Only for tests: specify dump path prefix if spark.rapids.sql.test.get_json_object " +
-          "is enabled.")
+  val TEST_GET_JSON_OBJECT_SAVE_PATH = conf("spark.rapids.sql.test.get_json_object.savePath")
+      .doc("Only for tests: specify csv path to save diffs if " +
+          "spark.rapids.sql.test.get_json_object is enabled. " +
+          "Saves by date, the date with yyyyMMdd format will be append to the end of file path")
       .internal()
       .stringConf
-      .createWithDefault("/tmp/get-json-object_diff_")
+      .createWithDefault("/tmp/get-json-object_diffs_")
+
+  val TEST_GET_JSON_OBJECT_SAVE_ROWS = conf("spark.rapids.sql.test.get_json_object.saveRows")
+      .doc("Only for tests: specify save rows for each block that GPUGetJsonObject handles " +
+          "if spark.rapids.sql.test.get_json_object is enabled. ")
+      .internal()
+      .integerConf
+      .createWithDefault(1024)
 
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
@@ -2889,7 +2897,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val testGetJsonObject: Boolean = get(TEST_GET_JSON_OBJECT)
 
-  lazy val testGetJsonObjectSavePathPrefix: String = get(TEST_GET_JSON_OBJECT_SAVE_PREFIX)
+  lazy val testGetJsonObjectSavePath: String = get(TEST_GET_JSON_OBJECT_SAVE_PATH)
+
+  lazy val testGetJsonObjectSaveRows: Int = get(TEST_GET_JSON_OBJECT_SAVE_ROWS)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2114,6 +2114,20 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createOptional
 
+  val TEST_GET_JSON_OBJECT = conf("spark.rapids.sql.test.get_json_object")
+      .doc("Only for tests: verify for get_json_object. If enabled, dump the data that " +
+          "causes differences between Spark and GPU.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
+  val TEST_GET_JSON_OBJECT_SAVE_PREFIX = conf("spark.rapids.sql.test.get_json_object.save.prefix")
+      .doc("Only for tests: specify dump path prefix if spark.rapids.sql.test.get_json_object " +
+          "is enabled.")
+      .internal()
+      .stringConf
+      .createWithDefault("/tmp/get-json-object_diff_")
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2872,6 +2886,10 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val spillToDiskBounceBufferSize: Long = get(SPILL_TO_DISK_BOUNCE_BUFFER_SIZE)
 
   lazy val splitUntilSizeOverride: Option[Long] = get(SPLIT_UNTIL_SIZE_OVERRIDE)
+
+  lazy val testGetJsonObject: Boolean = get(TEST_GET_JSON_OBJECT)
+
+  lazy val testGetJsonObjectSavePathPrefix: String = get(TEST_GET_JSON_OBJECT_SAVE_PREFIX)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
@@ -155,12 +155,12 @@ object GetJsonObjectMask {
     map.toMap
   }
 
-  private def getDigitMap(seed: Int): Map[Int, Int] = {
+  private def getDigitMap(seed: Int): Map[Char, Char] = {
     val random = new Random(seed)
-    val digits = 1 to 9
+    val digits = '1' to '9'
     val from = digits.toList
     val to = random.shuffle(digits.toList)
-    val map = mutable.Map[Int, Int]()
+    val map = mutable.Map[Char, Char]()
     for (i <- from.indices) {
       map(from(i)) = to(i)
     }
@@ -179,12 +179,13 @@ object GetJsonObjectMask {
       originStr: String,
       retainChars: Set[Char],
       oneToOneMap: Map[Char, Char],
-      digitMap: Map[Int, Int]): String = {
+      digitMap: Map[Char, Char]): String = {
     if (originStr != null) {
       val buf = new StringBuffer(originStr.length)
       var idx = 0
       while (idx < originStr.length) {
         val originChar = originStr(idx)
+        idx += 1
         if (originChar >= '1' && originChar <= '9') {
           // digits need to one to one map
           val toDigit = digitMap(originChar)
@@ -204,7 +205,6 @@ object GetJsonObjectMask {
               buf.append(originChar)
             }
           }
-          idx += 1
         }
       }
       buf.toString

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
@@ -16,29 +16,24 @@
 
 package org.apache.spark.sql.rapids.test
 
-import java.io.{ByteArrayOutputStream, FileWriter, StringWriter}
+import java.io.FileWriter
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Objects
 
-import scala.util.parsing.combinator.RegexParsers
-
 import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector}
-import com.fasterxml.jackson.core.{JsonEncoding, JsonFactoryBuilder, JsonGenerator, JsonParser, JsonProcessingException, JsonToken}
-import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuScalar}
 import com.nvidia.spark.rapids.Arm.withResource
-import com.nvidia.spark.rapids.GpuColumnVector
 import com.univocity.parsers.csv.{CsvWriter, CsvWriterSettings}
-import java.util
 
-import org.apache.spark.sql.catalyst.json.CreateJacksonParser
+import org.apache.spark.sql.catalyst.expressions.{GetJsonObject, Literal}
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.Utils
 
 case class CsvWriterWrapper(filePath: String) extends AutoCloseable {
   // create file writer with append mode
-  val writer: FileWriter = new FileWriter(filePath, true)
-  val csvWriter: CsvWriter = new CsvWriter(writer, new CsvWriterSettings())
+  private val writer: FileWriter = new FileWriter(filePath, true)
+  private val csvWriter: CsvWriter = new CsvWriter(writer, new CsvWriterSettings())
 
   override def close(): Unit = {
     if (csvWriter != null) {
@@ -49,17 +44,98 @@ case class CsvWriterWrapper(filePath: String) extends AutoCloseable {
     }
   }
 
-  def writeHeaders(headers: util.Collection[String]): Unit = {
-    csvWriter.writeHeaders(headers)
-  }
-
   def writeRow(row: Array[String]): Unit = {
     csvWriter.writeRow(row)
   }
 }
 
+object GetJsonObjectMask {
+
+  /**
+   * Used by mask data
+   */
+  private val RETAIN_CHARS_FOR_JSON = Set[Char](
+    '{', '}', '[', ']', ',', ':', '"', '\'',
+    '\\', '/', 'b', 'f', 'n', 'r', 't', 'u',
+    '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'e', 'E',
+    'u', 'A', 'a', 'B', 'b', 'C', 'c', 'D', 'd', 'E', 'e', 'F', 'f',
+    't', 'r', 'u', 'e',
+    'f', 'a', 'l', 's', 'e',
+    'n', 'u', 'l', 'l'
+  )
+
+  /**
+   * Mask data. RAPIDS Accelerator should now dump the original Customer data.
+   * This dump tool only care about the functionality of get-json-object, so just replace
+   * characters to a const 's' except the following cases:
+   *     { } [ ] , : " ' :  JSON structure chars, should not replace
+   *     \  :  escape char, should not replace
+   *     / b f n r t u : can follow \, should not replace
+   *     - :  used by number, should not replace
+   *     0-9  : used by number, should not replace
+   *     e E  : used by number, e,g,: 1.0E-3, should not replace
+   *     u A-F a-f : used by unicode: \u HEX HEX HEX HEX, should not replace
+   *     true :  should not replace
+   *     false :  should not replace
+   *     null :  should not replace
+   * To simplify more,
+   * Replace all the chars to 's' except above chars, including chars in true, false, null.
+   *
+   * @param jsonStr original JSON data
+   * @return Desensitized data
+   */
+  def maskData(jsonStr: String): String = {
+    replaceIfNotRetain(jsonStr, RETAIN_CHARS_FOR_JSON)
+  }
+
+  // used by mask path
+  private val RETAIN_CHARS_FOR_PATH = Set[Char]('$', '[', ']', '*', '.')
+
+  /**
+   * mask path
+   * @param pathStr original path
+   * @return masked path
+   */
+  def maskPath(pathStr: String): String = {
+    replaceIfNotRetain(pathStr, RETAIN_CHARS_FOR_PATH)
+  }
+
+  /**
+   * Replace chars not in `retainChars` to const char 's' to mask data
+   * @param originStr origin string
+   * @param retainChars retain chars
+   * @return masked string
+   */
+  private def replaceIfNotRetain(originStr: String, retainChars: Set[Char] ): String = {
+    if (originStr != null) {
+      val buf = new StringBuffer(originStr.length)
+      var idx = 0
+      while (idx < originStr.length) {
+        if (!retainChars.contains(originStr(idx))) {
+          // if it's not a retain char, replace to a const char 's'
+          buf.append('s')
+        } else {
+          buf.append(originStr(idx))
+        }
+        idx += 1
+      }
+      buf.toString
+    } else {
+      null
+    }
+  }
+}
+
 object CpuGetJsonObject {
-  // verify results from Cpu and Gpu, save diffs if have
+  /**
+   * verify results from Cpu and Gpu, save diffs if have
+   * @param dataCv original JSON data
+   * @param path the path to extract JSON data
+   * @param fromGpuCv result from GPU
+   * @param fromCpuHCV result from CPU
+   * @param savePathForVerify save path if have diffs
+   * @param saveRowsForVerify max diff rows to save, Note: only take effective for current data
+   */
   def verify(
       dataCv: ColumnVector,
       path: UTF8String,
@@ -69,6 +145,7 @@ object CpuGetJsonObject {
       saveRowsForVerify: Int): Unit = {
     withResource(dataCv.copyToHost()) { dataHCV =>
       withResource(fromGpuCv.copyToHost()) { fromGpuHCV =>
+        // save file is generated by date: yyyyMMdd.csv
         val savePath = savePathForVerify +
             DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now()) + ".csv"
         withResource(CsvWriterWrapper(savePath)) { csvWriter =>
@@ -83,8 +160,15 @@ object CpuGetJsonObject {
             val gpuStr = if (fromGpuHCV.isNull(currRow)) null else fromGpuHCV.getJavaString(currRow)
             if (!Objects.equals(cpuStr, gpuStr)) { // if have diff
               diffRowsNum += 1
-              // write to csv file
-              csvWriter.writeRow(Array(pathStr, str, cpuStr, gpuStr))
+
+              // mask customer data
+              val maskedPath = GetJsonObjectMask.maskPath(pathStr)
+              val maskedOriginJson = GetJsonObjectMask.maskData(str)
+              val maskedCpuRet = GetJsonObjectMask.maskData(cpuStr)
+              val maskedGpuRet = GetJsonObjectMask.maskData(gpuStr)
+
+              // append to csv file: yyyyMMdd.csv
+              csvWriter.writeRow(Array(maskedPath, maskedOriginJson, maskedCpuRet, maskedGpuRet))
             }
             currRow += 1
           }
@@ -93,16 +177,26 @@ object CpuGetJsonObject {
     }
   }
 
-  // get_json_object on Cpu
-  def getJsonObjectOnCpu(dataCv: GpuColumnVector, path: UTF8String): HostColumnVector = {
+  /**
+   * Run get-json-object on CPU
+   * @param dataCv original JSON data
+   * @param pathScalar path scalar
+   * @return CPU result of get-json-object
+   */
+  def getJsonObjectOnCpu(dataCv: GpuColumnVector, pathScalar: GpuScalar): HostColumnVector = {
     withResource(dataCv.copyToHost()) { dataHCV =>
       withResource(HostColumnVector.builder(DType.STRING, dataHCV.getRowCount.toInt)) {
         resultBuilder =>
-          val cpuGetJsonObject = GetJsonObject(path)
+          val path = pathScalar.getValue.asInstanceOf[UTF8String]
+          val pathLiteral = Literal.create(path, StringType)
           for (i <- 0 until dataHCV.getRowCount.toInt) {
-            val s = dataHCV.getUTF8String(i)
-            // Call Cpu get_json_object
-            val utf8String = cpuGetJsonObject.eval(s)
+            val json = dataHCV.getUTF8String(i)
+            // In order to use `GetJsonObject` directly,
+            // here use a literal json and a literal path
+            val jsonLiteral = Literal.create(json, StringType)
+            val cpuGetJsonObject = GetJsonObject(jsonLiteral, pathLiteral)
+            // input null is safe because both json and path are literal
+            val utf8String = cpuGetJsonObject.eval(null)
             if (utf8String == null) {
               resultBuilder.appendNull()
             } else {
@@ -111,291 +205,6 @@ object CpuGetJsonObject {
           }
           resultBuilder.build()
       }
-    }
-  }
-}
-
-// below code is copied from Spark
-private[this] sealed trait PathInstruction
-
-private[this] object PathInstruction {
-  private[test] case object Subscript extends PathInstruction
-
-  private[test] case object Wildcard extends PathInstruction
-
-  private[test] case object Key extends PathInstruction
-
-  private[test] case class Index(index: Long) extends PathInstruction
-
-  private[test] case class Named(name: String) extends PathInstruction
-}
-
-private[this] sealed trait WriteStyle
-
-private[this] object WriteStyle {
-  private[test] case object RawStyle extends WriteStyle
-
-  private[test] case object QuotedStyle extends WriteStyle
-
-  private[test] case object FlattenStyle extends WriteStyle
-}
-
-private[this] object JsonPathParser extends RegexParsers {
-
-  import PathInstruction._
-
-  def root: Parser[Char] = '$'
-
-  def long: Parser[Long] = "\\d+".r ^? {
-    case x => x.toLong
-  }
-
-  // parse `[*]` and `[123]` subscripts
-  def subscript: Parser[List[PathInstruction]] =
-    for {
-      operand <- '[' ~> ('*' ^^^ Wildcard | long ^^ Index) <~ ']'
-    } yield {
-      Subscript :: operand :: Nil
-    }
-
-  // parse `.name` or `['name']` child expressions
-  def named: Parser[List[PathInstruction]] =
-    for {
-      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
-    } yield {
-      Key :: Named(name) :: Nil
-    }
-
-  // child wildcards: `..`, `.*` or `['*']`
-  def wildcard: Parser[List[PathInstruction]] =
-    (".*" | "['*']") ^^^ List(Wildcard)
-
-  def node: Parser[List[PathInstruction]] =
-    wildcard |
-        named |
-        subscript
-
-  val expression: Parser[List[PathInstruction]] = {
-    phrase(root ~> rep(node) ^^ (x => x.flatten))
-  }
-
-  def parse(str: String): Option[List[PathInstruction]] = {
-    this.parseAll(expression, str) match {
-      case Success(result, _) =>
-        Some(result)
-
-      case _ =>
-        None
-    }
-  }
-}
-
-private[this] object SharedFactory {
-  val jsonFactory = new JsonFactoryBuilder()
-      // The two options below enabled for Hive compatibility
-      .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
-      .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
-      .build()
-}
-
-private[this] case class GetJsonObject(path: UTF8String) {
-
-  import com.fasterxml.jackson.core.JsonToken._
-
-  import PathInstruction._
-  import SharedFactory._
-  import WriteStyle._
-
-  private lazy val parsedPath = parsePath(path)
-
-  private[test] def eval(jsonStr: UTF8String): UTF8String = {
-    if (jsonStr == null) {
-      return null
-    }
-
-    val parsed = parsedPath
-
-    if (parsed.isDefined) {
-      try {
-        /* We know the bytes are UTF-8 encoded. Pass a Reader to avoid having Jackson
-          detect character encoding which could fail for some malformed strings */
-        withResource(CreateJacksonParser.utf8String(jsonFactory, jsonStr)) { parser =>
-          val output = new ByteArrayOutputStream()
-          val matched = withResource(
-            jsonFactory.createGenerator(output, JsonEncoding.UTF8)) { generator =>
-            parser.nextToken()
-            evaluatePath(parser, generator, RawStyle, parsed.get)
-          }
-          if (matched) {
-            UTF8String.fromBytes(output.toByteArray)
-          } else {
-            null
-          }
-        }
-      } catch {
-        case _: JsonProcessingException => null
-      }
-    } else {
-      null
-    }
-  }
-
-  private def parsePath(path: UTF8String): Option[List[PathInstruction]] = {
-    if (path != null) {
-      JsonPathParser.parse(path.toString)
-    } else {
-      None
-    }
-  }
-
-  // advance to the desired array index, assumes to start at the START_ARRAY token
-  private def arrayIndex(p: JsonParser, f: () => Boolean): Long => Boolean = {
-    case _ if p.getCurrentToken == END_ARRAY =>
-      // terminate, nothing has been written
-      false
-
-    case 0 =>
-      // we've reached the desired index
-      val dirty = f()
-
-      while (p.nextToken() != END_ARRAY) {
-        // advance the token stream to the end of the array
-        p.skipChildren()
-      }
-
-      dirty
-
-    case i if i > 0 =>
-      // skip this token and evaluate the next
-      p.skipChildren()
-      p.nextToken()
-      arrayIndex(p, f)(i - 1)
-  }
-
-  /**
-   * Evaluate a list of JsonPath instructions, returning a bool that indicates if any leaf nodes
-   * have been written to the generator
-   */
-  private def evaluatePath(
-      p: JsonParser,
-      g: JsonGenerator,
-      style: WriteStyle,
-      path: List[PathInstruction]): Boolean = {
-    (p.getCurrentToken, path) match {
-      case (VALUE_STRING, Nil) if style == RawStyle =>
-        // there is no array wildcard or slice parent, emit this string without quotes
-        if (p.hasTextCharacters) {
-          g.writeRaw(p.getTextCharacters, p.getTextOffset, p.getTextLength)
-        } else {
-          g.writeRaw(p.getText)
-        }
-        true
-
-      case (START_ARRAY, Nil) if style == FlattenStyle =>
-        // flatten this array into the parent
-        var dirty = false
-        while (p.nextToken() != END_ARRAY) {
-          dirty |= evaluatePath(p, g, style, Nil)
-        }
-        dirty
-
-      case (_, Nil) =>
-        // general case: just copy the child tree verbatim
-        g.copyCurrentStructure(p)
-        true
-
-      case (START_OBJECT, Key :: xs) =>
-        var dirty = false
-        while (p.nextToken() != END_OBJECT) {
-          if (dirty) {
-            // once a match has been found we can skip other fields
-            p.skipChildren()
-          } else {
-            dirty = evaluatePath(p, g, style, xs)
-          }
-        }
-        dirty
-
-      case (START_ARRAY, Subscript :: Wildcard :: Subscript :: Wildcard :: xs) =>
-        // special handling for the non-structure preserving double wildcard behavior in Hive
-        var dirty = false
-        g.writeStartArray()
-        while (p.nextToken() != END_ARRAY) {
-          dirty |= evaluatePath(p, g, FlattenStyle, xs)
-        }
-        g.writeEndArray()
-        dirty
-
-      case (START_ARRAY, Subscript :: Wildcard :: xs) if style != QuotedStyle =>
-        // retain Flatten, otherwise use Quoted... cannot use Raw within an array
-        val nextStyle = style match {
-          case RawStyle => QuotedStyle
-          case FlattenStyle => FlattenStyle
-          case QuotedStyle => throw new IllegalStateException()
-        }
-
-        // temporarily buffer child matches, the emitted json will need to be
-        // modified slightly if there is only a single element written
-        val buffer = new StringWriter()
-
-        var dirty = 0
-        Utils.tryWithResource(jsonFactory.createGenerator(buffer)) { flattenGenerator =>
-          flattenGenerator.writeStartArray()
-
-          while (p.nextToken() != END_ARRAY) {
-            // track the number of array elements and only emit an outer array if
-            // we've written more than one element, this matches Hive's behavior
-            dirty += (if (evaluatePath(p, flattenGenerator, nextStyle, xs)) 1 else 0)
-          }
-          flattenGenerator.writeEndArray()
-        }
-
-        val buf = buffer.getBuffer
-        if (dirty > 1) {
-          g.writeRawValue(buf.toString)
-        } else if (dirty == 1) {
-          // remove outer array tokens
-          g.writeRawValue(buf.substring(1, buf.length() - 1))
-        } // else do not write anything
-
-        dirty > 0
-
-      case (START_ARRAY, Subscript :: Wildcard :: xs) =>
-        var dirty = false
-        g.writeStartArray()
-        while (p.nextToken() != END_ARRAY) {
-          // wildcards can have multiple matches, continually update the dirty count
-          dirty |= evaluatePath(p, g, QuotedStyle, xs)
-        }
-        g.writeEndArray()
-
-        dirty
-
-      case (START_ARRAY, Subscript :: Index(idx) :: (xs@Subscript :: Wildcard :: _)) =>
-        p.nextToken()
-        // we're going to have 1 or more results, switch to QuotedStyle
-        arrayIndex(p, () => evaluatePath(p, g, QuotedStyle, xs))(idx)
-
-      case (START_ARRAY, Subscript :: Index(idx) :: xs) =>
-        p.nextToken()
-        arrayIndex(p, () => evaluatePath(p, g, style, xs))(idx)
-
-      case (FIELD_NAME, Named(name) :: xs) if p.getCurrentName == name =>
-        // exact field match
-        if (p.nextToken() != JsonToken.VALUE_NULL) {
-          evaluatePath(p, g, style, xs)
-        } else {
-          false
-        }
-
-      case (FIELD_NAME, Wildcard :: xs) =>
-        // wildcard field match
-        p.nextToken()
-        evaluatePath(p, g, style, xs)
-
-      case _ =>
-        p.skipChildren()
-        false
     }
   }
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.test
+
+import java.io.{ByteArrayOutputStream, StringWriter}
+import java.util.Objects
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.parsing.combinator.RegexParsers
+
+import ai.rapids.cudf.{ColumnVector, DType, HostColumnVector, Table}
+import com.fasterxml.jackson.core.{JsonEncoding, JsonFactoryBuilder, JsonGenerator, JsonParser, JsonProcessingException, JsonToken}
+import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.nvidia.spark.rapids.{DumpUtils, GpuColumnVector, GpuScalar}
+import com.nvidia.spark.rapids.Arm.withResource
+
+import org.apache.spark.sql.catalyst.json.CreateJacksonParser
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.Utils
+
+object CpuGetJsonObject {
+
+  private val maxRowsToSave = 1024 * 10
+
+  // verify results from Cpu and Gpu, save diffs if has
+  def verify(
+      dataCv: ColumnVector,
+      fromGpuCv: ColumnVector,
+      fromCpuHCV: HostColumnVector,
+      verifyDiffSavePathPrefix: String): Unit = {
+    withResource(dataCv.copyToHost()) { dataHCV =>
+      withResource(fromGpuCv.copyToHost()) { fromGpuHCV =>
+        //1. compare Cpu and Gpu results, if not equal, record (data, cpu result, gpu result)
+        val diffs = new ArrayBuffer[String]
+        var currRow = 0
+        while (currRow < dataCv.getRowCount.toInt &&
+            diffs.size < maxRowsToSave * 3 // limit max rows to save to avoid memory foot print
+        ) {
+          val str = dataHCV.getJavaString(currRow)
+          val cpuStr = if (fromCpuHCV.isNull(currRow)) null else fromCpuHCV.getJavaString(currRow)
+          val gpuStr = if (fromGpuHCV.isNull(currRow)) null else fromGpuHCV.getJavaString(currRow)
+          if (!Objects.equals(cpuStr, gpuStr)) { // if have diff
+            diffs += str
+            diffs += cpuStr
+            diffs += gpuStr
+          }
+          currRow += 1
+        }
+
+        val diffNum = diffs.size / 3
+        if (diffNum > 0) {
+          // 2. create table to save diffs
+          val table = withResource(HostColumnVector.builder(DType.STRING, diffNum)) { dataBuilder =>
+            withResource(HostColumnVector.builder(DType.STRING, diffNum)) { cpuBuilder =>
+              withResource(HostColumnVector.builder(DType.STRING, diffNum)) { gpuBuilder =>
+                for (i <- 0 until diffNum) {
+                  val str = diffs(3 * i)
+                  val cpuStr = diffs(3 * i + 1)
+                  val gpuStr = diffs(3 * i + 2)
+                  append(dataBuilder, str)
+                  append(cpuBuilder, cpuStr)
+                  append(gpuBuilder, gpuStr)
+                }
+
+                withResource(dataBuilder.build()) { dataHCV =>
+                  withResource(cpuBuilder.build()) { cpuHCV =>
+                    withResource(gpuBuilder.build()) { gpuHCV =>
+                      withResource(dataHCV.copyToDevice()) { dataCv =>
+                        withResource(cpuHCV.copyToDevice()) { cpuCv =>
+                          withResource(gpuHCV.copyToDevice()) { gpuCv =>
+                            new Table(dataCv, cpuCv, gpuCv)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          // 3. save table into a Parquet file
+          withResource(table) { _ =>
+            DumpUtils.dumpToParquetFile(table, verifyDiffSavePathPrefix)
+          }
+        }
+      }
+    }
+  }
+
+  private def append(builder: HostColumnVector.Builder, v: String): Unit = {
+    if (v == null) {
+      builder.appendNull()
+    } else {
+      builder.append(v)
+    }
+  }
+
+  // get_json_object on Cpu
+  def getJsonObjectOnCpu(dataCv: GpuColumnVector, rhs: GpuScalar): HostColumnVector = {
+    withResource(dataCv.copyToHost()) { dataHCV =>
+      withResource(HostColumnVector.builder(DType.STRING, dataHCV.getRowCount.toInt)) {
+        resultBuilder =>
+          val path = rhs.getValue.asInstanceOf[UTF8String]
+          val cpuGetJsonObject = GetJsonObject(path)
+          for (i <- 0 until dataHCV.getRowCount.toInt) {
+            val s = dataHCV.getUTF8String(i)
+            // Call Cpu get_json_object
+            val utf8String = cpuGetJsonObject.eval(s)
+            if (utf8String == null) {
+              resultBuilder.appendNull()
+            } else {
+              resultBuilder.append(utf8String.toString)
+            }
+          }
+          resultBuilder.build()
+      }
+    }
+  }
+}
+
+// below code is copied from Spark
+private[this] sealed trait PathInstruction
+
+private[this] object PathInstruction {
+  private[test] case object Subscript extends PathInstruction
+
+  private[test] case object Wildcard extends PathInstruction
+
+  private[test] case object Key extends PathInstruction
+
+  private[test] case class Index(index: Long) extends PathInstruction
+
+  private[test] case class Named(name: String) extends PathInstruction
+}
+
+private[this] sealed trait WriteStyle
+
+private[this] object WriteStyle {
+  private[test] case object RawStyle extends WriteStyle
+
+  private[test] case object QuotedStyle extends WriteStyle
+
+  private[test] case object FlattenStyle extends WriteStyle
+}
+
+private[this] object JsonPathParser extends RegexParsers {
+
+  import PathInstruction._
+
+  def root: Parser[Char] = '$'
+
+  def long: Parser[Long] = "\\d+".r ^? {
+    case x => x.toLong
+  }
+
+  // parse `[*]` and `[123]` subscripts
+  def subscript: Parser[List[PathInstruction]] =
+    for {
+      operand <- '[' ~> ('*' ^^^ Wildcard | long ^^ Index) <~ ']'
+    } yield {
+      Subscript :: operand :: Nil
+    }
+
+  // parse `.name` or `['name']` child expressions
+  def named: Parser[List[PathInstruction]] =
+    for {
+      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+    } yield {
+      Key :: Named(name) :: Nil
+    }
+
+  // child wildcards: `..`, `.*` or `['*']`
+  def wildcard: Parser[List[PathInstruction]] =
+    (".*" | "['*']") ^^^ List(Wildcard)
+
+  def node: Parser[List[PathInstruction]] =
+    wildcard |
+        named |
+        subscript
+
+  val expression: Parser[List[PathInstruction]] = {
+    phrase(root ~> rep(node) ^^ (x => x.flatten))
+  }
+
+  def parse(str: String): Option[List[PathInstruction]] = {
+    this.parseAll(expression, str) match {
+      case Success(result, _) =>
+        Some(result)
+
+      case _ =>
+        None
+    }
+  }
+}
+
+private[this] object SharedFactory {
+  val jsonFactory = new JsonFactoryBuilder()
+      // The two options below enabled for Hive compatibility
+      .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+      .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+      .build()
+}
+
+private[this] case class GetJsonObject(path: UTF8String) {
+
+  import com.fasterxml.jackson.core.JsonToken._
+
+  import PathInstruction._
+  import SharedFactory._
+  import WriteStyle._
+
+  private lazy val parsedPath = parsePath(path)
+
+  private[test] def eval(jsonStr: UTF8String): UTF8String = {
+    if (jsonStr == null) {
+      return null
+    }
+
+    val parsed = parsedPath
+
+    if (parsed.isDefined) {
+      try {
+        /* We know the bytes are UTF-8 encoded. Pass a Reader to avoid having Jackson
+          detect character encoding which could fail for some malformed strings */
+        withResource(CreateJacksonParser.utf8String(jsonFactory, jsonStr)) { parser =>
+          val output = new ByteArrayOutputStream()
+          val matched = withResource(
+            jsonFactory.createGenerator(output, JsonEncoding.UTF8)) { generator =>
+            parser.nextToken()
+            evaluatePath(parser, generator, RawStyle, parsed.get)
+          }
+          if (matched) {
+            UTF8String.fromBytes(output.toByteArray)
+          } else {
+            null
+          }
+        }
+      } catch {
+        case _: JsonProcessingException => null
+      }
+    } else {
+      null
+    }
+  }
+
+  private def parsePath(path: UTF8String): Option[List[PathInstruction]] = {
+    if (path != null) {
+      JsonPathParser.parse(path.toString)
+    } else {
+      None
+    }
+  }
+
+  // advance to the desired array index, assumes to start at the START_ARRAY token
+  private def arrayIndex(p: JsonParser, f: () => Boolean): Long => Boolean = {
+    case _ if p.getCurrentToken == END_ARRAY =>
+      // terminate, nothing has been written
+      false
+
+    case 0 =>
+      // we've reached the desired index
+      val dirty = f()
+
+      while (p.nextToken() != END_ARRAY) {
+        // advance the token stream to the end of the array
+        p.skipChildren()
+      }
+
+      dirty
+
+    case i if i > 0 =>
+      // skip this token and evaluate the next
+      p.skipChildren()
+      p.nextToken()
+      arrayIndex(p, f)(i - 1)
+  }
+
+  /**
+   * Evaluate a list of JsonPath instructions, returning a bool that indicates if any leaf nodes
+   * have been written to the generator
+   */
+  private def evaluatePath(
+      p: JsonParser,
+      g: JsonGenerator,
+      style: WriteStyle,
+      path: List[PathInstruction]): Boolean = {
+    (p.getCurrentToken, path) match {
+      case (VALUE_STRING, Nil) if style == RawStyle =>
+        // there is no array wildcard or slice parent, emit this string without quotes
+        if (p.hasTextCharacters) {
+          g.writeRaw(p.getTextCharacters, p.getTextOffset, p.getTextLength)
+        } else {
+          g.writeRaw(p.getText)
+        }
+        true
+
+      case (START_ARRAY, Nil) if style == FlattenStyle =>
+        // flatten this array into the parent
+        var dirty = false
+        while (p.nextToken() != END_ARRAY) {
+          dirty |= evaluatePath(p, g, style, Nil)
+        }
+        dirty
+
+      case (_, Nil) =>
+        // general case: just copy the child tree verbatim
+        g.copyCurrentStructure(p)
+        true
+
+      case (START_OBJECT, Key :: xs) =>
+        var dirty = false
+        while (p.nextToken() != END_OBJECT) {
+          if (dirty) {
+            // once a match has been found we can skip other fields
+            p.skipChildren()
+          } else {
+            dirty = evaluatePath(p, g, style, xs)
+          }
+        }
+        dirty
+
+      case (START_ARRAY, Subscript :: Wildcard :: Subscript :: Wildcard :: xs) =>
+        // special handling for the non-structure preserving double wildcard behavior in Hive
+        var dirty = false
+        g.writeStartArray()
+        while (p.nextToken() != END_ARRAY) {
+          dirty |= evaluatePath(p, g, FlattenStyle, xs)
+        }
+        g.writeEndArray()
+        dirty
+
+      case (START_ARRAY, Subscript :: Wildcard :: xs) if style != QuotedStyle =>
+        // retain Flatten, otherwise use Quoted... cannot use Raw within an array
+        val nextStyle = style match {
+          case RawStyle => QuotedStyle
+          case FlattenStyle => FlattenStyle
+          case QuotedStyle => throw new IllegalStateException()
+        }
+
+        // temporarily buffer child matches, the emitted json will need to be
+        // modified slightly if there is only a single element written
+        val buffer = new StringWriter()
+
+        var dirty = 0
+        Utils.tryWithResource(jsonFactory.createGenerator(buffer)) { flattenGenerator =>
+          flattenGenerator.writeStartArray()
+
+          while (p.nextToken() != END_ARRAY) {
+            // track the number of array elements and only emit an outer array if
+            // we've written more than one element, this matches Hive's behavior
+            dirty += (if (evaluatePath(p, flattenGenerator, nextStyle, xs)) 1 else 0)
+          }
+          flattenGenerator.writeEndArray()
+        }
+
+        val buf = buffer.getBuffer
+        if (dirty > 1) {
+          g.writeRawValue(buf.toString)
+        } else if (dirty == 1) {
+          // remove outer array tokens
+          g.writeRawValue(buf.substring(1, buf.length() - 1))
+        } // else do not write anything
+
+        dirty > 0
+
+      case (START_ARRAY, Subscript :: Wildcard :: xs) =>
+        var dirty = false
+        g.writeStartArray()
+        while (p.nextToken() != END_ARRAY) {
+          // wildcards can have multiple matches, continually update the dirty count
+          dirty |= evaluatePath(p, g, QuotedStyle, xs)
+        }
+        g.writeEndArray()
+
+        dirty
+
+      case (START_ARRAY, Subscript :: Index(idx) :: (xs@Subscript :: Wildcard :: _)) =>
+        p.nextToken()
+        // we're going to have 1 or more results, switch to QuotedStyle
+        arrayIndex(p, () => evaluatePath(p, g, QuotedStyle, xs))(idx)
+
+      case (START_ARRAY, Subscript :: Index(idx) :: xs) =>
+        p.nextToken()
+        arrayIndex(p, () => evaluatePath(p, g, style, xs))(idx)
+
+      case (FIELD_NAME, Named(name) :: xs) if p.getCurrentName == name =>
+        // exact field match
+        if (p.nextToken() != JsonToken.VALUE_NULL) {
+          evaluatePath(p, g, style, xs)
+        } else {
+          false
+        }
+
+      case (FIELD_NAME, Wildcard :: xs) =>
+        // wildcard field match
+        p.nextToken()
+        evaluatePath(p, g, style, xs)
+
+      case _ =>
+        p.skipChildren()
+        false
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/test/cpuJsonExpressions.scala
@@ -70,7 +70,7 @@ object CpuGetJsonObject {
     withResource(dataCv.copyToHost()) { dataHCV =>
       withResource(fromGpuCv.copyToHost()) { fromGpuHCV =>
         val savePath = savePathForVerify +
-            DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now())
+            DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now()) + ".csv"
         withResource(CsvWriterWrapper(savePath)) { csvWriter =>
           val pathStr = if (path == null) "null" else path.toString
           var currRow = 0


### PR DESCRIPTION
Verify the CPU and GPU results of get_json_object, if find diffs, save to Csv files.
This is only for testing.

- port Spark get_json_object code
- compare cpu/gpu results
- write to Csv file if have diffs. Append to csv file, one day create one csv file. By default, csv file name format is:  /tmp/get-json-object_diffs_yyyyMMdd.csv

How to open, set the following configs:
```
{
'spark.rapids.sql.expression.GetJsonObject': 'true',  // enable GetJsonObject
'spark.rapids.sql.test.get_json_object': 'true',  // enable verify GetJsonObject
'spark.rapids.sql.test.get_json_object.savePath': '/tmp/get-json-object_diffs_', // path will be /tmp/get-json-object_diffs_yyyyMMdd.csv, yyyyMMdd is current date. 
'spark.rapids.sql.test.get_json_object.saveRows': '1024' // max rows for each block in GetJsonObject operator when saving diffs. Note: this config can not control total rows, need tuning when the csv file is too big.
}
```

Signed-off-by: Chong Gao <res_life@163.com>
