### PR TITLE
LOcal REplay framework: dump and replay GpuProjectExec runtime [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -100,7 +100,7 @@ abstract class GpuOptimisticTransactionBase
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan, dumpForReplay = false)() else plan
   }
 
   /**

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
@@ -80,7 +80,7 @@ abstract class GpuOptimisticTransactionBase(
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan, dumpForReplay = false)() else plan
   }
 
   /**

--- a/docs/dev/replay-exec.md
+++ b/docs/dev/replay-exec.md
@@ -1,0 +1,87 @@
+This doc describes how to dump an Exec runtime meta and column batch data to a directory,
+and replay the Exec with the dumped meta and data. When encountering a perf issue using this tool
+can dump the runtime meta/data and then replay. It will spend less time when collecting NSYS and
+NCU information when replaying the dumped runtime meta/data.
+
+# Dump a Exec meta and a column batch data
+
+## compile Spark-Rapids jar
+Compile with option "-DallowConventionalDistJar"
+e.g.: compile for Spark330
+```
+mvn clean install -DskipTests -pl dist -am -DallowConventionalDistJar=true -Dbuildver=330 
+```
+Note: Should specify `-DallowConventionalDistJar`, this config will make sure to generate a
+conventional jar. If you do not specify this config, then replay will fail because of can not
+find the class `org.apache.spark.sql.rapids.debug.ProjectExecReplayer`
+
+## enable dump
+This assumes that the RAPIDs Accelerator has already been enabled.   
+This feature is disabled by default.   
+Set the following configurations to enable this feature:
+
+``` 
+spark.conf.set("spark.rapids.sql.debug.replay.exec.types", "project")
+```
+Default `types` value is empty which means do not dump.
+Define the Exec types for dumping, separated by comma, e.g.: `project`.
+Note currently only support `project`, so it's no need to specify comma.
+
+```
+spark.conf.set("spark.rapids.sql.debug.replay.exec.dumpDir", "file:/tmp")
+```
+Specify the dump directory which can be a local path or a remote path. E.g.: 
+`file:/tmp/my-debug-path`. Default value is `file:/tmp`.
+This path should be a directory or someplace that we can create a directory to
+store files in. Remote path is supported e.g.: `hdfs://url:9000/path/to/save`. When using
+remote path, should specify corresponding configs to get access for the remote storage.
+
+```
+spark.conf.set("spark.rapids.sql.debug.replay.exec.threshold.timeMS", 1000)
+```
+Default value is 1000MS.   
+Only dump the column batches when it's executing time exceeds threshold time.
+
+```  
+spark.conf.set("spark.rapids.sql.debug.replay.exec.batch.limit", 1)
+```
+This config defines the max dumping number of column batches.   
+It's a limit for per Exec instance.   
+Default value is 1.
+
+## run a Spark job
+This dumping only happens when GPU Exec is running, so should enable Spark-Rapids.
+After the job is done, check the dump path will have files like:
+```
+/tmp/replay-exec:
+  - execUUID_xxx_meta_GpuTieredProject_randomID_xxx.meta // this is serialized GPU Tiered Project case class  
+  - execUUID_xxx_meta_cb_types_randomID_xxx.meta         // this is types for column batch
+  - execUUID_xxx_cb_data_index_0_randomID_xxx_744305176.parquet // this is data for column batch
+```
+The `xxx` after `execUUID` is the UUID for a specific Project Exec, this is used to distinguish multiple
+Project Execs.
+
+# Replay saved Exec runtime meta and data
+
+## Set environment variable
+```
+export PLUGIN_JAR=path_to_spark_rapids_jar
+export SPARK_HOME=path_to_spark_home_330
+```
+
+## replay command
+
+### Collect NSYS with replaying
+```
+nsys profile $SPARK_HOME/bin/spark-submit \
+  --class org.apache.spark.sql.rapids.debug.ProjectExecReplayer \
+  --conf spark.rapids.sql.explain=ALL \
+  --master local[*] \
+  --jars ${PLUGIN_JAR} \
+  ${PLUGIN_JAR} <path_to_saved_replay_dir> <UUID_of_project_exec>
+```
+
+<path_to_saved_replay_dir> is the replay directory.   
+<UUID_of_project_exec> is the UUID for a specific Project Exec. Dumping may generate
+multiple data for each project, here should specify replay which project.   
+If there are multiple column batches for a project, it will only replay the first column batch.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -2274,6 +2274,41 @@ val SHUFFLE_COMPRESSION_LZ4_CHUNK_SIZE = conf("spark.rapids.shuffle.compression.
       .integerConf
       .createWithDefault(1024)
 
+  /**
+   * refer to dev doc: `replay-exec.md`
+   * only supports "project" now
+   */
+  val DEBUG_REPLAY_EXEC_TYPE =
+    conf("spark.rapids.sql.debug.replay.exec.types")
+        .doc("Only for debug: Define the Exec types for dumping, separated by comma, e.g.: " +
+            "project,aggregate,sort. Note currently only support project")
+        .internal()
+        .stringConf
+        .createWithDefault("")
+
+  val DEBUG_REPLAY_EXEC_DUMP_DIR =
+    conf("spark.rapids.sql.debug.replay.exec.dumpDir")
+        .doc("Only for debug: Define the directory when dumping Exec runtime " +
+            "meta and column batch data")
+        .internal()
+        .stringConf
+        .createWithDefault("file:/tmp")
+
+  val DEBUG_REPLAY_EXEC_THRESHOLD_MS =
+    conf("spark.rapids.sql.debug.replay.exec.threshold.MS")
+        .doc("Only for debug: Only dump the column batch when executing time against it " +
+            " exceeds this threshold time in MS")
+        .internal()
+        .integerConf
+        .createWithDefault(1000)
+
+  val DEBUG_REPLAY_EXEC_BATCH_LIMIT =
+    conf("spark.rapids.sql.debug.replay.batch.limit")
+        .doc("Only for debug: Max dumping number of column batches")
+        .internal()
+        .integerConf
+        .createWithDefault(1)
+
   private def printSectionHeader(category: String): Unit =
     println(s"\n### $category")
 
