### PR TITLE
Profiler: Disable collecting async allocation events by default

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -744,6 +744,12 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .createOptional
 
+  val PROFILE_ASYNC_ALLOC_CAPTURE = conf("spark.rapids.profile.asyncAllocCapture")
+    .doc("Whether the profiler should capture async CUDA allocation and free events")
+    .internal()
+    .booleanConf
+    .createWithDefault(false)
+
   val PROFILE_DRIVER_POLL_MILLIS = conf("spark.rapids.profile.driverPollMillis")
     .doc("Interval in milliseconds the executors will poll for job and stage completion when " +
       "stage-level profiling is used.")
@@ -771,7 +777,7 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .doc("Buffer size to use when writing profile records.")
     .internal()
     .bytesConf(ByteUnit.BYTE)
-    .createWithDefault(1024 * 1024)
+    .createWithDefault(8 * 1024 * 1024)
 
   // ENABLE/DISABLE PROCESSING
 
@@ -2473,6 +2479,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val profileStages: Option[String] = get(PROFILE_STAGES)
 
   lazy val profileDriverPollMillis: Int = get(PROFILE_DRIVER_POLL_MILLIS)
+
+  lazy val profileAsyncAllocCapture: Boolean = get(PROFILE_ASYNC_ALLOC_CAPTURE)
 
   lazy val profileCompression: String = get(PROFILE_COMPRESSION)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/profiler.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/profiler.scala
@@ -80,7 +80,12 @@ object ProfilerOnExecutor extends Logging {
           case c => Some(TrampolineUtil.createCodec(pluginCtx.conf(), c))
         }
         val w = new ProfileWriter(pluginCtx, pathPrefix, codec)
-        Profiler.init(w, conf.profileWriteBufferSize, conf.profileFlushPeriodMillis)
+        val profilerConf = new Profiler.Config.Builder()
+          .withWriteBufferSize(conf.profileWriteBufferSize)
+          .withFlushPeriodMillis(conf.profileFlushPeriodMillis)
+          .withAllocAsyncCapturing(conf.profileAsyncAllocCapture)
+          .build()
+        Profiler.init(w, profilerConf)
         Some(w)
       } else {
         None


### PR DESCRIPTION
Depends on NVIDIA/spark-rapids-jni#2105.

Adds a config to enable/disable collecting CUDA async allocation and free events in the profiler.  Default is false, as pool allocation/free events are often uninteresting and clutters the profile.

Also bumps up the event buffer size from 1MB to 8MB to increase the string sharing between events, as strings are only deduplicated within an event buffer.