### PR TITLE
Fix `test_window_group_limits_fallback` [databricks]

### DIFF
--- a/integration_tests/src/main/python/window_function_test.py
+++ b/integration_tests/src/main/python/window_function_test.py
@@ -2102,8 +2102,8 @@ def test_window_aggs_for_batched_finite_row_windows_fallback(data_gen):
                                       ],
                          ids=idfn)
 @pytest.mark.parametrize('rank_clause', [
-                            'RANK() OVER (PARTITION BY a ORDER BY b) ',
-                            'DENSE_RANK() OVER (PARTITION BY a ORDER BY b) ',
+                            'RANK() OVER (PARTITION BY a ORDER BY b, c) ',
+                            'DENSE_RANK() OVER (PARTITION BY a ORDER BY b, c) ',
                             'RANK() OVER (ORDER BY a,b,c) ',
                             'DENSE_RANK() OVER (ORDER BY a,b,c) ',
                         ])
@@ -2151,7 +2151,7 @@ def test_window_group_limits_fallback_for_row_number():
     data_gen = _grpkey_longs_with_no_nulls
     query = """
         SELECT * FROM (
-          SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rnk
+          SELECT *, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b, c) AS rnk
           FROM window_agg_table
         )
         WHERE rnk < 3


### PR DESCRIPTION
Fixes #11119.

`test_window_group_limits_fallback_for_row_number` can fail non-deterministically when run against a multi-node Spark cluster.  This is because the ordering of the input is non-deterministic when multiple null rows are included.

The tests have been changed for deterministic ordering, by including a unique order by column.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
