### PR TITLE
Use parser from spark to normalize json path in GetJsonObject

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -479,16 +479,6 @@ The following is a list of known differences.
 
 The following is a list of bugs in either the GPU version or arguably in Apache Spark itself.
    * https://github.com/NVIDIA/spark-rapids/issues/10219 non-matching quotes in quoted strings
-   * https://github.com/NVIDIA/spark-rapids/issues/10213 array index notation works without root
-   * https://github.com/NVIDIA/spark-rapids/issues/10214 unquoted array index notation is not
-     supported
-   * https://github.com/NVIDIA/spark-rapids/issues/10215 leading spaces can be stripped from named
-     keys.
-   * https://github.com/NVIDIA/spark-rapids/issues/10216 It appears that Spark is flattening some
-     output, which is different from other implementations including the GPU version.
-   * https://github.com/NVIDIA/spark-rapids/issues/10217 a JSON path execution bug
-   * https://issues.apache.org/jira/browse/SPARK-46761 Apache Spark does not allow the `?` character in
-     a quoted JSON path string.
 
 ## Avro
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -479,16 +479,9 @@ The following is a list of known differences.
 
 The following is a list of bugs in either the GPU version or arguably in Apache Spark itself.
    * https://github.com/NVIDIA/spark-rapids/issues/10219 non-matching quotes in quoted strings
-   * https://github.com/NVIDIA/spark-rapids/issues/10213 array index notation works without root
-   * https://github.com/NVIDIA/spark-rapids/issues/10214 unquoted array index notation is not
-     supported
-   * https://github.com/NVIDIA/spark-rapids/issues/10215 leading spaces can be stripped from named
-     keys.
    * https://github.com/NVIDIA/spark-rapids/issues/10216 It appears that Spark is flattening some
      output, which is different from other implementations including the GPU version.
    * https://github.com/NVIDIA/spark-rapids/issues/10217 a JSON path execution bug
-   * https://issues.apache.org/jira/browse/SPARK-46761 Apache Spark does not allow the `?` character in
-     a quoted JSON path string.
 
 ## Avro
 

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -85,8 +85,7 @@ def test_get_json_object_single_quotes():
     pytest.param("$.a",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10196')),
     "$.non_exist_key",
     "$..no_recursive",
-    "$.store.book[0].non_exist_key",
-    "$.store.basket[*].non_exist_key"])
+    "$.store.book[0].non_exist_key"])
 def test_get_json_object_spark_unit_tests(query):
     schema = StructType([StructField("jsonStr", StringType())])
     data = [

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -93,7 +93,7 @@ def test_get_json_object_single_quotes():
     "$.fb:testid",
     pytest.param("$.a",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10196')),
     "$.non_exist_key",
-    pytest.param("$..no_recursive", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10212')),
+    "$..no_recursive",
     "$.store.book[0].non_exist_key",
     "$.store.basket[*].non_exist_key"])
 def test_get_json_object_spark_unit_tests(query):
@@ -132,7 +132,7 @@ def test_get_json_object_normalize_non_string_output():
             f.get_json_object('jsonStr', '$')),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-@pytest.mark.xfail(reason="https://issues.apache.org/jira/browse/SPARK-46761")
+# @pytest.mark.xfail(reason="https://issues.apache.org/jira/browse/SPARK-46761")
 def test_get_json_object_quoted_question():
     schema = StructType([StructField("jsonStr", StringType())])
     data = [[r'{"?":"QUESTION"}']]
@@ -221,7 +221,7 @@ def test_get_json_object_invalid_path():
             ),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10213")
+# @pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10213")
 def test_get_json_object_top_level_array_notation():
     # This is a special version of invalid path. It is something that the GPU supports
     # but the CPU thinks is invalid
@@ -239,7 +239,7 @@ def test_get_json_object_top_level_array_notation():
             ),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10214")
+# @pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10214")
 def test_get_json_object_unquoted_array_notation():
     # This is a special version of invalid path. It is something that the GPU supports
     # but the CPU thinks is invalid
@@ -269,7 +269,8 @@ def test_get_json_object_white_space_removal():
             ['{" a":"b","a.a":"c","b":{"a":"ab"}}'],
             ['{" a":"b"," a. a":"c","b":{"a":"ab"}}'],
             ['{" a":"b","a .a ":"c","b":{"a":"ab"}}'],
