### PR TITLE
Update Scala2.13 premerge CI against JDK17

### DIFF
--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -40,7 +40,7 @@ ARG UCX_VER
 ARG ARCH=amd64
 ARG UCX_ARCH=x86_64
 
-# Install jdk-8, jdk-11, maven, docker image
+# Install jdk-8, jdk-11, jdk-17, maven, docker image
 RUN apt-get update -y && \
     apt-get install -y software-properties-common rsync
 
@@ -48,7 +48,7 @@ RUN apt-get update -y && \
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y maven \
-    openjdk-8-jdk openjdk-11-jdk python3.9 python3.9-distutils python3-setuptools tzdata git zip unzip wget \
+    openjdk-8-jdk openjdk-11-jdk openjdk-17-jdk python3.9 python3.9-distutils python3-setuptools tzdata git zip unzip wget \
     inetutils-ping expect wget libnuma1 libgomp1 locales
 
 # apt python3-pip would install pip for OS default python3 version only

--- a/jenkins/spark-premerge-build.sh
+++ b/jenkins/spark-premerge-build.sh
@@ -183,6 +183,11 @@ ci_2() {
 
 ci_scala213() {
     echo "Run premerge ci (Scala 2.13) testing..."
+    # Run scala2.13 build and test against JDK17
+    export JAVA_HOME=$(echo /usr/lib/jvm/java-1.17.0-*)
+    update-java-alternatives --set $JAVA_HOME
+    java -version
+
     cd scala2.13
     ln -sf ../jenkins jenkins
 


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/11113

To support Spark 4.0+ shims, we change scala2.13 build and test against JDK17.

