### PR TITLE
parameterize threshold for growth of single pass partial sort agg

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -1315,7 +1315,7 @@ abstract class GpuBaseAggregateMeta[INPUT <: SparkPlan](
     val allowSinglePassAgg = (conf.forceSinglePassPartialSortAgg ||
         (conf.allowSinglePassPartialSortAgg &&
             hasSingleBasicGroupingKey &&
-            estimatedPreProcessGrowth > 1.1)) &&
+            estimatedPreProcessGrowth > conf.singlePassPartialSortAggGrowthThreshold)) &&
         canUsePartialSortAgg &&
         groupingCanBeSorted
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1510,6 +1510,15 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .booleanConf
     .createWithDefault(true)
 
+  val SINGLE_PASS_PARTIAL_SORT_AGG_GROWTH_THRESHOLD: ConfEntryWithDefault[Double] =
+    conf("spark.rapids.sql.agg.singlePassPartialSort.estimatedGrowthThreshold")
+      .doc("Even if spark.rapids.sql.agg.singlePassPartialSortEnabled is true, if the estimated " +
+        "growth of size per row is less than this config, single pass partial sort will not " +
+        "be enabled")
+      .internal()
+      .doubleConf
+      .createWithDefault(1.1)
+
   val SKIP_AGG_PASS_REDUCTION_RATIO = conf("spark.rapids.sql.agg.skipAggPassReductionRatio")
     .doc("In non-final aggregation stages, if the previous pass has a row reduction ratio " +
         "greater than this value, the next aggregation pass will be skipped." +
@@ -3097,6 +3106,9 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val batchedBoundedRowsWindowMax: Int = get(BATCHED_BOUNDED_ROW_WINDOW_MAX)
 
   lazy val allowSinglePassPartialSortAgg: Boolean = get(ENABLE_SINGLE_PASS_PARTIAL_SORT_AGG)
+
+  lazy val singlePassPartialSortAggGrowthThreshold: Double =
+    get(SINGLE_PASS_PARTIAL_SORT_AGG_GROWTH_THRESHOLD)
 
   lazy val forceSinglePassPartialSortAgg: Boolean = get(FORCE_SINGLE_PASS_PARTIAL_SORT_AGG)
 


### PR DESCRIPTION
add a config called spark.rapids.sql.agg.singlePassPartialSort.estimatedGrowthThreshold. (default value 1.1)

Even if spark.rapids.sql.agg.singlePassPartialSortEnabled is true, if the estimated growth of size per row is less than this config, single pass partial sort will not be enabled.

This PR has no related issue yet, we'll evaluate the necessarity first at customer side
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
