### PR TITLE
Improve the diagnostics for 'conv' fallback explain

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2060,8 +2060,8 @@ class GpuConvMeta(
       case (Some(Literal(fromBaseVal, IntegerType)), Some(Literal(toBaseVal, IntegerType)))
         if Set(fromBaseVal, toBaseVal).subsetOf(Set(10, 16)) => ()
       case _ =>
-        (willNotWorkOnGpu(because = s"either ${fromBaseLit.getOrElse(Nil)} or " +
-          s"${toBaseLit.getOrElse(Nil)} is not supported; only literal 10 or 16 for " +
+        (willNotWorkOnGpu(because = s"either ${fromBaseLit.getOrElse("''")} or " +
+          s"${toBaseLit.getOrElse("''")} is not supported; only literal 10 or 16 for " +
           "from_base and to_base are supported"))
     }
   }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2060,7 +2060,9 @@ class GpuConvMeta(
       case (Some(Literal(fromBaseVal, IntegerType)), Some(Literal(toBaseVal, IntegerType)))
         if Set(fromBaseVal, toBaseVal).subsetOf(Set(10, 16)) => ()
       case _ =>
-        willNotWorkOnGpu(because = "only literal 10 or 16 for from_base and to_base are supported")
+        (willNotWorkOnGpu(because = s"either ${fromBaseLit.getOrElse(Nil)} or " +
+          s"${toBaseLit.getOrElse(Nil)} is not supported; only literal 10 or 16 for " +
+          "from_base and to_base are supported"))
     }
   }
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2059,10 +2059,7 @@ class GpuConvMeta(
     val errorPostfix = "only literal 10 or 16 are supported for source and target radixes"
     (fromBaseLit, toBaseLit) match {
       case (Some(Literal(fromBaseVal, IntegerType)), Some(Literal(toBaseVal, IntegerType))) =>
-        def isBaseSupported(base: Any): Boolean = base match {
-          case 10 | 16 => true
-          case _ => false
-        }
+        def isBaseSupported(base: Any): Boolean = base == 10 || base == 16
         if (!isBaseSupported(fromBaseVal) && !isBaseSupported(toBaseVal)) {
           willNotWorkOnGpu(because = s"both ${fromBaseVal} and ${toBaseVal} are not " +
             s"a supported radix, ${errorPostfix}")

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/stringFunctions.scala
@@ -2056,24 +2056,28 @@ class GpuConvMeta(
   override def tagExprForGpu(): Unit = {
     val fromBaseLit = GpuOverrides.extractLit(expr.fromBaseExpr)
     val toBaseLit = GpuOverrides.extractLit(expr.toBaseExpr)
-    val errorPostfix = "only literal 10 or 16 for from_base and to_base are supported"
+    val errorPostfix = "only literal 10 or 16 are supported for source and target radixes"
     (fromBaseLit, toBaseLit) match {
       case (Some(Literal(fromBaseVal, IntegerType)), Some(Literal(toBaseVal, IntegerType))) =>
-        val isBaseSupported = (base: Any) => base match {
+        def isBaseSupported(base: Any): Boolean = base match {
           case 10 | 16 => true
           case _ => false
         }
-        if (!isBaseSupported(fromBaseVal) || !isBaseSupported(toBaseVal)) {
-          willNotWorkOnGpu(because = s"either ${fromBaseVal} or ${toBaseVal} is not supported; " +
+        if (!isBaseSupported(fromBaseVal) && !isBaseSupported(toBaseVal)) {
+          willNotWorkOnGpu(because = s"both ${fromBaseVal} and ${toBaseVal} are not " +
+            s"a supported radix, ${errorPostfix}")
+        } else if (!isBaseSupported(fromBaseVal)) {
+          willNotWorkOnGpu(because = s"${fromBaseVal} is not a supported source radix, " +
             s"${errorPostfix}")
-        } else {
-          ()
+        } else if (!isBaseSupported(toBaseVal)) {
+          willNotWorkOnGpu(because = s"${toBaseVal} is not a supported target radix, " +
+            s"${errorPostfix}")
         }
       case _ =>
         // This will never happen in production as the function signature enforces
         // integer types for the bases, but nice to have an edge case handling.
-        (willNotWorkOnGpu(because = "either from_base or to_base is not an integer literal; " +
-          errorPostfix))
+        willNotWorkOnGpu(because = "either source radix or target radix is not an integer " +
+          "literal, " + errorPostfix)
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->

Fixes https://github.com/NVIDIA/spark-rapids/issues/9340. 

This PR improves the diagnosis message for the 'conv' function, so that it includes the unsupported base value in the message.

Signed-off-by: Jihoon Son <ghoonson@gmail.com>