### PR TITLE
Add short circuit path for get-json-object when there is separate wildcard path

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -189,11 +189,51 @@ case class GpuGetJsonObject(json: Expression, path: Expression)
     }
   }
 
+  /**
+   * get_json_object(any_json, '$.*') always return null.
+   * '$.*' will be parsed to be a single `Wildcard`.
+   * Check whether has separated `Wildcard`
+   *
+   * @param instructions query path instructions
+   * @return true if has separated `Wildcard`, false otherwise.
+   */
+  private def hasSeparateWildcard(instructions: Option[List[PathInstruction]]): Boolean = {
+    import PathInstruction._
+    def hasSeparate(ins: List[PathInstruction], idx: Int): Boolean = {
+      if (idx == 0) {
+        ins(0) match {
+          case Wildcard => true
+          case _ => false
+        }
+      } else {
+        (ins(idx - 1), ins(idx)) match {
+          case (Key, Wildcard) => false
+          case (Subscript, Wildcard) => false
+          case (_, Wildcard) => true
+          case _ => false
+        }
+      }
+    }
+
+    if (instructions.isEmpty) {
+      false
+    } else {
+      val list = instructions.get
+      list.indices.exists { idx => hasSeparate(list, idx) }
+    }
+  }
+
   override def doColumnar(lhs: GpuColumnVector, rhs: GpuScalar): ColumnVector = {
     cachedInstructions.getOrElse {
       val pathInstructions = parseJsonPath(rhs)
-      cachedInstructions = Some(pathInstructions)
-      pathInstructions
+      val checkedPathInstructions = if (hasSeparateWildcard(pathInstructions)) {
+        // If has separate wildcard path, should return all nulls
+        None
+      } else {
+        pathInstructions
+      }
+      cachedInstructions = Some(checkedPathInstructions)
+      checkedPathInstructions
     } match {
       case Some(instructions) => {
         val jniInstructions = JsonPathParser.convertToJniObject(instructions)


### PR DESCRIPTION


This PR is related to a JNI perf improvement: https://github.com/NVIDIA/spark-rapids-jni/pull/1987

This JNI PR needs Spark-Rapids to do an extra check.
JNI PR is depending on this Spark-Rapids PR.
First merge this PR, then merge JNI PR.

Signed-off-by: Chong Gao <res_life@163.com>