### PR TITLE
Move 351 shims into noSnapshot buildvers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -782,7 +782,7 @@
         <spark332db.version>3.3.2-databricks</spark332db.version>
         <spark341db.version>3.4.1-databricks</spark341db.version>
         <spark350.version>3.5.0</spark350.version>
-        <spark351.version>3.5.1-SNAPSHOT</spark351.version>
+        <spark351.version>3.5.1</spark351.version>
         <mockito.version>3.12.4</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
@@ -831,10 +831,10 @@
             340,
             341,
             342,
-            350
+            350,
+            351
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            351
         </snapshot.buildvers>
         <databricks.buildvers>
             321db,

--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,8 @@
             333,
             340,
             341,
-            350
+            350,
+            351
         </noSnapshotScala213.buildvers>
         <snapshotScala213.buildvers>
         </snapshotScala213.buildvers>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -782,7 +782,7 @@
         <spark332db.version>3.3.2-databricks</spark332db.version>
         <spark341db.version>3.4.1-databricks</spark341db.version>
         <spark350.version>3.5.0</spark350.version>
-        <spark351.version>3.5.1-SNAPSHOT</spark351.version>
+        <spark351.version>3.5.1</spark351.version>
         <mockito.version>3.12.4</mockito.version>
         <scala.plugin.version>4.3.0</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
@@ -831,10 +831,10 @@
             340,
             341,
             342,
-            350
+            350,
+            351
         </noSnapshot.buildvers>
         <snapshot.buildvers>
-            351
         </snapshot.buildvers>
         <databricks.buildvers>
             321db,

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -883,7 +883,8 @@
             333,
             340,
             341,
-            350
+            350,
+            351
         </noSnapshotScala213.buildvers>
         <snapshotScala213.buildvers>
         </snapshotScala213.buildvers>


### PR DESCRIPTION
Move 351 shims into noSnapshot buildvers as it has been released.

Follow up of https://github.com/NVIDIA/spark-rapids/pull/10465#issuecomment-1965533960


