### PR TITLE
Add number normalization test and address followup for getJsonObject

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -392,14 +392,10 @@ def test_get_json_object_number_normalization_legacy():
               'spark.rapids.sql.getJsonObject.legacy.enabled': 'true'})
     assert([[row[1]] for row in gpu_result] == data)
 
-@pytest.mark.parametrize('data_gen', [StringGen(r'''-?[1-9]\d{0,20}\.\d{1,20}''', nullable=False),
-                                      StringGen(r'''-?[1-9]\d{0,5}\.\d{1,20}''', nullable=False),
+@pytest.mark.parametrize('data_gen', [StringGen(r'''-?[1-9]\d{0,5}\.\d{1,20}''', nullable=False),
                                       StringGen(r'''-?[1-9]\d{0,20}\.\d{1,5}''', nullable=False),
-                                      StringGen(r'''-?[1-9]\d{0,5}\.\d{1,5}''', nullable=False),
-                                      StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,20}''', nullable=False),
                                       StringGen(r'''-?[1-9]\d{0,5}E-?\d{1,20}''', nullable=False),
-                                      StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,5}''', nullable=False),
-                                      StringGen(r'''-?[1-9]\d{0,5}E-?\d{1,5}''', nullable=False)], ids=idfn)
+                                      StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,5}''', nullable=False)], ids=idfn)
 def test_get_json_object_floating_normalization(data_gen):
     schema = StructType([StructField("jsonStr", StringType())])
     normalization = lambda spark: unary_op_df(spark, data_gen).selectExpr(

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -391,3 +391,31 @@ def test_get_json_object_number_normalization_legacy():
         conf={'spark.rapids.sql.expression.GetJsonObject': 'true',
               'spark.rapids.sql.getJsonObject.legacy.enabled': 'true'})
     assert([[row[1]] for row in gpu_result] == data)
+
+@pytest.mark.parametrize('data_gen', [StringGen(r'''-?[1-9]\d{0,20}\.\d{1,20}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,5}\.\d{1,20}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,20}\.\d{1,5}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,5}\.\d{1,5}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,20}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,5}E-?\d{1,20}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,20}E-?\d{1,5}''', nullable=False),
+                                      StringGen(r'''-?[1-9]\d{0,5}E-?\d{1,5}''', nullable=False)], ids=idfn)
+def test_get_json_object_floating_normalization(data_gen):
+    schema = StructType([StructField("jsonStr", StringType())])
+    normalization = lambda spark: unary_op_df(spark, data_gen).selectExpr(
+                        'a',
+                        'get_json_object(a,"$")'
+                        ).collect()
+    gpu_res = [[row[1]] for row in with_gpu_session(
+        normalization,
+        conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})]
+    cpu_res = [[row[1]] for row in with_cpu_session(normalization)]
+    def json_string_to_float(x):
+        if x == '"-Infinity"':
+            return float('-inf')
+        elif x == '"Infinity"':
+            return float('inf')
+        else:
+            return float(x)
+    for i in range(len(gpu_res)):
+        assert math.isclose(json_string_to_float(gpu_res[i][0]), json_string_to_float(cpu_res[i][0]))

--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -418,4 +418,5 @@ def test_get_json_object_floating_normalization(data_gen):
         else:
             return float(x)
     for i in range(len(gpu_res)):
+        # verify relatively diff < 1e-9 (default value for is_close)
         assert math.isclose(json_string_to_float(gpu_res[i][0]), json_string_to_float(cpu_res[i][0]))

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -89,7 +89,7 @@ object JsonPathParser extends RegexParsers {
 
   def fallbackCheck(instructions: List[PathInstruction]): Boolean = {
     // JNI kernel has a limit of 16 nested nodes, fallback to CPU if we exceed that
-    instructions.length > 16
+    instructions.length > JSONUtils.MAX_PATH_DEPTH
   }
 
   def unzipInstruction(instruction: PathInstruction): (String, String, Long) = {


### PR DESCRIPTION
closes #10688 
closes #10646 

A minor follow-up pr for getJsonObject

This pr:
- Query max instructions length from JNI instead of hardcoding in plugin code.
- Adds tests for floating number normalization, it was fixed but didn't add cases in plugin.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
