### PR TITLE
Turn off state logging in HostAllocSuite

### DIFF
--- a/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
+++ b/sql-plugin/src/test/scala/com/nvidia/spark/rapids/HostAllocSuite.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.rapids.execution.TrampolineUtil
 class HostAllocSuite extends AnyFunSuite with BeforeAndAfterEach with
     BeforeAndAfterAll with TimeLimits {
   private val sqlConf = new SQLConf()
-  sqlConf.setConfString("spark.rapids.memory.gpu.state.debug", "stderr")
   private val rc = new RapidsConf(sqlConf)
   private val timeoutMs = 10000
 


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10585

This reverts part of https://github.com/NVIDIA/spark-rapids/pull/10590 to turn off again the state logging. In my tests, this logging made the race condition stop happening and so the tests only fail without the logging.

This is waiting for https://github.com/rapidsai/cudf/pull/15351 to be merged and the fix to propagate to spark-rapids-jni.