### PR TITLE
Multi-get_json_object [databricks]

### DIFF
--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -100,7 +100,7 @@ abstract class GpuOptimisticTransactionBase
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan) else plan
   }
 
   /**

--- a/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/databricks/scala/com/databricks/sql/transaction/tahoe/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * This file was derived from OptimisticTransaction.scala and TransactionalWrite.scala
  * in the Delta Lake project at https://github.com/delta-io/delta.

--- a/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
+++ b/delta-lake/common/src/main/delta-io/scala/org/apache/spark/sql/delta/rapids/GpuOptimisticTransactionBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ abstract class GpuOptimisticTransactionBase(
         GpuAlias(GpuEmpty2Null(p), p.name)()
       case attr => attr
     }
-    if (needConvert) GpuProjectExec(projectList.toList, plan)() else plan
+    if (needConvert) GpuProjectExec(projectList.toList, plan) else plan
   }
 
   /**

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -172,7 +172,8 @@ object AggregateModeInfo {
  *                             the merge steps for each aggregate function
  * @param isSorted             if the batch is sorted this is set to true and is passed to cuDF
  *                             as an optimization hint
- * @param conf                 A configuration used to control TieredProject operations in an aggregation.
+ * @param conf                 A configuration used to control TieredProject operations in an
+ *                             aggregation.
  */
 class AggHelper(
     inputAttributes: Seq[Attribute],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuAggregateExec.scala
@@ -172,7 +172,7 @@ object AggregateModeInfo {
  *                             the merge steps for each aggregate function
  * @param isSorted             if the batch is sorted this is set to true and is passed to cuDF
  *                             as an optimization hint
- * @param useTieredProject     if true, used tiered project for input projections
+ * @param conf                 A configuration used to control TieredProject operations in an aggregation.
  */
 class AggHelper(
     inputAttributes: Seq[Attribute],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -132,7 +132,7 @@ object GpuBindReferences extends Logging {
   /**
    * A helper function to bind given expressions to an input schema where the expressions are
    * to be processed on the GPU, and the result type indicates this.
-   * Some expressions that can be combined into a single expression call might be as well as
+   * Some expressions that can be combined into a single expression call as well as
    * common sub-expressions may be factored out where possible to reduce the runtime and memory.
    * All of these can be controlled by the configuration passed in.
    */

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.shims.ShimExpression
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSeq, Expression, ExprId, NamedExpression, SortOrder}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.catalyst.expressions.GpuEquivalentExpressions
 import org.apache.spark.sql.types.DataType
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -138,11 +139,14 @@ object GpuBindReferences extends Logging {
   def bindGpuReferencesTiered[A <: Expression](
       expressions: Seq[A],
       input: AttributeSeq,
-      runTiered: Boolean): GpuTieredProject = {
+      conf: SQLConf): GpuTieredProject = {
 
-    if (runTiered) {
-      // TODO put this under a config??? OR should be be for each expressions??
-      val replaced = GpuEquivalentExpressions.replaceMultiExpressions(expressions)
+    if (RapidsConf.ENABLE_TIERED_PROJECT.get(conf)) {
+      val replaced = if (RapidsConf.ENABLE_COMBINED_EXPRESSIONS.get(conf)) {
+        GpuEquivalentExpressions.replaceMultiExpressions(expressions, conf)
+      } else {
+        expressions
+      }
       val exprTiers = GpuEquivalentExpressions.getExprTiers(replaced)
       val inputTiers = GpuEquivalentExpressions.getInputTiers(exprTiers, input)
       // Update ExprTiers to include the columns that are pass through and drop unneeded columns
@@ -163,6 +167,22 @@ object GpuBindReferences extends Logging {
       val tiered = newExprTiers.zip(inputTiers).map {
         case (es: Seq[Expression], is: AttributeSeq) =>
           es.map(GpuBindReferences.bindGpuReference(_, is)).toList
+      }
+      logTrace {
+        "INPUT:\n" +
+          expressions.zipWithIndex.map {
+            case (expr, idx) =>
+              s"\t$idx:\t$expr"
+          }.mkString("\n") +
+          "\nOUTPUT:\n" +
+          tiered.zipWithIndex.map {
+            case (exprs, tier) =>
+              s"\tTIER $tier\n" +
+                exprs.zipWithIndex.map {
+                  case (expr, idx) =>
+                    s"\t\t$idx:\t$expr"
+                }.mkString("\n")
+          }.mkString("\n")
       }
       GpuTieredProject(tiered)
     } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuBoundAttribute.scala
@@ -131,10 +131,10 @@ object GpuBindReferences extends Logging {
 
   /**
    * A helper function to bind given expressions to an input schema where the expressions are
-   * to be processed on the GPU, and the result type indicates this. If runTiered is true
-   * Common sub-expressions will be factored out where possible to reduce the runtime and memory.
-   * If set to false a GpuTieredProject object will still be returned, but no common
-   * sub-expressions will be factored out.
+   * to be processed on the GPU, and the result type indicates this.
+   * Some expressions that can be combined into a single expression call might be as well as
+   * common sub-expressions may be factored out where possible to reduce the runtime and memory.
+   * All of these can be controlled by the configuration passed in.
    */
   def bindGpuReferencesTiered[A <: Expression](
       expressions: Seq[A],

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGenerateExec.scala
@@ -79,7 +79,6 @@ class GpuGenerateExecSparkPlanMeta(
     }
     val output: Seq[Attribute] = gen.requiredChildOutput ++ gen.generatorOutput.take(numFields)
     GpuExpandExec(projections, output, childPlans.head.convertIfNeeded())(
-        useTieredProject = conf.isTieredProjectEnabled,
         preprojectEnabled = conf.isExpandPreprojectEnabled)
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuGetJsonObject.scala
@@ -215,12 +215,9 @@ case class GpuMultiGetJsonObject(json: Expression,
       case _ => false
     }.map(_._2)
 
-    val validPathsWithIndexes = jniInstructions.zipWithIndex.filter {
-      case (Some(_), _) => true
-      case _ => false
-    }.map {
-      case (Some(arr), idx) => (java.util.Arrays.asList(arr: _*), idx)
-      case _ => throw new IllegalStateException("Internal Error")
+    val validPathsWithIndexes = jniInstructions.zipWithIndex.flatMap {
+      case (Some(arr), idx) => Some((java.util.Arrays.asList(arr: _*), idx))
+      case _ => None
     }
 
     val validPaths = validPathsWithIndexes.map(_._1)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4177,7 +4177,7 @@ object GpuOverrides extends Logging {
           // The GPU does not yet support conditional joins, so conditions are implemented
           // as a filter after the join when possible.
           condition.map(c => GpuFilterExec(c.convertToGpu(),
-            joinExec)(useTieredProject = this.conf.isTieredProjectEnabled)).getOrElse(joinExec)
+            joinExec)()).getOrElse(joinExec)
         }
       }),
     exec[HashAggregateExec](

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuShuffledHashJoinExec.scala
@@ -100,7 +100,7 @@ class GpuShuffledHashJoinMeta(
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
     filterCondition.map(c => GpuFilterExec(c,
-      joinExec)(useTieredProject = conf.isTieredProjectEnabled)).getOrElse(joinExec)
+      joinExec)()).getOrElse(joinExec)
   }
 }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuSortMergeJoinMeta.scala
@@ -112,6 +112,6 @@ class GpuSortMergeJoinMeta(
     // For inner joins we can apply a post-join condition for any conditions that cannot be
     // evaluated directly in a mixed join that leverages a cudf AST expression
     filterCondition.map(c => GpuFilterExec(c,
-      joinExec)(useTieredProject = conf.isTieredProjectEnabled)).getOrElse(joinExec)
+      joinExec)()).getOrElse(joinExec)
   }
 }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -995,6 +995,20 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_COMBINED_EXPR_PREFIX = "spark.rapids.sql.expression.combined."
+
+  val ENABLE_COMBINED_EXPRESSIONS = conf("spark.rapids.sql.combined.expressions.enabled")
+    .doc("For some expressions it can be much more efficient to combine multiple " +
+      "expressions together into a single kernel call. This enables or disables that " +
+      s"feature. Note that this requires that $ENABLE_TIERED_PROJECT is turned on or " +
+      "else there is no performance improvement. You can also disable this feature for " +
+      "expressions that support it. Each config is expression specific and starts with " +
+      s"$ENABLE_COMBINED_EXPR_PREFIX followed by the name of the GPU expression class " +
+      s"similar to what we do for enabling converting individual expressions to the GPU.")
+    .internal()
+    .booleanConf
+    .createWithDefault(true)
+
   val ENABLE_RLIKE_REGEX_REWRITE = conf("spark.rapids.sql.rLikeRegexRewrite.enabled")
       .doc("Enable the optimization to rewrite rlike regex to contains in some cases.")
       .internal()
@@ -2811,6 +2825,8 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
   lazy val isProjectAstEnabled: Boolean = get(ENABLE_PROJECT_AST)
 
   lazy val isTieredProjectEnabled: Boolean = get(ENABLE_TIERED_PROJECT)
+
+  lazy val isCombinedExpressionsEnabled: Boolean = get(ENABLE_COMBINED_EXPRESSIONS)
 
   lazy val isRlikeRegexRewriteEnabled: Boolean = get(ENABLE_RLIKE_REGEX_REWRITE)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/basicPhysicalOperators.scala
@@ -65,7 +65,7 @@ class GpuProjectExecMeta(
         }
       }
     }
