### PR TITLE
Fix Delta log cache size settings during integration tests [databricks]

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -227,7 +227,9 @@ else
     TZ=${TZ:-UTC}
 
     # Set the Delta log cache size to prevent the driver from caching every Delta log indefinitely
-    export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=10 $COVERAGE_SUBMIT_FLAGS"
+    export PYSP_TEST_spark_databricks_delta_delta_log_cacheSize=${PYSP_TEST_spark_databricks_delta_delta_log_cacheSize:-10}
+    deltaCacheSize=$PYSP_TEST_spark_databricks_delta_delta_log_cacheSize
+    export PYSP_TEST_spark_driver_extraJavaOptions="-ea -Duser.timezone=$TZ -Ddelta.log.cacheSize=$deltaCacheSize $COVERAGE_SUBMIT_FLAGS"
     export PYSP_TEST_spark_executor_extraJavaOptions="-ea -Duser.timezone=$TZ"
     export PYSP_TEST_spark_ui_showConsoleProgress='false'
     export PYSP_TEST_spark_sql_session_timeZone=$TZ
@@ -380,6 +382,7 @@ EOF
 
         # avoid double processing of variables passed to spark in
         # spark_conf_init
+        unset PYSP_TEST_spark_databricks_delta_delta_log_cacheSize
         unset PYSP_TEST_spark_driver_extraClassPath
         unset PYSP_TEST_spark_driver_extraJavaOptions
         unset PYSP_TEST_spark_jars
@@ -391,6 +394,7 @@ EOF
             --driver-java-options "$driverJavaOpts" \
             $SPARK_SUBMIT_FLAGS \
             --conf 'spark.rapids.memory.gpu.allocSize='"$gpuAllocSize" \
+            --conf 'spark.databricks.delta.delta.log.cacheSize='"$deltaCacheSize" \
             "${RUN_TESTS_COMMAND[@]}" "${TEST_COMMON_OPTS[@]}"
     fi
 fi


### PR DESCRIPTION
Fixes #10530.  Databricks added a new config to control the amount of Delta snapshots that will be cached, and that config effectively overrides the old way of setting the cache size.  Updated the integration tests to set it both ways so it works on new and older Databricks versions.