### PR TITLE
Fix NoSuchElementException when rlike with empty pattern

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -495,6 +495,7 @@ The following regular expression patterns are not yet supported on the GPU and w
 - Character classes that use union, intersection, or subtraction semantics, such as `[a-d[m-p]]`, `[a-z&&[def]]`,
   or `[a-z&&[^bc]]`
 - Empty groups: `()`
+- Empty pattern: `""`
 
 Work is ongoing to increase the range of regular expressions that can run on the GPU.
 

--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -790,6 +790,15 @@ def test_rlike_fallback_empty_group():
             'RLike',
         conf=_regexp_conf)
 
+@allow_non_gpu('ProjectExec', 'RLike')
+def test_rlike_fallback_empty_pattern():
+    gen = mk_str_gen('[abcd]{1,3}')
+    assert_gpu_fallback_collect(
+            lambda spark: unary_op_df(spark, gen).selectExpr(
+                'a rlike ""'),
+            'RLike',
+        conf=_regexp_conf)
+
 def test_rlike_escape():
     gen = mk_str_gen('[ab]{0,2};?[\\-\\+]{0,2}/?')
     assert_gpu_and_cpu_are_equal_collect(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -2045,10 +2045,10 @@ object RegexRewrite {
   private def getPrefixRangePattern(astLs: collection.Seq[RegexAST]): 
       Option[(String, Int, Int, Int)] = {
     val haveLiteralPrefix = isliteralString(astLs.dropRight(1))
-    val endsWithRange = astLs.last match {
-      case RegexRepetition(
-          RegexCharacterClass(false,ListBuffer(RegexCharacterRange(a,b))), 
-          quantifier) => {
+    val endsWithRange = astLs.lastOption match {
+      case Some(RegexRepetition(
+          RegexCharacterClass(false, ListBuffer(RegexCharacterRange(a,b))), 
+          quantifier)) => {
         val (start, end) = (a, b) match {
           case (RegexChar(start), RegexChar(end)) => (start, end)
           case _ => return None


### PR DESCRIPTION
Fix #10913 

`rlike` with empty pattern failed with 'NoSuchElementException' when enabling regex rewrite, it is because we didn't handle empty pattern well in regex rewrite.

This PR fixes the bug. Seems empty pattern is not supported in plugin and will be fallback, this pr also adds this to doc.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
