### PR TITLE
Fix `Inheritance Shadowing` to add support for Spark 4.0.0 [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/iceberg/IcebergProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,18 +30,18 @@ class IcebergProviderImpl extends IcebergProvider {
     Seq(new ScanRule[Scan](
       (a, conf, p, r) => new ScanMeta[Scan](a, conf, p, r) {
         private lazy val convertedScan: Try[GpuSparkBatchQueryScan] = Try {
-          GpuSparkBatchQueryScan.fromCpu(a, conf)
+          GpuSparkBatchQueryScan.fromCpu(a, this.conf)
         }
 
         override def supportsRuntimeFilters: Boolean = true
 
         override def tagSelfForGpu(): Unit = {
-          if (!conf.isIcebergEnabled) {
+          if (!this.conf.isIcebergEnabled) {
             willNotWorkOnGpu("Iceberg input and output has been disabled. To enable set " +
                 s"${RapidsConf.ENABLE_ICEBERG} to true")
           }
 
-          if (!conf.isIcebergReadEnabled) {
+          if (!this.conf.isIcebergReadEnabled) {
             willNotWorkOnGpu("Iceberg input has been disabled. To enable set " +
                 s"${RapidsConf.ENABLE_ICEBERG_READ} to true")
           }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/HiveProviderImpl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/HiveProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
           }
 
           override def tagExprForGpu(): Unit = {
-            if (opRapidsFunc.isEmpty && !conf.isCpuBasedUDFEnabled) {
+            if (opRapidsFunc.isEmpty && !this.conf.isCpuBasedUDFEnabled) {
               willNotWorkOnGpu(s"Hive SimpleUDF ${a.name} implemented by " +
                   s"${a.funcWrapper.functionClassName} does not provide a GPU implementation " +
                   s"and CPU-based UDFs are not enabled by `${RapidsConf.ENABLE_CPU_BASED_UDF.key}`")
@@ -78,7 +78,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
                 a.deterministic)
             }.getOrElse {
               // This `require` is just for double check.
-              require(conf.isCpuBasedUDFEnabled)
+              require(this.conf.isCpuBasedUDFEnabled)
               GpuRowBasedHiveSimpleUDF(
                 a.name,
                 a.funcWrapper,
@@ -101,7 +101,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
           }
 
           override def tagExprForGpu(): Unit = {
-            if (opRapidsFunc.isEmpty && !conf.isCpuBasedUDFEnabled) {
+            if (opRapidsFunc.isEmpty && !this.conf.isCpuBasedUDFEnabled) {
               willNotWorkOnGpu(s"Hive GenericUDF ${a.name} implemented by " +
                   s"${a.funcWrapper.functionClassName} does not provide a GPU implementation " +
                   s"and CPU-based UDFs are not enabled by `${RapidsConf.ENABLE_CPU_BASED_UDF.key}`")
@@ -121,7 +121,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
                 a.foldable)
             }.getOrElse {
               // This `require` is just for double check.
-              require(conf.isCpuBasedUDFEnabled)
+              require(this.conf.isCpuBasedUDFEnabled)
               GpuRowBasedHiveGenericUDF(
                 a.name,
                 a.funcWrapper,
@@ -195,11 +195,11 @@ class HiveProviderImpl extends HiveProviderCmdShims {
           }
 
           private def checkIfEnabled(): Unit = {
-            if (!conf.isHiveDelimitedTextEnabled) {
+            if (!this.conf.isHiveDelimitedTextEnabled) {
               willNotWorkOnGpu("Hive text I/O has been disabled. To enable this, " +
                                s"set ${RapidsConf.ENABLE_HIVE_TEXT} to true")
             }
-            if (!conf.isHiveDelimitedTextReadEnabled) {
+            if (!this.conf.isHiveDelimitedTextReadEnabled) {
               willNotWorkOnGpu("reading Hive delimited text tables has been disabled, " +
                                s"to enable this, set ${RapidsConf.ENABLE_HIVE_TEXT_READ} to true")
             }
@@ -268,7 +268,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
               TrampolineUtil.dataTypeExistsRecursively(att.dataType, dt => dt == FloatType)
             }
 
-            if (!conf.shouldHiveReadFloats && hasFloats) {
+            if (!this.conf.shouldHiveReadFloats && hasFloats) {
               willNotWorkOnGpu("reading of floats has been disabled set " +
                   s"${RapidsConf.ENABLE_READ_HIVE_FLOATS} to true to enable this.")
             }
@@ -277,7 +277,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
               TrampolineUtil.dataTypeExistsRecursively(att.dataType, dt => dt == DoubleType)
             }
 
-            if (!conf.shouldHiveReadDoubles && hasDoubles) {
+            if (!this.conf.shouldHiveReadDoubles && hasDoubles) {
               willNotWorkOnGpu("reading of doubles has been disabled set " +
                   s"${RapidsConf.ENABLE_READ_HIVE_DOUBLES} to true to enable this.")
             }
@@ -287,7 +287,7 @@ class HiveProviderImpl extends HiveProviderCmdShims {
                 dt => dt.isInstanceOf[DecimalType])
             }
 
-            if (!conf.shouldHiveReadDecimals && hasDecimals) {
+            if (!this.conf.shouldHiveReadDecimals && hasDecimals) {
               willNotWorkOnGpu("reading of decimal typed values has been disabled set " +
                   s"${RapidsConf.ENABLE_READ_HIVE_DECIMALS} to true to enable this.")
             }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/AvroProviderImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ class AvroProviderImpl extends AvroProvider {
               a.readPartitionSchema,
               a.options,
               a.pushedFilters,
-              conf,
+              this.conf,
               a.partitionFilters,
               a.dataFilters)
         })

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuScalaUDF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ object GpuScalaUDFMeta {
       lazy val opRapidsFunc = GpuScalaUDF.getRapidsUDFInstance(expr.function)
 
       override def tagExprForGpu(): Unit = {
-        if (opRapidsFunc.isEmpty && !conf.isCpuBasedUDFEnabled) {
+        if (opRapidsFunc.isEmpty && !this.conf.isCpuBasedUDFEnabled) {
           val udfName = expr.udfName.getOrElse("UDF")
           val udfClass = expr.function.getClass
           willNotWorkOnGpu(s"neither $udfName implemented by $udfClass provides " +
@@ -76,7 +76,7 @@ object GpuScalaUDFMeta {
             expr.udfDeterministic)
         }.getOrElse {
           // This `require` is just for double check.
-          require(conf.isCpuBasedUDFEnabled)
+          require(this.conf.isCpuBasedUDFEnabled)
           GpuRowBasedScalaUDF(
             expr.function,
             expr.dataType,

--- a/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
+++ b/sql-plugin/src/main/spark320/scala/com/nvidia/spark/rapids/shims/Spark320PlusShims.scala
@@ -168,7 +168,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
           TypeSig.numericAndInterval + TypeSig.NULL))),
       (a, conf, p, r) => new AggExprMeta[Average](a, conf, p, r) {
         override def tagAggForGpu(): Unit = {
-          GpuOverrides.checkAndTagFloatAgg(a.child.dataType, conf, this)
+          GpuOverrides.checkAndTagFloatAgg(a.child.dataType, this.conf, this)
         }
 
         override def convertToGpu(childExprs: Seq[Expression]): GpuExpression =
@@ -296,7 +296,7 @@ trait Spark320PlusShims extends SparkShims with RebaseShims with Logging {
           TypeSig.all),
         (winPy, conf, p, r) => new GpuWindowInPandasExecMetaBase(winPy, conf, p, r) {
           override val windowExpressions: Seq[BaseExprMeta[NamedExpression]] =
-            getWindowExpressions(winPy).map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+            getWindowExpressions(winPy).map(GpuOverrides.wrapExpr(_, this.conf, Some(this)))
 
           override def convertToGpu(): GpuExec = {
             GpuWindowInPandasExec(

--- a/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusNonDBShims.scala
+++ b/sql-plugin/src/main/spark340/scala/com/nvidia/spark/rapids/shims/Spark340PlusNonDBShims.scala
@@ -62,9 +62,9 @@ trait Spark340PlusNonDBShims extends Spark331PlusNonDBShims {
       (takeExec, conf, p, r) =>
         new SparkPlanMeta[TakeOrderedAndProjectExec](takeExec, conf, p, r) {
           val sortOrder: Seq[BaseExprMeta[SortOrder]] =
-            takeExec.sortOrder.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+            takeExec.sortOrder.map(GpuOverrides.wrapExpr(_, this.conf, Some(this)))
           val projectList: Seq[BaseExprMeta[NamedExpression]] =
-            takeExec.projectList.map(GpuOverrides.wrapExpr(_, conf, Some(this)))
+            takeExec.projectList.map(GpuOverrides.wrapExpr(_, this.conf, Some(this)))
           override val childExprs: Seq[BaseExprMeta[_]] = sortOrder ++ projectList
 
           override def convertToGpu(): GpuExec = {


### PR DESCRIPTION
This PR fixes compilation issues related to Inheritance Shadowing introduced in Scala 2.13 in which an inherited member from a parent class or trait can shadow another member declared in the outer scope. For more details read https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html

To fix we access the member `conf` using `this` qualifier

contributes to #9259 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
