### PR TITLE
Fix Python runtime error caused by numpy 2.0.0 release [databricks]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 pytest
 sre_yield
-pandas
-pyarrow
+numpy <= 1.24.4
+pandas == 1.4.3
+pyarrow == 16.1.0
 pytest-xdist >= 2.0.0
 findspark
 fastparquet == 0.8.3


### PR DESCRIPTION
Signed-off-by: Ahmed Hussein (amahussein) <a@ahussein.me>

Fixes #11070

- pin numpy to 1.24.4 which is the latest version to support python3.8. This implies that we drop support to python 3.12
- pin pandas to 1.4.3 which works for python3.8-3.10
- pin pyArrow to 16.1.0 which works for both numpy 1.0 and 2.0