### PR TITLE
Add log message if using the legacy code path for `getJsonObject`

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -166,6 +166,7 @@ class GpuGetJsonObjectMeta(
       GpuGetJsonObject(lhs, rhs,
         conf.testGetJsonObjectSavePath, conf.testGetJsonObjectSaveRows)
     } else {
+      logWarning("Enabled get_json_object legacy code path.")
       GpuGetJsonObjectLegacy(lhs, rhs,
         conf.testGetJsonObjectSavePath, conf.testGetJsonObjectSaveRows)
     }


### PR DESCRIPTION
This adds a warning log when the legacy code path for `getJsonObject` is called. By doing so, we can figure out which code path is called during query execution.