### PR TITLE
More accurate estimation for the result serialization time in RapidsShuffleThreadedWriterBase

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/RapidsShuffleInternalManagerBase.scala
@@ -272,12 +272,14 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
    */
   private var stopping = false
 
-  val diskBlockObjectWriters = new mutable.HashMap[Int, (Int, DiskBlockObjectWriter)]()
+  private val diskBlockObjectWriters = new mutable.HashMap[Int, (Int, DiskBlockObjectWriter)]()
 
   /**
    * Simple wrapper that tracks the time spent iterating the given iterator.
    */
-  class TimeTrackingIterator(delegate: Iterator[Product2[K, V]]) extends Iterator[Product2[K, V]] {
+  private class TimeTrackingIterator(delegate: Iterator[Product2[K, V]])
+    extends Iterator[Product2[K, V]] {
+
     private var iterateTimeNs: Long = 0L
 
     override def hasNext: Boolean = {
@@ -303,7 +305,7 @@ abstract class RapidsShuffleThreadedWriterBase[K, V](
     write(new TimeTrackingIterator(records))
   }
 
-  def write(records: TimeTrackingIterator): Unit = {
+  private def write(records: TimeTrackingIterator): Unit = {
     withResource(new NvtxRange("ThreadedWriter.write", NvtxColor.RED)) { _ =>
       withResource(new NvtxRange("compute", NvtxColor.GREEN)) { _ =>
         val mapOutputWriter = shuffleExecutorComponents.createMapOutputWriter(


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids/issues/11173.

The shuffle result serialization time metric currently includes input data processing time as well, which is misleading. This PR excludes the processing time from the serialization time estimation. 

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
