### PR TITLE
Fix class not found error: com/nvidia/spark/rapids/GpuScalar

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
@@ -57,54 +57,55 @@ object GpuColumnVectorUtils {
 
   /**
    * Create column vector from scalars
-   * @param dt data type
-   * @param scalars literals, Boolean, Byte, ... from `GpuScalar.getValue`
+   * @param scalars literals
    * @return column vector for the specified scalars
    */
-  def createFromScalarList(dt: DataType, scalars: Seq[Any]): CudfCV = {
-    dt match {
+  def createFromScalarList(scalars: Seq[GpuScalar]): CudfCV = {
+    scalars.head.dataType match {
       case BooleanType =>
-        val booleans = scalars.map(s => s.asInstanceOf[java.lang.Boolean])
+        val booleans = scalars.map(s => s.getValue.asInstanceOf[java.lang.Boolean])
         CudfCV.fromBoxedBooleans(booleans: _*)
       case ByteType =>
-        val bytes = scalars.map(s => s.asInstanceOf[java.lang.Byte])
+        val bytes = scalars.map(s => s.getValue.asInstanceOf[java.lang.Byte])
         CudfCV.fromBoxedBytes(bytes: _*)
       case ShortType =>
-        val shorts = scalars.map(s => s.asInstanceOf[java.lang.Short])
+        val shorts = scalars.map(s => s.getValue.asInstanceOf[java.lang.Short])
         CudfCV.fromBoxedShorts(shorts: _*)
       case IntegerType =>
-        val ints = scalars.map(s => s.asInstanceOf[java.lang.Integer])
+        val ints = scalars.map(s => s.getValue.asInstanceOf[java.lang.Integer])
         CudfCV.fromBoxedInts(ints: _*)
       case LongType =>
-        val longs = scalars.map(s => s.asInstanceOf[java.lang.Long])
+        val longs = scalars.map(s => s.getValue.asInstanceOf[java.lang.Long])
         CudfCV.fromBoxedLongs(longs: _*)
       case FloatType =>
-        val floats = scalars.map(s => s.asInstanceOf[java.lang.Float])
+        val floats = scalars.map(s => s.getValue.asInstanceOf[java.lang.Float])
         CudfCV.fromBoxedFloats(floats: _*)
       case DoubleType =>
-        val doubles = scalars.map(s => s.asInstanceOf[java.lang.Double])
+        val doubles = scalars.map(s => s.getValue.asInstanceOf[java.lang.Double])
         CudfCV.fromBoxedDoubles(doubles: _*)
       case StringType =>
         val utf8Bytes = scalars.map(s => {
-          if (s == null) {
+          val v = s.getValue
+          if (v == null) {
             null
           } else {
-            s.asInstanceOf[UTF8String].getBytes
+            v.asInstanceOf[UTF8String].getBytes
           }
         })
         CudfCV.fromUTF8Strings(utf8Bytes: _*)
       case dt: DecimalType =>
         val decimals = scalars.map(s => {
-          if (s == null) {
+          val v = s.getValue
+          if (v == null) {
             null
           } else {
-           s.asInstanceOf[Decimal].toJavaBigDecimal
+           v.asInstanceOf[Decimal].toJavaBigDecimal
           }
         })
         fromDecimals(dt, decimals: _*)
       case _ =>
-        throw new UnsupportedOperationException(s"Creating column vector from a scalar list" +
-            s" is not supported for type dt.")
+        throw new UnsupportedOperationException(s"Creating column vector from a GpuScalar list" +
+            s" is not supported for type ${scalars.head.dataType}.")
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
@@ -57,55 +57,54 @@ object GpuColumnVectorUtils {
 
   /**
    * Create column vector from scalars
-   * @param scalars literals
+   * @param dt data type
+   * @param scalars literals, Boolean, Byte, ... from `GpuScalar.getValue`
    * @return column vector for the specified scalars
    */
-  def createFromScalarList(scalars: Seq[GpuScalar]): CudfCV = {
-    scalars.head.dataType match {
+  def createFromScalarList(dt: DataType, scalars: Seq[Any]): CudfCV = {
+    dt match {
       case BooleanType =>
-        val booleans = scalars.map(s => s.getValue.asInstanceOf[java.lang.Boolean])
+        val booleans = scalars.map(s => s.asInstanceOf[java.lang.Boolean])
         CudfCV.fromBoxedBooleans(booleans: _*)
       case ByteType =>
-        val bytes = scalars.map(s => s.getValue.asInstanceOf[java.lang.Byte])
+        val bytes = scalars.map(s => s.asInstanceOf[java.lang.Byte])
         CudfCV.fromBoxedBytes(bytes: _*)
       case ShortType =>
-        val shorts = scalars.map(s => s.getValue.asInstanceOf[java.lang.Short])
+        val shorts = scalars.map(s => s.asInstanceOf[java.lang.Short])
         CudfCV.fromBoxedShorts(shorts: _*)
       case IntegerType =>
-        val ints = scalars.map(s => s.getValue.asInstanceOf[java.lang.Integer])
+        val ints = scalars.map(s => s.asInstanceOf[java.lang.Integer])
         CudfCV.fromBoxedInts(ints: _*)
       case LongType =>
-        val longs = scalars.map(s => s.getValue.asInstanceOf[java.lang.Long])
+        val longs = scalars.map(s => s.asInstanceOf[java.lang.Long])
         CudfCV.fromBoxedLongs(longs: _*)
       case FloatType =>
-        val floats = scalars.map(s => s.getValue.asInstanceOf[java.lang.Float])
+        val floats = scalars.map(s => s.asInstanceOf[java.lang.Float])
         CudfCV.fromBoxedFloats(floats: _*)
       case DoubleType =>
-        val doubles = scalars.map(s => s.getValue.asInstanceOf[java.lang.Double])
+        val doubles = scalars.map(s => s.asInstanceOf[java.lang.Double])
         CudfCV.fromBoxedDoubles(doubles: _*)
       case StringType =>
         val utf8Bytes = scalars.map(s => {
-          val v = s.getValue
-          if (v == null) {
+          if (s == null) {
             null
           } else {
-            v.asInstanceOf[UTF8String].getBytes
+            s.asInstanceOf[UTF8String].getBytes
           }
         })
         CudfCV.fromUTF8Strings(utf8Bytes: _*)
       case dt: DecimalType =>
         val decimals = scalars.map(s => {
-          val v = s.getValue
-          if (v == null) {
+          if (s == null) {
             null
           } else {
-           v.asInstanceOf[Decimal].toJavaBigDecimal
+           s.asInstanceOf[Decimal].toJavaBigDecimal
           }
         })
         fromDecimals(dt, decimals: _*)
       case _ =>
-        throw new UnsupportedOperationException(s"Creating column vector from a GpuScalar list" +
-            s" is not supported for type ${scalars.head.dataType}.")
+        throw new UnsupportedOperationException(s"Creating column vector from a scalar list" +
+            s" is not supported for type dt.")
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuColumnVectorUtils.scala
@@ -16,18 +16,16 @@
 
 package com.nvidia.spark.rapids
 
-import ai.rapids.cudf.{ColumnVector => CudfCV, HostColumnVector, Table}
-import com.nvidia.spark.rapids.Arm.withResource
 import java.lang.reflect.Method
-import java.util.function.Consumer
 
-import org.apache.spark.sql.types._
+import ai.rapids.cudf.Table
+
+import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnVector
-import org.apache.spark.unsafe.types.UTF8String
 
 object GpuColumnVectorUtils {
   lazy val extractHostColumnsMethod: Method = ShimLoader.loadGpuColumnVector()
-    .getDeclaredMethod("extractHostColumns", classOf[Table], classOf[Array[DataType]])
+      .getDeclaredMethod("extractHostColumns", classOf[Table], classOf[Array[DataType]])
 
   /**
    * Extract the columns from a table and convert them to RapidsHostColumnVector.
@@ -38,98 +36,5 @@ object GpuColumnVectorUtils {
   def extractHostColumns(table: Table, colType: Array[DataType]): Array[ColumnVector] = {
     val columnVectors = extractHostColumnsMethod.invoke(null, table, colType)
     columnVectors.asInstanceOf[Array[ColumnVector]]
-  }
-
-  def isCaseWhenFusionSupportedType(dataType: DataType): Boolean = {
-    dataType match {
-      case BooleanType => true
-      case ByteType => true
-      case ShortType => true
-      case IntegerType => true
-      case LongType => true
-      case FloatType => true
-      case DoubleType => true
-      case StringType => true
-      case _: DecimalType => true
-      case _ => false
-    }
-  }
-
-  /**
-   * Create column vector from scalars
-   * @param scalars literals
-   * @return column vector for the specified scalars
-   */
-  def createFromScalarList(scalars: Seq[GpuScalar]): CudfCV = {
-    scalars.head.dataType match {
-      case BooleanType =>
-        val booleans = scalars.map(s => s.getValue.asInstanceOf[java.lang.Boolean])
-        CudfCV.fromBoxedBooleans(booleans: _*)
-      case ByteType =>
-        val bytes = scalars.map(s => s.getValue.asInstanceOf[java.lang.Byte])
-        CudfCV.fromBoxedBytes(bytes: _*)
-      case ShortType =>
-        val shorts = scalars.map(s => s.getValue.asInstanceOf[java.lang.Short])
-        CudfCV.fromBoxedShorts(shorts: _*)
-      case IntegerType =>
-        val ints = scalars.map(s => s.getValue.asInstanceOf[java.lang.Integer])
-        CudfCV.fromBoxedInts(ints: _*)
-      case LongType =>
-        val longs = scalars.map(s => s.getValue.asInstanceOf[java.lang.Long])
-        CudfCV.fromBoxedLongs(longs: _*)
-      case FloatType =>
-        val floats = scalars.map(s => s.getValue.asInstanceOf[java.lang.Float])
-        CudfCV.fromBoxedFloats(floats: _*)
-      case DoubleType =>
-        val doubles = scalars.map(s => s.getValue.asInstanceOf[java.lang.Double])
-        CudfCV.fromBoxedDoubles(doubles: _*)
-      case StringType =>
-        val utf8Bytes = scalars.map(s => {
-          val v = s.getValue
-          if (v == null) {
-            null
-          } else {
-            v.asInstanceOf[UTF8String].getBytes
-          }
-        })
-        CudfCV.fromUTF8Strings(utf8Bytes: _*)
-      case dt: DecimalType =>
-        val decimals = scalars.map(s => {
-          val v = s.getValue
-          if (v == null) {
-            null
-          } else {
-           v.asInstanceOf[Decimal].toJavaBigDecimal
-          }
-        })
-        fromDecimals(dt, decimals: _*)
-      case _ =>
-        throw new UnsupportedOperationException(s"Creating column vector from a GpuScalar list" +
-            s" is not supported for type ${scalars.head.dataType}.")
-    }
-  }
-
-  /**
-   * Create decimal column vector according to DecimalType.
-   * Note: it will create 3 types of column vector according to DecimalType precision
-   *  - Decimal 32 bits
-   *  - Decimal 64 bits
-   *  - Decimal 128 bits
-   * E.g.: If the max of values are decimal 32 bits, but DecimalType is 128 bits,
-   * then return a Decimal 128 bits column vector
-   */
-  def fromDecimals(dt: DecimalType, values: java.math.BigDecimal*): CudfCV = {
-    val hcv = HostColumnVector.build(
-      DecimalUtil.createCudfDecimal(dt),
-      values.length,
-      new Consumer[HostColumnVector.Builder]() {
-        override def accept(b: HostColumnVector.Builder): Unit = {
-          b.appendBoxed(values: _*)
-        }
-      }
-    )
-    withResource(hcv) { _ =>
-      hcv.copyToDevice()
-    }
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -387,7 +387,9 @@ case class GpuCaseWhen(
               .asInstanceOf[GpuScalar])
           withResource(thenElseScalars) { _ =>
             // 2. generate a column to store all scalars
-            withResource(GpuColumnVectorUtils.createFromScalarList(thenElseScalars)) {
+            val scalarType = thenElseScalars.head.dataType
+            val scalars = thenElseScalars.map(s => s.getValue).toArray
+            withResource(GpuColumnVectorUtils.createFromScalarList(scalarType, scalars)) {
               scalarCol =>
                 val finalRet = withResource(new Table(scalarCol)) { oneColumnTable =>
                   // 3. execute final select

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/conditionalExpressions.scala
@@ -387,9 +387,7 @@ case class GpuCaseWhen(
               .asInstanceOf[GpuScalar])
           withResource(thenElseScalars) { _ =>
             // 2. generate a column to store all scalars
-            val scalarType = thenElseScalars.head.dataType
-            val scalars = thenElseScalars.map(s => s.getValue).toArray
-            withResource(GpuColumnVectorUtils.createFromScalarList(scalarType, scalars)) {
+            withResource(GpuColumnVectorUtils.createFromScalarList(thenElseScalars)) {
               scalarCol =>
                 val finalRet = withResource(new Table(scalarCol)) { oneColumnTable =>
                   // 3. execute final select


### PR DESCRIPTION
closes #11196 

### Bug
The bug is that GpuColumnVectorUtils  accesses shimmed GpuScalar from  unshimmed GpuColumnVectorUtils.
Two class paths in Rapids jar:
./com/nvidia/spark/rapids/GpuColumnVectorUtils.class
./spark-shared/com/nvidia/spark/rapids/GpuScalar.class

### fix
Move related utility functions to GpuCaseWhen.


Signed-off-by: Chong Gao <res_life@163.com>