### PR TITLE
Fix scalar leak in SumBinaryFixer (#10510)

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExpression.scala
@@ -1600,6 +1600,8 @@ class SumBinaryFixer(toType: DataType, isAnsi: Boolean)
   override def close(): Unit = {
     previousResult.foreach(_.close())
     previousResult = None
+    previousOverflow.foreach(_.close())
+    previousOverflow = None
   }
 }
 


### PR DESCRIPTION
This is a cherry-pick of #10510, which went into 24.04.

I am putting this up in case we want to merge this in 24.02 at this point?
