### PR TITLE
Remove unused shared lib in Jenkins files

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -1,6 +1,6 @@
 #!/usr/local/env groovy
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import hudson.model.Result
 import hudson.model.Run
 import jenkins.model.CauseOfInterruption.UserInterruption
 
-@Library(['shared-libs', 'blossom-lib']) _
+@Library('blossom-lib')
 @Library('blossom-github-lib@master')
 import ipp.blossom.*
 
@@ -68,10 +68,10 @@ pipeline {
         PREMERGE_SCRIPT = '$JENKINS_ROOT/spark-premerge-build.sh'
         MVN_URM_MIRROR = '-s jenkins/settings.xml -P mirror-apache-to-urm'
         LIBCUDF_KERNEL_CACHE_PATH = '/tmp/.cudf'
-        ARTIFACTORY_NAME = "${ArtifactoryConstants.ARTIFACTORY_NAME}"
+        ARTIFACTORY_NAME = "${common.ARTIFACTORY_NAME}"
         GITHUB_TOKEN = credentials("github-token")
         URM_CREDS = credentials("urm_creds")
-        URM_URL = "https://${ArtifactoryConstants.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
+        URM_URL = "https://${common.ARTIFACTORY_NAME}/artifactory/sw-spark-maven"
         PVC = credentials("pvc")
         CUSTOM_WORKSPACE = "/home/jenkins/agent/workspace/${BUILD_TAG}"
         CLASSIFIER = 'cuda11'

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -21,7 +21,7 @@
  *
  */
 
-@Library(['shared-libs', 'blossom-lib']) _
+@Library('blossom-lib')
 @Library('blossom-github-lib@master')
 
 import ipp.blossom.*


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids/issues/10621

"shared-libs" had not been used since we switched to blossom Jenkins.

We had ever used "shared-libs" before, but now only need "blossom-lib".