### PR TITLE
Change parameter name for memory limit in Parquet chunked reader

### DIFF
--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquet.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquet.java
@@ -69,7 +69,7 @@ public class GpuParquet {
     private long maxBatchSizeBytes = Integer.MAX_VALUE;
     private long targetBatchSizeBytes = Integer.MAX_VALUE;
     private boolean useChunkedReader = false;
-    private boolean useSubPageChunked = false;
+    private long maxChunkedReaderMemoryUsageSizeBytes = 0;
     private scala.Option<String> debugDumpPrefix = null;
     private boolean debugDumpAlways = false;
     private scala.collection.immutable.Map<String, GpuMetric> metrics = null;
@@ -141,9 +141,10 @@ public class GpuParquet {
       return this;
     }
 
-    public ReadBuilder withUseChunkedReader(boolean useChunkedReader, boolean useSubPageChunked) {
+    public ReadBuilder withUseChunkedReader(boolean useChunkedReader,
+        long maxChunkedReaderMemoryUsageSizeBytes) {
       this.useChunkedReader = useChunkedReader;
-      this.useSubPageChunked = useSubPageChunked;
+      this.maxChunkedReaderMemoryUsageSizeBytes = maxChunkedReaderMemoryUsageSizeBytes;
       return this;
     }
 
@@ -164,8 +165,8 @@ public class GpuParquet {
           InternalRow.empty(), file.location(), start, length);
       return new GpuParquetReader(file, projectSchema, options, nameMapping, filter, caseSensitive,
           idToConstant, deleteFilter, partFile, conf, maxBatchSizeRows, maxBatchSizeBytes,
-          targetBatchSizeBytes, useChunkedReader, useSubPageChunked, debugDumpPrefix,
-          debugDumpAlways, metrics);
+          targetBatchSizeBytes, useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
+          debugDumpPrefix, debugDumpAlways, metrics);
     }
   }
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/parquet/GpuParquetReader.java
@@ -87,7 +87,7 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
   private final boolean useChunkedReader;
-  private final boolean useSubPageChunked;
+  private final long maxChunkedReaderMemoryUsageSizeBytes;
   private final scala.Option<String> debugDumpPrefix;
   private final boolean debugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
@@ -98,7 +98,7 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
       Map<Integer, ?> idToConstant, GpuDeleteFilter deleteFilter,
       PartitionedFile partFile, Configuration conf, int maxBatchSizeRows,
       long maxBatchSizeBytes, long targetBatchSizeBytes, boolean useChunkedReader,
