### PR TITLE
Drop Databricks 10.4 runtime from CI

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -88,7 +88,7 @@ pipeline {
                         // 'name' and 'value' only supprt literal string in the declarative Jenkins
                         // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
                         name 'DB_RUNTIME'
-                        values '10.4', '11.3', '12.2', '13.3'
+                        values '11.3', '12.2', '13.3'
                     }
                 }
                 stages {

--- a/pom.xml
+++ b/pom.xml
@@ -837,7 +837,6 @@
             351
         </snapshot.buildvers>
         <databricks.buildvers>
-            321db,
             330db,
             332db,
             341db

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -837,7 +837,6 @@
             351
         </snapshot.buildvers>
         <databricks.buildvers>
-            321db,
             330db,
             332db,
             341db


### PR DESCRIPTION
Part of  https://github.com/NVIDIA/spark-rapids/issues/10429

Drop Databricks 10.4 runtime from CI pipelines, @razajafri  will help remove 10.4 related source code.