@@ -3082,6 +3117,14 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val testGetJsonObjectSavePath: Option[String] = get(TEST_GET_JSON_OBJECT_SAVE_PATH)
 
   lazy val testGetJsonObjectSaveRows: Int = get(TEST_GET_JSON_OBJECT_SAVE_ROWS)
+
+  lazy val debugReplayExecDumpDir: String = get(DEBUG_REPLAY_EXEC_DUMP_DIR)
+
+  lazy val debugReplayExecType: String = get(DEBUG_REPLAY_EXEC_TYPE)
+
+  lazy val debugReplayExecThresholdMS: Int = get(DEBUG_REPLAY_EXEC_THRESHOLD_MS)
+
+  lazy val debugReplayExecBatchLimit: Int = get(DEBUG_REPLAY_EXEC_BATCH_LIMIT)
 
   private val optimizerDefaults = Map(
     // this is not accurate because CPU projections do have a cost due to appending values

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/debug/ProjectExecReplayer.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/debug/ProjectExecReplayer.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.debug
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Paths}
+
+import scala.reflect.ClassTag
+
+import ai.rapids.cudf.Table
+import com.nvidia.spark.rapids.{GpuColumnVector, GpuProjectExec, GpuTieredProject, NoopMetric}
+import com.nvidia.spark.rapids.Arm.withResource
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.DataType
+
+/**
+ * Replayer for dumped Project Exec runtime.
+ * for how to dump, refer to dev doc `replay-exec.md`
+ */
+object ProjectExecReplayer extends Logging {
+  private def deserializeObject[T: ClassTag](readPath: String): T = {
+    val bytes = Files.readAllBytes(Paths.get(readPath))
+    val buffer = ByteBuffer.wrap(bytes)
+    SparkEnv.get.closureSerializer.newInstance().deserialize(buffer)
+  }
+
+  /**
+   * Replay data dir should contains, e.g.::
+   * - execUUID_xxx_meta_GpuTieredProject_randomID_xxx.meta
+   * - execUUID_xxx_meta_cb_types_randomID_xxx.meta
+   * - execUUID_xxx_cb_data_index_0_randomID_xxx_744305176.parquet
+   * Here first xxx is UUID for a Project.
+   * Only replay one Parquet in the replay path
+   * @param args specify data path and project UUID, e.g.:
+   *   /path/to/replay <UUID>
+   */
+  def main(args: Array[String]): Unit = {
+    // check arguments and get paths
+    if (args.length < 2) {
+      logError("Project Exec replayer: Specify 2 args: data path and projectUUID")
+      printUsage()
+      return
+    }
+    var replayDir = args(0)
+    val projectUUID = args(1)
+    logWarning("Project Exec replayer: start running.")
+
+    // start a Spark session with Spark-Rapids initialization
+    SparkSession.builder()
+        .master("local[*]")
+        .config("spark.plugins", "com.nvidia.spark.SQLPlugin")
+        .appName("Replay")
+        .getOrCreate()
+    logWarning("Project Exec replayer: started a Spark session")
+
+    // copy to local dir
+    replayDir = copyToLocal(replayDir)
+
+    // execUUID_${execUUID}_meta_${metaName}
+    val cbTypesFiles = new File(replayDir).listFiles(
+      f => f.getName.startsWith(s"execUUID_${projectUUID}_meta_cb_types_randomID_") &&
+        f.getName.endsWith(".meta"))
+    if (cbTypesFiles == null || cbTypesFiles.isEmpty) {
+      logError(s"Project Exec replayer: " +
+        s"there is no execUUID_xxx_meta_cb_types_randomID_xxx.meta file in $replayDir")
+      printUsage()
+      return
+    }
+    val cbTypesPath = replayDir + "/" + cbTypesFiles(0).getName
+
+    val projectMetaFiles = new File(replayDir).listFiles(
+      f => f.getName.startsWith(s"execUUID_${projectUUID}_meta_GpuTieredProject_randomID_") &&
+        f.getName.endsWith(".meta"))
+    if (projectMetaFiles == null || projectMetaFiles.isEmpty) {
+      logError(s"Project Exec replayer: " +
+        s"there is no execUUID_xxx_meta_GpuTieredProject_randomID_xxx.meta file in $replayDir")
+      printUsage()
+      return
+    }
+    val projectMetaPath = replayDir + "/" + projectMetaFiles(0).getName
+
+    // find a Parquet file, e.g.: xxx_cb_data_101656570.parquet
+    val parquets = new File(replayDir).listFiles(
+      f => f.getName.startsWith(s"execUUID_${projectUUID}_cb_data_index_") &&
+          f.getName.contains("randomID") &&
+          f.getName.endsWith(".parquet"))
+    if (parquets == null || parquets.isEmpty) {
+      logError(s"Project Exec replayer: " +
+          s"there is no execUUID_xxx_cb_data_index_x_randomID_xxx.parquet file in $replayDir")
+      printUsage()
+      return
+    }
+    // NOTE: only replay 1st parquet
+    val cbPath = replayDir + "/" + parquets(0).getName
+
+    // restore project meta
+    val restoredProject: GpuTieredProject = deserializeObject[GpuTieredProject](projectMetaPath)
+    // print expressions in project
+    restoredProject.exprTiers.foreach { exprs =>
+      exprs.foreach { expr =>
+        logWarning(s"Project Exec replayer: Project expression: ${expr.sql}")
+      }
+    }
+    logWarning("Project Exec replayer: restored Project Exec meta")
+
+    // restore column batch data
+    val restoredCbTypes = deserializeObject[Array[DataType]](cbTypesPath)
+
+    // replay
+    withResource(Table.readParquet(new File(cbPath))) { restoredTable =>
+      // this `restoredCb` will be closed in the `projectCb`
+      val restoredCb = GpuColumnVector.from(restoredTable, restoredCbTypes)
+      logWarning("Project Exec replayer: restored column batch data")
+      logWarning("Project Exec replayer: begin to replay")
+      // execute project
+      withResource(GpuProjectExec.projectCb(restoredProject, restoredCb, NoopMetric)) { retCB =>
+        logWarning(s"Project Exec replayer: project result has ${retCB.numRows()} rows.")
+      }
+      logWarning("Project Exec replayer: project replay completed successfully!!!")
+    }
+  }
+
+  private def printUsage(): Unit = {
+    val usageString =
+"""
+Usage is:
+$SPARK_HOME/bin/spark-submit \
+  --class org.apache.spark.sql.rapids.test.ProjectExecReplayer \
+  --conf spark.rapids.sql.explain=ALL \
+  --master local[*] \
+  --jars ${PLUGIN_JAR} \
+  ${PLUGIN_JAR} <dumped path> <project UUID>
+e.g.:
+The files in dumped path(hdfs://host/path/to/dir) are:
+  execUUID_xxx_meta_GpuTieredProject_randomID_xxx.meta
+  execUUID_xxx_meta_cb_types_randomID_xxx.meta
+  execUUID_xxx_cb_data_index_0_randomID_xxx_744305176.parquet
+The project UUID is the `xxx` after execUUID
+The command will be:
+$SPARK_HOME/bin/spark-submit \
+  --class org.apache.spark.sql.rapids.test.ProjectExecReplayer \
+  --conf spark.rapids.sql.explain=ALL \
+  --master local[*] \
+  --jars ${PLUGIN_JAR} \
+  ${PLUGIN_JAR} hdfs://host/path/to/dir 123e4567-e89b-12d3-a456-426655440000
+Note:
+  dumped path could be remote path or local path, e.g.:
+   hdfs://host/path/to/dir
+   file:/path/to/dir
+  Replay will only run one parquet file in the replay dir.
+"""
+    logError(usageString)
+  }
+
+  private def copyToLocal(replayDir: String): String = {
+    // used to access remote path
+    val hadoopConf = SparkSession.active.sparkContext.hadoopConfiguration
+    // copy from remote to local
+    val replayDirPath = new Path(replayDir)
+    val fs = replayDirPath.getFileSystem(hadoopConf)
+
+    if (!fs.getScheme.equals("file")) {
+      // remote file system; copy to local dir
+      val uuid = java.util.UUID.randomUUID.toString
+      val localReplayDir = s"/tmp/replay-exec-tmp-$uuid"
+      fs.copyToLocalFile(replayDirPath, new Path(s"/tmp/replay-exec-tmp-$uuid"))
+      logWarning(s"Copied from remote dir $replayDir to local dir $localReplayDir")
+      localReplayDir
+    } else {
+      // Remove the 'file:' prefix. e.g.: file:/a/b/c => /a/b/c
+      replayDirPath.toUri.getPath
+    }
+  }
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/debug/ReplayDumper.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/debug/ReplayDumper.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.debug
+
+import java.io.{File, FileInputStream}
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.reflect.ClassTag
+
+import com.nvidia.spark.rapids.{DumpUtils, GpuColumnVector, RapidsConf}
+import com.nvidia.spark.rapids.Arm.withResource
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.fs.{FSDataOutputStream, Path}
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SerializableConfiguration
+
+/**
+ * Dump tool for replay feature, refer to dev doc `replay-exec.md`
+ *
+ */
+case class ReplayDumper(
+    hadoopConf: SerializableConfiguration,
+    dumpDir: String,
+    thresholdMS: Int,
+    batchLimit: Int,
+    execUUID: String
+) extends Logging {
+
+  // current dumped number
+  private val currentNumOfColumnBatch: AtomicInteger = new AtomicInteger(0)
+
+  private def getOutputStream(filePath: String): FSDataOutputStream = {
+    val hadoopPath = new Path(filePath)
+    val fs = hadoopPath.getFileSystem(hadoopConf.value)
+    // multiple may call this concurrently, make overwrite as true
+    fs.create(hadoopPath, false)
+  }
+
+  def dumpMeta[T: ClassTag](metaName: String, obj: T): Unit = {
+    // use random Id in the file name, because there are multiple threads using the same
+    // exec UUID, random Id will avoid file name collision
+    val randomId = UUID.randomUUID().toString
+    val byteBuff = SparkEnv.get.closureSerializer.newInstance().serialize[T](obj)
+    val fos = getOutputStream(
+      s"$dumpDir/execUUID_${execUUID}_meta_${metaName}_randomID_$randomId.meta")
+    fos.write(byteBuff.array())
+    fos.close()
+    logWarning(s"dump project: dump project meta $metaName done")
+  }
+
+  def dumpColumnBatch(elapsedTimeNS: Long, cb: ColumnarBatch): Unit = {
+    val elapsedTimeMS = elapsedTimeNS / 1000000L
+    if (elapsedTimeMS > thresholdMS) {
+      val currBatchIndex = currentNumOfColumnBatch.getAndIncrement()
+      if (currBatchIndex < batchLimit) {
+        logWarning(s"dump project: currentNumOfColumnBatch " +
+            s"$currBatchIndex < batchLimit $batchLimit")
+
+        logWarning(s"dump project: elapsedTime(MS) $elapsedTimeMS > thresholdMS $thresholdMS")
+        logWarning(s"dump project: dump dir is $dumpDir")
+        logWarning(s"dump project: threshold MS is $thresholdMS")
+        logWarning(s"dump project: batch limit is $batchLimit")
+        logWarning(s"dump project: execUUID $execUUID")
+
+        // dump col types for column batch to remote storage
+        val cbTypes = GpuColumnVector.extractTypes(cb)
+        dumpMeta("cb_types", cbTypes)
+        logWarning(s"dump project: dump column batch column types done")
+
+        // dump data for column batch to /tmp dir
+        val tmpDir = "/tmp"
+        val randomId = UUID.randomUUID().toString
+        val filePrefix = s"$tmpDir/" +
+          s"execUUID_${execUUID}_cb_data_index_${currBatchIndex}_randomID_$randomId"
+        val tmpParquetPathOpt = withResource(GpuColumnVector.from(cb)) { table =>
+          DumpUtils.dumpToParquetFile(table, filePrefix)
+        }
+        // copy from /tmp dir to remote dir
+        tmpParquetPathOpt.map { tmpParquetPath =>
+          try {
+            val tmpParquetName = new File(tmpParquetPath).getName
+            val dataOutput = getOutputStream(s"$dumpDir/$tmpParquetName")
+            val dataInput = new FileInputStream(tmpParquetPath)
+            IOUtils.copy(dataInput, dataOutput)
+            dataOutput.close()
+            logWarning(s"dump project: dump column batch data done")
+          } finally {
+            // delete tmp file
+            new File(tmpParquetPath).delete()
+          }
+        }.orElse {
+          logError(s"dump project: dump column batch data failed !!! ")
+          None
+        }
+      }
+    }
+  }
+}
+
+object ReplayDumper {
+  def enabledReplayForProject(conf: RapidsConf): Boolean =
+    conf.debugReplayExecType.contains("project")
+}

--- a/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark311/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -133,7 +133,7 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
+      if (projectList.nonEmpty) GpuProjectExec(projectList, plan, dumpForReplay = false)() else plan
     }
 
     val writerBucketSpec: Option[GpuWriterBucketSpec] = bucketSpec.map { spec =>

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -231,7 +231,11 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
+      if (projectList.nonEmpty) {
+        GpuProjectExec(projectList, plan, dumpForReplay = false)()
+      } else {
+        plan
+      }
     }
 
     writeAndCommit(job, description, committer) {


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/10862
Collecting nsys/ncu files are time-consuming when running customer data because usually customer data is huge.
Actually we only need a small data segment which is running in a JNI/cuDF kernel.
This PR aims to dump/replay the runtime(data and meta) when Project Exec(s) execution time on a batch exceeds the threshold time.

This is a feature to dump and replay Project Exec runtime (by column batch) for performance purpose debug.

- Project exec
  store/restore GpuTieredProject case class
  store/restore ColumnarBatch data
  replay GpuProejctExec