### PR TITLE
Add rows-only batches support to RebatchingRoundoffIterator

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -464,3 +464,13 @@ def test_map_in_arrow_with_barrier_mode(is_barrier):
 
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark: spark.range(0, 10, 1, 1).mapInArrow(func, "id long", is_barrier))
+
+
+def test_pandas_udf_rows_only():
+    def add_one(a):
+        return a + 1
+    my_udf = f.pandas_udf(add_one, returnType=IntegerType())
+    assert_gpu_and_cpu_are_equal_collect(
+        lambda spark: unary_op_df(spark, int_gen, num_slices=4, length=52345)
+            .select(my_udf(f.lit(0))),
+        conf=arrow_udf_conf)


### PR DESCRIPTION
fix https://github.com/NVIDIA/spark-rapids/issues/10751

A cuDF Table requires non empyt columns, so need to check the number of columns when converting a batch to a cuDF table. This PR adds the support for rows-only batches in `RebatchingRoundoffIterator`.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
