### PR TITLE
Update rapids private dependency to 24.04.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,7 +699,7 @@
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>24.04.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.04.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-private.version>24.04.1-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.12</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -699,7 +699,7 @@
         <cuda.version>cuda11</cuda.version>
         <jni.classifier>${cuda.version}</jni.classifier>
         <spark-rapids-jni.version>24.04.0-SNAPSHOT</spark-rapids-jni.version>
-        <spark-rapids-private.version>24.04.0-SNAPSHOT</spark-rapids-private.version>
+        <spark-rapids-private.version>24.04.1-SNAPSHOT</spark-rapids-private.version>
         <scala.binary.version>2.13</scala.binary.version>
         <alluxio.client.version>2.8.0</alluxio.client.version>
         <scala.recompileMode>incremental</scala.recompileMode>


### PR DESCRIPTION
To fix: https://github.com/NVIDIA/spark-rapids/issues/10665

Due to the part of 2.12 private jar has been uploaded and can not be removed from maven central

we'll need to upgrade dependency version of rapids private jar to 24.04.1 for spark-rapids v24.04.0 release


Signed-off-by: Tim Liu <timl@nvidia.com>