-      boolean useSubPageChunked,
+      long maxChunkedReaderMemoryUsageSizeBytes,
       scala.Option<String> debugDumpPrefix, boolean debugDumpAlways,
       scala.collection.immutable.Map<String, GpuMetric> metrics) {
     this.input = input;
@@ -115,7 +115,7 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
     this.maxBatchSizeBytes = maxBatchSizeBytes;
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.useChunkedReader = useChunkedReader;
-    this.useSubPageChunked = useSubPageChunked;
+    this.maxChunkedReaderMemoryUsageSizeBytes = maxChunkedReaderMemoryUsageSizeBytes;
     this.debugDumpPrefix = debugDumpPrefix;
     this.debugDumpAlways = debugDumpAlways;
     this.metrics = metrics;
@@ -143,7 +143,7 @@ public class GpuParquetReader extends CloseableGroup implements CloseableIterabl
           new Path(input.location()), clippedBlocks, fileReadSchema, caseSensitive,
           partReaderSparkSchema, debugDumpPrefix, debugDumpAlways,
           maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, useChunkedReader,
-          useSubPageChunked,
+          maxChunkedReaderMemoryUsageSizeBytes,
           metrics,
           DateTimeRebaseCorrected$.MODULE$, // dateRebaseMode
           DateTimeRebaseCorrected$.MODULE$, // timestampRebaseMode

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuBatchDataReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuBatchDataReader.java
@@ -48,14 +48,15 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
   private final long maxBatchSizeBytes;
   private final long targetBatchSizeBytes;
   private final boolean useChunkedReader;
-  private final boolean useSubPageChunked;
+  private final long maxChunkedReaderMemoryUsageSizeBytes;
   private final scala.Option<String> parquetDebugDumpPrefix;
   private final boolean parquetDebugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
 
   GpuBatchDataReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive,
                      Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
-                     long targetBatchSizeBytes, boolean useChunkedReader, boolean useSubPageChunked,
+                     long targetBatchSizeBytes,
+                     boolean useChunkedReader, long maxChunkedReaderMemoryUsageSizeBytes,
                      scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
                      scala.collection.immutable.Map<String, GpuMetric> metrics) {
     super(table, task);
@@ -67,7 +68,7 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
     this.maxBatchSizeBytes = maxBatchSizeBytes;
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.useChunkedReader = useChunkedReader;
-    this.useSubPageChunked = useSubPageChunked;
+    this.maxChunkedReaderMemoryUsageSizeBytes = maxChunkedReaderMemoryUsageSizeBytes;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
     this.parquetDebugDumpAlways = parquetDebugDumpAlways;
     this.metrics = metrics;
@@ -102,7 +103,7 @@ class GpuBatchDataReader extends BaseDataReader<ColumnarBatch> {
           .withMaxBatchSizeRows(maxBatchSizeRows)
           .withMaxBatchSizeBytes(maxBatchSizeBytes)
           .withTargetBatchSizeBytes(targetBatchSizeBytes)
-          .withUseChunkedReader(useChunkedReader, useSubPageChunked)
+          .withUseChunkedReader(useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes)
           .withDebugDump(parquetDebugDumpPrefix, parquetDebugDumpAlways)
           .withMetrics(metrics);
 

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/iceberg/spark/source/GpuMultiFileBatchReader.java
@@ -68,7 +68,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
   private final long maxGpuColumnSizeBytes;
 
   private final boolean useChunkedReader;
-  private final boolean useSubPageChunked;
+  private final long maxChunkedReaderMemoryUsageSizeBytes;
   private final scala.Option<String> parquetDebugDumpPrefix;
   private final boolean parquetDebugDumpAlways;
   private final scala.collection.immutable.Map<String, GpuMetric> metrics;
@@ -87,7 +87,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
   GpuMultiFileBatchReader(CombinedScanTask task, Table table, Schema expectedSchema,
       boolean caseSensitive, Configuration conf, int maxBatchSizeRows, long maxBatchSizeBytes,
       long targetBatchSizeBytes, long maxGpuColumnSizeBytes,
-      boolean useChunkedReader, boolean useSubPageChunked,
+      boolean useChunkedReader, long maxChunkedReaderMemoryUsageSizeBytes,
       scala.Option<String> parquetDebugDumpPrefix, boolean parquetDebugDumpAlways,
       int numThreads, int maxNumFileProcessed,
       boolean useMultiThread, FileFormat fileFormat,
@@ -102,7 +102,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
     this.targetBatchSizeBytes = targetBatchSizeBytes;
     this.maxGpuColumnSizeBytes = maxGpuColumnSizeBytes;
     this.useChunkedReader = useChunkedReader;
-    this.useSubPageChunked = useSubPageChunked;
+    this.maxChunkedReaderMemoryUsageSizeBytes = maxChunkedReaderMemoryUsageSizeBytes;
     this.parquetDebugDumpPrefix = parquetDebugDumpPrefix;
     this.parquetDebugDumpAlways = parquetDebugDumpAlways;
     this.useMultiThread = useMultiThread;
@@ -352,7 +352,7 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
       return new MultiFileCloudParquetPartitionReader(conf, pFiles,
           this::filterParquetBlocks, caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways,
           maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
-          useChunkedReader, useSubPageChunked, metrics, partitionSchema,
+          useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes, metrics, partitionSchema,
           numThreads, maxNumFileProcessed,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles
@@ -428,9 +428,9 @@ class GpuMultiFileBatchReader extends BaseDataReader<ColumnarBatch> {
 
       return new MultiFileParquetPartitionReader(conf, pFiles,
           JavaConverters.asScalaBuffer(clippedBlocks).toSeq(),
-          caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways, useChunkedReader,
-          useSubPageChunked,
+          caseSensitive, parquetDebugDumpPrefix, parquetDebugDumpAlways,
           maxBatchSizeRows, maxBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes,
+          useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
           metrics, partitionSchema, numThreads,
           false, // ignoreMissingFiles
           false, // ignoreCorruptFiles

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuMultiFileReader.scala
@@ -214,8 +214,14 @@ abstract class MultiFilePartitionReaderFactoryBase(
   protected val maxReadBatchSizeRows: Int = rapidsConf.maxReadBatchSizeRows
   protected val maxReadBatchSizeBytes: Long = rapidsConf.maxReadBatchSizeBytes
   protected val targetBatchSizeBytes: Long = rapidsConf.gpuTargetBatchSizeBytes
-  protected val subPageChunked: Boolean = rapidsConf.chunkedSubPageReaderEnabled
   protected val maxGpuColumnSizeBytes: Long = rapidsConf.maxGpuColumnSizeBytes
+  protected val useChunkedReader: Boolean = rapidsConf.chunkedReaderEnabled
+  protected val maxChunkedReaderMemoryUsageSizeBytes: Long =
+    if(rapidsConf.limitChunkedReaderMemoryUsage) {
+      (rapidsConf.chunkedReaderMemoryUsageRatio * targetBatchSizeBytes).toLong
+    } else {
+      0L
+    }
   private val allCloudSchemes = rapidsConf.getCloudSchemes.toSet
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1084,8 +1084,6 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     rapidsConf, alluxioPathReplacementMap) {
 
   private val isCaseSensitive = sqlConf.caseSensitiveAnalysis
-  private val useChunkedReader = rapidsConf.chunkedReaderEnabled
-  private val useSubPageChunked = rapidsConf.chunkedSubPageReaderEnabled
   private val debugDumpPrefix = rapidsConf.parquetDebugDumpPrefix
   private val debugDumpAlways = rapidsConf.parquetDebugDumpAlways
   private val numThreads = rapidsConf.multiThreadReadNumThreads
@@ -1151,10 +1149,11 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     val combineConf = CombineConf(combineThresholdSize, combineWaitTime)
     new MultiFileCloudParquetPartitionReader(conf, files, filterFunc, isCaseSensitive,
       debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
-      targetBatchSizeBytes, maxGpuColumnSizeBytes, useChunkedReader, subPageChunked, metrics,
-      partitionSchema, numThreads, maxNumFileProcessed, ignoreMissingFiles, ignoreCorruptFiles,
-      readUseFieldId, alluxioPathReplacementMap.getOrElse(Map.empty), alluxioReplacementTaskTime,
-      queryUsesInputFile, keepReadsInOrderFromConf, combineConf)
+      targetBatchSizeBytes, maxGpuColumnSizeBytes,
+      useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
+      metrics, partitionSchema, numThreads, maxNumFileProcessed, ignoreMissingFiles,
+      ignoreCorruptFiles, readUseFieldId, alluxioPathReplacementMap.getOrElse(Map.empty),
+      alluxioReplacementTaskTime, queryUsesInputFile, keepReadsInOrderFromConf, combineConf)
   }
 
   private def filterBlocksForCoalescingReader(
@@ -1266,9 +1265,10 @@ case class GpuParquetMultiFilePartitionReaderFactory(
       _ += TimeUnit.NANOSECONDS.toMillis(filterTime)
     }
     new MultiFileParquetPartitionReader(conf, files, clippedBlocks.toSeq, isCaseSensitive,
-      debugDumpPrefix, debugDumpAlways, useChunkedReader, useSubPageChunked, maxReadBatchSizeRows,
-      maxReadBatchSizeBytes, targetBatchSizeBytes, maxGpuColumnSizeBytes, metrics, partitionSchema,
-      numThreads, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId)
+      debugDumpPrefix, debugDumpAlways, maxReadBatchSizeRows, maxReadBatchSizeBytes,
+      targetBatchSizeBytes, maxGpuColumnSizeBytes,
+      useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
+      metrics, partitionSchema, numThreads, ignoreMissingFiles, ignoreCorruptFiles, readUseFieldId)
   }
 
   /**
@@ -1302,7 +1302,12 @@ case class GpuParquetPartitionReaderFactory(
   private val targetSizeBytes = rapidsConf.gpuTargetBatchSizeBytes
   private val maxGpuColumnSizeBytes = rapidsConf.maxGpuColumnSizeBytes
   private val useChunkedReader = rapidsConf.chunkedReaderEnabled
-  private val useSubPageChunked = rapidsConf.chunkedSubPageReaderEnabled
+  private val maxChunkedReaderMemoryUsageSizeBytes =
+    if(rapidsConf.limitChunkedReaderMemoryUsage) {
+      (rapidsConf.chunkedReaderMemoryUsageRatio * targetSizeBytes).toLong
+    } else {
+      0L
+    }
   private val filterHandler = GpuParquetFileFilterHandler(sqlConf, metrics)
   private val readUseFieldId = ParquetSchemaClipShims.useFieldId(sqlConf)
   private val footerReadType = GpuParquetScan.footerReaderHeuristic(
@@ -1333,7 +1338,8 @@ case class GpuParquetPartitionReaderFactory(
     new ParquetPartitionReader(conf, file, singleFileInfo.filePath, singleFileInfo.blocks,
       singleFileInfo.schema, isCaseSensitive, readDataSchema, debugDumpPrefix, debugDumpAlways,
       maxReadBatchSizeRows, maxReadBatchSizeBytes, targetSizeBytes,
-      useChunkedReader, useSubPageChunked, metrics, singleFileInfo.dateRebaseMode,
+      useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
+      metrics, singleFileInfo.dateRebaseMode,
       singleFileInfo.timestampRebaseMode, singleFileInfo.hasInt96Timestamps, readUseFieldId)
   }
 }
@@ -1851,6 +1857,11 @@ private case class ParquetSingleDataBlockMeta(
  * @param debugDumpAlways whether to debug dump always or only on errors
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
+ * @param targetBatchSizeBytes the target size of a batch
+ * @param maxGpuColumnSizeBytes the maximum size of a GPU column
+ * @param useChunkedReader whether to read Parquet by chunks or read all at once
+ * @param maxChunkedReaderMemoryUsageSizeBytes soft limit on the number of bytes of internal memory
+ *                                             usage that the reader will use
  * @param execMetrics metrics
  * @param partitionSchema Schema of partitions.
  * @param numThreads the size of the threadpool
@@ -1864,12 +1875,12 @@ class MultiFileParquetPartitionReader(
     override val isSchemaCaseSensitive: Boolean,
     debugDumpPrefix: Option[String],
     debugDumpAlways: Boolean,
-    useChunkedReader: Boolean,
-    useSubPageChunked: Boolean,
     maxReadBatchSizeRows: Integer,
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
     maxGpuColumnSizeBytes: Long,
+    useChunkedReader: Boolean,
+    maxChunkedReaderMemoryUsageSizeBytes: Long,
     override val execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
     numThreads: Int,
@@ -1975,7 +1986,7 @@ class MultiFileParquetPartitionReader(
     // About to start using the GPU
     GpuSemaphore.acquireIfNecessary(TaskContext.get())
 
-    MakeParquetTableProducer(useChunkedReader, useSubPageChunked,
+    MakeParquetTableProducer(useChunkedReader, maxChunkedReaderMemoryUsageSizeBytes,
       conf, currentTargetBatchSize, parseOpts,
       dataBuffer, 0, dataSize, metrics,
       extraInfo.dateRebaseMode, extraInfo.timestampRebaseMode,
@@ -2033,6 +2044,11 @@ class MultiFileParquetPartitionReader(
  * @param debugDumpAlways whether to debug dump always or only on errors
  * @param maxReadBatchSizeRows soft limit on the maximum number of rows the reader reads per batch
  * @param maxReadBatchSizeBytes soft limit on the maximum number of bytes the reader reads per batch
+ * @param targetBatchSizeBytes the target size of the batch
+ * @param maxGpuColumnSizeBytes the maximum size of a GPU column
+ * @param useChunkedReader whether to read Parquet by chunks or read all at once
+ * @param maxChunkedReaderMemoryUsageSizeBytes soft limit on the number of bytes of internal memory
+ *                                             usage that the reader will use
  * @param execMetrics metrics
  * @param partitionSchema Schema of partitions.
  * @param numThreads the size of the threadpool
@@ -2060,7 +2076,7 @@ class MultiFileCloudParquetPartitionReader(
     targetBatchSizeBytes: Long,
     maxGpuColumnSizeBytes: Long,
     useChunkedReader: Boolean,
-    subPageChunked: Boolean,
+    maxChunkedReaderMemoryUsageSizeBytes: Long,
     override val execMetrics: Map[String, GpuMetric],
     partitionSchema: StructType,
     numThreads: Int,
@@ -2549,7 +2565,8 @@ class MultiFileCloudParquetPartitionReader(
       // The MakeParquetTableProducer will close the input buffer, and that would be bad
       // because we don't want to close it until we know that we are done with it
       hostBuffer.incRefCount()
-      val tableReader = MakeParquetTableProducer(useChunkedReader, subPageChunked,
+      val tableReader = MakeParquetTableProducer(useChunkedReader,
+        maxChunkedReaderMemoryUsageSizeBytes,
         conf, targetBatchSizeBytes,
         parseOpts,
         hostBuffer, 0, dataSize, metrics,
@@ -2581,7 +2598,7 @@ class MultiFileCloudParquetPartitionReader(
 object MakeParquetTableProducer extends Logging {
   def apply(
       useChunkedReader: Boolean,
-      useSubPageChunked: Boolean,
+      maxChunkedReaderMemoryUsageSizeBytes: Long,
       conf: Configuration,
       chunkSizeByteLimit: Long,
       opts: ParquetOptions,
@@ -2601,12 +2618,8 @@ object MakeParquetTableProducer extends Logging {
       debugDumpAlways: Boolean
   ): GpuDataProducer[Table] = {
     if (useChunkedReader) {
-      val passReadLimit = if (useSubPageChunked) {
-        4 * chunkSizeByteLimit
-      } else {
-        0L
-      }
-      ParquetTableReader(conf, chunkSizeByteLimit, passReadLimit, opts, buffer, offset,
+      ParquetTableReader(conf, chunkSizeByteLimit, maxChunkedReaderMemoryUsageSizeBytes,
+        opts, buffer, offset,
         len, metrics, dateRebaseMode, timestampRebaseMode, hasInt96Timestamps,
         isSchemaCaseSensitive, useFieldId, readDataSchema, clippedParquetSchema,
         splits, debugDumpPrefix, debugDumpAlways)
@@ -2750,7 +2763,7 @@ class ParquetPartitionReader(
     maxReadBatchSizeBytes: Long,
     targetBatchSizeBytes: Long,
     useChunkedReader: Boolean,
-    useSubPageChunked: Boolean,
+    maxChunkedReaderMemoryUsageSizeBytes: Long,
     override val execMetrics: Map[String, GpuMetric],
     dateRebaseMode: DateTimeRebaseMode,
     timestampRebaseMode: DateTimeRebaseMode,
@@ -2818,7 +2831,8 @@ class ParquetPartitionReader(
               // Inc the ref count because MakeParquetTableProducer will try to close the dataBuffer
               // which we don't want until we know that the retry is done with it.
               dataBuffer.incRefCount()
-              val producer = MakeParquetTableProducer(useChunkedReader, useSubPageChunked, conf,
+              val producer = MakeParquetTableProducer(useChunkedReader,
+                maxChunkedReaderMemoryUsageSizeBytes, conf,
                 targetBatchSizeBytes, parseOpts,
                 dataBuffer, 0, dataSize, metrics,
                 dateRebaseMode, timestampRebaseMode,

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -566,6 +566,29 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
       s"Batch size must be positive and not exceed ${Integer.MAX_VALUE} bytes.")
     .createWithDefault(1 * 1024 * 1024 * 1024) // 1 GiB is the default
 
+  val CHUNKED_READER = conf("spark.rapids.sql.reader.chunked")
+    .doc("Enable a chunked reader where possible. A chunked reader allows " +
+      "reading highly compressed data that could not be read otherwise, but at the expense " +
+      "of more GPU memory, and in some cases more GPU computation. "+
+      "Currently this only supports ORC and Parquet formats.")
+    .booleanConf
+    .createWithDefault(true)
+
+  val CHUNKED_READER_MEMORY_USAGE_RATIO = conf("spark.rapids.sql.reader.chunked.memoryUsageRatio")
+    .doc("A value to compute soft limit on the internal memory usage of the chunked reader " +
+      "(if being used). Such limit is calculated as the multiplication of this value and " +
+      s"'${GPU_BATCH_SIZE_BYTES.key}'.")
+    .doubleConf
+    .checkValue(v => v > 0, "The ratio value must be positive.")
+    .createWithDefault(4)
+
+  val LIMIT_CHUNKED_READER_MEMORY_USAGE = conf("spark.rapids.sql.reader.chunked.limitMemoryUsage")
+    .doc("Enable a soft limit on the internal memory usage of the chunked reader " +
+      "(if being used). Such limit is calculated as the multiplication of " +
+      s"'${GPU_BATCH_SIZE_BYTES.key}' and '${CHUNKED_READER_MEMORY_USAGE_RATIO.key}'.")
+    .booleanConf
+    .createWithDefault(true)
+
   val MAX_GPU_COLUMN_SIZE_BYTES = conf("spark.rapids.sql.columnSizeBytes")
     .doc("Limit the max number of bytes for a GPU column. It is same as the cudf " +
       "row count limit of a column. It is used by the multi-file readers. " +
@@ -583,19 +606,6 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .commonlyUsed()
     .integerConf
     .createWithDefault(Integer.MAX_VALUE)
-
-  val CHUNKED_READER = conf("spark.rapids.sql.reader.chunked")
-      .doc("Enable a chunked reader where possible. A chunked reader allows " +
-          "reading highly compressed data that could not be read otherwise, but at the expense " +
-          "of more GPU memory, and in some cases more GPU computation.")
-      .booleanConf
-      .createWithDefault(true)
-
-  val CHUNKED_SUBPAGE_READER = conf("spark.rapids.sql.reader.chunked.subPage")
-      .doc("Enable a chunked reader where possible for reading data that is smaller " +
-          "than the typical row group/page limit. Currently this only works for parquet.")
-      .booleanConf
-      .createWithDefault(true)
 
   val MAX_READER_BATCH_SIZE_BYTES = conf("spark.rapids.sql.reader.batchSizeBytes")
     .doc("Soft limit on the maximum number of bytes the reader reads per batch. " +
@@ -2515,7 +2525,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val chunkedReaderEnabled: Boolean = get(CHUNKED_READER)
 
-  lazy val chunkedSubPageReaderEnabled: Boolean = get(CHUNKED_SUBPAGE_READER)
+  lazy val limitChunkedReaderMemoryUsage: Boolean = get(LIMIT_CHUNKED_READER_MEMORY_USAGE)
+
+  lazy val chunkedReaderMemoryUsageRatio: Double = get(CHUNKED_READER_MEMORY_USAGE_RATIO)
 
   lazy val maxReadBatchSizeRows: Int = get(MAX_READER_BATCH_SIZE_ROWS)
 


### PR DESCRIPTION
The parameter name for setting a limit on memory usage of Parquet chunked reader has been implemented in https://github.com/NVIDIA/spark-rapids/pull/9991. However, its name does not make much sense: `CHUNKED_SUBPAGE_READER`, and is very irrelevant as it is going to be used for ORC chunked reader.

This PR changes the parameter name into something more expressive (although a bit longer): `LIMIT_CHUNKED_READER_MEMORY_USAGE`. A new parameter is also added, allowing to change the memory limit from config: `CHUNKED_READER_MEMORY_USAGE_RATIO`.