### PR TITLE
Disabling the cuDF default pinned pool for 24.06

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -447,6 +447,8 @@ object GpuDeviceManager extends Logging {
     } else {
       (conf.pinnedPoolSize, -1L)
     }
+    // disable the cuDF provided default pinned pool for now
+    PinnedMemoryPool.configureDefaultCudfPinnedPoolSize(0L)
     if (!PinnedMemoryPool.isInitialized && pinnedSize > 0) {
       logInfo(s"Initializing pinned memory pool (${pinnedSize / 1024 / 1024.0} MiB)")
       PinnedMemoryPool.initialize(pinnedSize, gpuId, setCuioDefaultResource)


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10814

Depends on: https://github.com/rapidsai/cudf/pull/15665 and https://github.com/rapidsai/cudf/pull/15745

This PR disables a default pinned pool in cuDF since we already have one configured that is shared with cuDF and is also accessible for `HostMemoryBuffer` operations. 