### PR TITLE
Use random seed for `test_from_json_struct_decimal` [databricks]

### DIFF
--- a/integration_tests/src/main/python/json_test.py
+++ b/integration_tests/src/main/python/json_test.py
@@ -689,7 +689,6 @@ def test_from_json_struct_boolean(pattern):
         conf=_enable_all_types_conf)
 
 @allow_non_gpu(*non_utc_allow)
-@datagen_overrides(seed=0, reason='https://github.com/NVIDIA/spark-rapids/issues/10349')
 def test_from_json_struct_decimal():
     json_string_gen = StringGen(r'{ "a": "[+-]?([0-9]{0,5})?(\.[0-9]{0,2})?([eE][+-]?[0-9]{1,2})?" }') \
         .with_special_pattern('', weight=50) \


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10349

We should be able to re-enable this test with a random seed now that https://github.com/NVIDIA/spark-rapids/pull/10542 is merged