### PR TITLE
Fallback GetJsonObject when json paths containing "[*]"

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -484,9 +484,6 @@ The following is a list of bugs in either the GPU version or arguably in Apache 
      supported
    * https://github.com/NVIDIA/spark-rapids/issues/10215 leading spaces can be stripped from named
      keys.
-   * https://github.com/NVIDIA/spark-rapids/issues/10216 It appears that Spark is flattening some
-     output, which is different from other implementations including the GPU version.
-   * https://github.com/NVIDIA/spark-rapids/issues/10217 a JSON path execution bug
    * https://issues.apache.org/jira/browse/SPARK-46761 Apache Spark does not allow the `?` character in
      a quoted JSON path string.
 

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -73,29 +73,19 @@ def test_get_json_object_single_quotes():
     "$['key with spaces']",
     "$.store.book",
     "$.store.book[0]",
-    "$.store.book[*]",
     pytest.param("$",marks=[
         pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10218'),
         pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10196'),
         pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10194')]),
     "$.store.book[0].category",
-    "$.store.book[*].category",
-    "$.store.book[*].isbn",
-    pytest.param("$.store.book[*].reader",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10216')),
     "$.store.basket[0][1]",
-    "$.store.basket[*]",
-    "$.store.basket[*][0]",
-    "$.store.basket[0][*]",
-    "$.store.basket[*][*]",
     "$.store.basket[0][2].b",
-    pytest.param("$.store.basket[0][*].b",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10217')),
     "$.zip code",
     "$.fb:testid",
     pytest.param("$.a",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10196')),
     "$.non_exist_key",
     pytest.param("$..no_recursive", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10212')),
-    "$.store.book[0].non_exist_key",
-    "$.store.basket[*].non_exist_key"])
+    "$.store.book[0].non_exist_key"])
 def test_get_json_object_spark_unit_tests(query):
     schema = StructType([StructField("jsonStr", StringType())])
     data = [
@@ -108,6 +98,26 @@ def test_get_json_object_spark_unit_tests(query):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.createDataFrame(data,schema=schema).select(
             f.get_json_object('jsonStr', query)),
+        conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
+
+@allow_non_gpu("ProjectExec", "GetJsonObject")
+@pytest.mark.parametrize('query',["$.store.basket[0][*].b", 
+    "$.store.book[*].reader",
+    "$.store.book[*]",
+    "$.store.book[*].category",
+    "$.store.book[*].isbn",
+    "$.store.basket[*]",
+    "$.store.basket[*][0]",
+    "$.store.basket[0][*]",
+    "$.store.basket[*][*]",
+    "$.store.basket[*].non_exist_key"])
+def test_get_json_object_spark_unit_tests_fallback(query):
+    schema = StructType([StructField("jsonStr", StringType())])
+    data = [['''{"store":{"fruit":[{"weight":8,"type":"apple"},{"weight":9,"type":"pear"}],"basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],"book":[{"author":"Nigel Rees","title":"Sayings of the Century","category":"reference","price":8.95},{"author":"Herman Melville","title":"Moby Dick","category":"fiction","price":8.99,"isbn":"0-553-21311-3"},{"author":"J. R. R. Tolkien","title":"The Lord of the Rings","category":"fiction","reader":[{"age":25,"name":"bob"},{"age":26,"name":"jack"}],"price":22.99,"isbn":"0-395-19395-8"}],"bicycle":{"price":19.95,"color":"red"}},"email":"amy@only_for_json_udf_test.net","owner":"amy","zip code":"94025","fb:testid":"1234"}''']]
+    assert_gpu_fallback_collect(
+        lambda spark: spark.createDataFrame(data,schema=schema).select(
+            f.get_json_object('jsonStr', query)),
+        "GetJsonObject",
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
 @pytest.mark.xfail(reason="https://github.com/NVIDIA/spark-rapids/issues/10218")


### PR DESCRIPTION
Contributes to #10216 and #10217

This PR fallback GetJsonObject when json paths contain "[*]", as the plugin may produce different results in this case.

A long term way is to fix it to match Spark, so this pr will not close those issues.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
