### PR TITLE
Coalesce batches after a logical coalesce operation

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -1281,6 +1281,8 @@ case class GpuCoalesceExec(numPartitions: Int, child: SparkPlan)
       rdd.coalesce(numPartitions, shuffle = false)
     }
   }
+
+  override val coalesceAfter: Boolean = true
 }
 
 object GpuCoalesceExec {


### PR DESCRIPTION
I don't know how important this is in practice, but it definitely helps in some contrived cases.