### PR TITLE
Fix ANSI mode failures in subquery_test.py [databricks]

### DIFF
--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -146,7 +146,7 @@ def test_scalar_subquery_array_ansi_mode_failures(spark_tmp_table_factory):
           SELECT SORT_ARRAY(arr),
                  SORT_ARRAY((SELECT LAST(arr) FROM {table_name}))
           FROM {table_name}
-          WHERE (SELECT FIRST(arr) FROM {table_name})[0] > arr[0]
+          WHERE (SELECT CAST(ARRAY() AS ARRAY<BIGINT>))[0] > arr[0]
         '''
         return spark.sql(query)
 

--- a/integration_tests/src/main/python/subquery_test.py
+++ b/integration_tests/src/main/python/subquery_test.py
@@ -86,11 +86,11 @@ def test_scalar_subquery_array(is_ansi_enabled, basic_gen):
     assert_gpu_and_cpu_are_equal_sql(
         # Fix num_slices at 1 to make sure that first/last returns same results under CPU and GPU.
         lambda spark: gen_df(spark, [('arr', test_array_gen)], num_slices=1),
-        'table',
+        'my_array_table',
         '''select sort_array(arr),
-                  sort_array((select last(arr) from table))
-        from table
-        where (select first(arr) from table)[0] > arr[0]
+                  sort_array((select last(arr) from my_array_table))
+        from my_array_table
+        where (select first(arr) from my_array_table)[0] > arr[0]
         ''',
         conf=conf)
 


### PR DESCRIPTION
Fixes #11029.

Some tests in subquery_test.py fail when run with ANSI mode enabled, because certain array columns are accessed with invalid indices. These tests predate the availability of ANSI mode in Spark.

This commit modifies the tests so that the generated data is appropriately sized for the query.

There is no loss of test coverage; failure cases for invalid index values in array columns are already tested as part of `array_test::test_array_item_ansi_fail_invalid_index`.

Edit: An additional (albeit minimal) test for ANSI on/off has been added to represent the removed cases.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
