### PR TITLE
Support zstd for GPU shuffle compression

### DIFF
--- a/sql-plugin/src/main/format/ShuffleCommon.fbs
+++ b/sql-plugin/src/main/format/ShuffleCommon.fbs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION.
+// Copyright (c) 2020-2024, NVIDIA CORPORATION.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ enum CodecType : byte {
 
   /// data compressed with the nvcomp LZ4 codec
   NVCOMP_LZ4 = 1,
+
+  /// data compressed with the nvcomp ZSTD codec
+  NVCOMP_ZSTD = 2,
 }
 
 /// Descriptor for a compressed buffer

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
@@ -17,7 +17,9 @@ public final class CodecType {
    */
   public static final byte NVCOMP_LZ4 = 1;
 
-  public static final String[] names = { "COPY", "UNCOMPRESSED", "NVCOMP_LZ4", };
+  public static final byte NVCOMP_ZSTD = 2;
+
+  public static final String[] names = { "COPY", "UNCOMPRESSED", "NVCOMP_LZ4", "NVCOMP_ZSTD"};
 
   public static String name(int e) { return names[e - COPY]; }
 }

--- a/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
+++ b/sql-plugin/src/main/java/com/nvidia/spark/rapids/format/CodecType.java
@@ -16,10 +16,12 @@ public final class CodecType {
    * data compressed with the nvcomp LZ4 codec
    */
   public static final byte NVCOMP_LZ4 = 1;
-
+  /**
+   * data compressed with the nvcomp ZSTD codec
+   */
   public static final byte NVCOMP_ZSTD = 2;
 
-  public static final String[] names = { "COPY", "UNCOMPRESSED", "NVCOMP_LZ4", "NVCOMP_ZSTD"};
+  public static final String[] names = { "COPY", "UNCOMPRESSED", "NVCOMP_LZ4", "NVCOMP_ZSTD", };
 
   public static String name(int e) { return names[e - COPY]; }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long,
   override protected def compress(
       tables: Array[ContiguousTable],
       stream: Cuda.Stream): Array[CompressedTable] = {
-    val batchCompressor = new BatchedLZ4Compressor(codecConfigs.lz4ChunkSize,
+    val batchCompressor = new BatchedLZ4Compressor(codecConfigs.chunkSize,
       maxBatchMemorySize)
     val inputBuffers: Array[BaseDeviceMemoryBuffer] = tables.map { table =>
       val buffer = table.getBuffer
@@ -89,7 +89,7 @@ class BatchedNvcompLZ4Decompressor(maxBatchMemory: Long,
           s"buffers (${bufferMetas.length}")
     val outputBuffers = allocateOutputBuffers(inputBuffers, bufferMetas)
     BatchedLZ4Decompressor.decompressAsync(
-      codecConfigs.lz4ChunkSize,
+      codecConfigs.chunkSize,
       inputBuffers,
       outputBuffers.asInstanceOf[Array[BaseDeviceMemoryBuffer]],
       stream)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompLZ4CompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class BatchedNvcompLZ4Compressor(maxBatchMemorySize: Long,
   override protected def compress(
       tables: Array[ContiguousTable],
       stream: Cuda.Stream): Array[CompressedTable] = {
-    val batchCompressor = new BatchedLZ4Compressor(codecConfigs.chunkSize,
+    val batchCompressor = new BatchedLZ4Compressor(codecConfigs.lz4ChunkSize,
       maxBatchMemorySize)
     val inputBuffers: Array[BaseDeviceMemoryBuffer] = tables.map { table =>
       val buffer = table.getBuffer
@@ -89,7 +89,7 @@ class BatchedNvcompLZ4Decompressor(maxBatchMemory: Long,
           s"buffers (${bufferMetas.length}")
     val outputBuffers = allocateOutputBuffers(inputBuffers, bufferMetas)
     BatchedLZ4Decompressor.decompressAsync(
-      codecConfigs.chunkSize,
+      codecConfigs.lz4ChunkSize,
       inputBuffers,
       outputBuffers.asInstanceOf[Array[BaseDeviceMemoryBuffer]],
       stream)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompZSTDCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompZSTDCompressionCodec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import ai.rapids.cudf.{BaseDeviceMemoryBuffer, ContiguousTable, Cuda, DeviceMemoryBuffer, NvtxColor, NvtxRange}
+import ai.rapids.cudf.nvcomp.{BatchedZstdCompressor, BatchedZstdDecompressor}
+import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
+import com.nvidia.spark.rapids.RapidsPluginImplicits.AutoCloseableProducingArray
+import com.nvidia.spark.rapids.format.{BufferMeta, CodecType}
+
+/** A table compression codec that uses nvcomp's ZSTD-GPU codec */
+class NvcompZSTDCompressionCodec(codecConfigs: TableCompressionCodecConfig)
+    extends TableCompressionCodec {
+  override val name: String = "nvcomp-ZSTD"
+  override val codecId: Byte = CodecType.NVCOMP_ZSTD
+
+  override def createBatchCompressor(
+      maxBatchMemoryBytes: Long,
+      stream: Cuda.Stream): BatchedTableCompressor = {
+    new BatchedNvcompZSTDCompressor(maxBatchMemoryBytes, codecConfigs, stream)
+  }
+
+  override def createBatchDecompressor(
+      maxBatchMemoryBytes: Long,
+      stream: Cuda.Stream): BatchedBufferDecompressor = {
+    new BatchedNvcompZSTDDecompressor(maxBatchMemoryBytes, codecConfigs, stream)
+  }
+}
+
+class BatchedNvcompZSTDCompressor(maxBatchMemorySize: Long,
+    codecConfigs: TableCompressionCodecConfig,
+    stream: Cuda.Stream) extends BatchedTableCompressor(maxBatchMemorySize, stream) {
+
+  private val batchCompressor =
+    new BatchedZstdCompressor(codecConfigs.chunkSize, maxBatchMemorySize)
+
+  override protected def compress(tables: Array[ContiguousTable],
+      stream: Cuda.Stream): Array[CompressedTable] = {
+    // Increase ref count to keep inputs alive since cudf compressor will close input buffers.
+    val inputBufs = DeviceBuffersUtils.incRefCount(tables.map(_.getBuffer))
+    closeOnExcept(batchCompressor.compress(inputBufs, stream)) { compressedBufs =>
+      withResource(new NvtxRange("zstd post process", NvtxColor.YELLOW)) { _ =>
+        require(compressedBufs.length == tables.length,
+          s"expected ${tables.length} buffers, but compress() returned ${compressedBufs.length}")
+        compressedBufs.zip(tables).map { case (buffer, table) =>
+          val compressedLen = buffer.getLength
+          val meta = MetaUtils.buildTableMeta(None, table, CodecType.NVCOMP_ZSTD, compressedLen)
+          CompressedTable(compressedLen, meta, buffer)
+        }.toArray
+      }
+    }
+  }
+}
+
+class BatchedNvcompZSTDDecompressor(maxBatchMemory: Long,
+    codecConfigs: TableCompressionCodecConfig,
+    stream: Cuda.Stream) extends BatchedBufferDecompressor(maxBatchMemory, stream) {
+  private val batchDecompressor = new BatchedZstdDecompressor(codecConfigs.chunkSize)
+
+  override val codecId: Byte = CodecType.NVCOMP_ZSTD
+
+  override def decompressAsync(inputBufs: Array[BaseDeviceMemoryBuffer],
+      bufMetas: Array[BufferMeta], stream: Cuda.Stream): Array[DeviceMemoryBuffer] = {
+    require(inputBufs.length == bufMetas.length,
+      s"Got ${inputBufs.length} input buffers but ${bufMetas.length} metadata buffers")
+
+    // Increase ref count to keep inputs alive since cudf decompressor will close the inputs.
+    val compressedBufs = DeviceBuffersUtils.incRefCount(inputBufs)
+    val outputBufs = closeOnExcept(compressedBufs) { _ =>
+      withResource(new NvtxRange("alloc output bufs", NvtxColor.YELLOW)) { _ =>
+        DeviceBuffersUtils.allocateBuffers(bufMetas.map(_.uncompressedSize()))
+      }
+    }
+    batchDecompressor.decompressAsync(compressedBufs,
+      outputBufs.asInstanceOf[Array[BaseDeviceMemoryBuffer]], stream)
+    outputBufs
+  }
+}
+
+object DeviceBuffersUtils {
+  def incRefCount(bufs: Array[BaseDeviceMemoryBuffer]): Array[BaseDeviceMemoryBuffer] = {
+    bufs.safeMap { b =>
+      b.incRefCount()
+      b
+    }
+  }
+
+  def allocateBuffers(bufSizes: Array[Long]): Array[DeviceMemoryBuffer] = {
+    var curPos = 0L
+    withResource(DeviceMemoryBuffer.allocate(bufSizes.sum)) { singleBuf =>
+      bufSizes.safeMap { len =>
+        val ret = singleBuf.slice(curPos, len)
+        curPos += len
+        ret
+      }
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompZSTDCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvcompZSTDCompressionCodec.scala
@@ -46,7 +46,7 @@ class BatchedNvcompZSTDCompressor(maxBatchMemorySize: Long,
     stream: Cuda.Stream) extends BatchedTableCompressor(maxBatchMemorySize, stream) {
 
   private val batchCompressor =
-    new BatchedZstdCompressor(codecConfigs.chunkSize, maxBatchMemorySize)
+    new BatchedZstdCompressor(codecConfigs.zstdChunkSize, maxBatchMemorySize)
 
   override protected def compress(tables: Array[ContiguousTable],
       stream: Cuda.Stream): Array[CompressedTable] = {
@@ -69,7 +69,7 @@ class BatchedNvcompZSTDCompressor(maxBatchMemorySize: Long,
 class BatchedNvcompZSTDDecompressor(maxBatchMemory: Long,
     codecConfigs: TableCompressionCodecConfig,
     stream: Cuda.Stream) extends BatchedBufferDecompressor(maxBatchMemory, stream) {
-  private val batchDecompressor = new BatchedZstdDecompressor(codecConfigs.chunkSize)
+  private val batchDecompressor = new BatchedZstdDecompressor(codecConfigs.zstdChunkSize)
 
   override val codecId: Byte = CodecType.NVCOMP_ZSTD
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1744,14 +1744,14 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
 
   val SHUFFLE_COMPRESSION_CODEC = conf("spark.rapids.shuffle.compression.codec")
     .doc("The GPU codec used to compress shuffle data when using RAPIDS shuffle. " +
-      "Supported codecs: lz4, copy, none")
+      "Supported codecs: zstd, lz4, copy, none")
     .internal()
     .startupOnly()
     .stringConf
     .createWithDefault("none")
 
-val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.lz4.chunkSize")
-    .doc("A configurable chunk size to use when compressing with LZ4.")
+val SHUFFLE_COMPRESSION_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.chunkSize")
+    .doc("A configurable chunk size to use when compressing with LZ4 or ZSTD.")
     .internal()
     .startupOnly()
     .bytesConf(ByteUnit.BYTE)
@@ -2820,7 +2820,7 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val shuffleCompressionCodec: String = get(SHUFFLE_COMPRESSION_CODEC)
 
-  lazy val shuffleCompressionLz4ChunkSize: Long = get(SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE)
+  lazy val shuffleCompressionChunkSize: Long = get(SHUFFLE_COMPRESSION_CHUNK_SIZE)
 
   lazy val shuffleCompressionMaxBatchMemory: Long = get(SHUFFLE_COMPRESSION_MAX_BATCH_MEMORY)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1750,12 +1750,20 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .createWithDefault("none")
 
-val SHUFFLE_COMPRESSION_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.chunkSize")
-    .doc("A configurable chunk size to use when compressing with LZ4 or ZSTD.")
+val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.lz4.chunkSize")
+    .doc("A configurable chunk size to use when compressing with LZ4.")
     .internal()
     .startupOnly()
     .bytesConf(ByteUnit.BYTE)
     .createWithDefault(64 * 1024)
+
+  val SHUFFLE_COMPRESSION_ZSTD_CHUNK_SIZE =
+    conf("spark.rapids.shuffle.compression.zstd.chunkSize")
+      .doc("A configurable chunk size to use when compressing with ZSTD.")
+      .internal()
+      .startupOnly()
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(64 * 1024)
 
   val SHUFFLE_MULTITHREADED_MAX_BYTES_IN_FLIGHT =
     conf("spark.rapids.shuffle.multiThreaded.maxBytesInFlight")
@@ -2820,7 +2828,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val shuffleCompressionCodec: String = get(SHUFFLE_COMPRESSION_CODEC)
 
-  lazy val shuffleCompressionChunkSize: Long = get(SHUFFLE_COMPRESSION_CHUNK_SIZE)
+  lazy val shuffleCompressionLz4ChunkSize: Long = get(SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE)
+
+  lazy val shuffleCompressionZstdChunkSize: Long = get(SHUFFLE_COMPRESSION_ZSTD_CHUNK_SIZE)
 
   lazy val shuffleCompressionMaxBatchMemory: Long = get(SHUFFLE_COMPRESSION_MAX_BATCH_MEMORY)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
@@ -74,7 +74,7 @@ trait TableCompressionCodec {
 /**
  * A small case class used to carry codec-specific settings.
  */
-case class TableCompressionCodecConfig(chunkSize: Long)
+case class TableCompressionCodecConfig(lz4ChunkSize: Long, zstdChunkSize: Long)
 
 object TableCompressionCodec extends Logging {
   private val codecNameToId = Map(
@@ -85,7 +85,8 @@ object TableCompressionCodec extends Logging {
   /** Make a codec configuration object which can be serialized (can be used in tasks) */
   def makeCodecConfig(rapidsConf: RapidsConf): TableCompressionCodecConfig =
     TableCompressionCodecConfig(
-      rapidsConf.shuffleCompressionChunkSize)
+      rapidsConf.shuffleCompressionLz4ChunkSize,
+      rapidsConf.shuffleCompressionZstdChunkSize)
 
   /** Get a compression codec by short name or fully qualified class name */
   def getCodec(name: String, codecConfigs: TableCompressionCodecConfig): TableCompressionCodec = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/TableCompressionCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,17 +74,18 @@ trait TableCompressionCodec {
 /**
  * A small case class used to carry codec-specific settings.
  */
-case class TableCompressionCodecConfig(lz4ChunkSize: Long)
+case class TableCompressionCodecConfig(chunkSize: Long)
 
-object TableCompressionCodec {
+object TableCompressionCodec extends Logging {
   private val codecNameToId = Map(
     "copy" -> CodecType.COPY,
+    "zstd" -> CodecType.NVCOMP_ZSTD,
     "lz4" -> CodecType.NVCOMP_LZ4)
 
   /** Make a codec configuration object which can be serialized (can be used in tasks) */
   def makeCodecConfig(rapidsConf: RapidsConf): TableCompressionCodecConfig =
     TableCompressionCodecConfig(
-      rapidsConf.shuffleCompressionLz4ChunkSize)
+      rapidsConf.shuffleCompressionChunkSize)
 
   /** Get a compression codec by short name or fully qualified class name */
   def getCodec(name: String, codecConfigs: TableCompressionCodecConfig): TableCompressionCodec = {
@@ -95,11 +96,14 @@ object TableCompressionCodec {
 
   /** Get a compression codec by ID, using a cache. */
   def getCodec(codecId: Byte, codecConfig: TableCompressionCodecConfig): TableCompressionCodec = {
-    codecId match {
+    val ret = codecId match {
+      case CodecType.NVCOMP_ZSTD => new NvcompZSTDCompressionCodec(codecConfig)
       case CodecType.NVCOMP_LZ4 => new NvcompLZ4CompressionCodec(codecConfig)
       case CodecType.COPY => new CopyCompressionCodec
       case _ => throw new IllegalArgumentException(s"Unknown codec ID: $codecId")
     }
+    logDebug(s"Using codec: ${ret.name}")
+    ret
   }
 }
 

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuCoalesceBatchesRetrySuite.scala
@@ -310,7 +310,7 @@ class GpuCoalesceBatchesRetrySuite
         NoopMetric,
         NoopMetric,
         "test",
-        TableCompressionCodecConfig(1024)) with CoalesceIteratorMocks {
+        TableCompressionCodecConfig(1024, 1024)) with CoalesceIteratorMocks {
     override def populateCandidateBatches(): Boolean = {
       val lastBatchTag = super.populateCandidateBatches()
       injectError(injectRetry, injectSplitAndRetry)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuPartitioningSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,9 +145,17 @@ class GpuPartitioningSuite extends AnyFunSuite {
     }
   }
 
-  test("GPU partition with compression") {
+  test("GPU partition with lz4 compression") {
+    testGpuPartitionWithCompression("lz4")
+  }
+
+  test("GPU partition with zstd compression") {
+    testGpuPartitionWithCompression("zstd")
+  }
+
+  private def testGpuPartitionWithCompression(codecName: String): Unit = {
     val conf = new SparkConf()
-        .set(RapidsConf.SHUFFLE_COMPRESSION_CODEC.key, "lz4")
+        .set(RapidsConf.SHUFFLE_COMPRESSION_CODEC.key, codecName)
     TestUtils.withGpuSparkSession(conf) { _ =>
       GpuShuffleEnv.init(new RapidsConf(conf), new RapidsDiskBlockManager(conf))
       val spillPriority = 7L


### PR DESCRIPTION
contribute to https://github.com/NVIDIA/spark-rapids/issues/10790

This PR is to add the ZSTD codec for GPU shuffle compression.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
