### PR TITLE
Fix a hive write test failure for Spark 350

### DIFF
--- a/integration_tests/src/main/python/hive_parquet_write_test.py
+++ b/integration_tests/src/main/python/hive_parquet_write_test.py
@@ -19,7 +19,7 @@ from conftest import is_databricks_runtime
 from data_gen import *
 from hive_write_test import _restricted_timestamp
 from marks import allow_non_gpu, ignore_order
-from spark_session import with_cpu_session, is_before_spark_320, is_spark_351_or_later
+from spark_session import with_cpu_session, is_before_spark_320, is_spark_350_or_later
 
 # Disable the meta conversion from Hive write to FrameData write in Spark, to test
 # "GpuInsertIntoHiveTable" for Parquet write.
@@ -55,7 +55,7 @@ _hive_map_gens = [simple_string_to_string_map_gen] + [MapGen(f(nullable=False), 
 _hive_write_gens = [_hive_basic_gens, _hive_struct_gens, _hive_array_gens, _hive_map_gens]
 
 # ProjectExec falls back on databricks due to no GPU version of "MapFromArrays".
-fallback_nodes = ['ProjectExec'] if is_databricks_runtime() or is_spark_351_or_later() else []
+fallback_nodes = ['ProjectExec'] if is_databricks_runtime() or is_spark_350_or_later() else []
 
 
 @allow_non_gpu(*(non_utc_allow + fallback_nodes))


### PR DESCRIPTION
fixes https://github.com/NVIDIA/spark-rapids/issues/10956

This is a bug fix for the hive write tests. This is simliar as https://github.com/NVIDIA/spark-rapids/pull/10958 but it fixes the failures for Spark 350.

The tests fail because the ProjectExec will fall back to CPU due to missing the GPU version of the MapFromArrays expression.

This PR adds the ProjectExec to the allowed list of fallback for Spark 350 and the laters.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
