### PR TITLE
Disable default cuDF pinned pool

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -448,7 +448,11 @@ object GpuDeviceManager extends Logging {
       (conf.pinnedPoolSize, -1L)
     }
     // disable the cuDF provided default pinned pool for now
-    PinnedMemoryPool.configureDefaultCudfPinnedPoolSize(0L)
+    if (!PinnedMemoryPool.configureDefaultCudfPinnedPoolSize(0L)) {
+      // This is OK in tests because they don't unload/reload our shared
+      // library, and in prod it would be nice to know about it.
+      logWarning("The default cuDF host pool was already configured")
+    }
     if (!PinnedMemoryPool.isInitialized && pinnedSize > 0) {
       logInfo(s"Initializing pinned memory pool (${pinnedSize / 1024 / 1024.0} MiB)")
       PinnedMemoryPool.initialize(pinnedSize, gpuId, setCuioDefaultResource)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuDeviceManager.scala
@@ -447,6 +447,8 @@ object GpuDeviceManager extends Logging {
     } else {
       (conf.pinnedPoolSize, -1L)
     }
+    // disable the cuDF provided default pinned pool for now
+    PinnedMemoryPool.configureDefaultCudfPinnedPoolSize(0L)
     if (!PinnedMemoryPool.isInitialized && pinnedSize > 0) {
       logInfo(s"Initializing pinned memory pool (${pinnedSize / 1024 / 1024.0} MiB)")
       PinnedMemoryPool.initialize(pinnedSize, gpuId, setCuioDefaultResource)


### PR DESCRIPTION
This is a revival of https://github.com/NVIDIA/spark-rapids/pull/10815 with one notable change.

Waiting for https://github.com/rapidsai/cudf/pull/15815

The cuDF code is no longer going to throw when `configureDefaultCudfPinnedPoolSize` fails. Instead it's going to return a boolean. If the boolean is true, we successfully disabled the cuDF default pool. Else, it will be false, and we will have 100MB of pinned pool around that we will not use, or we already have called this function ahead of time.

I only anticipate this warning to show up in tests. We call this early enough and we only initialize once, so I don't think we'll ever see this in real life. Even in tests, we will set our own pinned resource, so we will use our own resource no matter what.