### PR TITLE
Update the 24.06 POM to reference cudf 24.06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,8 +699,8 @@
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
         <!-- TODO: https://github.com/NVIDIA/spark-rapids/issues/10622 -->
-        <spark-rapids-jni.version>24.04.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.04.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-jni.version>24.06.0-SNAPSHOT</spark-rapids-jni.version>
+        <spark-rapids-private.version>24.06.0-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION

The POM for 24.06 was still referencing cudf 24.04.  This PR updates it.