### PR TITLE
[DOC] ignore released plugin links to reduce the bother info [skip ci]

### DIFF
--- a/.github/workflows/markdown-links-check/markdown-links-check-config.json
+++ b/.github/workflows/markdown-links-check/markdown-links-check-config.json
@@ -14,6 +14,9 @@
     },
     {
       "pattern": "https://www.nvidia.com/en-us/security/pgp-key"
+    },
+    {
+      "pattern": "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/*"
     }
   ],
   "timeout": "15s",

--- a/.github/workflows/markdown-links-check/markdown-links-check-config.json
+++ b/.github/workflows/markdown-links-check/markdown-links-check-config.json
@@ -16,7 +16,7 @@
       "pattern": "https://www.nvidia.com/en-us/security/pgp-key"
     },
     {
-      "pattern": "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/*"
+      "pattern": "https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.*"
     }
   ],
   "timeout": "15s",


### PR DESCRIPTION
Add released jar links to ignore pattern to reduce the bother info each release.
Will add a Jenkins job or some other monitors to check the Maven links. cc @NvTimLiu 

fix #10834
Signed-off-by: liyuan <yuali@nvidia.com>