### PR TITLE
Filter out unused json_path tokens

### DIFF
--- a/integration_tests/src/main/python/get_json_test.py
+++ b/integration_tests/src/main/python/get_json_test.py
@@ -315,7 +315,6 @@ def test_get_json_object_jni_java_tests():
             conf={'spark.rapids.sql.expression.GetJsonObject': 'true'})
 
 
-@allow_non_gpu('ProjectExec')
 def test_get_json_object_deep_nested_json():
     schema = StructType([StructField("jsonStr", StringType())])
     data = [['{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"l":{"m":{"n":{"o":{"p":{"q":{"r":{"s":{"t":{"u":{"v":{"w":{"x":{"y":{"z":"A"}}'

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -160,7 +160,7 @@ class GpuGetJsonObjectMeta(
         if (updated.exists(JsonPathParser.fallbackCheck)) {
           willNotWorkOnGpu(s"get_json_object on GPU does not support more " +
             s"than ${JSONUtils.MAX_PATH_DEPTH} nested paths." +
-            s"(Found ${instructions.map(_.length)})")
+            instructions.map(i => s" (Found ${i.length})").getOrElse(""))
         }
       } else {
         if (instructions.exists(JsonPathParser.containsUnsupportedPath)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuJsonTuple.scala
@@ -63,11 +63,9 @@ case class GpuJsonTuple(children: Seq[Expression]) extends GpuGenerator
           withResourceIfAllowed(field.columnarEvalAny(inputBatch)) {
             case fieldScalar: GpuScalar =>
               val fieldString = fieldScalar.getBase.getJavaString
-              val key = new JSONUtils.PathInstructionJni(
-                  JSONUtils.PathInstructionType.KEY, "", -1)
               val named = new JSONUtils.PathInstructionJni(
                   JSONUtils.PathInstructionType.NAMED, fieldString, -1)
-              Array(key, named)
+              Array(named)
             case _ => throw new UnsupportedOperationException(s"JSON field must be a scalar value")
           }
         }


### PR DESCRIPTION
This is related to https://github.com/NVIDIA/spark-rapids-jni/pull/2047

The code in spark-rapids-jni filters out the path tokens that it does not care about. But that is not clear how it is happening. It also makes the error message confusing because `$.foo` has a depth of 2, even though most would expect it to have a depth of 1.  This does the filtering on the plugin side and updates the message about falling back to the CPU to be more user friendly. https://github.com/NVIDIA/spark-rapids-jni/pull/2047 will be updated to remove the unused/unneeded token enums entirely.