### PR TITLE
Update CI script to build and deploy using the same CUDA classifier[skip ci]

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -31,6 +31,7 @@
 #   OUT_PATH:       The path where jar files are
 #   CUDA_CLASSIFIERS:    Comma separated classifiers, e.g., "cuda11,cuda12"
 #   CLASSIFIERS:    Comma separated classifiers, e.g., "cuda11,cuda12,cuda11-arm64,cuda12-arm64"
+#   DEFAULT_CUDA_CLASSIFIER: The default cuda classifer, will get from project's pom.xml if not set
 ###
 
 set -ex
@@ -47,7 +48,7 @@ function mvnEval {
 ART_ID=$(mvnEval $DIST_PL project.artifactId)
 ART_GROUP_ID=$(mvnEval $DIST_PL project.groupId)
 ART_VER=$(mvnEval $DIST_PL project.version)
-DEFAULT_CUDA_CLASSIFIER=$(mvnEval $DIST_PL cuda.version)
+DEFAULT_CUDA_CLASSIFIER=${DEFAULT_CUDA_CLASSIFIER:-$(mvnEval $DIST_PL cuda.version)}
 CUDA_CLASSIFIERS=${CUDA_CLASSIFIERS:-"$DEFAULT_CUDA_CLASSIFIER"}
 CLASSIFIERS=${CLASSIFIERS:-"$CUDA_CLASSIFIERS"} # default as CUDA_CLASSIFIERS for compatibility
 SERVER_ID=${SERVER_ID:-"snapshots"}


### PR DESCRIPTION
Update CI script to support building and deploying using the same CUDA classifier:

Currently our [deploy.sh](https://github.com/NVIDIA/spark-rapids/blob/branch-24.04/jenkins/deploy.sh#L112) always try to upload [cuda.version(default cuda11)](https://github.com/NVIDIA/spark-rapids/blob/branch-24.04/pom.xml#L699) jars by default, due to DEFAULT_CUDA_CLASSIFIER always be overwrite here.

We can set DEFAULT_CUDA_CLASSIFIER=cuda12 to only build cuda12 jar [DEFAULT_CUDA_CLASSIFIER=${DEFAULT_CUDA_CLASSIFIER:-$(mvnEval cuda.version)} # default cuda version](
https://github.com/NVIDIA/spark-rapids/blob/branch-24.04/jenkins/spark-nightly-build.sh#L43)

So we should only upload cuda12 jar also by set [DEFAULT_CUDA_CLASSIFIER=cuda12](
https://github.com/NVIDIA/spark-rapids/blob/branch-24.04/jenkins/deploy.sh#L50) and not overwrite it by cuda11