### PR TITLE
Replace ThreadPoolExecutor creation with ThreadUtils API [databricks]

### DIFF
--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -30,6 +30,7 @@ import com.nvidia.spark.rapids.shuffle._
 import com.nvidia.spark.rapids.shuffle.{BounceBufferManager, BufferReceiveState, ClientConnection, PendingTransferRequest, RapidsShuffleClient, RapidsShuffleRequestHandler, RapidsShuffleServer, RapidsShuffleTransport, RefCountedDirectByteBuffer}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.storage.BlockManagerId
 
 /**
@@ -240,21 +241,27 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
   }
 
   // NOTE: this pool, as is, will add a new thread per task. This will likely change.
-  private[this] val clientExecutor = new ThreadPoolExecutor(1,
-    rapidsConf.shuffleMaxClientThreads,
-    rapidsConf.shuffleClientThreadKeepAliveTime,
-    TimeUnit.SECONDS,
-    new ArrayBlockingQueue[Runnable](1),
-    GpuDeviceManager.wrapThreadFactory(
-      new ThreadFactoryBuilder()
-        .setNameFormat("shuffle-transport-client-exec-%d")
-        .setDaemon(true)
-        .build,
-      null,
-      () => RmmSpark.removeAllCurrentThreadAssociation()),
+  private[this] val clientExecutor = {
+    // We are using the TrampolineUtil to create a ThreadPoolExecutor even though we are
+    // resetting most of the params that were set using the ThreadUtils class.
+    // The reason is that this way we will get the Hadoop conf necessary for Unity Catalog
+    val threadPoolExecutor = TrampolineUtil.newDaemonCachedThreadPool("ucx-shuffle-transport",
+      rapidsConf.shuffleMaxClientThreads,
+      rapidsConf.shuffleClientThreadKeepAliveTime)
+    threadPoolExecutor.setCorePoolSize(1)
+    threadPoolExecutor.setThreadFactory(
+      GpuDeviceManager.wrapThreadFactory(
+        new ThreadFactoryBuilder()
+          .setNameFormat("shuffle-transport-client-exec-%d")
+          .setDaemon(true)
+          .build,
+        null,
+        () => RmmSpark.removeAllCurrentThreadAssociation()))
     // if we can't hand off because we are too busy, block the caller (in UCX's case,
     // the progress thread)
-    new CallerRunsAndLogs())
+    threadPoolExecutor.setRejectedExecutionHandler(new CallerRunsAndLogs())
+    threadPoolExecutor
+  }
 
   // This executor handles any task that would block (e.g. wait for spill synchronously due to OOM)
   private[this] val clientCopyExecutor = Executors.newSingleThreadExecutor(

--- a/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
+++ b/shuffle-plugin/src/main/scala/com/nvidia/spark/rapids/shuffle/ucx/UCXShuffleTransport.scala
@@ -251,10 +251,7 @@ class UCXShuffleTransport(shuffleServerId: BlockManagerId, rapidsConf: RapidsCon
     threadPoolExecutor.setCorePoolSize(1)
     threadPoolExecutor.setThreadFactory(
       GpuDeviceManager.wrapThreadFactory(
-        new ThreadFactoryBuilder()
-          .setNameFormat("shuffle-transport-client-exec-%d")
-          .setDaemon(true)
-          .build,
+        threadPoolExecutor.getThreadFactory,
         null,
         () => RmmSpark.removeAllCurrentThreadAssociation()))
     // if we can't hand off because we are too busy, block the caller (in UCX's case,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -515,7 +515,7 @@ abstract class GpuBroadcastExchangeExecBase(
 
 object GpuBroadcastExchangeExecBase {
   val executionContext = ExecutionContext.fromExecutorService(
-    TrampolineUtil.newDaemonCachedThreadPool("gpu-broadcast-exchange",
+    org.apache.spark.util.ThreadUtils.newDaemonCachedThreadPool("gpu-broadcast-exchange",
       SQLConf.get.getConf(StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD)))
 
   protected def checkRowLimit(numRows: Int) = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastExchangeExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -514,33 +514,8 @@ abstract class GpuBroadcastExchangeExecBase(
 }
 
 object GpuBroadcastExchangeExecBase {
-  /**
-   * Create a thread factory that names threads with a prefix and also sets the threads to daemon.
-   */
-  private def namedThreadFactory(prefix: String): ThreadFactory = {
-    new ThreadFactoryBuilder().setDaemon(true).setNameFormat(prefix + "-%d").build()
-  }
-
-  /**
-   * Create a cached thread pool whose max number of threads is `maxThreadNumber`. Thread names
-   * are formatted as prefix-ID, where ID is a unique, sequentially assigned integer.
-   */
-  private def newDaemonCachedThreadPool(
-      prefix: String, maxThreadNumber: Int, keepAliveSeconds: Int = 60): ThreadPoolExecutor = {
-    val threadFactory = namedThreadFactory(prefix)
-    val threadPool = new ThreadPoolExecutor(
-      maxThreadNumber, // corePoolSize: the max number of threads to create before queuing the tasks
-      maxThreadNumber, // maximumPoolSize: because we use LinkedBlockingDeque, this one is not used
-      keepAliveSeconds,
-      TimeUnit.SECONDS,
-      new LinkedBlockingQueue[Runnable],
-      threadFactory)
-    threadPool.allowCoreThreadTimeOut(true)
-    threadPool
-  }
-
   val executionContext = ExecutionContext.fromExecutorService(
-    newDaemonCachedThreadPool("gpu-broadcast-exchange",
+    TrampolineUtil.newDaemonCachedThreadPool("gpu-broadcast-exchange",
       SQLConf.get.getConf(StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD)))
 
   protected def checkRowLimit(numRows: Int) = {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -224,7 +224,7 @@ object TrampolineUtil {
   def newDaemonCachedThreadPool(
       prefix: String,
       maxThreadNumber: Int,
-      keepAliveSeconds: Int): ThreadPoolExecutor = {
+      keepAliveSeconds: Int = 60): ThreadPoolExecutor = {
     org.apache.spark.util.ThreadUtils.newDaemonCachedThreadPool(prefix, maxThreadNumber,
       keepAliveSeconds)
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -225,6 +225,9 @@ object TrampolineUtil {
       prefix: String,
       maxThreadNumber: Int,
       keepAliveSeconds: Int = 60): ThreadPoolExecutor = {
+    // We want to utilize the ThreadUtils class' ThreadPoolExecutor creation
+    // which gives us important Hadoop config variables that are needed for the
+    // Unity Catalog authentication
     org.apache.spark.util.ThreadUtils.newDaemonCachedThreadPool(prefix, maxThreadNumber,
       keepAliveSeconds)
   }


### PR DESCRIPTION
This PR replaces the manual thread pool creation with the `TrampolieUtil` API which uses the `org.apache.spark.util.ThreadUtils` under the hood. 

fixes #10759 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