-    GpuProjectExec(gpuExprs, gpuChild)(useTieredProject = conf.isTieredProjectEnabled)
+    GpuProjectExec(gpuExprs, gpuChild)
   }
 }
 
@@ -357,12 +357,8 @@ case class GpuProjectExec(
    // serde: https://github.com/scala/scala/blob/2.12.x/src/library/scala/collection/
    //   immutable/List.scala#L516
    projectList: List[NamedExpression],
-   child: SparkPlan)(
-   useTieredProject : Boolean = false
- ) extends GpuProjectExecLike {
+   child: SparkPlan) extends GpuProjectExecLike {
 
-  override def otherCopyArgs: Seq[AnyRef] =
-    Seq[AnyRef](useTieredProject.asInstanceOf[java.lang.Boolean])
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)
 
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
@@ -373,7 +369,7 @@ case class GpuProjectExec(
     val numOutputBatches = gpuLongMetric(NUM_OUTPUT_BATCHES)
     val opTime = gpuLongMetric(OP_TIME)
     val boundProjectList = GpuBindReferences.bindGpuReferencesTiered(projectList, child.output,
-      useTieredProject)
+      conf)
 
     val rdd = child.executeColumnar()
     rdd.map { cb =>
@@ -788,20 +784,18 @@ case class GpuFilterExecMeta(
 ) extends SparkPlanMeta[FilterExec](filter, conf, parentMetaOpt, rule) {
   override def convertToGpu(): GpuExec = {
     GpuFilterExec(childExprs.head.convertToGpu(),
-      childPlans.head.convertIfNeeded())(useTieredProject = this.conf.isTieredProjectEnabled)
+      childPlans.head.convertIfNeeded())()
   }
 }
 
 case class GpuFilterExec(
     condition: Expression,
     child: SparkPlan)(
-    useTieredProject : Boolean = false,
     override val coalesceAfter: Boolean = true)
     extends ShimUnaryExecNode with ShimPredicateHelper with GpuExec {
 
   override def otherCopyArgs: Seq[AnyRef] =
-    Seq[AnyRef](useTieredProject.asInstanceOf[java.lang.Boolean],
-      coalesceAfter.asInstanceOf[java.lang.Boolean])
+    Seq[AnyRef](coalesceAfter.asInstanceOf[java.lang.Boolean])
 
   override lazy val additionalMetrics: Map[String, GpuMetric] = Map(
     OP_TIME -> createNanoTimingMetric(MODERATE_LEVEL, DESCRIPTION_OP_TIME))
@@ -841,7 +835,7 @@ case class GpuFilterExec(
     val opTime = gpuLongMetric(OP_TIME)
     val rdd = child.executeColumnar()
     val boundCondition = GpuBindReferences.bindGpuReferencesTiered(Seq(condition), child.output,
-      useTieredProject)
+      conf)
     rdd.flatMap { batch =>
       GpuFilter.filterAndClose(batch, boundCondition, numOutputRows,
         numOutputBatches, opTime)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/window/GpuWindowExecMeta.scala
@@ -142,7 +142,7 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     val input = if (isPreNeeded) {
-      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded())()
+      GpuProjectExec(pre.toList, childPlans.head.convertIfNeeded())
     } else {
       childPlans.head.convertIfNeeded()
     }
@@ -165,9 +165,9 @@ abstract class GpuBaseWindowExecMeta[WindowExecType <: SparkPlan] (windowExec: W
     }
 
     if (isPostNeeded) {
-      GpuProjectExec(post.toList, windowExpr)()
+      GpuProjectExec(post.toList, windowExpr)
     } else if (windowExpr.output != windowExec.output) {
-      GpuProjectExec(windowExec.output.toList, windowExpr)()
+      GpuProjectExec(windowExec.output.toList, windowExpr)
     } else {
       windowExpr
     }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/catalyst/expressions/GpuEquivalentExpressions.scala
@@ -55,7 +55,7 @@ class GpuEquivalentExpressions {
           stats.useCount += 1
           true
         case _ =>
-          map.put(wrapper, GpuExpressionStats(expr)())
+          map.put(wrapper, new GpuExpressionStats(expr))
           false
       }
     } else {
@@ -374,6 +374,47 @@ object GpuEquivalentExpressions {
     }
   }
 