-            ['{" a":"b"," a . a ":"c","b":{"a":"ab"}}'],]
+            ['{" a":"b"," a . a ":"c","b":{"a":"ab"}}']
+            ]
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.createDataFrame(data,schema=schema).select(
@@ -278,7 +279,6 @@ def test_get_json_object_white_space_removal():
             f.get_json_object('jsonStr', '$. a').alias('dot_space_a'),
             f.get_json_object('jsonStr', '$.\ta').alias('dot_tab_a'),
             f.get_json_object('jsonStr', '$.    a').alias('dot_spaces_a3'),
-            f.get_json_object('jsonStr', '$. a').alias('dot_space_a'),
             f.get_json_object('jsonStr', '$.a ').alias('dot_a_space'),
             f.get_json_object('jsonStr', '$. a ').alias('dot_space_a_space'),
             f.get_json_object('jsonStr', "$['b']").alias('dot_b'),

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -257,7 +257,6 @@ def test_get_json_object_unquoted_array_notation():
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
 
-@pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10215")
 def test_get_json_object_white_space_removal():
     # This is a special version of invalid path. It is something that the GPU supports
     # but the CPU thinks is invalid
@@ -265,12 +264,20 @@ def test_get_json_object_white_space_removal():
     data = [['{" a":" A"," b":" B"}'],
             ['{"a":"A","b":"B"}'],
             ['{"a ":"A ","b ":"B "}'],
-            ['{" a ":" A "," b ":" B "}']]
+            ['{" a ":" A "," b ":" B "}'],
+            ['{" a ": {" a ":" A "}," b ": " B "}'],
+            ['{" a":"b","a.a":"c","b":{"a":"ab"}}'],
+            ['{" a":"b"," a. a":"c","b":{"a":"ab"}}'],
+            ['{" a":"b","a .a ":"c","b":{"a":"ab"}}'],
+            ['{" a":"b"," a . a ":"c","b":{"a":"ab"}}'],]
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.createDataFrame(data,schema=schema).select(
             f.col('jsonStr'),
             f.get_json_object('jsonStr', '$.a').alias('dot_a'),
+            f.get_json_object('jsonStr', '$. a').alias('dot_space_a'),
+            f.get_json_object('jsonStr', '$.\ta').alias('dot_tab_a'),
+            f.get_json_object('jsonStr', '$.    a').alias('dot_spaces_a3'),
             f.get_json_object('jsonStr', '$. a').alias('dot_space_a'),
             f.get_json_object('jsonStr', '$.a ').alias('dot_a_space'),
             f.get_json_object('jsonStr', '$. a ').alias('dot_space_a_space'),
@@ -278,6 +285,12 @@ def test_get_json_object_white_space_removal():
             f.get_json_object('jsonStr', "$[' b']").alias('dot_space_b'),
             f.get_json_object('jsonStr', "$['b ']").alias('dot_b_space'),
             f.get_json_object('jsonStr', "$[' b ']").alias('dot_space_b_space'),
+            f.get_json_object('jsonStr', "$. a. a").alias('dot_space_a_dot_space_a'),
+            f.get_json_object('jsonStr', "$.a .a ").alias('dot_a_space_dot_a_space'),
+            f.get_json_object('jsonStr', "$. a . a ").alias('dot_space_a_space_dot_space_a_space'),
+            f.get_json_object('jsonStr', "$[' a. a']").alias('space_a_dot_space_a'),
+            f.get_json_object('jsonStr', "$['a .a ']").alias('a_space_dot_a_space'),
+            f.get_json_object('jsonStr', "$[' a . a ']").alias('space_a_space_dot_space_a_space'),
             ),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -132,7 +132,6 @@ def test_get_json_object_normalize_non_string_output():
             f.get_json_object('jsonStr', '$')),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-# @pytest.mark.xfail(reason="https://issues.apache.org/jira/browse/SPARK-46761")
 def test_get_json_object_quoted_question():
     schema = StructType([StructField("jsonStr", StringType())])
     data = [[r'{"?":"QUESTION"}']]
@@ -221,7 +220,6 @@ def test_get_json_object_invalid_path():
             ),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-# @pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10213")
 def test_get_json_object_top_level_array_notation():
     # This is a special version of invalid path. It is something that the GPU supports
     # but the CPU thinks is invalid
@@ -239,7 +237,6 @@ def test_get_json_object_top_level_array_notation():
             ),
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
-# @pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10214")
 def test_get_json_object_unquoted_array_notation():
     # This is a special version of invalid path. It is something that the GPU supports
     # but the CPU thinks is invalid

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -88,6 +88,7 @@ private[this] object JsonPathParser extends RegexParsers {
     // see https://github.com/NVIDIA/spark-rapids/issues/10216
     instructions.exists {
       case Wildcard => true
+      case Named(name) if name == "*" => true
       case _ => false
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -38,14 +38,12 @@ case class GpuGetJsonObject(json: Expression, path: Expression)
     } else {
       throw new IllegalArgumentException("Invalid path")
     }
-    // remove all leading whitespaces before names
-    // so we erase all whitespaces after . or ['
+    // Remove all leading whitespaces before names, so we erase all whitespaces after . or ['
     val normalizedPath = pathStr.replaceAll("""\.(\s+)""", ".").replaceAll("""\['(\s+)""", "['")
     Scalar.fromString(normalizedPath)
   }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {   
-    // get the base rhs and erase all whitespaces from it
     val normalizedScalar = normalizeJsonPath(rhs)
     lhs.getBase().getJSONObject(normalizedScalar, 
     GetJsonObjectOptions.builder().allowSingleQuotes(true).build());

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -96,6 +96,23 @@ private[this] object JsonPathParser extends RegexParsers {
   }
 }
 
