### PR TITLE
Support regex patterns with brackets when rewriting to PrefixRange pattern in rlike.

### DIFF
--- a/integration_tests/src/main/python/regexp_test.py
+++ b/integration_tests/src/main/python/regexp_test.py
@@ -468,6 +468,8 @@ def test_rlike_rewrite_optimization():
                 'rlike(a, "a[a-c]{1,3}")',
                 'rlike(a, "a[a-c]{1,}")',
                 'rlike(a, "a[a-c]+")',
+                'rlike(a, "(ab)([a-c]{1})")',
+                'rlike(a, "(ab[a-c]{1})")',
                 'rlike(a, "(aaa|bbb|ccc)")',
                 'rlike(a, ".*.*(aaa|bbb).*.*")',
                 'rlike(a, "^.*(aaa|bbb|ccc)")',

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -2051,8 +2051,8 @@ object RegexRewrite {
       Option[(String, Int, Int, Int)] = {
     val haveLiteralPrefix = isLiteralString(astLs.dropRight(1))
     val endsWithRange = astLs.lastOption match {
-      case Some(ast) => removeBrackets(Seq(ast)) match {
-        case Seq(RegexRepetition(
+      case Some(ast) => removeBrackets(collection.Seq(ast)) match {
+        case collection.Seq(RegexRepetition(
             RegexCharacterClass(false, ListBuffer(RegexCharacterRange(a,b))), 
             quantifier)) => {
           val (start, end) = (a, b) match {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RegexParser.scala
@@ -2035,7 +2035,7 @@ object RegexRewrite {
   @scala.annotation.tailrec
   private def removeBrackets(astLs: collection.Seq[RegexAST]): collection.Seq[RegexAST] = {
     astLs match {
-      case collection.Seq(RegexGroup(_, term, None)) => removeBrackets(term.children())
+      case collection.Seq(RegexGroup(_, RegexSequence(terms), None)) => removeBrackets(terms)
       case _ => astLs
     }
   }
@@ -2051,28 +2051,31 @@ object RegexRewrite {
       Option[(String, Int, Int, Int)] = {
     val haveLiteralPrefix = isLiteralString(astLs.dropRight(1))
     val endsWithRange = astLs.lastOption match {
-      case Some(RegexRepetition(
-          RegexCharacterClass(false, ListBuffer(RegexCharacterRange(a,b))), 
-          quantifier)) => {
-        val (start, end) = (a, b) match {
-          case (RegexChar(start), RegexChar(end)) => (start, end)
-          case _ => return None
-        }
-        val length = quantifier match {
-          // In Rlike, contains [a-b]{minLen,maxLen} pattern is equivalent to contains 
-          // [a-b]{minLen} because the matching will return the result once it finds the 
-          // minimum match so y here is unnecessary.
-          case QuantifierVariableLength(minLen, _) => minLen
-          case QuantifierFixedLength(len) => len
-          case SimpleQuantifier(ch) => ch match {
-            case '*' | '?' => 0
-            case '+' => 1
+      case Some(ast) => removeBrackets(Seq(ast)) match {
+        case Seq(RegexRepetition(
+            RegexCharacterClass(false, ListBuffer(RegexCharacterRange(a,b))), 
+            quantifier)) => {
+          val (start, end) = (a, b) match {
+            case (RegexChar(start), RegexChar(end)) => (start, end)
             case _ => return None
           }
-          case _ => return None
+          val length = quantifier match {
+            // In Rlike, contains [a-b]{minLen,maxLen} pattern is equivalent to contains 
+            // [a-b]{minLen} because the matching will return the result once it finds the 
+            // minimum match so y here is unnecessary.
+            case QuantifierVariableLength(minLen, _) => minLen
+            case QuantifierFixedLength(len) => len
+            case SimpleQuantifier(ch) => ch match {
+              case '*' | '?' => 0
+              case '+' => 1
+              case _ => return None
+            }
+            case _ => return None
+          }
+          // Convert start and end to code points
+          Some((length, start.toInt, end.toInt))
         }
-        // Convert start and end to code points
-        Some((length, start.toInt, end.toInt))
+        case _ => None
       }
       case _ => None
     }
@@ -2153,7 +2156,7 @@ object RegexRewrite {
       }
     }
 
-    val noStartsWithAst = stripLeadingWildcards(noTailingWildcards)
+    val noStartsWithAst = removeBrackets(stripLeadingWildcards(noTailingWildcards))
 
     // Check if the pattern is a contains literal pattern
     if (isLiteralString(noStartsWithAst)) {

--- a/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionRewriteSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/RegularExpressionRewriteSuite.scala
@@ -52,6 +52,8 @@ class RegularExpressionRewriteSuite extends AnyFunSuite {
       "(.*)abc[0-9]{1,3}(.*)",
       "(.*)abc[0-9a-z]{1,3}(.*)",
       "(.*)abc[0-9]{2}.*",
+      "((abc))([0-9]{3})",
+      "(abc[0-9]{3})",
       "^abc[0-9]{1,3}",
       "火花急流[\u4e00-\u9fa5]{1}",
       "^[0-9]{6}",
@@ -63,6 +65,8 @@ class RegularExpressionRewriteSuite extends AnyFunSuite {
       PrefixRange("abc", 1, 48, 57),
       NoOptimization, // prefix followed by a multi-range not supported
       PrefixRange("abc", 2, 48, 57),
+      PrefixRange("abc", 3, 48, 57),
+      PrefixRange("abc", 3, 48, 57),
       NoOptimization, // starts with PrefixRange not supported
       PrefixRange("火花急流", 1, 19968, 40869),
       NoOptimization, // starts with PrefixRange not supported


### PR DESCRIPTION
Closes https://github.com/NVIDIA/spark-rapids/issues/11087

This PR supports regex patterns with brackets when rewriting to PrefixRange pattern in rlike. After this PR, patterns like `((abc))([0-9]{3})` and `(abc[0-9]{3})` can be optimized by regex rewrite.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
