### PR TITLE
Calculate parallelism to speed up pre-merge CI

### DIFF
--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -173,13 +173,13 @@ else
 
     # We found that when parallelism > 8, as it increases, the test speed will become slower and slower. So we set the default maximum parallelism to 8.
     # Note that MAX_PARALLEL varies with the hardware, OS, and test case. Please overwrite it with an appropriate value if needed.
-    MAX_PALALLEL=${MAX_PALALLEL:-8}
+    MAX_PARALLEL=${MAX_PARALLEL:-8}
     if [[ ${TEST_PARALLEL} -lt 2 ]];
     then
         # With xdist 0 and 1 are the same parallelism but
         # 0 is more efficient
         TEST_PARALLEL_OPTS=()
-    elif [[ ${TEST_PARALLEL} -gt ${MAX_PALALLEL} ]]; then
+    elif [[ ${TEST_PARALLEL} -gt ${MAX_PARALLEL} ]]; then
         TEST_PARALLEL_OPTS=("-n" "$MAX_PARALLEL")
     else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -171,11 +171,16 @@ else
         TEST_TYPE_PARAM="--test_type $TEST_TYPE"
     fi
 
+    # We found that when parallelism > 8, as it increases, the test speed will become slower and slower. So we set the default maximum parallelism to 8.
+    # Note that MAX_PARALLEL varies with the hardware, OS, and test case. Please overwrite it with an appropriate value if needed.
+    MAX_PALALLEL=${MAX_PALALLEL:-8}
     if [[ ${TEST_PARALLEL} -lt 2 ]];
     then
         # With xdist 0 and 1 are the same parallelism but
         # 0 is more efficient
         TEST_PARALLEL_OPTS=()
+    elif [[ ${TEST_PARALLEL} -gt ${MAX_PALALLEL} ]]; then
+        TEST_PARALLEL_OPTS=("-n" "$MAX_PARALLEL")
     else
         TEST_PARALLEL_OPTS=("-n" "$TEST_PARALLEL")
     fi

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -75,13 +75,10 @@ mvn_verify() {
           -DwildcardSuites=com.nvidia.spark.rapids.ConditionalsSuite,com.nvidia.spark.rapids.RegularExpressionSuite,com.nvidia.spark.rapids.RegularExpressionTranspilerSuite
     done
 
-    # Calculate parallelism based on GPU memory. When parallelism > 8, as it increases, the test speed will become slower and slower. So we set the maximum parallelism to 8.
-    GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk '{if (MAX < $1){ MAX = $1}} END {print int((MAX - 2 * 1024) / ((1.5 * 1024) + 750))}'`
-    export TEST_PARALLEL=$(( $GPU_MEM_PARALLEL < 8 ? $GPU_MEM_PARALLEL : 8 ))
     # Here run Python integration tests tagged with 'premerge_ci_1' only, that would help balance test duration and memory
     # consumption from two k8s pods running in parallel, which executes 'mvn_verify()' and 'ci_2()' respectively.
     $MVN_CMD -B $MVN_URM_MIRROR $PREMERGE_PROFILES clean verify -Dpytest.TEST_TAGS="premerge_ci_1" \
-        -Dpytest.TEST_TYPE="pre-commit" -Dpytest.TEST_PARALLEL=$TEST_PARALLEL -Dcuda.version=$CLASSIFIER
+        -Dpytest.TEST_TYPE="pre-commit" -Dcuda.version=$CLASSIFIER
 
     # The jacoco coverage should have been collected, but because of how the shade plugin
     # works and jacoco we need to clean some things up so jacoco will only report for the
@@ -165,9 +162,6 @@ ci_2() {
     $MVN_CMD -U -B $MVN_URM_MIRROR clean package $MVN_BUILD_ARGS -DskipTests=true
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
-    # Calculate parallelism based on GPU memory. When parallelism > 8, as it increases, the test speed will become slower and slower. So we set the maximum parallelism to 8.
-    GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk '{if (MAX < $1){ MAX = $1}} END {print int((MAX - 2 * 1024) / ((1.5 * 1024) + 750))}'`
-    export TEST_PARALLEL=$(( $GPU_MEM_PARALLEL < 8 ? $GPU_MEM_PARALLEL : 8 ))
 
     # Download a Scala 2.12 build of spark
     prepare_spark $SPARK_VER 2.12
@@ -211,9 +205,6 @@ ci_scala213() {
     cd .. # Run integration tests in the project root dir to leverage test cases and resource files
     export TEST_TAGS="not premerge_ci_1"
     export TEST_TYPE="pre-commit"
-    # Calculate parallelism based on GPU memory. When parallelism > 8, as it increases, the test speed will become slower and slower. So we set the maximum parallelism to 8.
-    GPU_MEM_PARALLEL=`nvidia-smi --query-gpu=memory.free --format=csv,noheader | awk '{if (MAX < $1){ MAX = $1}} END {print int((MAX - 2 * 1024) / ((1.5 * 1024) + 750))}'`
-    export TEST_PARALLEL=$(( $GPU_MEM_PARALLEL < 8 ? $GPU_MEM_PARALLEL : 8 ))
     # SPARK_HOME (and related) must be set to a Spark built with Scala 2.13
     SPARK_HOME=$SPARK_HOME PYTHONPATH=$PYTHONPATH \
         ./integration_tests/run_pyspark_from_build.sh


### PR DESCRIPTION
Calculate parallelism based on GPU memory to speed up pre-merge CI with appropriate amount of parallelism.

But when TMP_PARALLEL > 8 and as it increases, the integration tests running speed will become slower and slower, so we limit TMP_PARALLEL <= 8.

Based on this change, and ran pre-merge CI on powerful nodes, we observed the pre-merge CI 1 hour less than on common nodes.

    16 CPU/128G Mem/24G GPU : [2hours]  VS
    8  CPU/64G  Mem/16G GPU : [3hours]

![image](https://github.com/NVIDIA/spark-rapids/assets/50287591/48dad4a0-59df-4cdf-a388-1d87a1bee472)

Note: currently we only have 3 fixed powerful nodes for the pre-merge CI job, so only 1 pre-merge CI be speeded up at the same time.

I'll specify the powerful nodes on our internal Jenkins to speed up pre-merge CI, after this PR get merged.