### PR TITLE
Fix scalar leak in SumBinaryFixer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1606,6 +1606,8 @@ class SumBinaryFixer(toType: DataType, isAnsi: Boolean)
   override def close(): Unit = {
     previousResult.foreach(_.close())
     previousResult = None
+    previousOverflow.foreach(_.close())
+    previousOverflow = None
   }
 }
 


### PR DESCRIPTION
Closes #10509.

This fixes the leak of a scalar value in `previousOverflow` in `SumBinaryFixer` by making sure we close it.
Tested by re-running nds to verify there were no leaks.
