### PR TITLE
Fix dynamic pruning regression in GpuFileSourceScanExec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -558,11 +558,12 @@ case class GpuFileSourceScanExec(
     val partitions = StaticPartitionShims.getStaticPartitions(fsRelation).getOrElse {
       val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
       val maxSplitBytes =
-        FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
+        FilePartition.maxSplitBytes(fsRelation.sparkSession, dynamicallySelectedPartitions)
       logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
         s"open cost is considered as scanning $openCostInBytes bytes.")
 
-      val splitFiles = FilePartitionShims.splitFiles(selectedPartitions, relation, maxSplitBytes)
+      val splitFiles = FilePartitionShims.splitFiles(dynamicallySelectedPartitions, relation,
+        maxSplitBytes)
 
       FilePartition.getFilePartitions(relation.sparkSession, splitFiles, maxSplitBytes)
     }


### PR DESCRIPTION
Fixes #11189.  The change in #11170 removed the `selectedPartitions` parameter but forgot to update the occurrences in the method to use `dynamicallySelectedPartitions` which is what was actually passed to the method.  This effectively caused dynamic partition filters to not be applied.