+  /**
+   * This takes a set of expressions and finds all multi-expressions that can be replaced
+   * and replaces them.
+   */
+  def replaceMultiExpressions(exprs: Seq[Expression]): Seq[Expression] = {
+    // GpuEquivalentExpressions is really find all expressions that will execute
+    // unconditionally, or at least it will be. This gives us the ability to
+    // know that if we combine expressions into multi-expressions then we will
+    // not accidentally cause side effects to happen that should have been hidden
+    // by a conditional expression. It also guarantees that the dedupe code
+    // will combine the multi-expressions so we don't run them multiple times.
+    val equivalentExpressions = new GpuEquivalentExpressions
+    exprs.foreach(equivalentExpressions.addExprTree(_))
+    val combinableMap = mutable.HashMap.empty[GpuExpressionCombiner, GpuExpressionCombiner]
+    equivalentExpressions.equivalenceMap.values.map(_.expr).foreach {
+      case e: GpuCombinable =>
+        val key = e.getCombiner()
+        combinableMap.get(key).map { c =>
+          c.addExpression(e)
+        }.getOrElse {
+          combinableMap.put(key, key)
+        }
+      case _ => //Noop
+    }
+    val filtered = combinableMap.filter {
+      case (_, v) => v.useCount > 1
+    }
+
+    // We now have a set of values that should be replaced
+    if (filtered.isEmpty) {
+      exprs
+    } else {
+      exprs.map { expr =>
+        expr.transform {
+          case c: GpuCombinable if filtered.contains(c.getCombiner()) =>
+            filtered(c.getCombiner()).getReplacementExpression(c)
+        }
+      }
+    }
+  }
+
   def getExprTiers(expressions: Seq[Expression]): Seq[Seq[Expression]] = {
     // Get tiers of common expressions
     val expressionTiers = recurseCommonExpressions(expressions, Seq(expressions))
@@ -413,6 +454,45 @@ object GpuEquivalentExpressions {
   }
 }
 
