### PR TITLE
Improve MetricsSuite to allow more gc jitter [databricks]

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
@@ -26,12 +26,12 @@ class MetricsSuite extends AnyFunSuite {
     val m1 = new LocalGpuMetric()
     m1.ns(
       m1.ns(
-        Thread.sleep(100)
+        Thread.sleep(1000)
       )
     )
     // if the timing is duplicated, the value should be around 200,000,000
-    assert(m1.value < 100000000 * 1.5)
-    assert(m1.value > 100000000 * 0.5)
+    assert(m1.value < 1000000000 * 1.9)
+    assert(m1.value > 1000000000 * 0.5)
   }
 
   test("MetricRange: duplicate timing on the same metrics") {
@@ -39,15 +39,15 @@ class MetricsSuite extends AnyFunSuite {
     val m2 = new LocalGpuMetric()
     withResource(new MetricRange(m1, m2)) { _ =>
       withResource(new MetricRange(m2, m1)) { _ =>
-        Thread.sleep(100)
+        Thread.sleep(1000)
       }
     }
 
     // if the timing is duplicated, the value should be around 200,000,000
-    assert(m1.value < 100000000 * 1.5)
-    assert(m1.value > 100000000 * 0.5)
-    assert(m2.value < 100000000 * 1.5)
-    assert(m2.value > 100000000 * 0.5)
+    assert(m1.value < 1000000000 * 1.9)
+    assert(m1.value > 1000000000 * 0.5)
+    assert(m2.value < 1000000000 * 1.9)
+    assert(m2.value > 1000000000 * 0.5)
   }
 
   test("NvtxWithMetrics: duplicate timing on the same metrics") {
@@ -55,14 +55,14 @@ class MetricsSuite extends AnyFunSuite {
     val m2 = new LocalGpuMetric()
     withResource(new NvtxWithMetrics("a", NvtxColor.BLUE, m1, m2)) { _ =>
       withResource(new NvtxWithMetrics("b", NvtxColor.BLUE, m2, m1)) { _ =>
-        Thread.sleep(100)
+        Thread.sleep(1000)
       }
     }
 
     // if the timing is duplicated, the value should be around 200,000,000
-    assert(m1.value < 100000000 * 1.5)
-    assert(m1.value > 100000000 * 0.5)
-    assert(m2.value < 100000000 * 1.5)
-    assert(m2.value > 100000000 * 0.5)
+    assert(m1.value < 1000000000 * 1.9)
+    assert(m1.value > 1000000000 * 0.5)
+    assert(m2.value < 1000000000 * 1.9)
+    assert(m2.value > 1000000000 * 0.5)
   }
 }

--- a/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/MetricsSuite.scala
@@ -29,7 +29,7 @@ class MetricsSuite extends AnyFunSuite {
         Thread.sleep(1000)
       )
     )
-    // if the timing is duplicated, the value should be around 200,000,000
+    // if the timing is duplicated, the value should be around 2,000,000,000
     assert(m1.value < 1000000000 * 1.9)
     assert(m1.value > 1000000000 * 0.5)
   }
@@ -43,7 +43,7 @@ class MetricsSuite extends AnyFunSuite {
       }
     }
 
-    // if the timing is duplicated, the value should be around 200,000,000
+    // if the timing is duplicated, the value should be around 2,000,000,000
     assert(m1.value < 1000000000 * 1.9)
     assert(m1.value > 1000000000 * 0.5)
     assert(m2.value < 1000000000 * 1.9)
@@ -59,7 +59,7 @@ class MetricsSuite extends AnyFunSuite {
       }
     }
 
-    // if the timing is duplicated, the value should be around 200,000,000
+    // if the timing is duplicated, the value should be around 2,000,000,000
     assert(m1.value < 1000000000 * 1.9)
     assert(m1.value > 1000000000 * 0.5)
     assert(m2.value < 1000000000 * 1.9)


### PR DESCRIPTION
This PR closes #11122 by improving the robustness of the failed UT test case

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
