### PR TITLE
Throw Anonymous Child of AnalysisException [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/RapidsHiveErrors.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/hive/rapids/RapidsHiveErrors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ object RapidsHiveErrors {
 
   def cannotResolveAttributeError(name: String, outputStr: String): Throwable = {
     new AnalysisException(
-      s"Unable to resolve $name given [$outputStr]")
+      s"Unable to resolve $name given [$outputStr]") {}
   }
 
   def writePartitionExceedConfigSizeWhenDynamicPartitionError(

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuDataSourceBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuDataSourceBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ abstract class GpuDataSourceBase(
             inferredOpt
           }.getOrElse {
             throw new AnalysisException(s"Failed to resolve the schema for $format for " +
-              s"the partition column: $partitionColumn. It must be specified manually.")
+              s"the partition column: $partitionColumn. It must be specified manually.") {}
           }
         }
         StructType(partitionFields)
@@ -163,7 +163,7 @@ abstract class GpuDataSourceBase(
         SparkShimImpl.filesFromFileIndex(tempFileIndex))
     }.getOrElse {
       throw new AnalysisException(
-        s"Unable to infer schema for $format. It must be specified manually.")
+        s"Unable to infer schema for $format. It must be specified manually.") {}
     }
 
     // We just print a waring message if the data schema and partition schema have the duplicate
@@ -201,7 +201,7 @@ abstract class GpuDataSourceBase(
       case (dataSource: RelationProvider, None) =>
         dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
       case (_: SchemaRelationProvider, None) =>
-        throw new AnalysisException(s"A schema needs to be specified when using $className.")
+        throw new AnalysisException(s"A schema needs to be specified when using $className.") {}
       case (dataSource: RelationProvider, Some(schema)) =>
         val baseRelation =
           dataSource.createRelation(sparkSession.sqlContext, caseInsensitiveOptions)
@@ -211,7 +211,7 @@ abstract class GpuDataSourceBase(
             s"user-specified: ${schema.toDDL}, actual: ${baseRelation.schema.toDDL}. If " +
             "you're using DataFrameReader.schema API or creating a table, please do not " +
             "specify the schema. Or if you're scanning an existed table, please drop " +
-            "it and re-create it.")
+            "it and re-create it.") {}
         }
         baseRelation
 