+trait GpuExpressionCombiner {
+  /**
+   * Get a hash code that can be used to find other ExpressionCombiner instances
+   * that could be combined together.
+   */
+  def hashCode: Int
+
+  /**
+   * Check to see if this ExpressionCombiner could be combined with another one.
+   */
+  def equals(o: Any): Boolean
+
+  /**
+   * Add another expression to this combiner. Note that equals must have returned true
+   * already.
+   */
+  def addExpression(e: Expression): Unit
+
+  /**
+   * For a specific expression return a multi-expression that can be used to replace it.
+   * Note that deduplication of these will happen as a part of tiered project.
+   * @param e the expression to be replaced
+   * @return the replacement expression
+   */
+  def getReplacementExpression(e: Expression): Expression
+
+  /**
+   * Get the number of expressions that can be combined (excluding duplicates)
+   */
+  def useCount: Int
+}
+
+trait GpuCombinable extends GpuExpression {
+  /**
+   * Get a combiner that can be used to find candidates to combine
+   */
+  def getCombiner(): GpuExpressionCombiner
+}
+
 /**
  * Wrapper around an Expression that provides semantic equality.
  */
@@ -432,10 +512,11 @@ case class GpuExpressionEquals(e: Expression) {
  * Instead of appending to a mutable list/buffer of Expressions, just update the "flattened"
  * useCount in this wrapper in-place.
  */
-case class GpuExpressionStats(expr: Expression)(var useCount: Int = 1) {
+class GpuExpressionStats(val expr: Expression) {
+  var useCount: Int = 1
   // This is used to do a fast pre-check for child-parent relationship. For example, expr1 can
   // only be a parent of expr2 if expr1.height is larger than expr2.height.
-  lazy val height = getHeight(expr)
+  lazy val height: Int = getHeight(expr)
 
   private def getHeight(tree: Expression): Int = {
     tree.children.map(getHeight).reduceOption(_ max _).getOrElse(0) + 1

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExecBase.scala
@@ -537,7 +537,7 @@ abstract class GpuBroadcastNestedLoopJoinExecBase(
         // internalDoExecuteColumnar. This is to workaround especial handle to build broadcast
         // batch.
         val proj = GpuBindReferences.bindGpuReferencesTiered(
-          postBuildCondition, p.child.output, true)
+          postBuildCondition, p.child.output, conf)
         withResource(makeBuiltBatchInternal(relation, buildTime, buildDataSize)) {
           cb => proj.project(cb)
         }

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -131,7 +131,7 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
+      if (projectList.nonEmpty) GpuProjectExec(projectList, plan) else plan
     }
 
     val writerBucketSpec = BucketingUtilsShim.getWriterBucketSpec(bucketSpec, dataColumns,

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -58,16 +58,16 @@ class GpuBroadcastNestedLoopJoinMeta(
     // If ast-able, try to split if needed. Otherwise, do post-filter
     val isAstCondition = canJoinCondAstAble()
 
-    if(isAstCondition){
+    if (isAstCondition) {
       // Try to extract non-ast-able conditions from join conditions
       val (remains, leftExpr, rightExpr) = AstUtil.extractNonAstFromJoinCond(
         conditionMeta, left.output, right.output, true)
 
       // Reconstruct the childern with wrapped project node if needed.
       val leftChild =
-        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left)(true) else left
+        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left) else left
       val rightChild =
-        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right)(true) else right
+        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right) else right
       val postBuildCondition =
         if (gpuBuildSide == GpuBuildLeft) leftExpr ++ left.output else rightExpr ++ right.output
 
@@ -89,7 +89,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         GpuProjectExec(
           GpuBroadcastNestedLoopJoinExecBase.output(
             join.joinType, left.output, right.output).toList,
-          joinExec)(false)
+          joinExec)
       }
     } else {
       join.joinType match {

--- a/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark330db/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -63,9 +63,9 @@ class GpuBroadcastNestedLoopJoinMeta(
 
       // Reconstruct the child with wrapped project node if needed.
       val leftChild =
-        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left)(true) else left
+        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left) else left
       val rightChild =
-        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right)(true) else right
+        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right) else right
       val postBuildCondition =
         if (gpuBuildSide == GpuBuildLeft) leftExpr ++ left.output else rightExpr ++ right.output
 
