### PR TITLE
Cleanup async state when multi-threaded shuffle readers fail

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -33,7 +33,6 @@ import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
 import com.nvidia.spark.rapids.format.TableMeta
 import com.nvidia.spark.rapids.shuffle.{RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport}
 
-
 import org.apache.spark.{InterruptibleIterator, MapOutputTracker, ShuffleDependency, SparkConf, SparkEnv, TaskContext}
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.internal.{config, Logging}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -850,7 +850,9 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
             None // no further batches
           }
         } finally {
-          blockState.close()
+          if (!success) {
+            blockState.close()
+          }
         }
       })
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -831,7 +831,6 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
 
     private def deserializeTask(blockState: BlockState): Unit = {
       val slot = RapidsShuffleInternalManagerBase.getNextReaderSlot
-      val tc = TaskContext.get()
       futures += RapidsShuffleInternalManagerBase.queueReadTask(slot, () => {
         var success = false
         try {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -730,11 +730,21 @@ abstract class RapidsShuffleThreadedReaderBase[K, C](
           }
         }
       futures.clear()
-      if (fallbackIter != null) {
-        fallbackIter.close()
-      }
-      failedFuture.foreach { e =>
-        throw e
+      try { 
+        if (fallbackIter != null) {
+          fallbackIter.close()
+        }
+      } catch {
+        case t: Throwable => 
+          if (failedFuture.isEmpty) {
+            failedFuture = Some(t)
+          } else {
+            failedFuture.get.addSuppressed(t)
+          }
+      } finally {
+        failedFuture.foreach { e =>
+          throw e
+        }
       }
     }
 

--- a/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
+++ b/tests/src/test/spark321/scala/org/apache/spark/sql/rapids/RapidsShuffleThreadedReaderSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,15 @@ import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.sql.rapids.shims.RapidsShuffleThreadedReader
 import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
 
+class InjectedShuffleErrorInTests extends Exception {
+}
+
+class ErrorInputStream(wrapped: InputStream) extends InputStream {
+  override def read(): Int = {
+    throw new InjectedShuffleErrorInTests
+  }
+}
+
 /**
  *
  * Code ported over from `BlockStoreShuffleReaderSuite` in Apache Spark.
@@ -56,15 +65,23 @@ import org.apache.spark.storage.{BlockManager, BlockManagerId, ShuffleBlockId}
  * We need to define this class ourselves instead of using a spy because the NioManagedBuffer class
  * is final (final classes cannot be spied on).
  */
-class RecordingManagedBuffer(underlyingBuffer: NioManagedBuffer) extends ManagedBuffer {
+class RecordingManagedBuffer(
+    underlyingBuffer: NioManagedBuffer,
+    injectError: Boolean) extends ManagedBuffer {
   var callsToRetain = 0
   var callsToRelease = 0
 
   override def size(): Long = underlyingBuffer.size()
   override def nioByteBuffer(): ByteBuffer = underlyingBuffer.nioByteBuffer()
-  override def createInputStream(): InputStream = underlyingBuffer.createInputStream()
+  override def createInputStream(): InputStream = {
+    val is = underlyingBuffer.createInputStream()
+    if (injectError) {
+      new ErrorInputStream(is)
+    } else {
+      is
+    }
+  }
   override def convertToNetty(): AnyRef = underlyingBuffer.convertToNetty()
-
   override def retain(): ManagedBuffer = {
     callsToRetain += 1
     underlyingBuffer.retain()
@@ -82,110 +99,133 @@ class RapidsShuffleThreadedReaderSuite
     RapidsShuffleInternalManagerBase.stopThreadPool()
   }
 
+  def runShuffleRead(numReaderThreads: Int, injectError: Boolean = false): Unit = {
+    val testConf = new SparkConf(false)
+    // this sets the session and the SparkEnv
+    SparkSessionHolder.withSparkSession(testConf, _ => {
+      if (numReaderThreads > 1) {
+        RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(0, numReaderThreads)
+      }
+
+      val reduceId = 15
+      val shuffleId = 22
+      val numMaps = 6
+      val keyValuePairsPerMap = 10
+      val serializer = new GpuColumnarBatchSerializer(NoopMetric)
+
+      // Make a mock BlockManager that will return RecordingManagedByteBuffers of data, so that we
+      // can ensure retain() and release() are properly called.
+      val blockManager = mock(classOf[BlockManager])
+
+      // Create a buffer with some randomly generated key-value pairs to use as the shuffle data
+      // from each mappers (all mappers return the same shuffle data).
+      val byteOutputStream = new ByteArrayOutputStream()
+      val serializationStream = serializer.newInstance().serializeStream(byteOutputStream)
+      withResource(GpuColumnVector.emptyBatchFromTypes(Array.empty)) { emptyBatch =>
+        (0 until keyValuePairsPerMap).foreach { i =>
+          serializationStream.writeKey(i)
+          serializationStream.writeValue(GpuColumnVector.incRefCounts(emptyBatch))
+        }
+      }
+
+      // Setup the mocked BlockManager to return RecordingManagedBuffers.
+      val localBlockManagerId = BlockManagerId("test-client", "test-client", 1)
+      when(blockManager.blockManagerId).thenReturn(localBlockManagerId)
+      val buffers = (0 until numMaps).map { mapId =>
+        // Create a ManagedBuffer with the shuffle data.
+        val nioBuffer = new NioManagedBuffer(ByteBuffer.wrap(byteOutputStream.toByteArray))
+        val managedBuffer = new RecordingManagedBuffer(nioBuffer, injectError)
+
+        // Setup the blockManager mock so the buffer gets returned when the shuffle code tries to
+        // fetch shuffle data.
+        val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
+        when(blockManager.getLocalBlockData(meq(shuffleBlockId))).thenReturn(managedBuffer)
+        managedBuffer
+      }
+
+      // Make a mocked MapOutputTracker for the shuffle reader to use to determine what
+      // shuffle data to read.
+      val mapOutputTracker = mock(classOf[MapOutputTracker])
+      when(mapOutputTracker.getMapSizesByExecutorId(
+        shuffleId, 0, numMaps, reduceId, reduceId + 1)).thenReturn {
+        // Test a scenario where all data is local, to avoid creating a bunch of additional mocks
+        // for the code to read data over the network.
+        val shuffleBlockIdsAndSizes = (0 until numMaps).map { mapId =>
+          val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
+          (shuffleBlockId, byteOutputStream.size().toLong, mapId)
+        }
+        Seq((localBlockManagerId, shuffleBlockIdsAndSizes)).iterator
+      }
+
+      // Create a mocked shuffle handle to pass into HashShuffleReader.
+      val shuffleHandle = {
+        val dependency = mock(classOf[GpuShuffleDependency[Int, Int, Int]])
+        when(dependency.serializer).thenReturn(serializer)
+        when(dependency.aggregator).thenReturn(None)
+        when(dependency.keyOrdering).thenReturn(None)
+        new ShuffleHandleWithMetrics[Int, Int, Int](
+          shuffleId, Map.empty, dependency)
+      }
+
+      val serializerManager = new SerializerManager(
+        serializer,
+        new SparkConf()
+          .set(config.SHUFFLE_COMPRESS, false)
+          .set(config.SHUFFLE_SPILL_COMPRESS, false))
+
+      val taskContext = TaskContext.empty()
+      val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
+      val shuffleReader = new RapidsShuffleThreadedReader[Int, Int](
+        0,
+        numMaps,
+        reduceId,
+        reduceId + 1,
+        shuffleHandle,
+        taskContext,
+        metrics,
+        1024 * 1024,
+        serializerManager,
+        blockManager,
+        mapOutputTracker = mapOutputTracker,
+        numReaderThreads = numReaderThreads)
+
+      if (injectError) {
+        var e: Throwable = null
+        assertThrows[InjectedShuffleErrorInTests] {
+          try {
+            shuffleReader.read().length
+          } catch {
+            case t: Throwable =>
+              e = t
+              throw t
+          }
+        }
+        taskContext.markTaskCompleted(Some(e))
+      } else {
+        assert(shuffleReader.read().length === keyValuePairsPerMap * numMaps)
+        taskContext.markTaskCompleted(None)
+      }
+
+      // Calling .length above will have exhausted the iterator; make sure that exhausting the
+      // iterator caused retain and release to be called on each buffer.
+      buffers.foreach { buffer =>
+        assert(buffer.callsToRetain === 1)
+        assert(buffer.callsToRelease === 1)
+      }
+    })
+  }
+
   /**
    * This test makes sure that, when data is read from a HashShuffleReader, the underlying
    * ManagedBuffers that contain the data are eventually released.
    */
   Seq(1, 2).foreach { numReaderThreads =>
     test(s"read() releases resources on completion - numThreads=$numReaderThreads") {
-      val testConf = new SparkConf(false)
-      // this sets the session and the SparkEnv
-      SparkSessionHolder.withSparkSession(testConf, _ => {
-        if (numReaderThreads > 1) {
-          RapidsShuffleInternalManagerBase.startThreadPoolIfNeeded(0, numReaderThreads)
-        }
+      runShuffleRead(numReaderThreads)
+    }
 
-        val reduceId = 15
-        val shuffleId = 22
-        val numMaps = 6
-        val keyValuePairsPerMap = 10
-        val serializer = new GpuColumnarBatchSerializer(NoopMetric)
-
-        // Make a mock BlockManager that will return RecordingManagedByteBuffers of data, so that we
-        // can ensure retain() and release() are properly called.
-        val blockManager = mock(classOf[BlockManager])
-
-        // Create a buffer with some randomly generated key-value pairs to use as the shuffle data
-        // from each mappers (all mappers return the same shuffle data).
-        val byteOutputStream = new ByteArrayOutputStream()
-        val serializationStream = serializer.newInstance().serializeStream(byteOutputStream)
-        withResource(GpuColumnVector.emptyBatchFromTypes(Array.empty)) { emptyBatch =>
-          (0 until keyValuePairsPerMap).foreach { i =>
-            serializationStream.writeKey(i)
-            serializationStream.writeValue(GpuColumnVector.incRefCounts(emptyBatch))
-          }
-        }
-
-        // Setup the mocked BlockManager to return RecordingManagedBuffers.
-        val localBlockManagerId = BlockManagerId("test-client", "test-client", 1)
-        when(blockManager.blockManagerId).thenReturn(localBlockManagerId)
-        val buffers = (0 until numMaps).map { mapId =>
-          // Create a ManagedBuffer with the shuffle data.
-          val nioBuffer = new NioManagedBuffer(ByteBuffer.wrap(byteOutputStream.toByteArray))
-          val managedBuffer = new RecordingManagedBuffer(nioBuffer)
-
-          // Setup the blockManager mock so the buffer gets returned when the shuffle code tries to
-          // fetch shuffle data.
-          val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
-          when(blockManager.getLocalBlockData(meq(shuffleBlockId))).thenReturn(managedBuffer)
-          managedBuffer
-        }
-
-        // Make a mocked MapOutputTracker for the shuffle reader to use to determine what
-        // shuffle data to read.
-        val mapOutputTracker = mock(classOf[MapOutputTracker])
-        when(mapOutputTracker.getMapSizesByExecutorId(
-          shuffleId, 0, numMaps, reduceId, reduceId + 1)).thenReturn {
-          // Test a scenario where all data is local, to avoid creating a bunch of additional mocks
-          // for the code to read data over the network.
-          val shuffleBlockIdsAndSizes = (0 until numMaps).map { mapId =>
-            val shuffleBlockId = ShuffleBlockId(shuffleId, mapId, reduceId)
-            (shuffleBlockId, byteOutputStream.size().toLong, mapId)
-          }
-          Seq((localBlockManagerId, shuffleBlockIdsAndSizes)).iterator
-        }
-
-        // Create a mocked shuffle handle to pass into HashShuffleReader.
-        val shuffleHandle = {
-          val dependency = mock(classOf[GpuShuffleDependency[Int, Int, Int]])
-          when(dependency.serializer).thenReturn(serializer)
-          when(dependency.aggregator).thenReturn(None)
-          when(dependency.keyOrdering).thenReturn(None)
-          new ShuffleHandleWithMetrics[Int, Int, Int](
-            shuffleId, Map.empty, dependency)
-        }
-
-        val serializerManager = new SerializerManager(
-          serializer,
-          new SparkConf()
-              .set(config.SHUFFLE_COMPRESS, false)
-              .set(config.SHUFFLE_SPILL_COMPRESS, false))
-
-        val taskContext = TaskContext.empty()
-        val metrics = taskContext.taskMetrics.createTempShuffleReadMetrics()
-        val shuffleReader = new RapidsShuffleThreadedReader[Int, Int](
-          0,
-          numMaps,
-          reduceId,
-          reduceId + 1,
-          shuffleHandle,
-          taskContext,
-          metrics,
-          1024 * 1024,
-          serializerManager,
-          blockManager,
-          mapOutputTracker = mapOutputTracker,
-          numReaderThreads = numReaderThreads)
-
-        assert(shuffleReader.read().length === keyValuePairsPerMap * numMaps)
-
-        // Calling .length above will have exhausted the iterator; make sure that exhausting the
-        // iterator caused retain and release to be called on each buffer.
-        buffers.foreach { buffer =>
-          assert(buffer.callsToRetain === 1)
-          assert(buffer.callsToRelease === 1)
-        }
-      })
+    test(s"read() releases resources on error - numThreads=$numReaderThreads") {
+      runShuffleRead(numReaderThreads, injectError = true)
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10631

We had some reports of file descriptors left open from the multi-threaded shuffle reader, likely due to a wave of other exceptions. I started to look at it and found that it did not handle cases when tasks were cancelled correctly, nor errors such as stream close. I added code in the task completion callback to close out any accumulated future or to-be-processed batch. 

I also fixed an issue where we would leak a batch if a stream closes after we materialize the batch, but before we read the next header. I found that one because I was testing this by introducing exceptions manually.

I am going to add a test in `RapidsShuffleThreadedReaderSuite` shortly.