### PR TITLE
Allow more expressions to be tiered [databricks]

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,7 +182,7 @@ trait GpuExpression extends Expression {
    * If this returns true then tiered project will stop looking to combine expressions when
    * this is seen.
    */
-  def disableTieredProjectCombine: Boolean = hasSideEffects
+  def disableTieredProjectCombine: Boolean = false
 
   /**
    * Whether an expression itself is non-deterministic when its "deterministic" is false,

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,6 +289,9 @@ abstract class GpuAddBase extends CudfBinaryArithmetic with Serializable {
 
   override def binaryOp: BinaryOp = BinaryOp.ADD
   override def astOperator: Option[BinaryOperator] = Some(ast.BinaryOperator.ADD)
+
+  override def hasSideEffects: Boolean =
+    (failOnError && GpuAnsi.needBasicOpOverflowCheck(dataType)) || super.hasSideEffects
 
   override def doColumnar(lhs: BinaryOperable, rhs: BinaryOperable): ColumnVector = {
     val ret = super.doColumnar(lhs, rhs)

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
@@ -108,6 +108,7 @@ class GpuEquivalentExpressions {
 
   private def hasSideEffects(e: Expression): Boolean = e match {
     case e: GpuExpression => e.hasSideEffects
+    case _: AttributeReference => false // This is what we expect to see and it is okay
     case _ => true // Just assume that it does because we don't know
   }
 

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -44,7 +44,7 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
 
   override def dataType: DataType = left.dataType
   // arithmetic operations can overflow and throw exceptions in ANSI mode
-  override def hasSideEffects: Boolean = super.hasSideEffects || SQLConf.get.ansiEnabled
+  override def hasSideEffects: Boolean = super.hasSideEffects || failOnError
 
   override def nullable: Boolean = left.nullable || right.nullable
 }

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/arithmetic.scala
@@ -50,7 +50,7 @@ abstract class CudfBinaryArithmetic extends CudfBinaryOperator with NullIntolera
   protected def allowPrecisionLoss = SQLConf.get.decimalOperationsAllowPrecisionLoss
 
   // arithmetic operations can overflow and throw exceptions in ANSI mode
-  override def hasSideEffects: Boolean = super.hasSideEffects || SQLConf.get.ansiEnabled
+  override def hasSideEffects: Boolean = super.hasSideEffects || failOnError
 
   def dataTypeInternal(lhs: Expression, rhs: Expression) = (lhs.dataType, rhs.dataType) match {
     case (DecimalType.Fixed(p1, s1), DecimalType.Fixed(p2, s2)) =>


### PR DESCRIPTION
This is part of some work I am doing to be able to combine multiple expressions together into a single kernel. But this was large enough that I thought I should do it separately.

Essentially this comes down to that we are being very conservative in doing tiered projects. We assume that all expressions could throw an exception so we have to have rules that deal with conditional expressions so we don't accidentally rewrite something like `if(never going to happen, throw an error, it is all good)` to always `throw an error`.  But we have a `hasSideEffects` method on all `GpuExpression`s, which is used in the conditionals code to avoid these same situations. This updates the tiered expression code to only be conservative in cases where it is warranted.