@@ -88,7 +88,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         GpuProjectExec(
           GpuBroadcastNestedLoopJoinExecBase.output(
             join.joinType, left.output, right.output).toList,
-          joinExec)(false)
+          joinExec)
       }
     } else {
       val condition = conditionMeta.map(_.convertToGpu())

--- a/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
+++ b/sql-plugin/src/main/spark332db/scala/org/apache/spark/sql/rapids/GpuFileFormatWriter.scala
@@ -228,7 +228,7 @@ object GpuFileFormatWriter extends Logging {
       plan
     } else {
       val projectList = GpuV1WriteUtils.convertGpuEmptyToNull(plan.output, partitionSet)
-      if (projectList.nonEmpty) GpuProjectExec(projectList, plan)() else plan
+      if (projectList.nonEmpty) GpuProjectExec(projectList, plan) else plan
     }
 
     writeAndCommit(job, description, committer) {

--- a/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
+++ b/sql-plugin/src/main/spark340/scala/org/apache/spark/sql/rapids/execution/GpuBroadcastNestedLoopJoinExec.scala
@@ -59,9 +59,9 @@ class GpuBroadcastNestedLoopJoinMeta(
 
       // Reconstruct the child with wrapped project node if needed.
       val leftChild =
-        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left)(true) else left
+        if (!leftExpr.isEmpty) GpuProjectExec(leftExpr ++ left.output, left) else left
       val rightChild =
-        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right)(true) else right
+        if (!rightExpr.isEmpty) GpuProjectExec(rightExpr ++ right.output, right) else right
       val postBuildCondition =
         if (gpuBuildSide == GpuBuildLeft) leftExpr ++ left.output else rightExpr ++ right.output
 
@@ -83,7 +83,7 @@ class GpuBroadcastNestedLoopJoinMeta(
         GpuProjectExec(
           GpuBroadcastNestedLoopJoinExecBase.output(
             join.joinType, left.output, right.output).toList,
-          joinExec)(false)
+          joinExec)
       }
     } else {
       val condition = conditionMeta.map(_.convertToGpu())

--- a/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/HashAggregateRetrySuite.scala
@@ -24,6 +24,7 @@ import com.nvidia.spark.rapids.jni.RmmSpark
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.aggregate.{CudfAggregate, CudfSum}
 import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 
@@ -58,7 +59,7 @@ class HashAggregateRetrySuite
     when(mockMetrics.numAggOps).thenReturn(NoopMetric)
     val aggHelper = spy(new AggHelper(
       Seq.empty, Seq.empty, Seq.empty,
-      forceMerge = false, isSorted = false))
+      forceMerge = false, new SQLConf(), isSorted = false))
 
     // mock out a reduction on the first column
     val aggs = new ArrayBuffer[CudfAggregate]()
