### PR TITLE
Improve log to print more lines in build [skip ci]

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -265,7 +265,7 @@ function build_single_shim() {
       -Dmaven.scaladoc.skip \
       -Dmaven.scalastyle.skip="$SKIP_CHECKS" \
       -pl tools -am > "$LOG_FILE" 2>&1 || {
-        [[ "$LOG_FILE" != "/dev/tty" ]] && echo "$LOG_FILE:" && tail -20 "$LOG_FILE" || true
+        [[ "$LOG_FILE" != "/dev/tty" ]] && echo "$LOG_FILE:" && tail -500 "$LOG_FILE" || true
         exit 255
       }
 }


### PR DESCRIPTION
As mentioned in #10967 the 500 lines are being printed instead of 20. 20 is too small and I can not get enough info sometimes as mentioned in the issue 

Closes #10967 