### PR TITLE
Fix NPE in GpuParseUrl for null keys.

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -79,7 +79,7 @@ case class GpuParseUrl(children: Seq[Expression])
 
   def doColumnar(col: GpuColumnVector, partToExtract: GpuScalar, key: GpuScalar): ColumnVector = {
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString
-    if (part != QUERY) {
+    if (part != QUERY || key == null || key.getValue == null) {
       // return a null columnvector
       return GpuColumnVector.columnVectorFromNull(col.getRowCount.toInt, StringType)
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuParseUrl.scala
@@ -79,7 +79,7 @@ case class GpuParseUrl(children: Seq[Expression])
 
   def doColumnar(col: GpuColumnVector, partToExtract: GpuScalar, key: GpuScalar): ColumnVector = {
     val part = partToExtract.getValue.asInstanceOf[UTF8String].toString
-    if (part != QUERY || key == null || key.getValue == null) {
+    if (part != QUERY || key == null || !key.isValid) {
       // return a null columnvector
       return GpuColumnVector.columnVectorFromNull(col.getRowCount.toInt, StringType)
     }


### PR DESCRIPTION
Fixes #10810.

This commit fixes an NPE that occurred when `ParseUrl` is called to extract a specific key from the `QUERY` portion of the URL, and the specified key is `null`.

The NPE would manifest as follows:
```
24/05/13 14:28:35.379 Executor task launch worker for task 1.0 in stage 746.0 (TID 1493) ERROR Executor: Exception in task 1.0 in stage 746.0 (TID 1493)
java.lang.NullPointerException: null
	at org.apache.spark.sql.rapids.GpuParseUrl.doColumnar(GpuParseUrl.scala:86) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at org.apache.spark.sql.rapids.GpuParseUrl.$anonfun$columnarEval$5(GpuParseUrl.scala:123) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at com.nvidia.spark.rapids.Arm$.withResourceIfAllowed(Arm.scala:84) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at org.apache.spark.sql.rapids.GpuParseUrl.$anonfun$columnarEval$4(GpuParseUrl.scala:120) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at com.nvidia.spark.rapids.Arm$.withResourceIfAllowed(Arm.scala:84) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at org.apache.spark.sql.rapids.GpuParseUrl.$anonfun$columnarEval$3(GpuParseUrl.scala:119) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
	at com.nvidia.spark.rapids.Arm$.withResourceIfAllowed(Arm.scala:84) ~[rapids-4-spark-aggregator_2.12-24.06.0-SNAPSHOT-spark330.jar:?]
...
```

