### PR TITLE
Fix batch splitting for partition column size on row-count-only batches

### DIFF
--- a/integration_tests/src/main/python/parquet_test.py
+++ b/integration_tests/src/main/python/parquet_test.py
@@ -1492,3 +1492,14 @@ def test_parquet_column_name_with_dots(spark_tmp_path, reader_confs):
     assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`"), conf=all_confs)
     assert_gpu_and_cpu_are_equal_collect(lambda spark: reader(spark).selectExpr("`a.b`.`c.d.e`.`f.g`"),
                                          conf=all_confs)
+
+def test_parquet_partition_batch_row_count_only_splitting(spark_tmp_path):
+    data_path = spark_tmp_path + "/PARQUET_DATA"
+    def setup_table(spark):
+        spark.range(1000).withColumn("p", f.lit("x")).coalesce(1)\
+            .write\
+            .partitionBy("p")\
+            .parquet(data_path)
+    with_cpu_session(lambda spark: setup_table(spark))
+    assert_gpu_and_cpu_are_equal_collect(lambda spark: spark.read.parquet(data_path).select("p"),
+                                         conf={"spark.rapids.sql.columnSizeBytes": "100"})


### PR DESCRIPTION
Fixes #11155.

Updated BatchWithPartitionData.splitColumnarBatch to handle batches that do not have any columns (i.e.: row-count-only batches).  It converts the split indices into a sequence of row counts for each batch and then converts that into a sequence of row-count-only batches with the corresponding row counts.