### PR TITLE
Handle minimum GPU architecture supported [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -73,6 +73,7 @@ object RapidsPluginUtils extends Logging {
   private val TASK_GPU_AMOUNT_KEY = "spark.task.resource.gpu.amount"
   private val EXECUTOR_GPU_AMOUNT_KEY = "spark.executor.resource.gpu.amount"
   private val SPARK_MASTER = "spark.master"
+  private val SPARK_RAPIDS_REPO_URL = "https://github.com/NVIDIA/spark-rapids"
 
   {
     val pluginProps = loadProps(PLUGIN_PROPS_FILENAME)
@@ -362,25 +363,42 @@ object RapidsPluginUtils extends Logging {
   /**
    * Checks if the current GPU architecture is supported by the spark-rapids-jni
    * and cuDF libraries.
+   */
+  def validateGpuArchitecture(): Unit = {
+    val gpuArch = Cuda.getComputeCapabilityMajor * 10 + Cuda.getComputeCapabilityMinor
+    validateGpuArchitectureInternal(gpuArch, getSupportedGpuArchitectures(JNI_PROPS_FILENAME),
+      getSupportedGpuArchitectures(CUDF_PROPS_FILENAME))
+  }
+
+  /**
+   * Checks the validity of the provided GPU architecture in the provided architecture set.
    *
    * See: https://docs.nvidia.com/cuda/ampere-compatibility-guide/index.html
    */
-  def checkGpuArchitecture(): Unit = {
-    val supportedGpuArchsSet = getSupportedGpuArchitectures(JNI_PROPS_FILENAME)
-      .intersect(getSupportedGpuArchitectures(CUDF_PROPS_FILENAME))
-    val minSupportedGpuArch = supportedGpuArchsSet.min
-    val majorGpuArch = Cuda.getComputeCapabilityMajor
-    val minorGpuArch = Cuda.getComputeCapabilityMinor
-    val gpuArch = majorGpuArch * 10 + minorGpuArch
+  def validateGpuArchitectureInternal(gpuArch: Int, jniSupportedGpuArchs: Set[Int],
+      cudfSupportedGpuArchs: Set[Int]): Unit = {
+    val supportedGpuArchs = jniSupportedGpuArchs.intersect(cudfSupportedGpuArchs)
+    if (supportedGpuArchs.isEmpty) {
+      val jniSupportedGpuArchsStr = jniSupportedGpuArchs.toSeq.sorted.mkString(", ")
+      val cudfSupportedGpuArchsStr = cudfSupportedGpuArchs.toSeq.sorted.mkString(", ")
+      throw new IllegalStateException(s"Compatibility check failed for GPU architecture " +
+        s"$gpuArch. Supported GPU architectures by JNI: $jniSupportedGpuArchsStr and " +
+        s"cuDF: $cudfSupportedGpuArchsStr. Please report this issue at $SPARK_RAPIDS_REPO_URL." +
+        s" This check can be disabled by setting `spark.rapids.skipGpuArchitectureCheck` to" +
+        s" `true`, but it may lead to functional failures.")
+    }
+
+    val minSupportedGpuArch = supportedGpuArchs.min
     // Check if the device architecture is supported
     if (gpuArch < minSupportedGpuArch) {
       throw new RuntimeException(s"Device architecture $gpuArch is unsupported." +
         s" Minimum supported architecture: $minSupportedGpuArch.")
     }
-    val supportedMajorGpuArchsSet = supportedGpuArchsSet.map(_/10)
+    val supportedMajorGpuArchs = supportedGpuArchs.map(_/10)
+    val majorGpuArch = gpuArch/10
     // Warn the user if the device's major architecture is not available
-    if (!supportedMajorGpuArchsSet.contains(majorGpuArch)) {
-      val supportedMajorArchStr = supportedMajorGpuArchsSet.toSeq.sorted.mkString(", ")
+    if (!supportedMajorGpuArchs.contains(majorGpuArch)) {
+      val supportedMajorArchStr = supportedMajorGpuArchs.toSeq.sorted.mkString(", ")
       logWarning(s"No precompiled binaries for device major architecture $majorGpuArch. " +
         "This may lead to expensive JIT compile on startup. " +
         s"Binaries available for architectures $supportedMajorArchStr.")
@@ -478,7 +496,7 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       // spark-rapids-jni and cuDF libraries.
       // Note: We allow this check to be skipped for off-chance cases.
       if (!conf.skipGpuArchCheck) {
-        RapidsPluginUtils.checkGpuArchitecture()
+        RapidsPluginUtils.validateGpuArchitecture()
       }
 
       // Fail if there are multiple plugin jars in the classpath.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -394,8 +394,8 @@ object RapidsPluginUtils extends Logging {
       throw new RuntimeException(s"Device architecture $gpuArch is unsupported." +
         s" Minimum supported architecture: $minSupportedGpuArch.")
     }
-    val supportedMajorGpuArchs = supportedGpuArchs.map(_/10)
-    val majorGpuArch = gpuArch/10
+    val supportedMajorGpuArchs = supportedGpuArchs.map(_ / 10)
+    val majorGpuArch = gpuArch / 10
     // Warn the user if the device's major architecture is not available
     if (!supportedMajorGpuArchs.contains(majorGpuArch)) {
       val supportedMajorArchStr = supportedMajorGpuArchs.toSeq.sorted.mkString(", ")

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -427,16 +427,18 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       pluginContext: PluginContext,
       extraConf: java.util.Map[String, String]): Unit = {
     try {
-      if (Cuda.getComputeCapabilityMajor < 6) {
-        throw new RuntimeException(s"GPU compute capability ${Cuda.getComputeCapabilityMajor}" +
-          " is unsupported, requires 6.0+")
-      }
       // if configured, re-register checking leaks hook.
       reRegisterCheckLeakHook()
 
       val sparkConf = pluginContext.conf()
       val numCores = RapidsPluginUtils.estimateCoresOnExec(sparkConf)
       val conf = new RapidsConf(extraConf.asScala.toMap)
+
+      // Fail if the device's compute capability is less than minimum supported
+      if (Cuda.getComputeCapabilityMajor < conf.minCudaComputeCapabilitySupported) {
+        throw new RuntimeException(s"GPU compute capability ${Cuda.getComputeCapabilityMajor}" +
+          s" is unsupported, requires ${conf.minCudaComputeCapabilitySupported}+")
+      }
 
       // Fail if there are multiple plugin jars in the classpath.
       RapidsPluginUtils.detectMultipleJars(conf)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -382,8 +382,8 @@ object RapidsPluginUtils extends Logging {
     if (!supportedMajorGpuArchsSet.contains(majorGpuArch)) {
       val supportedMajorArchStr = supportedMajorGpuArchsSet.toSeq.sorted.mkString(", ")
       logWarning(s"No precompiled binaries for device major architecture $majorGpuArch. " +
-        s"Binaries available for architectures $supportedMajorArchStr. " +
-        s"May lead to expensive JIT compile on startup.")
+        "This may lead to expensive JIT compile on startup. " +
+        s"Binaries available for architectures $supportedMajorArchStr.")
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2133,7 +2133,7 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .createOptional
 
   val SKIP_GPU_ARCH_CHECK = conf("spark.rapids.skipGpuArchitectureCheck")
-    .doc("When true, skips GPU architecture compatibility check. Note that this check" +
+    .doc("When true, skips GPU architecture compatibility check. Note that this check " +
       "might still be present in cuDF.")
     .internal()
     .booleanConf

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2132,6 +2132,13 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createOptional
 
+  val MIN_CUDA_COMPUTE_CAPABILITY_SUPPORTED = conf("spark.rapids.minCudaComputeCapabilitySupported")
+    .internal()
+    .startupOnly()
+    .doc("Config to store the minimum CUDA compute capability supported by the RAPIDS plugin")
+    .integerConf
+    .createWithDefault(7)
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2894,6 +2901,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val spillToDiskBounceBufferSize: Long = get(SPILL_TO_DISK_BOUNCE_BUFFER_SIZE)
 
   lazy val splitUntilSizeOverride: Option[Long] = get(SPLIT_UNTIL_SIZE_OVERRIDE)
+
+  lazy val minCudaComputeCapabilitySupported: Int = get(MIN_CUDA_COMPUTE_CAPABILITY_SUPPORTED)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2132,6 +2132,13 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createOptional
 
+  val SKIP_GPU_ARCH_CHECK = conf("spark.rapids.skipGpuArchitectureCheck")
+    .doc("When true, skips GPU architecture compatibility check. Note that this check" +
+      "might still be present in cuDF.")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2894,6 +2901,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val spillToDiskBounceBufferSize: Long = get(SPILL_TO_DISK_BOUNCE_BUFFER_SIZE)
 
   lazy val splitUntilSizeOverride: Option[Long] = get(SPLIT_UNTIL_SIZE_OVERRIDE)
+
+  lazy val skipGpuArchCheck: Boolean = get(SKIP_GPU_ARCH_CHECK)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2132,13 +2132,6 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
     .booleanConf
     .createOptional
 
-  val MIN_CUDA_COMPUTE_CAPABILITY_SUPPORTED = conf("spark.rapids.minCudaComputeCapabilitySupported")
-    .internal()
-    .startupOnly()
-    .doc("Config to store the minimum CUDA compute capability supported by the RAPIDS plugin")
-    .integerConf
-    .createWithDefault(7)
-
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -2901,8 +2894,6 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val spillToDiskBounceBufferSize: Long = get(SPILL_TO_DISK_BOUNCE_BUFFER_SIZE)
 
   lazy val splitUntilSizeOverride: Option[Long] = get(SPLIT_UNTIL_SIZE_OVERRIDE)
-
-  lazy val minCudaComputeCapabilitySupported: Int = get(MIN_CUDA_COMPUTE_CAPABILITY_SUPPORTED)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
@@ -51,7 +51,7 @@ class GpuArchitectureTestSuite extends AnyFunSuite {
   }
 
   test("test empty supported architecture set") {
-    assertThrows[RuntimeException] {
+    assertThrows[IllegalStateException] {
       val jniSupportedGpuArchs = Set(50, 60)
       val cudfSupportedGpuArchs = Set(70, 80)
       val gpuArch = 60

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
@@ -28,12 +28,13 @@ class GpuArchitectureTestSuite extends AnyFunSuite {
   }
 
   test("test unsupported architecture") {
-    assertThrows[RuntimeException] {
-      val jniSupportedGpuArchs = Set(50, 60, 70)
-      val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
-      val gpuArch = 40
+    val jniSupportedGpuArchs = Set(50, 60, 70)
+    val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
+    val gpuArch = 40
+    val exception = intercept[RuntimeException] {
       validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
     }
+    assert(exception.getMessage.contains(s"Device architecture $gpuArch is unsupported"))
   }
 
   test("test supported major architecture with higher minor version") {
@@ -51,11 +52,13 @@ class GpuArchitectureTestSuite extends AnyFunSuite {
   }
 
   test("test empty supported architecture set") {
-    assertThrows[IllegalStateException] {
-      val jniSupportedGpuArchs = Set(50, 60)
-      val cudfSupportedGpuArchs = Set(70, 80)
-      val gpuArch = 60
+    val jniSupportedGpuArchs = Set(50, 60)
+    val cudfSupportedGpuArchs = Set(70, 80)
+    val gpuArch = 60
+    val exception = intercept[IllegalStateException] {
       validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
     }
+    assert(exception.getMessage.contains(
+      s"Compatibility check failed for GPU architecture $gpuArch"))
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuArchitectureTestSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.RapidsPluginUtils.validateGpuArchitectureInternal
+import org.scalatest.funsuite.AnyFunSuite
+
+class GpuArchitectureTestSuite extends AnyFunSuite {
+  test("test supported architecture") {
+    val jniSupportedGpuArchs = Set(50, 60, 70)
+    val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
+    val gpuArch = 60
+    validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
+  }
+
+  test("test unsupported architecture") {
+    assertThrows[RuntimeException] {
+      val jniSupportedGpuArchs = Set(50, 60, 70)
+      val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
+      val gpuArch = 40
+      validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
+    }
+  }
+
+  test("test supported major architecture with higher minor version") {
+    val jniSupportedGpuArchs = Set(50, 60, 65, 70)
+    val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
+    val gpuArch = 67
+    validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
+  }
+
+  test("test supported major architecture with lower minor version") {
+    val jniSupportedGpuArchs = Set(50, 60, 65, 70)
+    val cudfSupportedGpuArchs = Set(50, 60, 65, 70)
+    val gpuArch = 63
+    validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
+  }
+
+  test("test empty supported architecture set") {
+    assertThrows[RuntimeException] {
+      val jniSupportedGpuArchs = Set(50, 60)
+      val cudfSupportedGpuArchs = Set(70, 80)
+      val gpuArch = 60
+      validateGpuArchitectureInternal(gpuArch, jniSupportedGpuArchs, cudfSupportedGpuArchs)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #10430. This PR ensures that Spark RAPIDS jobs are executed on supported GPU architectures without relying on manual configuration. 

### Changes:
1. Processes `gpu_architectures` property from the `*version-info.properties` file generated by the native builds. 
2. Verifies if the user is running the job on an architecture supported by the cuDF and JNI libraries and throws an exception if the architecture is unsupported.

### Testing
Tested on a Dataproc VM running on Nvidia P4 (GPU Architecture 6.1)

```
24/03/06 17:44:58 WARN RapidsPluginUtils: spark.rapids.sql.explain is set to `NOT_ON_GPU`. Set it to 'NONE' to suppress the diagnostics logging about the query placement on the GPU.
24/03/06 17:45:10 ERROR RapidsExecutorPlugin: Exception in the executor plugin, shutting down!
java.lang.RuntimeException: Device architecture 61 is unsupported. Minimum supported architecture: 75.
        at com.nvidia.spark.rapids.RapidsPluginUtils$.checkGpuArchitectureInternal(Plugin.scala:366)
        at com.nvidia.spark.rapids.RapidsPluginUtils$.checkGpuArchitecture(Plugin.scala:375)
        at com.nvidia.spark.rapids.RapidsExecutorPlugin.init(Plugin.scala:461)
```


### Related PR
* https://github.com/NVIDIA/spark-rapids-jni/pull/1840


