### PR TITLE
[Test only] Run integration tests in parallel on Databricks

### DIFF
--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -275,7 +275,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
 
                 stage('Databricks IT1') {
                     when {
-                        expression { db_build }
+                        expression { db_build && skipped }
                     }
                     steps {
                         script {
@@ -299,7 +299,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
 
                 stage('Databricks IT2') {
                     when {
-                        expression { db_build }
+                        expression { db_build && skipped }
                     }
                     steps {
                         script {

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -273,7 +273,7 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                     }
                 } // end of Unit Test stage
 
-                stage('Databricks') {
+                stage('Databricks IT1') {
                     when {
                         expression { db_build }
                     }
@@ -284,7 +284,8 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                                 propagate: false, wait: true,
                                 parameters: [
                                         string(name: 'REF', value: params.REF),
-                                        string(name: 'GITHUB_DATA', value: params.GITHUB_DATA)
+                                        string(name: 'GITHUB_DATA', value: params.GITHUB_DATA),
+                                        string(name: 'EXTRA_ENV', value: 'IT_PART=part1')
                                 ])
                             if ( DBJob.result != 'SUCCESS' ) {
                                 // Output Databricks failure logs to uploaded onto the pre-merge PR
@@ -294,7 +295,31 @@ git --no-pager diff --name-only HEAD \$BASE -- ${PREMERGE_DOCKERFILE} || true"""
                             }
                         }
                     }
-                } // end of Databricks
+                } // end of Databricks IT1
+
+                stage('Databricks IT2') {
+                    when {
+                        expression { db_build }
+                    }
+                    steps {
+                        script {
+                            githubHelper.updateCommitStatus("", "Running - includes databricks", GitHubCommitState.PENDING)
+                            def DBJob = build(job: 'rapids-databricks_premerge-github',
+                                propagate: false, wait: true,
+                                parameters: [
+                                        string(name: 'REF', value: params.REF),
+                                        string(name: 'GITHUB_DATA', value: params.GITHUB_DATA),
+                                        string(name: 'EXTRA_ENV', value: 'IT_PART=part2')
+                                ])
+                            if ( DBJob.result != 'SUCCESS' ) {
+                                // Output Databricks failure logs to uploaded onto the pre-merge PR
+                                print(DBJob.getRawBuild().getLog())
+                                // Fail the pipeline
+                                error "Databricks build result : " + DBJob.result
+                            }
+                        }
+                    }
+                } // end of Databricks IT2
 
                 stage('Dummy stage: blue ocean log view') {
                     steps {

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -50,6 +50,8 @@ pipeline {
             description: 'Merged commit of specific PR')
         string(name: 'GITHUB_DATA', defaultValue: '',
             description: 'Json-formatted github data from upstream blossom-ci')
+        string(name: 'EXTRA_ENV', defaultValue: '',
+            description: 'Extra environments for integration test, e.g. IT_PART=part2')
     }
 
     environment {
@@ -63,7 +65,7 @@ pipeline {
         DATABRICKS_HOST = DbUtils.getHost("$DB_TYPE")
         DATABRICKS_TOKEN = credentials("${DbUtils.getToken("$DB_TYPE")}")
         DATABRICKS_PUBKEY = credentials("SPARK_DATABRICKS_PUBKEY")
-        DATABRICKS_DRIVER = DbUtils.getDriver("$DB_TYPE")
+        DATABRICKS_DRIVER = 'Standard_NV36ads_A10_v5'
         DATABRICKS_WORKER = DbUtils.getWorker("$DB_TYPE")
         INIT_SCRIPTS_DIR = "/databricks/init_scripts/${BUILD_TAG}"
     }
@@ -88,7 +90,7 @@ pipeline {
                         // 'name' and 'value' only supprt literal string in the declarative Jenkins
                         // Refer to Jenkins issue https://issues.jenkins.io/browse/JENKINS-62127
                         name 'DB_RUNTIME'
-                        values '11.3', '12.2', '13.3'
+                        values '13.3'
                     }
                 }
                 stages {
@@ -182,6 +184,7 @@ void databricksBuild() {
                             if (params.SPARK_CONF) {
                                 TEST_PARAMS += " -f ${params.SPARK_CONF}"
                             }
+                            TEST_PARAMS += params.EXTRA_ENV ? " -e  ${params.EXTRA_ENV}" : ''
                             sh "python3 ./jenkins/databricks/run-tests.py $TEST_PARAMS"
                         }
                     } finally {

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -79,7 +79,7 @@ mvn_verify() {
     # consumption from two k8s pods running in parallel, which executes 'mvn_verify()' and 'ci_2()' respectively.
     # Let the pytest script itself calculate the parallel num
     $MVN_CMD -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
-        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL= -Dcuda.version=$CLASSIFIER
+        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=8 -Dcuda.version=$CLASSIFIER
 
     # The jacoco coverage should have been collected, but because of how the shade plugin
     # works and jacoco we need to clean some things up so jacoco will only report for the
@@ -164,7 +164,7 @@ ci_2() {
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
     # Let the pytest script itself calculate the parallel num
-    # export TEST_PARALLEL=5 
+    export TEST_PARALLEL=8 
 
     # Download a Scala 2.12 build of spark
     prepare_spark $SPARK_VER 2.12
@@ -209,7 +209,7 @@ ci_scala213() {
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
     # Let the pytest script itself calculate the parallel num
-    # export TEST_PARALLEL=5
+    export TEST_PARALLEL=8
     # SPARK_HOME (and related) must be set to a Spark built with Scala 2.13
     SPARK_HOME=$SPARK_HOME PYTHONPATH=$PYTHONPATH \
         ./integration_tests/run_pyspark_from_build.sh

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -77,8 +77,9 @@ mvn_verify() {
 
     # Here run Python integration tests tagged with 'premerge_ci_1' only, that would help balance test duration and memory
     # consumption from two k8s pods running in parallel, which executes 'mvn_verify()' and 'ci_2()' respectively.
+    # Let the pytest script itself calculate the parallel num
     $MVN_CMD -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
-        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=4 -Dcuda.version=$CLASSIFIER
+        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL= -Dcuda.version=$CLASSIFIER
 
     # The jacoco coverage should have been collected, but because of how the shade plugin
     # works and jacoco we need to clean some things up so jacoco will only report for the
@@ -162,7 +163,8 @@ ci_2() {
     $MVN_CMD -U -B $MVN_URM_MIRROR clean package $MVN_BUILD_ARGS -DskipTests=true
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
-    export TEST_PARALLEL=5
+    # Let the pytest script itself calculate the parallel num
+    # export TEST_PARALLEL=5 
 
     # Download a Scala 2.12 build of spark
     prepare_spark $SPARK_VER 2.12
@@ -206,7 +208,8 @@ ci_scala213() {
     cd .. # Run integration tests in the project root dir to leverage test cases and resource files
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
-    export TEST_PARALLEL=5
+    # Let the pytest script itself calculate the parallel num
+    # export TEST_PARALLEL=5
     # SPARK_HOME (and related) must be set to a Spark built with Scala 2.13
     SPARK_HOME=$SPARK_HOME PYTHONPATH=$PYTHONPATH \
         ./integration_tests/run_pyspark_from_build.sh


### PR DESCRIPTION
Divide integration tests into two parts, and run them in different DB clusters in parallel to accelerate the tests.

