### PR TITLE
Add default value for REF of premerge jenkinsfile to avoid bad overwritten [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # RAPIDS Accelerator For Apache Spark
 NOTE: For the latest stable [README.md](https://github.com/nvidia/spark-rapids/blob/main/README.md) ensure you are on the main branch.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # RAPIDS Accelerator For Apache Spark
 NOTE: For the latest stable [README.md](https://github.com/nvidia/spark-rapids/blob/main/README.md) ensure you are on the main branch.
 

--- a/jenkins/Jenkinsfile-blossom.premerge
+++ b/jenkins/Jenkinsfile-blossom.premerge
@@ -57,7 +57,8 @@ pipeline {
     }
 
     parameters {
-        string(name: 'REF', defaultValue: '',
+        // Put a default value for REF to avoid error when running the pipeline manually
+        string(name: 'REF', defaultValue: 'main',
             description: 'Merged commit of specific PR')
         string(name: 'GITHUB_DATA', defaultValue: '',
             description: 'Json-formatted github data from upstream blossom-ci')

--- a/jenkins/Jenkinsfile-blossom.premerge-databricks
+++ b/jenkins/Jenkinsfile-blossom.premerge-databricks
@@ -46,7 +46,8 @@ pipeline {
     }
 
     parameters {
-        string(name: 'REF', defaultValue: '',
+        // Put a default value for REF to avoid error when running the pipeline manually
+        string(name: 'REF', defaultValue: 'main',
             description: 'Merged commit of specific PR')
         string(name: 'GITHUB_DATA', defaultValue: '',
             description: 'Json-formatted github data from upstream blossom-ci')


### PR DESCRIPTION
fix #10964 

Currently, premerge should only be triggered from a Pull request, but there could be some unexpected manual trigger from the internal pipeline directly. And people could forget to put the required REF for the pipeline to fetch the corresponding jenkinsfile, **this could cause the default param got overwritten by an old jenkinsfile** (currently the oldest tag in repo which has no `REF` param), the pipeline lose the `REF` param for upstream router to pass the jenkinsfile commit and then fail all following runs.

Solution:
Add a default value as `main` for the `REF`, to make sure that even unexpected manual ops would not remove the `REF` param for the pipeline itself.

this will be applied to JNI and ML repos later