### PR TITLE
Fix scalar leak in RankFixer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1709,7 +1709,7 @@ class RankFixer extends BatchedRunningWindowFixer with Logging {
   }
 
   override def close(): Unit = {
-    previousRank.foreach(_.close())
+    previousRank.foreach(_.safeClose())
     previousRank = None
     rowNumFixer.close()
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -24,6 +24,7 @@ import com.nvidia.spark.Retryable
 import com.nvidia.spark.rapids._
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuOverrides.wrapExpr
+import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.shims.{GpuWindowUtil, ShimExpression}
 import scala.util.{Left, Right}
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1711,6 +1711,7 @@ class RankFixer extends BatchedRunningWindowFixer with Logging {
   override def close(): Unit = {
     previousRank.foreach(_.close())
     previousRank = None
+    rowNumFixer.close()
   }
 }
 


### PR DESCRIPTION
Fixes #10473.  Updates the RankFixer.close() method to close the BatchedRunningWindowBinaryFixer instance which is caching a scalar.