### PR TITLE
Add spark343 shim for scala2.13 dist jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -886,6 +886,7 @@
             340,
             341,
             342,
+            343,
             350,
             351
         </noSnapshotScala213.buildvers>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -886,6 +886,7 @@
             340,
             341,
             342,
+            343,
             350,
             351
         </noSnapshotScala213.buildvers>


### PR DESCRIPTION
We missed spark343 shim for the scala2.13 dist jar on branch-24.06.

Add scala2.13 spark343 shim for v24.06.0
    


Signed-off-by: Tim Liu <timl@nvidia.com>