### PR TITLE
Replace anonymous classes for SortOrder and FIlterExec overrides

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2078,7 +2078,7 @@ object GpuOverrides extends Logging {
       "Sort order",
       ExprChecks.projectOnly(
         pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+           .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
         TypeSig.orderable,
         Seq(ParamCheck(
           "input",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4082,13 +4082,15 @@ object GpuOverrides extends Logging {
       ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
         TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all),
-      GpuCollectLimitMeta)
+      (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r))
         .disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
             "of rows in a batch it could help by limiting the number of rows transferred from " +
             "GPU to CPU"),
     exec[FilterExec](
       "The backend for most filter statements",
-      GpuFilterExec.typeChecks,
+      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
+        TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.BINARY +
+        GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(), TypeSig.all),
       GpuFilterExecMeta),
     exec[ShuffleExchangeExec](
       "The backend for most data being exchanged between processes",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4156,15 +4156,8 @@ object GpuOverrides extends Logging {
             "GPU to CPU"),
     exec[FilterExec](
       "The backend for most filter statements",
-      ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
-          TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.BINARY +
-          GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(), TypeSig.all),
-      (filter, conf, p, r) => new SparkPlanMeta[FilterExec](filter, conf, p, r) {
-        override def convertToGpu(): GpuExec = {
-          GpuFilterExec(childExprs.head.convertToGpu(),
-            childPlans.head.convertIfNeeded())(useTieredProject = this.conf.isTieredProjectEnabled)
-        }
-      }),
+      GpuFilterExec.typeChecks,
+      GpuFilterExec.wrapMeta),
     exec[ShuffleExchangeExec](
       "The backend for most data being exchanged between processes",
       ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.DECIMAL_128 + TypeSig.BINARY +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2078,12 +2078,12 @@ object GpuOverrides extends Logging {
       "Sort order",
       ExprChecks.projectOnly(
         pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-           .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
         TypeSig.orderable,
         Seq(ParamCheck(
           "input",
           pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-              .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+             .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
           TypeSig.orderable))),
       GpuSortOrderMeta),
     expr[PivotFirst](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -2078,12 +2078,12 @@ object GpuOverrides extends Logging {
       "Sort order",
       ExprChecks.projectOnly(
         pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-          .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
         TypeSig.orderable,
         Seq(ParamCheck(
           "input",
           pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-            .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
+              .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
           TypeSig.orderable))),
       GpuSortOrderMeta),
     expr[PivotFirst](
@@ -4055,7 +4055,7 @@ object GpuOverrides extends Logging {
       // The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
       // The types below are allowed as inputs and outputs.
       ExecChecks((pluginSupportedOrderableSig +
-        TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
+          TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all),
       GpuTakeOrderedAndProjectExecMeta),
     exec[LocalLimitExec](
       "Per-partition limiting of results",
@@ -4080,7 +4080,7 @@ object GpuOverrides extends Logging {
     exec[CollectLimitExec](
       "Reduce to single partition and apply limit",
       ExecChecks((TypeSig.commonCudfTypes + TypeSig.DECIMAL_128 + TypeSig.NULL +
-        TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
+          TypeSig.STRUCT + TypeSig.ARRAY + TypeSig.MAP).nested(),
         TypeSig.all),
       (collectLimitExec, conf, p, r) => new GpuCollectLimitMeta(collectLimitExec, conf, p, r))
         .disabledByDefault("Collect Limit replacement can be slower on the GPU, if huge number " +
@@ -4089,8 +4089,8 @@ object GpuOverrides extends Logging {
     exec[FilterExec](
       "The backend for most filter statements",
       ExecChecks((TypeSig.commonCudfTypes + TypeSig.NULL + TypeSig.STRUCT + TypeSig.MAP +
-        TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.BINARY +
-        GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(), TypeSig.all),
+          TypeSig.ARRAY + TypeSig.DECIMAL_128 + TypeSig.BINARY +
+          GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(), TypeSig.all),
       GpuFilterExecMeta),
     exec[ShuffleExchangeExec](
       "The backend for most data being exchanged between processes",

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/SortUtils.scala
@@ -20,12 +20,11 @@ import scala.collection.mutable
 
 import ai.rapids.cudf.{ColumnVector, NvtxColor, OrderByArg, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
-import com.nvidia.spark.rapids.GpuOverrides.{gpuCommonTypes, pluginSupportedOrderableSig}
 import com.nvidia.spark.rapids.RapidsPluginImplicits.{AutoCloseableProducingSeq, AutoCloseableSeq}
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, BoundReference, Expression, NullsFirst, NullsLast, SortOrder}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
-import org.apache.spark.sql.types.{ArrayType, BinaryType, DataType, MapType, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 object SortUtils {
@@ -448,16 +447,4 @@ case class GpuSortOrderMeta(
       }
     case _ => false
   }
-}
-
-object GpuSortOrder {
-  val pluginChecks: ExprChecks = ExprChecks.projectOnly(
-    pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-      .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
-    TypeSig.orderable,
-    Seq(ParamCheck(
-      "input",
-      pluginSupportedOrderableSig + TypeSig.ARRAY.nested(gpuCommonTypes)
-        .withPsNote(TypeEnum.ARRAY, "STRUCT is not supported as a child type for ARRAY"),
-      TypeSig.orderable)))
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.nvidia.spark.rapids
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
-
 import ai.rapids.cudf
 import ai.rapids.cudf._
 import com.nvidia.spark.Retryable
@@ -28,18 +27,17 @@ import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRestoreOnRetry, withRetry, withRetryNoSplit}
 import com.nvidia.spark.rapids.jni.GpuSplitAndRetryOOM
 import com.nvidia.spark.rapids.shims._
-
 import org.apache.spark.{InterruptibleIterator, Partition, SparkContext, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, RangePartitioning, SinglePartition, UnknownPartitioning}
-import org.apache.spark.sql.execution.{ProjectExec, SampleExec, SparkPlan}
+import org.apache.spark.sql.execution.{FilterExec, ProjectExec, SampleExec, SparkPlan}
 import org.apache.spark.sql.rapids.{GpuPartitionwiseSampledRDD, GpuPoissonSampler}
 import org.apache.spark.sql.rapids.execution.TrampolineUtil
 import org.apache.spark.sql.types.{DataType, LongType}
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch}
 import org.apache.spark.util.random.BernoulliCellSampler
 
 class GpuProjectExecMeta(
@@ -778,6 +776,34 @@ object GpuFilter {
     val checkedFilterMask = computeCheckedFilterMask(boundCondition, batch)
     doFilter(checkedFilterMask, batch)
   }
+}
+
+object GpuFilterExec {
+  def wrapMeta(
+    filter: FilterExec,
+    conf: RapidsConf,
+    p: Option[RapidsMeta[_, _, _]],
+    r: DataFromReplacementRule
+  ): SparkPlanMeta[FilterExec] = {
+    new SparkPlanMeta[FilterExec](filter, conf, p, r) {
+      override def convertToGpu(): GpuExec = {
+        sys.error("convertToGpu failed")
+        GpuFilterExec(childExprs.head.convertToGpu(),
+          childPlans.head.convertIfNeeded())(useTieredProject = this.conf.isTieredProjectEnabled)
+      }
+    }
+  }
+
+  val typeChecks = ExecChecks(
+    (TypeSig.commonCudfTypes +
+      TypeSig.NULL +
+      TypeSig.STRUCT +
+      TypeSig.MAP +
+      TypeSig.ARRAY +
+      TypeSig.DECIMAL_128 +
+      TypeSig.BINARY +
+      GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
+    TypeSig.all)
 }
 
 case class GpuFilterExec(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -792,19 +792,6 @@ case class GpuFilterExecMeta(
   }
 }
 
-object GpuFilterExec {
-  val typeChecks: ExecChecks = ExecChecks(
-    (TypeSig.commonCudfTypes +
-      TypeSig.NULL +
-      TypeSig.STRUCT +
-      TypeSig.MAP +
-      TypeSig.ARRAY +
-      TypeSig.DECIMAL_128 +
-      TypeSig.BINARY +
-      GpuTypeShims.additionalCommonOperatorSupportedTypes).nested(),
-    TypeSig.all)
-}
-
 case class GpuFilterExec(
     condition: Expression,
     child: SparkPlan)(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable.ArrayBuffer
 import ai.rapids.cudf.{NvtxColor, Table}
 import com.nvidia.spark.rapids.Arm.{closeOnExcept, withResource}
 import com.nvidia.spark.rapids.GpuMetric._
-import com.nvidia.spark.rapids.GpuOverrides.pluginSupportedOrderableSig
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.RmmRapidsRetryIterator.{splitSpillableInHalfByRows, withRetry}
 import com.nvidia.spark.rapids.SpillPriorities.ACTIVE_ON_DECK_PRIORITY

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -181,22 +181,12 @@ case class GpuGlobalLimitExec(limit: Int = -1, child: SparkPlan,
   }
 }
 
-case object GpuCollectLimit {
-  val pluginChecks: ExecChecks = ExecChecks(
-    (TypeSig.commonCudfTypes +
-      TypeSig.DECIMAL_128 +
-      TypeSig.NULL +
-      TypeSig.STRUCT +
-      TypeSig.ARRAY +
-      TypeSig.MAP).nested(),
-    TypeSig.all)
-}
-case class GpuCollectLimitMeta(
+class GpuCollectLimitMeta(
                       collectLimit: CollectLimitExec,
-                      override val conf: RapidsConf,
-                      parentOpt: Option[RapidsMeta[_, _, _]],
+                      conf: RapidsConf,
+                      parent: Option[RapidsMeta[_, _, _]],
                       rule: DataFromReplacementRule)
-  extends SparkPlanMeta[CollectLimitExec](collectLimit, conf, parentOpt, rule) {
+  extends SparkPlanMeta[CollectLimitExec](collectLimit, conf, parent, rule) {
   override val childParts: scala.Seq[PartMeta[_]] =
     Seq(GpuOverrides.wrapPart(collectLimit.outputPartitioning, conf, Some(this)))
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/limit.scala
@@ -431,13 +431,6 @@ case class GpuTopN(
   }
 }
 
-case object GpuTakeOrderedAndProjectExec {
-  // The SortOrder TypeSig will govern what types can actually be used as sorting key data type.
-  // The types below are allowed as inputs and outputs.
-  val pluginChecks = ExecChecks((pluginSupportedOrderableSig +
-    TypeSig.ARRAY + TypeSig.STRUCT + TypeSig.MAP).nested(), TypeSig.all)
-}
-
 case class GpuTakeOrderedAndProjectExecMeta(
    takeExec: TakeOrderedAndProjectExec,
    rapidsConf: RapidsConf,


### PR DESCRIPTION
Demo PR contributing to #10838 

It showcases a coding convention to follow using SortOrder and FilterExec replacements as an example

```scala
scala>  spark.range(100).where($"id" <= 10).collect()

java.lang.RuntimeException: convertToGpu failed
  at scala.sys.package$.error(package.scala:30)
  at com.nvidia.spark.rapids.GpuFilterExecMeta.convertToGpu(basicPhysicalOperators.scala:790)
  at com.nvidia.spark.rapids.GpuFilterExecMeta.convertToGpu(basicPhysicalOperators.scala:783)
  at com.nvidia.spark.rapids.SparkPlanMeta.convertIfNeeded(RapidsMeta.scala:838)
  at com.nvidia.spark.rapids.GpuOverrides$.com$nvidia$spark$rapids$GpuOverrides$$doConvertPlan(GpuOverrides.scala:4383)
  at com.nvidia.spark.rapids.GpuOverrides.applyOverrides(GpuOverrides.scala:4728)
  at com.nvidia.spark.rapids.GpuOverrides.$anonfun$applyWithContext$3(GpuOverrides.scala:4588)
  at com.nvidia.spark.rapids.GpuOverrides$.logDuration(GpuOverrides.scala:455)
  at com.nvidia.spark.rapids.GpuOverrides.$anonfun$applyWithContext$1(GpuOverrides.scala:4585)
  at com.nvidia.spark.rapids.GpuOverrideUtil$.$anonfun$tryOverride$1(GpuOverrides.scala:4551)
  at com.nvidia.spark.rapids.GpuOverrides.applyWithContext(GpuOverrides.scala:4605)
  at com.nvidia.spark.rapids.GpuOverrides.apply(GpuOverrides.scala:4578)
  at com.nvidia.spark.rapids.GpuOverrides.apply(GpuOverrides.scala:4574)
  at org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions.$anonfun$apply$1(Columnar.scala:532)
```

Signed-off-by: Gera Shegalov <gera@apache.org>

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