+class GpuGetJsonObjectMeta(
+    expr: GetJsonObject,
+    conf: RapidsConf,
+    parent: Option[RapidsMeta[_, _, _]],
+    rule: DataFromReplacementRule
+  ) extends BinaryExprMeta[GpuGetJsonObject](expr, conf, parent, rule) {
+
+  override def tagExprForGpu(): Unit = {
+    if (expr.right.dataType != StringType) {
+      willNotWorkOnGpu("Only StringType is supported for path")
+    }
+  }
+
+  override def convertToGpu(lhs: GpuExpression, rhs: GpuExpression): GpuExpression =
+    GpuGetJsonObject(lhs, rhs)
+}
+
 case class GpuGetJsonObject(json: Expression, path: Expression)
     extends GpuBinaryExpressionArgsAnyScalar
         with ExpectsInputTypes {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -16,11 +16,85 @@
 
 package com.nvidia.spark.rapids
 
+import scala.util.parsing.combinator.RegexParsers
+
 import ai.rapids.cudf.{ColumnVector, GetJsonObjectOptions, Scalar}
 import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
 import org.apache.spark.sql.types.{DataType, StringType}
+
+// Copied from Apache Spark org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+private[this] sealed trait PathInstruction
+private[this] object PathInstruction {
+  case object Subscript extends PathInstruction
+  case object Wildcard extends PathInstruction
+  case object Key extends PathInstruction
+  case class Index(index: Long) extends PathInstruction
+  case class Named(name: String) extends PathInstruction
+}
+
+private[this] object JsonPathParser extends RegexParsers {
+  import PathInstruction._
+
+  def root: Parser[Char] = '$'
+
+  def long: Parser[Long] = "\\d+".r ^? {
+    case x => x.toLong
+  }
+
+  // parse `[*]` and `[123]` subscripts
+  def subscript: Parser[List[PathInstruction]] =
+    for {
+      operand <- '[' ~> ('*' ^^^ Wildcard | long ^^ Index) <~ ']'
+    } yield {
+      Subscript :: operand :: Nil
+    }
+
+  // parse `.name` or `['name']` child expressions
+  def named: Parser[List[PathInstruction]] =
+    for {
+      name <- '.' ~> "[^\\.\\[]+".r | "['" ~> "[^\\'\\?]+".r <~ "']"
+    } yield {
+      Key :: Named(name) :: Nil
+    }
+
+  // child wildcards: `..`, `.*` or `['*']`
+  def wildcard: Parser[List[PathInstruction]] =
+    (".*" | "['*']") ^^^ List(Wildcard)
+
+  def node: Parser[List[PathInstruction]] =
+    wildcard |
+      named |
+      subscript
+
+  val expression: Parser[List[PathInstruction]] = {
+    phrase(root ~> rep(node) ^^ (x => x.flatten))
+  }
+
+  def parse(str: String): Option[List[PathInstruction]] = {
+    this.parseAll(expression, str) match {
+      case Success(result, _) =>
+        Some(result)
+
+      case _ =>
+        None
+    }
+  }
+
+  def normalize(str: String): Option[String] = {
+    // convert List[PathInstruction] to String
+    parse(str).map {
+      "$" + _.map {
+        case Subscript | Key => ""
+        case Wildcard => "[*]"
+        case Index(index) => s"[$index]"
+        case Named(name) => s"['$name']"
+        case _ => throw new IllegalArgumentException(s"Invalid instruction in path: $str")
+      }.mkString
+    }
+  }
+}
 
 case class GpuGetJsonObject(json: Expression, path: Expression)
     extends GpuBinaryExpressionArgsAnyScalar
@@ -32,21 +106,23 @@ case class GpuGetJsonObject(json: Expression, path: Expression)
   override def nullable: Boolean = true
   override def prettyName: String = "get_json_object"
 
-  def normalizeJsonPath(path: GpuScalar): Scalar = {
+  def normalizeJsonPath(path: GpuScalar): Option[Scalar] = {
     val pathStr = if (path.isValid) {
       path.getValue.toString()
     } else {
       throw new IllegalArgumentException("Invalid path")
     }
-    // Remove all leading whitespaces before names, so we erase all whitespaces after . or ['
-    val normalizedPath = pathStr.replaceAll("""\.(\s+)""", ".").replaceAll("""\['(\s+)""", "['")
-    Scalar.fromString(normalizedPath)
+    JsonPathParser.normalize(pathStr) map {
+      Scalar.fromString(_)
+    }
   }
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {   
-    val normalizedScalar = normalizeJsonPath(rhs)
-    lhs.getBase().getJSONObject(normalizedScalar, 
-    GetJsonObjectOptions.builder().allowSingleQuotes(true).build());
+    normalizeJsonPath(rhs) match {
+      case Some(scalar) => lhs.getBase().getJSONObject(scalar, 
+          GetJsonObjectOptions.builder().allowSingleQuotes(true).build());
+      case None => GpuColumnVector.columnVectorFromNull(lhs.getRowCount.toInt, StringType)
+    }
   }
 
   override def doColumnar(numRows: Int, lhs: GpuScalar, rhs: GpuScalar): ColumnVector = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -119,12 +119,12 @@ case class GpuGetJsonObject(json: Expression, path: Expression)
 
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     cachedNormalizedPath.getOrElse {
-      val normalized = normalizeJsonPath(rhs)
-      cachedNormalizedPath = Some(normalized)
-      normalized
+      val normalizedPath: Option[String] = normalizeJsonPath(rhs)
+      cachedNormalizedPath = Some(normalizedPath)
+      normalizedPath
     } match {
-      case Some(normalized) => 
-        withResource(Scalar.fromString(normalized)) { scalar =>
+      case Some(normalizedStr) => 
+        withResource(Scalar.fromString(normalizedStr)) { scalar =>
           lhs.getBase().getJSONObject(scalar, 
               GetJsonObjectOptions.builder().allowSingleQuotes(true).build())
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -3646,10 +3646,7 @@ object GpuOverrides extends Logging {
       ExprChecks.projectOnly(
         TypeSig.STRING, TypeSig.STRING, Seq(ParamCheck("json", TypeSig.STRING, TypeSig.STRING),
           ParamCheck("path", TypeSig.lit(TypeEnum.STRING), TypeSig.STRING))),
-      (a, conf, p, r) => new BinaryExprMeta[GetJsonObject](a, conf, p, r) {
-        override def convertToGpu(lhs: Expression, rhs: Expression): GpuExpression =
-          GpuGetJsonObject(lhs, rhs)
-      }
+      (a, conf, p, r) => new GpuGetJsonObjectMeta(a, conf, p, r)
     ).disabledByDefault("escape sequences are not processed correctly, the input is not " +
         "validated, and the output is not normalized the same as Spark"),
     expr[JsonToStructs](


### PR DESCRIPTION
Fix #10213 
Fix #10214
Fix #10215
Contributes to https://github.com/NVIDIA/spark-rapids/issues/10216 and https://github.com/NVIDIA/spark-rapids/issues/10217

Spark has implemented a JsonPathParser to parse the json path in getJsonObject, which will have some different behavior than https://jsonpath.com/ and the cudf implementation. 

https://github.com/apache/spark/blob/78f7c30e140fd8cf4a80b783dd7e9ee4d1b4d7e2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala#L59

This PR uses JsonPathParser to normalize the json path before passing it to the kernel, so GetJsonObject will better match Spark in some cases related to json path.

This PR also fallback GetJsonObject when json paths contain wildcard ("*"), as the plugin may produce different results in this case. Note that `. *` and `[ *]` will be parsed to a `Named("*")` by Spark parser, so it also checked `Named("*")` from path.

The reason why I didn't put it in kernel is I think this feature is only for Spark and we only support scalar for this parameter, so it will consume constant time to do this preprocessing.

In 10213, path not starting with a `$` like `[0]` or `['a']` should be invalid. The parser will reject these cases so this issue can be fixed.

In 10214, Spark and https://jsonpath.com/ happily support paths like `$[a]` or `$[a1]` while our implementation throws an exception about them not being a valid number. In fact, such cases should be invalid and rejected by the parser, so this PR will return nulls for them instead of passing them to the kernel and throwing an exception. So this issue can also be fixed in this PR.

In 10215, gpu and https://jsonpath.com/ agree that whitespace should not be stripped from the path, but Spark will treats `$. a` and `$.a` the same. This PR normalizes those cases so that the whitespace is stripped according to Spark's way.

In [SPARK-46761](https://issues.apache.org/jira/browse/SPARK-46761), Spark does not support `?` characters. With the parser in this PR, these cases will be rejected so that the behavior matches Spark.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
