### PR TITLE
Fix some GpuBroadcastToRowExec by not dropping columns [databricks]

### DIFF
--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -24,7 +24,7 @@ from spark_session import with_cpu_session, is_databricks113_or_later, is_before
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
 not_utc_aqe_allow=['ShuffleExchangeExec', 'HashAggregateExec'] if is_not_utc() else []
 
-_adaptive_conf = { "spark.sql.adaptive.enabled": "true" }
+_adaptive_conf = { "spark.sql.adaptive.enabled": "true"}
 
 def create_skew_df(spark, length):
     root = spark.range(0, length)
@@ -391,3 +391,78 @@ def test_aqe_join_with_dpp(spark_tmp_path):
         """)
 
     assert_gpu_and_cpu_are_equal_collect(run_test, conf=_adaptive_conf)
+
+# Verify that DPP and AQE can coexist in even some odd cases involving 2 tables with multiple columns
+@ignore_order(local=True)
+@allow_non_gpu(*aqe_join_with_dpp_fallback)
+def test_aqe_join_with_dpp_multi_columns(spark_tmp_path):
+    conf = copy_and_update(_adaptive_conf, {
+        "spark.rapids.sql.explain": "ALL",
+        "spark.rapids.sql.debug.logTransformations": "true"})
+
+    data_path = spark_tmp_path + '/PARQUET_DATA'
+    def write_data(spark):
+        spark.range(100).selectExpr(
+            "concat('t_name_', id % 9) as t_name",
+            "concat('t_id_', id % 9) as t_id",
+            "concat('v_id_', id % 3) as v_id",
+            "concat('site_', id % 2) as site_id"
+            ).repartition(200).write.parquet(data_path + "/tests")
+        spark.range(2000).selectExpr(
+            "concat('t_id_', id % 9) as t_spec",
+            "concat('v_id_', id % 3) as v_spec",
+            "CAST(id as STRING) as extra_1",
+            "concat('LONG_SITE_NAME_', id % 2) as site_id",
+            "if (id % 2 == 0, '1990-01-01', '1990-01-02') as day"
+            ).write.partitionBy("site_id", "day").parquet(data_path + "/infoB")
+        spark.range(2000).selectExpr(
+            "CAST(id as STRING) as extra_1",
+            "concat('v_id_', id % 3) as v_id",
+            "CAST(id + 10 as STRING) as extra_3",
+            "if (id % 3 == 0, 'site_0', 'site_3') as site_id",
+            "if (id % 2 == 0, '1990-01-01', '1990-01-02') as day",
+            "concat('t_id_', id % 9) as t_id"
+            ).write.partitionBy("site_id", "day", "t_id").parquet(data_path + "/infoA")
+
+    with_cpu_session(write_data)
+
+    def run_test(spark):
+        spark.read.parquet(data_path + "/tests/").createOrReplaceTempView("tests")
+        spark.read.parquet(data_path + "/infoA/").createOrReplaceTempView("infoA")
+        spark.read.parquet(data_path + "/infoB/").createOrReplaceTempView("infoB")
+        return spark.sql("""
+        WITH tmp AS 
+        ( SELECT
+            extra_1,
+            v_id,
+            site_id,
+            day,
+            t_id
+          FROM infoA WHERE
+            day >= '1980-01-01' AND
+            extra_3 != 50
+        UNION ALL
+          SELECT
+            extra_1,
+            v_spec as v_id,
+            CASE
+              WHEN site_id = 'LONG_SITE_NAME_0' then 'site_0'
+              WHEN site_id = 'LONG_SITE_NAME_1' then 'site_1'
+              ELSE site_id
+            END AS site_id,
+            day,
+            t_spec as t_id
+            FROM infoB
+        )
+        SELECT
+        a.t_id,
+        b.t_name,
+        a.extra_1,
+        day
+        FROM tmp a
+        JOIN tests b ON a.t_id = b.t_id AND a.v_id = b.v_id AND a.site_id = b.site_id
+        and day = '1990-01-01'
+        and a.site_id IN ('site_0', 'site_1');
+        """)
+
+    assert_gpu_and_cpu_are_equal_collect(run_test, conf=conf)

--- a/integration_tests/src/main/python/aqe_test.py
+++ b/integration_tests/src/main/python/aqe_test.py
@@ -24,7 +24,7 @@ from spark_session import with_cpu_session, is_databricks113_or_later, is_before
 # allow non gpu when time zone is non-UTC because of https://github.com/NVIDIA/spark-rapids/issues/9653'
 not_utc_aqe_allow=['ShuffleExchangeExec', 'HashAggregateExec'] if is_not_utc() else []
 
-_adaptive_conf = { "spark.sql.adaptive.enabled": "true"}
+_adaptive_conf = { "spark.sql.adaptive.enabled": "true" }
 
 def create_skew_df(spark, length):
     root = spark.range(0, length)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastToRowExec.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
-import org.apache.spark.sql.execution.joins.HashedRelationBroadcastMode
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ThreadUtils
@@ -46,10 +45,8 @@ import org.apache.spark.util.ThreadUtils
 case class GpuBroadcastToRowExec(
   buildKeys: Seq[Expression],
   broadcastMode: BroadcastMode,
-  child: SparkPlan)(index: Option[Int], modeKeys: Option[Seq[Expression]])
+  child: SparkPlan)
   extends ShimBroadcastExchangeLike with ShimUnaryExecNode with GpuExec with Logging {
-
-  override def otherCopyArgs: Seq[AnyRef] = index :: modeKeys :: Nil
 
   @transient
   private val timeout: Long = conf.broadcastTimeout
@@ -79,37 +76,21 @@ case class GpuBroadcastToRowExec(
 
   override def doCanonicalize(): SparkPlan = {
     val keys = buildKeys.map(k => QueryPlan.normalizeExpressions(k, child.output))
-    GpuBroadcastToRowExec(keys, broadcastMode, child.canonicalized)(index, modeKeys)
+    GpuBroadcastToRowExec(keys, broadcastMode, child.canonicalized)
   }
-
 
   private def projectSerializedBatch(
       serBatch: SerializeConcatHostBuffersDeserializeBatch): Any = {
     val beforeCollect = System.nanoTime()
 
-    // Creates projection to extract target fields from Row, as what Spark does.
-    // Note that unlike Spark, the GPU broadcast data has not applied the key expressions from
-    // the HashedRelation, so that is applied here if necessary to ensure the proper values
-    // are being extracted. The CPU already has the key projections applied in the broadcast
-    // data and thus does not have similar logic here.
-    val broadcastModeProject = modeKeys.map { keyExprs =>
-      UnsafeProjection.create(keyExprs)
-    }
-
     // Deserializes the batch on the host. Then, transforms it to rows and performs row-wise
     // projection. We should NOT run any device operation on the driver node.
     val result = withResource(serBatch.hostBatch) { hostBatch =>
+      val projection = UnsafeProjection.create((0 until hostBatch.numCols()).map { idx =>
+        BoundReference(idx, hostBatch.column(idx).dataType, nullable = true)
+      }.toSeq)
       hostBatch.rowIterator().asScala.map { row =>
-        val broadcastRow = broadcastModeProject.map(_(row)).getOrElse(row)
-        broadcastMode match {
-          case HashedRelationBroadcastMode(_, _) =>
-            broadcastRow.copy()
-          case _ =>
-            val idx = index.get
-            val rowProject = UnsafeProjection.create(
-              BoundReference(idx, buildKeys(idx).dataType, buildKeys(idx).nullable))
-            rowProject(broadcastRow).copy().asInstanceOf[InternalRow]
-        }
+        projection(row).copy().asInstanceOf[InternalRow]
       }.toArray // force evaluation so we don't close hostBatch too soon
     }
 


### PR DESCRIPTION
This fixes another issue with AQE and GpuBroadcastToRowExec by not dropping columns when the rows are converted to unsafe rows. Any columns that are not needed will be dropped by the broadcast mode conversion anyways.