### PR TITLE
Exclude a case based on JDK version in Spark UT

### DIFF
--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/BackendTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/BackendTestSettings.scala
@@ -86,6 +86,19 @@ abstract class BackendTestSettings {
   case class ADJUST_UT(reason: String) extends ExcludeReason
   case class WONT_FIX_ISSUE(reason: String) extends ExcludeReason
 
+  protected def getJavaMajorVersion(): Int = {
+    val version = System.getProperty("java.version")
+    // Allow these formats:
+    // 1.8.0_72-ea
+    // 9-ea
+    // 9
+    // 11.0.1
+    val versionRegex = """(1\.)?(\d+)([._].+)?""".r
+    version match {
+      case versionRegex(_, major, _) => major.toInt
+      case _ => throw new IllegalStateException(s"Cannot parse java version: $version")
+    }
+  }
 
   final protected class SuiteSettings {
     private[utils] val inclusion: util.List[IncludeBase] = new util.ArrayList()
@@ -96,42 +109,54 @@ abstract class BackendTestSettings {
       inclusion.add(Include(testNames: _*))
       this
     }
-    def exclude(testNames: String, reason: ExcludeReason): SuiteSettings = {
-      exclusion.add(Exclude(testNames))
-      excludeReasons.add(reason)
+
+    def exclude(testNames: String, reason: ExcludeReason, condition: Boolean = true): 
+        SuiteSettings = {
+      if (condition) {
+        exclusion.add(Exclude(testNames))
+        excludeReasons.add(reason)
+      }
       this
     }
+
     def includeRapidsTest(testName: String*): SuiteSettings = {
       inclusion.add(IncludeRapidsTest(testName: _*))
       this
     }
+
     def excludeRapidsTest(testName: String, reason: ExcludeReason): SuiteSettings = {
       exclusion.add(ExcludeRapidsTest(testName))
       excludeReasons.add(reason)
       this
     }
+
     def includeByPrefix(prefixes: String*): SuiteSettings = {
       inclusion.add(IncludeByPrefix(prefixes: _*))
       this
     }
+
     def excludeByPrefix(prefixes: String, reason: ExcludeReason): SuiteSettings = {
       exclusion.add(ExcludeByPrefix(prefixes))
       excludeReasons.add(reason)
       this
     }
+
     def includeRapidsTestsByPrefix(prefixes: String*): SuiteSettings = {
       inclusion.add(IncludeRapidsTestByPrefix(prefixes: _*))
       this
     }
+
     def excludeRapidsTestsByPrefix(prefixes: String, reason: ExcludeReason): SuiteSettings = {
       exclusion.add(ExcludeRadpisTestByPrefix(prefixes))
       excludeReasons.add(reason)
       this
     }
+
     def includeAllRapidsTests(): SuiteSettings = {
       inclusion.add(IncludeByPrefix(RAPIDS_TEST))
       this
     }
+
     def excludeAllRapidsTests(reason: ExcludeReason): SuiteSettings = {
       exclusion.add(ExcludeByPrefix(RAPIDS_TEST))
       excludeReasons.add(reason)
@@ -142,25 +167,31 @@ abstract class BackendTestSettings {
   protected trait IncludeBase {
     def isIncluded(testName: String): Boolean
   }
+
   protected trait ExcludeBase {
     def isExcluded(testName: String): Boolean
   }
+
   private case class Include(testNames: String*) extends IncludeBase {
     val nameSet: Set[String] = Set(testNames: _*)
     override def isIncluded(testName: String): Boolean = nameSet.contains(testName)
   }
+
   private case class Exclude(testNames: String*) extends ExcludeBase {
     val nameSet: Set[String] = Set(testNames: _*)
     override def isExcluded(testName: String): Boolean = nameSet.contains(testName)
   }
+
   private case class IncludeRapidsTest(testNames: String*) extends IncludeBase {
     val nameSet: Set[String] = testNames.map(name => RAPIDS_TEST + name).toSet
     override def isIncluded(testName: String): Boolean = nameSet.contains(testName)
   }
+
   private case class ExcludeRapidsTest(testNames: String*) extends ExcludeBase {
     val nameSet: Set[String] = testNames.map(name => RAPIDS_TEST + name).toSet
     override def isExcluded(testName: String): Boolean = nameSet.contains(testName)
   }
+
   private case class IncludeByPrefix(prefixes: String*) extends IncludeBase {
     override def isIncluded(testName: String): Boolean = {
       if (prefixes.exists(prefix => testName.startsWith(prefix))) {
@@ -169,6 +200,7 @@ abstract class BackendTestSettings {
       false
     }
   }
+
   private case class ExcludeByPrefix(prefixes: String*) extends ExcludeBase {
     override def isExcluded(testName: String): Boolean = {
       if (prefixes.exists(prefix => testName.startsWith(prefix))) {
@@ -177,6 +209,7 @@ abstract class BackendTestSettings {
       false
     }
   }
+
   private case class IncludeRapidsTestByPrefix(prefixes: String*) extends IncludeBase {
     override def isIncluded(testName: String): Boolean = {
       if (prefixes.exists(prefix => testName.startsWith(RAPIDS_TEST + prefix))) {
@@ -185,6 +218,7 @@ abstract class BackendTestSettings {
       false
     }
   }
+
   private case class ExcludeRadpisTestByPrefix(prefixes: String*) extends ExcludeBase {
     override def isExcluded(testName: String): Boolean = {
       if (prefixes.exists(prefix => testName.startsWith(RAPIDS_TEST + prefix))) {

--- a/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
+++ b/tests/src/test/spark330/scala/org/apache/spark/sql/rapids/utils/RapidsTestSettings.scala
@@ -42,7 +42,7 @@ class RapidsTestSettings extends BackendTestSettings {
     .exclude("collect functions should be able to cast to array type with no null values", ADJUST_UT("order of elements in the array is non-deterministic in collect"))
     .exclude("SPARK-17641: collect functions should not collect null values", ADJUST_UT("order of elements in the array is non-deterministic in collect"))
     .exclude("SPARK-19471: AggregationIterator does not initialize the generated result projection before using it", WONT_FIX_ISSUE("Codegen related UT, not applicable for GPU"))
-    .exclude("SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10801"))
+    .exclude("SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10801"), (getJavaMajorVersion() >= 17))
   enableSuite[RapidsJsonExpressionsSuite]
     .exclude("from_json - invalid data", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10849"))
     .exclude("from_json - input=empty array, schema=struct, output=single row with null", KNOWN_ISSUE("https://github.com/NVIDIA/spark-rapids/issues/10849"))


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/10801
Closes https://github.com/NVIDIA/spark-rapids/issues/10889

This PR supports excluding a case based on JDK version in Spark UT and excluding "SPARK-24788: RelationalGroupedDataset.toString with unresolved exprs should not fail" on JDK 17 only.

Also cleaned up some code.

For this case in 330 limit jdk version is enough, we can add support for excluding a case based on Scala version easily if needed.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
