### PR TITLE
Update fastparquet to 2024.5.0 for numpy2 compatibility [databricks]

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -15,6 +15,7 @@ pytest
 sre_yield
 pandas
 pyarrow
-pytest-xdist >= 2.0.0
+pytest-xdist>=2.0.0
 findspark
-fastparquet == 2024.5.0
+fastparquet==0.8.3;python_version=='3.8'
+fastparquet==2024.5.0;python_version>='3.9'

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -17,4 +17,4 @@ pandas
 pyarrow
 pytest-xdist >= 2.0.0
 findspark
-fastparquet == 0.8.3
+fastparquet == 2024.5.0

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@ pytest
 sre_yield
 pandas
 pyarrow
-pytest-xdist>=2.0.0
+pytest-xdist >= 2.0.0
 findspark
-fastparquet==0.8.3;python_version=='3.8'
-fastparquet==2024.5.0;python_version>='3.9'
+fastparquet == 0.8.3 ; python_version == '3.8'
+fastparquet == 2024.5.0 ; python_version >= '3.9'

--- a/integration_tests/src/main/python/fastparquet_compatibility_test.py
+++ b/integration_tests/src/main/python/fastparquet_compatibility_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration_tests/src/main/python/fastparquet_compatibility_test.py
+++ b/integration_tests/src/main/python/fastparquet_compatibility_test.py
@@ -30,8 +30,6 @@ def fastparquet_unavailable():
         return False
     except ImportError:
         return True
-    except ValueError: # TODO: remove when https://github.com/NVIDIA/spark-rapids/issues/11070 is fixed
-        return True
 
 
 rebase_write_corrected_conf = {

--- a/jenkins/Dockerfile-blossom.integration.rocky
+++ b/jenkins/Dockerfile-blossom.integration.rocky
@@ -57,7 +57,7 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 # install pytest plugins for xdist parallel run
-RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==0.8.3
+RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==2024.5.0
 
 # Set default java as 1.8.0
 ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-openjdk"

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/Dockerfile-blossom.integration.ubuntu
+++ b/jenkins/Dockerfile-blossom.integration.ubuntu
@@ -69,7 +69,7 @@ RUN export CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f 1,2` && \
     conda install -y -c conda-forge sre_yield && \
     conda clean -ay
 # install pytest plugins for xdist parallel run
-RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==0.8.3
+RUN python -m pip install findspark pytest-xdist pytest-order fastparquet==2024.5.0
 
 RUN apt install -y inetutils-ping expect
 

--- a/jenkins/Dockerfile-blossom.ubuntu
+++ b/jenkins/Dockerfile-blossom.ubuntu
@@ -61,7 +61,7 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-${ARCH}
 
 RUN ln -sfn /usr/bin/python3.9 /usr/bin/python
 RUN ln -sfn /usr/bin/python3.9 /usr/bin/python3
-RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit pytest-order fastparquet==0.8.3
+RUN python -m pip install pytest sre_yield requests pandas pyarrow findspark pytest-xdist pre-commit pytest-order fastparquet==2024.5.0
 
 RUN UCX_CUDA_VER=`echo ${CUDA_VER} | cut -d '.' -f1` && \
     mkdir -p /tmp/ucx && \

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -53,4 +53,4 @@ $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES pytest sre_yield r
 
 # Install fastparquet (and numpy as its dependency).
 $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES numpy
-$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES fastparquet==0.8.3
+$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES fastparquet==2024.5.0

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -52,4 +52,5 @@ PYTHON_SITE_PACKAGES="$HOME/.local/lib/${PYTHON_VERSION}/site-packages"
 $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES pytest sre_yield requests pandas pyarrow findspark pytest-xdist pytest-order
 
 # Install fastparquet (and numpy as its dependency).
-$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES numpy fastparquet==2024.5.0
+echo -e "fastparquet==0.8.3;python_version=='3.8'\nfastparquet==2024.5.0;python_version>='3.9'" > fastparquet.txt
+$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES -r fastparquet.txt

--- a/jenkins/databricks/setup.sh
+++ b/jenkins/databricks/setup.sh
@@ -52,5 +52,4 @@ PYTHON_SITE_PACKAGES="$HOME/.local/lib/${PYTHON_VERSION}/site-packages"
 $PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES pytest sre_yield requests pandas pyarrow findspark pytest-xdist pytest-order
 
 # Install fastparquet (and numpy as its dependency).
-$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES numpy
-$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES fastparquet==2024.5.0
+$PYSPARK_PYTHON -m pip install --target $PYTHON_SITE_PACKAGES numpy fastparquet==2024.5.0


### PR DESCRIPTION
try fix #11070 

1. update fastparquet to 2024.5.0 based on https://github.com/numpy/numpy/issues/26191
2. keep fastparquet 0.8.3 for python 3.8 only (databricks 11.x,12.x runtime)
3. revert the previous WAR to check if all tests work fine