### PR TITLE
Update rapids jni and private dependency version to 24.02.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -722,8 +722,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <spark-rapids-jni.version>24.02.0</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.02.0</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.02.1</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.02.1</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -722,8 +722,8 @@
         <spark.version.classifier>spark${buildver}</spark.version.classifier>
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
-        <spark-rapids-jni.version>24.02.0</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.02.0</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.02.1</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.02.1</spark-rapids-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
Update spark-rapids-private and spark-rapids-jni dependencies to 24.02.1, 

Because cuDF native has a new release [v24.02.02](https://github.com/rapidsai/cudf/releases/tag/v24.02.02) to fix buts.

Our v24.02.0 which depends on old cuDF native release have already been released to maven central.

We must update them to v24.02.1 to catch cuDF native bugs fixing in [v24.02.02 release](https://github.com/rapidsai/cudf/releases/tag/v24.02.02) 