### PR TITLE
fix duplicate counted metrics like op time for GpuCoalesceBatches

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCoalesceBatches.scala
@@ -462,7 +462,7 @@ abstract class AbstractGpuCoalesceIterator(
         // If we have reached the cuDF limit once, proactively filter batches
         // after that first limit is reached.
         GpuFilter.filterAndClose(cbFromIter, inputFilterTier.get,
-          NoopMetric, NoopMetric, opTime)
+          NoopMetric, NoopMetric, NoopMetric)
       } else {
         Iterator(cbFromIter)
       }
@@ -499,7 +499,7 @@ abstract class AbstractGpuCoalesceIterator(
                     var filteredBytes = 0L
                     if (hasAnyToConcat) {
                       val filteredDowIter = GpuFilter.filterAndClose(concatAllAndPutOnGPU(),
-                        filterTier, NoopMetric, NoopMetric, opTime)
+                        filterTier, NoopMetric, NoopMetric, NoopMetric)
                       while (filteredDowIter.hasNext) {
                         closeOnExcept(filteredDowIter.next()) { filteredDownCb =>
                           filteredNumRows += filteredDownCb.numRows()
@@ -512,7 +512,7 @@ abstract class AbstractGpuCoalesceIterator(
                     // filterAndClose takes ownership of CB so we should not close it on a failure
                     // anymore...
                     val filteredCbIter = GpuFilter.filterAndClose(cb.release, filterTier,
-                      NoopMetric, NoopMetric, opTime)
+                      NoopMetric, NoopMetric, NoopMetric)
                     while (filteredCbIter.hasNext) {
                       closeOnExcept(filteredCbIter.next()) { filteredCb =>
                         val filteredWouldBeRows = filteredNumRows + filteredCb.numRows()

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -153,13 +153,15 @@ sealed abstract class GpuMetric extends Serializable {
   def add(v: Long): Unit
 
   final def ns[T](f: => T): T = {
-    ThreadLocalMetrics.onMetricsEnter(this)
+    val needTrack = ThreadLocalMetrics.onMetricsEnter(this)
     val start = System.nanoTime()
     try {
       f
     } finally {
-      add(System.nanoTime() - start)
-      ThreadLocalMetrics.onMetricsExit(this)
+      if (needTrack) {
+        add(System.nanoTime() - start)
+        ThreadLocalMetrics.onMetricsExit(this)
+      }
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExec.scala
@@ -153,11 +153,13 @@ sealed abstract class GpuMetric extends Serializable {
   def add(v: Long): Unit
 
   final def ns[T](f: => T): T = {
+    ThreadLocalMetrics.onMetricsEnter(this)
     val start = System.nanoTime()
     try {
       f
     } finally {
       add(System.nanoTime() - start)
+      ThreadLocalMetrics.onMetricsExit(this)
     }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
@@ -58,7 +58,7 @@ object ThreadLocalMetrics {
   def onMetricsExit(gpuMetric: GpuMetric): Unit = {
     if (gpuMetric != NoopMetric) {
       if (!ThreadLocalMetrics.currentThreadMetrics.get().contains(gpuMetric)) {
-        throw new IllegalStateException()("Metric missing from thread local storage: "
+        throw new IllegalStateException("Metric missing from thread local storage: "
           + gpuMetric)
       }
       ThreadLocalMetrics.currentThreadMetrics.get().remove(gpuMetric)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/NvtxWithMetrics.scala
@@ -58,7 +58,7 @@ object ThreadLocalMetrics {
   def onMetricsExit(gpuMetric: GpuMetric): Unit = {
     if (gpuMetric != NoopMetric) {
       if (!ThreadLocalMetrics.currentThreadMetrics.get().contains(gpuMetric)) {
-        throw new IllegalArgumentException("Metric missing from thread local storage: "
+        throw new IllegalStateException()("Metric missing from thread local storage: "
           + gpuMetric)
       }
       ThreadLocalMetrics.currentThreadMetrics.get().remove(gpuMetric)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import com.nvidia.spark.rapids.Arm.withResource
+import org.scalatest.funsuite.AnyFunSuite
+
+class MetricsSuite extends AnyFunSuite {
+
+  test("duplicate timing on the same metrics") {
+    val m1 = new LocalGpuMetric()
+    val m2 = new LocalGpuMetric()
+    withResource(new MetricRange(m1, m2)) { _ =>
+      withResource(new MetricRange(m2, m1)) { _ =>
+        Thread.sleep(100)
+      }
+    }
+
+    // if the timing is duplicated, the value should be around 200,000,000
+    assert(m1.value < 100000000 * 1.5)
+    assert(m2.value < 100000000 * 1.5)
+  }
+}


### PR DESCRIPTION
We observed that `op time` metrics for GpuCoalesceBatches is often larger than expected.
After some digging I found that in some cases GpuMetrics will be duplicately counted. (a test case example is shown in the PR)

I tried to to fix the duplicate issue GpuCoalesceBatches, but I have no idea how many other duplicates are there for other operators. So I refined NvtxWithMetrics, MetricRange and GpuMetric#ns a little bit to avoid duplicate counting elapsed time.

closes https://github.com/NVIDIA/spark-rapids/issues/11063