### PR TITLE
fixing build break on DBR [databricks] 

### DIFF
--- a/integration_tests/src/main/python/udf_test.py
+++ b/integration_tests/src/main/python/udf_test.py
@@ -15,8 +15,8 @@
 import pytest
 from pyspark import BarrierTaskContext, TaskContext
 
-from conftest import is_at_least_precommit_run
-from spark_session import is_databricks_runtime, is_before_spark_330, is_before_spark_350, is_spark_341
+from conftest import is_at_least_precommit_run, is_databricks_runtime
+from spark_session import is_before_spark_330, is_before_spark_350, is_spark_341
 
 from pyspark.sql.pandas.utils import require_minimum_pyarrow_version, require_minimum_pandas_version
 
@@ -98,6 +98,8 @@ def test_pandas_scalar_udf_nested_type(data_gen):
 # ======= Test aggregate in Pandas =======
 @approximate_float
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_single_aggregate_udf(data_gen):
     @f.pandas_udf('double')
     def pandas_sum(to_process: pd.Series) -> float:
@@ -111,6 +113,8 @@ def test_single_aggregate_udf(data_gen):
 
 @approximate_float
 @pytest.mark.parametrize('data_gen', arrow_common_gen, ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_single_aggregate_udf_more_types(data_gen):
     @f.pandas_udf('double')
     def group_size_udf(to_process: pd.Series) -> float:
@@ -124,6 +128,8 @@ def test_single_aggregate_udf_more_types(data_gen):
 
 @ignore_order
 @pytest.mark.parametrize('data_gen', integral_gens, ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_group_aggregate_udf(data_gen):
     @f.pandas_udf('long')
     def pandas_sum(to_process: pd.Series) -> int:
@@ -141,6 +147,8 @@ def test_group_aggregate_udf(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', arrow_common_gen, ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_group_aggregate_udf_more_types(data_gen):
     @f.pandas_udf('long')
     def group_size_udf(to_process: pd.Series) -> int:
@@ -238,6 +246,8 @@ def test_window_aggregate_udf_array_input(data_gen, window):
 @ignore_order(local=True)
 @pytest.mark.parametrize('zero_enabled', [False, True])
 @pytest.mark.parametrize('data_gen', [LongGen()], ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_group_apply_udf_zero_conf(data_gen, zero_enabled):
     def pandas_add(data):
         data.sum = data.b + data.a
@@ -271,6 +281,8 @@ def test_group_apply_udf(data_gen):
 
 @ignore_order(local=True)
 @pytest.mark.parametrize('data_gen', arrow_common_gen, ids=idfn)
+@pytest.mark.xfail(condition=is_databricks_runtime() and is_spark_341(),
+    reason='https://github.com/NVIDIA/spark-rapids/issues/10797')
 def test_group_apply_udf_more_types(data_gen):
     def group_size_udf(key, pdf):
         return pd.DataFrame([[len(key), len(pdf), len(pdf.columns)]])

--- a/scala2.13/tests/pom.xml
+++ b/scala2.13/tests/pom.xml
@@ -90,9 +90,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-          <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -102,27 +102,6 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-avro_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatestplus</groupId>
-            <artifactId>scalatestplus-scalacheck_${scala.binary.version}</artifactId>
-            <version>3.1.0.0-RC2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -142,4 +121,42 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release330</id>
+            <activation>
+                <!-- #if scala-2.13 -->
+                <activeByDefault>true</activeByDefault>
+                <!-- #endif scala-2.13 -->
+                <property>
+                    <name>buildver</name>
+                    <value>330</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-core_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-sql_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.scalatestplus</groupId>
+                    <artifactId>scalatestplus-scalacheck_${scala.binary.version}</artifactId>
+                    <version>3.1.0.0-RC2</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -90,9 +90,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-          <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -102,27 +102,6 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-avro_${scala.binary.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatestplus</groupId>
-            <artifactId>scalatestplus-scalacheck_${scala.binary.version}</artifactId>
-            <version>3.1.0.0-RC2</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -142,4 +121,42 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release330</id>
+            <activation>
+                <!-- #if scala-2.13 --><!--
+                <activeByDefault>true</activeByDefault>
+                --><!-- #endif scala-2.13 -->
+                <property>
+                    <name>buildver</name>
+                    <value>330</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-core_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-sql_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
+                    <type>test-jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.scalatestplus</groupId>
+                    <artifactId>scalatestplus-scalacheck_${scala.binary.version}</artifactId>
+                    <version>3.1.0.0-RC2</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Previously merged PR https://github.com/NVIDIA/spark-rapids/pull/10756 breaks build on DBR, because some of the newly add dependencies cannot be found in DBR environment.
This PR puts all the new dependencies in profile "release330", so that no other profiles will be affected (including DBR related profiles).

Also mark some udf_test on DB13.3 xfail due to https://github.com/NVIDIA/spark-rapids/issues/10797