@@ -78,7 +79,8 @@ class HashAggregateRetrySuite
   def makeGroupByAggHelper(forceMerge: Boolean): AggHelper = {
     val aggHelper = spy(new AggHelper(
       Seq.empty, Seq.empty, Seq.empty,
-      forceMerge = forceMerge, isSorted = false))
+      forceMerge = forceMerge, new SQLConf(),
+      isSorted = false))
 
     // mock out a group by with the first column as key, and second column
     // as a group by sum

--- a/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/ProjectExprSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, Literal, NamedExpression}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.rapids.GpuAdd
 import org.apache.spark.sql.types._
 
@@ -102,7 +103,7 @@ class ProjectExprSuite extends SparkQueryCompareTestSuite {
       val b = AttributeReference("b", LongType)()
       val simpleAdd = GpuAdd(a, b, false)
       val fullAdd = GpuAlias(GpuAdd(simpleAdd, simpleAdd, false), "ret")()
-      val tp = GpuBindReferences.bindGpuReferencesTiered(Seq(fullAdd), Seq(a, b), true)
+      val tp = GpuBindReferences.bindGpuReferencesTiered(Seq(fullAdd), Seq(a, b), new SQLConf())
       val sb = buildProjectBatch()
 
       RmmSpark.forceRetryOOM(RmmSpark.getCurrentThreadId, 1,


### PR DESCRIPTION
This depends on https://github.com/NVIDIA/spark-rapids-jni/pull/2201 or something like it that adds in the new API. I also have not done any performance testing on this yet as the dependency code is not done. I really want to see if we can get some better performance by ordering or grouping the expressions better. This does not support dumping results of a comparison against the CPU. If the code sees that it will not combine them into a multi-get.

This does add in a framework to do other multi-GPU like expressions in the future.

Be aware that a lot of the changes here are related to changes to how we configure TieredProject which is a key part of this.

The general idea here is that a multi-expression will output a struct of results, and then the TieredProject will be able to dedupe the multi-expressions so we only do it once, and then pull out the fields from that multi-expression.

To make that work we reuse the code in TieredProject to find the expressions that meet the criteria to dedupe so we have confidence that after we have combined them the TieredProject will do the right thing.