### PR TITLE
Fix miscellaneous integ tests for Spark 4 [databricks]

### DIFF
--- a/integration_tests/src/main/python/date_time_test.py
+++ b/integration_tests/src/main/python/date_time_test.py
@@ -17,7 +17,7 @@ from asserts import assert_gpu_and_cpu_are_equal_collect, assert_gpu_fallback_co
 from conftest import is_utc, is_supported_time_zone, get_test_tz
 from data_gen import *
 from datetime import date, datetime, timezone
-from marks import ignore_order, incompat, allow_non_gpu, datagen_overrides, tz_sensitive_test
+from marks import allow_non_gpu, datagen_overrides, disable_ansi_mode, ignore_order, incompat, tz_sensitive_test
 from pyspark.sql.types import *
 from spark_session import with_cpu_session, is_before_spark_330, is_before_spark_350
 import pyspark.sql.functions as f
@@ -91,6 +91,8 @@ def test_timesub_from_subquery(data_gen):
 
     assert_gpu_and_cpu_are_equal_collect(fun)
 
+
+@disable_ansi_mode  # ANSI mode tested separately.
 # Should specify `spark.sql.legacy.interval.enabled` to test `DateAddInterval` after Spark 3.2.0,
 # refer to https://issues.apache.org/jira/browse/SPARK-34896
 # [SPARK-34896][SQL] Return day-time interval from dates subtraction
@@ -437,6 +439,8 @@ def test_string_unix_timestamp_ansi_exception():
         error_message="Exception",
         conf=ansi_enabled_conf)
 
+
+@disable_ansi_mode  # ANSI mode is tested separately.
 @tz_sensitive_test
 @pytest.mark.skipif(not is_supported_time_zone(), reason="not all time zones are supported now, refer to https://github.com/NVIDIA/spark-rapids/issues/6839, please update after all time zones are supported")
 @pytest.mark.parametrize('parser_policy', ["CORRECTED", "EXCEPTION"], ids=idfn)
@@ -561,6 +565,8 @@ def test_date_format_maybe_incompat(data_gen, date_format):
     assert_gpu_and_cpu_are_equal_collect(
         lambda spark : unary_op_df(spark, data_gen).selectExpr("date_format(a, '{}')".format(date_format)), conf)
 
+
+@disable_ansi_mode  # ANSI mode tested separately.
 # Reproduce conditions for https://github.com/NVIDIA/spark-rapids/issues/5670
 # where we had a failure due to GpuCast canonicalization with timezone.
 # In this case it was doing filter after project, the way I get that to happen is by adding in the
@@ -594,6 +600,7 @@ def test_unsupported_fallback_date_format(data_gen):
         conf)
 
 
+@disable_ansi_mode  # Failure cases for ANSI mode are tested separately.
 @allow_non_gpu('ProjectExec')
 def test_unsupported_fallback_to_date():
     date_gen = StringGen(pattern="2023-08-01")

--- a/integration_tests/src/main/python/grouping_sets_test.py
+++ b/integration_tests/src/main/python/grouping_sets_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/grouping_sets_test.py
+++ b/integration_tests/src/main/python/grouping_sets_test.py
@@ -41,6 +41,8 @@ _grouping_set_sqls = [
         'GROUP BY a, GROUPING SETS((a, b), (a), (), (a, b), (a), (b), ())',
 ]
 
+
+@disable_ansi_mode  # https://github.com/NVIDIA/spark-rapids/issues/5114
 # test nested syntax of grouping set, rollup and cube
 @ignore_order
 @pytest.mark.parametrize('data_gen', [_grouping_set_gen], ids=idfn)

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/map_test.py
+++ b/integration_tests/src/main/python/map_test.py
@@ -18,7 +18,7 @@ from asserts import *
 from conftest import is_not_utc
 from data_gen import *
 from conftest import is_databricks_runtime
-from marks import allow_non_gpu, ignore_order, datagen_overrides
+from marks import allow_non_gpu, datagen_overrides, disable_ansi_mode, ignore_order
 from spark_session import *
 from pyspark.sql.functions import create_map, col, lit, row_number
 from pyspark.sql.types import *
@@ -138,6 +138,7 @@ numeric_key_map_gens = [MapGen(key, value(), max_length=6)
                         for key in numeric_key_gens for value in get_map_value_gens()]
 
 
+@disable_ansi_mode  # ANSI mode failures are tested separately.
 @pytest.mark.parametrize('data_gen', numeric_key_map_gens, ids=idfn)
 def test_get_map_value_numeric_keys(data_gen):
     key_gen = data_gen._key_gen
@@ -151,6 +152,7 @@ def test_get_map_value_numeric_keys(data_gen):
             'a[999]'))
 
 
+@disable_ansi_mode  # ANSI mode failures are tested separately.
 @pytest.mark.parametrize('data_gen', supported_key_map_gens, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_get_map_value_supported_keys(data_gen):
@@ -174,6 +176,7 @@ def test_get_map_value_fallback_keys(data_gen):
         cpu_fallback_class_name="GetMapValue")
 
 
+@disable_ansi_mode  # ANSI mode failures are tested separately.
 @pytest.mark.parametrize('key_gen', numeric_key_gens, ids=idfn)
 def test_basic_scalar_map_get_map_value(key_gen):
     def query_map_scalar(spark):
@@ -639,6 +642,8 @@ def test_map_element_at_ansi_null(data_gen):
                 'element_at(a, "NOT_FOUND")'),
             conf=ansi_enabled_conf)
 
+
+@disable_ansi_mode  # ANSI mode failures are tested separately.
 @pytest.mark.parametrize('data_gen', map_gens_sample, ids=idfn)
 @allow_non_gpu(*non_utc_allow)
 def test_transform_values(data_gen):


### PR DESCRIPTION
Fixes #11020. (grouping_sets_test.py)
Fixes #11023. (dpp_test.py)
Fixes #11025. (date_time_test.py)
Fixes #11026. (map_test.py)

This commit prepares miscellaneous integration tests to be run on Spark 4.

Certain integration tests fail on Spark 4 because of ANSI mode being enabled by default.  This commit disables ANSI on the failing tests, or introduces other fixes so that the tests may pass correctly.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
