### PR TITLE
Workaround numpy2 failed fastparquet compatibility tests [databricks]

### DIFF
--- a/integration_tests/src/main/python/fastparquet_compatibility_test.py
+++ b/integration_tests/src/main/python/fastparquet_compatibility_test.py
@@ -30,6 +30,8 @@ def fastparquet_unavailable():
         return False
     except ImportError:
         return True
+    except ValueError: # TODO: remove when https://github.com/NVIDIA/spark-rapids/issues/11070 is fixed
+        return True
 
 
 rebase_write_corrected_conf = {


### PR DESCRIPTION
workaround to skip fastparquet_compatibility_test if incompatibility`ValueError`
before we figure out how should we fix #11070. 

this will unblock all CI relying on integration tests.