### PR TITLE
Move to parsing from_json input preserving quoted strings.

### DIFF
--- a/integration_tests/src/main/python/json_matrix_test.py
+++ b/integration_tests/src/main/python/json_matrix_test.py
@@ -537,8 +537,8 @@ def test_scan_json_bytes(std_input_path, read_func, spark_tmp_table_factory, inp
     "int_formatted.json",
     pytest.param("float_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
     pytest.param("sci_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
+    "float_formatted_strings.json",
     "sci_formatted_strings.json",
     "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
@@ -572,10 +572,10 @@ def test_scan_json_shorts(std_input_path, read_func, spark_tmp_table_factory, in
     "int_formatted.json",
     pytest.param("float_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
     pytest.param("sci_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
+    "float_formatted_strings.json",
     "sci_formatted_strings.json",
-    pytest.param("decimal_locale_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
@@ -607,10 +607,10 @@ def test_scan_json_ints(std_input_path, read_func, spark_tmp_table_factory, inpu
     "int_formatted.json",
     pytest.param("float_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
     pytest.param("sci_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
+    "float_formatted_strings.json",
     "sci_formatted_strings.json",
-    pytest.param("decimal_locale_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
@@ -642,10 +642,10 @@ def test_scan_json_longs(std_input_path, read_func, spark_tmp_table_factory, inp
     "int_formatted.json",
     pytest.param("float_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
     pytest.param("sci_formatted.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10460')),
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
+    "float_formatted_strings.json",
     "sci_formatted_strings.json",
-    pytest.param("decimal_locale_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
@@ -819,10 +819,10 @@ def test_scan_json_floats(std_input_path, read_func, spark_tmp_table_factory, in
     "int_formatted.json",
     pytest.param("float_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10481')),
     "sci_formatted.json",
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
     pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("sci_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("decimal_locale_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "sci_formatted_strings.json",
+    "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453
@@ -856,10 +856,10 @@ def test_scan_json_doubles(std_input_path, read_func, spark_tmp_table_factory, i
     "int_formatted.json",
     pytest.param("float_formatted.json", marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10481')),
     "sci_formatted.json",
-    pytest.param("int_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "int_formatted_strings.json",
     pytest.param("float_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("sci_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
-    pytest.param("decimal_locale_formatted_strings.json",marks=pytest.mark.xfail(reason='https://github.com/NVIDIA/spark-rapids/issues/10468')),
+    "sci_formatted_strings.json",
+    "decimal_locale_formatted_strings.json",
     "single_quoted_strings.json",
     "boolean_formatted.json"])
 @allow_non_gpu(TEXT_INPUT_EXEC, *non_utc_allow) # https://github.com/NVIDIA/spark-rapids/issues/10453

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCast.scala
@@ -1299,7 +1299,7 @@ object GpuCast {
 
   /** This method does not close the `input` ColumnVector. */
   def convertDateOrNull(
-      input: ColumnVector,
+      input: ColumnView,
       regex: String,
       cudfFormat: String,
       failOnInvalid: Boolean = false): ColumnVector = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -270,14 +270,9 @@ case class GpuJsonToStructs(
                   }
                 }
 
-                // join all the JSON lines into one string
-                val joined = withResource(withNewline) { _ =>
-                  withResource(Scalar.fromString("")) { emptyString =>
-                    withNewline.joinStrings(emptyString, emptyRow)
-                  }
-                }
-
-                (isNullOrEmptyInput, joined)
+                // We technically don't need to join the strings together as we just want the buffer
+                // which should be the same either way.
+                (isNullOrEmptyInput, withNewline)
               }
             }
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -80,7 +80,6 @@ object GpuJsonToStructs {
     case _: MapType =>
       throw new IllegalArgumentException("MapType is not supported yet for schema conversion")
     case _ =>
-      // TODO do we need to read all of the leaf nodes as strings???
       builder.addColumn(DType.STRING, name)
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuJsonToStructs.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.sql.rapids
 
 import ai.rapids.cudf
-import ai.rapids.cudf.{ColumnVector, ColumnView, Cuda, DataSource, DeviceMemoryBuffer, DType, HostMemoryBuffer, Scalar}
-import com.nvidia.spark.rapids.{GpuCast, GpuColumnVector, GpuScalar, GpuUnaryExpression, HostAlloc}
+import ai.rapids.cudf.{ColumnVector, ColumnView, Cuda, DataSource, DeviceMemoryBuffer, DType, HostMemoryBuffer, Scalar, Schema}
+import com.nvidia.spark.rapids.{ColumnCastUtil, GpuCast, GpuColumnVector, GpuScalar, GpuUnaryExpression, HostAlloc}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingSeq
+import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
 import com.nvidia.spark.rapids.jni.MapUtils
 import com.nvidia.spark.rapids.shims.GpuJsonToStructsShim
 import org.apache.commons.text.StringEscapeUtils
@@ -66,6 +66,150 @@ class JsonDeviceDataSource(combined: ColumnVector) extends DataSource {
   }
 }
 
+object GpuJsonToStructs {
+  private def populateSchema(dt: DataType,
+      name: String, builder: Schema.Builder): Unit = dt match {
+    case at: ArrayType =>
+      val child = builder.addColumn(DType.LIST, name)
+      populateSchema(at.elementType, "element", child)
+    case st: StructType =>
+      val child = builder.addColumn(DType.STRUCT, name)
+      for (sf <- st.fields) {
+        populateSchema(sf.dataType, sf.name, child)
+      }
+    case _: MapType =>
+      throw new IllegalArgumentException("MapType is not supported yet for schema conversion")
+    case _ =>
+      // TODO do we need to read all of the leaf nodes as strings???
+      builder.addColumn(DType.STRING, name)
+  }
+
+  def makeSchema(input: StructType): Schema = {
+    val builder = Schema.builder
+    input.foreach(f => populateSchema(f.dataType, f.name, builder))
+    builder.build
+  }
+
+  private def castJsonStringToBool(input: ColumnView): ColumnVector = {
+    val isTrue = withResource(Scalar.fromString("true")) { trueStr =>
+      input.equalTo(trueStr)
+    }
+    withResource(isTrue) { _ =>
+      val isFalse = withResource(Scalar.fromString("false")) { falseStr =>
+        input.equalTo(falseStr)
+      }
+      val falseOrNull = withResource(isFalse) { _ =>
+        withResource(Scalar.fromBool(false)) { falseLit =>
+          withResource(Scalar.fromNull(DType.BOOL8)) { nul =>
+            isFalse.ifElse(falseLit, nul)
+          }
+        }
+      }
+      withResource(falseOrNull) { _ =>
+        withResource(Scalar.fromBool(true)) { trueLit =>
+          isTrue.ifElse(trueLit, falseOrNull)
+        }
+      }
+    }
+  }
+
+  private def isQuotedString(input: ColumnView): ColumnVector = {
+    // TODO make this a custom kernel if we need it someplace else
+    withResource(Scalar.fromString("\"")) { quote =>
+      withResource(input.startsWith(quote)) { sw =>
+        withResource(input.endsWith(quote)) { ew =>
+          sw.binaryOp(cudf.BinaryOp.LOGICAL_AND, ew, cudf.DType.BOOL8)
+        }
+      }
+    }
+  }
+
+  private def stripFirstAndLastChar(input: ColumnView): ColumnVector = {
+    // TODO make this a custom kernel
+    withResource(Scalar.fromInt(1)) { one =>
+      val end = withResource(input.getCharLengths) { cc =>
+        withResource(cc.sub(one)) { endWithNulls =>
+          withResource(endWithNulls.isNull) { eIsNull =>
+            eIsNull.ifElse(one, endWithNulls)
+          }
+        }
+      }
+      withResource(end) { _ =>
+        withResource(ColumnVector.fromScalar(one, end.getRowCount.toInt)) { start =>
+          input.substring(start, end)
+        }
+      }
+    }
+  }
+
+  private def undoKeepQuotes(input: ColumnView): ColumnVector = {
+    // TODO make this go away once we have decimal parsing doing the right thing for
+    //  both cases
+    withResource(isQuotedString(input)) { iq =>
+      withResource(stripFirstAndLastChar(input)) { stripped =>
+        iq.ifElse(stripped, input)
+      }
+    }
+  }
+
+  private def fixupQuotedStrings(input: ColumnView): ColumnVector = {
+    // TODO make this a custom kernel
+    withResource(isQuotedString(input)) { iq =>
+      withResource(stripFirstAndLastChar(input)) { stripped =>
+        withResource(Scalar.fromString(null)) { ns =>
+          iq.ifElse(stripped, ns)
+        }
+      }
+    }
+  }
+
+  private def convertToDesiredType(inputCv: ColumnVector,
+      topLevelType: DataType,
+      options: Map[String, String]): ColumnVector = {
+    ColumnCastUtil.deepTransform(inputCv, Some(topLevelType)) {
+      case (cv, Some(BooleanType)) if cv.getType == DType.STRING =>
+        castJsonStringToBool(cv)
+      case (cv, Some(DateType)) if cv.getType == DType.STRING =>
+        withResource(fixupQuotedStrings(cv)) { fixed =>
+          GpuJsonToStructsShim.castJsonStringToDate(fixed, options)
+        }
+      case (cv, Some(TimestampType)) if cv.getType == DType.STRING =>
+        withResource(fixupQuotedStrings(cv)) { fixed =>
+          GpuJsonToStructsShim.castJsonStringToTimestamp(fixed, options)
+        }
+      case (cv, Some(StringType)) if cv.getType == DType.STRING =>
+        undoKeepQuotes(cv)
+      case (cv, Some(dt: DecimalType)) if cv.getType == DType.STRING =>
+        // This is not actually correct, but there are other follow on issues to fix this
+        withResource(undoKeepQuotes(cv)) { undone =>
+          GpuCast.doCast(undone, StringType, dt)
+        }
+      case (cv, Some(FloatType)) if cv.getType == DType.STRING =>
+        // This is not actually correct, but there are other follow on issues to fix this
+        withResource(undoKeepQuotes(cv)) { undone =>
+          GpuCast.doCast(cv, StringType, FloatType)
+        }
+      case (cv, Some(DoubleType)) if cv.getType == DType.STRING =>
+        // This is not actually correct, but there are other follow on issues to fix this
+        withResource(undoKeepQuotes(cv)) { undone =>
+          GpuCast.doCast(cv, StringType, DoubleType)
+        }
+      case(cv, Some(dt)) if cv.getType == DType.STRING =>
+        GpuCast.doCast(cv, StringType, dt)
+    }
+  }
+
+  def convertTableToDesiredType(table: cudf.Table,
+      desired: StructType,
+      options: Map[String, String]): Array[ColumnVector] = {
+    val dataTypes = desired.fields.map(_.dataType)
+    dataTypes.zipWithIndex.safeMap {
+      case (dt, i) =>
+        convertToDesiredType(table.getColumn(i), dt, options)
+    }
+  }
+}
+
 case class GpuJsonToStructs(
     schema: DataType,
     options: Map[String, String],
@@ -74,6 +218,7 @@ case class GpuJsonToStructs(
     timeZoneId: Option[String] = None)
     extends GpuUnaryExpression with TimeZoneAwareExpression with ExpectsInputTypes
         with NullIntolerant {
+  import GpuJsonToStructs._
 
   lazy val emptyRowStr = constructEmptyRow(schema)
 
@@ -154,46 +299,6 @@ case class GpuJsonToStructs(
     }
   }
 
-  // Process a sequence of field names. If there are duplicated field names, we only keep the field
-  // name with the largest index in the sequence, for others, replace the field names with null.
-  // Example:
-  // Input = [("a", StringType), ("b", StringType), ("a", IntegerType)]
-  // Output = [(null, StringType), ("b", StringType), ("a", IntegerType)]
-  private def processFieldNames(names: Seq[(String, DataType)]): Seq[(String, DataType)] = {
-    val zero = (Set.empty[String], Seq.empty[(String, DataType)])
-    val (_, resultFields) = names.foldRight (zero) { case ((name, dtype), (existingNames, acc)) =>
-      if (existingNames(name)) {
-        (existingNames, (null, dtype) +: acc)
-      } else {
-        (existingNames + name, (name, dtype) +: acc)
-      }
-    }
-    resultFields
-  }
-
-  // Given a cudf column, return its Spark type
-  private def getSparkType(col: cudf.ColumnView): DataType = {
-    col.getType match {
-      case cudf.DType.INT8 | cudf.DType.UINT8 => ByteType
-      case cudf.DType.INT16 | cudf.DType.UINT16 => ShortType
-      case cudf.DType.INT32 | cudf.DType.UINT32 => IntegerType
-      case cudf.DType.INT64 | cudf.DType.UINT64 => LongType
-      case cudf.DType.FLOAT32 => FloatType
-      case cudf.DType.FLOAT64 => DoubleType
-      case cudf.DType.BOOL8 => BooleanType
-      case cudf.DType.STRING => StringType
-      case cudf.DType.LIST => ArrayType(getSparkType(col.getChildColumnView(0)))
-      case cudf.DType.STRUCT =>
-        val structFields = (0 until col.getNumChildren).map { i =>
-          val child = col.getChildColumnView(i)
-          StructField("", getSparkType(child))
-        }
-        StructType(structFields)
-      case t => throw new IllegalArgumentException(
-        s"GpuJsonToStructs currently cannot process CUDF column of type $t.")
-    }
-  }
-
   private lazy val jsonOptions = {
     val parsedOptions = new JSONOptions(
       options,
@@ -202,6 +307,7 @@ case class GpuJsonToStructs(
     cudf.JSONOptions.builder()
         .withRecoverWithNull(true)
         .withMixedTypesAsStrings(enableMixedTypesAsString)
+        .withKeepQuotes(true)
         .withNormalizeSingleQuotes(parsedOptions.allowSingleQuotes)
         .build()
   }
@@ -211,6 +317,10 @@ case class GpuJsonToStructs(
       case _: MapType =>
         MapUtils.extractRawMapFromJsonString(input.getBase)
       case struct: StructType => {
+        // if we ever need to support duplicate keys we need to keep track of the duplicates
+        //  and make the first one null, but I don't think this will ever happen in practice
+        val cudfSchema = makeSchema(struct)
+
         // We cannot handle all corner cases with this right now. The parser just isn't
         // good enough, but we will try to handle a few common ones.
         val numRows = input.getRowCount.toInt
@@ -220,56 +330,23 @@ case class GpuJsonToStructs(
         val (isNullOrEmpty, combined) = cleanAndConcat(input.getBase)
         withResource(isNullOrEmpty) { isNullOrEmpty =>
           // Step 3: setup a datasource
-          val (names, rawTable) = withResource(new JsonDeviceDataSource(combined)) { ds =>
+          val table = withResource(new JsonDeviceDataSource(combined)) { ds =>
             // Step 4: Have cudf parse the JSON data
-            withResource(
-              cudf.Table.readAndInferJSON(jsonOptions, ds)) { tableWithMeta =>
-              val names = tableWithMeta.getColumnNames
-              (names, tableWithMeta.releaseTable())
-            }
+            cudf.Table.readJSON(cudfSchema, jsonOptions, ds)
           }
 
           // process duplicated field names in input struct schema
-          val fieldNames = processFieldNames(struct.fields.map (f => (f.name, f.dataType)))
 
-          withResource(rawTable) { rawTable =>
+          withResource(table) { _ =>
             // Step 5: verify that the data looks correct
-            if (rawTable.getRowCount != numRows) {
+            if (table.getRowCount != numRows) {
               throw new IllegalStateException("The input data didn't parse correctly and we read " +
                   s"a different number of rows than was expected. Expected $numRows, " +
-                  s"but got ${rawTable.getRowCount}")
-            }
-
-            // Step 6: get the data based on input struct schema
-            val columns = fieldNames.safeMap { case (name, dtype) =>
-              val i = names.indexOf(name)
-              if (i == -1) {
-                GpuColumnVector.columnVectorFromNull(numRows, dtype)
-              } else {
-                val col = rawTable.getColumn(i)
-                // getSparkType is only used to get the "from type" for cast
-                val sparkType = getSparkType(col)
-                (sparkType, dtype) match {
-                  case (DataTypes.StringType, DataTypes.BooleanType) =>
-                    castJsonStringToBool(col)
-                  case (DataTypes.StringType, DataTypes.DateType) =>
-                    GpuJsonToStructsShim.castJsonStringToDate(col, options)
-                  case (_, DataTypes.DateType) =>
-                    castToNullDate(input.getBase)
-                  case (DataTypes.StringType, DataTypes.TimestampType) =>
-                    GpuJsonToStructsShim.castJsonStringToTimestamp(col, options)
-                  case (DataTypes.LongType, DataTypes.TimestampType) =>
-                    GpuCast.castLongToTimestamp(col, DataTypes.TimestampType)
-                  case (_, DataTypes.TimestampType) =>
-                    castToNullTimestamp(input.getBase)
-                  case _ => GpuCast.doCast(col, sparkType, dtype)
-                }
-
-              }
+                  s"but got ${table.getRowCount}")
             }
 
             // Step 7: turn the data into a Struct
-            withResource(columns) { columns =>
+            withResource(convertTableToDesiredType(table, struct, options)) { columns =>
               withResource(cudf.ColumnVector.makeStruct(columns: _*)) { structData =>
                 // Step 8: put nulls back in for nulls and empty strings
                 withResource(GpuScalar.from(null, struct)) { nullVal =>
@@ -282,41 +359,6 @@ case class GpuJsonToStructs(
       }
       case _ => throw new IllegalArgumentException(
         s"GpuJsonToStructs currently does not support schema of type $schema.")
-    }
-  }
-
-  private def castJsonStringToBool(input: ColumnVector): ColumnVector = {
-    val isTrue = withResource(Scalar.fromString("true")) { trueStr =>
-      input.equalTo(trueStr)
-    }
-    withResource(isTrue) { _ =>
-      val isFalse = withResource(Scalar.fromString("false")) { falseStr =>
-        input.equalTo(falseStr)
-      }
-      val falseOrNull = withResource(isFalse) { _ =>
-        withResource(Scalar.fromBool(false)) { falseLit =>
-          withResource(Scalar.fromNull(DType.BOOL8)) { nul =>
-            isFalse.ifElse(falseLit, nul)
-          }
-        }
-      }
-      withResource(falseOrNull) { _ =>
-        withResource(Scalar.fromBool(true)) { trueLit =>
-          isTrue.ifElse(trueLit, falseOrNull)
-        }
-      }
-    }
-  }
-
-  private def castToNullDate(input: ColumnVector): ColumnVector = {
-    withResource(Scalar.fromNull(DType.TIMESTAMP_DAYS)) { nullScalar =>
-      ColumnVector.fromScalar(nullScalar, input.getRowCount.toInt)
-    }
-  }
-
-  private def castToNullTimestamp(input: ColumnVector): ColumnVector = {
-    withResource(Scalar.fromNull(DType.TIMESTAMP_MICROSECONDS)) { nullScalar =>
-      ColumnVector.fromScalar(nullScalar, input.getRowCount.toInt)
     }
   }
 

--- a/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark311/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -20,7 +20,7 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.{GpuCast, GpuOverrides, RapidsMeta}
 import com.nvidia.spark.rapids.Arm.withResource
 
@@ -36,7 +36,7 @@ object GpuJsonToStructsShim {
     }
   }
 
-  def castJsonStringToDate(input: ColumnVector, options: Map[String, String]): ColumnVector = {
+  def castJsonStringToDate(input: ColumnView, options: Map[String, String]): ColumnVector = {
     GpuJsonUtils.optionalDateFormatInRead(options) match {
       case None | Some("yyyy-MM-dd") =>
         withResource(Scalar.fromString(" ")) { space =>
@@ -54,7 +54,7 @@ object GpuJsonToStructsShim {
     tagDateFormatSupport(meta, dateFormat)
   }
 
-  def castJsonStringToDateFromScan(input: ColumnVector, dt: DType,
+  def castJsonStringToDateFromScan(input: ColumnView, dt: DType,
       dateFormat: Option[String]): ColumnVector = {
     dateFormat match {
       case None | Some("yyyy-MM-dd") =>
@@ -71,7 +71,7 @@ object GpuJsonToStructsShim {
   def tagTimestampFormatSupport(meta: RapidsMeta[_, _, _],
     timestampFormat: Option[String]): Unit = {}
 
-  def castJsonStringToTimestamp(input: ColumnVector,
+  def castJsonStringToTimestamp(input: ColumnView,
       options: Map[String, String]): ColumnVector = {
     withResource(Scalar.fromString(" ")) { space =>
       withResource(input.strip(space)) { trimmed =>

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -32,20 +32,19 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.{DateUtils, GpuCast, GpuOverrides, RapidsMeta}
 import com.nvidia.spark.rapids.Arm.withResource
 
 import org.apache.spark.sql.rapids.ExceptionTimeParserPolicy
 
 object GpuJsonToStructsShim {
-
   def tagDateFormatSupport(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
     // dateFormat is ignored by JsonToStructs in Spark 3.2.x and 3.3.x because it just
     // performs a regular cast from string to date
   }
 
-  def castJsonStringToDate(input: ColumnVector, options: Map[String, String]): ColumnVector = {
+  def castJsonStringToDate(input: ColumnView, options: Map[String, String]): ColumnVector = {
     // dateFormat is ignored in from_json in Spark 3.2.x and 3.3.x
     withResource(Scalar.fromString(" ")) { space =>
       withResource(input.strip(space)) { trimmed =>
@@ -57,7 +56,7 @@ object GpuJsonToStructsShim {
   def tagDateFormatSupportFromScan(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
   }
 
-  def castJsonStringToDateFromScan(input: ColumnVector, dt: DType,
+  def castJsonStringToDateFromScan(input: ColumnView, dt: DType,
       dateFormat: Option[String]): ColumnVector = {
     dateFormat match {
       case None =>
@@ -85,7 +84,7 @@ object GpuJsonToStructsShim {
     // performs a regular cast from string to timestamp
   }
 
-  def castJsonStringToTimestamp(input: ColumnVector,
+  def castJsonStringToTimestamp(input: ColumnView,
       options: Map[String, String]): ColumnVector = {
     // legacy behavior
     withResource(Scalar.fromString(" ")) { space =>

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/GpuJsonToStructsShim.scala
@@ -23,7 +23,7 @@
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
-import ai.rapids.cudf.{ColumnVector, DType, Scalar}
+import ai.rapids.cudf.{ColumnVector, ColumnView, DType, Scalar}
 import com.nvidia.spark.rapids.{DateUtils, GpuCast, GpuOverrides, RapidsMeta}
 import com.nvidia.spark.rapids.Arm.withResource
 
@@ -35,7 +35,7 @@ object GpuJsonToStructsShim {
   def tagDateFormatSupport(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
   }
 
-  def castJsonStringToDate(input: ColumnVector, options: Map[String, String]): ColumnVector = {
+  def castJsonStringToDate(input: ColumnView, options: Map[String, String]): ColumnVector = {
     GpuJsonUtils.optionalDateFormatInRead(options) match {
       case None =>
         // legacy behavior
@@ -53,7 +53,7 @@ object GpuJsonToStructsShim {
   def tagDateFormatSupportFromScan(meta: RapidsMeta[_, _, _], dateFormat: Option[String]): Unit = {
   }
 
-  def castJsonStringToDateFromScan(input: ColumnVector, dt: DType,
+  def castJsonStringToDateFromScan(input: ColumnView, dt: DType,
       dateFormat: Option[String]): ColumnVector = {
     dateFormat match {
       case None =>
@@ -68,7 +68,7 @@ object GpuJsonToStructsShim {
     }
   }
 
-  private def jsonStringToDate(input: ColumnVector, dateFormatPattern: String,
+  private def jsonStringToDate(input: ColumnView, dateFormatPattern: String,
       failOnInvalid: Boolean): ColumnVector = {
     val regexRoot = dateFormatPattern
       .replace("yyyy", raw"\d{4}")
@@ -84,7 +84,7 @@ object GpuJsonToStructsShim {
     timestampFormat.foreach(f => meta.willNotWorkOnGpu(s"Unsupported timestampFormat: $f"))
   }
 
-  def castJsonStringToTimestamp(input: ColumnVector,
+  def castJsonStringToTimestamp(input: ColumnView,
       options: Map[String, String]): ColumnVector = {
     options.get("timestampFormat") match {
       case None =>


### PR DESCRIPTION
This is based on some of the great work that @andygrove did https://github.com/NVIDIA/spark-rapids/pull/10326 but has evolved quite a bit past that.

With this we are now asking CUDF to return all leaf nodes as strings and to preserve the quotes on those strings if they are there.  This lets us handle parsing different data types in a spark compatible way.  For example when parsing a decimal value from the following data a, b, and  d are valid decimal input, but c is not.
```
{"a":12345}
{"b":"12345"}
{"c":12,345}
{"d":"12,345"}
```

This does not fix all of those use cases. It just lays the ground work to be able to fix them, ideally we would fix this with a small number of custom kernels after we have made the code common between from_json/JsonToStructs and ScanJson.

Because the code is not common we cannot close some of the issues that this fixes because the issues were filed against both JsonToStructs and ScanJson.

This has a dependency on something that was just merged into CUDF today so it will fail to compile, but I would love to have some reviews for this before then.

There are two small regressions introduced by this. We no longer support duplicate struct keys and fall back to the CPU if we see them. We could make it work by injecting nulls for one of the keys, but it should be a really rare case, and it totally messes up SQL/dataframe access to those columns so I don't think it is a priority.

I also have not finished fixing up date/timestamp parsing for unquoted numbers. The old code worked only when all of the values in the batch were that type, but didn't work if they were mixed.

Performance Results:

In my testing I saw about a 4% slow down for simple queries compared to the current code. I would need to do some traces to see how much of that we can expect to get back with custom kernels for conversion and such, but I would expect that we can speed it up significantly over time.