@@ -235,7 +235,7 @@ abstract class GpuDataSourceBase(
         }.getOrElse {
           throw new AnalysisException(
             s"Unable to infer schema for $format at ${fileCatalog.allFiles().mkString(",")}. " +
-                "It must be specified manually")
+                "It must be specified manually") {}
         }
 
         HadoopFsRelation(
@@ -277,7 +277,7 @@ abstract class GpuDataSourceBase(
 
       case _ =>
         throw new AnalysisException(
-          s"$className is not a valid Spark SQL Data Source.")
+          s"$className is not a valid Spark SQL Data Source.") {}
     }
 
     relation match {
@@ -414,19 +414,19 @@ object GpuDataSourceBase extends Logging {
                   throw new AnalysisException(
                     "Hive built-in ORC data source must be used with Hive support enabled. " +
                     "Please use the native ORC data source by setting 'spark.sql.orc.impl' to " +
-                    "'native'")
+                    "'native'") {}
                 } else if (provider1.toLowerCase(Locale.ROOT) == "avro" ||
                   provider1 == "com.databricks.spark.avro" ||
                   provider1 == "org.apache.spark.sql.avro") {
                   throw new AnalysisException(
                     s"Failed to find data source: $provider1. Avro is built-in but external data " +
                     "source module since Spark 2.4. Please deploy the application as per " +
-                    "the deployment section of \"Apache Avro Data Source Guide\".")
+                    "the deployment section of \"Apache Avro Data Source Guide\".") {}
                 } else if (provider1.toLowerCase(Locale.ROOT) == "kafka") {
                   throw new AnalysisException(
                     s"Failed to find data source: $provider1. Please deploy the application as " +
                     "per the deployment section of " +
-                    "\"Structured Streaming + Kafka Integration Guide\".")
+                    "\"Structured Streaming + Kafka Integration Guide\".") {}
                 } else {
                   throw new ClassNotFoundException(
                     s"Failed to find data source: $provider1. Please find packages at " +
@@ -460,7 +460,7 @@ object GpuDataSourceBase extends Logging {
             internalSources.head.getClass
           } else {
             throw new AnalysisException(s"Multiple sources found for $provider1 " +
-              s"(${sourceNames.mkString(", ")}), please specify the fully qualified class name.")
+              s"(${sourceNames.mkString(", ")}), please specify the fully qualified class name.") {}
           }
       }
     } catch {
@@ -513,7 +513,7 @@ object GpuDataSourceBase extends Logging {
           }
 
           if (checkEmptyGlobPath && globResult.isEmpty) {
-            throw new AnalysisException(s"Path does not exist: $globPath")
+            throw new AnalysisException(s"Path does not exist: $globPath") {}
           }
 
           globResult
@@ -527,7 +527,7 @@ object GpuDataSourceBase extends Logging {
         ThreadUtils.parmap(nonGlobPaths, "checkPathsExist", numThreads) { path =>
           val fs = path.getFileSystem(hadoopConf)
           if (!fs.exists(path)) {
-            throw new AnalysisException(s"Path does not exist: $path")
+            throw new AnalysisException(s"Path does not exist: $path") {}
           }
         }
       } catch {

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInsertIntoHadoopFsRelationCommand.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuInsertIntoHadoopFsRelationCommand.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ case class GpuInsertIntoHadoopFsRelationCommand(
       val pathExists = fs.exists(qualifiedOutputPath)
       (mode, pathExists) match {
         case (SaveMode.ErrorIfExists, true) =>
-          throw new AnalysisException(s"path $qualifiedOutputPath already exists.")
+          throw new AnalysisException(s"path $qualifiedOutputPath already exists.") {}
         case (SaveMode.Overwrite, true) =>
           if (ifPartitionNotExists && matchingPartitions.nonEmpty) {
             false

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuRandomExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ case class GpuRand(child: Expression) extends ShimUnaryExpression with GpuExpres
     case GpuLiteral(s, IntegerType) => s.asInstanceOf[Int]
     case GpuLiteral(s, LongType) => s.asInstanceOf[Long]
     case _ => throw new AnalysisException(
-      s"Input argument to $prettyName must be an integer, long or null literal.")
+      s"Input argument to $prettyName must be an integer, long or null literal.") {}
   }
 
   @transient protected var previousPartition: Int = 0

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/TrampolineUtil.scala
@@ -157,7 +157,7 @@ object TrampolineUtil {
   }
 
   /** Throw a Spark analysis exception */
-  def throwAnalysisException(msg: String) = throw new AnalysisException(msg)
+  def throwAnalysisException(msg: String) = throw new AnalysisException(msg) {}
 
   /** Set the task context for the current thread */
   def setTaskContext(tc: TaskContext): Unit = TaskContext.setTaskContext(tc)

--- a/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuInsertIntoHiveTable.scala
+++ b/sql-plugin/src/main/spark332db/scala/com/nvidia/spark/rapids/shims/GpuInsertIntoHiveTable.scala
@@ -181,7 +181,7 @@ case class GpuInsertIntoHiveTable(
       // Report error if any static partition appears after a dynamic partition
       val isDynamic = partitionColumnNames.map(partitionSpec(_).isEmpty)
       if (isDynamic.init.zip(isDynamic.tail).contains((true, false))) {
-        throw new AnalysisException(ErrorMsg.PARTITION_DYN_STA_ORDER.getMsg)
+        throw new AnalysisException(ErrorMsg.PARTITION_DYN_STA_ORDER.getMsg) {}
       }
     }
 

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -62,7 +62,7 @@ object GpuFileFormatWriter extends Logging {
     schema.foreach { field =>
       if (!format.supportDataType(field.dataType)) {
         throw new AnalysisException(
-          s"$format data source does not support ${field.dataType.catalogString} data type.")
+          s"$format data source does not support ${field.dataType.catalogString} data type.") {}
       }
     }
   }

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/shims/GpuCreateDataSourceTableAsSelectCommandShims.scala
@@ -64,7 +64,8 @@ case class GpuCreateDataSourceTableAsSelectCommand(
         s"Expect the table $tableName has been dropped when the save mode is Overwrite")
 
       if (mode == SaveMode.ErrorIfExists) {
-        throw new AnalysisException(s"Table $tableName already exists. You need to drop it first.")
+        throw new AnalysisException(s"Table $tableName already exists. " +
+          "You need to drop it first.") {}
       }
       if (mode == SaveMode.Ignore) {
         // Since the table already exists and the save mode is Ignore, we will just return.


### PR DESCRIPTION
In Spark 4.0.0 the constructor of AnalysisException that takes a String parameter has been protected. One way to get around this is to add a shim where we can throw a defined class for Spark 4.0.0 while keeping the same logic for other versions of Spark. That would be a lot of code churn and be hard to review for no added benefit IMO.

This change is small enough and simple enough to where we can throw an anonymous class without making it difficult to read

contributes to #9259 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
