### PR TITLE
Fix "Could not find any rapids-4-spark jars in classpath" error when debugging UT in IDEA

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -156,18 +156,18 @@ object RapidsPluginUtils extends Logging {
     lazy val msg = s"Multiple $jarName jars found in the classpath:\n$rapidsJarsVersMsg" +
         s"Please make sure there is only one $jarName jar in the classpath. "
 
-    require(revisionMap.size > 0, s"Could not find any $jarName jars in the classpath")
+    // require(revisionMap.size > 0, s"Could not find any $jarName jars in the classpath")
 
     conf.allowMultipleJars match {
       case AllowMultipleJars.ALWAYS =>
-        if (revisionMap.size != 1 || revisionMap.values.exists(_.size != 1)) {
+        if (revisionMap.size > 1 || revisionMap.values.exists(_.size != 1)) {
           logWarning(msg)
         }
       case AllowMultipleJars.SAME_REVISION =>
         val recommended = "If it is impossible to fix the classpath you can suppress the " +
               s"error by setting ${RapidsConf.ALLOW_MULTIPLE_JARS.key} to ALWAYS, but this " +
               s"can cause unpredictable behavior as the plugin may pick up the wrong jar."
-        require(revisionMap.size == 1, msg + recommended)
+        require(revisionMap.size <= 1, msg + recommended)
         if (revisionMap.values.exists(_.size != 1)) {
           logWarning(msg + recommended)
         }
@@ -176,7 +176,7 @@ object RapidsPluginUtils extends Logging {
             s"error by setting ${RapidsConf.ALLOW_MULTIPLE_JARS.key} to SAME_REVISION or ALWAYS." +
             " But setting it to ALWAYS can cause unpredictable behavior as the plugin may pick " +
             "up the wrong jar."
-        require(revisionMap.size == 1 && revisionMap.values.forall(_.size == 1), msg + recommended)
+        require(revisionMap.size <= 1 && revisionMap.values.forall(_.size == 1), msg + recommended)
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -156,8 +156,7 @@ object RapidsPluginUtils extends Logging {
     lazy val msg = s"Multiple $jarName jars found in the classpath:\n$rapidsJarsVersMsg" +
         s"Please make sure there is only one $jarName jar in the classpath. "
 
-    // require(revisionMap.size > 0, s"Could not find any $jarName jars in the classpath")
-
+    // revisionMap.size could be 0 when debugging in IDE, so allow it in that case
     conf.allowMultipleJars match {
       case AllowMultipleJars.ALWAYS =>
         if (revisionMap.size > 1 || revisionMap.values.exists(_.size != 1)) {


### PR DESCRIPTION
Fix #10722

There is no jar in classpath when debugging UT in IDE, so following require fails:

```
require(revisionMap.size > 0, s"Could not find any $jarName jars in the classpath")
```

This PR removes this require and modifies the related logic to make debugging in IDEA work again.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
